### PR TITLE
tune: thrust + apo/peri markers + n default (v0.3.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.3.4**.
+Latest release: **v0.3.5**.
 
 ```bash
 # Linux x86_64
@@ -115,6 +115,20 @@ mass loss tracked from the rocket equation.
 A duration of `0` plants an impulsive burn (instant Δv). A non-zero
 duration starts a finite burn that runs for up to that many seconds, or
 until the requested Δv is delivered, whichever first.
+
+## Features (v0.3.5)
+
+- **Punchier default engine.** `Thrust` on `NewInLEO` bumped from 1 kN
+  to 10 kN. 200 m/s `n` burn now takes 20 s sim-time instead of 200 s;
+  3.6 km/s Mars departure ≈ 6 min sim-time instead of 1 hr.
+- **Apoapsis / periapsis markers.** The orbit renderer now plants two
+  filled disks on the current orbit — larger disk at apoapsis (ν=π),
+  smaller at periapsis (ν=0). Low-eccentricity orbits (e < 0.1) are
+  near-circular in *shape* even when the apo/peri altitudes differ by
+  hundreds of km; the markers show the two extremes at a glance
+  without requiring the player to read altitudes off the HUD.
+- **`n` default Δv** bumped 50 → 200 m/s so a single press produces a
+  visibly-offset orbit (e ≈ 0.05) at default FocusCraft zoom.
 
 ## Features (v0.3.4)
 

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -52,7 +52,7 @@ func NewInLEO(earth bodies.CelestialBody) *Spacecraft {
 		DryMass: 500,
 		Fuel:    500,
 		Isp:     300,
-		Thrust:  1000, // 1 kN — small enough that finite effects show up at realistic Δv
+		Thrust:  10000, // 10 kN — burns finish in seconds-to-minutes for sub-km/s Δv, ~minutes for km/s transfers
 		Primary: earth,
 		State: physics.StateVector{
 			R: orbital.Vec3{X: r},

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -89,14 +89,14 @@ func TestRemainingDeltaV(t *testing.T) {
 	}
 }
 
-// TestMassFlowRate: at default Thrust=1000 N, Isp=300 s,
-// ṁ = 1000 / (300 · 9.80665) ≈ 0.340 kg/s.
+// TestMassFlowRate: at default Thrust=10000 N, Isp=300 s,
+// ṁ = 10000 / (300 · 9.80665) ≈ 3.399 kg/s.
 func TestMassFlowRate(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	earth := systems[0].FindBody("Earth")
 	sc := NewInLEO(*earth)
 	got := sc.MassFlowRate()
-	want := 1000.0 / (300.0 * 9.80665)
+	want := 10000.0 / (300.0 * 9.80665)
 	if math.Abs(got-want) > 1e-6 {
 		t.Errorf("MassFlowRate = %.6f, want %.6f", got, want)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -203,7 +203,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.PlanNode):
 			if a.world.CraftVisibleHere() {
-				const defaultDV = 50.0
+				const defaultDV = 200.0
 				dur := finiteBurnDuration(defaultDV, a.world.Craft.TotalMass(), a.world.Craft.Thrust)
 				a.world.PlanNode(sim.ManeuverNode{
 					TriggerTime: a.world.Clock.SimTime.Add(5 * time.Minute),

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -45,7 +45,7 @@ func DefaultKeymap() Keymap {
 		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
 		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
 		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
-		PlanNode:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "plan node (T+5m prograde 50m/s)")),
+		PlanNode:     key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "plan node (T+5m prograde 200m/s)")),
 		ClearNodes:   key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "clear nodes")),
 		PlanTransfer: key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "plant Hohmann transfer to selected body")),
 		Porkchop:     key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "porkchop plot for selected body")),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -117,8 +117,18 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		c := w.Craft
 		muCraft := c.Primary.GravitationalParameter()
 		el := orbital.ElementsFromState(c.State.R, c.State.V, muCraft)
+		primaryPos := w.BodyPosition(c.Primary)
 		if el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
-			v.canvas.DrawEllipseOffsetDotted(el, w.BodyPosition(c.Primary), 360, 3)
+			v.canvas.DrawEllipseOffsetDotted(el, primaryPos, 360, 3)
+			// Apoapsis / periapsis markers — render even for low-e
+			// orbits so the player sees WHERE the two extremes are
+			// when the ellipse shape alone is near-circular. Apoapsis
+			// gets a larger disk, periapsis smaller; distinct sizes
+			// read at a glance.
+			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
+			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
+			v.canvas.FillDisk(peri, 2)
+			v.canvas.FillDisk(apo, 3)
 		}
 		// Directional vessel glyph — chevron rotated into the craft's
 		// velocity frame so the player reads "which way am I going"


### PR DESCRIPTION
## Summary

Game-feel tuning from jason's v0.3.4 test feedback:

1. **Thrust 1 kN → 10 kN.** 3.6 km/s Mars departure now 6 min sim-time instead of 1 hr.
2. **Apo/peri markers** on the orbit canvas — low-e orbits (e ≈ 0.05) are near-circular in shape even when apo/peri altitudes differ by hundreds of km; markers at the two extremes read at a glance.
3. **`n` default Δv** 50 → 200 m/s. At the new thrust, 200 m/s is a 5 s burn yielding e ≈ 0.05 — visibly offset once markers are in place.

## Test plan

- [x] `go test ./...` clean (6 files, +32/−8)
- [x] `go vet ./...` clean
- [x] `TestMassFlowRate` updated for 10 kN expected ṁ

🤖 Generated with [Claude Code](https://claude.com/claude-code)