### PR TITLE
v0.2.0 slice-1: maneuver planning, view focus, SOI viz

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./... -race -count=1

--- a/internal/planner/hohmann.go
+++ b/internal/planner/hohmann.go
@@ -1,14 +1,38 @@
 package planner
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
-// ErrNotImplemented is returned by Phase-3 stubs that slip past v0.1 per
-// plan §MVP deferrals.
-var ErrNotImplemented = errors.New("planner: not implemented in v0.1 (deferred to v0.2)")
+// ErrNotImplemented is returned by planner entry points that are still
+// stubbed (e.g. Lambert in v0.2).
+var ErrNotImplemented = errors.New("planner: not implemented")
 
-// HohmannTransfer would compute Δv1, Δv2, and transfer time for a
-// circular-to-circular coplanar Hohmann transfer. Stubbed for v0.1; the
-// math is ~10 lines but the UI integration isn't ready.
+// ErrInvalidOrbit is returned when HohmannTransfer is asked to solve for a
+// non-physical input (non-positive radius or mu).
+var ErrInvalidOrbit = errors.New("planner: invalid orbit (r1, r2, mu must be > 0)")
+
+// HohmannTransfer computes the two impulsive burns and transfer time for a
+// circular-to-circular coplanar Hohmann transfer between orbital radii r1
+// and r2 around a primary with standard gravitational parameter mu. All
+// SI units: r1, r2 in meters, mu in m^3/s^2.
+//
+// Returned dv1 and dv2 are magnitudes (always ≥ 0). Direction is implicit
+// in r1 vs r2: outbound (r2 > r1) → both burns prograde; inbound → both
+// retrograde. tTransfer is the half-period of the transfer ellipse (time
+// between burn 1 and burn 2).
 func HohmannTransfer(r1, r2, mu float64) (dv1, dv2, tTransfer float64, err error) {
-	return 0, 0, 0, ErrNotImplemented
+	if r1 <= 0 || r2 <= 0 || mu <= 0 {
+		return 0, 0, 0, ErrInvalidOrbit
+	}
+	aT := (r1 + r2) / 2
+	vCirc1 := math.Sqrt(mu / r1)
+	vCirc2 := math.Sqrt(mu / r2)
+	vTrans1 := math.Sqrt(mu * (2/r1 - 1/aT))
+	vTrans2 := math.Sqrt(mu * (2/r2 - 1/aT))
+	dv1 = math.Abs(vTrans1 - vCirc1)
+	dv2 = math.Abs(vCirc2 - vTrans2)
+	tTransfer = math.Pi * math.Sqrt(aT*aT*aT/mu)
+	return dv1, dv2, tTransfer, nil
 }

--- a/internal/planner/hohmann_test.go
+++ b/internal/planner/hohmann_test.go
@@ -1,0 +1,110 @@
+package planner
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// muSun is the standard gravitational parameter for the Sun, derived from
+// G * M_sun. Canonical Hohmann numerics in textbooks use slightly
+// different μ values (1.32712440018e20 is the JPL DE440 figure); the
+// internal value here is consistent with internal/bodies so tolerances
+// are relative.
+var muSun = bodies.G * bodies.SunMassKg
+
+// TestHohmannEarthToMars checks the canonical textbook case: circular
+// Earth orbit to circular Mars orbit around the Sun. Expected values from
+// Curtis, "Orbital Mechanics for Engineering Students" §6.2 Example 6.1:
+//   Δv1 ≈ 2.943 km/s, Δv2 ≈ 2.649 km/s, t ≈ 258.8 days.
+// We allow 2% tolerance to absorb the μ_sun difference between our
+// G·M_sun and the JPL-published value.
+func TestHohmannEarthToMars(t *testing.T) {
+	r1 := bodies.AU
+	r2 := 1.524 * bodies.AU
+	dv1, dv2, tTransfer, err := HohmannTransfer(r1, r2, muSun)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedDV1 := 2943.0 // m/s
+	expectedDV2 := 2649.0 // m/s
+	expectedT := 258.8 * bodies.SecondsPerDay
+
+	if !within(dv1, expectedDV1, 0.02) {
+		t.Errorf("dv1: got %.1f m/s, want ~%.1f m/s (±2%%)", dv1, expectedDV1)
+	}
+	if !within(dv2, expectedDV2, 0.02) {
+		t.Errorf("dv2: got %.1f m/s, want ~%.1f m/s (±2%%)", dv2, expectedDV2)
+	}
+	if !within(tTransfer, expectedT, 0.02) {
+		t.Errorf("tTransfer: got %.1f d, want ~%.1f d (±2%%)",
+			tTransfer/bodies.SecondsPerDay, expectedT/bodies.SecondsPerDay)
+	}
+}
+
+// TestHohmannInboundSymmetry checks that reversing r1/r2 yields the same
+// |Δv1|, |Δv2|, and transfer time (with the burns swapping roles).
+func TestHohmannInboundSymmetry(t *testing.T) {
+	r1 := bodies.AU
+	r2 := 1.524 * bodies.AU
+	outDV1, outDV2, outT, err := HohmannTransfer(r1, r2, muSun)
+	if err != nil {
+		t.Fatalf("outbound: %v", err)
+	}
+	inDV1, inDV2, inT, err := HohmannTransfer(r2, r1, muSun)
+	if err != nil {
+		t.Fatalf("inbound: %v", err)
+	}
+	if !within(outDV1, inDV2, 1e-9) {
+		t.Errorf("outbound dv1 (%.3f) != inbound dv2 (%.3f)", outDV1, inDV2)
+	}
+	if !within(outDV2, inDV1, 1e-9) {
+		t.Errorf("outbound dv2 (%.3f) != inbound dv1 (%.3f)", outDV2, inDV1)
+	}
+	if !within(outT, inT, 1e-9) {
+		t.Errorf("outbound t (%.3f) != inbound t (%.3f)", outT, inT)
+	}
+}
+
+// TestHohmannSameOrbitZeroDeltaV checks that r1 == r2 produces dv == 0
+// and a transfer time equal to π·√(r³/μ) (half the circular period).
+func TestHohmannSameOrbitZeroDeltaV(t *testing.T) {
+	r := bodies.AU
+	dv1, dv2, tTransfer, err := HohmannTransfer(r, r, muSun)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dv1 > 1e-9 || dv2 > 1e-9 {
+		t.Errorf("expected zero Δv, got dv1=%g dv2=%g", dv1, dv2)
+	}
+	halfPeriod := math.Pi * math.Sqrt(r*r*r/muSun)
+	if !within(tTransfer, halfPeriod, 1e-9) {
+		t.Errorf("tTransfer: got %g, want %g", tTransfer, halfPeriod)
+	}
+}
+
+// TestHohmannInvalidOrbit covers the guard clauses.
+func TestHohmannInvalidOrbit(t *testing.T) {
+	cases := []struct{ r1, r2, mu float64 }{
+		{0, bodies.AU, muSun},
+		{bodies.AU, 0, muSun},
+		{bodies.AU, bodies.AU, 0},
+		{-1, bodies.AU, muSun},
+	}
+	for _, c := range cases {
+		if _, _, _, err := HohmannTransfer(c.r1, c.r2, c.mu); !errors.Is(err, ErrInvalidOrbit) {
+			t.Errorf("HohmannTransfer(%g,%g,%g): expected ErrInvalidOrbit, got %v",
+				c.r1, c.r2, c.mu, err)
+		}
+	}
+}
+
+func within(got, want, tol float64) bool {
+	if want == 0 {
+		return math.Abs(got) <= tol
+	}
+	return math.Abs(got-want)/math.Abs(want) <= tol
+}

--- a/internal/planner/predictor_test.go
+++ b/internal/planner/predictor_test.go
@@ -61,12 +61,11 @@ func TestPredictPreservesRadiusForCircularOrbit(t *testing.T) {
 	}
 }
 
-// TestStubsReturnErr: planner/hohmann.go and planner/lambert.go must
-// return ErrNotImplemented rather than panicking or silently succeeding.
-func TestStubsReturnErr(t *testing.T) {
-	if _, _, _, err := HohmannTransfer(7e6, 4.2e7, 3.986e14); err == nil {
-		t.Error("HohmannTransfer returned nil error; stubbed implementation should return ErrNotImplemented")
-	}
+// TestLambertStubReturnsErr: LambertSolve is still stubbed in v0.2 slice-1
+// and must return ErrNotImplemented rather than panicking or silently
+// succeeding. HohmannTransfer has its own dedicated test file now
+// (hohmann_test.go) — it is no longer stubbed.
+func TestLambertStubReturnsErr(t *testing.T) {
 	if _, _, err := LambertSolve(
 		orbital.Vec3{X: 7e6}, orbital.Vec3{X: 4.2e7}, 1000, 3.986e14); err == nil {
 		t.Error("LambertSolve returned nil error; stubbed implementation should return ErrNotImplemented")

--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -1,0 +1,150 @@
+package sim
+
+import (
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// FocusKind enumerates what the OrbitView canvas is centered on.
+type FocusKind int
+
+const (
+	// FocusSystem centers on the system primary (Sun) and auto-fits to the
+	// outermost body's apoapsis. This is the v0.1.0 default.
+	FocusSystem FocusKind = iota
+	// FocusBody centers on a specific body by its index in System().Bodies.
+	FocusBody
+	// FocusCraft centers on the spacecraft's inertial position. Only
+	// reachable when CraftVisibleHere is true.
+	FocusCraft
+)
+
+// Focus describes the current OrbitView center. The zero value (FocusSystem,
+// BodyIdx=0) is the v0.1.0 behavior.
+type Focus struct {
+	Kind    FocusKind
+	BodyIdx int
+}
+
+// CycleFocus advances the focus to the next target (or previous if
+// forward=false). Order: System → Body(0) → Body(1) → … → Body(n-1) →
+// Craft (only if CraftVisibleHere) → System.
+func (w *World) CycleFocus(forward bool) {
+	targets := w.focusTargets()
+	if len(targets) == 0 {
+		return
+	}
+	idx := 0
+	for i, f := range targets {
+		if f == w.Focus {
+			idx = i
+			break
+		}
+	}
+	if forward {
+		idx = (idx + 1) % len(targets)
+	} else {
+		idx = (idx - 1 + len(targets)) % len(targets)
+	}
+	w.Focus = targets[idx]
+}
+
+// ResetFocus snaps back to the system-wide view.
+func (w *World) ResetFocus() { w.Focus = Focus{Kind: FocusSystem} }
+
+// focusTargets enumerates the valid focus cycle for the current system.
+// Rebuilt each cycle rather than cached because CraftVisibleHere is
+// system-dependent and may flip when the user hits [s] to switch systems.
+func (w *World) focusTargets() []Focus {
+	targets := []Focus{{Kind: FocusSystem}}
+	for i := range w.System().Bodies {
+		targets = append(targets, Focus{Kind: FocusBody, BodyIdx: i})
+	}
+	if w.CraftVisibleHere() {
+		targets = append(targets, Focus{Kind: FocusCraft})
+	}
+	return targets
+}
+
+// FocusPosition returns the inertial (system primary-centric) position of
+// the current focus target. Origin for FocusSystem.
+func (w *World) FocusPosition() orbital.Vec3 {
+	switch w.Focus.Kind {
+	case FocusBody:
+		sys := w.System()
+		if w.Focus.BodyIdx >= 0 && w.Focus.BodyIdx < len(sys.Bodies) {
+			return w.BodyPosition(sys.Bodies[w.Focus.BodyIdx])
+		}
+	case FocusCraft:
+		if w.CraftVisibleHere() {
+			return w.CraftInertial()
+		}
+	}
+	return orbital.Vec3{}
+}
+
+// FocusZoomRadius suggests a world-space radius for auto-fit. Canvas.FitTo
+// uses ~90% of the smaller pixel axis, so a returned radius R yields a
+// frame that comfortably shows a circle of radius R around the focus.
+func (w *World) FocusZoomRadius() float64 {
+	switch w.Focus.Kind {
+	case FocusBody:
+		sys := w.System()
+		if w.Focus.BodyIdx >= 0 && w.Focus.BodyIdx < len(sys.Bodies) {
+			b := sys.Bodies[w.Focus.BodyIdx]
+			if b.SemimajorAxis == 0 {
+				// System primary: fall back to outermost-body fit.
+				return w.systemOutermostRadius()
+			}
+			// Use SOI relative to the system primary — gives a close-up
+			// that still shows any moons / nearby spacecraft.
+			primary := sys.Bodies[0]
+			if soi := physics.SOIRadius(b, primary); soi > 0 {
+				return soi
+			}
+			return b.RadiusMeters() * 50
+		}
+	case FocusCraft:
+		if w.Craft != nil {
+			// Fit to an altitude circle comfortably larger than the craft's
+			// current altitude — so the primary planet + craft orbit are
+			// both visible.
+			alt := w.Craft.State.R.Norm()
+			if alt <= 0 {
+				alt = w.Craft.Primary.RadiusMeters() * 2
+			}
+			return alt * 3
+		}
+	}
+	return w.systemOutermostRadius()
+}
+
+func (w *World) systemOutermostRadius() float64 {
+	var maxR float64
+	for _, b := range w.System().Bodies {
+		r := b.SemimajorAxisMeters() * (1 + b.Eccentricity)
+		if r > maxR {
+			maxR = r
+		}
+	}
+	if maxR == 0 {
+		return 1e11
+	}
+	return maxR
+}
+
+// FocusName returns a short human label for the current focus.
+func (w *World) FocusName() string {
+	switch w.Focus.Kind {
+	case FocusBody:
+		sys := w.System()
+		if w.Focus.BodyIdx >= 0 && w.Focus.BodyIdx < len(sys.Bodies) {
+			return sys.Bodies[w.Focus.BodyIdx].EnglishName
+		}
+	case FocusCraft:
+		if w.Craft != nil {
+			return w.Craft.Name
+		}
+	}
+	return "System-wide"
+}

--- a/internal/sim/focus_test.go
+++ b/internal/sim/focus_test.go
@@ -1,0 +1,152 @@
+package sim
+
+import (
+	"testing"
+)
+
+func TestFocusDefaultsToSystem(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.Focus.Kind != FocusSystem {
+		t.Errorf("default focus kind: got %v, want FocusSystem", w.Focus.Kind)
+	}
+	if name := w.FocusName(); name != "System-wide" {
+		t.Errorf("default FocusName: got %q, want System-wide", name)
+	}
+}
+
+func TestCycleFocusForwardWrapsThroughBodiesAndCraftAndBack(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Start at System. Cycle forward through every body, then Craft
+	// (visible in Sol), then back to System.
+	nBodies := len(w.System().Bodies)
+	expected := []Focus{{Kind: FocusSystem}}
+	for i := 0; i < nBodies; i++ {
+		expected = append(expected, Focus{Kind: FocusBody, BodyIdx: i})
+	}
+	expected = append(expected, Focus{Kind: FocusCraft})
+	expected = append(expected, Focus{Kind: FocusSystem})
+
+	for i, want := range expected[1:] {
+		w.CycleFocus(true)
+		if w.Focus != want {
+			t.Errorf("step %d: got %+v, want %+v", i, w.Focus, want)
+		}
+	}
+}
+
+func TestCycleFocusBackwardFromSystemLandsOnCraft(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.CycleFocus(false)
+	if w.Focus.Kind != FocusCraft {
+		t.Errorf("backward from system: got %+v, want FocusCraft", w.Focus)
+	}
+}
+
+func TestCycleFocusSkipsCraftOutsideSol(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Advance to a non-Sol system. CraftVisibleHere() returns false there,
+	// so the focus cycle must not include FocusCraft.
+	w.CycleSystem()
+	if w.CraftVisibleHere() {
+		t.Fatal("precondition: craft should not be visible outside Sol")
+	}
+	w.ResetFocus()
+	targets := w.focusTargets()
+	for _, f := range targets {
+		if f.Kind == FocusCraft {
+			t.Errorf("focusTargets includes FocusCraft in non-Sol system: %+v", targets)
+		}
+	}
+}
+
+func TestResetFocusFromBodyReturnsToSystem(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Focus = Focus{Kind: FocusBody, BodyIdx: 3}
+	w.ResetFocus()
+	if w.Focus.Kind != FocusSystem {
+		t.Errorf("after reset: got %+v, want FocusSystem", w.Focus)
+	}
+}
+
+func TestCycleSystemResetsFocus(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Focus = Focus{Kind: FocusBody, BodyIdx: 5}
+	w.CycleSystem()
+	if w.Focus.Kind != FocusSystem {
+		t.Errorf("after system switch: got %+v, want FocusSystem", w.Focus)
+	}
+}
+
+func TestFocusPositionForSystemIsOrigin(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	p := w.FocusPosition()
+	if p.Norm() != 0 {
+		t.Errorf("FocusSystem position: got %+v, want origin", p)
+	}
+}
+
+func TestFocusPositionForBodyMatchesBodyPosition(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	// Index 3 is typically Earth in Sol (Sun, Mercury, Venus, Earth, …).
+	// We don't assume the order — just verify that FocusPosition tracks
+	// BodyPosition for whichever body we select.
+	idx := len(sys.Bodies) - 1
+	w.Focus = Focus{Kind: FocusBody, BodyIdx: idx}
+	got := w.FocusPosition()
+	want := w.BodyPosition(sys.Bodies[idx])
+	if got.Sub(want).Norm() > 1e-6 {
+		t.Errorf("FocusPosition(%s): got %+v, want %+v",
+			sys.Bodies[idx].EnglishName, got, want)
+	}
+}
+
+func TestFocusPositionForCraftMatchesCraftInertial(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Focus = Focus{Kind: FocusCraft}
+	got := w.FocusPosition()
+	want := w.CraftInertial()
+	if got.Sub(want).Norm() > 1e-6 {
+		t.Errorf("FocusCraft position: got %+v, want %+v", got, want)
+	}
+}
+
+func TestFocusZoomRadiusNonzeroForAllTargets(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	for _, f := range w.focusTargets() {
+		w.Focus = f
+		if r := w.FocusZoomRadius(); r <= 0 {
+			t.Errorf("FocusZoomRadius for %+v: got %g, want > 0", f, r)
+		}
+	}
+}

--- a/internal/sim/hohmann.go
+++ b/internal/sim/hohmann.go
@@ -1,0 +1,78 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+)
+
+// HohmannPreview summarises a reference heliocentric (system-primary-
+// centered) Hohmann transfer from the craft's current distance to a
+// target body's orbital radius. The numbers assume both legs are
+// circular and coplanar — textbook Hohmann. Phasing is ignored; this
+// is a "what would it cost?" display, not a physically-accurate
+// multi-impulse planner.
+type HohmannPreview struct {
+	TargetName string
+	DV1, DV2   float64 // m/s
+	TTransfer  float64 // seconds
+	Valid      bool    // false when inputs are degenerate
+	Note       string  // human-readable reason when !Valid
+}
+
+// HohmannPreviewFor computes a preview to the indicated body index in the
+// current system. Uses the system primary's GM, the craft's current
+// inertial distance as r1, and the target's semimajor axis as r2.
+func (w *World) HohmannPreviewFor(bodyIdx int) HohmannPreview {
+	sys := w.System()
+	if bodyIdx < 0 || bodyIdx >= len(sys.Bodies) {
+		return HohmannPreview{Note: "no target"}
+	}
+	target := sys.Bodies[bodyIdx]
+	if target.SemimajorAxis == 0 {
+		return HohmannPreview{TargetName: target.EnglishName, Note: "system primary — no orbital radius"}
+	}
+	if w.Craft == nil {
+		return HohmannPreview{TargetName: target.EnglishName, Note: "no spacecraft"}
+	}
+	if !w.CraftVisibleHere() {
+		return HohmannPreview{TargetName: target.EnglishName, Note: "spacecraft not in this system"}
+	}
+
+	primary := sys.Bodies[0]
+	mu := primary.GravitationalParameter()
+	r1 := w.CraftInertial().Norm()
+	r2 := target.SemimajorAxisMeters()
+
+	dv1, dv2, t, err := planner.HohmannTransfer(r1, r2, mu)
+	if err != nil {
+		return HohmannPreview{TargetName: target.EnglishName, Note: err.Error()}
+	}
+	if math.IsNaN(dv1) || math.IsNaN(dv2) || math.IsNaN(t) {
+		return HohmannPreview{TargetName: target.EnglishName, Note: "degenerate solution"}
+	}
+	return HohmannPreview{
+		TargetName: target.EnglishName,
+		DV1:        dv1,
+		DV2:        dv2,
+		TTransfer:  t,
+		Valid:      true,
+	}
+}
+
+// Format renders the preview as 3 short lines for the HUD.
+func (p HohmannPreview) Format() []string {
+	if !p.Valid {
+		if p.TargetName == "" {
+			return nil
+		}
+		return []string{fmt.Sprintf("  Hohmann: %s", p.Note)}
+	}
+	return []string{
+		fmt.Sprintf("  Δv1: %.2f km/s", p.DV1/1000),
+		fmt.Sprintf("  Δv2: %.2f km/s", p.DV2/1000),
+		fmt.Sprintf("  t:   %.1f d", p.TTransfer/bodies.SecondsPerDay),
+	}
+}

--- a/internal/sim/hohmann_test.go
+++ b/internal/sim/hohmann_test.go
@@ -1,0 +1,84 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+func TestHohmannPreviewForMarsApproximatesTextbookNumbers(t *testing.T) {
+	w := mustWorld(t)
+	// Find Mars.
+	sys := w.System()
+	marsIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Mars" {
+			marsIdx = i
+			break
+		}
+	}
+	if marsIdx < 0 {
+		t.Fatalf("Mars not found in Sol system")
+	}
+
+	p := w.HohmannPreviewFor(marsIdx)
+	if !p.Valid {
+		t.Fatalf("preview invalid: %s", p.Note)
+	}
+
+	// The textbook Earth→Mars Hohmann numbers (Curtis §6.2 Ex 6.1) are
+	// Δv1 ≈ 2.94 km/s, Δv2 ≈ 2.65 km/s, t ≈ 258.8 d. Our preview uses
+	// the craft's *inertial* distance from the Sun as r1, which is
+	// approximately 1 AU (Earth orbital radius + LEO altitude ~ 1 AU
+	// for the spawned LEO-1). Allow 10% tolerance to absorb LEO offset.
+	expectedDV1 := 2943.0
+	expectedDV2 := 2649.0
+	expectedT := 258.8 * bodies.SecondsPerDay
+
+	if !within(p.DV1, expectedDV1, 0.1) {
+		t.Errorf("dv1: got %.1f m/s, want ~%.1f m/s (±10%%)", p.DV1, expectedDV1)
+	}
+	if !within(p.DV2, expectedDV2, 0.1) {
+		t.Errorf("dv2: got %.1f m/s, want ~%.1f m/s (±10%%)", p.DV2, expectedDV2)
+	}
+	if !within(p.TTransfer, expectedT, 0.1) {
+		t.Errorf("t: got %.1f d, want ~%.1f d (±10%%)",
+			p.TTransfer/bodies.SecondsPerDay, expectedT/bodies.SecondsPerDay)
+	}
+}
+
+func TestHohmannPreviewForSystemPrimaryIsInvalid(t *testing.T) {
+	w := mustWorld(t)
+	// Index 0 in every system is the primary.
+	p := w.HohmannPreviewFor(0)
+	if p.Valid {
+		t.Errorf("system primary should produce Invalid preview")
+	}
+	if p.Note == "" {
+		t.Errorf("invalid preview must carry a Note")
+	}
+}
+
+func TestHohmannPreviewFormatInvalidReturnsNoteLine(t *testing.T) {
+	p := HohmannPreview{TargetName: "X", Note: "oops"}
+	lines := p.Format()
+	if len(lines) != 1 {
+		t.Fatalf("invalid preview Format: got %d lines, want 1", len(lines))
+	}
+}
+
+func TestHohmannPreviewFormatValidReturnsThreeLines(t *testing.T) {
+	p := HohmannPreview{Valid: true, DV1: 1000, DV2: 2000, TTransfer: 86400}
+	lines := p.Format()
+	if len(lines) != 3 {
+		t.Fatalf("valid preview Format: got %d lines, want 3 (got %v)", len(lines), lines)
+	}
+}
+
+func within(got, want, tol float64) bool {
+	if want == 0 {
+		return math.Abs(got) <= tol
+	}
+	return math.Abs(got-want)/math.Abs(want) <= tol
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1,0 +1,123 @@
+package sim
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// ManeuverNode represents a planned impulsive burn that will fire when
+// World.Clock.SimTime reaches TriggerTime. Nodes are forward-looking only;
+// once fired, they are removed from World.Nodes.
+type ManeuverNode struct {
+	TriggerTime time.Time
+	Mode        spacecraft.BurnMode
+	DV          float64
+}
+
+// PlanNode inserts a node into World.Nodes, keeping the slice sorted by
+// TriggerTime. Past-dated nodes are allowed — they fire on the next Tick.
+func (w *World) PlanNode(n ManeuverNode) {
+	w.Nodes = append(w.Nodes, n)
+	sort.Slice(w.Nodes, func(i, j int) bool {
+		return w.Nodes[i].TriggerTime.Before(w.Nodes[j].TriggerTime)
+	})
+}
+
+// ClearNodes wipes every pending node.
+func (w *World) ClearNodes() { w.Nodes = nil }
+
+// executeDueNodes fires every node whose TriggerTime has passed, applying
+// the burn to the spacecraft in order. Called from Tick after sim-time
+// advances. Re-entrant: if two nodes fall in the same tick, both fire.
+func (w *World) executeDueNodes() {
+	if w.Craft == nil {
+		return
+	}
+	fired := 0
+	for _, n := range w.Nodes {
+		if n.TriggerTime.After(w.Clock.SimTime) {
+			break
+		}
+		w.Craft.ApplyImpulsive(n.Mode, n.DV)
+		fired++
+	}
+	if fired > 0 {
+		w.Nodes = w.Nodes[fired:]
+	}
+}
+
+// NodeInertialPosition returns the inertial (system-primary-centered)
+// position where the node will fire. Forward-integrates the craft state
+// from now to the node's trigger time using the same Verlet integrator
+// as the live sim, then adds the primary's inertial position.
+//
+// Returns zero Vec3 if the craft is nil or the node is already past-due.
+func (w *World) NodeInertialPosition(n ManeuverNode) orbital.Vec3 {
+	if w.Craft == nil {
+		return orbital.Vec3{}
+	}
+	dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	if dt <= 0 {
+		return w.CraftInertial()
+	}
+	state := w.propagateCraft(dt)
+	primaryPos := w.BodyPosition(w.Craft.Primary)
+	return primaryPos.Add(state.R)
+}
+
+// PostBurnState returns the craft's primary-relative state vector
+// immediately after the given node would fire. Forward-integrates to the
+// trigger time, then applies the Δv in the node's direction mode. Used
+// by OrbitView to predict the post-burn trajectory without disturbing
+// live state.
+func (w *World) PostBurnState(n ManeuverNode) physics.StateVector {
+	if w.Craft == nil {
+		return physics.StateVector{}
+	}
+	dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	var state physics.StateVector
+	if dt <= 0 {
+		state = w.Craft.State
+	} else {
+		state = w.propagateCraft(dt)
+	}
+	dir := spacecraft.DirectionUnit(n.Mode, state.R, state.V)
+	if dir.Norm() == 0 || n.DV == 0 {
+		return state
+	}
+	state.V = state.V.Add(dir.Scale(n.DV))
+	return state
+}
+
+// propagateCraft forward-integrates the craft's primary-relative state
+// dt seconds into the future without mutating live state. Used by
+// NodeInertialPosition and by OrbitView's predicted-trajectory preview.
+func (w *World) propagateCraft(dt float64) physics.StateVector {
+	mu := w.Craft.Primary.GravitationalParameter()
+	period := orbitalPeriod(w.Craft.State, mu)
+	maxStep := period / 100.0
+	if maxStep <= 0 || math.IsNaN(maxStep) || math.IsInf(maxStep, 0) {
+		maxStep = 1.0
+	}
+	nSteps := int(math.Ceil(dt / maxStep))
+	if nSteps < 1 {
+		nSteps = 1
+	}
+	// Cap large propagation windows so a 10-period look-ahead doesn't
+	// grind. At 1024 sub-steps over `period` we still resolve each orbit
+	// at ≈10× the live-sim fidelity.
+	if nSteps > 1024 {
+		nSteps = 1024
+	}
+	step := dt / float64(nSteps)
+	state := w.Craft.State
+	for i := 0; i < nSteps; i++ {
+		state = physics.StepVerlet(state, mu, step)
+	}
+	return state
+}

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1,0 +1,140 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+func TestPlanNodeKeepsSortedByTriggerTime(t *testing.T) {
+	w := mustWorld(t)
+	base := w.Clock.SimTime
+
+	w.PlanNode(ManeuverNode{TriggerTime: base.Add(60 * time.Second), DV: 10, Mode: spacecraft.BurnPrograde})
+	w.PlanNode(ManeuverNode{TriggerTime: base.Add(30 * time.Second), DV: 20, Mode: spacecraft.BurnPrograde})
+	w.PlanNode(ManeuverNode{TriggerTime: base.Add(120 * time.Second), DV: 30, Mode: spacecraft.BurnPrograde})
+
+	times := []time.Duration{
+		w.Nodes[0].TriggerTime.Sub(base),
+		w.Nodes[1].TriggerTime.Sub(base),
+		w.Nodes[2].TriggerTime.Sub(base),
+	}
+	wanted := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
+	for i := range times {
+		if times[i] != wanted[i] {
+			t.Errorf("sort[%d]: got %v, want %v", i, times[i], wanted[i])
+		}
+	}
+}
+
+func TestExecuteDueNodesFiresPastNodesAndPopsThem(t *testing.T) {
+	w := mustWorld(t)
+	dvBefore := w.Craft.OrbitalSpeed()
+	fuelBefore := w.Craft.Fuel
+	_ = dvBefore
+	_ = fuelBefore
+
+	// Plan a node in the past so the next Tick fires it.
+	w.PlanNode(ManeuverNode{
+		TriggerTime: w.Clock.SimTime.Add(-time.Second),
+		DV:          50,
+		Mode:        spacecraft.BurnPrograde,
+	})
+	if len(w.Nodes) != 1 {
+		t.Fatalf("precondition: expected 1 node, got %d", len(w.Nodes))
+	}
+
+	w.executeDueNodes()
+
+	if len(w.Nodes) != 0 {
+		t.Errorf("after executeDueNodes, expected 0 nodes, got %d", len(w.Nodes))
+	}
+	// Fuel should have been consumed (rocket equation > 0 for any dv > 0
+	// with positive Isp).
+	if w.Craft.Fuel >= fuelBefore {
+		t.Errorf("expected fuel decrease, got %g → %g", fuelBefore, w.Craft.Fuel)
+	}
+}
+
+func TestExecuteDueNodesLeavesFutureNodes(t *testing.T) {
+	w := mustWorld(t)
+	// One past, one future.
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(-1 * time.Second), DV: 10, Mode: spacecraft.BurnPrograde})
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(60 * time.Second), DV: 20, Mode: spacecraft.BurnPrograde})
+
+	w.executeDueNodes()
+
+	if len(w.Nodes) != 1 {
+		t.Fatalf("expected 1 surviving node, got %d", len(w.Nodes))
+	}
+	if w.Nodes[0].DV != 20 {
+		t.Errorf("surviving node: got dv=%g, want 20", w.Nodes[0].DV)
+	}
+}
+
+func TestClearNodesRemovesAll(t *testing.T) {
+	w := mustWorld(t)
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(10 * time.Second)})
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(20 * time.Second)})
+	w.ClearNodes()
+	if len(w.Nodes) != 0 {
+		t.Errorf("after ClearNodes: got %d nodes, want 0", len(w.Nodes))
+	}
+}
+
+// TestNodeInertialPositionMatchesFuturePropagation verifies that the node
+// preview position equals what the craft's future state would have been
+// at that time if untouched — i.e., the preview is along the current
+// orbit, not some offset.
+func TestNodeInertialPositionMatchesFuturePropagation(t *testing.T) {
+	w := mustWorld(t)
+	dt := 300.0 // 5 min forward
+	n := ManeuverNode{TriggerTime: w.Clock.SimTime.Add(time.Duration(dt) * time.Second)}
+
+	want := w.propagateCraft(dt)
+	wantInertial := w.BodyPosition(w.Craft.Primary).Add(want.R)
+	got := w.NodeInertialPosition(n)
+
+	if got.Sub(wantInertial).Norm() > 1e-3 {
+		t.Errorf("NodeInertialPosition drift %.3e m", got.Sub(wantInertial).Norm())
+	}
+}
+
+// TestNodeInertialPositionReturnsCraftInertialForPastNode confirms the
+// past-due short-circuit: no propagation, just return where the craft
+// currently is.
+func TestNodeInertialPositionReturnsCraftInertialForPastNode(t *testing.T) {
+	w := mustWorld(t)
+	n := ManeuverNode{TriggerTime: w.Clock.SimTime.Add(-time.Second)}
+	got := w.NodeInertialPosition(n)
+	want := w.CraftInertial()
+	if got.Sub(want).Norm() > 1e-6 {
+		t.Errorf("past node: got %+v, want %+v", got, want)
+	}
+}
+
+// TestPropagateCraftPreservesCircularRadius: propagating a circular LEO
+// orbit by any dt should return a point on the same radius, within the
+// integrator's 1% tolerance (matches predictor_test).
+func TestPropagateCraftPreservesCircularRadius(t *testing.T) {
+	w := mustWorld(t)
+	r0 := w.Craft.State.R.Norm()
+	for _, dt := range []float64{60, 600, 3000} {
+		state := w.propagateCraft(dt)
+		r := state.R.Norm()
+		if math.Abs(r-r0)/r0 > 0.01 {
+			t.Errorf("dt=%g: r=%g drifted >1%% from r0=%g", dt, r, r0)
+		}
+	}
+}
+
+func mustWorld(t *testing.T) *World {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	return w
+}

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -1,0 +1,121 @@
+package sim
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// SOISegment is a contiguous run of predicted-trajectory samples that
+// share the same owning SOI primary. PrimaryID == craft's home primary
+// means "still in the home SOI"; a different ID means the segment has
+// crossed into another body's sphere of influence.
+type SOISegment struct {
+	PrimaryID string
+	Points    []orbital.Vec3 // inertial, system-primary-centered
+}
+
+// PredictedSegments forward-integrates a post-burn state by totalSeconds
+// (sampled into `samples` points), converts each sample into inertial
+// coordinates, and partitions the trajectory into SOISegments whenever
+// the dominant SOI changes.
+//
+// Body positions are taken as a snapshot at Clock.SimTime — this ignores
+// planet motion during the preview and is accurate for short horizons
+// relative to the target body's orbital period. For a 1-period LEO
+// preview (≈ 90 min) this is trivially true. For interplanetary horizons
+// it's an approximation, flagged in the commit body.
+func (w *World) PredictedSegments(post physics.StateVector, totalSeconds float64, samples int) []SOISegment {
+	if w.Craft == nil || samples < 2 {
+		return nil
+	}
+
+	sys := w.System()
+	primary := sys.Bodies[0]
+	primaryPos := w.BodyPosition(primary) // should be zero — system primary is at origin
+
+	// Snapshot every other body's inertial position once.
+	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
+	for _, b := range sys.Bodies {
+		positions[b.ID] = w.BodyPosition(b)
+	}
+
+	// Step the predictor around the craft's current primary (where the
+	// burn is applied). We track two frames: state is primary-relative;
+	// inertial = state + home-primary-inertial.
+	homePrimary := w.Craft.Primary
+	homePrimaryPos := positions[homePrimary.ID]
+	if homePrimary.ID == primary.ID {
+		homePrimaryPos = primaryPos
+	}
+
+	mu := homePrimary.GravitationalParameter()
+	period := orbitalPeriod(post, mu)
+	maxStep := period / 100.0
+	if maxStep <= 0 || math.IsNaN(maxStep) || math.IsInf(maxStep, 0) {
+		maxStep = 1.0
+	}
+	stepSecs := totalSeconds / float64(samples-1)
+	s := post
+
+	segments := []SOISegment{{PrimaryID: homePrimary.ID, Points: []orbital.Vec3{homePrimaryPos.Add(s.R)}}}
+	current := homePrimary.ID
+
+	for i := 1; i < samples; i++ {
+		nSub := int(math.Ceil(stepSecs / maxStep))
+		if nSub < 1 {
+			nSub = 1
+		}
+		if nSub > 256 {
+			nSub = 256
+		}
+		dt := stepSecs / float64(nSub)
+		for j := 0; j < nSub; j++ {
+			s = physics.StepVerlet(s, mu, dt)
+		}
+
+		inertial := homePrimaryPos.Add(s.R)
+		prim := dominantSOI(sys, positions, inertial, homePrimary)
+
+		if prim.ID != current {
+			segments = append(segments, SOISegment{PrimaryID: prim.ID})
+			current = prim.ID
+		}
+		seg := &segments[len(segments)-1]
+		seg.Points = append(seg.Points, inertial)
+	}
+	return segments
+}
+
+// dominantSOI returns the body whose SOI contains the given inertial
+// position, preferring the smallest containing SOI. Falls back to the
+// home primary when no other SOI contains the point.
+func dominantSOI(
+	sys bodies.System,
+	positions map[string]orbital.Vec3,
+	r orbital.Vec3,
+	homePrimary bodies.CelestialBody,
+) bodies.CelestialBody {
+	primary := sys.Bodies[0]
+	best := homePrimary
+	bestSOI := math.Inf(1)
+	for i := 1; i < len(sys.Bodies); i++ {
+		b := sys.Bodies[i]
+		bPos, ok := positions[b.ID]
+		if !ok {
+			continue
+		}
+		soi := physics.SOIRadius(b, primary)
+		if soi == 0 {
+			continue
+		}
+		d := r.Sub(bPos).Norm()
+		if d <= soi && soi < bestSOI {
+			best = b
+			bestSOI = soi
+		}
+	}
+	return best
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -23,6 +23,10 @@ type World struct {
 	// Nil when no primary is loaded (unreachable in v0.1).
 	Craft *spacecraft.Spacecraft
 
+	// Focus selects what the OrbitView canvas is centered on. Zero value
+	// (FocusSystem) matches v0.1.0 behavior.
+	Focus Focus
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -58,9 +62,12 @@ func (w *World) System() bodies.System { return w.Systems[w.SystemIdx] }
 
 // CycleSystem advances to the next system (wraps). Recreates the calculator.
 // Spacecraft does not follow — remains in Sol per plan §MVP scope.
+// Resets focus to system-wide because body indices don't carry across
+// systems and the craft is only visible in Sol.
 func (w *World) CycleSystem() {
 	w.SystemIdx = (w.SystemIdx + 1) % len(w.Systems)
 	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+	w.ResetFocus()
 }
 
 // CraftVisibleHere reports whether the spacecraft should be drawn in the

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -27,6 +27,10 @@ type World struct {
 	// (FocusSystem) matches v0.1.0 behavior.
 	Focus Focus
 
+	// Nodes holds planned impulsive burns, sorted by TriggerTime. Each
+	// fires automatically when Clock.SimTime reaches its trigger.
+	Nodes []ManeuverNode
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -119,6 +123,7 @@ func (w *World) Tick() {
 
 	if w.Craft != nil {
 		w.integrateSpacecraft(simDelta)
+		w.executeDueNodes()
 		w.soiCheckCounter++
 		if w.soiCheckCounter >= 20 {
 			w.soiCheckCounter = 0

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,10 +1,13 @@
 package tui
 
 import (
+	"time"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
@@ -175,6 +178,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.FocusReset):
 			a.world.ResetFocus()
+			return a, nil
+		case key.Matches(m, a.keys.PlanNode):
+			if a.world.CraftVisibleHere() {
+				a.world.PlanNode(sim.ManeuverNode{
+					TriggerTime: a.world.Clock.SimTime.Add(5 * time.Minute),
+					Mode:        spacecraft.BurnPrograde,
+					DV:          50,
+				})
+			}
+			return a, nil
+		case key.Matches(m, a.keys.ClearNodes):
+			a.world.ClearNodes()
 			return a, nil
 		}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -167,6 +167,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.ZoomOut):
 			a.orbitView.ZoomOut()
 			return a, nil
+		case key.Matches(m, a.keys.FocusNext):
+			a.world.CycleFocus(true)
+			return a, nil
+		case key.Matches(m, a.keys.FocusPrev):
+			a.world.CycleFocus(false)
+			return a, nil
+		case key.Matches(m, a.keys.FocusReset):
+			a.world.ResetFocus()
+			return a, nil
 		}
 	}
 	return a, nil

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -18,6 +18,9 @@ type Keymap struct {
 	ZoomIn     key.Binding
 	ZoomOut    key.Binding
 	Back       key.Binding
+	FocusNext  key.Binding
+	FocusPrev  key.Binding
+	FocusReset key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -35,5 +38,8 @@ func DefaultKeymap() Keymap {
 		ZoomIn:     key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "zoom in")),
 		ZoomOut:    key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "zoom out")),
 		Back:       key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
+		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
+		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
 	}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -21,6 +21,8 @@ type Keymap struct {
 	FocusNext  key.Binding
 	FocusPrev  key.Binding
 	FocusReset key.Binding
+	PlanNode   key.Binding
+	ClearNodes key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -41,5 +43,7 @@ func DefaultKeymap() Keymap {
 		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
 		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
 		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
+		PlanNode:   key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "plan node (T+5m prograde 50m/s)")),
+		ClearNodes: key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "clear nodes")),
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -30,6 +30,9 @@ func (h *Help) Render() string {
 			{"s", "next system"},
 			{"i", "body info"},
 			{"+ / -", "zoom in / out"},
+			{"f", "next focus target"},
+			{"F", "previous focus target"},
+			{"g", "reset to system-wide view"},
 		}},
 		{"TIME", [][2]string{
 			{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -39,10 +39,12 @@ func (h *Help) Render() string {
 			{",", "warp down"},
 			{"0 / space", "pause / resume"},
 		}},
-		{"FLIGHT (v0.1 Phase 2)", [][2]string{
-			{"m", "open maneuver planner"},
+		{"FLIGHT", [][2]string{
+			{"m", "open maneuver planner (burn now)"},
 			{"enter", "commit burn"},
 			{"esc (in planner)", "cancel burn"},
+			{"n", "plan a node (T+5m prograde 50m/s)"},
+			{"N", "clear all planned nodes"},
 		}},
 	}
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -25,9 +25,12 @@ type OrbitView struct {
 	canvas *widgets.Canvas
 	theme  Theme
 
-	// lastSystemIdx tracks the system the canvas was last fit to, so we
-	// re-FitTo only on a real switch (not every frame).
+	// lastSystemIdx + lastFocus track the (system, focus) pair the canvas
+	// was last fit to, so we re-FitTo only on a real change (not every
+	// frame). Focus fit keeps the camera on moving targets smoothly without
+	// reshooting the zoom level each tick.
 	lastSystemIdx int
+	lastFocus     sim.Focus
 	fitted        bool
 }
 
@@ -61,14 +64,19 @@ func (v *OrbitView) ZoomOut() { v.canvas.ZoomBy(1.0 / 1.25) }
 func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows int) string {
 	sys := w.System()
 
-	if v.lastSystemIdx != w.SystemIdx || !v.fitted {
+	// Refit only on system switch or focus-kind/idx change. When focused on
+	// a moving target (body or craft), we still re-center every frame
+	// below — this path only fires when the camera "target" changes, not
+	// when the target moves.
+	if v.lastSystemIdx != w.SystemIdx || v.lastFocus != w.Focus || !v.fitted {
 		v.lastSystemIdx = w.SystemIdx
+		v.lastFocus = w.Focus
 		v.fitted = true
-		v.autoFit(sys)
+		v.canvas.FitTo(w.FocusZoomRadius())
 	}
 
 	v.canvas.Clear()
-	v.canvas.Center(orbital.Vec3{}) // primary at origin
+	v.canvas.Center(w.FocusPosition())
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
 	for i := range sys.Bodies {
@@ -106,7 +114,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	title := v.theme.Title.Render(fmt.Sprintf("terminal-space-program — %s", sys.Name))
 	footer := v.theme.Footer.Render(
-		"[q] quit  [s] next system  [←/→] body  [+/-] zoom  [i] info  [?] help  [.,] warp  [0] pause",
+		"[q] quit  [s] system  [←/→] body  [+/-] zoom  [f/F] focus  [g] sys-view  [i] info  [?] help  [.,] warp  [0] pause",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)
@@ -121,21 +129,6 @@ func (v *OrbitView) plotCluster(center orbital.Vec3, n int) {
 		v.canvas.Plot(center.Add(orbital.Vec3{X: float64(i) * step}))
 		v.canvas.Plot(center.Add(orbital.Vec3{Y: float64(i) * step}))
 	}
-}
-
-// autoFit sets the canvas scale so the outermost body's apoapsis is visible.
-func (v *OrbitView) autoFit(sys bodies.System) {
-	var maxR float64
-	for _, b := range sys.Bodies {
-		r := b.SemimajorAxisMeters() * (1 + b.Eccentricity)
-		if r > maxR {
-			maxR = r
-		}
-	}
-	if maxR == 0 {
-		maxR = 1e11 // 1/7 AU fallback
-	}
-	v.canvas.FitTo(maxR)
 }
 
 func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
@@ -156,6 +149,11 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	if w.Clock.Paused {
 		lines = append(lines, "  "+v.theme.Warning.Render("[PAUSED]"))
 	}
+	lines = append(lines,
+		"",
+		v.theme.Primary.Render("FOCUS"),
+		"  "+w.FocusName(),
+	)
 
 	// Spacecraft block — only in Sol per plan §MVP.
 	if w.CraftVisibleHere() {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
-	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
@@ -142,9 +141,11 @@ func (v *OrbitView) plotCluster(center orbital.Vec3, n int) {
 }
 
 // drawNodes plots every planned maneuver node at its projected inertial
-// position and draws a dashed predicted trajectory starting from the
-// first node's post-burn state. Sampling horizon is one orbit period
-// around the craft's primary — long enough to see the new ellipse.
+// position and draws the post-burn predicted trajectory starting from
+// the first node. The trajectory is segmented by SOI: samples inside
+// the craft's home SOI use stride-2 (dashed); samples that cross into
+// another body's SOI use stride-1 (solid) so the crossing is visually
+// distinct at a glance.
 func (v *OrbitView) drawNodes(w *sim.World) {
 	if len(w.Nodes) == 0 || w.Craft == nil {
 		return
@@ -156,19 +157,24 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 	first := w.Nodes[0]
 	post := w.PostBurnState(first)
 	mu := w.Craft.Primary.GravitationalParameter()
-	// Horizon: 1 orbital period of the post-burn orbit, bounded so an
-	// escape trajectory doesn't blow up into an infinite line.
 	horizon := postBurnHorizon(post, mu)
 	if horizon <= 0 {
 		return
 	}
-	pts := planner.Predict(post, mu, horizon, 96)
-	primaryPos := w.BodyPosition(w.Craft.Primary)
-	for i, p := range pts {
-		if i%2 == 0 { // stride 2 → dashed
-			continue
+
+	segments := w.PredictedSegments(post, horizon, 96)
+	homeID := w.Craft.Primary.ID
+	for _, seg := range segments {
+		stride := 2
+		if seg.PrimaryID != homeID {
+			stride = 1 // foreign SOI — solid, eye-catching
 		}
-		v.canvas.Plot(primaryPos.Add(p))
+		for i, p := range seg.Points {
+			if stride > 1 && i%stride == 0 {
+				continue
+			}
+			v.canvas.Plot(p)
+		}
 	}
 }
 
@@ -273,6 +279,11 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			lines = append(lines, fmt.Sprintf("  a: %.3f AU", auVal))
 			lines = append(lines, fmt.Sprintf("  e: %.4f", b.Eccentricity))
 			lines = append(lines, fmt.Sprintf("  T: %.1f d", b.SideralOrbit))
+
+			if preview := w.HohmannPreviewFor(selectedIdx); preview.Valid || preview.Note != "" {
+				lines = append(lines, "", v.theme.Primary.Render("HOHMANN PREVIEW"))
+				lines = append(lines, preview.Format()...)
+			}
 		} else {
 			lines = append(lines, v.theme.Dim.Render("  (primary)"))
 		}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -4,12 +4,15 @@ package screens
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
@@ -104,6 +107,13 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		v.plotCluster(w.CraftInertial(), 8)
 	}
 
+	// Planned maneuver nodes — cluster glyph at each node's inertial
+	// position, plus a dashed predicted trajectory from the first node's
+	// post-burn state. Only meaningful when the craft is visible here.
+	if w.CraftVisibleHere() {
+		v.drawNodes(w)
+	}
+
 	canvasStr := v.canvas.String()
 	canvasPanel := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -114,7 +124,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	title := v.theme.Title.Render(fmt.Sprintf("terminal-space-program — %s", sys.Name))
 	footer := v.theme.Footer.Render(
-		"[q] quit  [s] system  [←/→] body  [+/-] zoom  [f/F] focus  [g] sys-view  [i] info  [?] help  [.,] warp  [0] pause",
+		"[q]quit [s]system [←/→]body [+/-]zoom [f/F]focus [g]sys [n]node [N]clr [m]burn [i]info [?]help [.,]warp [0]pause",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)
@@ -129,6 +139,53 @@ func (v *OrbitView) plotCluster(center orbital.Vec3, n int) {
 		v.canvas.Plot(center.Add(orbital.Vec3{X: float64(i) * step}))
 		v.canvas.Plot(center.Add(orbital.Vec3{Y: float64(i) * step}))
 	}
+}
+
+// drawNodes plots every planned maneuver node at its projected inertial
+// position and draws a dashed predicted trajectory starting from the
+// first node's post-burn state. Sampling horizon is one orbit period
+// around the craft's primary — long enough to see the new ellipse.
+func (v *OrbitView) drawNodes(w *sim.World) {
+	if len(w.Nodes) == 0 || w.Craft == nil {
+		return
+	}
+	for _, n := range w.Nodes {
+		v.plotCluster(w.NodeInertialPosition(n), 6)
+	}
+
+	first := w.Nodes[0]
+	post := w.PostBurnState(first)
+	mu := w.Craft.Primary.GravitationalParameter()
+	// Horizon: 1 orbital period of the post-burn orbit, bounded so an
+	// escape trajectory doesn't blow up into an infinite line.
+	horizon := postBurnHorizon(post, mu)
+	if horizon <= 0 {
+		return
+	}
+	pts := planner.Predict(post, mu, horizon, 96)
+	primaryPos := w.BodyPosition(w.Craft.Primary)
+	for i, p := range pts {
+		if i%2 == 0 { // stride 2 → dashed
+			continue
+		}
+		v.canvas.Plot(primaryPos.Add(p))
+	}
+}
+
+// postBurnHorizon picks a sensible prediction window based on the
+// orbit's semimajor axis. Returns the orbital period for bound orbits,
+// or a time-of-flight covering ~10 primary-radii of travel for
+// hyperbolic (a ≤ 0) orbits so the preview is visible but finite.
+func postBurnHorizon(state physics.StateVector, mu float64) float64 {
+	a := physics.SemimajorAxis(state, mu)
+	if a > 0 && !math.IsNaN(a) {
+		return 2 * math.Pi * math.Sqrt(a*a*a/mu)
+	}
+	v := state.V.Norm()
+	if v <= 0 {
+		return 0
+	}
+	return 10 * state.R.Norm() / v
 }
 
 func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
@@ -185,6 +242,17 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		lines = append(lines, "",
 			v.theme.Dim.Render("VESSEL (in Sol — [s] to switch)"),
 		)
+	}
+
+	if len(w.Nodes) > 0 {
+		lines = append(lines, "", v.theme.Primary.Render("NODES"))
+		for i, n := range w.Nodes {
+			dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+			lines = append(lines, fmt.Sprintf(
+				"  #%d T%+.0fs  %s  %.0f m/s",
+				i+1, dt, n.Mode.String(), n.DV,
+			))
+		}
 	}
 
 	lines = append(lines, "", v.theme.Primary.Render("SYSTEM"),


### PR DESCRIPTION
## Summary

v0.2.0 slice-1 per sidechat-approved plan (`tsp-v0.2-slice-1.md` attached on SideChat msg 2227):

- Replace `HohmannTransfer` `ErrNotImplemented` stub with real circular-to-circular coplanar Hohmann math.
- Add view focus / camera follow (spacecraft + selectable bodies, tab-cycle, auto-zoom) — fold-in from jason msg 2224.
- Add maneuver nodes on OrbitView (place, edit, predicted trajectory).
- "Plan Hohmann to target" action in maneuver screen — auto-populates two burn nodes.
- Extend predictor to detect SOI crossings and color trajectory per primary.
- Tag `v0.2.0` at slice exit.

## Progress (commits land incrementally)

- [x] `HohmannTransfer` math + tests (Earth→Mars canonical, symmetry, guards)
- [x] CI test workflow (`go vet` + `go test -race` on PR + main)
- [ ] View focus / camera follow
- [ ] Maneuver nodes on OrbitView
- [ ] Plan-Hohmann-to-target action + SOI-crossing trajectory coloring
- [ ] Tag `v0.2.0`

## Test plan

- [x] Hohmann math: Earth→Mars within 2% of Curtis §6.2 Ex 6.1 values.
- [ ] View focus: camera re-centers on every focus target cycle; reset returns to system-wide.
- [ ] Maneuver node placement: placing a node redraws trajectory live; deleting restores unchanged orbit.
- [ ] Hohmann action: selecting Mars + pressing "Plan Hohmann" produces two nodes whose combined Δv matches `HohmannTransfer` output.
- [ ] SOI viz: trajectory segment crossing a planet's SOI renders in the SOI's color.
- [ ] Release: goreleaser green on `v0.2.0` tag push, all 5 archives + checksums, `--version` prints `terminal-space-program 0.2.0 (<sha>)`.