### PR TITLE
fix: adaptive body sizing + peri-below-surface warning (v0.3.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.3.5**.
+Latest release: **v0.3.6**.
 
 ```bash
 # Linux x86_64
@@ -115,6 +115,21 @@ mass loss tracked from the rocket equation.
 A duration of `0` plants an impulsive burn (instant Δv). A non-zero
 duration starts a finite burn that runs for up to that many seconds, or
 until the requested Δv is delivered, whichever first.
+
+## Features (v0.3.6)
+
+- **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
+  scale rendering when the body's projected radius would be ≥ 4 px,
+  capped at 64 px so the Sun can't fill the canvas at extreme zoom.
+  Below the threshold it falls back to the existing tier buckets so
+  bodies stay visible at system-wide zoom (where true scale would be
+  sub-pixel). Practical effect: Earth fills its real radius on
+  FocusCraft, so a periapsis marker inside the rendered disk reads
+  visually as "you're going to hit the surface" — pre-fix, the 2 px
+  tier disk hid sub-orbital periapsis behind a token glyph.
+- **Periapsis-below-surface warning.** VESSEL HUD block renders
+  `PERIAPSIS BELOW SURFACE` in the Alert style whenever the craft's
+  computed periapsis altitude goes negative, regardless of zoom level.
 
 ## Features (v0.3.5)
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -93,10 +93,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// Plot each body at its perceived-size disk. System primary (index 0)
 	// gets a hollow ring + filled center to distinguish it from planets.
 	// See BodyPixelRadius for the size-tier logic.
+	scale := v.canvas.Scale()
 	for i := range sys.Bodies {
 		b := sys.Bodies[i]
 		pos := w.BodyPosition(b)
-		r := BodyPixelRadius(b, i == 0)
+		r := BodyPixelRadius(b, i == 0, scale)
 		if i == 0 {
 			v.canvas.RingOutline(pos, r)
 			v.canvas.FillDisk(pos, 1)
@@ -160,15 +161,34 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	return title + "\n" + body + "\n" + footer
 }
 
-// BodyPixelRadius returns the perceived-size pixel radius for a body on
-// the orbit canvas, bucketed by physical radius rather than projected
-// to true scale — even the Sun is a sub-pixel speck at Sol-wide zoom.
-// Size tiers keep the visual hierarchy readable: star > gas giant >
-// terrestrial > small body. The `isPrimary` flag is advisory (the
-// caller decides how to render; today that's a hollow ring for the
-// primary vs a filled disk for everything else).
-func BodyPixelRadius(b bodies.CelestialBody, isPrimary bool) int {
+// BodyPixelRadius returns the body's render radius in pixels. When the
+// canvas is zoomed in enough that the body's true radius projects to
+// at least trueSizeThreshold pixels, render at true size — so the
+// rendered disk represents real surface, and a periapsis marker
+// inside it visually reads as a collision. When zoomed out, fall back
+// to a tier bucket so the body stays visible (true would be sub-pixel
+// at system-wide zoom).
+//
+// Pass scale=0 to force the tier-bucket path (used when projection
+// metadata isn't available).
+//
+// The `isPrimary` flag promotes a small body to star tier in the
+// fallback path so the system primary always renders bigger than its
+// planets even when its physical radius wouldn't otherwise put it
+// there.
+func BodyPixelRadius(b bodies.CelestialBody, isPrimary bool, scale float64) int {
+	const trueSizeThreshold = 4
+	const trueSizeCap = 64 // keep the Sun from filling the canvas at extreme zoom-in
 	r := b.RadiusMeters()
+	if scale > 0 && r > 0 {
+		truePx := int(math.Round(r * scale))
+		if truePx >= trueSizeThreshold {
+			if truePx > trueSizeCap {
+				truePx = trueSizeCap
+			}
+			return truePx
+		}
+	}
 	switch {
 	case isPrimary, r >= 1e8: // star-class
 		return 6
@@ -309,6 +329,11 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  apoapsis:  %.1f km", apoAlt/1000),
 			fmt.Sprintf("  periapsis: %.1f km", periAlt/1000),
 			fmt.Sprintf("  inclin.:   %.2f°", incDeg),
+		)
+		if periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
+			lines = append(lines, "  "+v.theme.Alert.Render("PERIAPSIS BELOW SURFACE"))
+		}
+		lines = append(lines,
 			"",
 			v.theme.Primary.Render("PROPELLANT"),
 			fmt.Sprintf("  fuel:      %.0f kg", c.Fuel),

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -62,7 +62,7 @@ func TestBodyPixelRadiusMonotonic(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			b := bodies.CelestialBody{MeanRadius: c.radius / 1000} // Radius field is in km
-			got := BodyPixelRadius(b, false)
+			got := BodyPixelRadius(b, false, 0)                   // scale=0 → tier path
 			if got != c.want {
 				t.Errorf("got pxRadius=%d, want %d (radius %.0f km)",
 					got, c.want, c.radius/1000)
@@ -76,13 +76,37 @@ func TestBodyPixelRadiusMonotonic(t *testing.T) {
 	}
 }
 
+// TestBodyPixelRadiusAdaptive: when scale × radius produces ≥ 4 px,
+// the function switches to true-size rendering (so a periapsis marker
+// inside the rendered Earth disk reads as a surface collision instead
+// of being hidden by tier bucketing).
+func TestBodyPixelRadiusAdaptive(t *testing.T) {
+	earth := bodies.CelestialBody{MeanRadius: 6378} // km
+
+	// Sol-wide zoom: 6378 km × ~1e-12 px/m → way below threshold,
+	// stays at terrestrial tier (2 px).
+	if got := BodyPixelRadius(earth, false, 1e-12); got != 2 {
+		t.Errorf("system zoom: got %d px, want 2 (tier)", got)
+	}
+	// FocusCraft-style zoom: scale ~2e-6 px/m → 6.378e6 m × 2e-6 ≈
+	// 13 px, well past the 4 px threshold. Should render true.
+	if got := BodyPixelRadius(earth, false, 2e-6); got < 8 {
+		t.Errorf("close zoom: got %d px, want true-size ≥ 8", got)
+	}
+	// Extreme zoom-in shouldn't blow past the cap (64 px) and let
+	// Earth fill the entire canvas.
+	if got := BodyPixelRadius(earth, false, 1); got != 64 {
+		t.Errorf("absurd zoom: got %d px, want capped at 64", got)
+	}
+}
+
 // TestBodyPixelRadiusPrimaryFlag: even a sub-star-sized body rendered
 // as system primary gets the star tier so the rendering distinguishes
 // it from planets.
 func TestBodyPixelRadiusPrimaryFlag(t *testing.T) {
 	small := bodies.CelestialBody{MeanRadius: 1000} // 1000 km = terrestrial
-	nonPrim := BodyPixelRadius(small, false)
-	prim := BodyPixelRadius(small, true)
+	nonPrim := BodyPixelRadius(small, false, 0)
+	prim := BodyPixelRadius(small, true, 0)
 	if prim <= nonPrim {
 		t.Errorf("primary flag should promote size: non-primary=%d primary=%d",
 			nonPrim, prim)


### PR DESCRIPTION
## Summary

A periapsis altitude of −932 km is meaningless if the rendered Earth disk doesn't show the orbit cutting through the surface. Pre-v0.3.6 every body rendered at a fixed perceived-size tier regardless of zoom; on FocusCraft the canvas has plenty of resolution to show Earth at real scale.

- `BodyPixelRadius` now switches to true-scale rendering when `radius × scale ≥ 4 px`, capped at 64 px. Tier fallback below the threshold so system-wide zoom doesn't lose bodies to sub-pixel rendering.
- VESSEL HUD adds `PERIAPSIS BELOW SURFACE` Alert line whenever computed periapsis altitude < 0 — visible regardless of zoom level.

## Test plan

- [x] `go test ./...` clean (3 files, +77/−13)
- [x] `go vet ./...` clean
- [x] BodyPixelRadius adaptive switch tested across system / close / extreme-zoom
- [x] Existing tier-bucket tests still pass with new `scale` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)