### PR TITLE
fix(sim): trail samples are primary-relative, not heliocentric (v0.5.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.3**.
+Latest release: **v0.5.4**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.3)
+## Features (v0.5.4)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.3 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.4 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.3)
+## 1. What works today (v0.5.4)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -217,7 +217,8 @@ features and the version sequence that delivers them.
 | v0.5.0 ✓ | | Body hierarchy: `ParentID`, recursive `BodyPosition`/`bodyInertialVelocity`, hierarchical `FindPrimary`. Major moons: Luna, Phobos, Deimos, Galilean ×4, Titan, Enceladus |
 | v0.5.1 ✓ | | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
 | v0.5.2 ✓ | | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
-| **v0.5.3 ✓** | **(current)** | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.4+. |
+| v0.5.3 ✓ | | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.x+. |
+| **v0.5.4 ✓** | **(current)** | Vessel trail stores primary-relative R per sample (was: heliocentric inertial). Trail now follows the craft's apparent orbit around its primary; pre-fix it was a heliocentric trace drifting at Earth's orbital speed (~30 km/s). |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -40,17 +40,31 @@ type World struct {
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
 
-	// trail is a ring buffer of recent craft inertial positions for the
-	// vessel-position-trail render (v0.5.2). Capacity = trailCap; when
-	// full, new samples overwrite the oldest. trailLen ≤ trailCap is
-	// the live count. trailAccumSec is the sim-time accrued since the
-	// last sample — we sample at trailIntervalSec, not every tick, so
-	// trail length corresponds to ~trailCap × trailIntervalSec of sim
-	// history regardless of warp.
-	trail         [trailCap]orbital.Vec3
+	// trail is a ring buffer of recent craft samples for the vessel-
+	// position-trail render. Each sample stores the primary's body ID
+	// and the craft's position *in that primary's frame* (v0.5.4) — at
+	// render time the inertial position is reconstructed via
+	// BodyPosition(primary). Pre-v0.5.4 stored heliocentric inertial
+	// directly, which made the trail a heliocentric trace rather than
+	// following the craft's apparent orbit around its primary.
+	//
+	// trailLen ≤ trailCap is the live count. trailAccumSec is sim-time
+	// accrued since the last sample — we sample at trailIntervalSec,
+	// not every tick, so trail length covers ~trailCap × trailIntervalSec
+	// of sim history regardless of warp.
+	trail         [trailCap]trailSample
 	trailIdx      int
 	trailLen      int
 	trailAccumSec float64
+}
+
+// trailSample captures the craft's position in its primary's frame at
+// the moment of capture. The primary may differ across samples (an
+// SOI crossing changes which body the craft is bound to); each sample
+// is independently re-translated at render time.
+type trailSample struct {
+	primaryID string
+	relR      orbital.Vec3
 }
 
 const (
@@ -168,41 +182,69 @@ func (w *World) Tick() {
 	}
 }
 
-// maybeRecordTrail appends the craft's current inertial position to
-// the trail ring buffer when trailIntervalSec of sim time has elapsed
-// since the last sample. The sim-time gating means trail density
-// stays roughly constant across warp levels — at warp=1 we sample
-// every ~10 sim seconds (≈200 ticks), at warp=10000× every ~10
-// sim seconds (≈one tick). Either way the visible trail covers
-// trailCap × trailIntervalSec ≈ 33 minutes of sim history.
+// maybeRecordTrail appends the craft's current state (in its primary's
+// frame) to the trail ring buffer when trailIntervalSec of sim time
+// has elapsed since the last sample. Storing primary-relative R and
+// re-translating at render time keeps the trail aligned with the
+// craft's apparent orbit around its primary — pre-v0.5.4 we stored
+// heliocentric inertial directly, which made LEO trails appear to
+// drift through space at Earth's orbital speed (~30 km/s).
+//
+// The sim-time gating means trail density stays roughly constant
+// across warp levels — at warp=1 we sample every ~10 sim seconds
+// (≈200 ticks), at warp=10000× every ~10 sim seconds (≈one tick).
+// Either way the visible trail covers trailCap × trailIntervalSec
+// ≈ 33 minutes of sim history.
 func (w *World) maybeRecordTrail(secs float64) {
 	w.trailAccumSec += secs
 	if w.trailAccumSec < trailIntervalSec {
 		return
 	}
 	w.trailAccumSec = 0
-	w.trail[w.trailIdx] = w.CraftInertial()
+	w.trail[w.trailIdx] = trailSample{
+		primaryID: w.Craft.Primary.ID,
+		relR:      w.Craft.State.R,
+	}
 	w.trailIdx = (w.trailIdx + 1) % trailCap
 	if w.trailLen < trailCap {
 		w.trailLen++
 	}
 }
 
-// CraftTrail returns the trail samples in oldest-to-newest order. The
-// returned slice is a fresh copy — callers can iterate / reverse
-// safely. Empty when the craft has just spawned and hasn't accumulated
-// trailIntervalSec of sim time yet.
+// CraftTrail returns the trail samples in oldest-to-newest order,
+// each translated into current-tick inertial coordinates via
+// BodyPosition(sample.primary). The returned slice is a fresh copy —
+// callers can iterate / reverse safely. Empty when the craft has
+// just spawned and hasn't accumulated trailIntervalSec of sim time
+// yet.
+//
+// Note: the inertial positions returned here move with the body each
+// frame — a stationary LEO craft over 100 ticks produces samples whose
+// raw stored .relR is identical, but whose translated inertial drifts
+// with Earth. The trail effectively floats with the primary, which is
+// what the player sees (Earth is fixed at canvas center under
+// FocusBody, and the trail loops around it).
 func (w *World) CraftTrail() []orbital.Vec3 {
 	if w.trailLen == 0 {
 		return nil
 	}
+	sys := w.System()
 	out := make([]orbital.Vec3, w.trailLen)
 	start := w.trailIdx - w.trailLen
 	if start < 0 {
 		start += trailCap
 	}
 	for i := 0; i < w.trailLen; i++ {
-		out[i] = w.trail[(start+i)%trailCap]
+		s := w.trail[(start+i)%trailCap]
+		// Re-translate to current inertial. Primary lookup falls back
+		// to system primary if the recorded ID isn't found (e.g. a
+		// system swap removed the body — defensive, shouldn't normally
+		// happen).
+		var primaryPos orbital.Vec3
+		if b := sys.FindBody(s.primaryID); b != nil {
+			primaryPos = w.BodyPosition(*b)
+		}
+		out[i] = primaryPos.Add(s.relR)
 	}
 	return out
 }

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -204,6 +204,41 @@ func TestCraftTrailGrowsAndCaps(t *testing.T) {
 	}
 }
 
+// TestCraftTrailFollowsPrimaryFrame: regression for the v0.5.4 fix.
+// Pre-fix the trail stored heliocentric inertial samples; LEO trail
+// samples taken minutes apart appeared displaced by Earth's motion
+// (~30 km/s × elapsed sim time). Storing primary-relative R + re-
+// translating via current BodyPosition keeps the trail aligned with
+// the craft's apparent orbit around its primary.
+//
+// Test: run enough ticks for several samples to land, then verify
+// that *every* sample's distance from current Earth position is
+// within LEO orbit radius (a few ×10^6 m), not the AU-scale offsets
+// produced by the heliocentric-trail bug.
+func TestCraftTrailFollowsPrimaryFrame(t *testing.T) {
+	w, _ := NewWorld()
+	w.Clock.BaseStep = 60 * time.Second // 1 sample per tick (60s ≥ 10s interval)
+	for i := 0; i < trailCap; i++ {
+		w.Tick()
+	}
+	tr := w.CraftTrail()
+	if len(tr) != trailCap {
+		t.Fatalf("expected full trail (%d), got %d", trailCap, len(tr))
+	}
+	earthPos := w.BodyPosition(w.Craft.Primary)
+	craftR := w.Craft.State.R.Norm()
+	// Allow 2× LEO radius for trail spread over ticks; bug would
+	// produce 1e8+ m displacements.
+	maxAllowed := 2 * craftR
+	for i, p := range tr {
+		dist := p.Sub(earthPos).Norm()
+		if dist > maxAllowed {
+			t.Errorf("trail sample %d: distance from Earth %.3e m > %.3e m (heliocentric drift bug?)",
+				i, dist, maxAllowed)
+		}
+	}
+}
+
 // TestPausedTickDoesNothing: world.Clock.Paused must block both time
 // advancement and physics stepping.
 func TestPausedTickDoesNothing(t *testing.T) {


### PR DESCRIPTION
## Summary

Bug: v0.5.2 trail rendered as a heliocentric trace, drifting at Earth's orbital speed (~30 km/s) — so an LEO trail from 10 minutes ago was ~18000 km behind current Earth. Trail was correct in Sun's frame; wrong in Earth's frame, which is what the player sees.

Fix: trail samples store `(primaryID, primary-relative R)` instead of heliocentric inertial. `CraftTrail()` re-translates each sample via current `BodyPosition(primary)` so samples float with their primary as it moves heliocentrically.

Handles SOI changes naturally — a pre-escape sample stays Earth-relative even after the craft escapes; a post-escape sample is Sun-relative. Both translate independently each frame.

## Tests

- `TestCraftTrailFollowsPrimaryFrame` — full 200-sample trail from a stationary LEO must keep every sample within 2× LEO radius of current Earth. Pre-fix this distance grew unboundedly with elapsed sim time.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: warp from default LEO and watch the trail — should now hug the orbit ellipse, not drift through space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)