### PR TITLE
feat: body-identity glyph overlays (v0.5.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.11**.
+Latest release: **v0.5.12**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.11)
+## Features (v0.5.12)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.11 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.12 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.11)
+## 1. What works today (v0.5.12)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -239,7 +239,8 @@ features and the version sequence that delivers them.
 | v0.5.8 ✓ | | Keybind cleanup: `P` → porkchop (was `k`), `H` → Hohmann auto-plant (was `P`). Mnemonic: P/Porkchop, H/Hohmann. |
 | v0.5.9 ✓ | | Phase-corrected intra-primary Hohmann: `H` on a moon now waits for the next launch window (Luna leads craft by `π − n_target·T_transfer`) so the craft actually rendezvous with the target instead of arriving at empty apoapsis. Synodic period for LEO+Luna ≈ 89 min so the wait is short. Also fixes porkchop redirect-banner text from `[P]` to `[H]`. |
 | v0.5.10 ✓ | | Lunar-mission delivery pass: Tick clamps to finite-burn TriggerTime (no high-warp burn-fire lag); planner pads launch window so centered burns don't fire retroactively; default vessel swapped to S-IVB-1 (J-2 1023 kN, 11000+40000 kg, Δv 6.3 km/s, ~110s TLI); intra-primary auto-plant returns to finite burns; ManeuverNode.TriggerTime is now the burn *center* (engine fires Duration/2 earlier — HUD shows the planner's intended moment). |
-| **v0.5.11 ✓** | **(current)** | Saturn rings render — concentric outer ring at the B–A range (92k–137k km from Saturn), drawn in Saturn's palette color when zoom resolves the rings beyond the body disk. `render.BodyRings(id)` extensible for future ringed bodies. Face-on simplification (always concentric circles regardless of view angle). |
+| v0.5.11 ✓ | | Saturn rings render — concentric outer ring at the B–A range (92k–137k km from Saturn), drawn in Saturn's palette color when zoom resolves the rings beyond the body disk. `render.BodyRings(id)` extensible for future ringed bodies. Face-on simplification (always concentric circles regardless of view angle). |
+| **v0.5.12 ✓** | **(current)** | Body-identity glyph overlays — `Canvas.SetCellOverlay` replaces the cell at a body's center with a Unicode glyph (☉ star / ◉ gas giant / ● terrestrial / ○ moon) so types read distinctly even at small pixel radius. `render.GlyphFor(b)` keys on BodyType + MeanRadius. Skips system primary (already has ring+dot draw). |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -117,6 +117,34 @@ func Style(b bodies.CelestialBody) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(ColorFor(b))
 }
 
+// GlyphFor returns the body-identity Unicode glyph for the given
+// body. Used as a single-cell overlay on top of the body's drawille
+// disk so different body types read distinctly even at small pixel-
+// radius. v0.5.12+.
+//
+//   - Star  → ☉ (sun symbol)
+//   - Gas giant (radius > 20 000 km) → ◉ (fisheye)
+//   - Terrestrial planet → ● (filled circle)
+//   - Moon → ○ (open circle)
+//
+// Returns 0 (zero rune) when no overlay is appropriate (e.g. system
+// primary already has a ring+dot draw style and shouldn't be
+// double-glyphed).
+func GlyphFor(b bodies.CelestialBody) rune {
+	switch b.BodyType {
+	case "Star":
+		return '☉'
+	case "Moon":
+		return '○'
+	case "Planet":
+		if b.MeanRadius > 20000 {
+			return '◉'
+		}
+		return '●'
+	}
+	return 0
+}
+
 // BodyRings returns the inner and outer ring radii (meters from body
 // center) for ringed bodies, or ok=false if the body has no
 // renderable rings. Numbers are face-on simplifications — our

--- a/internal/render/palette_test.go
+++ b/internal/render/palette_test.go
@@ -27,6 +27,31 @@ func TestColorForKnownBodies(t *testing.T) {
 	}
 }
 
+// TestGlyphForBodyTypes: v0.5.12 — different body types resolve to
+// distinct identity glyphs. Star → ☉, gas giant → ◉, terrestrial → ●,
+// moon → ○.
+func TestGlyphForBodyTypes(t *testing.T) {
+	star := bodies.CelestialBody{BodyType: "Star"}
+	gas := bodies.CelestialBody{BodyType: "Planet", MeanRadius: 70000}
+	terr := bodies.CelestialBody{BodyType: "Planet", MeanRadius: 6371}
+	moon := bodies.CelestialBody{BodyType: "Moon"}
+	cases := []struct {
+		b    bodies.CelestialBody
+		want rune
+	}{
+		{star, '☉'},
+		{gas, '◉'},
+		{terr, '●'},
+		{moon, '○'},
+	}
+	for _, c := range cases {
+		got := GlyphFor(c.b)
+		if got != c.want {
+			t.Errorf("%+v → %q, want %q", c.b, got, c.want)
+		}
+	}
+}
+
 // TestBodyRingsForSaturn: v0.5.11 — Saturn has rendered rings; other
 // bodies don't.
 func TestBodyRingsForSaturn(t *testing.T) {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -121,6 +121,15 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				v.canvas.RingColoredOutline(pos, outerPx, color)
 			}
 		}
+		// Body-identity glyph overlay (v0.5.12). Skip the system
+		// primary — it already has the ring+dot draw style and a
+		// glyph would clash. Other bodies get ☉ / ◉ / ● / ○ based on
+		// type so they read distinctly even at small pixel radius.
+		if i != 0 {
+			if g := render.GlyphFor(b); g != 0 {
+				v.canvas.SetCellOverlay(pos, g)
+			}
+		}
 		if i == selectedIdx {
 			v.plotCluster(pos, r+4)
 		}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -39,6 +39,14 @@ type Canvas struct {
 	// Per-pixel tagging keeps body color confined to the body's own
 	// pixels.
 	pixelTags map[[2]int]lipgloss.Color
+
+	// cellOverlays maps a cell coord → a Unicode glyph that replaces
+	// the drawille-derived char at String() time. v0.5.12+ — used by
+	// the orbit renderer to overlay body-identity glyphs (☉ ◉ ● ○)
+	// on top of the underlying braille so different body types read
+	// distinctly even at small pixel-radius. Overlay color comes from
+	// the cell's pixelTags as usual.
+	cellOverlays map[[2]int]rune
 }
 
 // NewCanvas builds a canvas sized to fit cols × rows terminal cells.
@@ -73,11 +81,33 @@ func (c *Canvas) Resize(cols, rows int) {
 	c.pxW, c.pxH = cols*2, rows*4
 }
 
-// Clear wipes the drawille buffer and per-pixel color tags. Call at
-// the start of every frame.
+// Clear wipes the drawille buffer, per-pixel color tags, and cell
+// overlays. Call at the start of every frame.
 func (c *Canvas) Clear() {
 	c.dc.Clear()
 	c.pixelTags = nil
+	c.cellOverlays = nil
+}
+
+// SetCellOverlay places a Unicode glyph at the cell containing the
+// given world coord, replacing whatever drawille would have rendered
+// there at String() time. Color comes from the cell's pixel tags
+// (FillColoredDisk etc) — combine with a tagged draw to get a
+// colored overlay. v0.5.12+ — used for body-identity glyphs (☉ ◉ ●
+// ○) so different body types read distinctly.
+func (c *Canvas) SetCellOverlay(w orbital.Vec3, glyph rune) {
+	px, py, ok := c.Project(w)
+	if !ok {
+		return
+	}
+	cellX, cellY := px/2, py/4
+	if cellX < 0 || cellX >= c.cols || cellY < 0 || cellY >= c.rows {
+		return
+	}
+	if c.cellOverlays == nil {
+		c.cellOverlays = make(map[[2]int]rune)
+	}
+	c.cellOverlays[[2]int{cellX, cellY}] = glyph
 }
 
 // FillColoredDisk fills a disk of the given pixel radius around a
@@ -348,7 +378,7 @@ func (c *Canvas) DrawEllipseOffsetDotted(el orbital.Elements, offset orbital.Vec
 // content (orbit lines, craft glyph) with the body's color.
 func (c *Canvas) String() string {
 	rows := c.dc.Rows(0, 0, c.pxW, c.pxH)
-	if len(c.pixelTags) == 0 {
+	if len(c.pixelTags) == 0 && len(c.cellOverlays) == 0 {
 		return c.joinRows(rows)
 	}
 	// Aggregate tags per cell: for each tagged pixel, accumulate a
@@ -384,11 +414,17 @@ func (c *Canvas) String() string {
 			line = rows[i]
 		}
 		// Colorize per-cell, padding short lines with spaces.
+		// Cell overlays (v0.5.12) replace the drawille char with a
+		// specific glyph at the same cell — used for body-identity
+		// markers (☉ ◉ ● ○).
 		runes := []rune(line)
 		for x := 0; x < c.cols; x++ {
 			var ch rune = ' '
 			if x < len(runes) {
 				ch = runes[x]
+			}
+			if overlay, ok := c.cellOverlays[[2]int{x, i}]; ok {
+				ch = overlay
 			}
 			color, hasColor := cellColor[[2]int{x, i}]
 			if hasColor && ch != ' ' {


### PR DESCRIPTION
## Summary

Closes the v0.5.3 grab-bag's "different glyph density for stars vs gas giants vs terrestrial" item.

- **`Canvas.SetCellOverlay(world, glyph)`** — registers a Unicode glyph at the cell containing the world point. `String()` applies it on top of the drawille-derived char (color comes from existing pixelTags so the glyph picks up the body's palette color).
- **`render.GlyphFor(b)`** — picks the glyph by BodyType + MeanRadius:
  - Star → ☉ (sun symbol)
  - Gas giant (radius > 20 000 km) → ◉ (fisheye)
  - Terrestrial planet → ● (filled circle)
  - Moon → ○ (open circle)
- **`orbit.go`** applies the overlay after each body's `FillColoredDisk` (skipping the system primary which already has the ring+dot draw style).

Distinguishes types at a glance even when bodies render as 1-cell disks at system-wide zoom — pre-v0.5.12 a moon and a planet looked identical at that scale.

## Tests

- `TestGlyphForBodyTypes` — the four body-type buckets resolve to ☉ / ◉ / ● / ○.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: open game, look at Sol system view — Sun should show ☉, Jupiter ◉, Earth ●, Luna ○.

🤖 Generated with [Claude Code](https://claude.com/claude-code)