### PR TITLE
ux(tui): HUD section dividers (v0.5.13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.12**.
+Latest release: **v0.5.13**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.12)
+## Features (v0.5.13)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.12 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.13 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.12)
+## 1. What works today (v0.5.13)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -240,7 +240,8 @@ features and the version sequence that delivers them.
 | v0.5.9 ✓ | | Phase-corrected intra-primary Hohmann: `H` on a moon now waits for the next launch window (Luna leads craft by `π − n_target·T_transfer`) so the craft actually rendezvous with the target instead of arriving at empty apoapsis. Synodic period for LEO+Luna ≈ 89 min so the wait is short. Also fixes porkchop redirect-banner text from `[P]` to `[H]`. |
 | v0.5.10 ✓ | | Lunar-mission delivery pass: Tick clamps to finite-burn TriggerTime (no high-warp burn-fire lag); planner pads launch window so centered burns don't fire retroactively; default vessel swapped to S-IVB-1 (J-2 1023 kN, 11000+40000 kg, Δv 6.3 km/s, ~110s TLI); intra-primary auto-plant returns to finite burns; ManeuverNode.TriggerTime is now the burn *center* (engine fires Duration/2 earlier — HUD shows the planner's intended moment). |
 | v0.5.11 ✓ | | Saturn rings render — concentric outer ring at the B–A range (92k–137k km from Saturn), drawn in Saturn's palette color when zoom resolves the rings beyond the body disk. `render.BodyRings(id)` extensible for future ringed bodies. Face-on simplification (always concentric circles regardless of view angle). |
-| **v0.5.12 ✓** | **(current)** | Body-identity glyph overlays — `Canvas.SetCellOverlay` replaces the cell at a body's center with a Unicode glyph (☉ star / ◉ gas giant / ● terrestrial / ○ moon) so types read distinctly even at small pixel radius. `render.GlyphFor(b)` keys on BodyType + MeanRadius. Skips system primary (already has ring+dot draw). |
+| v0.5.12 ✓ | | Body-identity glyph overlays — `Canvas.SetCellOverlay` replaces the cell at a body's center with a Unicode glyph (☉ star / ◉ gas giant / ● terrestrial / ○ moon) so types read distinctly even at small pixel radius. `render.GlyphFor(b)` keys on BodyType + MeanRadius. Skips system primary (already has ring+dot draw). |
+| **v0.5.13 ✓** | **(current)** | HUD section dividers — replace blank-line separators with dim `─` rules across the HUD width. Active-burn block gets a leading ● indicator; peri-below-surface alert gets a leading ⚠. Section grouping much more scannable. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -339,6 +339,16 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	}
 	sys := w.System()
 
+	// section emits a divider + colored section header, used in place of
+	// the v0.5.12 plain "" blank-line separators. Visually groups the
+	// HUD into scannable blocks. v0.5.13.
+	section := func(title string) []string {
+		return []string{
+			v.theme.Dim.Render(strings.Repeat("─", width-2)),
+			v.theme.Primary.Render(title),
+		}
+	}
+
 	warpLine := fmt.Sprintf("  warp: %.0fx", w.Clock.Warp())
 	if eff := w.EffectiveWarp(); eff < w.Clock.Warp() {
 		warpLine += v.theme.Warning.Render(fmt.Sprintf(" (clamped to %.0fx)", eff))
@@ -351,11 +361,8 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	if w.Clock.Paused {
 		lines = append(lines, "  "+v.theme.Warning.Render("[PAUSED]"))
 	}
-	lines = append(lines,
-		"",
-		v.theme.Primary.Render("FOCUS"),
-		"  "+w.FocusName(),
-	)
+	lines = append(lines, section("FOCUS")...)
+	lines = append(lines, "  "+w.FocusName())
 
 	// Spacecraft block — only in Sol per plan §MVP.
 	if w.CraftVisibleHere() {
@@ -367,9 +374,8 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		periAlt := el.Periapsis() - primaryR
 		incDeg := el.I * 180.0 / 3.141592653589793
 
+		lines = append(lines, section("VESSEL")...)
 		lines = append(lines,
-			"",
-			v.theme.Primary.Render("VESSEL"),
 			"  "+c.Name,
 			"  primary:   "+c.Primary.EnglishName,
 			fmt.Sprintf("  altitude:  %.1f km", c.Altitude()/1000),
@@ -379,11 +385,10 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  inclin.:   %.2f°", incDeg),
 		)
 		if periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
-			lines = append(lines, "  "+v.theme.Alert.Render("PERIAPSIS BELOW SURFACE"))
+			lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
 		}
+		lines = append(lines, section("PROPELLANT")...)
 		lines = append(lines,
-			"",
-			v.theme.Primary.Render("PROPELLANT"),
 			fmt.Sprintf("  fuel:      %.0f kg", c.Fuel),
 			fmt.Sprintf("  mass:      %.0f kg", c.TotalMass()),
 			fmt.Sprintf("  Δv budget: %.0f m/s", c.RemainingDeltaV()),
@@ -399,16 +404,17 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		if remaining < 0 {
 			remaining = 0
 		}
-		lines = append(lines, "",
-			v.theme.Warning.Render("BURN ACTIVE"),
-			fmt.Sprintf("  mode:    %s", w.ActiveBurn.Mode.String()),
+		lines = append(lines,
+			v.theme.Dim.Render(strings.Repeat("─", width-2)),
+			v.theme.Warning.Render("● BURN ACTIVE"),
+			fmt.Sprintf("  mode:     %s", w.ActiveBurn.Mode.String()),
 			fmt.Sprintf("  Δv-to-go: %.1f m/s", w.ActiveBurn.DVRemaining),
 			fmt.Sprintf("  T-%.1fs remaining", remaining),
 		)
 	}
 
 	if len(w.Nodes) > 0 {
-		lines = append(lines, "", v.theme.Primary.Render("NODES"))
+		lines = append(lines, section("NODES")...)
 		for i, n := range w.Nodes {
 			dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
 			kind := "imp"
@@ -422,12 +428,12 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		}
 	}
 
-	lines = append(lines, "", v.theme.Primary.Render("SYSTEM"),
+	lines = append(lines, section("SYSTEM")...)
+	lines = append(lines,
 		"  "+sys.Name,
 		fmt.Sprintf("  %d bodies", len(sys.Bodies)),
-		"",
-		v.theme.Primary.Render("SELECTED"),
 	)
+	lines = append(lines, section("SELECTED")...)
 
 	if selectedIdx >= 0 && selectedIdx < len(sys.Bodies) {
 		b := sys.Bodies[selectedIdx]


### PR DESCRIPTION
## Summary

Closes the v0.5.3 grab-bag's "HUD section dividers, alignment, clearer status indicators" item.

- Internal `section(title)` helper returns `[divider, title-line]` so each block reads consistently.
- Dim `─` rules across the HUD width replace blank-line separators between sections.
- Active-burn block: leading `●` indicator.
- Peri-below-surface alert: leading `⚠`.
- SYSTEM and SELECTED previously crammed into one block — now separate sections with their own dividers.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: open game; HUD sections visually distinct via `─` rules. Plant a burn → "● BURN ACTIVE" reads clearly during the burn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)