### PR TITLE
feat(save): v0.4.0 save/load with versioned envelope

### DIFF
--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,0 +1,413 @@
+# terminal-space-program — state of game
+
+*Snapshot at v0.3.6 (April 2026). Updated at each minor / patch boundary.*
+
+`docs/plan.md` is the original architecture / phase plan. This doc complements it
+with a "what plays today, what's queued next" view organised around player-facing
+features and the version sequence that delivers them.
+
+---
+
+## 1. What works today (v0.3.6)
+
+### Physics
+- Two-body patched-conic propagation with **SOI-aware** state transitions.
+  Crossing a sphere of influence (outward or inward) rebases the state into the
+  new primary's frame and switches μ for subsequent steps.
+- Symplectic **Verlet** integrator for free flight (energy-conserving within
+  ~1e-7 % over 1000 orbits at LEO).
+- **RK4** integrator on the active-burn path so non-conservative thrust forces
+  integrate cleanly. Verlet stays on the inactive-burn path.
+- **Stumpff-universal-variables Lambert solver** (Curtis Algorithm 5.2). Single-
+  rev plus multi-rev branches — `LambertSolveRev(..., nRev)`. Single branch
+  per N (lower-z side of the minimum-energy critical point).
+- **Hohmann transfer** math: classical two-impulse for circular-to-circular.
+- **Patched-conic v∞ → Δv** identity for departure / capture burns.
+- **Time warp** clamps to ≤10× during an active burn so the integrator never
+  outruns the burn window's temporal resolution. Outside burns the clamp is
+  the (1024 sub-steps × period/100) / base-step guard from v0.1.
+
+### Spacecraft & burns
+- **Finite-duration burns**. `Spacecraft.Thrust = 10 kN` default; a node's
+  `Duration` field controls integration. Mass flow `dm/dt = -Thrust/(Isp·g0)`
+  debits fuel each sub-step; burn ends on Δv delivered, fuel exhausted, or
+  duration elapsed (whichever first).
+- **Six burn modes**: prograde, retrograde, normal±, radial±. Direction is
+  recomputed each sub-step from live (r, v) so held-prograde follows the
+  rotating velocity frame.
+- Default vessel: 500 kg dry + 500 kg fuel, Isp 300 s, Thrust 10 kN, spawned
+  in 200 km LEO.
+
+### Planning
+- **Manual planner** (`m`): three-field form (mode / Δv / duration). `Tab`
+  cycles fields, `←/→` cycles modes when mode field is focused, Δv > budget
+  warns, duration 0 = impulsive, > 0 = finite.
+- **`n` quick-plant**: T+5 min prograde 200 m/s, finite (sized to thrust).
+- **`P` auto-plant Hohmann transfer**: select target body, one keystroke
+  plants two finite nodes (geocentric departure + destination-frame arrival)
+  with `Duration = Δv × mass / thrust`. Frame-aware via `ManeuverNode.PrimaryID`.
+- **`k` porkchop plot**: ASCII heatmap over departure-day × time-of-flight,
+  intensity ramp `█▓▒░ ` cheap → expensive. Cursor navigates cells, snaps to
+  min-Δv on open. Read-only — no plant from cursor yet (deferred).
+
+### Rendering (orbit canvas)
+- **Adaptive body sizing**: bodies render at true scale when `radius × scale
+  ≥ 4 px`, capped at 64 px; otherwise tier buckets (1 small / 2 terrestrial
+  / 4 gas giant / 6 star). System primary is a hollow ring + filled center
+  to distinguish from planets.
+- **Vessel orbit ellipse**: live Keplerian orbit drawn dotted (stride 3) in
+  the craft's primary frame, translated into the system frame for cross-frame
+  rendering. Hyperbolic / degenerate orbits skipped (the SOI-segmented
+  trajectory preview covers those).
+- **Apo / peri markers**: filled disks at ν=0 (peri, 2 px) and ν=π (apo, 3
+  px) so low-eccentricity orbits — visually near-circular — still show their
+  two extremes at a glance.
+- **Vessel arrow glyph**: chevron rotated into the velocity direction.
+- **SOI-segmented trajectory preview**: post-burn trajectory partitioned by
+  the dominant primary at each sample. Inside-home-SOI uses stride-2 dashed,
+  foreign SOI uses stride-1 solid. Continuity fixed at boundary crossings.
+- **Camera focus** (`f`/`F`/`g`): cycles system-wide / each body / craft.
+  FocusCraft auto-fits to ~3× current altitude.
+
+### HUD
+- Clock + warp + paused indicator.
+- Vessel block: name, primary, altitude, velocity, apoapsis, periapsis,
+  inclination, plus **PERIAPSIS BELOW SURFACE** alert when periapsis altitude
+  goes negative.
+- Propellant: fuel, total mass, Δv budget remaining (rocket equation).
+- Active-burn block (when in flight): mode, Δv-to-go, T-remaining.
+- Planned nodes: list with mode / Δv / time-to-fire / impulsive vs finite tag.
+- Selected body: name, type, semimajor axis, eccentricity, period, plus
+  Hohmann preview when applicable.
+
+### Systems loaded
+- **Sol** (playable — craft spawns here).
+- **Alpha Centauri**, **TRAPPIST-1**, **Kepler-452** (viewable; craft does
+  not yet move between systems).
+
+### Distribution
+- **GoReleaser** matrix: linux + darwin amd64/arm64, windows amd64.
+- `CGO_ENABLED=0`, `-ldflags "-s -w"` static binaries.
+- CI: `go test ./...` on every PR.
+
+---
+
+## 2. Backlog
+
+### From v0.3 testing — small polish items
+- **Lambert multi-branch selection**. Today the multi-rev path returns the
+  first root the bracket finds (lower-z side); a per-N "cheap" / "long" flag
+  would expose both. Useful when porkchop multi-rev lands.
+- **Enter-to-plant from porkchop cursor**. Reuses `World.PlanTransfer` once
+  it accepts explicit (departure offset, TOF) params. Slated for v0.4.1.
+- **Explicit retrograde flag for `LambertSolve`**. Today direction is driven
+  by the bracket starting point; a caller hint would be cleaner.
+
+### Larger queued features
+- **Save / load** (v0.4.0 target). No state persistence today — close the
+  program and your orbit is gone. JSON state file at
+  `$XDG_STATE_HOME/terminal-space-program/save.json`, manual `S` / `L`, autosave on quit.
+- **Mid-course corrections** (v0.4.1 target). Auto-plant produces a single
+  two-impulse plan; no replanning during the coast. A "refine arrival"
+  key re-runs Lambert from the live state and updates the planted arrival
+  node; paired with porkchop Enter-to-plant so the cursor can feed the
+  same path.
+- **Mission system / objectives** (v0.6 target, see §3). Starter objectives
+  such as "achieve a 1000 km circular orbit," "intercept Mars within Δv X."
+- **Burn-at-next scheduler** (v0.6 target). Event-relative maneuver nodes:
+  fire at next periapsis / apoapsis / ascending node / descending node.
+  Foundation for richer triggers (at-SOI-exit, at-fuel<X). v0.6 also
+  extends `PlanTransfer()` to handle Earth → Luna (and any planet → moon)
+  transfers — needs an inter-SOI capture pass that today's shared-primary
+  assumption skips.
+- **Body hierarchy + moons** (v0.5.0 target, see §3). Today's body model
+  is flat star → planet. v0.5.0 adds arbitrary-depth `ParentID` refs,
+  hierarchical SOI lookup, and recursive `BodyPosition()` so Luna,
+  Phobos/Deimos, the Galilean four, Titan, and Enceladus all orbit
+  their planets in a single release.
+- **Multi-system spacecraft**. The craft is currently locked to Sol. Allowing
+  it to enter Alpha Cen / TRAPPIST / Kepler unlocks the system-cycle UX.
+  Requires interstellar transfer math (or deus-ex-machina jump for now).
+- **Inclination-change planner**. Today's burn modes don't expose a clean
+  out-of-plane corrector. Adds a third burn at the line-of-nodes.
+- **N-body perturbations**. The sim is strict patched-conic; Lagrangian
+  points and three-body trajectories aren't representable.
+- **Custom systems via config file**. `bodies/systems.go` is hardcoded; a
+  TOML or JSON loader unlocks modding.
+- **Mission editor / scripting** (long-tail). Once basic missions exist,
+  expose a config format so users can author custom objectives without
+  touching Go.
+- **Optional simple atmospheric drag model** (opt-in, off by default). Toy
+  drag below ~150 km to enable reentry / aerobraking gameplay; patched-conic
+  two-body stays the primary integrator. Previously on "excluded forever",
+  softened here — only *realistic* multi-species drag stays out of scope.
+- **Mouse support** (v0.6 target, see §3). Currently keyboard-only;
+  v0.6 adds click-to-focus on bodies, click-to-plant on porkchop cells,
+  and drag-to-edit on planted maneuver nodes.
+
+### Visual / UX targets
+- **Color** (v0.5 target). The renderer is monochrome. Hardcoded palette
+  first; planets and the sun colored reminiscent of their actual appearance
+  (Sol gold-white, Mars rust, Jupiter banded ochre, Neptune deep blue), with
+  a temperature-based tint for non-Sol stars (TRAPPIST-1 red dwarf, Alpha
+  Cen A yellow). Promoted to user-configurable in v0.7 alongside the
+  systems config-file loader.
+- **Vessel position trail**. A fading dotted history of where the craft has
+  *actually* been, distinct from the current orbit ellipse.
+- **Maneuver node editing**. Nodes are plant-once today; adding drag/scrub
+  on a planted node (adjust Δv, duration, fire-time in place) would make
+  the planner iterative rather than plant-and-replace.
+- **HUD typography polish**. Dense lipgloss panels could read cleaner with
+  better spacing, dividers, alignment.
+- **Body details on the canvas**. Today bodies are filled disks; texture
+  hints (poles, rings for Saturn, day/night terminator for Earth) would add
+  identity.
+- **Better porkchop axis labels**. Current implementation cuts off; needs a
+  proper axis-label renderer.
+- **Active-burn flame animation**. The arrow glyph could pulse / extend
+  while a burn is firing.
+
+### Polish / quality
+- **Race-detector CI**. Currently no `-race` because the local environment
+  doesn't have cgo; CI could enable it with `CGO_ENABLED=1`.
+- **Throttle control**. Engine is on/off — adding a 0–100 % throttle field
+  would make finite burns more flexible.
+- **More integration tests** at the World tick level. Most tests are
+  unit-scale.
+
+---
+
+## 3. Version frame
+
+| Version | Theme | Headline features |
+|---------|-------|-------------------|
+| v0.3.6 ✓ | (current) | Adaptive body sizing, peri-below-surface warning |
+| **v0.4** | **Persistence** | Save / load (v0.4.0); mid-course corrections + porkchop Enter-to-plant (v0.4.1) |
+| **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
+| **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
+| v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |
+| v0.8+ | Open *(speculative)* | N-body, multi-system spacecraft, multi-rev porkchop, mission editor/scripting, optional drag, maneuver node editing, multiplayer implementation |
+
+### v0.4 — save / load + mid-course corrections
+
+The v0.3.x line built up a lot of orbital state — multi-frame nodes, active
+burns, focus / zoom prefs, planted transfers — but a session ends and it all
+evaporates. Adding state persistence is the gap most likely to break "I want
+to come back to this" friction. Missions are deliberately **not** part of
+v0.4; they slip to v0.6 so this release stays narrowly scoped to persistence
+and closing the porkchop / replan loop.
+
+Concrete v0.4 slices:
+
+- **v0.4.0 — save / load.** JSON state file at
+  `$XDG_STATE_HOME/terminal-space-program/save.json`, manual save / load with
+  `S` / `L` keys, autosave on quit. Roundtrip the full `World` (clock, focus,
+  craft, nodes, active burn). Save schema ships the **richer header from
+  day one**: `{"version": 1, "generator": "tsp <semver>", "clock_t0":
+  <unix-nanos>, "body_catalog_hash": "<sha256-of-canonical-bodies>",
+  "payload": {...}}`. `generator` preserves forensics across versions,
+  `clock_t0` separates wall-clock from sim-clock for replay, and
+  `body_catalog_hash` rejects saves built against a stale universe
+  (e.g. after a systems-JSON edit). Reserves the slot for v0.6's
+  `session` block (multiplayer envelope) without a schema bump. About
+  250–350 LOC + tests.
+- **v0.4.1 — mid-course corrections.** Enter-to-plant from porkchop cursor
+  (requires `World.PlanTransfer` to accept explicit departure-offset / TOF
+  params) plus a "refine plan" key that re-runs Lambert from the live
+  state and updates the planted arrival node. Closes the porkchop loop and
+  gives the user a way to correct drift during a coast. About 150–200 LOC
+  + tests.
+
+### v0.5 — moons + visual enhancement
+
+v0.5 leads with an architectural prereq — arbitrary-depth body hierarchy
+so moons can orbit planets — then ships the visual work on top. Because
+the hierarchy work is the expensive part and the moon catalog is mostly
+JSON once it lands, v0.5.0 commits to the full major-moon set in one
+go: Luna, Phobos/Deimos, the Galilean four, Titan, Enceladus. One
+release validates the hierarchy across single-moon (Earth) *and*
+multi-moon (Jupiter, Saturn) primaries, and the visual work in v0.5.1+
+has a full cast to colour.
+
+- **v0.5.0 — body hierarchy + major moons.** Today the body model is
+  flat star → planet (`internal/bodies/body.go:26,39` carry moon
+  *metadata* only, not propagated bodies); `FindPrimary()` in
+  `internal/physics/soi.go:32–58` only computes SOI against
+  `system.Bodies[0]`; `BodyPosition()` in `internal/sim/world.go:90–99`
+  propagates Keplerian elements directly relative to the system primary.
+  v0.5.0 introduces **arbitrary-depth hierarchy via `ParentID`**: add a
+  `ParentID` field to `bodies.Body`, make `BodyPosition()` recursively
+  resolve as `BodyPosition(parent) + propagate(elements, parent.μ)`,
+  and rewrite `FindPrimary()` as a hierarchical walk (craft → check
+  innermost SOI → fall outward). No depth cap in code — two-level is
+  all Sol needs today, but sub-moons / ring shepherds cost nothing to
+  accommodate at the schema layer and match how `FindPrimary()` already
+  wants to recurse. Moon catalog in this release: **Luna + Phobos +
+  Deimos + the four Galilean moons (Io, Europa, Ganymede, Callisto) +
+  Titan + Enceladus**. The data surface is mostly JSON edits once the
+  hierarchy lands; validating across single-moon (Earth) and
+  multi-moon (Jupiter, Saturn) primaries in one release flushes out
+  hierarchy bugs early. Estimated ~8–12 targeted edits on the physics
+  side + ~9 moon entries in `bodies/systems/sol.json`, ~4–6 hours +
+  tests. Transfer planning to/from moons is **not** in v0.5.0 scope —
+  `PlanTransfer()` (`internal/sim/maneuver.go:70–113`) assumes shared
+  primary; Earth → Luna pathing slips to v0.6 alongside the planner UX
+  work, where it composes naturally with the burn-at-next scheduler.
+- **v0.5.1 — color** — source of truth is a checked-in
+  `internal/render/palette.go` constant table keyed by body name/type
+  (plus UI-tier constants for alerts / nodes / trajectory). Faster to
+  ship than threading a `Color` field through `bodies.Body` + every
+  `systems/*.json`; the v0.7 config-file loader will promote the table
+  to per-body JSON fields with a one-shot migration then. Palette:
+  - Alerts red, warnings yellow, planted nodes cyan, trajectory white,
+    foreign-SOI segments magenta (UI/status tier).
+  - Bodies colored reminiscent of their actual appearance: Sol gold-white,
+    Mercury grey, Venus pale yellow, Earth blue/green, Luna pale grey,
+    Mars rust, Phobos / Deimos dark grey, Jupiter banded ochre, Io
+    sulfur yellow, Europa off-white, Ganymede tan, Callisto dark tan,
+    Saturn pale gold, Titan burnt orange, Enceladus bright white,
+    Uranus cyan, Neptune deep blue.
+  - Non-Sol stars: temperature-based tint (TRAPPIST-1 red dwarf deep red,
+    Alpha Cen A yellow, Kepler-452 sun-like gold-white).
+- **v0.5.2 — vessel position trail**. Ring buffer of last N inertial
+  positions; render with fading stride.
+- **v0.5.3 — body identity + HUD polish.** Different glyph density for
+  stars vs gas giants vs terrestrial; rings drawn for ringed bodies
+  (Saturn, eventually); HUD section dividers, alignment, clearer status
+  indicators; porkchop axis labels rendered correctly.
+
+### v0.6 — planner UX + missions + multiplayer design
+
+v0.6 bundles four related strands: richer maneuver planning (event-relative
+nodes + mouse), the mission scaffold that slipped out of v0.4, and the
+first written exploration of what multiplayer would look like.
+
+- **Burn-at-next scheduler.** Today maneuver nodes use absolute T+ time
+  only. Add an event-relative mode: "fire at next periapsis / apoapsis /
+  ascending node / descending node" computed from live orbit. Foundation
+  for richer triggers later ("at SOI exit", "when fuel < X"). Planner UX
+  is **hybrid**: common modes (T+ absolute, next peri, next apo) live in
+  the existing `m` form via a new `fire at` field; advanced triggers
+  (AN / DN, SOI-exit, fuel < X) sit behind a secondary event-trigger
+  picker reachable from `m`. Keeps the simple flow one form; gives the
+  advanced triggers a place to grow into without bloating `m`.
+- **Mouse support.** Promoted from "speculative v0.8+" because v0.6's
+  planner UX work is mouse-shaped: porkchop cells want click-to-plant
+  (composes with v0.4.1 Enter-to-plant), planted maneuver nodes want
+  drag-to-edit, and bodies want click-to-focus as a faster path than
+  cycling `f` / `F`. Bubble Tea exposes mouse events natively
+  (`tea.MouseMsg`); scope is click + drag + wheel-zoom on the orbit
+  canvas, click on HUD panels and porkchop cells. Keyboard remains
+  primary — every mouse action has a key equivalent. About 150–250
+  LOC + tests. Note: full *maneuver node editing* (in-place Δv /
+  duration / fire-time scrub with rich UX) stays in §2 backlog —
+  v0.6's mouse work delivers the input plumbing and a basic drag
+  interaction; the broader edit-in-place flow can land later.
+- **Mission scaffold.** `missions.go` with a couple of starter objectives
+  ("circularize at apoapsis," "visit Mars SOI"). Pure pass/fail check
+  against current state. Mission state persists via the v0.4.0 save format
+  (hence the `version` field shipping in v0.4). About 200 LOC + a
+  `missions.json` data file.
+- **Multiplayer design-doc spike.** Short `docs/multiplayer-design.md`
+  scoped to **networking + persistence**: transport choice, authority
+  model, what "shared sandbox" means for time warp, *and* a persistence /
+  save-slot story for shared sessions (host-authoritative snapshot vs.
+  per-player envelope, conflict resolution on rejoin, how the v0.4 save
+  schema accommodates a `session` block). The persistence half is
+  explicitly in scope so the v0.4 save envelope can be future-proofed
+  deliberately rather than retrofitted. Implementation roadmap (which
+  release ships networking, the v0.6.x → v0.9 path) stays **out of scope**
+  for the v0.6 spike — the doc records constraints, not a schedule.
+  Writing the design now lets v0.6 save-format decisions (and any v0.7
+  schema work) stay open to shared-session use cases without committing
+  code. Multiplayer leaves the "excluded forever" list because of this.
+
+### Excluded forever
+- **Full 3D rendering** — terminal native is the project ethos.
+
+Previously on this list: *realistic atmospheric drag* (softened to an
+opt-in simple drag model in §2 backlog — realistic multi-species drag is
+still out), and *multiplayer / network sync* (demoted to a v0.6 design
+spike; shipped implementation deferred but no longer forbidden).
+
+---
+
+## 4. Resolved
+
+### v0.4 cycle
+
+The v0.3.6 edition of this doc closed with four open scoping questions.
+They've been answered in the v0.4 planning cycle:
+
+1. **v0.4 theme.** Save / load only. Missions slip to v0.6 so v0.4 stays
+   narrowly scoped to persistence.
+2. **v0.5 color.** Hardcoded palette now; planets and stars colored
+   reminiscent of their real appearance (see §3 v0.5). Theme is promoted
+   to user-configurable in v0.7 alongside the systems config-file loader.
+3. **Mid-course corrections.** Folded into v0.4.1, paired with porkchop
+   Enter-to-plant as a single "close the replan loop" release.
+4. **Multi-rev porkchop.** Still deferred — re-evaluate as v0.5.x polish
+   once the v0.5 visual work lands.
+
+### Current cycle
+
+All six open questions resolved in one round so the v0.4 → v0.6
+implementation work can start from a fixed set of assumptions. Grouped
+by target version:
+
+**v0.4 — save format**
+
+1. **Save-schema header.** Richer header from day one:
+   `{"version": 1, "generator": "tsp <semver>", "clock_t0": <unix-nanos>,
+   "body_catalog_hash": "<sha256>", "payload": {...}}`. Catches the
+   universe-drift footgun (edit `systems/sol.json`, old saves reject),
+   preserves forensics across versions, and the v0.6 multiplayer spike
+   already guarantees we need to extend the envelope — committing the
+   slot now beats a v0.5 schema migration. See §3 v0.4.0.
+
+**v0.5 — moons + visuals**
+
+2. **Color palette source of truth.** Checked-in
+   `internal/render/palette.go` constant table keyed by body name/type.
+   Faster than threading a `Color` field through `bodies.Body` + every
+   `systems/*.json`; v0.7 config-file loader promotes it to per-body
+   JSON fields with a one-shot migration.
+3. **Moon coverage.** v0.5.0 ships **Luna + Phobos/Deimos + four
+   Galilean (Io, Europa, Ganymede, Callisto) + Titan + Enceladus**.
+   Validates the hierarchy against single-moon *and* multi-moon
+   primaries in one release; catalog is mostly JSON once the code lands.
+4. **Hierarchy depth.** Arbitrary depth via `Body.ParentID` + recursive
+   `BodyPosition()` + hierarchical `FindPrimary()`. No code-level depth
+   cap. Sol only needs two levels today, but the schema accommodates
+   sub-moons / ring shepherds at zero incremental cost.
+
+**v0.6 — planner UX + MP design**
+
+5. **Burn-scheduler UX.** Hybrid. Common triggers (T+ absolute, next
+   peri, next apo) live inside `m` via a new `fire at` field; advanced
+   triggers (AN / DN, SOI-exit, fuel < X) sit behind a secondary picker
+   reachable from `m`.
+6. **Multiplayer design scope.** Networking + persistence. The spike
+   covers transport / authority / time-warp **and** a persistence /
+   save-slot story for shared sessions, so the v0.4 save envelope is
+   future-proofed deliberately. Implementation roadmap is explicitly
+   *not* in scope for the v0.6 doc — constraints only, no schedule.
+
+---
+
+## 5. Open questions for the next cycle
+
+None open. All v0.4 → v0.6 scoping questions are resolved (see §4
+current cycle). The next scoping round naturally re-opens at the v0.4
+ship boundary — expected new questions:
+
+- What the v0.5 `Body` schema needs to expose for the v0.7 config-file
+  loader (beyond moving the palette table into per-body JSON).
+- How `PlanTransfer()` extends to Earth → Luna once the hierarchy is in
+  (v0.6 work, surfaces during mid-course-correction integration).
+- Whether v0.6 missions persist in the `payload` block or alongside it
+  as a sibling (e.g. `{"version":1, ..., "payload":{...},
+  "missions":{...}}`) — affects save-schema ergonomics more than
+  correctness.
+
+Update this doc on each minor/patch boundary so the snapshot stays current.

--- a/internal/bodies/catalog.go
+++ b/internal/bodies/catalog.go
@@ -1,0 +1,45 @@
+package bodies
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// CatalogHash returns a sha256 hex of the canonical JSON encoding of
+// every loaded system, sorted by name (Sol first). Stamped into save
+// files so a load can reject saves built against a stale universe —
+// e.g. after a v0.5 systems-JSON edit adds Luna and rewrites Body
+// indices, the old save's body references no longer line up.
+//
+// Hash is over re-marshalled structs, not raw file bytes, so cosmetic
+// JSON whitespace edits don't churn the hash. Only semantic catalog
+// changes (new bodies, mass / element edits) bump it.
+func CatalogHash() (string, error) {
+	systems, err := LoadAll()
+	if err != nil {
+		return "", fmt.Errorf("load systems for catalog hash: %w", err)
+	}
+	b, err := json.Marshal(systems)
+	if err != nil {
+		return "", fmt.Errorf("marshal canonical systems: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// LookupByID searches every system for a body with the given ID and
+// returns it by value. Used by the save/load layer to rehydrate the
+// craft's primary across system boundaries — v0.1 craft is locked to
+// Sol, but the save schema doesn't bake that assumption in.
+func LookupByID(systems []System, id string) (CelestialBody, bool) {
+	for _, s := range systems {
+		for _, b := range s.Bodies {
+			if b.ID == id {
+				return b, true
+			}
+		}
+	}
+	return CelestialBody{}, false
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -1,0 +1,285 @@
+// Package save persists and restores the simulation World as JSON.
+//
+// The on-disk envelope ships a richer header from day one — version,
+// generator, clock_t0, body_catalog_hash, payload — so future schema
+// migrations and the v0.6 multiplayer `session` block can land without
+// bumping every caller. See docs/state-of-game.md §3 v0.4.0 for the
+// rationale.
+package save
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/version"
+)
+
+// SchemaVersion is the on-disk version. v0.4.0 ships v1; later schema
+// changes bump and migrate.
+const SchemaVersion = 1
+
+// File is the on-disk envelope.
+type File struct {
+	Version         int     `json:"version"`
+	Generator       string  `json:"generator"`
+	ClockT0         int64   `json:"clock_t0"`
+	BodyCatalogHash string  `json:"body_catalog_hash"`
+	Payload         Payload `json:"payload"`
+}
+
+// Payload carries the live simulation state. Anything derivable from
+// the catalog (Systems, Calculator) is reconstructed on Load.
+type Payload struct {
+	SystemIdx    int         `json:"system_idx"`
+	SimTimeNano  int64       `json:"sim_time_unix_nano"`
+	BaseStepNano int64       `json:"base_step_nano"`
+	WarpIdx      int         `json:"warp_idx"`
+	Paused       bool        `json:"paused"`
+	Focus        Focus       `json:"focus"`
+	Craft        *Craft      `json:"craft,omitempty"`
+	Nodes        []Node      `json:"nodes,omitempty"`
+	ActiveBurn   *ActiveBurn `json:"active_burn,omitempty"`
+}
+
+// Focus mirrors sim.Focus by value.
+type Focus struct {
+	Kind    int `json:"kind"`
+	BodyIdx int `json:"body_idx"`
+}
+
+// Vec3 is the wire form of orbital.Vec3.
+type Vec3 struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+	Z float64 `json:"z"`
+}
+
+// Craft mirrors spacecraft.Spacecraft. Primary is referenced by ID;
+// the rehydrated value is looked up across loaded systems on Load.
+type Craft struct {
+	Name      string  `json:"name"`
+	DryMass   float64 `json:"dry_mass"`
+	Fuel      float64 `json:"fuel"`
+	Isp       float64 `json:"isp"`
+	Thrust    float64 `json:"thrust"`
+	PrimaryID string  `json:"primary_id"`
+	R         Vec3    `json:"r"`
+	V         Vec3    `json:"v"`
+	M         float64 `json:"m"`
+}
+
+// Node mirrors sim.ManeuverNode.
+type Node struct {
+	TriggerTimeNano int64   `json:"trigger_time_unix_nano"`
+	Mode            int     `json:"mode"`
+	DV              float64 `json:"dv"`
+	DurationNano    int64   `json:"duration_nano"`
+	PrimaryID       string  `json:"primary_id"`
+}
+
+// ActiveBurn mirrors sim.ActiveBurn.
+type ActiveBurn struct {
+	Mode        int     `json:"mode"`
+	DVRemaining float64 `json:"dv_remaining"`
+	EndTimeNano int64   `json:"end_time_unix_nano"`
+	PrimaryID   string  `json:"primary_id"`
+}
+
+// Errors returned by Load.
+var (
+	ErrSchemaMismatch  = errors.New("save: schema version mismatch")
+	ErrCatalogMismatch = errors.New("save: body catalog hash mismatch")
+	ErrCraftPrimary    = errors.New("save: craft primary not found in loaded systems")
+)
+
+// DefaultPath returns the platform-appropriate save path. Honors
+// $XDG_STATE_HOME on linux/macOS; falls back to ~/.local/state. Windows
+// users can set $XDG_STATE_HOME explicitly.
+func DefaultPath() (string, error) {
+	if x := os.Getenv("XDG_STATE_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "save.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "terminal-space-program", "save.json"), nil
+}
+
+// Save serialises w to path, creating parent directories as needed.
+// Atomic on POSIX: writes to a sibling tmpfile and renames into place.
+func Save(w *sim.World, path string) error {
+	hash, err := bodies.CatalogHash()
+	if err != nil {
+		return err
+	}
+	f := File{
+		Version:         SchemaVersion,
+		Generator:       fmt.Sprintf("tsp %s", version.Version),
+		ClockT0:         time.Now().UnixNano(),
+		BodyCatalogHash: hash,
+		Payload:         payloadFromWorld(w),
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal save: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create save dir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmpfile: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename into place: %w", err)
+	}
+	return nil
+}
+
+// Load reads path, validates the envelope, and returns a fresh World
+// hydrated from the payload. Errors with ErrSchemaMismatch on version
+// drift, ErrCatalogMismatch on body-catalog drift, or ErrCraftPrimary
+// when the craft references a primary that no longer exists.
+func Load(path string) (*sim.World, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read save: %w", err)
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse save: %w", err)
+	}
+	if f.Version != SchemaVersion {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrSchemaMismatch, f.Version, SchemaVersion)
+	}
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		return nil, err
+	}
+	currentHash, err := bodies.CatalogHash()
+	if err != nil {
+		return nil, err
+	}
+	if f.BodyCatalogHash != currentHash {
+		return nil, fmt.Errorf("%w: save=%s current=%s", ErrCatalogMismatch, f.BodyCatalogHash, currentHash)
+	}
+	return worldFromPayload(f.Payload, systems)
+}
+
+func payloadFromWorld(w *sim.World) Payload {
+	p := Payload{
+		SystemIdx:    w.SystemIdx,
+		SimTimeNano:  w.Clock.SimTime.UnixNano(),
+		BaseStepNano: int64(w.Clock.BaseStep),
+		WarpIdx:      w.Clock.WarpIdx,
+		Paused:       w.Clock.Paused,
+		Focus: Focus{
+			Kind:    int(w.Focus.Kind),
+			BodyIdx: w.Focus.BodyIdx,
+		},
+	}
+	if w.Craft != nil {
+		p.Craft = &Craft{
+			Name:      w.Craft.Name,
+			DryMass:   w.Craft.DryMass,
+			Fuel:      w.Craft.Fuel,
+			Isp:       w.Craft.Isp,
+			Thrust:    w.Craft.Thrust,
+			PrimaryID: w.Craft.Primary.ID,
+			R:         vec3From(w.Craft.State.R),
+			V:         vec3From(w.Craft.State.V),
+			M:         w.Craft.State.M,
+		}
+	}
+	for _, n := range w.Nodes {
+		p.Nodes = append(p.Nodes, Node{
+			TriggerTimeNano: n.TriggerTime.UnixNano(),
+			Mode:            int(n.Mode),
+			DV:              n.DV,
+			DurationNano:    int64(n.Duration),
+			PrimaryID:       n.PrimaryID,
+		})
+	}
+	if w.ActiveBurn != nil {
+		p.ActiveBurn = &ActiveBurn{
+			Mode:        int(w.ActiveBurn.Mode),
+			DVRemaining: w.ActiveBurn.DVRemaining,
+			EndTimeNano: w.ActiveBurn.EndTime.UnixNano(),
+			PrimaryID:   w.ActiveBurn.PrimaryID,
+		}
+	}
+	return p
+}
+
+func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
+	if p.SystemIdx < 0 || p.SystemIdx >= len(systems) {
+		return nil, fmt.Errorf("save: system_idx %d out of range (have %d systems)", p.SystemIdx, len(systems))
+	}
+	clock := &sim.Clock{
+		SimTime:  time.Unix(0, p.SimTimeNano).UTC(),
+		WarpIdx:  p.WarpIdx,
+		Paused:   p.Paused,
+		BaseStep: time.Duration(p.BaseStepNano),
+	}
+	w := &sim.World{
+		Systems:   systems,
+		SystemIdx: p.SystemIdx,
+		Clock:     clock,
+		Focus: sim.Focus{
+			Kind:    sim.FocusKind(p.Focus.Kind),
+			BodyIdx: p.Focus.BodyIdx,
+		},
+	}
+	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+
+	if p.Craft != nil {
+		primary, ok := bodies.LookupByID(systems, p.Craft.PrimaryID)
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrCraftPrimary, p.Craft.PrimaryID)
+		}
+		w.Craft = &spacecraft.Spacecraft{
+			Name:    p.Craft.Name,
+			DryMass: p.Craft.DryMass,
+			Fuel:    p.Craft.Fuel,
+			Isp:     p.Craft.Isp,
+			Thrust:  p.Craft.Thrust,
+			Primary: primary,
+			State: physics.StateVector{
+				R: vec3To(p.Craft.R),
+				V: vec3To(p.Craft.V),
+				M: p.Craft.M,
+			},
+		}
+	}
+	for _, n := range p.Nodes {
+		w.Nodes = append(w.Nodes, sim.ManeuverNode{
+			TriggerTime: time.Unix(0, n.TriggerTimeNano).UTC(),
+			Mode:        spacecraft.BurnMode(n.Mode),
+			DV:          n.DV,
+			Duration:    time.Duration(n.DurationNano),
+			PrimaryID:   n.PrimaryID,
+		})
+	}
+	if p.ActiveBurn != nil {
+		w.ActiveBurn = &sim.ActiveBurn{
+			Mode:        spacecraft.BurnMode(p.ActiveBurn.Mode),
+			DVRemaining: p.ActiveBurn.DVRemaining,
+			EndTime:     time.Unix(0, p.ActiveBurn.EndTimeNano).UTC(),
+			PrimaryID:   p.ActiveBurn.PrimaryID,
+		}
+	}
+	return w, nil
+}
+
+func vec3From(v orbital.Vec3) Vec3 { return Vec3{X: v.X, Y: v.Y, Z: v.Z} }
+func vec3To(v Vec3) orbital.Vec3   { return orbital.Vec3{X: v.X, Y: v.Y, Z: v.Z} }

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -1,0 +1,317 @@
+package save_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+func TestRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Clock.SimTime = w.Clock.SimTime.Add(73 * time.Hour)
+	w.Clock.WarpIdx = 3
+	w.Clock.Paused = true
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: 4}
+	w.Craft.Fuel = 412.5
+	w.Craft.State.V = w.Craft.State.V.Add(orbital.Vec3{Y: 25.5})
+	w.Nodes = append(w.Nodes, sim.ManeuverNode{
+		TriggerTime: w.Clock.SimTime.Add(5 * time.Minute),
+		Mode:        spacecraft.BurnPrograde,
+		DV:          200,
+		Duration:    20 * time.Second,
+		PrimaryID:   "earth",
+	})
+	w.ActiveBurn = &sim.ActiveBurn{
+		Mode:        spacecraft.BurnRetrograde,
+		DVRemaining: 50,
+		EndTime:     w.Clock.SimTime.Add(8 * time.Second),
+		PrimaryID:   "earth",
+	}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if !got.Clock.SimTime.Equal(w.Clock.SimTime) {
+		t.Errorf("SimTime: got %v want %v", got.Clock.SimTime, w.Clock.SimTime)
+	}
+	if got.Clock.WarpIdx != w.Clock.WarpIdx {
+		t.Errorf("WarpIdx: got %d want %d", got.Clock.WarpIdx, w.Clock.WarpIdx)
+	}
+	if got.Clock.Paused != w.Clock.Paused {
+		t.Errorf("Paused: got %v want %v", got.Clock.Paused, w.Clock.Paused)
+	}
+	if got.Clock.BaseStep != w.Clock.BaseStep {
+		t.Errorf("BaseStep: got %v want %v", got.Clock.BaseStep, w.Clock.BaseStep)
+	}
+	if got.SystemIdx != w.SystemIdx {
+		t.Errorf("SystemIdx: got %d want %d", got.SystemIdx, w.SystemIdx)
+	}
+	if got.Focus != w.Focus {
+		t.Errorf("Focus: got %+v want %+v", got.Focus, w.Focus)
+	}
+	if got.Craft.Name != w.Craft.Name {
+		t.Errorf("Craft.Name: got %q want %q", got.Craft.Name, w.Craft.Name)
+	}
+	if got.Craft.Fuel != w.Craft.Fuel {
+		t.Errorf("Craft.Fuel: got %v want %v", got.Craft.Fuel, w.Craft.Fuel)
+	}
+	if got.Craft.Primary.ID != w.Craft.Primary.ID {
+		t.Errorf("Craft.Primary.ID: got %q want %q", got.Craft.Primary.ID, w.Craft.Primary.ID)
+	}
+	if !vecEq(got.Craft.State.R, w.Craft.State.R) {
+		t.Errorf("Craft.State.R: got %v want %v", got.Craft.State.R, w.Craft.State.R)
+	}
+	if !vecEq(got.Craft.State.V, w.Craft.State.V) {
+		t.Errorf("Craft.State.V: got %v want %v", got.Craft.State.V, w.Craft.State.V)
+	}
+	if len(got.Nodes) != 1 || got.Nodes[0].DV != 200 || got.Nodes[0].PrimaryID != "earth" {
+		t.Errorf("Nodes: got %+v", got.Nodes)
+	}
+	if got.ActiveBurn == nil || got.ActiveBurn.DVRemaining != 50 {
+		t.Errorf("ActiveBurn: got %+v", got.ActiveBurn)
+	}
+	if got.Calculator == nil {
+		t.Error("Calculator nil after Load — should be reconstructed via orbital.ForSystem")
+	}
+}
+
+func TestRoundtripEmptyState(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Craft == nil {
+		t.Fatal("Craft nil after roundtrip on default world")
+	}
+	if len(got.Nodes) != 0 {
+		t.Errorf("Nodes: expected empty, got %d", len(got.Nodes))
+	}
+	if got.ActiveBurn != nil {
+		t.Errorf("ActiveBurn: expected nil, got %+v", got.ActiveBurn)
+	}
+}
+
+func TestHeaderShape(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if f.Version != save.SchemaVersion {
+		t.Errorf("Version: got %d want %d", f.Version, save.SchemaVersion)
+	}
+	if f.Generator == "" {
+		t.Error("Generator empty")
+	}
+	if f.ClockT0 == 0 {
+		t.Error("ClockT0 zero")
+	}
+	if len(f.BodyCatalogHash) != 64 {
+		t.Errorf("BodyCatalogHash: got len %d want 64 hex chars", len(f.BodyCatalogHash))
+	}
+}
+
+func TestCatalogMismatchRejected(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	f.BodyCatalogHash = "deadbeef" // tamper
+	tampered, _ := json.Marshal(f)
+	if err := os.WriteFile(path, tampered, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err = save.Load(path)
+	if !errors.Is(err, save.ErrCatalogMismatch) {
+		t.Errorf("expected ErrCatalogMismatch, got %v", err)
+	}
+}
+
+func TestSchemaMismatchRejected(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	f.Version = 999 // future schema we don't understand
+	tampered, _ := json.Marshal(f)
+	if err := os.WriteFile(path, tampered, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err = save.Load(path)
+	if !errors.Is(err, save.ErrSchemaMismatch) {
+		t.Errorf("expected ErrSchemaMismatch, got %v", err)
+	}
+}
+
+func TestUnknownPrimaryRejected(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	f.Payload.Craft.PrimaryID = "no-such-body"
+	tampered, _ := json.Marshal(f)
+	if err := os.WriteFile(path, tampered, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err = save.Load(path)
+	if !errors.Is(err, save.ErrCraftPrimary) {
+		t.Errorf("expected ErrCraftPrimary, got %v", err)
+	}
+}
+
+func TestDefaultPathHonorsXDG(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/xdg-state")
+	got, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := "/tmp/xdg-state/terminal-space-program/save.json"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDefaultPathFallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "/tmp/fakehome")
+	got, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := "/tmp/fakehome/.local/state/terminal-space-program/save.json"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestSaveAtomicRename(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf(".tmp file should be removed by rename, got err=%v", err)
+	}
+}
+
+func TestStatePreservedAfterRoundtrip(t *testing.T) {
+	// Ensures the rehydrated craft state physics matches.
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	wantR := w.Craft.State.R
+	wantV := w.Craft.State.V
+	wantPrimaryID := w.Craft.Primary.ID
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !vecEq(got.Craft.State.R, wantR) {
+		t.Errorf("R: got %+v want %+v", got.Craft.State.R, wantR)
+	}
+	if !vecEq(got.Craft.State.V, wantV) {
+		t.Errorf("V: got %+v want %+v", got.Craft.State.V, wantV)
+	}
+	if got.Craft.Primary.ID != wantPrimaryID {
+		t.Errorf("Primary.ID: got %q want %q", got.Craft.Primary.ID, wantPrimaryID)
+	}
+	if got.Craft.Primary.GravitationalParameter() == 0 {
+		t.Error("rehydrated primary has zero μ — body lookup didn't preserve mass")
+	}
+	// Confirm a state vector still propagates: pre/post Verlet step
+	// from rehydrated state should not blow up.
+	mu := got.Craft.Primary.GravitationalParameter()
+	stepped := physics.StepVerlet(got.Craft.State, mu, 1.0)
+	if stepped.R.Norm() == 0 {
+		t.Error("post-load Verlet step produced zero state — primary μ likely wrong")
+	}
+}
+
+func vecEq(a, b orbital.Vec3) bool {
+	return a.X == b.X && a.Y == b.Y && a.Z == b.Z
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
@@ -39,6 +41,12 @@ type App struct {
 	help      *screens.Help
 	maneuver  *screens.Maneuver
 	porkchop  *screens.Porkchop
+
+	// statusMsg flashes a one-line notice in the HUD footer for ~3
+	// seconds after save / load. Cleared by clearStatusAfter via a
+	// scheduled tea.Cmd.
+	statusMsg     string
+	statusExpires time.Time
 }
 
 // New builds a root App. Returns an error if systems can't load.
@@ -111,6 +119,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// screen's handler so it can clean up.
 		if a.active == screenManeuver {
 			if key.Matches(m, a.keys.Quit) {
+				a.autosave()
 				return a, tea.Quit
 			}
 			if key.Matches(m, a.keys.Back) {
@@ -127,6 +136,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Porkchop: ←/→/↑/↓ navigate cells, Esc returns.
 		if a.active == screenPorkchop {
 			if key.Matches(m, a.keys.Quit) {
+				a.autosave()
 				return a, tea.Quit
 			}
 			_, done := a.porkchop.HandleKey(m)
@@ -137,6 +147,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch {
 		case key.Matches(m, a.keys.Quit):
+			a.autosave()
 			return a, tea.Quit
 		case key.Matches(m, a.keys.Help):
 			if a.active == screenHelp {
@@ -232,9 +243,58 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.ClearNodes):
 			a.world.ClearNodes()
 			return a, nil
+		case key.Matches(m, a.keys.Save):
+			a.flashStatus("save", a.doSave())
+			return a, nil
+		case key.Matches(m, a.keys.Load):
+			a.flashStatus("load", a.doLoad())
+			return a, nil
 		}
 	}
 	return a, nil
+}
+
+// doSave writes the current world to the default save path.
+func (a *App) doSave() error {
+	path, err := save.DefaultPath()
+	if err != nil {
+		return err
+	}
+	return save.Save(a.world, path)
+}
+
+// doLoad replaces the live world with the one persisted at the default
+// save path. Failures leave the existing world untouched.
+func (a *App) doLoad() error {
+	path, err := save.DefaultPath()
+	if err != nil {
+		return err
+	}
+	w, err := save.Load(path)
+	if err != nil {
+		return err
+	}
+	a.world = w
+	a.active = screenOrbit
+	return nil
+}
+
+// autosave persists on quit. Errors are swallowed — the user is leaving
+// and there's no surface to flash a message on. Console-printable saves
+// can be wired later if needed.
+func (a *App) autosave() {
+	_ = a.doSave()
+}
+
+// flashStatus writes a transient message to the HUD footer.
+func (a *App) flashStatus(op string, err error) {
+	if err != nil {
+		a.statusMsg = fmt.Sprintf("%s failed: %v", op, err)
+	} else {
+		path, _ := save.DefaultPath()
+		a.statusMsg = fmt.Sprintf("%s ok — %s", op, path)
+	}
+	a.statusExpires = time.Now().Add(3 * time.Second)
 }
 
 // finiteBurnDuration returns the sim-time duration needed to deliver dv
@@ -252,21 +312,27 @@ func finiteBurnDuration(dv, mass, thrust float64) time.Duration {
 	return time.Duration(secs * float64(time.Second))
 }
 
-// View delegates to the active screen.
+// View delegates to the active screen, then overlays a transient
+// status line at the bottom for ~3s after a save / load.
 func (a *App) View() string {
 	if a.width == 0 {
 		return "initializing…"
 	}
+	var base string
 	switch a.active {
 	case screenHelp:
-		return a.help.Render()
+		base = a.help.Render()
 	case screenBodyInfo:
-		return a.bodyInfo.Render(a.world, a.selectedBody, a.width, a.height)
+		base = a.bodyInfo.Render(a.world, a.selectedBody, a.width, a.height)
 	case screenManeuver:
-		return a.maneuver.Render(a.world, a.width, a.height)
+		base = a.maneuver.Render(a.world, a.width, a.height)
 	case screenPorkchop:
-		return a.porkchop.Render(a.world, a.width, a.height)
+		base = a.porkchop.Render(a.world, a.width, a.height)
 	default:
-		return a.orbitView.Render(a.world, a.selectedBody, a.width, a.height)
+		base = a.orbitView.Render(a.world, a.selectedBody, a.width, a.height)
 	}
+	if a.statusMsg != "" && time.Now().Before(a.statusExpires) {
+		base += "\n" + a.theme.Footer.Render(a.statusMsg)
+	}
+	return base
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -25,6 +25,8 @@ type Keymap struct {
 	ClearNodes    key.Binding
 	PlanTransfer  key.Binding
 	Porkchop      key.Binding
+	Save          key.Binding
+	Load          key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -49,5 +51,7 @@ func DefaultKeymap() Keymap {
 		ClearNodes:   key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "clear nodes")),
 		PlanTransfer: key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "plant Hohmann transfer to selected body")),
 		Porkchop:     key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "porkchop plot for selected body")),
+		Save:         key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "save game")),
+		Load:         key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "load game")),
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -46,6 +46,11 @@ func (h *Help) Render() string {
 			{"n", "plan a node (T+5m prograde 50m/s)"},
 			{"N", "clear all planned nodes"},
 		}},
+		{"PERSISTENCE", [][2]string{
+			{"S", "save game (XDG_STATE_HOME)"},
+			{"L", "load game"},
+			{"q", "quit (autosaves)"},
+		}},
 	}
 
 	var b strings.Builder


### PR DESCRIPTION
## Summary
v0.4.0 — first release of the v0.4 *Persistence* line.

- New `internal/save` package: roundtrips the live `World` as JSON. Envelope ships the v0.4 spec'd header from day one — `version`, `generator`, `clock_t0`, `body_catalog_hash`, `payload` — so the v0.6 multiplayer `session` block extension and any future schema migration land without a callsite change.
- New `internal/bodies/catalog.go`: `CatalogHash()` returns sha256 of the canonical-marshalled `LoadAll()` output. Cosmetic JSON whitespace edits don't churn the hash; semantic catalog changes (new bodies, μ edits) bump it. Mismatch on Load returns `ErrCatalogMismatch` so v0.5 hierarchy reshuffles cleanly reject old saves instead of silently mis-mapping body indices.
- TUI: `S` saves, `L` loads, `q` autosaves before quit. Help screen documents all three under PERSISTENCE. 3s status flash in the footer on save / load.
- Default path: `$XDG_STATE_HOME/terminal-space-program/save.json`, falling back to `~/.local/state/terminal-space-program/save.json`. Atomic on POSIX (`.tmp` + rename).
- Also includes the revised `docs/state-of-game.md` from c0abf2e — all six v0.4-v0.6 scoping questions resolved.

## Test plan
- [x] `go test ./...` — full suite green (8 new save/load tests + existing 200+ pass)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Manual smoke: launch tsp, plant a node, hit `S`, quit, relaunch, hit `L`, confirm node + clock + craft state restored
- [ ] Manual smoke: corrupt the save file's `body_catalog_hash` field, hit `L`, confirm refusal with sane error

## What's in scope
- v0.4.0 only — save / load + autosave-on-quit
- Schema header (committed v0.6 multiplayer `session`-slot reserve in design, not yet exercised)

## What's deferred
- v0.4.1: porkchop Enter-to-plant + mid-course `refine plan` key (separate branch when v0.4.0 ships)
- v0.5.0: body hierarchy + major moons (separate cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)