### PR TITLE
ux(porkchop): fix axis labels (v0.5.14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.5.13**.
+Latest release: **v0.5.14**.
 
 ```bash
 # Linux x86_64
@@ -130,7 +130,7 @@ until the requested Δv is delivered, whichever first.
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
 where Lambert didn't converge — `Enter` on those is a no-op.
 
-## Features (v0.5.13)
+## Features (v0.5.14)
 
 - **Adaptive body sizing.** `BodyPixelRadius` now switches to true-
   scale rendering when the body's projected radius would be ≥ 4 px,

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,6 +1,6 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.5.13 (April 2026). Updated at each minor / patch boundary.*
+*Snapshot at v0.5.14 (April 2026). Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -8,7 +8,7 @@ features and the version sequence that delivers them.
 
 ---
 
-## 1. What works today (v0.5.13)
+## 1. What works today (v0.5.14)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -241,7 +241,8 @@ features and the version sequence that delivers them.
 | v0.5.10 ✓ | | Lunar-mission delivery pass: Tick clamps to finite-burn TriggerTime (no high-warp burn-fire lag); planner pads launch window so centered burns don't fire retroactively; default vessel swapped to S-IVB-1 (J-2 1023 kN, 11000+40000 kg, Δv 6.3 km/s, ~110s TLI); intra-primary auto-plant returns to finite burns; ManeuverNode.TriggerTime is now the burn *center* (engine fires Duration/2 earlier — HUD shows the planner's intended moment). |
 | v0.5.11 ✓ | | Saturn rings render — concentric outer ring at the B–A range (92k–137k km from Saturn), drawn in Saturn's palette color when zoom resolves the rings beyond the body disk. `render.BodyRings(id)` extensible for future ringed bodies. Face-on simplification (always concentric circles regardless of view angle). |
 | v0.5.12 ✓ | | Body-identity glyph overlays — `Canvas.SetCellOverlay` replaces the cell at a body's center with a Unicode glyph (☉ star / ◉ gas giant / ● terrestrial / ○ moon) so types read distinctly even at small pixel radius. `render.GlyphFor(b)` keys on BodyType + MeanRadius. Skips system primary (already has ring+dot draw). |
-| **v0.5.13 ✓** | **(current)** | HUD section dividers — replace blank-line separators with dim `─` rules across the HUD width. Active-burn block gets a leading ● indicator; peri-below-surface alert gets a leading ⚠. Section grouping much more scannable. |
+| v0.5.13 ✓ | | HUD section dividers — replace blank-line separators with dim `─` rules across the HUD width. Active-burn block gets a leading ● indicator; peri-below-surface alert gets a leading ⚠. Section grouping much more scannable. |
+| **v0.5.14 ✓** | **(current)** | Porkchop axis labels — fix the v0.3.3 misalignment (lead-in width mismatch + label overflow past grid edge). Tick line `└────` under the grid, dep-day labels at every 5th column properly centered, dim "dep day" axis title. |
 | **v0.5** | **Moons + visual enhancement** | Body hierarchy + Luna/Phobos/Deimos/Galilean/Titan/Enceladus (v0.5.0), then color (palette.go, realistic palette), vessel trail, HUD polish, body identity |
 | **v0.6** | **Planner UX + missions + MP design** | Burn-at-next scheduler, mission scaffold, multiplayer design-doc spike, mouse support |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |

--- a/internal/tui/screens/porkchop.go
+++ b/internal/tui/screens/porkchop.go
@@ -148,6 +148,11 @@ func (p *Porkchop) Render(w *sim.World, cols, rows int) string {
 	b.WriteString(p.theme.Title.Render(title))
 	b.WriteString("\n\n")
 
+	// Grid lead-in width: "tof XXXd │" = 4 + 3 + 2 + 1 = 10 chars
+	// (e.g. "tof 100d │"). v0.5.14 axis-label fix uses this constant
+	// so the dep-day labels under the grid line up properly.
+	const gridLead = 10
+
 	// Grid body. Y axis = tof (top = short, bottom = long), X axis = dep.
 	for j, tof := range p.tofDays {
 		b.WriteString(fmt.Sprintf("tof %3.0fd │", tof))
@@ -161,18 +166,32 @@ func (p *Porkchop) Render(w *sim.World, cols, rows int) string {
 		}
 		b.WriteString("│\n")
 	}
-	// X axis labels (every 5th column).
-	b.WriteString("         ")
-	for i, dep := range p.depDays {
-		if i%5 == 0 {
-			b.WriteString(fmt.Sprintf("%-5.0f", dep))
-		} else if i%5 != 0 && i%5 != 1 && i%5 != 2 && i%5 != 3 && i%5 != 4 {
-			// noop — above covers 0..4
+
+	// X axis tick line: "└" + dashes under each cell.
+	b.WriteString(strings.Repeat(" ", gridLead-1))
+	b.WriteString("└")
+	b.WriteString(strings.Repeat("─", len(p.depDays)))
+	b.WriteString("\n")
+
+	// X axis labels (every 5th column). Each label is exactly 5 chars
+	// wide so column alignment with the grid stays correct. Skip
+	// labels that would overflow past the grid right edge.
+	b.WriteString(strings.Repeat(" ", gridLead))
+	for i := 0; i < len(p.depDays); i++ {
+		if i%5 != 0 {
+			continue
 		}
+		if i+5 > len(p.depDays) {
+			// Final partial group — emit just the digits without padding.
+			b.WriteString(fmt.Sprintf("%.0f", p.depDays[i]))
+			break
+		}
+		b.WriteString(fmt.Sprintf("%-5.0f", p.depDays[i]))
 	}
-	b.WriteString("\n         ")
-	b.WriteString(strings.Repeat(" ", len(p.depDays)))
-	b.WriteString("\n         dep days\n\n")
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat(" ", gridLead))
+	b.WriteString(p.theme.Dim.Render("dep day"))
+	b.WriteString("\n\n")
 
 	// Selection readout.
 	selDv := p.grid[p.selTof][p.selDep]


### PR DESCRIPTION
## Summary

Closes the v0.5.3 grab-bag's last polish item — "porkchop axis labels rendered correctly". With this, all four v0.5.3 sub-items (Saturn rings, body-identity glyphs, HUD dividers, porkchop labels) have shipped as v0.5.11 / .12 / .13 / .14.

Pre-v0.5.14 the X-axis was misaligned: 9-char lead-in vs 10-char grid prefix, and 5-char labels at every-5th-column overflowed past the grid's right edge by ~3 chars.

Fix:
- `gridLead` constant for the 10-char lead-in.
- Tick line `└─────` under the grid for visual anchoring.
- Each label exactly 5 chars wide; final partial group writes only digits.
- Dim "dep day" axis title under the labels.

## Test plan

- [x] `go test ./...` green.
- [x] `go build ./...` green.
- [ ] Manual: select Mars, press `P`, confirm dep-day labels (0, 50, 100, ..., 350) sit under the right grid columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)