### PR TITLE
feat(render): color palette + HUD/bodyinfo coloring (v0.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.0**.
+Latest release: **v0.5.1**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.0)
+## Features (v0.5.1)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.0 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.1 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.0)
+## 1. What works today (v0.5.1)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -214,7 +214,8 @@ features and the version sequence that delivers them.
 | v0.4.2 ✓ | | Per-sub-step SOI check in live integrator (high-warp orbit drift fix) |
 | v0.4.3 ✓ | | Warp-lock: analytic Kepler propagation when warp > 1× and no active burn (eliminates Verlet eccentricity drift) |
 | v0.4.4 ✓ | | Sub-divided Kepler step: chunks the analytic warp path so foreign SOIs (e.g. Mars during a heliocentric transfer) aren't skipped |
-| **v0.5.0 ✓** | **(current)** | Body hierarchy: `ParentID`, recursive `BodyPosition`/`bodyInertialVelocity`, hierarchical `FindPrimary`. Major moons: Luna, Phobos, Deimos, Galilean ×4, Titan, Enceladus |
+| v0.5.0 ✓ | | Body hierarchy: `ParentID`, recursive `BodyPosition`/`bodyInertialVelocity`, hierarchical `FindPrimary`. Major moons: Luna, Phobos, Deimos, Galilean ×4, Titan, Enceladus |
+| **v0.5.1 ✓** | **(current)** | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -1,0 +1,118 @@
+// Package render holds the visual constant tables shared across screens
+// — body color palette, UI tier colors for status / nodes / trajectory.
+//
+// v0.5.1 source of truth per docs/state-of-game.md §3 v0.5: a hardcoded
+// table here, keyed by body name (or stellar tint by temperature for
+// non-Sol stars). The v0.7 config-file body loader will promote the
+// table to per-body JSON fields with a one-shot migration; in the
+// meantime this single file is the only place to edit when adding a
+// new body or retuning a color.
+package render
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// UI tier colors — used for non-body UI elements that need consistent
+// semantic colors across screens. Independent of the body palette so
+// editing one doesn't shift the other.
+var (
+	ColorAlert       = lipgloss.Color("#FF5F5F") // hard errors, peri-below-surface
+	ColorWarning     = lipgloss.Color("#FFAF00") // warp clamps, near-collision
+	ColorPlannedNode = lipgloss.Color("#5FD7FF") // maneuver-node markers
+	ColorTrajectory  = lipgloss.Color("#FFFFFF") // home-SOI trajectory preview
+	ColorForeignSOI  = lipgloss.Color("#D75FFF") // post-SOI-crossing trajectory segments
+	ColorDim         = lipgloss.Color("#5F5F5F") // background / inactive
+)
+
+// bodyPalette maps a body's ID → its rendered color. IDs are the same
+// ones in the systems/*.json files (e.g. "earth", "moon", "io"). Keep
+// this table in sync with the moons + planets defined there.
+//
+// Picks reminiscent of each body's actual appearance in visible light.
+// Non-Sol stars use a temperature-keyed tint via StellarTint() rather
+// than a per-system entry here.
+var bodyPalette = map[string]lipgloss.Color{
+	// Sol & inner planets
+	"sun":     "#FFE9A6", // gold-white
+	"mercury": "#9C9C9C", // grey
+	"venus":   "#E8D08F", // pale yellow / cloud-tops
+	"earth":   "#5BB3FF", // ocean blue (continents would need a per-pixel render)
+	"mars":    "#C1440E", // rust
+
+	// Earth's moon
+	"moon": "#C8C8C8", // pale grey
+
+	// Mars moons
+	"phobos": "#5A5048", // dark grey
+	"deimos": "#5A5048", // dark grey
+
+	// Jupiter & Galilean
+	"jupiter":  "#C9925E", // banded ochre
+	"io":       "#E8D940", // sulfur yellow
+	"europa":   "#E5DBC6", // off-white ice
+	"ganymede": "#A48E6A", // tan
+	"callisto": "#5C4A36", // dark tan
+
+	// Saturn + named moons
+	"saturn":    "#E0CFA1", // pale gold
+	"titan":     "#D67F2A", // burnt orange (haze)
+	"enceladus": "#FFFFFF", // bright icy white
+
+	// Outer ice giants
+	"uranus":  "#7DD3D8", // cyan
+	"neptune": "#3D5BFF", // deep blue
+}
+
+// ColorFor returns the palette color for a body. Falls back to a
+// per-bodyType default for bodies not in the table (e.g. fictional
+// systems' planets), and finally to ColorTrajectory for unrecognised
+// types. Star colors come from StellarTint when temperature is set.
+func ColorFor(b bodies.CelestialBody) lipgloss.Color {
+	if c, ok := bodyPalette[b.ID]; ok {
+		return c
+	}
+	if b.Temperature > 0 && (b.BodyType == "Star" || b.StellarClass != "") {
+		return StellarTint(b.Temperature)
+	}
+	switch b.BodyType {
+	case "Star":
+		return "#FFE9A6"
+	case "Planet":
+		return "#7BA1B6" // generic muted blue-grey
+	case "Moon":
+		return "#9A9A9A" // generic grey
+	default:
+		return ColorTrajectory
+	}
+}
+
+// StellarTint maps a star's effective temperature (Kelvin) to a
+// rough visible-light color. Used for non-Sol stars that don't have
+// a hand-picked entry in bodyPalette. Banding is coarse — five
+// buckets covering M-dwarf through O-class.
+func StellarTint(tempK float64) lipgloss.Color {
+	switch {
+	case tempK < 3700: // M (red dwarf)
+		return "#FF6E40"
+	case tempK < 5200: // K (orange)
+		return "#FFB04A"
+	case tempK < 6000: // G (yellow — sun-like)
+		return "#FFE9A6"
+	case tempK < 7500: // F (yellow-white)
+		return "#F8F2D6"
+	case tempK < 10000: // A (white)
+		return "#E5ECFF"
+	default: // B / O (blue-white)
+		return "#9CB8FF"
+	}
+}
+
+// Style returns a lipgloss.Style with the body's color as the
+// foreground. Convenience wrapper for HUD / body-info text — call
+// Style(b).Render("Earth") to print a colored label.
+func Style(b bodies.CelestialBody) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(ColorFor(b))
+}

--- a/internal/render/palette_test.go
+++ b/internal/render/palette_test.go
@@ -1,0 +1,54 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// TestColorForKnownBodies: every body in Sol must resolve to a
+// non-default palette color. Catches the case where a moon is added
+// to sol.json but its bodyPalette entry is missed.
+func TestColorForKnownBodies(t *testing.T) {
+	sys, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	for _, s := range sys {
+		if s.Name != "Sol" {
+			continue
+		}
+		for _, b := range s.Bodies {
+			if _, hit := bodyPalette[b.ID]; !hit {
+				t.Errorf("Sol body %q (%s) has no palette entry — add to bodyPalette",
+					b.ID, b.EnglishName)
+			}
+		}
+	}
+}
+
+// TestStellarTintBuckets: spot-check that StellarTint returns
+// distinct colors across the temperature ladder. Catches accidental
+// collapse of the bucket boundaries (e.g. wrong threshold ordering).
+func TestStellarTintBuckets(t *testing.T) {
+	cases := []struct {
+		tempK float64
+		name  string
+	}{
+		{2500, "M-dwarf"},
+		{4500, "K"},
+		{5778, "G (sun)"},
+		{6800, "F"},
+		{9000, "A"},
+		{20000, "B/O"},
+	}
+	seen := make(map[string]string)
+	for _, c := range cases {
+		got := string(StellarTint(c.tempK))
+		if prev, ok := seen[got]; ok {
+			t.Errorf("StellarTint collision: %s and %s both → %s",
+				prev, c.name, got)
+		}
+		seen[got] = c.name
+	}
+}

--- a/internal/tui/screens/bodyinfo.go
+++ b/internal/tui/screens/bodyinfo.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
@@ -24,8 +27,9 @@ func (b *BodyInfo) Render(w *sim.World, selectedIdx, cols, rows int) string {
 	}
 	cb := sys.Bodies[selectedIdx]
 
+	titleStyle := lipgloss.NewStyle().Foreground(render.ColorFor(cb)).Bold(true)
 	sections := []string{
-		b.theme.Title.Render(cb.EnglishName),
+		titleStyle.Render(cb.EnglishName),
 		b.theme.Dim.Render(fmt.Sprintf("%s in %s", cb.BodyType, sys.Name)),
 		"",
 		b.theme.Primary.Render("PHYSICAL"),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
@@ -383,8 +384,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 
 	if selectedIdx >= 0 && selectedIdx < len(sys.Bodies) {
 		b := sys.Bodies[selectedIdx]
+		nameStyle := lipgloss.NewStyle().Foreground(render.ColorFor(b)).Bold(true)
 		lines = append(lines,
-			"  "+b.EnglishName,
+			"  "+nameStyle.Render(b.EnglishName),
 			"  "+b.BodyType,
 		)
 		if b.SemimajorAxis > 0 {


### PR DESCRIPTION
## Summary

First v0.5.x visual pass per `docs/state-of-game.md` §3 v0.5.

- **`internal/render/palette.go`** — checked-in constant table keyed by body ID (the source of truth promised by the state-of-game). Hand-picked colors reminiscent of each body's actual appearance (Sol gold-white, Mars rust, Jupiter banded ochre, Titan burnt orange, etc).
- **UI-tier colors** — alert / warning / planted-node / trajectory / foreign-SOI / dim, separate from body palette so editing one doesn't shift the other.
- **`StellarTint(tempK)`** — temperature-keyed color for non-Sol stars (M / K / G / F / A / B-O bucket).
- **Wired into** the HUD SELECTED-body name and the body-info screen title.

Per-cell canvas body coloring stays scoped for v0.5.3 (body identity) — drawille braille cells aggregate multiple bodies' pixels into one character, so colorizing them needs a per-layer render redesign that fits naturally with the body-identity glyph work in v0.5.3.

## Tests

- `TestColorForKnownBodies` — every body in Sol has a palette entry. Catches the case where a moon is added to sol.json but its color is missed.
- `TestStellarTintBuckets` — temperature ladder buckets return distinct colors.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: open the game, press `i` on Mars — title should render rust-colored.
- [ ] Manual: cycle the body cursor in HUD — selected name should change color (Earth blue, Mars rust, Jupiter ochre, Saturn pale gold, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)