### PR TITLE
fix(sim): bodyEphemeris recurses through hierarchy (v0.5.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.4**.
+Latest release: **v0.5.5**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.4)
+## Features (v0.5.5)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.4 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.5 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.4)
+## 1. What works today (v0.5.5)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -218,7 +218,8 @@ features and the version sequence that delivers them.
 | v0.5.1 ✓ | | Color palette (`internal/render/palette.go`): hand-picked body colors + temperature-keyed stellar tint + UI-tier (alert / warning / node / trajectory / SOI). Wired into HUD selected-body name + body-info title. Per-cell canvas coloring stays scoped for v0.5.3 body-identity work. |
 | v0.5.2 ✓ | | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
 | v0.5.3 ✓ | | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.x+. |
-| **v0.5.4 ✓** | **(current)** | Vessel trail stores primary-relative R per sample (was: heliocentric inertial). Trail now follows the craft's apparent orbit around its primary; pre-fix it was a heliocentric trace drifting at Earth's orbital speed (~30 km/s). |
+| v0.5.4 ✓ | | Vessel trail stores primary-relative R per sample (was: heliocentric inertial). Trail now follows the craft's apparent orbit around its primary; pre-fix it was a heliocentric trace drifting at Earth's orbital speed (~30 km/s). |
+| **v0.5.5 ✓** | **(current)** | `bodyEphemeris` now recurses through the v0.5.0 hierarchy. Pre-fix it returned moon's parent-relative position as if heliocentric, so PorkchopGrid + PlanTransferAt for moon targets quoted nonsense Δv (~380 m/s display, ~25 km/s plant). Fix folds in for both. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -348,18 +348,50 @@ func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]flo
 
 // bodyEphemeris returns an EphemerisFn closure for a body: heliocentric
 // (r, v) evaluated at an arbitrary Unix-epoch timestamp.
+//
+// Recurses through the v0.5.0 hierarchy (v0.5.5 fix): a moon's
+// heliocentric state = parent's heliocentric state + moon's state in
+// the parent's frame. Velocity uses the parent's μ, not the system
+// primary's. Pre-v0.5.5 this returned moon's parent-relative position
+// as if it were heliocentric, breaking PorkchopGrid + PlanTransferAt
+// for moon targets — Lambert solved from Earth_helio to ~origin and
+// quoted nonsense Δv (porkchop displayed ~380 m/s, plant produced
+// ~25 km/s, both wrong).
 func (w *World) bodyEphemeris(b bodies.CelestialBody) planner.EphemerisFn {
 	return func(epoch float64) (orbital.Vec3, orbital.Vec3) {
-		t := time.Unix(int64(epoch), 0)
-		M := w.Calculator.CalculateMeanAnomaly(b, t)
-		E := orbital.SolveKepler(M, b.Eccentricity)
-		nu := orbital.TrueAnomaly(E, b.Eccentricity)
-		el := orbital.ElementsFromBody(b)
-		r := orbital.PositionAtTrueAnomaly(el, nu)
-		mu := w.Systems[0].Bodies[0].GravitationalParameter()
-		v := orbital.VelocityAtTrueAnomaly(el, nu, mu)
-		return r, v
+		return w.bodyHelioStateAt(b, epoch)
 	}
+}
+
+// bodyHelioStateAt is the recursive worker behind bodyEphemeris.
+// Returns (heliocentric position, heliocentric velocity) of body b
+// at the given Unix epoch by recursively summing parent-relative
+// state up the hierarchy.
+func (w *World) bodyHelioStateAt(b bodies.CelestialBody, epoch float64) (orbital.Vec3, orbital.Vec3) {
+	if b.SemimajorAxis == 0 {
+		// System primary anchored at origin with zero velocity.
+		return orbital.Vec3{}, orbital.Vec3{}
+	}
+	t := time.Unix(int64(epoch), 0)
+	M := w.Calculator.CalculateMeanAnomaly(b, t)
+	E := orbital.SolveKepler(M, b.Eccentricity)
+	nu := orbital.TrueAnomaly(E, b.Eccentricity)
+	el := orbital.ElementsFromBody(b)
+	rRel := orbital.PositionAtTrueAnomaly(el, nu)
+
+	sys := w.System()
+	parent := sys.ParentOf(b)
+	if parent == nil {
+		parent = sys.Primary()
+	}
+	mu := parent.GravitationalParameter()
+	vRel := orbital.VelocityAtTrueAnomaly(el, nu, mu)
+
+	if b.ParentID == "" {
+		return rRel, vRel
+	}
+	rParent, vParent := w.bodyHelioStateAt(*parent, epoch)
+	return rParent.Add(rRel), vParent.Add(vRel)
 }
 
 // transferNodeToManeuver converts a planner.TransferNode into a

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -325,6 +325,51 @@ func TestPlanTransferRejectsBadTargets(t *testing.T) {
 	}
 }
 
+// TestPorkchopGridForMoonTargetIsHeliocentric: regression for the
+// v0.5.5 fix. Pre-fix bodyEphemeris returned moon's parent-relative
+// position as if heliocentric, so PorkchopGrid for a moon target
+// solved Lambert with one endpoint near the system origin and
+// produced wildly wrong Δv (often <1 km/s — geometrically suspicious
+// for a heliocentric transfer to anything in Earth's vicinity).
+//
+// Sanity gate: the cheapest Δv on a Earth → Luna porkchop grid must
+// at minimum cover a typical Earth-escape (~3 km/s). If we see <1 km/s
+// the bug has regressed.
+func TestPorkchopGridForMoonTargetIsHeliocentric(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	moonIdx := -1
+	for i := range sys.Bodies {
+		if sys.Bodies[i].ID == "moon" {
+			moonIdx = i
+			break
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	depDays := []float64{0, 5, 10}
+	tofDays := []float64{3, 5, 7}
+	grid, err := w.PorkchopGrid(moonIdx, depDays, tofDays)
+	if err != nil {
+		t.Fatalf("PorkchopGrid: %v", err)
+	}
+	best := math.Inf(1)
+	for _, row := range grid {
+		for _, v := range row {
+			if !math.IsNaN(v) && v < best {
+				best = v
+			}
+		}
+	}
+	if math.IsInf(best, 1) {
+		t.Fatal("entire porkchop grid was NaN — Lambert never converged")
+	}
+	if best < 1000 {
+		t.Errorf("Earth → Luna best porkchop Δv = %.1f m/s, suspiciously cheap (heliocentric-vs-parent-relative bug?)", best)
+	}
+}
+
 func mustWorld(t *testing.T) *World {
 	t.Helper()
 	w, err := NewWorld()


### PR DESCRIPTION
## Summary

v0.5.0 added body hierarchy via ParentID and recursed `BodyPosition` + `bodyInertialVelocity` correctly. `bodyEphemeris` (used by `PorkchopGrid` + `PlanTransferAt` for arbitrary-epoch state queries) was missed. For moon targets:

- Returned moon's parent-relative position as if heliocentric (Luna at ~384k m from origin instead of Earth's ~1.5e11 m).
- Used Sun's μ for velocity instead of the parent's (Luna's orbital elements are around Earth, not Sun).

Effect: porkchop quoted nonsense Δv for Earth → Luna (~380 m/s display, ~25 km/s plant — both wrong, just broken in different ways through the patched-conic conversion).

Fix: `bodyHelioStateAt` recurses up the parent chain, summing parent-relative state at each level. Moon's heliocentric state = parent's heliocentric state + moon's state in parent's frame. Velocity uses parent's μ. `bodyEphemeris` becomes a thin wrapper.

## Tests

- `TestPorkchopGridForMoonTargetIsHeliocentric` — Earth → Luna best porkchop Δv must be ≥ 1 km/s. Pre-fix it was sub-km/s, geometrically suspicious for a transfer that needs Earth-escape.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: select Luna, press `k`, navigate the porkchop — quoted Δv should now be in km/s range (Earth-escape neighborhood). Plant with Enter; the planted node Δv should match cell display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)