### PR TITLE
balance(spacecraft): default vessel modeled on Artemis II ICPS (v0.5.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.5**.
+Latest release: **v0.5.6**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.5)
+## Features (v0.5.6)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.5 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.6 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.5)
+## 1. What works today (v0.5.6)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -28,14 +28,14 @@ features and the version sequence that delivers them.
   the (1024 sub-steps × period/100) / base-step guard from v0.1.
 
 ### Spacecraft & burns
-- **Finite-duration burns**. `Spacecraft.Thrust = 10 kN` default; a node's
+- **Finite-duration burns**. `Spacecraft.Thrust = 108 kN` default (RL-10C-3); a node's
   `Duration` field controls integration. Mass flow `dm/dt = -Thrust/(Isp·g0)`
   debits fuel each sub-step; burn ends on Δv delivered, fuel exhausted, or
   duration elapsed (whichever first).
 - **Six burn modes**: prograde, retrograde, normal±, radial±. Direction is
   recomputed each sub-step from live (r, v) so held-prograde follows the
   rotating velocity frame.
-- Default vessel: 500 kg dry + 500 kg fuel, Isp 300 s, Thrust 10 kN, spawned
+- Default vessel ("ICPS-1"): 3500 kg dry + 25000 kg fuel, Isp 462 s, Thrust 108 kN, spawned
   in 200 km LEO.
 
 ### Planning
@@ -219,7 +219,8 @@ features and the version sequence that delivers them.
 | v0.5.2 ✓ | | Vessel position trail: 200-sample ring buffer of inertial positions, sampled every 10 sim seconds (warp-independent density). Renders as a fading-stride dot trail on the orbit canvas behind the live ellipse. |
 | v0.5.3 ✓ | | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.x+. |
 | v0.5.4 ✓ | | Vessel trail stores primary-relative R per sample (was: heliocentric inertial). Trail now follows the craft's apparent orbit around its primary; pre-fix it was a heliocentric trace drifting at Earth's orbital speed (~30 km/s). |
-| **v0.5.5 ✓** | **(current)** | `bodyEphemeris` now recurses through the v0.5.0 hierarchy. Pre-fix it returned moon's parent-relative position as if heliocentric, so PorkchopGrid + PlanTransferAt for moon targets quoted nonsense Δv (~380 m/s display, ~25 km/s plant). Fix folds in for both. |
+| v0.5.5 ✓ | | `bodyEphemeris` now recurses through the v0.5.0 hierarchy. Pre-fix it returned moon's parent-relative position as if heliocentric, so PorkchopGrid + PlanTransferAt for moon targets quoted nonsense Δv (~380 m/s display, ~25 km/s plant). Fix folds in for both. |
+| **v0.5.6 ✓** | **(current)** | Default vessel is now an ICPS-like upper stage: 3500 kg dry + 25000 kg fuel, Isp 462 s (RL-10C-3), thrust 108 kN. Δv ~9.5 km/s — comfortable for a Earth → Luna round trip. Pre-v0.5.6 default (500/500/Isp 300, ~2 km/s) couldn't even reach Luna one-way. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -41,23 +41,33 @@ func (s *Spacecraft) OrbitalSpeed() float64 { return s.State.V.Norm() }
 // NewInLEO builds a spacecraft in a 200 km circular prograde parking orbit
 // around the provided primary (typically Earth). Orbit lies in the primary's
 // equatorial plane (z=0) with periapsis along +X, velocity along +Y.
-// Mass numbers: 500 kg dry + 500 kg fuel, Isp 300s — generic upper-stage
-// ballpark, good enough for a sandbox.
+//
+// Mass / propulsion numbers (v0.5.6) modeled on the SLS Interim Cryogenic
+// Propulsion Stage (ICPS) — the upper stage that performs trans-lunar
+// injection on Artemis II:
+//   - DryMass 3500 kg (close to ICPS empty mass 3490 kg)
+//   - Fuel 25000 kg (close to ICPS LH2/LOX capacity ~27220 kg)
+//   - Isp 462 s (RL-10C-3, ICPS's engine)
+//   - Thrust 108 kN (RL-10C-3 spec)
+//
+// Δv budget = 462 × g₀ × ln(28500/3500) ≈ 9.5 km/s — comfortable for a
+// LEO → TLI → LOI → TEI → Earth-return round trip with margin. Pre-v0.5.6
+// the default (500/500/Isp 300, ~2 km/s) couldn't even reach Luna one-way.
 func NewInLEO(earth bodies.CelestialBody) *Spacecraft {
 	r := earth.RadiusMeters() + 200e3
 	mu := earth.GravitationalParameter()
 	v := math.Sqrt(mu / r)
 	return &Spacecraft{
-		Name:    "LEO-1",
-		DryMass: 500,
-		Fuel:    500,
-		Isp:     300,
-		Thrust:  10000, // 10 kN — burns finish in seconds-to-minutes for sub-km/s Δv, ~minutes for km/s transfers
+		Name:    "ICPS-1",
+		DryMass: 3500,
+		Fuel:    25000,
+		Isp:     462,
+		Thrust:  108000, // 108 kN — RL-10C-3 vacuum thrust
 		Primary: earth,
 		State: physics.StateVector{
 			R: orbital.Vec3{X: r},
 			V: orbital.Vec3{Y: v},
-			M: 1000,
+			M: 28500,
 		},
 	}
 }

--- a/internal/spacecraft/spacecraft_test.go
+++ b/internal/spacecraft/spacecraft_test.go
@@ -12,8 +12,9 @@ func TestNewInLEO(t *testing.T) {
 	earth := systems[0].FindBody("Earth")
 	sc := NewInLEO(*earth)
 
-	if sc.TotalMass() != 1000 {
-		t.Errorf("total mass = %v, want 1000", sc.TotalMass())
+	// v0.5.6 default: ICPS-like 3500 kg dry + 25000 kg fuel.
+	if sc.TotalMass() != 28500 {
+		t.Errorf("total mass = %v, want 28500", sc.TotalMass())
 	}
 	// Altitude should be ~200 km.
 	alt := sc.Altitude()

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -76,27 +76,27 @@ func TestBurnConsumesFuel(t *testing.T) {
 	}
 }
 
-// TestRemainingDeltaV: starting fuel is half total mass (500 of 1000),
-// Isp 300s → Δv = 300 * 9.80665 * ln(2) ≈ 2038 m/s.
+// TestRemainingDeltaV: v0.5.6 default fuel 25000 kg / dry 3500 kg,
+// Isp 462s → Δv = 462 * 9.80665 * ln(28500/3500) ≈ 9510 m/s.
 func TestRemainingDeltaV(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	earth := systems[0].FindBody("Earth")
 	sc := NewInLEO(*earth)
 	got := sc.RemainingDeltaV()
-	want := 300.0 * 9.80665 * math.Ln2
+	want := 462.0 * 9.80665 * math.Log(28500.0/3500.0)
 	if math.Abs(got-want) > 1 {
 		t.Errorf("Δv_remaining = %.2f m/s, want %.2f m/s", got, want)
 	}
 }
 
-// TestMassFlowRate: at default Thrust=10000 N, Isp=300 s,
-// ṁ = 10000 / (300 · 9.80665) ≈ 3.399 kg/s.
+// TestMassFlowRate: v0.5.6 default Thrust 108000 N, Isp 462 s
+// (RL-10C-3) → ṁ = 108000 / (462 · 9.80665) ≈ 23.84 kg/s.
 func TestMassFlowRate(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	earth := systems[0].FindBody("Earth")
 	sc := NewInLEO(*earth)
 	got := sc.MassFlowRate()
-	want := 10000.0 / (300.0 * 9.80665)
+	want := 108000.0 / (462.0 * 9.80665)
 	if math.Abs(got-want) > 1e-6 {
 		t.Errorf("MassFlowRate = %.6f, want %.6f", got, want)
 	}


### PR DESCRIPTION
## Summary

Pre-v0.5.6 default vessel had ~2 km/s Δv. Earth → Luna one-way needs ~3.8 km/s, so the player couldn't actually execute the lunar mission the new porkchop / PlanTransferAt UI advertises.

Bump to ICPS-equivalent (the SLS Interim Cryogenic Propulsion Stage that performs trans-lunar injection on Artemis II):

| Field | Old | New | Source |
|-------|-----|-----|--------|
| DryMass | 500 kg | 3500 kg | ICPS empty: 3490 kg |
| Fuel | 500 kg | 25000 kg | ICPS LH2/LOX: ~27220 kg |
| Isp | 300 s | 462 s | RL-10C-3 |
| Thrust | 10 kN | 108 kN | RL-10C-3 vacuum |
| Name | "LEO-1" | "ICPS-1" | — |

Δv budget = 462 × g₀ × ln(28500/3500) ≈ 9.5 km/s — comfortable for LEO → TLI → LOI → TEI → Earth-return round trip with margin.

## Tests

Bumped: `TotalMass`, `RemainingDeltaV`, `MassFlowRate` now reflect new defaults.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: spawn, plant Hohmann to Luna, execute — should have visible margin in Δv budget.
- [ ] Manual: full round trip (TLI + LOI + parking-orbit + TEI + Earth recapture) should fit in 9.5 km/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)