### PR TITLE
feat: auto-plant Hohmann transfer + README rewrite (v0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.2.0**.
+Latest release: **v0.3.1**.
 
 ```bash
 # Linux x86_64
@@ -45,82 +45,163 @@ go build ./cmd/terminal-space-program
 
 Requires Go 1.24+ (bubbletea dependency chain).
 
+## Quick tour
+
+You spawn in low Earth orbit at 200 km altitude. The left panel is the
+canvas — Sun at the center, planets on their actual orbits, your
+spacecraft as a small cluster. The right HUD shows clock, vessel state,
+selected body, planted nodes, and (when relevant) the Hohmann preview to
+the selected target. Time-warp with `.` / `,` to watch planets move; pause
+with `0` or space.
+
+To make something happen:
+
+1. Press `←`/`→` to scroll the cursor through bodies. Pick Mars.
+2. Press `P` to plant a Hohmann transfer — two nodes appear on the canvas
+   (one in Earth's frame, one in Mars's), the HUD lists them with their
+   Δv and time-to-fire.
+3. Time-warp forward. Watch the departure node fire when its trigger time
+   hits. Your trajectory unrolls past Earth's SOI, the predictor switches
+   frames, and the curve bends sunward as it should.
+4. The arrival node fires near Mars. (Phasing isn't enforced in v0.3.1 —
+   the sandbox assumes Mars is where you need it. Real launch-window
+   selection comes with the porkchop plot in v0.3.2.)
+
+For finite engine burns instead of instant Δv, press `m` to open the
+planner — set mode, Δv, and a non-zero duration. The integrator switches
+from Verlet (energy-conserving free flight) to RK4 (handles the non-
+conservative thrust force) and ticks the burn across multiple frames with
+mass loss tracked from the rocket equation.
+
 ## Keybindings
+
+### Global
 
 | Key | Action |
 |---|---|
 | `q`, `Ctrl+C` | Quit |
 | `?` | Toggle help overlay |
-| `Esc` | Back / close |
-| `→` / `l` | Next body |
-| `←` / `h` | Previous body |
+| `Esc` | Back / close panel |
 | `s` | Switch system (Sol → Alpha Cen → TRAPPIST-1 → Kepler-452) |
-| `i` | Body info |
+| `i` | Body info screen |
+| `0`, `Space` | Pause / resume sim |
+| `.` / `,` | Warp up / down (1× → 100000×; clamped to ≤10× during a burn) |
+
+### Orbit view
+
+| Key | Action |
+|---|---|
+| `→` / `l` | Cursor: next body |
+| `←` / `h` | Cursor: previous body |
 | `+` / `-` | Zoom in / out |
 | `f` / `F` | Cycle camera focus forward / backward (system → bodies → craft) |
 | `g` | Reset camera focus to system |
-| `.` | Warp up (1× … 100000×) |
-| `,` | Warp down |
-| `0`, `Space` | Pause / resume |
-| `m` | Open maneuver planner |
-| `n` | Plan a maneuver node |
+| `n` | Plan a default node (T+5min, prograde, 50 m/s) |
 | `N` | Clear all planned nodes |
-| `Tab` (in planner) | Cycle direction mode |
-| `Enter` (in planner) | Commit burn |
-| `Esc` (in planner) | Cancel burn |
+| `P` | **Auto-plant Hohmann transfer to selected body** (v0.3.1) |
+| `m` | Open maneuver planner |
+
+### Maneuver planner (`m`)
+
+| Key | Action |
+|---|---|
+| `Tab` / `Shift+Tab` | Cycle field focus (mode → Δv → duration) |
+| `←` / `→` | Cycle direction mode (when mode field is focused) |
+| digits / backspace | Edit Δv or duration value |
+| `Enter` | Commit burn |
+| `Esc` | Cancel and back to orbit view |
+
+A duration of `0` plants an impulsive burn (instant Δv). A non-zero
+duration starts a finite burn that runs for up to that many seconds, or
+until the requested Δv is delivered, whichever first.
+
+## Features (v0.3.1)
+
+- **Auto-plant Hohmann transfer** (`P`). Select a target body, press one
+  key, two nodes plant: a geocentric departure burn at parking-orbit
+  periapsis (raises apoapsis past Earth's SOI), and a destination-frame
+  arrival burn (drops into low capture orbit). Patched-conic Δv math
+  matches Curtis Example 8.3 within 5% for Earth → Mars.
+- **Multi-frame nodes.** Each `ManeuverNode` carries a `PrimaryID` tag
+  identifying which body's frame the burn was planned in. The orbit-view
+  glyph cluster grows for foreign-frame nodes so the player can see at a
+  glance which leg is which on auto-planted transfers.
+- **Frame-aware `PostBurnState`**. Returns the post-burn state plus the
+  ID of the primary that frame is relative to — critical for nodes that
+  fire after the trajectory crosses an SOI boundary.
+
+## Features (v0.3.0)
+
+- **Lambert solver**. `planner.LambertSolve(r1, r2, dt, mu)` reproduces
+  Curtis Example 5.2 within 0.5%; round-trip via Verlet returns to r2
+  within integrator tolerance. Single-rev prograde only — multi-rev
+  branches and explicit retrograde handling deferred to v0.3.2.
+- **SOI-aware predictor**. When a sub-step crosses a sphere-of-influence
+  boundary, the state is rebased to the new primary's frame and μ
+  switches for subsequent steps. The closing point of each outgoing
+  segment lands at the actual crossing — no time gap, join continuous
+  in inertial coords. Resolves the LEO reference-frame trap that v0.2's
+  predictor punted on (predicted post-escape trajectories were
+  geometrically wrong even though their coloring was correct).
+
+## Features (v0.2.1)
+
+- **Finite-duration burns**. `Spacecraft.Thrust` (1 kN default) drives
+  per-sub-step engine acceleration via an RK4 integrator path that
+  handles the non-conservative force cleanly (Verlet would silently
+  drift). Mass flow `dm/dt = -Thrust/(Isp·g0)` debits fuel each tick.
+  Burn ends on Δv delivered, fuel exhausted, or duration elapsed.
+- **Active-burn HUD**. Orbit screen renders a `BURN ACTIVE` block while
+  a burn is in flight (mode, Δv-to-go, T-remaining). Time-warp clamps
+  to ≤10× during a burn so the integrator keeps temporal resolution on
+  the burn window.
 
 ## Features (v0.2)
 
-Slice-1 of the v0.2 scope — "maneuver planning, closed loop."
-
-- **View focus / camera follow.** `f`/`F` cycles the camera target across
-  the system primary, every body, and the spacecraft (Sol only); `g`
-  resets to the system view. Focus keeps moving targets centered without
-  refitting the zoom on every frame.
-- **Maneuver nodes.** `n` plants a node on the current orbit; `N` clears
-  all pending nodes. Nodes are rendered on-canvas at their projected
-  inertial position and listed in the HUD. When sim-time reaches a
-  node's trigger time, its impulsive burn fires and the node pops.
+- **View focus / camera follow.** `f`/`F` cycles the camera target
+  across the system primary, every body, and the spacecraft (Sol only);
+  `g` resets to the system view.
+- **Maneuver nodes.** `n` plants a node on the current orbit; `N`
+  clears all pending nodes. Nodes render on-canvas at their projected
+  inertial position and list in the HUD; firing pops them automatically.
 - **SOI-segmented trajectory viz.** The predicted post-burn trajectory
-  is partitioned by dominant sphere-of-influence. Samples inside the
-  craft's home SOI render stride-2 dashed; samples that cross into a
-  foreign SOI render stride-1 solid so capture arcs read visually
-  distinct from cruise.
+  is partitioned by dominant SOI. Home-SOI samples render dashed,
+  foreign-SOI samples solid so capture arcs read visually distinct.
 - **Hohmann preview HUD.** When the cursor-selected body has orbital
   data, the SELECTED block renders reference heliocentric Δv1 / Δv2 /
-  transfer time computed off the system primary's GM and the craft's
-  current inertial radius. Earth → Mars lands within 10% of the
-  Curtis §6.2 textbook values.
+  transfer time. Earth → Mars matches Curtis §6.2 within 10%.
 
 ## Features (v0.1)
 
 - **Viewer.** Physically-plausible renderings of Sol, Alpha Centauri,
   TRAPPIST-1, and Kepler-452. Planets move under time warp; orbit lines
-  drawn from the same Kepler math that places the planets.
+  from the same Kepler math that places the planets.
 - **Spacecraft.** One vessel in low Earth orbit, propagated with
   velocity-Verlet on a patched-conic two-body model. Energy-conservation
   verified under 1% drift across 1000 orbits (we ship at ~1e-7%).
 - **Burns.** Impulsive burns with prograde / retrograde / normal± /
-  radial± modes, rocket-equation fuel accounting, and live shadow-
-  trajectory preview in the maneuver planner.
-- **Time warp.** Six discrete steps (1× → 100000×) with integrator-
-  aware clamping so sim-time can't outrun numerical stability.
+  radial± modes, rocket-equation fuel accounting, live shadow-trajectory
+  preview in the planner.
+- **Time warp.** Six discrete steps (1× → 100000×) with integrator-aware
+  clamping so sim-time can't outrun numerical stability.
 - **Single binary.** 5-target GoReleaser matrix (linux+darwin amd64/arm64,
   windows amd64), `CGO_ENABLED=0`, `-ldflags "-s -w"`.
 
-### Deferred to v0.3+
+### Deferred to v0.3.2+
 
-Finite-duration burns (impulsive only through v0.2), Lambert targeting
-with auto-plant nodes in the correct SOI frame, multi-system spacecraft,
-save/load, N-body perturbations, config-file custom systems, mouse
-support.
+- **Porkchop plot** screen for real launch-window selection (the v0.3.1
+  auto-plant assumes ideal phasing).
+- **Lambert multi-revolution** branches and explicit retrograde handling.
+- **Inclination-change planner** for out-of-plane corrections.
+- **Mid-course corrections**, **save/load**, **multi-system spacecraft**,
+  **N-body perturbations**, **config-file custom systems**, **mouse**.
 
 ## Implementation plan
 
 Full design doc: [`docs/plan.md`](docs/plan.md). Summary:
 
-- 4-phase physics progression (viewer → Verlet propagation → impulsive
-  burns → maneuver library).
+- Phased physics progression (viewer → Verlet → impulsive burns → finite
+  burns + RK4 → SOI-aware predictor + Lambert → auto-plant transfers).
 - Bubble Tea root model with screen-level sub-models (orbit / bodyinfo /
   maneuver / help).
 - GoReleaser single-workflow CI; release artifacts on tag push.

--- a/internal/planner/departure.go
+++ b/internal/planner/departure.go
@@ -1,0 +1,44 @@
+package planner
+
+import (
+	"errors"
+	"math"
+)
+
+// EscapeBurnDeltaV returns the prograde Δv that, applied at periapsis
+// of a circular parking orbit of radius rPark around a primary with
+// gravitational parameter muPlanet, yields a hyperbolic escape
+// trajectory whose excess speed at infinity is vInfinity.
+//
+// Patched-conic identity (vis-viva at hyperbolic periapsis):
+//
+//	v_peri² = v∞² + 2·µ/r_peri
+//	Δv      = v_peri − v_circ
+//
+// The result is in m/s (matching the SI used everywhere else in this
+// repo). vInfinity is taken as a magnitude — direction is the caller's
+// concern (typically aligned with the outbound asymptote, which the
+// transfer-plan layer handles via Lambert).
+func EscapeBurnDeltaV(vInfinity, muPlanet, rPark float64) (float64, error) {
+	if muPlanet <= 0 {
+		return 0, errors.New("departure: muPlanet must be > 0")
+	}
+	if rPark <= 0 {
+		return 0, errors.New("departure: rPark must be > 0")
+	}
+	if vInfinity < 0 {
+		return 0, errors.New("departure: vInfinity must be ≥ 0")
+	}
+	vCirc := math.Sqrt(muPlanet / rPark)
+	vPeri := math.Sqrt(vInfinity*vInfinity + 2*muPlanet/rPark)
+	return vPeri - vCirc, nil
+}
+
+// CaptureBurnDeltaV mirrors EscapeBurnDeltaV for arrival: Δv to drop
+// from a hyperbolic approach (excess speed vInfinity) into a circular
+// orbit of radius rCapture around the destination primary. By
+// symmetry the magnitude equals EscapeBurnDeltaV; provided as a named
+// helper so the transfer-plan layer reads naturally.
+func CaptureBurnDeltaV(vInfinity, muPlanet, rCapture float64) (float64, error) {
+	return EscapeBurnDeltaV(vInfinity, muPlanet, rCapture)
+}

--- a/internal/planner/departure_test.go
+++ b/internal/planner/departure_test.go
@@ -1,0 +1,76 @@
+package planner
+
+import (
+	"math"
+	"testing"
+)
+
+// TestEscapeBurnDeltaVZeroVInf: a v∞=0 escape (parabolic) requires
+// Δv = (sqrt(2) − 1) · v_circ — Curtis Eq 8.42 boundary case.
+func TestEscapeBurnDeltaVZeroVInf(t *testing.T) {
+	const muEarth = 3.986e14
+	const rPark = 6.578e6 // 200 km LEO
+	dv, err := EscapeBurnDeltaV(0, muEarth, rPark)
+	if err != nil {
+		t.Fatalf("EscapeBurnDeltaV: %v", err)
+	}
+	vCirc := math.Sqrt(muEarth / rPark)
+	want := (math.Sqrt2 - 1) * vCirc
+	if d := math.Abs(dv-want) / want; d > 1e-9 {
+		t.Errorf("parabolic escape Δv: got %.3f, want %.3f", dv, want)
+	}
+}
+
+// TestEscapeBurnDeltaVPositiveVInf: at v∞ = 3 km/s from LEO the
+// formula gives Δv ≈ 3.61 km/s (textbook Earth→Mars departure).
+func TestEscapeBurnDeltaVPositiveVInf(t *testing.T) {
+	const muEarth = 3.986e14
+	const rPark = 6.578e6 // 200 km LEO
+	dv, err := EscapeBurnDeltaV(3000, muEarth, rPark)
+	if err != nil {
+		t.Fatalf("EscapeBurnDeltaV: %v", err)
+	}
+	// v_peri = sqrt(9e6 + 2·3.986e14/6.578e6) = sqrt(9e6 + 1.212e8) ≈ 11420 m/s
+	// v_circ = sqrt(3.986e14/6.578e6) ≈ 7785 m/s
+	// Δv ≈ 3635 m/s
+	want := 3635.0
+	if d := math.Abs(dv-want) / want; d > 0.01 {
+		t.Errorf("Δv at v∞=3 km/s: got %.1f, want ≈%.1f m/s (rel %.2e)", dv, want, d)
+	}
+}
+
+// TestEscapeBurnDeltaVRejectsBadInputs: non-positive mu / r and
+// negative v∞ all surface as errors.
+func TestEscapeBurnDeltaVRejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name              string
+		vInf, mu, r       float64
+	}{
+		{"negative vInf", -1, 1e14, 7e6},
+		{"zero mu", 1, 0, 7e6},
+		{"negative mu", 1, -1, 7e6},
+		{"zero r", 1, 1e14, 0},
+		{"negative r", 1, 1e14, -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := EscapeBurnDeltaV(c.vInf, c.mu, c.r); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}
+
+// TestCaptureBurnDeltaVMatchesEscape: by symmetry, capture Δv into a
+// given orbit equals the escape Δv from that same orbit at the same
+// hyperbolic excess.
+func TestCaptureBurnDeltaVMatchesEscape(t *testing.T) {
+	const muMars = 4.282837e13
+	const rCap = 9.378e6 // ~3000 km Mars orbit
+	const vInf = 2650.0
+	esc, _ := EscapeBurnDeltaV(vInf, muMars, rCap)
+	cap, _ := CaptureBurnDeltaV(vInf, muMars, rCap)
+	if math.Abs(esc-cap) > 1e-12 {
+		t.Errorf("capture %v != escape %v", cap, esc)
+	}
+}

--- a/internal/planner/transfer.go
+++ b/internal/planner/transfer.go
@@ -1,0 +1,115 @@
+package planner
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// TransferLeg names which end of a TransferPlan a node belongs to —
+// helpful for HUDs and logging that want to show "departure" vs
+// "arrival" without having to derive it from PrimaryID.
+type TransferLeg int
+
+const (
+	LegDeparture TransferLeg = iota
+	LegArrival
+)
+
+// TransferNode is a planner-layer description of a single burn that the
+// sim layer will turn into a sim.ManeuverNode. We keep it free of any
+// sim-package dependencies so planner stays a pure math/algorithms
+// surface — sim.PlanTransfer adapts these into sim.ManeuverNodes.
+type TransferNode struct {
+	Leg          TransferLeg
+	PrimaryID    string        // body whose frame the burn was planned in
+	DV           float64       // m/s, magnitude
+	OffsetTime   time.Duration // time after PlanTransfer returns when this fires
+	IsRetrograde bool          // true → retrograde mode; false → prograde
+}
+
+// TransferPlan is the two-burn output of an auto-plant transfer.
+// Departure fires at a parking-orbit periapsis around the origin
+// primary; Arrival fires at the destination's SOI/circular-capture
+// radius after the transfer ellipse coast.
+type TransferPlan struct {
+	Departure  TransferNode
+	Arrival    TransferNode
+	TransferDt time.Duration // coast time (Departure → Arrival)
+}
+
+// PlanHohmannTransfer constructs a Hohmann-style transfer plan from a
+// circular parking orbit at radius rPark around a departure planet
+// (helios distance rDeparture, gravitational parameter muDeparture) to
+// a circular capture orbit at radius rCapture around a destination
+// planet (helios distance rArrival, gravitational parameter
+// muDestination), all heliocentric distances in the system primary's
+// frame (mu = muSun).
+//
+// Result Δv magnitudes are the patched-conic Hohmann values:
+//
+//	departure: v∞_dep = sqrt(µ_sun · (2/r_dep − 1/a_t)) − v_dep_orbit
+//	         Δv_dep = EscapeBurnDeltaV(v∞_dep, µ_planet, r_park)
+//	arrival:   v∞_arr = v_arr_orbit − sqrt(µ_sun · (2/r_arr − 1/a_t))
+//	         Δv_arr = CaptureBurnDeltaV(|v∞_arr|, µ_dest, r_capture)
+//
+// PrimaryIDs are set so the sim layer can render frame-aware glyphs
+// and the planner UI can label the legs. Phasing is *not* accounted
+// for — both burns assume the destination planet is at the right place
+// at the right time, which the v0.3.1 sandbox doesn't enforce. A
+// porkchop-plot screen (deferred to v0.3.2) is the natural next step.
+func PlanHohmannTransfer(
+	muSun float64,
+	rDeparture, rArrival float64,
+	muDeparture, rPark float64, departureID string,
+	muDestination, rCapture float64, destinationID string,
+) (TransferPlan, error) {
+	if muSun <= 0 || rDeparture <= 0 || rArrival <= 0 {
+		return TransferPlan{}, errors.New("planhohmann: heliocentric inputs must be positive")
+	}
+	if rDeparture == rArrival {
+		return TransferPlan{}, errors.New("planhohmann: departure and arrival radii are equal — no transfer")
+	}
+
+	aT := (rDeparture + rArrival) / 2
+	vDepOrbit := math.Sqrt(muSun / rDeparture)
+	vArrOrbit := math.Sqrt(muSun / rArrival)
+	vTransAtDep := math.Sqrt(muSun * (2/rDeparture - 1/aT))
+	vTransAtArr := math.Sqrt(muSun * (2/rArrival - 1/aT))
+
+	vInfDep := vTransAtDep - vDepOrbit
+	vInfArr := vArrOrbit - vTransAtArr
+
+	dvDep, err := EscapeBurnDeltaV(math.Abs(vInfDep), muDeparture, rPark)
+	if err != nil {
+		return TransferPlan{}, err
+	}
+	dvArr, err := CaptureBurnDeltaV(math.Abs(vInfArr), muDestination, rCapture)
+	if err != nil {
+		return TransferPlan{}, err
+	}
+
+	transferTime := math.Pi * math.Sqrt(aT*aT*aT/muSun)
+
+	// Outbound (rArr > rDep): departure raises apoapsis (prograde),
+	// arrival drops periapsis (retrograde — relative velocity points
+	// against Mars's motion at intercept). Inbound: opposite.
+	outbound := rArrival > rDeparture
+	return TransferPlan{
+		Departure: TransferNode{
+			Leg:          LegDeparture,
+			PrimaryID:    departureID,
+			DV:           dvDep,
+			OffsetTime:   0,
+			IsRetrograde: !outbound,
+		},
+		Arrival: TransferNode{
+			Leg:          LegArrival,
+			PrimaryID:    destinationID,
+			DV:           dvArr,
+			OffsetTime:   time.Duration(transferTime * float64(time.Second)),
+			IsRetrograde: outbound,
+		},
+		TransferDt: time.Duration(transferTime * float64(time.Second)),
+	}, nil
+}

--- a/internal/planner/transfer_test.go
+++ b/internal/planner/transfer_test.go
@@ -1,0 +1,131 @@
+package planner
+
+import (
+	"math"
+	"testing"
+)
+
+// Reference values for textbook Earth → Mars Hohmann transfer
+// (Curtis Example 8.3, slightly reformulated for SI):
+//
+//   r_earth      = 1 AU                = 1.496e11 m
+//   r_mars       = 1.524 AU            = 2.279e11 m
+//   r_park (LEO) = 6378 + 200 km       = 6.578e6 m
+//   r_capture    = Mars 200 km altitude = 3.39e6 + 200e3 = 3.59e6 m
+//
+//   Δv_departure ≈ 3.61 km/s (heliocentric v∞ ≈ 2.945 km/s, escape from LEO)
+//   Δv_arrival   ≈ 2.09 km/s (heliocentric v∞ ≈ 2.65 km/s, capture at low Mars)
+//   total        ≈ 5.7 km/s
+//   t_transfer   ≈ 258.8 days
+// muSun is shared with hohmann_test.go (var declared there).
+const (
+	muEarth  = 3.986004418e14
+	muMars   = 4.282837e13
+	rEarth   = 1.495978707e11
+	rMars    = 1.524 * 1.495978707e11
+	rPark    = 6.578e6
+	rMarsCap = 3.39e6 + 200e3
+)
+
+// TestPlanHohmannTransferEarthToMars: top-level Δv and transfer time
+// match Curtis Example 8.3 (textbook Earth→Mars Hohmann) within 5%.
+// The scope-excluded "phasing not enforced" caveat means absolute
+// timing accuracy isn't tested — only the canonical Δv budget.
+func TestPlanHohmannTransferEarthToMars(t *testing.T) {
+	plan, err := PlanHohmannTransfer(
+		muSun, rEarth, rMars,
+		muEarth, rPark, "earth",
+		muMars, rMarsCap, "mars",
+	)
+	if err != nil {
+		t.Fatalf("PlanHohmannTransfer: %v", err)
+	}
+
+	// Δv_departure ~ 3.61 km/s.
+	wantDvDep := 3610.0
+	if d := math.Abs(plan.Departure.DV-wantDvDep) / wantDvDep; d > 0.05 {
+		t.Errorf("departure Δv: got %.0f, want ≈%.0f m/s (rel %.2e)",
+			plan.Departure.DV, wantDvDep, d)
+	}
+
+	// Δv_arrival ~ 2.09 km/s — that's into a LOW Mars orbit. The
+	// 5% tolerance covers small variations in textbook reference
+	// (some sources use ~2.6 km/s for higher capture orbits).
+	wantDvArr := 2090.0
+	if d := math.Abs(plan.Arrival.DV-wantDvArr) / wantDvArr; d > 0.05 {
+		t.Errorf("arrival Δv: got %.0f, want ≈%.0f m/s (rel %.2e)",
+			plan.Arrival.DV, wantDvArr, d)
+	}
+
+	// Frame tagging: departure in Earth frame, arrival in Mars frame.
+	if plan.Departure.PrimaryID != "earth" {
+		t.Errorf("departure PrimaryID: got %q, want earth", plan.Departure.PrimaryID)
+	}
+	if plan.Arrival.PrimaryID != "mars" {
+		t.Errorf("arrival PrimaryID: got %q, want mars", plan.Arrival.PrimaryID)
+	}
+
+	// Transfer time ≈ 258.8 days ≈ 22.36e6 s.
+	wantTransfer := 22.36e6
+	gotTransfer := plan.TransferDt.Seconds()
+	if d := math.Abs(gotTransfer-wantTransfer) / wantTransfer; d > 0.02 {
+		t.Errorf("transfer time: got %.3e s, want ≈%.3e s (rel %.2e)",
+			gotTransfer, wantTransfer, d)
+	}
+
+	// Outbound transfer: departure prograde, arrival retrograde
+	// (slow down at apoapsis to drop into Mars orbit).
+	if plan.Departure.IsRetrograde {
+		t.Errorf("outbound departure should be prograde, got retrograde")
+	}
+	if !plan.Arrival.IsRetrograde {
+		t.Errorf("outbound arrival should be retrograde, got prograde")
+	}
+}
+
+// TestPlanHohmannTransferInbound: a Mars→Earth transfer flips the
+// retrograde flags (slow down at departure to drop perihelion;
+// speed up at Earth to circularize at the new lower radius).
+func TestPlanHohmannTransferInbound(t *testing.T) {
+	plan, err := PlanHohmannTransfer(
+		muSun, rMars, rEarth,
+		muMars, rMarsCap, "mars",
+		muEarth, rPark, "earth",
+	)
+	if err != nil {
+		t.Fatalf("PlanHohmannTransfer: %v", err)
+	}
+	if !plan.Departure.IsRetrograde {
+		t.Errorf("inbound departure should be retrograde, got prograde")
+	}
+	if plan.Arrival.IsRetrograde {
+		t.Errorf("inbound arrival should be prograde, got retrograde")
+	}
+}
+
+// TestPlanHohmannTransferRejectsDegenerate: equal radii, zero/negative
+// inputs all surface as errors rather than panicking or NaN-ing
+// silently.
+func TestPlanHohmannTransferRejectsDegenerate(t *testing.T) {
+	cases := []struct {
+		name             string
+		muSun, rDep, rArr float64
+	}{
+		{"equal radii", muSun, rEarth, rEarth},
+		{"zero rDep", muSun, 0, rMars},
+		{"negative rArr", muSun, rEarth, -1},
+		{"zero muSun", 0, rEarth, rMars},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := PlanHohmannTransfer(
+				c.muSun, c.rDep, c.rArr,
+				muEarth, rPark, "earth",
+				muMars, rMarsCap, "mars",
+			)
+			if err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+		})
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -5,8 +5,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -18,20 +20,32 @@ import (
 // path); non-zero = sustained engine burn lasting up to Duration or
 // until DV is delivered, whichever first. Finite-burn execution is
 // driven by World.ActiveBurn during subsequent ticks.
+//
+// PrimaryID is the body whose frame the burn was planned in (empty =
+// the craft's home primary at plant time, which is the v0.1 default
+// and keeps legacy nodes working). Auto-plant transfers (v0.3.1) plant
+// a geocentric departure plus a heliocentric arrival; PrimaryID lets
+// the planner UI render a frame-distinct glyph and lets the burn-
+// execution layer warn if a node fires in an unexpected frame.
 type ManeuverNode struct {
 	TriggerTime time.Time
 	Mode        spacecraft.BurnMode
 	DV          float64
 	Duration    time.Duration
+	PrimaryID   string
 }
 
 // ActiveBurn is the runtime state of an in-progress finite burn. Set by
 // executeDueNodes when a node with Duration>0 fires; cleared by the
 // integrator when DVRemaining hits zero or SimTime passes EndTime.
+// PrimaryID is propagated from the originating ManeuverNode (empty for
+// legacy nodes) — diagnostic only; the integrator always works in the
+// craft's current primary frame.
 type ActiveBurn struct {
 	Mode        spacecraft.BurnMode
 	DVRemaining float64
 	EndTime     time.Time
+	PrimaryID   string
 }
 
 // PlanNode inserts a node into World.Nodes, keeping the slice sorted by
@@ -42,6 +56,81 @@ func (w *World) PlanNode(n ManeuverNode) {
 		return w.Nodes[i].TriggerTime.Before(w.Nodes[j].TriggerTime)
 	})
 }
+
+// PlanTransfer constructs a Hohmann auto-plant to the body at the given
+// index in the active system and plants the resulting two-burn plan
+// onto World.Nodes (departure + arrival). Returns the plan so callers
+// can inspect Δv totals; returns nil and an error if the geometry is
+// degenerate (target index invalid, target is the system primary, or
+// craft state isn't ready).
+//
+// Phasing is not enforced — the plan assumes ideal alignment, matching
+// the v0.3.1 sandbox scope per docs/plan.md. Porkchop-plot polish for
+// real launch windows is v0.3.2.
+func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
+	sys := w.System()
+	if targetIdx <= 0 || targetIdx >= len(sys.Bodies) {
+		return nil, errInvalidTransferTarget
+	}
+	if w.Craft == nil {
+		return nil, errNoCraftForTransfer
+	}
+	target := sys.Bodies[targetIdx]
+	if target.SemimajorAxis == 0 {
+		return nil, errInvalidTransferTarget
+	}
+
+	primary := sys.Bodies[0]
+	muSun := primary.GravitationalParameter()
+	rDeparture := w.CraftInertial().Norm()
+	rArrival := target.SemimajorAxisMeters()
+
+	// Parking-orbit radius at departure: craft's current |r| in its
+	// home primary's frame. Capture radius at destination: hold-over
+	// 200 km altitude default to mirror NewInLEO ergonomics — the
+	// game-balance question of "what circular orbit does the player
+	// want around Mars" is documented, not enforced.
+	rPark := w.Craft.State.R.Norm()
+	muDeparture := w.Craft.Primary.GravitationalParameter()
+	rCapture := target.RadiusMeters() + 200e3
+	muDestination := target.GravitationalParameter()
+
+	plan, err := planner.PlanHohmannTransfer(
+		muSun, rDeparture, rArrival,
+		muDeparture, rPark, w.Craft.Primary.ID,
+		muDestination, rCapture, target.ID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	now := w.Clock.SimTime
+	w.PlanNode(transferNodeToManeuver(plan.Departure, now))
+	w.PlanNode(transferNodeToManeuver(plan.Arrival, now))
+	return &plan, nil
+}
+
+func transferNodeToManeuver(tn planner.TransferNode, now time.Time) ManeuverNode {
+	mode := spacecraft.BurnPrograde
+	if tn.IsRetrograde {
+		mode = spacecraft.BurnRetrograde
+	}
+	return ManeuverNode{
+		TriggerTime: now.Add(tn.OffsetTime),
+		Mode:        mode,
+		DV:          tn.DV,
+		PrimaryID:   tn.PrimaryID,
+	}
+}
+
+var (
+	errInvalidTransferTarget = transferError("invalid transfer target body")
+	errNoCraftForTransfer    = transferError("no craft to plan transfer for")
+)
+
+type transferError string
+
+func (e transferError) Error() string { return string(e) }
 
 // ClearNodes wipes every pending node.
 func (w *World) ClearNodes() { w.Nodes = nil }
@@ -72,6 +161,7 @@ func (w *World) executeDueNodes() {
 				Mode:        n.Mode,
 				DVRemaining: n.DV,
 				EndTime:     n.TriggerTime.Add(n.Duration),
+				PrimaryID:   n.PrimaryID,
 			}
 		}
 		fired++
@@ -83,8 +173,10 @@ func (w *World) executeDueNodes() {
 
 // NodeInertialPosition returns the inertial (system-primary-centered)
 // position where the node will fire. Forward-integrates the craft state
-// from now to the node's trigger time using the same Verlet integrator
-// as the live sim, then adds the primary's inertial position.
+// from now to the node's trigger time using SOI-aware Verlet sub-
+// stepping, then adds the OWNING primary's inertial position — the
+// frame may differ from the craft's current primary if the trajectory
+// crossed an SOI boundary.
 //
 // Returns zero Vec3 if the craft is nil or the node is already past-due.
 func (w *World) NodeInertialPosition(n ManeuverNode) orbital.Vec3 {
@@ -95,45 +187,59 @@ func (w *World) NodeInertialPosition(n ManeuverNode) orbital.Vec3 {
 	if dt <= 0 {
 		return w.CraftInertial()
 	}
-	state := w.propagateCraft(dt)
-	primaryPos := w.BodyPosition(w.Craft.Primary)
-	return primaryPos.Add(state.R)
+	state, primary := w.propagateCraftWithPrimary(dt)
+	return w.BodyPosition(primary).Add(state.R)
 }
 
 // PostBurnState returns the craft's primary-relative state vector
-// immediately after the given node would fire. Forward-integrates to the
-// trigger time, then applies the Δv in the node's direction mode. Used
-// by OrbitView to predict the post-burn trajectory without disturbing
-// live state.
-func (w *World) PostBurnState(n ManeuverNode) physics.StateVector {
+// immediately after the given node would fire, plus the ID of the
+// primary that frame is relative to. Forward-integrates SOI-aware to
+// the trigger time, then applies the Δv in the node's direction mode.
+// The PrimaryID return lets callers (OrbitView post-burn preview)
+// correctly translate state.R into inertial coords when the burn fires
+// in a frame other than the craft's home primary — critical for the
+// v0.3.1 auto-plant arrival node, which fires heliocentrically (or in
+// the destination SOI) by construction.
+func (w *World) PostBurnState(n ManeuverNode) (physics.StateVector, string) {
 	if w.Craft == nil {
-		return physics.StateVector{}
+		return physics.StateVector{}, ""
 	}
 	dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
 	var state physics.StateVector
+	var primaryID string
 	if dt <= 0 {
 		state = w.Craft.State
+		primaryID = w.Craft.Primary.ID
 	} else {
-		state = w.propagateCraft(dt)
+		var primary bodies.CelestialBody
+		state, primary = w.propagateCraftWithPrimary(dt)
+		primaryID = primary.ID
 	}
 	dir := spacecraft.DirectionUnit(n.Mode, state.R, state.V)
 	if dir.Norm() == 0 || n.DV == 0 {
-		return state
+		return state, primaryID
 	}
 	state.V = state.V.Add(dir.Scale(n.DV))
-	return state
+	return state, primaryID
 }
 
 // propagateCraft forward-integrates the craft's primary-relative state
-// dt seconds into the future without mutating live state. Used by
-// NodeInertialPosition and by OrbitView's predicted-trajectory preview.
-//
-// v0.3.0: SOI-aware. When a sub-step crosses an SOI boundary the state
-// is rebased to the new primary's frame and μ switches for subsequent
-// steps. The returned state is expressed relative to whichever primary
-// owns the spacecraft at dt — callers that need a stable frame should
-// add the relevant primary's inertial position themselves.
+// dt seconds into the future without mutating live state. Returns only
+// the state — used by callers that don't care which primary owns the
+// frame (legacy v0.2 paths, tests). For v0.3.0+ callers that need to
+// translate the result into inertial coords across SOI crossings, use
+// propagateCraftWithPrimary instead.
 func (w *World) propagateCraft(dt float64) physics.StateVector {
+	state, _ := w.propagateCraftWithPrimary(dt)
+	return state
+}
+
+// propagateCraftWithPrimary is the SOI-aware integrator: when a sub-
+// step crosses an SOI boundary the state is rebased and μ switches for
+// subsequent steps. Returns the final state plus the body that owns
+// the frame at dt — callers add BodyPosition(primary) to convert state.R
+// into inertial coords.
+func (w *World) propagateCraftWithPrimary(dt float64) (physics.StateVector, bodies.CelestialBody) {
 	current := w.Craft.Primary
 	muNow := current.GravitationalParameter()
 	state := w.Craft.State
@@ -170,5 +276,5 @@ func (w *World) propagateCraft(dt float64) physics.StateVector {
 			muNow = current.GravitationalParameter()
 		}
 	}
-	return state
+	return state, current
 }

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -224,6 +224,77 @@ func TestFiniteBurnEndsAtDurationWhenDVNotMet(t *testing.T) {
 	}
 }
 
+// TestPlanTransferLandsTwoNodes: PlanTransfer for a valid target body
+// should plant exactly two ManeuverNodes (departure + arrival) with
+// matching PrimaryIDs and a sensible time gap matching the returned
+// TransferDt. Validates the sim → planner integration end-to-end.
+func TestPlanTransferLandsTwoNodes(t *testing.T) {
+	w := mustWorld(t)
+
+	// Find Mars's index in Sol's body list.
+	sys := w.System()
+	marsIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Mars" {
+			marsIdx = i
+			break
+		}
+	}
+	if marsIdx < 0 {
+		t.Skip("Mars not in loaded Sol system — adjust if bodies changed")
+	}
+
+	plan, err := w.PlanTransfer(marsIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("PlanTransfer returned nil plan with nil error")
+	}
+	if len(w.Nodes) != 2 {
+		t.Fatalf("expected 2 planted nodes, got %d", len(w.Nodes))
+	}
+	if w.Nodes[0].PrimaryID != w.Craft.Primary.ID {
+		t.Errorf("first (departure) node PrimaryID = %q, want craft primary %q",
+			w.Nodes[0].PrimaryID, w.Craft.Primary.ID)
+	}
+	if w.Nodes[1].PrimaryID != sys.Bodies[marsIdx].ID {
+		t.Errorf("second (arrival) node PrimaryID = %q, want mars %q",
+			w.Nodes[1].PrimaryID, sys.Bodies[marsIdx].ID)
+	}
+	gap := w.Nodes[1].TriggerTime.Sub(w.Nodes[0].TriggerTime)
+	if gap != plan.TransferDt {
+		t.Errorf("planted-node time gap = %v, want plan.TransferDt = %v",
+			gap, plan.TransferDt)
+	}
+}
+
+// TestPlanTransferRejectsBadTargets: invalid index / system-primary /
+// out-of-range targets surface as errors without planting.
+func TestPlanTransferRejectsBadTargets(t *testing.T) {
+	w := mustWorld(t)
+	cases := []struct {
+		name string
+		idx  int
+	}{
+		{"system primary", 0},
+		{"negative index", -1},
+		{"out of range", 999},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			before := len(w.Nodes)
+			if _, err := w.PlanTransfer(c.idx); err == nil {
+				t.Errorf("expected error for %s", c.name)
+			}
+			if len(w.Nodes) != before {
+				t.Errorf("PlanTransfer planted nodes despite error path: %d → %d",
+					before, len(w.Nodes))
+			}
+		})
+	}
+}
+
 func mustWorld(t *testing.T) *World {
 	t.Helper()
 	w, err := NewWorld()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -196,6 +196,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				})
 			}
 			return a, nil
+		case key.Matches(m, a.keys.PlanTransfer):
+			if a.world.CraftVisibleHere() && a.selectedBody > 0 {
+				_, _ = a.world.PlanTransfer(a.selectedBody)
+				// Errors silently ignored: the targeted body is the one
+				// the user selected with ←/→, so the only failure modes
+				// (system primary, equal radii) are handled by the input
+				// guard above. A future polish item is showing the error
+				// message in the HUD when planting fails.
+			}
+			return a, nil
 		case key.Matches(m, a.keys.ClearNodes):
 			a.world.ClearNodes()
 			return a, nil

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -21,8 +21,9 @@ type Keymap struct {
 	FocusNext  key.Binding
 	FocusPrev  key.Binding
 	FocusReset key.Binding
-	PlanNode   key.Binding
-	ClearNodes key.Binding
+	PlanNode      key.Binding
+	ClearNodes    key.Binding
+	PlanTransfer  key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -43,7 +44,8 @@ func DefaultKeymap() Keymap {
 		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
 		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
 		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
-		PlanNode:   key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "plan node (T+5m prograde 50m/s)")),
-		ClearNodes: key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "clear nodes")),
+		PlanNode:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "plan node (T+5m prograde 50m/s)")),
+		ClearNodes:   key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "clear nodes")),
+		PlanTransfer: key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "plant Hohmann transfer to selected body")),
 	}
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -123,7 +123,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	title := v.theme.Title.Render(fmt.Sprintf("terminal-space-program — %s", sys.Name))
 	footer := v.theme.Footer.Render(
-		"[q]quit [s]system [←/→]body [+/-]zoom [f/F]focus [g]sys [n]node [N]clr [m]burn [i]info [?]help [.,]warp [0]pause",
+		"[q]quit [s]system [←/→]body [+/-]zoom [f/F]focus [g]sys [n]node [N]clr [P]plant [m]burn [i]info [?]help [.,]warp [0]pause",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)
@@ -150,20 +150,38 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 	if len(w.Nodes) == 0 || w.Craft == nil {
 		return
 	}
+	homeID := w.Craft.Primary.ID
 	for _, n := range w.Nodes {
-		v.plotCluster(w.NodeInertialPosition(n), 6)
+		// Frame-distinct cluster size: home-frame nodes get a tight cross,
+		// foreign-frame (heliocentric or destination-SOI) get a larger
+		// one so the player can see at a glance which leg is which on
+		// auto-planted transfers.
+		size := 6
+		if n.PrimaryID != "" && n.PrimaryID != homeID {
+			size = 10
+		}
+		v.plotCluster(w.NodeInertialPosition(n), size)
 	}
 
 	first := w.Nodes[0]
-	post := w.PostBurnState(first)
+	post, postPrimaryID := w.PostBurnState(first)
+	// Use the mu of whichever primary the post-burn state is expressed in
+	// — usually craft's current primary (departure node), but may differ
+	// for nodes planted in a foreign frame (auto-plant arrival).
 	mu := w.Craft.Primary.GravitationalParameter()
+	if postPrimaryID != w.Craft.Primary.ID {
+		// Post-burn frame differs from the craft's home; PredictedSegments
+		// is not yet parameterised on start-frame, so skip the trajectory
+		// preview rather than render a wrong one. Glyphs (drawn above)
+		// still mark where the burn fires.
+		return
+	}
 	horizon := postBurnHorizon(post, mu)
 	if horizon <= 0 {
 		return
 	}
 
 	segments := w.PredictedSegments(post, horizon, 96)
-	homeID := w.Craft.Primary.ID
 	for _, seg := range segments {
 		stride := 2
 		if seg.PrimaryID != homeID {


### PR DESCRIPTION
## Summary

Closes the originally-intended *select target → press one key → arrive* user story. Departure burn fires geocentrically at parking-orbit periapsis; SOI-aware predictor (v0.3.0) carries the trajectory through Earth escape into heliocentric; arrival burn fires in the destination's frame.

- **planner/departure.go** — `EscapeBurnDeltaV` / `CaptureBurnDeltaV` patched-conic identity (heliocentric v∞ → parking-orbit Δv).
- **planner/transfer.go** — `PlanHohmannTransfer` builds a `TransferPlan` (two `TransferNode`s tagged with their planning frame).
- **sim** — `ManeuverNode.PrimaryID` + `ActiveBurn.PrimaryID` (empty = legacy backward-compat); `World.PlanTransfer(targetIdx)` adapter; `propagateCraftWithPrimary` returns (state, primary) so post-escape callers translate state.R against the *owning* primary.
- **tui** — `P` keybind → `world.PlanTransfer(selectedBody)`; orbit-view footer + frame-aware node glyph size.
- **README** — rewritten for v0.3.1 state per project doc-bundling rule. Quick tour, restructured keybindings, version-block features list through v0.3.1.

## Test plan

- [x] `go test ./...` clean (10 files changed, +727/−73 incl. README)
- [x] `go vet ./...` clean
- [x] Departure helper: parabolic escape edge case + +v∞ Earth→Mars within 1% of textbook
- [x] Transfer plan: Earth→Mars Δv budget within 5% of Curtis Example 8.3 (departure ~3.61 km/s, arrival ~2.09 km/s); inbound retrograde flip; degenerate-input rejection
- [x] sim adapter: `PlanTransfer` plants 2 nodes with matching PrimaryIDs and time gap = TransferDt; rejects bad targets without planting
- [x] All v0.3.0 + v0.2.1 tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)