### PR TITLE
fix(sim): sub-divided Kepler step closes foreign-SOI gap (v0.4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.4.3**.
+Latest release: **v0.4.4**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.4.3)
+## Features (v0.4.4)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/integration-design.md
+++ b/docs/integration-design.md
@@ -1,0 +1,219 @@
+# Integration design
+
+*Written 2026-04-25 to consolidate the v0.4.2 / v0.4.3 / v0.4.4 patch
+sequence and stop chasing one-off bug reports about warp-vs-SOI-vs-
+thrust interactions. Lands as the design contract that v0.5.0
+implementation work will follow.*
+
+The v0.3.x line shipped Verlet sub-stepping with a per-20-tick SOI
+throttle. Subsequent reports surfaced enough edge cases (high-warp
+mid-tick SOI crossings; Verlet eccentricity drift on circular orbits;
+heliocentric transfers skipping planet SOIs under warp lock) that the
+sensible move is to write the integration model down once, settle on
+the events it must respect, and implement against the design.
+
+---
+
+## 1. Integration modes
+
+Three primitive step routines live in `internal/physics`:
+
+| Mode | Function | Order | Force model | Cost |
+|------|----------|-------|-------------|------|
+| **Verlet** | `physics.StepVerlet` | 2nd | gravity only | 1 force eval / step |
+| **RK4 thrust** | `World.stepThrust` (calls `physics.StepRK4ThrustState`) | 4th | gravity + thrust | 4 force evals / step |
+| **Kepler** | `physics.KeplerStep` (v0.4.3) | exact (Newton tol) | gravity, no thrust | 1 Kepler solve / step |
+
+Verlet is symplectic — energy is bounded, but second-order accuracy
+means *eccentricity* random-walks at coarse step sizes (the v0.4.3
+report). RK4 is non-symplectic — energy drifts secularly, but it
+handles non-conservative thrust correctly. KeplerStep is exact for
+bound elliptic two-body motion but knows nothing about thrust or
+foreign SOIs.
+
+Each mode covers a slice of the `(thrust, dt/period, bound?)` space.
+The integrator's job is selecting the right slice every tick.
+
+## 2. Events the integrator must respect
+
+A "tick" advances `Clock.SimTime` by `simDelta = warp × baseStep`. The
+craft's state must be correct at the end of `simDelta`. Events that
+*can* occur inside that interval and must not be skipped:
+
+1. **SOI crossing** (entering or leaving a body's sphere of influence).
+   Frame must rebase to the new primary; subsequent integration uses
+   that primary's μ.
+2. **Burn fire time** (planted `ManeuverNode.TriggerTime`). The Δv
+   applies to the craft's state at that exact moment.
+3. **Burn end time** (`ActiveBurn.EndTime`). Thrust stops cleanly so
+   post-burn integration switches back to free-flight modes.
+4. **Periapsis / apoapsis** (v0.6 burn-at-next scheduler). Not
+   integration-critical but the planner UX needs them.
+5. **Collision** with a body surface. Out of scope for v0.4.x; flagged
+   in the HUD via the peri-below-surface warning, not enforced.
+
+Events 1–3 are the integration-correctness ones. Event 4 is a planner-
+layer concern that the integrator can expose hooks for. Event 5 is
+deferred.
+
+## 3. Mode selection (gate matrix)
+
+For a tick with no active burn and no fire-time inside `simDelta`:
+
+| Condition | Mode |
+|-----------|------|
+| craft hyperbolic (e ≥ 1) | Verlet sub-stepped, per-sub-step SOI |
+| craft bound, apo < 0.95·primary SOI, no foreign SOI within reach | KeplerStep |
+| craft bound, but apo near or beyond primary SOI / foreign SOI within reach | Verlet sub-stepped |
+| warp == 1× | Verlet sub-stepped (cosmetic — Kepler would work, but matches paused/realtime behavior) |
+
+If a burn fires inside `simDelta`:
+
+| Pre-fire interval | Mode |
+|-------------------|------|
+| Free flight up to `TriggerTime` | KeplerStep or Verlet by the row above |
+| `[TriggerTime, EndTime]` | RK4 thrust at `min(dt, period/100)` sub-steps |
+| Post-`EndTime` interval | KeplerStep or Verlet by the row above |
+
+This naturally relaxes the v0.3.x rule that "warp clamps to 10× during
+active burn" — only the **burn segment** needs the warp clamp; the
+coast before/after can stay at the user's selected warp.
+
+## 4. Foreign-SOI proximity check
+
+The v0.4.3 gap: when craft is heliocentric (Sun primary), KeplerStep
+runs unconditionally because Sun has no enclosing SOI. An Earth→Mars
+transfer ellipse passes through Mars's SOI without entry being
+detected. Three approaches considered:
+
+- **A. Conservative gate** — reject KeplerStep if any other body's SOI
+  is within `max(r, apo)` of the craft. Hack. Loses warp benefit on
+  most heliocentric trajectories (every interplanetary transfer
+  trips it).
+- **B. Sub-divided KeplerStep** — cap each analytic step at
+  `min(simDelta, smallest_SOI_radius / craft_speed)`, run a Verlet-
+  style SOI test between caps. Pragmatic v0.4.4 fix.
+- **C. Event-driven step** — analytically predict time-to-next-SOI-
+  intersection (ray-cast the Kepler trajectory against each body's
+  SOI), step exactly up to that event, switch to Verlet for the
+  crossing, then resume. Right answer; v0.5.0 work.
+
+**Decision**: ship B as v0.4.4 to close the immediate gap, fold the
+event-driven version into v0.5.0 alongside body hierarchy. The
+sub-divided version still uses Kepler propagation for the bulk of
+each tick — only the SOI-test cadence is tighter — so the eccentricity-
+drift fix from v0.4.3 stays intact.
+
+## 5. Predictor / live integrator coherence
+
+`PredictedSegments` draws the dashed trajectory the player sees on the
+canvas; `integrateSpacecraft` advances the actual craft state. The two
+must agree, otherwise the predicted line and the live craft drift
+apart visibly under warp.
+
+State of play:
+
+- **v0.3.x**: predictor SOI-aware per sub-step; live integrator only
+  via per-20-tick `maybeSwitchPrimary`. Live drifted off prediction
+  at high warp.
+- **v0.4.2**: live integrator gained per-sub-step SOI. Now both used
+  Verlet end-to-end; agreement restored.
+- **v0.4.3**: live integrator gained KeplerStep on warp. Predictor
+  still Verlet. Agreement broken in the *opposite* direction —
+  prediction less accurate than live.
+
+**Decision**: the predictor uses the same mode-selection logic as the
+live integrator. Both share an internal `stepCraft(state, primary,
+dt) → (state, primary)` primitive that picks Verlet vs KeplerStep vs
+RK4-thrust per the gate matrix in §3, and both use the same event-
+driven outer loop from §6.
+
+This is the largest single refactor implied by this doc. It pays back
+not just in coherence — every accuracy improvement (e.g. KeplerStep,
+event-driven crossings) lands in both surfaces simultaneously, which
+is what was missed in the v0.3 → v0.4.3 sequence.
+
+## 6. Event-driven outer loop (v0.5.0 target)
+
+```
+remaining = simDelta
+while remaining > 0:
+    event_dt = min(
+        time_to_soi_crossing(),  // analytic ray-cast for Kepler; verlet bisection for non-Kepler
+        time_to_node_fire(),
+        time_to_active_burn_end(),
+        remaining,
+    )
+    mode = select_mode(state, primary, active_burn, warp)
+    state, primary = step(mode, state, primary, event_dt)
+    remaining -= event_dt
+    handle_event(state, primary, ...)  // rebase / fire node / end burn
+```
+
+`time_to_soi_crossing` is the open piece. For Kepler, the craft's
+trajectory is a known conic and SOI boundaries are spheres around
+moving bodies — we approximate body motion as linear over `event_dt`
+(adequate when `event_dt « body period`) and ray-cast. For Verlet/RK4
+sub-stepping we keep the per-sub-step `FindPrimary` test and bisect
+the crossing.
+
+## 7. Save / load
+
+KeplerStep is stateless — orbital elements are derived from `(r, v)`
+each step. No save format changes needed. The v0.4.0 envelope already
+captures everything the new modes need.
+
+## 8. Phased rollout
+
+- **v0.4.4** — Foreign-SOI proximity check (approach B). Closes the
+  heliocentric-warp gap reported 2026-04-25. ~30 LOC + a transfer-
+  through-Mars-SOI-under-warp test. *Tactical patch.*
+- **v0.5.0** — Body hierarchy (already planned) + event-driven outer
+  loop + predictor / live integrator unification (this doc). The two
+  stacks naturally compose: hierarchical SOI lookup is exactly what
+  `time_to_soi_crossing` needs anyway. ~250–400 LOC + integration
+  tests covering the gate matrix in §3. *Architectural milestone.*
+- **v0.6.0** — Event types extended for the burn-at-next scheduler
+  (next periapsis / apoapsis / AN / DN / SOI exit / fuel < X).
+  Reuses §6 machinery — these are just additional `time_to_X`
+  callbacks. ~100 LOC + UX work in the maneuver planner.
+
+## 9. Decisions locked in
+
+1. **Three integrator modes**, gate matrix per §3.
+2. **Event-driven outer loop** in v0.5.0; v0.4.4 patches the immediate
+   foreign-SOI gap with sub-divided KeplerStep but keeps the existing
+   tick-bounded loop.
+3. **Predictor and live integrator share the step machinery** in
+   v0.5.0. v0.4.x asymmetries are tolerated as the cost of staged
+   delivery.
+4. **Warp clamp scoped to burn segments** in v0.5.0 (not whole tick).
+5. **No save schema changes** — KeplerStep is stateless.
+
+## 10. Open questions
+
+- **Predictor sample density at high warp.** `PredictedSegments` uses a
+  fixed 96 samples over the predicted horizon. At 10000× warp the
+  predicted horizon can cover ~50 sim-days; for a 90-minute LEO that's
+  800 orbits compressed into 96 samples — the dashed line collapses to
+  a smear. Adaptive sampling (denser near "interesting" events from
+  §6) is a v0.5.x polish item, flagged here so it doesn't get
+  forgotten.
+- **`time_to_soi_crossing` for moving bodies.** Linear-extrapolation
+  body motion within `event_dt` is fine when `event_dt` is a fraction
+  of the body's period. For inter-system transfers where `event_dt`
+  approaches a planet's period, we'd need either (a) iterating the
+  ray-cast or (b) splitting into shorter sub-events. Decide during
+  v0.5.0 implementation.
+- **Behavior at warp == 1×.** Currently §3 picks Verlet at warp = 1×
+  for "matches paused/realtime behavior" reasons. Could just as well
+  use Kepler — but warp = 1× is the only mode where the user can
+  observe per-tick state changes, and we want the simplest visible
+  semantics. Revisit if it complicates the unified step machinery.
+
+---
+
+*This doc is the contract: v0.4.4 ships the tactical sub-division
+patch, v0.5.0 lands the architectural rework. Bug reports between
+those releases should be triaged against this design rather than
+patched in isolation.*

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.4.3 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.4.4 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.4.3)
+## 1. What works today (v0.4.4)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -194,7 +194,8 @@ features and the version sequence that delivers them.
 | v0.4.0 ✓ | Persistence | Save / load with versioned envelope |
 | v0.4.1 ✓ | | Porkchop Enter-to-plant + `R`-refine mid-course correction |
 | v0.4.2 ✓ | | Per-sub-step SOI check in live integrator (high-warp orbit drift fix) |
-| v0.4.3 ✓ | (current) | Warp-lock: analytic Kepler propagation when warp > 1× and no active burn (eliminates Verlet eccentricity drift) |
+| v0.4.3 ✓ | | Warp-lock: analytic Kepler propagation when warp > 1× and no active burn (eliminates Verlet eccentricity drift) |
+| v0.4.4 ✓ | (current) | Sub-divided Kepler step: chunks the analytic warp path so foreign SOIs (e.g. Mars during a heliocentric transfer) aren't skipped |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/sim/predict_test.go
+++ b/internal/sim/predict_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
@@ -181,6 +182,55 @@ func TestWarpLockPreservesCircularOrbit(t *testing.T) {
 	// Eccentricity must stay ~zero. Pre-fix: O(1e-3) random walk.
 	if endEl.E > 1e-9 {
 		t.Errorf("warp-lock eccentricity grew to %.3e (want < 1e-9)", endEl.E)
+	}
+}
+
+// TestWarpLockDetectsForeignSOIEntry: regression for v0.4.4. Place a
+// heliocentric craft already inside Mars's SOI (with craft.Primary
+// still set to Sun, simulating a craft that just crossed in). v0.4.3's
+// analytic warp path returned without SOI re-evaluation, so the primary
+// stayed Sun until the every-20-tick maybeSwitchPrimary throttle fired.
+// v0.4.4's keplerStepWithSOICheck calls FindPrimary between Kepler
+// chunks; one tick should be enough to switch primary.
+func TestWarpLockDetectsForeignSOIEntry(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	sun := sys.Bodies[0]
+	var mars bodies.CelestialBody
+	for _, b := range sys.Bodies {
+		if b.EnglishName == "Mars" {
+			mars = b
+			break
+		}
+	}
+	if mars.EnglishName == "" {
+		t.Skip("Mars not in loaded Sol system")
+	}
+
+	marsPos := w.BodyPosition(mars)
+	marsVel := w.bodyInertialVelocity(mars)
+	soi := physics.SOIRadius(mars, sun)
+
+	// Place craft 50% inside Mars's SOI, on the heliocentric +X side
+	// of Mars. Velocity = Mars's velocity + a small radial component
+	// so the craft is bound to Mars in the post-rebase frame.
+	w.Craft.Primary = sun
+	w.Craft.State.R = orbital.Vec3{X: marsPos.X + soi*0.5, Y: marsPos.Y, Z: marsPos.Z}
+	w.Craft.State.V = marsVel
+
+	// Bump to 1000× warp (well above 1× so warp-lock activates) but not
+	// so high we burn 20+ ticks of sim time waiting for the throttle.
+	for i := 0; i < 3; i++ {
+		w.Clock.WarpUp()
+	}
+	if w.Clock.Warp() != 1000 {
+		t.Fatalf("warp setup: got %.0f, want 1000", w.Clock.Warp())
+	}
+
+	w.Tick()
+	if w.Craft.Primary.ID != mars.ID {
+		t.Errorf("after 1 tick under warp lock, primary = %s, want Mars (SOI re-eval skipped between Kepler chunks)",
+			w.Craft.Primary.EnglishName)
 	}
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -195,11 +195,13 @@ func (w *World) integrateSpacecraft(simDelta time.Duration) {
 	period := orbitalPeriod(w.Craft.State, mu)
 	secs := simDelta.Seconds()
 
-	// Warp-lock fast path: analytic Kepler propagation when conditions
-	// are met. Falls back to Verlet sub-stepping otherwise.
+	// Warp-lock fast path: analytic Kepler propagation in chunks small
+	// enough that the craft can't outrun any other body's SOI per
+	// chunk (v0.4.4). Falls back to Verlet sub-stepping if the gate
+	// rejects (active burn, hyperbolic, warp=1) or any chunk's
+	// KeplerStep fails.
 	if w.canKeplerStep(simDelta) {
-		if newState, ok := physics.KeplerStep(w.Craft.State, mu, secs); ok {
-			w.Craft.State = newState
+		if w.keplerStepWithSOICheck(simDelta) {
 			return
 		}
 	}
@@ -300,13 +302,17 @@ func (w *World) burnExhausted() bool {
 }
 
 // canKeplerStep reports whether the analytic warp-lock fast path is
-// valid for this tick. Conditions (v0.4.3):
+// valid for this tick. Conditions (v0.4.4):
 //   - warp > 1× (else Verlet is fine and we want to avoid behavioral
 //     differences between paused/realtime and the live integrator)
 //   - no active burn (analytic propagation can't accommodate thrust)
 //   - bound orbit (e < 1) — KeplerStep itself rejects hyperbolic cases
-//   - apoapsis safely inside the primary's SOI (no boundary crossing
-//     during the analytic step)
+//
+// SOI containment is no longer gated here: keplerStepWithSOICheck
+// chunks the analytic step finely enough to detect crossings between
+// chunks (v0.4.4 fix for the v0.4.3 heliocentric-transfer-skips-Mars
+// bug). If e ≥ 1 we still fall back to Verlet so the per-sub-step SOI
+// path handles the non-conic case correctly.
 func (w *World) canKeplerStep(simDelta time.Duration) bool {
 	if w.ActiveBurn != nil {
 		return false
@@ -319,27 +325,94 @@ func (w *World) canKeplerStep(simDelta time.Duration) bool {
 	if el.E >= 1 || el.A <= 0 {
 		return false
 	}
-	apo := el.Apoapsis()
-	soi := w.craftPrimarySOI()
-	if soi <= 0 {
-		// System primary (Sun) — no enclosing SOI; any bound orbit stays
-		// in the heliocentric frame, so analytic is safe.
-		return true
-	}
-	// Conservative margin: apoapsis must be ≤ 0.95·SOI so a fractionally
-	// noisy ElementsFromState near the boundary still falls back to
-	// Verlet.
-	return apo < 0.95*soi
+	return true
 }
 
-// craftPrimarySOI returns the craft primary's SOI radius. Returns 0
-// for the system primary (no parent → no SOI bound).
-func (w *World) craftPrimarySOI() float64 {
+// keplerStepWithSOICheck propagates the craft analytically across the
+// tick by chunking simDelta into pieces small enough that the craft
+// can't outrun any non-current-primary body's SOI per chunk. Between
+// chunks, FindPrimary catches SOI crossings and rebases the state.
+//
+// Chunk size = min(simDelta, smallestForeignSOI / (4·speed)). The
+// factor of 4 leaves a 2× safety margin past the trivial "can't
+// traverse SOI in one chunk" bound — a bound orbit re-encountering
+// the same SOI region within a single tick would otherwise risk a
+// missed crossing at high warp.
+//
+// Returns ok=false if any chunk's KeplerStep fails (e.g. eccentricity
+// crossed into hyperbolic mid-propagation due to a primary switch);
+// caller then falls back to Verlet for the remaining time.
+func (w *World) keplerStepWithSOICheck(simDelta time.Duration) bool {
 	sys := w.System()
-	if w.Craft.Primary.ID == sys.Bodies[0].ID {
-		return 0
+	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
+	for _, b := range sys.Bodies {
+		positions[b.ID] = w.BodyPosition(b)
 	}
-	return physics.SOIRadius(w.Craft.Primary, sys.Bodies[0])
+
+	chunkCap := chunkDtCap(sys, w.Craft.Primary, w.Craft.State.V.Norm())
+
+	secs := simDelta.Seconds()
+	if chunkCap <= 0 || math.IsInf(chunkCap, 0) || math.IsNaN(chunkCap) {
+		chunkCap = secs
+	}
+	nChunks := int(math.Ceil(secs / chunkCap))
+	if nChunks < 1 {
+		nChunks = 1
+	}
+	// Safety cap matching the Verlet sub-step ceiling — a degenerate
+	// near-zero chunk size shouldn't blow up the loop.
+	if nChunks > 1024 {
+		nChunks = 1024
+	}
+	chunk := secs / float64(nChunks)
+
+	mu := w.Craft.Primary.GravitationalParameter()
+	for i := 0; i < nChunks; i++ {
+		newState, ok := physics.KeplerStep(w.Craft.State, mu, chunk)
+		if !ok {
+			return false
+		}
+		w.Craft.State = newState
+
+		inertial := positions[w.Craft.Primary.ID].Add(w.Craft.State.R)
+		cand := physics.FindPrimary(sys, inertial, positions)
+		if cand.Body.ID != w.Craft.Primary.ID {
+			vOld := w.bodyInertialVelocity(w.Craft.Primary)
+			vNew := w.bodyInertialVelocity(cand.Body)
+			w.Craft.State = physics.Rebase(w.Craft.State, positions[w.Craft.Primary.ID], cand.Inertial, vOld.Sub(vNew))
+			w.Craft.Primary = cand.Body
+			mu = w.Craft.Primary.GravitationalParameter()
+		}
+	}
+	return true
+}
+
+// chunkDtCap returns the maximum analytic-step duration for the
+// current craft primary, given craft speed. Bound by the smallest
+// foreign body's SOI radius / (4·speed) so no SOI can be traversed
+// without an intermediate FindPrimary check. +Inf when no foreign
+// SOI exists (single-body system) — caller treats that as "one chunk
+// covers the whole tick".
+func chunkDtCap(sys bodies.System, currentPrimary bodies.CelestialBody, speed float64) float64 {
+	if speed <= 0 {
+		speed = 1.0
+	}
+	primaryID := sys.Bodies[0].ID
+	cap := math.Inf(1)
+	for _, b := range sys.Bodies {
+		if b.ID == primaryID || b.ID == currentPrimary.ID {
+			continue
+		}
+		soi := physics.SOIRadius(b, sys.Bodies[0])
+		if soi <= 0 {
+			continue
+		}
+		dt := soi / (4 * speed)
+		if dt < cap {
+			cap = dt
+		}
+	}
+	return cap
 }
 
 // orbitalPeriod returns 2π√(a³/μ) or +Inf on unbound orbits. Used to


### PR DESCRIPTION
## Summary

Closes the v0.4.3 follow-up jason flagged: heliocentric craft on intercept paths skipped planet SOIs under warp because the analytic Kepler step ran across the whole `simDelta` with no SOI re-evaluation.

Per `docs/integration-design.md` §4 approach B (also new in this PR — bundled because the design doc was the gating decision). The event-driven loop in §6 stays scoped for v0.5.x.

- `keplerStepWithSOICheck` — chunks `simDelta` into pieces sized by `smallest_foreign_SOI / (4·craft_speed)`. Between chunks, `FindPrimary` catches SOI crossings and rebases (same pattern the v0.4.2 Verlet path uses).
- `chunkDtCap` — picks the chunk size from the system's smallest non-current-primary SOI; returns +Inf for single-body systems.
- `canKeplerStep` — drops the apo-gate. With per-chunk SOI checks, every containment case is handled.

## Tests

- `TestWarpLockDetectsForeignSOIEntry` — heliocentric craft placed inside Mars's SOI at 1000× warp switches primary to Mars within one tick. Pre-fix the every-20-tick `maybeSwitchPrimary` throttle was the only path.
- All v0.4.3 warp-lock + v0.4.2 SOI + v0.3.x tests still pass.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: plant a Hohmann to Mars (`P` selecting Mars), warp to 10000×, watch craft enter Mars SOI.
- [ ] Manual: 200×200 km LEO at 10000× warp still holds shape (v0.4.3 regression).

## Notes

- `docs/integration-design.md` lands here too — it's the v0.5.x architectural roadmap (event-driven step + predictor unification) and the rationale for keeping v0.5.0 narrowly scoped to the originally-planned body hierarchy + moons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)