### PR TITLE
feat(sim,tui): vessel position trail (v0.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.1**.
+Latest release: **v0.5.2**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.1)
+## Features (v0.5.2)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.1 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.2 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.1)
+## 1. What works today (v0.5.2)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -215,7 +215,8 @@ features and the version sequence that delivers them.
 | v0.4.3 ✓ | | Warp-lock: analytic Kepler propagation when warp > 1× and no active burn (eliminates Verlet eccentricity drift) |
 | v0.4.4 ✓ | | Sub-divided Kepler step: chunks the analytic warp path so foreign SOIs (e.g. Mars during a heliocentric transfer) aren't skipped |
 | v0.5.0 ✓ | | Body hierarchy: `ParentID`, recursive `BodyPosition`/`bodyInertialVelocity`, hierarchical `FindPrimary`. Major moons: Luna, Phobos, Deimos, Galilean ×4, Titan, Enceladus |
-| **v0.5.1 ✓** | **(current)** | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
+| v0.5.1 ✓ | | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
+| **v0.5.2 ✓** | **(current)** | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -39,7 +39,24 @@ type World struct {
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
+
+	// trail is a ring buffer of recent craft inertial positions for the
+	// vessel-position-trail render (v0.5.2). Capacity = trailCap; when
+	// full, new samples overwrite the oldest. trailLen ≤ trailCap is
+	// the live count. trailAccumSec is the sim-time accrued since the
+	// last sample — we sample at trailIntervalSec, not every tick, so
+	// trail length corresponds to ~trailCap × trailIntervalSec of sim
+	// history regardless of warp.
+	trail         [trailCap]orbital.Vec3
+	trailIdx      int
+	trailLen      int
+	trailAccumSec float64
 }
+
+const (
+	trailCap         = 200
+	trailIntervalSec = 10.0
+)
 
 // NewWorld loads the embedded systems, seeds clock at J2000 + 50 ms base
 // step, and spawns a spacecraft in LEO around Sol's Earth.
@@ -147,7 +164,47 @@ func (w *World) Tick() {
 			w.soiCheckCounter = 0
 			w.maybeSwitchPrimary()
 		}
+		w.maybeRecordTrail(simDelta.Seconds())
 	}
+}
+
+// maybeRecordTrail appends the craft's current inertial position to
+// the trail ring buffer when trailIntervalSec of sim time has elapsed
+// since the last sample. The sim-time gating means trail density
+// stays roughly constant across warp levels — at warp=1 we sample
+// every ~10 sim seconds (≈200 ticks), at warp=10000× every ~10
+// sim seconds (≈one tick). Either way the visible trail covers
+// trailCap × trailIntervalSec ≈ 33 minutes of sim history.
+func (w *World) maybeRecordTrail(secs float64) {
+	w.trailAccumSec += secs
+	if w.trailAccumSec < trailIntervalSec {
+		return
+	}
+	w.trailAccumSec = 0
+	w.trail[w.trailIdx] = w.CraftInertial()
+	w.trailIdx = (w.trailIdx + 1) % trailCap
+	if w.trailLen < trailCap {
+		w.trailLen++
+	}
+}
+
+// CraftTrail returns the trail samples in oldest-to-newest order. The
+// returned slice is a fresh copy — callers can iterate / reverse
+// safely. Empty when the craft has just spawned and hasn't accumulated
+// trailIntervalSec of sim time yet.
+func (w *World) CraftTrail() []orbital.Vec3 {
+	if w.trailLen == 0 {
+		return nil
+	}
+	out := make([]orbital.Vec3, w.trailLen)
+	start := w.trailIdx - w.trailLen
+	if start < 0 {
+		start += trailCap
+	}
+	for i := 0; i < w.trailLen; i++ {
+		out[i] = w.trail[(start+i)%trailCap]
+	}
+	return out
 }
 
 // clampedWarp returns min(selected warp, max warp allowed by the step-size

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -160,6 +160,50 @@ func TestFindPrimaryGalileanMultiMoon(t *testing.T) {
 	}
 }
 
+// TestCraftTrailGrowsAndCaps: v0.5.2 — sampling at trailIntervalSec
+// of sim time, not per tick. Ticks at warp=1 should sparsely add to
+// the trail; once trailCap entries are recorded, the buffer stops
+// growing and oldest entries get overwritten in FIFO order.
+func TestCraftTrailGrowsAndCaps(t *testing.T) {
+	w, _ := NewWorld()
+	if got := len(w.CraftTrail()); got != 0 {
+		t.Fatalf("fresh world trail = %d, want 0", got)
+	}
+
+	// Force a known sim-time advance per Tick. BaseStep=50ms × warp=1
+	// gives 0.05 s per tick. Need 200 sim seconds per sample at the
+	// default interval — i.e., 200 ticks for one sample.
+	w.Clock.BaseStep = 1 * time.Second // sim-step 1s/tick at warp=1
+	// 11 ticks × 1 s = 11 s ≥ trailIntervalSec (10) → 1 sample.
+	for i := 0; i < 11; i++ {
+		w.Tick()
+	}
+	if got := len(w.CraftTrail()); got != 1 {
+		t.Errorf("after 11 sim seconds: trail = %d, want 1", got)
+	}
+
+	// Push past trailCap to verify the buffer caps and rotates.
+	for i := 0; i < trailCap*15; i++ {
+		w.Tick()
+	}
+	if got := len(w.CraftTrail()); got != trailCap {
+		t.Errorf("after >>trailCap samples: trail = %d, want %d", got, trailCap)
+	}
+
+	// Newest sample (last in returned slice) should equal the live
+	// craft inertial position within one sample's worth of motion —
+	// the most recent recorded sample was taken at most trailIntervalSec
+	// ago, so a small (sub-orbit-fraction) gap is expected for LEO.
+	tr := w.CraftTrail()
+	last := tr[len(tr)-1]
+	live := w.CraftInertial()
+	gap := last.Sub(live).Norm()
+	// LEO speed ~7.78 km/s; 10 sim seconds covers ~78 km. Allow 2x.
+	if gap > 200e3 {
+		t.Errorf("newest trail sample too far from live craft: %.1f km", gap/1000)
+	}
+}
+
 // TestPausedTickDoesNothing: world.Clock.Paused must block both time
 // advancement and physics stepping.
 func TestPausedTickDoesNothing(t *testing.T) {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -110,6 +110,28 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		}
 	}
 
+	// Vessel position trail (v0.5.2): a fading dotted history of
+	// where the craft has actually been, distinct from the current
+	// Keplerian orbit ellipse. Stride increases (sparser dots) for
+	// older samples to give a visual gradient — newest = densest.
+	if w.CraftVisibleHere() {
+		trail := w.CraftTrail()
+		// Draw oldest first (sparse stride 4) → newest (every point),
+		// so newer samples overdraw older ones at any cell collision.
+		for i, p := range trail {
+			// stride: 4 at oldest end, 1 at newest end. Linear ramp.
+			progress := float64(i) / float64(len(trail))
+			stride := 4 - int(3*progress)
+			if stride < 1 {
+				stride = 1
+			}
+			if i%stride != 0 {
+				continue
+			}
+			v.canvas.Plot(p)
+		}
+	}
+
 	// Spacecraft current-orbit ellipse + glyph. Orbit is the craft's
 	// live Keplerian ellipse in its home primary's frame, translated
 	// into the system frame so it renders alongside planet orbits.


### PR DESCRIPTION
## Summary

Per `docs/state-of-game.md` §3 v0.5.2.

- **`World.trail` ring buffer** — 200 samples of inertial craft position, FIFO when full.
- **`maybeRecordTrail`** sample gating uses sim-time accumulation (`trailIntervalSec = 10s`), so trail density stays constant across warp levels. Trail covers ~33 minutes of sim history regardless of warp — dense at warp=1, dense at warp=10000×.
- **Orbit canvas render** — fading-stride dot trail behind the live Keplerian ellipse. Stride ramps from 4 (oldest) → 1 (newest) for a visual gradient.
- **Not in save format** — trail is ephemeral, regenerates as the craft flies. No schema change.

## Tests

- `TestCraftTrailGrowsAndCaps` — 11 sim seconds at 1 s/tick adds 1 sample; past trailCap the buffer caps and rotates; newest sample stays within ~one-sample's worth of motion of live craft.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: warp at 100× from default LEO — dot trail should appear behind the chevron, growing into a ring shape over 10–15 seconds of warp.
- [ ] Manual: zoom out to system view — trail should compress visually but stay continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)