### PR TITLE
fix: finite-default burns + equatorial elements + directional vessel (v0.3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.3.3**.
+Latest release: **v0.3.4**.
 
 ```bash
 # Linux x86_64
@@ -115,6 +115,25 @@ mass loss tracked from the rocket equation.
 A duration of `0` plants an impulsive burn (instant Δv). A non-zero
 duration starts a finite burn that runs for up to that many seconds, or
 until the requested Δv is delivered, whichever first.
+
+## Features (v0.3.4)
+
+- **Finite burns by default for planted nodes.** Both `P` (auto-plant
+  Hohmann) and `n` (default-node) now set `Duration = Δv × mass /
+  thrust` so the burn runs through the RK4+mass-flow integrator that
+  landed in v0.2.1 — no more "burn appears instantaneous" surprise.
+  Manual entry in the maneuver planner still accepts `duration = 0`
+  for impulsive testing.
+- **Equatorial orbit rendering fix.** `ElementsFromState` now computes
+  argument of periapsis directly from the eccentricity-vector angle
+  (`atan2(eVec.Y, eVec.X)`) when the node vector is degenerate
+  (equatorial orbit, `i ≈ 0`). Before the fix, post-burn periapsis
+  rotation wasn't reflected in the rendered ellipse because ω stayed
+  pinned at 0 for all equatorial orbits.
+- **Directional vessel glyph.** The spacecraft now renders as a
+  chevron (">"-style arrow) rotated into its velocity direction
+  rather than an 8-dot cross. Reads as "I'm going this way" at a
+  glance without having to parse the orbit curve.
 
 ## Features (v0.3.3)
 

--- a/internal/orbital/elements_test.go
+++ b/internal/orbital/elements_test.go
@@ -52,6 +52,39 @@ func TestElementsFromStateEllipticalApoPeri(t *testing.T) {
 	}
 }
 
+// TestElementsEquatorialArgPeriapsis: equatorial elliptical orbit with
+// periapsis rotated to the +Y direction (ω = π/2 when Ω = 0). Pre-
+// v0.3.4 the node vector degenerated at i≈0 and ω stayed at 0,
+// freezing the rendered orbit at the initial-state orientation after
+// a burn rotated the real periapsis.
+func TestElementsEquatorialArgPeriapsis(t *testing.T) {
+	mu := 3.986e14
+	rPeri := 7e6
+	rApo := 4.2e7
+	aWant := (rPeri + rApo) / 2
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/aWant))
+
+	// Start at +Y periapsis with retrograde-prograde tangent. Velocity
+	// at periapsis is perpendicular to r; for +Y periapsis the
+	// prograde tangent in the equatorial plane is -X (so h_z > 0).
+	el := ElementsFromState(
+		Vec3{Y: rPeri},
+		Vec3{X: -vPeri},
+		mu,
+	)
+
+	wantArg := math.Pi / 2
+	if d := math.Abs(el.Arg - wantArg); d > 1e-9 {
+		t.Errorf("equatorial ω = %.6f rad, want %.6f rad", el.Arg, wantArg)
+	}
+
+	// And the rendered periapsis position should land at +Y, not +X.
+	peri := PositionAtTrueAnomaly(el, 0)
+	if math.Abs(peri.X) > 1 || math.Abs(peri.Y-rPeri)/rPeri > 1e-6 {
+		t.Errorf("equatorial periapsis rendered at %+v, want ~(0, %g, 0)", peri, rPeri)
+	}
+}
+
 // TestInclinedOrbit: 30° inclination, circular, should produce i=30° and e≈0.
 func TestInclinedOrbit(t *testing.T) {
 	mu := 3.986e14

--- a/internal/orbital/kepler.go
+++ b/internal/orbital/kepler.go
@@ -126,7 +126,8 @@ func ElementsFromState(r, v Vec3, mu float64) Elements {
 
 	// Argument of periapsis ω.
 	var argp float64
-	if nMag > 0 && eMag > 0 {
+	switch {
+	case nMag > 0 && eMag > 0:
 		dot := (n.X*eVec.X + n.Y*eVec.Y + n.Z*eVec.Z) / (nMag * eMag)
 		if dot > 1 {
 			dot = 1
@@ -135,6 +136,19 @@ func ElementsFromState(r, v Vec3, mu float64) Elements {
 		}
 		argp = math.Acos(dot)
 		if eVec.Z < 0 {
+			argp = 2*math.Pi - argp
+		}
+	case eMag > 0:
+		// Equatorial orbit — node vector is degenerate. Take the
+		// "longitude of periapsis" straight from the eccentricity
+		// vector's angle in the equatorial plane. Retrograde (i ≈ π)
+		// flips the sign so +Y periapsis renders the same way in
+		// perifocal-to-inertial composition.
+		argp = math.Atan2(eVec.Y, eVec.X)
+		if argp < 0 {
+			argp += 2 * math.Pi
+		}
+		if hMag > 0 && h.Z < 0 {
 			argp = 2*math.Pi - argp
 		}
 	}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -105,8 +105,10 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 	}
 
 	now := w.Clock.SimTime
-	w.PlanNode(transferNodeToManeuver(plan.Departure, now))
-	w.PlanNode(transferNodeToManeuver(plan.Arrival, now))
+	mass := w.Craft.TotalMass()
+	thrust := w.Craft.Thrust
+	w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
+	w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
 	return &plan, nil
 }
 
@@ -168,15 +170,26 @@ func (w *World) bodyEphemeris(b bodies.CelestialBody) planner.EphemerisFn {
 	}
 }
 
-func transferNodeToManeuver(tn planner.TransferNode, now time.Time) ManeuverNode {
+// transferNodeToManeuver converts a planner.TransferNode into a
+// sim.ManeuverNode, adding a realistic burn duration based on the
+// craft's thrust and current mass (Δt = Δv · m / F). If thrust is
+// zero or inputs are degenerate the node stays impulsive (Duration=0),
+// matching the legacy behavior.
+func transferNodeToManeuver(tn planner.TransferNode, now time.Time, mass, thrust float64) ManeuverNode {
 	mode := spacecraft.BurnPrograde
 	if tn.IsRetrograde {
 		mode = spacecraft.BurnRetrograde
+	}
+	var duration time.Duration
+	if thrust > 0 && mass > 0 && tn.DV > 0 {
+		secs := tn.DV * mass / thrust
+		duration = time.Duration(secs * float64(time.Second))
 	}
 	return ManeuverNode{
 		TriggerTime: now.Add(tn.OffsetTime),
 		Mode:        mode,
 		DV:          tn.DV,
+		Duration:    duration,
 		PrimaryID:   tn.PrimaryID,
 	}
 }

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -269,6 +269,36 @@ func TestPlanTransferLandsTwoNodes(t *testing.T) {
 	}
 }
 
+// TestPlanTransferPlantsFiniteBurns: as of v0.3.4, auto-plant produces
+// finite burns sized from craft thrust + mass (Duration > 0). An all-
+// impulsive plant would feel instant to the player, defeating the
+// finite-burn machinery that v0.2.1 introduced.
+func TestPlanTransferPlantsFiniteBurns(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	marsIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Mars" {
+			marsIdx = i
+			break
+		}
+	}
+	if marsIdx < 0 {
+		t.Skip("Mars not in loaded Sol system")
+	}
+	if _, err := w.PlanTransfer(marsIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if len(w.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(w.Nodes))
+	}
+	for i, n := range w.Nodes {
+		if n.Duration <= 0 {
+			t.Errorf("node %d Duration = %v, want > 0 (finite burn)", i, n.Duration)
+		}
+	}
+}
+
 // TestPlanTransferRejectsBadTargets: invalid index / system-primary /
 // out-of-range targets surface as errors without planting.
 func TestPlanTransferRejectsBadTargets(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -203,10 +203,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.PlanNode):
 			if a.world.CraftVisibleHere() {
+				const defaultDV = 50.0
+				dur := finiteBurnDuration(defaultDV, a.world.Craft.TotalMass(), a.world.Craft.Thrust)
 				a.world.PlanNode(sim.ManeuverNode{
 					TriggerTime: a.world.Clock.SimTime.Add(5 * time.Minute),
 					Mode:        spacecraft.BurnPrograde,
-					DV:          50,
+					DV:          defaultDV,
+					Duration:    dur,
 				})
 			}
 			return a, nil
@@ -232,6 +235,21 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return a, nil
+}
+
+// finiteBurnDuration returns the sim-time duration needed to deliver dv
+// at the given mass and engine thrust: Δt = dv × m / F. Zero (impulsive
+// fallback) when thrust is zero or the inputs are otherwise degenerate;
+// callers set that on ManeuverNode.Duration to opt out of the finite-
+// burn integrator branch. Uses mass at plant time — the integrator
+// tracks real mass loss once the burn starts, so this is only a
+// starting-point budget.
+func finiteBurnDuration(dv, mass, thrust float64) time.Duration {
+	if thrust <= 0 || mass <= 0 || dv <= 0 {
+		return 0
+	}
+	secs := dv * mass / thrust
+	return time.Duration(secs * float64(time.Second))
 }
 
 // View delegates to the active screen.

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -120,7 +120,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		if el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
 			v.canvas.DrawEllipseOffsetDotted(el, w.BodyPosition(c.Primary), 360, 3)
 		}
-		v.plotCluster(w.CraftInertial(), 8)
+		// Directional vessel glyph — chevron rotated into the craft's
+		// velocity frame so the player reads "which way am I going"
+		// without staring at raw r, v numbers.
+		v.canvas.PlotArrow(w.CraftInertial(), c.State.V, 5)
 	}
 
 	// Planned maneuver nodes — cluster glyph at each node's inertial

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -169,6 +169,50 @@ func (c *Canvas) RingOutline(center orbital.Vec3, pxRadius int) {
 	}
 }
 
+// PlotArrow draws a chevron-style arrow (">") at a world point, rotated
+// so the tip points in the direction of the supplied velocity vector.
+// The arrow's body is two diagonal "wings" meeting at the forward tip;
+// no filled stem, so the shape reads as a directional glyph without
+// overwhelming the rest of the canvas. `size` is the half-length in
+// pixels (total arrow width is roughly 2×size). Velocity magnitude is
+// irrelevant — only the direction is used.
+func (c *Canvas) PlotArrow(center, velocity orbital.Vec3, size int) {
+	vMag := velocity.Norm()
+	if vMag == 0 || size < 1 {
+		return
+	}
+	const cos45 = 0.7071067811865476
+	dx := velocity.X / vMag
+	dy := -velocity.Y / vMag // screen Y flipped
+	bx, by := -dx, -dy       // back-pointing unit
+	// Left wing direction: rotate back-unit by +45°.
+	lx := cos45 * (bx - by)
+	ly := cos45 * (bx + by)
+	// Right wing direction: rotate back-unit by -45°.
+	rx := cos45 * (bx + by)
+	ry := cos45 * (-bx + by)
+
+	cx, cy, _ := c.Project(center)
+	tipX := cx + int(math.Round(dx*float64(size)))
+	tipY := cy + int(math.Round(dy*float64(size)))
+	wingLen := int(float64(size) * 1.2)
+	if wingLen < 1 {
+		wingLen = 1
+	}
+	for t := 0; t <= wingLen; t++ {
+		plx := tipX + int(math.Round(lx*float64(t)))
+		ply := tipY + int(math.Round(ly*float64(t)))
+		if plx >= 0 && plx < c.pxW && ply >= 0 && ply < c.pxH {
+			c.dc.Set(plx, ply)
+		}
+		prx := tipX + int(math.Round(rx*float64(t)))
+		pry := tipY + int(math.Round(ry*float64(t)))
+		if prx >= 0 && prx < c.pxW && pry >= 0 && pry < c.pxH {
+			c.dc.Set(prx, pry)
+		}
+	}
+}
+
 // DrawEllipseDotted traces an ellipse defined by orbital elements. Dotted:
 // every `stride`th sample is plotted. stride=1 gives a solid curve.
 // Points are assumed to live in the system primary's inertial frame

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -109,6 +109,26 @@ func TestDrawEllipseOffsetDottedTranslates(t *testing.T) {
 // as empty. drawille writes U+2800 for rows with no dots set; ignoring
 // it lets tests assert "nothing plotted" without caring about the
 // encoding.
+// TestPlotArrowProducesNonEmptyRender: the chevron glyph should paint
+// some pixels for any non-zero velocity. Zero velocity is a no-op
+// (direction is undefined) and must not panic.
+func TestPlotArrowProducesNonEmptyRender(t *testing.T) {
+	c := NewCanvas(20, 10)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	c.PlotArrow(orbital.Vec3{}, orbital.Vec3{X: 1}, 4)
+	if onlyWhitespace(c.String()) {
+		t.Error("PlotArrow in +X direction rendered empty canvas")
+	}
+	// Zero velocity must not panic and must leave the canvas untouched.
+	c.Clear()
+	c.PlotArrow(orbital.Vec3{}, orbital.Vec3{}, 4)
+	if !onlyWhitespace(c.String()) {
+		t.Error("PlotArrow with zero velocity plotted pixels")
+	}
+}
+
 func onlyWhitespace(s string) bool {
 	for _, r := range s {
 		if r != ' ' && r != '\n' && r != '\t' && r != '⠀' {


### PR DESCRIPTION
## Summary

Three fixes from jason's v0.3.3 test feedback, bundled because they're all in the "orbital-view UX feels wrong" cluster.

1. **Finite burns by default**. `P` and `n` now plant finite burns sized from current thrust and mass (`Δt = Δv × m / F`). At 1 kN / 1 t, 50 m/s = 50 s (n), 3.6 km/s ≈ 1 hr (P Mars departure). Manual planner `duration=0` still works for impulsive testing.
2. **Equatorial orbit argument-of-periapsis**. When the node vector degenerates (`nMag ≈ 0`), compute ω from `atan2(eVec.Y, eVec.X)` directly. Pre-fix the rendered ellipse pinned at 0 for all equatorial orbits, so post-burn periapsis rotation didn't show up on screen.
3. **Directional vessel glyph**. Chevron rotated into the craft's velocity frame replaces the 8-dot cross. New `widgets.Canvas.PlotArrow(center, velocity, size)` primitive.

## Test plan

- [x] `go test ./...` clean (9 files, +201/−7)
- [x] `go vet ./...` clean
- [x] Equatorial orbit with periapsis at +Y: `ElementsFromState` yields `ω = π/2`, `PositionAtTrueAnomaly(el, 0) ≈ (0, rPeri, 0)`
- [x] `PlanTransfer` now plants `Duration > 0` on both legs
- [x] `PlotArrow` non-empty for non-zero velocity, no-op (and no panic) for zero
- [x] All v0.3.3 + earlier tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)