### PR TITLE
fix(planner,sim): phase-corrected intra-primary Hohmann (v0.5.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.8**.
+Latest release: **v0.5.9**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.8)
+## Features (v0.5.9)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.8 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.9 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.8)
+## 1. What works today (v0.5.9)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -222,7 +222,8 @@ features and the version sequence that delivers them.
 | v0.5.5 ✓ | | `bodyEphemeris` now recurses through the v0.5.0 hierarchy. Pre-fix it returned moon's parent-relative position as if heliocentric, so PorkchopGrid + PlanTransferAt for moon targets quoted nonsense Δv (~380 m/s display, ~25 km/s plant). Fix folds in for both. |
 | v0.5.6 ✓ | | Default vessel is now an ICPS-like upper stage: 3500 kg dry + 25000 kg fuel, Isp 462 s (RL-10C-3), thrust 108 kN. Δv ~9.5 km/s — comfortable for a Earth → Luna round trip. Pre-v0.5.6 default (500/500/Isp 300, ~2 km/s) couldn't even reach Luna one-way. |
 | v0.5.7 ✓ | | Intra-primary Hohmann (`PlanIntraPrimaryHohmann`): when target shares craft's primary (e.g. Luna, both around Earth), Hohmann plants a geocentric Hohmann (~3.1 km/s TLI + ~0.7 km/s Luna-orbit insertion). Pre-v0.5.7 the heliocentric Hohmann/Lambert path treated Luna's parent-relative semimajor as heliocentric → wildly wrong Δv. Porkchop rejects same-primary targets with a banner redirecting to Hohmann. |
-| **v0.5.8 ✓** | **(current)** | Keybind cleanup: `P` → porkchop (was `k`), `H` → Hohmann auto-plant (was `P`). Mnemonic: P/Porkchop, H/Hohmann. |
+| v0.5.8 ✓ | | Keybind cleanup: `P` → porkchop (was `k`), `H` → Hohmann auto-plant (was `P`). Mnemonic: P/Porkchop, H/Hohmann. |
+| **v0.5.9 ✓** | **(current)** | Phase-corrected intra-primary Hohmann: `H` on a moon now waits for the next launch window (Luna leads craft by `π − n_target·T_transfer`) so the craft actually rendezvous with the target instead of arriving at empty apoapsis. Synodic period for LEO+Luna ≈ 89 min so the wait is short. Also fixes porkchop redirect-banner text from `[P]` to `[H]`. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/planner/transfer.go
+++ b/internal/planner/transfer.go
@@ -129,6 +129,12 @@ func PlanHohmannTransfer(
 //     ≈ 6571 km for 200 km altitude).
 //   - rArrival: target's semimajor axis around primary (e.g. Luna's
 //     384 399 km).
+//   - craftAngleNow / targetAngleNow: current angular positions of
+//     craft and target around the shared primary (radians, atan2 of
+//     position-vector y, x in the primary's frame). Used for phase-
+//     corrected launch-window timing — the departure burn fires when
+//     target leads craft by (π − n_target · T_transfer), so craft
+//     arrives at apoapsis when target is also there. v0.5.9+.
 //   - departureID: identifier of the primary (for ManeuverNode
 //     PrimaryID labeling).
 //   - muTarget, rCapture, targetID: target body's GM, capture-orbit
@@ -139,11 +145,10 @@ func PlanHohmannTransfer(
 //
 // Departure burn: prograde Δv at periapsis raising apoapsis to
 // rArrival. Arrival burn: capture into target SOI at rArrival.
-//
-// Phasing not enforced — same caveat as PlanHohmannTransfer.
 func PlanIntraPrimaryHohmann(
 	mu float64,
 	rDeparture, rArrival float64,
+	craftAngleNow, targetAngleNow float64,
 	departureID string,
 	muTarget, rCapture float64,
 	targetID string,
@@ -162,10 +167,6 @@ func PlanIntraPrimaryHohmann(
 	vTransAtArr := math.Sqrt(mu * (2/rArrival - 1/aT))
 
 	dvDep := vTransAtDep - vDepCirc
-	// Closing speed at rendezvous: target moves at vArrCirc, craft
-	// arrives with vTransAtArr. Outbound: target faster, craft is
-	// slower → target catches craft from "behind" relative to
-	// rendezvous geometry, vInf = vArrCirc - vTransAtArr.
 	vInfArr := math.Abs(vArrCirc - vTransAtArr)
 	dvArr, err := CaptureBurnDeltaV(vInfArr, muTarget, rCapture)
 	if err != nil {
@@ -175,24 +176,68 @@ func PlanIntraPrimaryHohmann(
 	// Coast time = half the transfer ellipse's period.
 	transferTime := math.Pi * math.Sqrt(aT*aT*aT/mu)
 
+	// Phase-corrected launch window. Mean motions:
+	//   n_craft  = √(µ / r_dep³)   (parking orbit)
+	//   n_target = √(µ / r_arr³)   (target's circular orbit)
+	// At burn time, target should lead craft by:
+	//   Δθ_required = π − n_target · T_transfer   (mod 2π)
+	// Current phase difference: Δθ_now = θ_target − θ_craft (mod 2π)
+	// Phase difference evolves as Δθ(t) = Δθ_now + (n_target − n_craft)·t.
+	// Solve for smallest τ ≥ 0 such that Δθ(τ) ≡ Δθ_required (mod 2π).
+	nCraft := math.Sqrt(mu / (rDeparture * rDeparture * rDeparture))
+	nTarget := math.Sqrt(mu / (rArrival * rArrival * rArrival))
+	requiredDelta := wrapTau(math.Pi - nTarget*transferTime)
+	currentDelta := wrapTau(targetAngleNow - craftAngleNow)
+	relativeRate := nTarget - nCraft // negative when craft is faster (LEO is)
+	deltaToWait := requiredDelta - currentDelta
+	if relativeRate > 0 {
+		// Δθ increases over time — wait until next forward arrival at requiredDelta.
+		for deltaToWait < 0 {
+			deltaToWait += 2 * math.Pi
+		}
+	} else if relativeRate < 0 {
+		// Δθ decreases over time — wait until next backward arrival at requiredDelta.
+		for deltaToWait > 0 {
+			deltaToWait -= 2 * math.Pi
+		}
+	}
+	var waitTime float64
+	if relativeRate != 0 {
+		waitTime = deltaToWait / relativeRate
+	}
+	if waitTime < 0 {
+		waitTime = 0
+	}
+
 	outbound := rArrival > rDeparture
+	depOffset := time.Duration(waitTime * float64(time.Second))
 	return TransferPlan{
 		Departure: TransferNode{
 			Leg:          LegDeparture,
 			PrimaryID:    departureID,
 			DV:           math.Abs(dvDep),
-			OffsetTime:   0,
+			OffsetTime:   depOffset,
 			IsRetrograde: !outbound,
 		},
 		Arrival: TransferNode{
 			Leg:          LegArrival,
 			PrimaryID:    targetID,
 			DV:           dvArr,
-			OffsetTime:   time.Duration(transferTime * float64(time.Second)),
+			OffsetTime:   depOffset + time.Duration(transferTime*float64(time.Second)),
 			IsRetrograde: outbound,
 		},
 		TransferDt: time.Duration(transferTime * float64(time.Second)),
 	}, nil
+}
+
+// wrapTau normalises an angle to [0, 2π).
+func wrapTau(a float64) float64 {
+	const tau = 2 * math.Pi
+	a = math.Mod(a, tau)
+	if a < 0 {
+		a += tau
+	}
+	return a
 }
 
 // PlanLambertTransfer builds a two-burn transfer for an arbitrary

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -89,11 +89,21 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 	// The patched-conic inter-primary path is wrong for in-SOI targets
 	// (it adds an Earth-escape burn that isn't physically required —
 	// craft and target both stay inside the shared primary's SOI).
+	//
+	// v0.5.9: pass current craft + target angles so the planner can
+	// phase-correct the launch window. Without phasing, craft arrives
+	// at apoapsis but target is somewhere else along its orbit and
+	// the rendezvous misses.
 	if target.ParentID == w.Craft.Primary.ID {
 		muShared := w.Craft.Primary.GravitationalParameter()
 		rArrival := target.SemimajorAxisMeters()
+		craftAngle := math.Atan2(w.Craft.State.R.Y, w.Craft.State.R.X)
+		// Target's position in its parent's frame == craft's primary
+		// here, since target.ParentID == craft.Primary.ID.
+		targetAngle := primaryFrameAngle(w, target)
 		plan, err := planner.PlanIntraPrimaryHohmann(
 			muShared, rPark, rArrival,
+			craftAngle, targetAngle,
 			w.Craft.Primary.ID,
 			muDestination, rCapture, target.ID,
 		)
@@ -381,6 +391,20 @@ func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]flo
 	return grid, nil
 }
 
+// primaryFrameAngle returns body b's angular position around its
+// parent (radians, atan2 of position-vector y, x in the parent's
+// frame), evaluated at the world's current sim time. Used by the
+// phase-corrected intra-primary Hohmann to compute target lead
+// angles.
+func primaryFrameAngle(w *World, b bodies.CelestialBody) float64 {
+	M := w.Calculator.CalculateMeanAnomaly(b, w.Clock.SimTime)
+	E := orbital.SolveKepler(M, b.Eccentricity)
+	nu := orbital.TrueAnomaly(E, b.Eccentricity)
+	el := orbital.ElementsFromBody(b)
+	rRel := orbital.PositionAtTrueAnomaly(el, nu)
+	return math.Atan2(rRel.Y, rRel.X)
+}
+
 // bodyEphemeris returns an EphemerisFn closure for a body: heliocentric
 // (r, v) evaluated at an arbitrary Unix-epoch timestamp.
 //
@@ -457,7 +481,7 @@ var (
 	errInvalidTransferTarget = transferError("invalid transfer target body")
 	errNoCraftForTransfer    = transferError("no craft to plan transfer for")
 	errNoRefineTarget        = transferError("no pending transfer to refine")
-	errSamePrimaryUseHohmann = transferError("target shares craft's primary — use [P] auto-Hohmann instead of porkchop")
+	errSamePrimaryUseHohmann = transferError("target shares craft's primary — use [H] auto-Hohmann instead of porkchop")
 )
 
 type transferError string

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -346,6 +347,77 @@ func TestPorkchopGridRejectsSamePrimaryTarget(t *testing.T) {
 	if _, err := w.PorkchopGrid(moonIdx, []float64{0}, []float64{5}); err == nil {
 		t.Errorf("PorkchopGrid for Moon (same-primary) returned nil error — should be errSamePrimaryUseHohmann")
 	}
+}
+
+// TestPlanTransferIntraPrimaryPhasingMatchesArrival: v0.5.9 — the
+// phase-corrected planner picks a launch window such that, at the
+// arrival node's TriggerTime, the target body is within Luna-SOI-
+// scale distance of where the craft will be (apoapsis at rArrival).
+// Pre-v0.5.9 the plan fired immediately with no phase correction
+// and missed Luna's actual position by tens of millions of km.
+func TestPlanTransferIntraPrimaryPhasingMatchesArrival(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	moonIdx := -1
+	for i := range sys.Bodies {
+		if sys.Bodies[i].ID == "moon" {
+			moonIdx = i
+			break
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	plan, err := w.PlanTransfer(moonIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer to Luna: %v", err)
+	}
+	moon := sys.Bodies[moonIdx]
+
+	// At arrival time, the craft will be at apoapsis ≈ rArrival in the
+	// burn-direction-perpendicular tangent. Approximate the craft's
+	// arrival position as a vector at angle (craftAngleNow +
+	// nCraft·waitTime + π) at distance rArrival around Earth.
+	waitSecs := plan.Departure.OffsetTime.Seconds()
+	transferSecs := plan.TransferDt.Seconds()
+	arrivalSimTime := w.Clock.SimTime.Add(plan.Arrival.OffsetTime)
+
+	mu := w.Craft.Primary.GravitationalParameter()
+	rDep := w.Craft.State.R.Norm()
+	craftAngleNow := math.Atan2(w.Craft.State.R.Y, w.Craft.State.R.X)
+	nCraft := math.Sqrt(mu / (rDep * rDep * rDep))
+	craftAtBurnAngle := craftAngleNow + nCraft*waitSecs
+	craftArrivalAngle := craftAtBurnAngle + math.Pi // apoapsis is opposite periapsis
+
+	// Where is Luna at arrival?
+	moonM := w.Calculator.CalculateMeanAnomaly(moon, arrivalSimTime)
+	moonE := orbital.SolveKepler(moonM, moon.Eccentricity)
+	moonNu := orbital.TrueAnomaly(moonE, moon.Eccentricity)
+	moonEl := orbital.ElementsFromBody(moon)
+	moonAtArrival := orbital.PositionAtTrueAnomaly(moonEl, moonNu)
+	moonAngleAtArrival := math.Atan2(moonAtArrival.Y, moonAtArrival.X)
+
+	// Phasing residual: difference in angular positions, wrapped to
+	// [-π, π]. Should be ~0 if phasing worked.
+	dTheta := craftArrivalAngle - moonAngleAtArrival
+	for dTheta > math.Pi {
+		dTheta -= 2 * math.Pi
+	}
+	for dTheta < -math.Pi {
+		dTheta += 2 * math.Pi
+	}
+	// Tolerance: 1° (0.017 rad). At Luna's distance, 1° = ~6700 km —
+	// within Luna's ~66 000 km SOI, so an actual rendezvous would
+	// capture. Pre-fix the angular gap was unconstrained.
+	if math.Abs(dTheta) > 0.017 {
+		t.Errorf("phasing residual = %.4f rad (%.2f°); want < 1°", dTheta, dTheta*180/math.Pi)
+	}
+	// Also: waitSecs must be non-negative and bounded by the synodic
+	// period (LEO + Luna ≈ 89 min). 7200s = 2h is generous.
+	if waitSecs < 0 || waitSecs > 7200 {
+		t.Errorf("waitSecs = %.1f s, want in [0, 7200]", waitSecs)
+	}
+	_ = transferSecs
 }
 
 // TestPlanTransferIntraPrimaryHohmannForMoon: v0.5.7 — PlanTransfer


### PR DESCRIPTION
## Summary

v0.5.7 added geocentric Hohmann for moon transfers but planted the burn at T+0 with no phasing — craft arrived at Luna's altitude with Luna long since moved elsewhere along its 27.3-day orbit. "ICPS overshot the moon" reproduces.

- **`PlanIntraPrimaryHohmann`** now takes `craftAngleNow` / `targetAngleNow` and computes a launch wait time τ such that target leads craft by `π − n_target · T_transfer` at burn moment.
- Synodic period for LEO + Luna is ~89 min so τ stays short.
- Departure node OffsetTime = τ; arrival OffsetTime = τ + T_transfer.
- Burn modes (prograde for outbound dep / retrograde for arrival) unchanged.

Also fixes the porkchop redirect-banner text from `[P]` to `[H]` (caught by @jason post-v0.5.8 swap).

## Tests

- `TestPlanTransferIntraPrimaryPhasingMatchesArrival` — phasing residual at arrival < 1° (≈ 6700 km at Luna's altitude, well inside Luna's 66 000 km SOI). Wait time bounded by 7200 s.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: select Moon, press `H`, watch the planted departure node — TriggerTime should be a few minutes in the future, not T+0.
- [ ] Manual: warp through to arrival — craft should rendezvous with Luna's actual position, not empty space.
- [ ] Manual: press `P` on Moon, banner should now say `[H] auto-Hohmann`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)