### PR TITLE
feat(planner,sim): intra-primary Hohmann for moon transfers (v0.5.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.6**.
+Latest release: **v0.5.7**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.6)
+## Features (v0.5.7)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.6 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.7 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.6)
+## 1. What works today (v0.5.7)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -220,7 +220,8 @@ features and the version sequence that delivers them.
 | v0.5.3 ✓ | | Per-cell canvas body coloring: `Canvas.AddColoredDisk` tags each body's cell footprint with its palette color; `String()` emits per-cell ANSI foregrounds. Body-identity glyphs / Saturn rings / HUD dividers / porkchop axis labels stay scoped for v0.5.x+. |
 | v0.5.4 ✓ | | Vessel trail stores primary-relative R per sample (was: heliocentric inertial). Trail now follows the craft's apparent orbit around its primary; pre-fix it was a heliocentric trace drifting at Earth's orbital speed (~30 km/s). |
 | v0.5.5 ✓ | | `bodyEphemeris` now recurses through the v0.5.0 hierarchy. Pre-fix it returned moon's parent-relative position as if heliocentric, so PorkchopGrid + PlanTransferAt for moon targets quoted nonsense Δv (~380 m/s display, ~25 km/s plant). Fix folds in for both. |
-| **v0.5.6 ✓** | **(current)** | Default vessel is now an ICPS-like upper stage: 3500 kg dry + 25000 kg fuel, Isp 462 s (RL-10C-3), thrust 108 kN. Δv ~9.5 km/s — comfortable for a Earth → Luna round trip. Pre-v0.5.6 default (500/500/Isp 300, ~2 km/s) couldn't even reach Luna one-way. |
+| v0.5.6 ✓ | | Default vessel is now an ICPS-like upper stage: 3500 kg dry + 25000 kg fuel, Isp 462 s (RL-10C-3), thrust 108 kN. Δv ~9.5 km/s — comfortable for a Earth → Luna round trip. Pre-v0.5.6 default (500/500/Isp 300, ~2 km/s) couldn't even reach Luna one-way. |
+| **v0.5.7 ✓** | **(current)** | Intra-primary Hohmann (`PlanIntraPrimaryHohmann`): when target shares craft's primary (e.g. Luna, both around Earth), `P` plants a geocentric Hohmann (~3.1 km/s TLI + ~0.7 km/s Luna-orbit insertion). Pre-v0.5.7 the heliocentric Hohmann/Lambert path treated Luna's parent-relative semimajor as heliocentric → wildly wrong Δv. Porkchop now rejects same-primary targets with a banner redirecting to `P`. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/planner/transfer.go
+++ b/internal/planner/transfer.go
@@ -116,6 +116,85 @@ func PlanHohmannTransfer(
 	}, nil
 }
 
+// PlanIntraPrimaryHohmann constructs a Hohmann transfer for the case
+// where craft and target both orbit the same primary (e.g. craft in
+// LEO around Earth → Luna also around Earth). Pre-v0.5.7 PlanTransfer
+// assumed craft and target both heliocentric; for moon targets it
+// computed nonsense (Luna's parent-relative semimajor used as a
+// heliocentric distance).
+//
+// Inputs:
+//   - mu: GM of the shared primary (e.g. Earth's GM).
+//   - rDeparture: craft's |R| in primary's frame (e.g. LEO radius
+//     ≈ 6571 km for 200 km altitude).
+//   - rArrival: target's semimajor axis around primary (e.g. Luna's
+//     384 399 km).
+//   - departureID: identifier of the primary (for ManeuverNode
+//     PrimaryID labeling).
+//   - muTarget, rCapture, targetID: target body's GM, capture-orbit
+//     radius around target, and ID. Used for the SOI-entry braking
+//     burn — closing speed at rendezvous becomes v∞ relative to
+//     target, which CaptureBurnDeltaV converts to a circular-orbit
+//     insertion Δv.
+//
+// Departure burn: prograde Δv at periapsis raising apoapsis to
+// rArrival. Arrival burn: capture into target SOI at rArrival.
+//
+// Phasing not enforced — same caveat as PlanHohmannTransfer.
+func PlanIntraPrimaryHohmann(
+	mu float64,
+	rDeparture, rArrival float64,
+	departureID string,
+	muTarget, rCapture float64,
+	targetID string,
+) (TransferPlan, error) {
+	if mu <= 0 || rDeparture <= 0 || rArrival <= 0 {
+		return TransferPlan{}, errors.New("planintra: mu and radii must be positive")
+	}
+	if rDeparture == rArrival {
+		return TransferPlan{}, errors.New("planintra: departure and arrival radii are equal — no transfer")
+	}
+
+	aT := (rDeparture + rArrival) / 2
+	vDepCirc := math.Sqrt(mu / rDeparture)
+	vArrCirc := math.Sqrt(mu / rArrival)
+	vTransAtDep := math.Sqrt(mu * (2/rDeparture - 1/aT))
+	vTransAtArr := math.Sqrt(mu * (2/rArrival - 1/aT))
+
+	dvDep := vTransAtDep - vDepCirc
+	// Closing speed at rendezvous: target moves at vArrCirc, craft
+	// arrives with vTransAtArr. Outbound: target faster, craft is
+	// slower → target catches craft from "behind" relative to
+	// rendezvous geometry, vInf = vArrCirc - vTransAtArr.
+	vInfArr := math.Abs(vArrCirc - vTransAtArr)
+	dvArr, err := CaptureBurnDeltaV(vInfArr, muTarget, rCapture)
+	if err != nil {
+		return TransferPlan{}, err
+	}
+
+	// Coast time = half the transfer ellipse's period.
+	transferTime := math.Pi * math.Sqrt(aT*aT*aT/mu)
+
+	outbound := rArrival > rDeparture
+	return TransferPlan{
+		Departure: TransferNode{
+			Leg:          LegDeparture,
+			PrimaryID:    departureID,
+			DV:           math.Abs(dvDep),
+			OffsetTime:   0,
+			IsRetrograde: !outbound,
+		},
+		Arrival: TransferNode{
+			Leg:          LegArrival,
+			PrimaryID:    targetID,
+			DV:           dvArr,
+			OffsetTime:   time.Duration(transferTime * float64(time.Second)),
+			IsRetrograde: outbound,
+		},
+		TransferDt: time.Duration(transferTime * float64(time.Second)),
+	}, nil
+}
+
 // PlanLambertTransfer builds a two-burn transfer for an arbitrary
 // (departure-time, time-of-flight) pair using a single-rev Lambert
 // solve for the heliocentric coast. Unlike PlanHohmannTransfer which

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -80,20 +80,40 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		return nil, errInvalidTransferTarget
 	}
 
+	rPark := w.Craft.State.R.Norm()
+	rCapture := target.RadiusMeters() + 200e3
+	muDestination := target.GravitationalParameter()
+
+	// v0.5.7: if target shares the craft's primary (e.g. craft in LEO
+	// targeting Luna, both around Earth), use intra-primary Hohmann.
+	// The patched-conic inter-primary path is wrong for in-SOI targets
+	// (it adds an Earth-escape burn that isn't physically required —
+	// craft and target both stay inside the shared primary's SOI).
+	if target.ParentID == w.Craft.Primary.ID {
+		muShared := w.Craft.Primary.GravitationalParameter()
+		rArrival := target.SemimajorAxisMeters()
+		plan, err := planner.PlanIntraPrimaryHohmann(
+			muShared, rPark, rArrival,
+			w.Craft.Primary.ID,
+			muDestination, rCapture, target.ID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		now := w.Clock.SimTime
+		mass := w.Craft.TotalMass()
+		thrust := w.Craft.Thrust
+		w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
+		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+		return &plan, nil
+	}
+
 	primary := sys.Bodies[0]
 	muSun := primary.GravitationalParameter()
 	rDeparture := w.CraftInertial().Norm()
 	rArrival := target.SemimajorAxisMeters()
 
-	// Parking-orbit radius at departure: craft's current |r| in its
-	// home primary's frame. Capture radius at destination: hold-over
-	// 200 km altitude default to mirror NewInLEO ergonomics — the
-	// game-balance question of "what circular orbit does the player
-	// want around Mars" is documented, not enforced.
-	rPark := w.Craft.State.R.Norm()
 	muDeparture := w.Craft.Primary.GravitationalParameter()
-	rCapture := target.RadiusMeters() + 200e3
-	muDestination := target.GravitationalParameter()
 
 	plan, err := planner.PlanHohmannTransfer(
 		muSun, rDeparture, rArrival,
@@ -265,6 +285,13 @@ func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.
 	if target.SemimajorAxis == 0 {
 		return nil, errInvalidTransferTarget
 	}
+	// v0.5.7: porkchop / Lambert is heliocentric — invalid for in-SOI
+	// targets (moon of craft's primary). Caller (porkchop screen) shows
+	// a banner directing the user to `P` (PlanTransfer auto-plants the
+	// intra-primary Hohmann correctly).
+	if target.ParentID == w.Craft.Primary.ID {
+		return nil, errSamePrimaryUseHohmann
+	}
 
 	primary := sys.Bodies[0]
 	muSun := primary.GravitationalParameter()
@@ -311,6 +338,11 @@ func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.
 //
 // Uses the same parking-orbit and capture-orbit defaults as PlanTransfer
 // (craft's current |r| at departure, 200 km altitude at destination).
+//
+// v0.5.7: rejects same-primary targets (moon of craft's primary) with
+// errSamePrimaryUseHohmann — the heliocentric Lambert math doesn't
+// model in-SOI transfers. The porkchop screen surfaces the error as a
+// "use [P] for Hohmann" banner.
 func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]float64, error) {
 	sys := w.System()
 	if targetIdx <= 0 || targetIdx >= len(sys.Bodies) {
@@ -322,6 +354,9 @@ func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]flo
 	target := sys.Bodies[targetIdx]
 	if target.SemimajorAxis == 0 {
 		return nil, errInvalidTransferTarget
+	}
+	if target.ParentID == w.Craft.Primary.ID {
+		return nil, errSamePrimaryUseHohmann
 	}
 
 	primary := sys.Bodies[0]
@@ -422,6 +457,7 @@ var (
 	errInvalidTransferTarget = transferError("invalid transfer target body")
 	errNoCraftForTransfer    = transferError("no craft to plan transfer for")
 	errNoRefineTarget        = transferError("no pending transfer to refine")
+	errSamePrimaryUseHohmann = transferError("target shares craft's primary — use [P] auto-Hohmann instead of porkchop")
 )
 
 type transferError string

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -325,17 +325,12 @@ func TestPlanTransferRejectsBadTargets(t *testing.T) {
 	}
 }
 
-// TestPorkchopGridForMoonTargetIsHeliocentric: regression for the
-// v0.5.5 fix. Pre-fix bodyEphemeris returned moon's parent-relative
-// position as if heliocentric, so PorkchopGrid for a moon target
-// solved Lambert with one endpoint near the system origin and
-// produced wildly wrong Δv (often <1 km/s — geometrically suspicious
-// for a heliocentric transfer to anything in Earth's vicinity).
-//
-// Sanity gate: the cheapest Δv on a Earth → Luna porkchop grid must
-// at minimum cover a typical Earth-escape (~3 km/s). If we see <1 km/s
-// the bug has regressed.
-func TestPorkchopGridForMoonTargetIsHeliocentric(t *testing.T) {
+// TestPorkchopGridRejectsSamePrimaryTarget: v0.5.7 — porkchop is
+// heliocentric Lambert, doesn't model in-SOI transfers correctly.
+// Same-primary moon targets must error out with errSamePrimaryUseHohmann
+// so the screen can redirect the user to [P] / PlanTransfer (which
+// dispatches to the intra-primary Hohmann path).
+func TestPorkchopGridRejectsSamePrimaryTarget(t *testing.T) {
 	w := mustWorld(t)
 	sys := w.System()
 	moonIdx := -1
@@ -348,25 +343,44 @@ func TestPorkchopGridForMoonTargetIsHeliocentric(t *testing.T) {
 	if moonIdx < 0 {
 		t.Skip("Moon missing from Sol")
 	}
-	depDays := []float64{0, 5, 10}
-	tofDays := []float64{3, 5, 7}
-	grid, err := w.PorkchopGrid(moonIdx, depDays, tofDays)
-	if err != nil {
-		t.Fatalf("PorkchopGrid: %v", err)
+	if _, err := w.PorkchopGrid(moonIdx, []float64{0}, []float64{5}); err == nil {
+		t.Errorf("PorkchopGrid for Moon (same-primary) returned nil error — should be errSamePrimaryUseHohmann")
 	}
-	best := math.Inf(1)
-	for _, row := range grid {
-		for _, v := range row {
-			if !math.IsNaN(v) && v < best {
-				best = v
-			}
+}
+
+// TestPlanTransferIntraPrimaryHohmannForMoon: v0.5.7 — PlanTransfer
+// must dispatch to PlanIntraPrimaryHohmann when target.ParentID matches
+// craft's primary. Sanity-check that Earth → Luna gives a realistic
+// trans-lunar injection Δv (~3 km/s departure) rather than the
+// pre-v0.5.7 nonsense from heliocentric Hohmann math interpreting
+// Luna's parent-relative semimajor as a heliocentric distance.
+func TestPlanTransferIntraPrimaryHohmannForMoon(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	moonIdx := -1
+	for i := range sys.Bodies {
+		if sys.Bodies[i].ID == "moon" {
+			moonIdx = i
+			break
 		}
 	}
-	if math.IsInf(best, 1) {
-		t.Fatal("entire porkchop grid was NaN — Lambert never converged")
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
 	}
-	if best < 1000 {
-		t.Errorf("Earth → Luna best porkchop Δv = %.1f m/s, suspiciously cheap (heliocentric-vs-parent-relative bug?)", best)
+	plan, err := w.PlanTransfer(moonIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer to Luna: %v", err)
+	}
+	// TLI Δv from 200 km LEO to Luna distance is ~3.1 km/s (geocentric
+	// Hohmann math). Capture into Luna SOI from closing speed ~0.8 km/s
+	// at Luna's altitude → Luna-orbit-insertion Δv ~0.7 km/s.
+	dep := plan.Departure.DV
+	arr := plan.Arrival.DV
+	if dep < 2500 || dep > 3500 {
+		t.Errorf("Earth → Luna departure Δv = %.0f m/s, want ~3100 (TLI)", dep)
+	}
+	if arr < 200 || arr > 1500 {
+		t.Errorf("Earth → Luna arrival Δv = %.0f m/s, want ~700 (Luna-orbit insertion)", arr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes "ICPS overshot the moon": the heliocentric Hohmann/Lambert path was the wrong physics model for Luna (an in-SOI target). Pre-v0.5.7 it treated Luna's parent-relative 384k km semimajor as a heliocentric distance, computing a Hohmann from Earth-helio (1.5e11 m) to "Luna at 384k km from Sun" — wildly wrong departure burn.

- **`planner.PlanIntraPrimaryHohmann`** — classic two-burn Hohmann around the shared primary. Departure prograde Δv at periapsis raises apoapsis to target's distance; arrival captures into target SOI from closing-speed v∞.
- **`World.PlanTransfer`** detects `target.ParentID == w.Craft.Primary.ID` and dispatches to the intra-primary path (Earth's μ, not Sun's).
- **Porkchop / `PlanTransferAt`** reject same-primary targets with `errSamePrimaryUseHohmann`. The screen's existing error path renders the message as a banner directing the user to `[P]`.

Earth → Luna now gives ~3.1 km/s TLI + ~0.7 km/s Luna-orbit insertion — matches the known TLI/LOI budget.

## Tests

- `TestPorkchopGridRejectsSamePrimaryTarget` — porkchop for Moon target returns the sentinel error.
- `TestPlanTransferIntraPrimaryHohmannForMoon` — `P` on Moon dispatches intra-primary; departure Δv in 2.5–3.5 km/s, arrival 0.2–1.5 km/s.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: select Moon, press `P` — should plant departure ~3.1 km/s + arrival ~0.7 km/s.
- [ ] Manual: select Moon, press `k` — porkchop should show the "use [P]" banner instead of a grid.
- [ ] Manual: execute the planted Earth → Luna burns — should rendezvous with Luna without overshooting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)