### PR TITLE
feat(render,tui): Saturn rings (v0.5.11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.10**.
+Latest release: **v0.5.11**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.10)
+## Features (v0.5.11)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.10 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.11 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.10)
+## 1. What works today (v0.5.11)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -238,7 +238,8 @@ features and the version sequence that delivers them.
 | v0.5.7 ✓ | | Intra-primary Hohmann (`PlanIntraPrimaryHohmann`): when target shares craft's primary (e.g. Luna, both around Earth), Hohmann plants a geocentric Hohmann (~3.1 km/s TLI + ~0.7 km/s Luna-orbit insertion). Pre-v0.5.7 the heliocentric Hohmann/Lambert path treated Luna's parent-relative semimajor as heliocentric → wildly wrong Δv. Porkchop rejects same-primary targets with a banner redirecting to Hohmann. |
 | v0.5.8 ✓ | | Keybind cleanup: `P` → porkchop (was `k`), `H` → Hohmann auto-plant (was `P`). Mnemonic: P/Porkchop, H/Hohmann. |
 | v0.5.9 ✓ | | Phase-corrected intra-primary Hohmann: `H` on a moon now waits for the next launch window (Luna leads craft by `π − n_target·T_transfer`) so the craft actually rendezvous with the target instead of arriving at empty apoapsis. Synodic period for LEO+Luna ≈ 89 min so the wait is short. Also fixes porkchop redirect-banner text from `[P]` to `[H]`. |
-| **v0.5.10 ✓** | **(current)** | Lunar-mission delivery pass: Tick clamps to finite-burn TriggerTime (no high-warp burn-fire lag); planner pads launch window so centered burns don't fire retroactively; default vessel swapped to S-IVB-1 (J-2 1023 kN, 11000+40000 kg, Δv 6.3 km/s, ~110s TLI); intra-primary auto-plant returns to finite burns; ManeuverNode.TriggerTime is now the burn *center* (engine fires Duration/2 earlier — HUD shows the planner's intended moment). |
+| v0.5.10 ✓ | | Lunar-mission delivery pass: Tick clamps to finite-burn TriggerTime (no high-warp burn-fire lag); planner pads launch window so centered burns don't fire retroactively; default vessel swapped to S-IVB-1 (J-2 1023 kN, 11000+40000 kg, Δv 6.3 km/s, ~110s TLI); intra-primary auto-plant returns to finite burns; ManeuverNode.TriggerTime is now the burn *center* (engine fires Duration/2 earlier — HUD shows the planner's intended moment). |
+| **v0.5.11 ✓** | **(current)** | Saturn rings render — concentric outer ring at the B–A range (92k–137k km from Saturn), drawn in Saturn's palette color when zoom resolves the rings beyond the body disk. `render.BodyRings(id)` extensible for future ringed bodies. Face-on simplification (always concentric circles regardless of view angle). |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -116,3 +116,20 @@ func StellarTint(tempK float64) lipgloss.Color {
 func Style(b bodies.CelestialBody) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(ColorFor(b))
 }
+
+// BodyRings returns the inner and outer ring radii (meters from body
+// center) for ringed bodies, or ok=false if the body has no
+// renderable rings. Numbers are face-on simplifications — our
+// equatorial-plane projection always shows rings as concentric
+// circles, not the inclination-dependent ellipses real Saturn rings
+// project to.
+func BodyRings(bodyID string) (innerR, outerR float64, ok bool) {
+	switch bodyID {
+	case "saturn":
+		// Saturn's main ring system: inner edge of D ring ~67k km,
+		// outer edge of A ring ~140k km. Use B–A range for a single
+		// visible ring outline (the brightest part).
+		return 92000e3, 137000e3, true
+	}
+	return 0, 0, false
+}

--- a/internal/render/palette_test.go
+++ b/internal/render/palette_test.go
@@ -27,6 +27,17 @@ func TestColorForKnownBodies(t *testing.T) {
 	}
 }
 
+// TestBodyRingsForSaturn: v0.5.11 — Saturn has rendered rings; other
+// bodies don't.
+func TestBodyRingsForSaturn(t *testing.T) {
+	if _, _, ok := BodyRings("saturn"); !ok {
+		t.Error("BodyRings(\"saturn\") should return ok=true")
+	}
+	if _, _, ok := BodyRings("earth"); ok {
+		t.Error("BodyRings(\"earth\") should return ok=false (no rings)")
+	}
+}
+
 // TestStellarTintBuckets: spot-check that StellarTint returns
 // distinct colors across the temperature ladder. Catches accidental
 // collapse of the bucket boundaries (e.g. wrong threshold ordering).

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -111,6 +111,16 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		} else {
 			v.canvas.FillColoredDisk(pos, r, color)
 		}
+		// Draw rings for ringed bodies (v0.5.11). World-scale ring
+		// radii project to pixel radii via the canvas scale; only
+		// draw when the outer ring would visibly clear the body's
+		// rendered disk.
+		if _, outerR, ok := render.BodyRings(b.ID); ok {
+			outerPx := int(outerR * scale)
+			if outerPx > r {
+				v.canvas.RingColoredOutline(pos, outerPx, color)
+			}
+		}
 		if i == selectedIdx {
 			v.plotCluster(pos, r+4)
 		}


### PR DESCRIPTION
## Summary

Closes the v0.5.3 grab-bag's "rings drawn for ringed bodies" item.

- `render.BodyRings(id)` returns inner/outer ring radii (meters) for ringed bodies. Saturn gets the B–A range (92k–137k km from Saturn center).
- `orbit.go` body-draw loop adds `Canvas.RingColoredOutline` at the outer-ring pixel radius when it would visibly clear the body's rendered disk.
- Face-on simplification — always concentric circles regardless of view angle, matching the existing equatorial-plane 2D projection.
- Extensible: any future body added to `BodyRings` switch automatically renders.

## Tests

- `TestBodyRingsForSaturn` — Saturn returns ok=true, Earth returns ok=false.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: zoom in on Saturn (`f` to cycle camera focus to it); should see a thin pale-gold ring around the body when the rings clear the body disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)