### PR TITLE
feat: finite burns (v0.2.1)

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -10,13 +10,28 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
-// ManeuverNode represents a planned impulsive burn that will fire when
+// ManeuverNode represents a planned burn that will fire when
 // World.Clock.SimTime reaches TriggerTime. Nodes are forward-looking only;
 // once fired, they are removed from World.Nodes.
+//
+// Duration controls finite vs impulsive: zero = instant Δv (legacy v0.1
+// path); non-zero = sustained engine burn lasting up to Duration or
+// until DV is delivered, whichever first. Finite-burn execution is
+// driven by World.ActiveBurn during subsequent ticks.
 type ManeuverNode struct {
 	TriggerTime time.Time
 	Mode        spacecraft.BurnMode
 	DV          float64
+	Duration    time.Duration
+}
+
+// ActiveBurn is the runtime state of an in-progress finite burn. Set by
+// executeDueNodes when a node with Duration>0 fires; cleared by the
+// integrator when DVRemaining hits zero or SimTime passes EndTime.
+type ActiveBurn struct {
+	Mode        spacecraft.BurnMode
+	DVRemaining float64
+	EndTime     time.Time
 }
 
 // PlanNode inserts a node into World.Nodes, keeping the slice sorted by
@@ -34,6 +49,13 @@ func (w *World) ClearNodes() { w.Nodes = nil }
 // executeDueNodes fires every node whose TriggerTime has passed, applying
 // the burn to the spacecraft in order. Called from Tick after sim-time
 // advances. Re-entrant: if two nodes fall in the same tick, both fire.
+//
+// Impulsive nodes (Duration==0) apply their Δv inline and are popped.
+// Finite nodes (Duration>0) start an ActiveBurn and are popped; the burn
+// then runs across subsequent ticks via the RK4 branch in
+// integrateSpacecraft. If a finite burn is already active when a new
+// finite node fires, the new one replaces it (last-write-wins; the
+// planner UI is responsible for not over-stacking).
 func (w *World) executeDueNodes() {
 	if w.Craft == nil {
 		return
@@ -43,7 +65,15 @@ func (w *World) executeDueNodes() {
 		if n.TriggerTime.After(w.Clock.SimTime) {
 			break
 		}
-		w.Craft.ApplyImpulsive(n.Mode, n.DV)
+		if n.Duration == 0 {
+			w.Craft.ApplyImpulsive(n.Mode, n.DV)
+		} else {
+			w.ActiveBurn = &ActiveBurn{
+				Mode:        n.Mode,
+				DVRemaining: n.DV,
+				EndTime:     n.TriggerTime.Add(n.Duration),
+			}
+		}
 		fired++
 	}
 	if fired > 0 {

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -130,6 +130,100 @@ func TestPropagateCraftPreservesCircularRadius(t *testing.T) {
 	}
 }
 
+// TestFiniteNodeStartsActiveBurn: a node with Duration > 0 should not
+// instantly mutate velocity; instead it sets World.ActiveBurn so the
+// integrator burn loop runs across subsequent ticks.
+func TestFiniteNodeStartsActiveBurn(t *testing.T) {
+	w := mustWorld(t)
+	vBefore := w.Craft.OrbitalSpeed()
+	w.PlanNode(ManeuverNode{
+		TriggerTime: w.Clock.SimTime.Add(-time.Second),
+		DV:          50,
+		Mode:        spacecraft.BurnPrograde,
+		Duration:    60 * time.Second,
+	})
+	w.executeDueNodes()
+
+	if w.ActiveBurn == nil {
+		t.Fatalf("expected ActiveBurn to be set after finite node fired")
+	}
+	if w.ActiveBurn.DVRemaining != 50 {
+		t.Errorf("DVRemaining = %g, want 50", w.ActiveBurn.DVRemaining)
+	}
+	if v := w.Craft.OrbitalSpeed(); math.Abs(v-vBefore) > 1e-9 {
+		t.Errorf("velocity changed by %g during executeDueNodes; finite burn should defer to integrator", v-vBefore)
+	}
+	if len(w.Nodes) != 0 {
+		t.Errorf("finite node should be popped from queue, got %d remaining", len(w.Nodes))
+	}
+}
+
+// TestFiniteBurnDeliversDeltaVAcrossTicks: across enough warp-1 ticks
+// for the requested duration, an active burn should deliver close to
+// the requested Δv, consume fuel, and clear ActiveBurn when done.
+func TestFiniteBurnDeliversDeltaVAcrossTicks(t *testing.T) {
+	w := mustWorld(t)
+	vBefore := w.Craft.OrbitalSpeed()
+	fuelBefore := w.Craft.Fuel
+
+	const targetDV = 5.0 // small enough to finish well within 60s budget
+	w.PlanNode(ManeuverNode{
+		TriggerTime: w.Clock.SimTime,
+		DV:          targetDV,
+		Mode:        spacecraft.BurnPrograde,
+		Duration:    60 * time.Second,
+	})
+
+	// Warp 1×, BaseStep 50 ms → 60s window = 1200 ticks. Add safety margin.
+	for i := 0; i < 2000 && w.ActiveBurn != nil || i == 0; i++ {
+		w.Tick()
+		if i > 0 && w.ActiveBurn == nil {
+			break
+		}
+	}
+
+	if w.ActiveBurn != nil {
+		t.Fatalf("ActiveBurn should be cleared after Δv delivered or duration elapsed; remaining=%g", w.ActiveBurn.DVRemaining)
+	}
+	dv := w.Craft.OrbitalSpeed() - vBefore
+	// Speed change isn't pure thrust Δv — gravity rotates v during the
+	// burn. Within a fraction of an orbital period the magnitude change
+	// should be within ~20% of target Δv (LEO period ≈ 5500s, burn ≈ 15s
+	// at our default 1 kN thrust to deliver 5 m/s on 1 ton craft).
+	if dv < targetDV*0.5 || dv > targetDV*1.5 {
+		t.Errorf("speed change after finite burn: got %.3f m/s, expected ~%.3f m/s", dv, targetDV)
+	}
+	if w.Craft.Fuel >= fuelBefore {
+		t.Errorf("fuel did not decrease: %g → %g", fuelBefore, w.Craft.Fuel)
+	}
+}
+
+// TestFiniteBurnEndsAtDurationWhenDVNotMet: if the engine cannot deliver
+// the requested Δv within the duration budget, the burn should still
+// terminate at EndTime.
+func TestFiniteBurnEndsAtDurationWhenDVNotMet(t *testing.T) {
+	w := mustWorld(t)
+	// Request way more Δv than the engine can produce in 1 second
+	// (1 kN / 1000 kg = 1 m/s² → ~1 m/s in 1 s; ask for 10 000).
+	w.PlanNode(ManeuverNode{
+		TriggerTime: w.Clock.SimTime,
+		DV:          10000,
+		Mode:        spacecraft.BurnPrograde,
+		Duration:    1 * time.Second,
+	})
+
+	// 50 ms base step × 30 ticks = 1.5 s — past the 1 s window.
+	for i := 0; i < 60; i++ {
+		w.Tick()
+		if w.ActiveBurn == nil {
+			break
+		}
+	}
+	if w.ActiveBurn != nil {
+		t.Errorf("burn should terminate at EndTime even if DV unmet; got DVRemaining=%g", w.ActiveBurn.DVRemaining)
+	}
+}
+
 func mustWorld(t *testing.T) *World {
 	t.Helper()
 	w, err := NewWorld()

--- a/internal/sim/warp_test.go
+++ b/internal/sim/warp_test.go
@@ -44,3 +44,23 @@ func TestWarpClampActuallyClampsVeryShortPeriod(t *testing.T) {
 		t.Errorf("expected clamp to reduce warp; got %.0f → %.0f", selected, effective)
 	}
 }
+
+// TestWarpCappedAt10xDuringActiveBurn: even at 100000× selected, an
+// in-flight finite burn must clamp to 10× per docs/plan.md §Time-warp UX.
+// Otherwise the integrator would skip past EndTime in a single tick and
+// the burn would lose all temporal resolution.
+func TestWarpCappedAt10xDuringActiveBurn(t *testing.T) {
+	w, _ := NewWorld()
+	w.Clock.WarpIdx = len(WarpFactors) - 1 // 100000×
+	w.ActiveBurn = &ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * 1e9)}
+
+	if eff := w.EffectiveWarp(); eff != 10 {
+		t.Errorf("active burn should cap warp to 10×, got %.0f", eff)
+	}
+
+	// And below the cap — selecting 1× during a burn stays at 1×.
+	w.Clock.WarpIdx = 0
+	if eff := w.EffectiveWarp(); eff != 1 {
+		t.Errorf("1× during burn should stay 1×, got %.0f", eff)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -27,9 +27,14 @@ type World struct {
 	// (FocusSystem) matches v0.1.0 behavior.
 	Focus Focus
 
-	// Nodes holds planned impulsive burns, sorted by TriggerTime. Each
-	// fires automatically when Clock.SimTime reaches its trigger.
+	// Nodes holds planned burns, sorted by TriggerTime. Each fires
+	// automatically when Clock.SimTime reaches its trigger.
 	Nodes []ManeuverNode
+
+	// ActiveBurn is non-nil while a finite-duration burn is mid-execution.
+	// Set by executeDueNodes when a Duration>0 node fires; cleared by
+	// integrateSpacecraft when DVRemaining hits zero or SimTime ≥ EndTime.
+	ActiveBurn *ActiveBurn
 
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
@@ -133,11 +138,17 @@ func (w *World) Tick() {
 }
 
 // clampedWarp returns min(selected warp, max warp allowed by the step-size
-// guard). max = (1024 sub-steps × period/100) / base_step.
+// guard, burn-warp cap if a finite burn is active). max = (1024 sub-steps
+// × period/100) / base_step. Active-burn cap = 10× per docs/plan.md
+// §Time-warp UX — finite burns at >10× warp would let the integrator
+// blast past the EndTime in a single tick and lose temporal resolution.
 func (w *World) clampedWarp() float64 {
 	selected := w.Clock.Warp()
 	if w.Craft == nil {
 		return selected
+	}
+	if w.ActiveBurn != nil && selected > 10 {
+		selected = 10
 	}
 	mu := w.Craft.Primary.GravitationalParameter()
 	period := orbitalPeriod(w.Craft.State, mu)
@@ -157,9 +168,12 @@ func (w *World) clampedWarp() float64 {
 // as Clock.Warp() when the user isn't hitting the step-size guard.
 func (w *World) EffectiveWarp() float64 { return w.clampedWarp() }
 
-// integrateSpacecraft sub-steps the Verlet integrator so that each
-// step dt obeys dt < period/100 (plan §Phase 1 numerical stability guard,
-// hard-coded here; exposed as a configurable warp-clamp at C21).
+// integrateSpacecraft sub-steps the integrator so that each step dt obeys
+// dt < period/100 (plan §Phase 1 numerical stability guard, hard-coded
+// here; exposed as a configurable warp-clamp at C21). When ActiveBurn is
+// in flight, sub-steps run RK4 with engine thrust on top of gravity so
+// the non-conservative force is handled cleanly (Verlet would silently
+// drift); otherwise pure Verlet for energy-conserving free flight.
 func (w *World) integrateSpacecraft(simDelta time.Duration) {
 	mu := w.Craft.Primary.GravitationalParameter()
 	period := orbitalPeriod(w.Craft.State, mu)
@@ -179,9 +193,65 @@ func (w *World) integrateSpacecraft(simDelta time.Duration) {
 		nSteps = 1024
 	}
 	dt := secs / float64(nSteps)
+	tickStart := w.Clock.SimTime.Add(-simDelta)
 	for i := 0; i < nSteps; i++ {
-		w.Craft.State = physics.StepVerlet(w.Craft.State, mu, dt)
+		if w.burnActiveAt(tickStart, dt, i) {
+			w.stepThrust(mu, dt)
+		} else {
+			w.Craft.State = physics.StepVerlet(w.Craft.State, mu, dt)
+		}
 	}
+	// Tear down the burn if it exhausted (Δv delivered, fuel gone, or
+	// EndTime passed during this tick).
+	if w.ActiveBurn != nil && w.burnExhausted() {
+		w.ActiveBurn = nil
+	}
+}
+
+// burnActiveAt reports whether sub-step i of the current tick should fire
+// the engine: ActiveBurn must exist, the sub-step must start before
+// EndTime, and DVRemaining + fuel must both be positive.
+func (w *World) burnActiveAt(tickStart time.Time, dt float64, i int) bool {
+	if w.ActiveBurn == nil {
+		return false
+	}
+	if w.ActiveBurn.DVRemaining <= 0 || w.Craft.Fuel <= 0 {
+		return false
+	}
+	subStart := tickStart.Add(time.Duration(float64(i) * dt * float64(time.Second)))
+	return subStart.Before(w.ActiveBurn.EndTime)
+}
+
+// stepThrust advances one RK4 sub-step with engine thrust, debits the
+// active-burn Δv budget by the analytical thrust contribution
+// (Thrust/mass × dt), and burns fuel via the configured mass flow.
+func (w *World) stepThrust(mu, dt float64) {
+	accelFn := w.Craft.ThrustAccelFn(w.ActiveBurn.Mode, mu)
+	w.Craft.State = physics.StepRK4(w.Craft.State, dt, accelFn, 0)
+
+	mass := w.Craft.TotalMass()
+	if mass > 0 {
+		dvApplied := (w.Craft.Thrust / mass) * dt
+		if dvApplied > w.ActiveBurn.DVRemaining {
+			dvApplied = w.ActiveBurn.DVRemaining
+		}
+		w.ActiveBurn.DVRemaining -= dvApplied
+	}
+	fuelBurned := w.Craft.MassFlowRate() * dt
+	if fuelBurned > w.Craft.Fuel {
+		fuelBurned = w.Craft.Fuel
+	}
+	w.Craft.Fuel -= fuelBurned
+	w.Craft.State.M = w.Craft.TotalMass()
+}
+
+// burnExhausted reports whether the active burn should be torn down: any
+// of Δv delivered, fuel empty, or sim-time past the duration window
+// terminates the burn.
+func (w *World) burnExhausted() bool {
+	return w.ActiveBurn.DVRemaining <= 0 ||
+		w.Craft.Fuel <= 0 ||
+		!w.Clock.SimTime.Before(w.ActiveBurn.EndTime)
 }
 
 // orbitalPeriod returns 2π√(a³/μ) or +Inf on unbound orbits. Used to

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -18,7 +18,8 @@ type Spacecraft struct {
 	Name    string
 	DryMass float64 // kg
 	Fuel    float64 // kg
-	Isp     float64 // s — specific impulse, used post-v0.1 for finite burns
+	Isp     float64 // s — specific impulse, used by finite burns
+	Thrust  float64 // N — max engine thrust; zero disables finite burns
 
 	Primary bodies.CelestialBody
 	State   physics.StateVector
@@ -51,6 +52,7 @@ func NewInLEO(earth bodies.CelestialBody) *Spacecraft {
 		DryMass: 500,
 		Fuel:    500,
 		Isp:     300,
+		Thrust:  1000, // 1 kN — small enough that finite effects show up at realistic Δv
 		Primary: earth,
 		State: physics.StateVector{
 			R: orbital.Vec3{X: r},

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -4,7 +4,10 @@ import (
 	"math"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
+
+const g0 = 9.80665
 
 // BurnMode enumerates the six direction modes from plan §Phase 2.
 type BurnMode int
@@ -98,7 +101,6 @@ func (s *Spacecraft) ApplyImpulsive(mode BurnMode, dv float64) {
 // consumeFuel deducts fuel assuming the rocket equation. fuelUsed =
 // m0 · (1 − exp(−dv / (Isp·g0))). Caps at available fuel.
 func (s *Spacecraft) consumeFuel(dvUsed float64) {
-	const g0 = 9.80665
 	if s.Isp <= 0 {
 		return
 	}
@@ -115,11 +117,48 @@ func (s *Spacecraft) consumeFuel(dvUsed float64) {
 // RemainingDeltaV estimates how much more Δv the current fuel supports,
 // from the rocket equation: Δv = Isp·g0·ln(m0/m_dry).
 func (s *Spacecraft) RemainingDeltaV() float64 {
-	const g0 = 9.80665
 	if s.DryMass == 0 || s.TotalMass() == 0 {
 		return 0
 	}
 	return s.Isp * g0 * math.Log(s.TotalMass()/s.DryMass)
+}
+
+// MassFlowRate returns the propellant mass-flow magnitude (kg/s) at the
+// configured thrust level: ṁ = Thrust/(Isp·g0). Zero if thrust or Isp is
+// zero. Used by the finite-burn integrator to step mass per sub-step.
+func (s *Spacecraft) MassFlowRate() float64 {
+	if s.Thrust <= 0 || s.Isp <= 0 {
+		return 0
+	}
+	return s.Thrust / (s.Isp * g0)
+}
+
+// ThrustAccelFn returns an RK4-compatible accel closure that adds engine
+// thrust along the given burn-mode direction on top of two-body gravity.
+// Direction is recomputed each sub-step from live (r, v), so prograde
+// follows the rotating velocity frame — the expected UX for held-prograde
+// burns.
+//
+// Mass is held constant for the closure (the integrator treats the
+// sub-step as ~constant-mass); the caller updates fuel via MassFlowRate
+// after the StepRK4 call. Thrust is gated to zero if fuel is empty.
+func (s *Spacecraft) ThrustAccelFn(mode BurnMode, mu float64) func(r, v orbital.Vec3, t float64) orbital.Vec3 {
+	mass := s.TotalMass()
+	thrust := s.Thrust
+	if s.Fuel <= 0 {
+		thrust = 0
+	}
+	return func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
+		gravity := physics.Accel(r, mu)
+		if thrust == 0 || mass == 0 {
+			return gravity
+		}
+		dir := DirectionUnit(mode, r, v)
+		if dir.Norm() == 0 {
+			return gravity
+		}
+		return gravity.Add(dir.Scale(thrust / mass))
+	}
 }
 
 // cross is the standard 3D cross product. Lifted here (rather than adding

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
 
 // TestProgradeAtLEORaisesApoapsis: plan §C17 accept criterion. Starting
@@ -85,5 +86,78 @@ func TestRemainingDeltaV(t *testing.T) {
 	want := 300.0 * 9.80665 * math.Ln2
 	if math.Abs(got-want) > 1 {
 		t.Errorf("Δv_remaining = %.2f m/s, want %.2f m/s", got, want)
+	}
+}
+
+// TestMassFlowRate: at default Thrust=1000 N, Isp=300 s,
+// ṁ = 1000 / (300 · 9.80665) ≈ 0.340 kg/s.
+func TestMassFlowRate(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	got := sc.MassFlowRate()
+	want := 1000.0 / (300.0 * 9.80665)
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("MassFlowRate = %.6f, want %.6f", got, want)
+	}
+}
+
+// TestMassFlowRateZeroWhenNoThrust: if engine has no thrust, ṁ must be 0
+// even when Isp is positive.
+func TestMassFlowRateZeroWhenNoThrust(t *testing.T) {
+	sc := &Spacecraft{Thrust: 0, Isp: 300}
+	if got := sc.MassFlowRate(); got != 0 {
+		t.Errorf("MassFlowRate with zero thrust = %v, want 0", got)
+	}
+}
+
+// TestThrustAccelFnAddsThrustOnTopOfGravity: at LEO with prograde mode,
+// the thrust component should equal Thrust/mass along the velocity unit
+// vector. Gravity component should match physics.Accel.
+func TestThrustAccelFnAddsThrustOnTopOfGravity(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	mu := earth.GravitationalParameter()
+	r := sc.State.R
+	v := sc.State.V
+	mass := sc.TotalMass()
+
+	accelFn := sc.ThrustAccelFn(BurnPrograde, mu)
+	got := accelFn(r, v, 0)
+
+	// Expected = gravity + (Thrust/mass) along v_hat.
+	gravity := orbital.Vec3{}
+	rMag := r.Norm()
+	gFactor := -mu / (rMag * rMag * rMag)
+	gravity.X = r.X * gFactor
+	gravity.Y = r.Y * gFactor
+	gravity.Z = r.Z * gFactor
+	vHat := v.Scale(1 / v.Norm())
+	want := gravity.Add(vHat.Scale(sc.Thrust / mass))
+
+	if got.Sub(want).Norm()/want.Norm() > 1e-9 {
+		t.Errorf("ThrustAccelFn: got %+v, want %+v", got, want)
+	}
+}
+
+// TestThrustAccelFnNoThrustWhenFuelEmpty: with Fuel=0, the closure must
+// return pure gravity even though Thrust is configured.
+func TestThrustAccelFnNoThrustWhenFuelEmpty(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	sc.Fuel = 0
+	mu := earth.GravitationalParameter()
+
+	accelFn := sc.ThrustAccelFn(BurnPrograde, mu)
+	got := accelFn(sc.State.R, sc.State.V, 0)
+
+	rMag := sc.State.R.Norm()
+	gFactor := -mu / (rMag * rMag * rMag)
+	want := orbital.Vec3{X: sc.State.R.X * gFactor, Y: sc.State.R.Y * gFactor, Z: sc.State.R.Z * gFactor}
+
+	if got.Sub(want).Norm() > 1e-9 {
+		t.Errorf("with empty fuel, got %+v, want pure gravity %+v", got, want)
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -88,7 +88,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case screens.BurnExecutedMsg:
 		if a.world.Craft != nil {
-			a.world.Craft.ApplyImpulsive(m.Mode, m.DV)
+			if m.Duration == 0 {
+				a.world.Craft.ApplyImpulsive(m.Mode, m.DV)
+			} else {
+				a.world.ActiveBurn = &sim.ActiveBurn{
+					Mode:        m.Mode,
+					DVRemaining: m.DV,
+					EndTime:     a.world.Clock.SimTime.Add(m.Duration),
+				}
+			}
 		}
 		a.world.Clock.Paused = false
 		a.active = screenOrbit

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -21,34 +22,58 @@ import (
 // BurnExecutedMsg that the app applies to the spacecraft.
 //
 // Per plan §C20: live preview = shadow trajectory on a miniature canvas.
-// v0.1 scope: direction mode + Δv magnitude; finite burns / pitch-yaw are v0.2.
+// v0.2.1: three fields — mode / Δv / duration. Duration zero = impulsive
+// (legacy v0.1 path); duration > 0 = finite burn.
 type Maneuver struct {
 	theme    Theme
 	canvas   *widgets.Canvas
 	dvInput  textinput.Model
+	durInput textinput.Model
 	modeIdx  int
+	focus    int // 0=mode, 1=dv, 2=duration
 }
 
 // BurnExecutedMsg is emitted when the user hits Enter. App consumes it.
+// Duration zero = impulsive (legacy path); >0 = finite burn.
 type BurnExecutedMsg struct {
-	Mode spacecraft.BurnMode
-	DV   float64
+	Mode     spacecraft.BurnMode
+	DV       float64
+	Duration time.Duration
 }
 
 func NewManeuver(th Theme) *Maneuver {
-	ti := textinput.New()
-	ti.Placeholder = "0"
-	ti.CharLimit = 8
-	ti.Width = 10
-	ti.SetValue("100")
-	ti.Focus()
+	dv := textinput.New()
+	dv.Placeholder = "0"
+	dv.CharLimit = 8
+	dv.Width = 10
+	dv.SetValue("100")
+
+	dur := textinput.New()
+	dur.Placeholder = "0"
+	dur.CharLimit = 6
+	dur.Width = 10
+	dur.SetValue("0")
 
 	m := &Maneuver{
-		theme:   th,
-		canvas:  widgets.NewCanvas(60, 20),
-		dvInput: ti,
+		theme:    th,
+		canvas:   widgets.NewCanvas(60, 20),
+		dvInput:  dv,
+		durInput: dur,
 	}
+	m.applyFocus()
 	return m
+}
+
+// applyFocus pushes focus state down to the bubbletea text inputs.
+func (m *Maneuver) applyFocus() {
+	m.dvInput.Blur()
+	m.durInput.Blur()
+	switch m.focus {
+	case 1:
+		m.dvInput.Focus()
+	case 2:
+		m.durInput.Focus()
+	}
 }
 
 // Resize handles terminal-size changes. Keep the maneuver canvas ≤ 60 cols
@@ -68,32 +93,52 @@ func (m *Maneuver) Resize(cols, rows int) {
 // means the app should exit the maneuver screen (commit or cancel).
 //
 // Key bindings:
-//   tab / shift+tab  — cycle direction modes
-//   enter            — commit burn → emits BurnExecutedMsg
-//   esc              — cancel → plain exit (app handles)
-//   anything else    — forwarded to dv text input
+//   tab / shift+tab    — cycle focus across mode / Δv / duration fields
+//   ←/→ (mode focused) — cycle direction modes
+//   enter              — commit burn → emits BurnExecutedMsg
+//   esc                — cancel → plain exit (app handles)
+//   digits/backspace   — forwarded to focused text input
 func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	switch msg.String() {
 	case "tab":
-		m.modeIdx = (m.modeIdx + 1) % len(spacecraft.AllBurnModes)
+		m.focus = (m.focus + 1) % 3
+		m.applyFocus()
 		return nil, false
 	case "shift+tab":
-		m.modeIdx = (m.modeIdx - 1 + len(spacecraft.AllBurnModes)) % len(spacecraft.AllBurnModes)
+		m.focus = (m.focus + 2) % 3
+		m.applyFocus()
 		return nil, false
+	case "left":
+		if m.focus == 0 {
+			m.modeIdx = (m.modeIdx - 1 + len(spacecraft.AllBurnModes)) % len(spacecraft.AllBurnModes)
+			return nil, false
+		}
+	case "right":
+		if m.focus == 0 {
+			m.modeIdx = (m.modeIdx + 1) % len(spacecraft.AllBurnModes)
+			return nil, false
+		}
 	case "enter":
 		dv := m.parsedDV()
 		if dv == 0 {
 			return nil, false // ignore — user needs to type a number
 		}
+		dur := m.parsedDuration()
 		return func() tea.Msg {
 			return BurnExecutedMsg{
-				Mode: spacecraft.AllBurnModes[m.modeIdx],
-				DV:   dv,
+				Mode:     spacecraft.AllBurnModes[m.modeIdx],
+				DV:       dv,
+				Duration: dur,
 			}
 		}, true
 	}
 	var cmd tea.Cmd
-	m.dvInput, cmd = m.dvInput.Update(msg)
+	switch m.focus {
+	case 1:
+		m.dvInput, cmd = m.dvInput.Update(msg)
+	case 2:
+		m.durInput, cmd = m.durInput.Update(msg)
+	}
 	return cmd, false
 }
 
@@ -106,6 +151,16 @@ func (m *Maneuver) parsedDV() float64 {
 		dv = -dv
 	}
 	return dv
+}
+
+// parsedDuration returns the duration field as a time.Duration. The field
+// is in seconds; zero means impulsive.
+func (m *Maneuver) parsedDuration() time.Duration {
+	var secs float64
+	if _, err := fmt.Sscanf(m.durInput.Value(), "%f", &secs); err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs * float64(time.Second))
 }
 
 // Render composes the preview canvas + form panel.
@@ -155,7 +210,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	body := strings.Join([]string{canvasPanel, form}, "\n")
 
 	footer := m.theme.Footer.Render(
-		"[tab] cycle mode  [enter] commit  [esc] cancel  [backspace/digits] edit Δv",
+		"[tab] cycle field  [←/→] cycle mode  [enter] commit  [esc] cancel  [digits] edit",
 	)
 	return m.theme.Title.Render("maneuver planner") + "\n" + body + "\n" + footer
 }
@@ -164,15 +219,44 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64) string {
 	c := w.Craft
 	mode := spacecraft.AllBurnModes[m.modeIdx]
 	budget := c.RemainingDeltaV()
+	dur := m.parsedDuration()
+
 	warn := ""
 	if dv > budget {
 		warn = m.theme.Alert.Render(fmt.Sprintf(" [EXCEEDS BUDGET by %.0f m/s]", dv-budget))
 	}
+
+	// Mode line — highlight if focused, otherwise dim.
+	modeLabel := mode.String()
+	if m.focus == 0 {
+		modeLabel = m.theme.Warning.Render(modeLabel) + "  (←/→ to cycle)"
+	} else {
+		modeLabel = m.theme.Dim.Render(modeLabel)
+	}
+
+	burnDescr := "impulsive"
+	if dur > 0 {
+		// At constant thrust the analytical estimate is dv = thrust/mass × dur.
+		// Show what the engine actually *can* deliver in the requested duration.
+		mass := c.TotalMass()
+		var estDv float64
+		if mass > 0 {
+			estDv = c.Thrust / mass * dur.Seconds()
+		}
+		actual := math.Min(dv, estDv)
+		burnDescr = fmt.Sprintf("finite burn (%.0f N × %.1fs → est %.1f m/s, target %.0f m/s)",
+			c.Thrust, dur.Seconds(), actual, dv)
+	}
+
 	lines := []string{
 		m.theme.Primary.Render("BURN PLAN"),
-		"  mode:  " + m.theme.Warning.Render(mode.String()) + "  (tab to cycle)",
-		"  Δv:    " + m.dvInput.View() + " m/s" + warn,
+		"  mode:     " + modeLabel,
+		"  Δv:       " + m.dvInput.View() + " m/s" + warn,
+		"  duration: " + m.durInput.View() + " s",
+		"  → " + burnDescr,
+		"",
 		"  Δv budget remaining: " + fmt.Sprintf("%.0f m/s", budget),
+		fmt.Sprintf("  thrust: %.0f N  Isp: %.0f s", c.Thrust, c.Isp),
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -250,13 +250,30 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		)
 	}
 
+	if w.ActiveBurn != nil {
+		remaining := w.ActiveBurn.EndTime.Sub(w.Clock.SimTime).Seconds()
+		if remaining < 0 {
+			remaining = 0
+		}
+		lines = append(lines, "",
+			v.theme.Warning.Render("BURN ACTIVE"),
+			fmt.Sprintf("  mode:    %s", w.ActiveBurn.Mode.String()),
+			fmt.Sprintf("  Δv-to-go: %.1f m/s", w.ActiveBurn.DVRemaining),
+			fmt.Sprintf("  T-%.1fs remaining", remaining),
+		)
+	}
+
 	if len(w.Nodes) > 0 {
 		lines = append(lines, "", v.theme.Primary.Render("NODES"))
 		for i, n := range w.Nodes {
 			dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+			kind := "imp"
+			if n.Duration > 0 {
+				kind = fmt.Sprintf("fin %.0fs", n.Duration.Seconds())
+			}
 			lines = append(lines, fmt.Sprintf(
-				"  #%d T%+.0fs  %s  %.0f m/s",
-				i+1, dt, n.Mode.String(), n.DV,
+				"  #%d T%+.0fs  %s  %.0f m/s  %s",
+				i+1, dt, n.Mode.String(), n.DV, kind,
 			))
 		}
 	}


### PR DESCRIPTION
## Summary

Replaces impulsive-only Δv with finite-duration thrust integration, wiring up the RK4 integrator that's been parked since Phase 1.

- `Spacecraft.Thrust` (N) — engine spec; `ThrustAccelFn` returns an RK4-compatible accel closure (gravity + thrust along live direction-mode unit vector).
- `ManeuverNode.Duration` — zero = legacy impulsive path; non-zero = finite burn that runs across ticks via `World.ActiveBurn{Mode, DVRemaining, EndTime}`.
- `World.integrateSpacecraft` branches: pure Verlet for free flight, RK4 + thrust + per-step mass flow during `ActiveBurn`. Burn tears down on Δv delivered, fuel exhausted, or sim-time past `EndTime`.
- Warp clamps to ≤10× during `ActiveBurn` (per docs/plan.md §Time-warp UX).
- Maneuver planner UI: tab cycles three fields (mode / Δv / duration); `←/→` cycles modes when focused. Orbit HUD shows `BURN ACTIVE` block; node list flags finite vs impulsive.

## Test plan

- [x] `go test ./...` clean (10 files changed, 477+/39−)
- [x] `go vet ./...` clean
- [x] New tests cover: mass flow rate, thrust-accel closure, fuel-empty gating, finite-node sets ActiveBurn (no instant Δv), Δv delivered across ticks, duration-bound termination when DV unmet, warp 10× cap during burn
- [x] Existing impulsive-burn tests still green (Duration=0 backward-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)