### PR TITLE
feat(widgets,tui): per-cell canvas body coloring (v0.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.2**.
+Latest release: **v0.5.3**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.2)
+## Features (v0.5.3)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.2 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.3 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.2)
+## 1. What works today (v0.5.3)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -216,7 +216,8 @@ features and the version sequence that delivers them.
 | v0.4.4 ✓ | | Sub-divided Kepler step: chunks the analytic warp path so foreign SOIs (e.g. Mars during a heliocentric transfer) aren't skipped |
 | v0.5.0 ✓ | | Body hierarchy: `ParentID`, recursive `BodyPosition`/`bodyInertialVelocity`, hierarchical `FindPrimary`. Major moons: Luna, Phobos, Deimos, Galilean ×4, Titan, Enceladus |
 | v0.5.1 ✓ | | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
-| **v0.5.2 ✓** | **(current)** | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
+| v0.5.2 ✓ | | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
+| **v0.5.3 ✓** | **(current)** | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.4+. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -93,18 +93,22 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	// Plot each body at its perceived-size disk. System primary (index 0)
 	// gets a hollow ring + filled center to distinguish it from planets.
+	// Each body's cells are tagged with its palette color (v0.5.3) so
+	// the canvas emits per-cell ANSI foreground at String() time.
 	// See BodyPixelRadius for the size-tier logic.
 	scale := v.canvas.Scale()
 	for i := range sys.Bodies {
 		b := sys.Bodies[i]
 		pos := w.BodyPosition(b)
 		r := BodyPixelRadius(b, i == 0, scale)
+		color := render.ColorFor(b)
 		if i == 0 {
 			v.canvas.RingOutline(pos, r)
 			v.canvas.FillDisk(pos, 1)
 		} else {
 			v.canvas.FillDisk(pos, r)
 		}
+		v.canvas.AddColoredDisk(pos, r, color)
 		if i == selectedIdx {
 			v.plotCluster(pos, r+4)
 		}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/exrook/drawille-go"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -18,11 +19,22 @@ import (
 // map (x_world, y_world) → (px, py) via a single scale and the cached
 // center (panning is out-of-scope for v0.1 per plan C8 commit body).
 type Canvas struct {
-	cols, rows int     // terminal cells
-	pxW, pxH   int     // pixel grid (cols*2, rows*4)
+	cols, rows int          // terminal cells
+	pxW, pxH   int          // pixel grid (cols*2, rows*4)
 	centerW    orbital.Vec3 // world coord at pixel center
-	scale      float64 // pixels per meter
+	scale      float64      // pixels per meter
 	dc         drawille.Canvas
+
+	// colorRegions records cell-coordinate rectangles to colorize at
+	// String() time. v0.5.3+ — used by the orbit renderer to color
+	// body disks by palette without per-pixel color tagging.
+	// Last-written wins on overlap.
+	colorRegions []colorRegion
+}
+
+type colorRegion struct {
+	cellX, cellY, w, h int
+	color              lipgloss.Color
 }
 
 // NewCanvas builds a canvas sized to fit cols × rows terminal cells.
@@ -57,8 +69,38 @@ func (c *Canvas) Resize(cols, rows int) {
 	c.pxW, c.pxH = cols*2, rows*4
 }
 
-// Clear wipes the drawille buffer. Call at the start of every frame.
-func (c *Canvas) Clear() { c.dc.Clear() }
+// Clear wipes the drawille buffer and the per-cell color regions.
+// Call at the start of every frame.
+func (c *Canvas) Clear() {
+	c.dc.Clear()
+	c.colorRegions = c.colorRegions[:0]
+}
+
+// AddColoredDisk records a cell-region tag for the disk that
+// FillDisk(center, pxRadius) would draw. Use it after a body's
+// FillDisk to colorize the body's footprint at String() time.
+// Translates pixel-radius to cell-radius via the 2×4 braille grid
+// (rounded up so single-pixel disks still hit a full cell).
+func (c *Canvas) AddColoredDisk(center orbital.Vec3, pxRadius int, color lipgloss.Color) {
+	cx, cy, _ := c.Project(center)
+	// Body cell footprint: convert pixel radius → cell radius. Add 1
+	// to ensure the disk's edge cells are included (drawille cells
+	// are 2 px wide × 4 px tall — round up generously so the rim of
+	// a body's pixels falls inside the colorized region).
+	cellRX := pxRadius/2 + 1
+	cellRY := pxRadius/4 + 1
+	cellX := cx/2 - cellRX
+	cellY := cy/4 - cellRY
+	w := 2*cellRX + 1
+	h := 2*cellRY + 1
+	c.colorRegions = append(c.colorRegions, colorRegion{
+		cellX: cellX,
+		cellY: cellY,
+		w:     w,
+		h:     h,
+		color: color,
+	})
+}
 
 // Cols / Rows expose the configured terminal cell dimensions.
 func (c *Canvas) Cols() int { return c.cols }
@@ -247,8 +289,65 @@ func (c *Canvas) DrawEllipseOffsetDotted(el orbital.Elements, offset orbital.Vec
 // String renders the canvas as a multi-line braille string, trimmed to
 // the configured cell dimensions. Pads short rows with spaces so the
 // rectangular shape is preserved (lipgloss borders need uniform width).
+//
+// When color regions are set (via AddColoredDisk), each cell inside a
+// region is wrapped in a lipgloss foreground color. Last-written
+// region wins on overlap; cells not in any region render uncolored.
+// Skips coloring blank cells so per-cell escape sequences don't
+// inflate output for empty space.
 func (c *Canvas) String() string {
 	rows := c.dc.Rows(0, 0, c.pxW, c.pxH)
+	if len(c.colorRegions) == 0 {
+		return c.joinRows(rows)
+	}
+	// Build per-cell color map (last-write-wins on overlap). Sparse —
+	// only set for cells inside any region.
+	cellColor := make(map[[2]int]lipgloss.Color)
+	for _, r := range c.colorRegions {
+		for dy := 0; dy < r.h; dy++ {
+			y := r.cellY + dy
+			if y < 0 || y >= c.rows {
+				continue
+			}
+			for dx := 0; dx < r.w; dx++ {
+				x := r.cellX + dx
+				if x < 0 || x >= c.cols {
+					continue
+				}
+				cellColor[[2]int{x, y}] = r.color
+			}
+		}
+	}
+	var b strings.Builder
+	for i := 0; i < c.rows; i++ {
+		var line string
+		if i < len(rows) {
+			line = rows[i]
+		}
+		// Colorize per-cell, padding short lines with spaces.
+		runes := []rune(line)
+		for x := 0; x < c.cols; x++ {
+			var ch rune = ' '
+			if x < len(runes) {
+				ch = runes[x]
+			}
+			color, hasColor := cellColor[[2]int{x, i}]
+			if hasColor && ch != ' ' {
+				b.WriteString(lipgloss.NewStyle().Foreground(color).Render(string(ch)))
+			} else {
+				b.WriteRune(ch)
+			}
+		}
+		if i < c.rows-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// joinRows is the uncolored fast path used when no color regions are
+// registered.
+func (c *Canvas) joinRows(rows []string) string {
 	var b strings.Builder
 	for i := 0; i < c.rows; i++ {
 		var line string

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -1,7 +1,10 @@
 package widgets
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
@@ -126,6 +129,31 @@ func TestPlotArrowProducesNonEmptyRender(t *testing.T) {
 	c.PlotArrow(orbital.Vec3{}, orbital.Vec3{}, 4)
 	if !onlyWhitespace(c.String()) {
 		t.Error("PlotArrow with zero velocity plotted pixels")
+	}
+}
+
+// TestColoredDiskEmitsAnsiOnRender: v0.5.3 — AddColoredDisk should
+// cause the corresponding cells to render with a lipgloss foreground
+// escape sequence. Sanity-check that the SGR (ESC [ 38 ;) substring
+// appears in the output when colored, and is absent when not.
+func TestColoredDiskEmitsAnsiOnRender(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1") // force lipgloss to emit ANSI in tests
+	c := NewCanvas(20, 10)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	c.FillDisk(orbital.Vec3{}, 3)
+	uncolored := c.String()
+	if strings.Contains(uncolored, "\x1b[") {
+		t.Errorf("uncolored canvas contained ANSI escape: %q", uncolored)
+	}
+
+	c.Clear()
+	c.FillDisk(orbital.Vec3{}, 3)
+	c.AddColoredDisk(orbital.Vec3{}, 3, lipgloss.Color("#FF0000"))
+	colored := c.String()
+	if !strings.Contains(colored, "\x1b[") {
+		t.Error("colored canvas missing ANSI escape sequence")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the v0.5.1 deferral. Bodies on the orbit canvas now render in their palette color via per-cell ANSI foreground.

- **`Canvas.colorRegions`** — list of (cellRect, color) entries. Cleared per-frame by `Canvas.Clear`.
- **`AddColoredDisk(center, pxRadius, color)`** — records the cell footprint for a disk drawn by `FillDisk`. Pixel→cell conversion rounds up so edge cells are included.
- **`Canvas.String()`** — builds a sparse cell→color map from registered regions (last-write wins on overlap), emits each non-blank cell in its color via lipgloss. Uncolored cells use the existing fast path.

Wired into `orbit.go`: each body's `FillDisk` is now followed by `AddColoredDisk(pos, r, render.ColorFor(b))`.

## Scope deferred to v0.5.4+

The v0.5.3 grab-bag from `state-of-game.md` §3 v0.5.3 includes Saturn rings, body-identity glyph density, HUD dividers / status indicators, and porkchop axis labels. Splitting these across follow-on patches keeps each release focused.

## Tests

- `TestColoredDiskEmitsAnsiOnRender` — `AddColoredDisk` causes ANSI escapes in the rendered string; uncolored renders contain none. Uses `CLICOLOR_FORCE=1` since lipgloss disables color in non-TTY tests.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: open the game, system view — Sun should render gold-white, Earth blue, Mars rust, Jupiter ochre, etc.
- [ ] Manual: zoom in on Earth — Earth's blue should remain visible while Luna renders pale grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)