### PR TITLE
fix(sim): analytic Kepler warp-lock for free-flight orbits (v0.4.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.4.2**.
+Latest release: **v0.4.3**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.4.2)
+## Features (v0.4.3)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.4.2 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.4.3 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.4.2)
+## 1. What works today (v0.4.3)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -193,7 +193,8 @@ features and the version sequence that delivers them.
 | v0.3.6 ✓ | | Adaptive body sizing, peri-below-surface warning |
 | v0.4.0 ✓ | Persistence | Save / load with versioned envelope |
 | v0.4.1 ✓ | | Porkchop Enter-to-plant + `R`-refine mid-course correction |
-| v0.4.2 ✓ | (current) | Per-sub-step SOI check in live integrator (high-warp orbit drift fix) |
+| v0.4.2 ✓ | | Per-sub-step SOI check in live integrator (high-warp orbit drift fix) |
+| v0.4.3 ✓ | (current) | Warp-lock: analytic Kepler propagation when warp > 1× and no active burn (eliminates Verlet eccentricity drift) |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/physics/kepler_step.go
+++ b/internal/physics/kepler_step.go
@@ -1,0 +1,80 @@
+package physics
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// KeplerStep advances a state vector by dt using analytic Kepler
+// propagation. Snapshots orbital elements, advances mean anomaly by
+// n·dt, and reconstructs (r, v) from the new true anomaly. Exact
+// (modulo Newton iteration tolerance in SolveKepler) — no numerical
+// drift, regardless of dt size relative to orbital period.
+//
+// Returns ok=false for hyperbolic / parabolic orbits (e ≥ 1) and
+// degenerate inputs; the caller falls back to numerical integration
+// (Verlet). Used for the v0.4.3 "warp lock": when warp > 1× and no
+// active burn, integrateSpacecraft takes one KeplerStep per tick
+// instead of looping Verlet sub-steps that drift eccentricity over
+// many orbits.
+//
+// SOI handling is the caller's responsibility: KeplerStep does not
+// detect or rebase across primary boundaries. integrateSpacecraft
+// guards against SOI crossings by checking apo < primary's SOI before
+// taking the analytic path.
+func KeplerStep(s StateVector, mu, dt float64) (StateVector, bool) {
+	if mu <= 0 {
+		return s, false
+	}
+	el := orbital.ElementsFromState(s.R, s.V, mu)
+	if el.E >= 1 || el.A <= 0 {
+		return s, false
+	}
+
+	rMag := s.R.Norm()
+	if rMag <= 0 {
+		return s, false
+	}
+
+	// Mean anomaly at t=0 derived from current state.
+	var M0 float64
+	if el.E > 1e-9 {
+		// Elliptic, non-circular. Standard formulas:
+		//   r = a(1 − e cos E)  →  cos E = (1 − r/a) / e
+		//   r·v = √(µa) · e · sin E
+		cosE := (1 - rMag/el.A) / el.E
+		if cosE > 1 {
+			cosE = 1
+		} else if cosE < -1 {
+			cosE = -1
+		}
+		rDotV := s.R.X*s.V.X + s.R.Y*s.V.Y + s.R.Z*s.V.Z
+		sinE := rDotV / (el.E * math.Sqrt(mu*el.A))
+		E0 := math.Atan2(sinE, cosE)
+		M0 = E0 - el.E*math.Sin(E0)
+	} else {
+		// Circular: ν ≡ M ≡ angle of r in the perifocal frame. Inverse-
+		// rotate r into perifocal (p, q) and take atan2(q, p).
+		cO, sO := math.Cos(el.Omega), math.Sin(el.Omega)
+		cw, sw := math.Cos(el.Arg), math.Sin(el.Arg)
+		ci, si := math.Cos(el.I), math.Sin(el.I)
+		px := cO*cw - sO*sw*ci
+		py := sO*cw + cO*sw*ci
+		pz := sw * si
+		qx := -cO*sw - sO*cw*ci
+		qy := -sO*sw + cO*cw*ci
+		qz := cw * si
+		p := s.R.X*px + s.R.Y*py + s.R.Z*pz
+		q := s.R.X*qx + s.R.Y*qy + s.R.Z*qz
+		M0 = math.Atan2(q, p)
+	}
+
+	n := math.Sqrt(mu / (el.A * el.A * el.A))
+	mNew := M0 + n*dt
+	eNew := orbital.SolveKepler(mNew, el.E)
+	nuNew := orbital.TrueAnomaly(eNew, el.E)
+	rNew := orbital.PositionAtTrueAnomaly(el, nuNew)
+	vNew := orbital.VelocityAtTrueAnomaly(el, nuNew, mu)
+	return StateVector{R: rNew, V: vNew, M: s.M}, true
+}

--- a/internal/sim/predict_test.go
+++ b/internal/sim/predict_test.go
@@ -143,6 +143,47 @@ func TestIntegrateSpacecraftMatchesPredictorAcrossSOI(t *testing.T) {
 	}
 }
 
+// TestWarpLockPreservesCircularOrbit: regression for v0.4.3. At
+// 10000× warp the default 200×200 km circular LEO drifted to roughly
+// 209×191 km within a few real-time seconds because Verlet sub-steps
+// at coarse dt accumulated eccentricity (random walk in apo/peri).
+// With the warp lock (analytic Kepler propagation when warp > 1× and
+// no active burn), the orbit must hold its semimajor axis and
+// eccentricity essentially unchanged across many ticks.
+func TestWarpLockPreservesCircularOrbit(t *testing.T) {
+	w := mustWorld(t)
+
+	// Bump to 10000× warp.
+	for i := 0; i < 4; i++ {
+		w.Clock.WarpUp()
+	}
+	if w.Clock.Warp() != 10000 {
+		t.Fatalf("warp setup: got %.0f, want 10000", w.Clock.Warp())
+	}
+
+	mu := w.Craft.Primary.GravitationalParameter()
+	startEl := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+
+	// Run 600 ticks ≈ 10 real-time seconds at the default 50 ms base
+	// step → 600 × 0.5 s × 10000× = ~50 simulated days. That covers
+	// ~1000 LEO orbits — enough sub-step error pre-fix to drift
+	// eccentricity from ~0 to >1e-3.
+	for i := 0; i < 600; i++ {
+		w.Tick()
+	}
+
+	endEl := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+
+	// Semimajor axis must be conserved (analytic Kepler is exact).
+	if relErr := math.Abs(endEl.A-startEl.A) / startEl.A; relErr > 1e-9 {
+		t.Errorf("warp-lock semimajor drift: %.3e (rel)", relErr)
+	}
+	// Eccentricity must stay ~zero. Pre-fix: O(1e-3) random walk.
+	if endEl.E > 1e-9 {
+		t.Errorf("warp-lock eccentricity grew to %.3e (want < 1e-9)", endEl.E)
+	}
+}
+
 // TestPropagateCraftSOIAware: forward-integrate a hyperbolic escape via
 // propagateCraft and confirm the resulting state isn't expressed in the
 // original primary's frame anymore (i.e. |r| would have to be absurdly

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -183,10 +183,26 @@ func (w *World) EffectiveWarp() float64 { return w.clampedWarp() }
 // which left the live integrator propagating in the wrong frame for
 // up to a tick after a mid-tick crossing — visible as orbits diverging
 // from the predicted trajectory at high warp.
+//
+// "Warp lock" (v0.4.3): when warp > 1× AND no active burn AND the
+// orbit is bound with apoapsis comfortably inside the primary's SOI,
+// take a single analytic Kepler step instead of looping Verlet. Verlet
+// at coarse dt is symplectic but second-order — eccentricity does a
+// random walk that turns 200×200 km circular orbits into 209×190 km
+// after a few seconds at 10000× warp. KeplerStep is exact, so no drift.
 func (w *World) integrateSpacecraft(simDelta time.Duration) {
 	mu := w.Craft.Primary.GravitationalParameter()
 	period := orbitalPeriod(w.Craft.State, mu)
 	secs := simDelta.Seconds()
+
+	// Warp-lock fast path: analytic Kepler propagation when conditions
+	// are met. Falls back to Verlet sub-stepping otherwise.
+	if w.canKeplerStep(simDelta) {
+		if newState, ok := physics.KeplerStep(w.Craft.State, mu, secs); ok {
+			w.Craft.State = newState
+			return
+		}
+	}
 
 	maxStep := period / 100.0
 	if maxStep <= 0 || math.IsNaN(maxStep) || math.IsInf(maxStep, 0) {
@@ -281,6 +297,49 @@ func (w *World) burnExhausted() bool {
 	return w.ActiveBurn.DVRemaining <= 0 ||
 		w.Craft.Fuel <= 0 ||
 		!w.Clock.SimTime.Before(w.ActiveBurn.EndTime)
+}
+
+// canKeplerStep reports whether the analytic warp-lock fast path is
+// valid for this tick. Conditions (v0.4.3):
+//   - warp > 1× (else Verlet is fine and we want to avoid behavioral
+//     differences between paused/realtime and the live integrator)
+//   - no active burn (analytic propagation can't accommodate thrust)
+//   - bound orbit (e < 1) — KeplerStep itself rejects hyperbolic cases
+//   - apoapsis safely inside the primary's SOI (no boundary crossing
+//     during the analytic step)
+func (w *World) canKeplerStep(simDelta time.Duration) bool {
+	if w.ActiveBurn != nil {
+		return false
+	}
+	if w.Clock.Warp() <= 1 {
+		return false
+	}
+	mu := w.Craft.Primary.GravitationalParameter()
+	el := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+	if el.E >= 1 || el.A <= 0 {
+		return false
+	}
+	apo := el.Apoapsis()
+	soi := w.craftPrimarySOI()
+	if soi <= 0 {
+		// System primary (Sun) — no enclosing SOI; any bound orbit stays
+		// in the heliocentric frame, so analytic is safe.
+		return true
+	}
+	// Conservative margin: apoapsis must be ≤ 0.95·SOI so a fractionally
+	// noisy ElementsFromState near the boundary still falls back to
+	// Verlet.
+	return apo < 0.95*soi
+}
+
+// craftPrimarySOI returns the craft primary's SOI radius. Returns 0
+// for the system primary (no parent → no SOI bound).
+func (w *World) craftPrimarySOI() float64 {
+	sys := w.System()
+	if w.Craft.Primary.ID == sys.Bodies[0].ID {
+		return 0
+	}
+	return physics.SOIRadius(w.Craft.Primary, sys.Bodies[0])
 }
 
 // orbitalPeriod returns 2π√(a³/μ) or +Inf on unbound orbits. Used to


### PR DESCRIPTION
## Summary

Fixes the v0.4.2 follow-on @jason flagged: at 10000× warp the default 200×200 km circular LEO drifted to ~209×191 km within a few real-time seconds. Root cause was Verlet's second-order error accumulating across coarse sub-steps — symplectic integrators preserve energy but eccentricity does a slow random walk at large dt.

The "orbit lock" jason proposed: when the user warps, snapshot Keplerian elements once and propagate analytically until warp drops or a burn fires. Exact, no drift, same approach the bodies already use.

- `physics.KeplerStep(state, mu, dt)` — snapshot elements, advance mean anomaly by `n·dt`, reconstruct `(r, v)`. Returns `ok=false` for hyperbolic / degenerate cases so the caller falls back to Verlet.
- `World.canKeplerStep` — gates the fast path on: warp > 1×, no active burn, bound orbit, apoapsis < 0.95·primary SOI (no boundary crossing during the analytic step).
- `integrateSpacecraft` takes the analytic path when gate passes; otherwise the v0.4.2 SOI-aware Verlet sub-step loop runs unchanged. Active burns + warp=1 behave exactly as before.

## Tests

- `TestWarpLockPreservesCircularOrbit` — 600 ticks at 10000× warp (~50 sim-days, ~1000 LEO orbits): semimajor axis drift < 1e-9 rel, eccentricity stays < 1e-9. Was O(1e-3) random walk pre-fix.

All existing tests still pass.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: load default world, warp to 10000×, watch HUD apo/peri — expect them to stay 200/200 km indefinitely.
- [ ] Manual: plant a finite burn, warp during the burn — burn should still run on RK4 (warp clamps to 10× during active burn anyway, but verify Verlet path stays selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)