### PR TITLE
feat(planner,sim): moon → parent escape transfer (v0.6.3)

### DIFF
--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -1,8 +1,10 @@
 # terminal-space-program — state of game
 
-*Snapshot at v0.6.2 (April 2026) — v0.6 cycle in flight (burn-at-next
+*Snapshot at v0.6.3 (April 2026) — v0.6 cycle in flight (burn-at-next
 scheduler + predicted-orbit HUD + finite-burn-aware iterative
-planner shipped). Updated at each minor / patch boundary.*
+planner + moon → parent escape transfer shipped; mouse + view-mode
+switcher next, then missions and the multiplayer design-doc spike).
+Updated at each minor / patch boundary.*
 
 `docs/plan.md` is the original architecture / phase plan. This doc complements it
 with a "what plays today, what's queued next" view organised around player-facing
@@ -12,7 +14,7 @@ by patch — this doc is the snapshot, those are the release notes.
 
 ---
 
-## 1. What works today (v0.6.2)
+## 1. What works today (v0.6.3)
 
 ### Physics
 - Two-body patched-conic propagation with **SOI-aware** state transitions.
@@ -154,14 +156,19 @@ by patch — this doc is the snapshot, those are the release notes.
 - Moon catalog: Luna, Phobos, Deimos, the four Galilean (Io, Europa,
   Ganymede, Callisto), Titan, Enceladus — single-moon (Earth) and
   multi-moon (Jupiter, Saturn) primaries both exercised.
-- Transfer planning to/from moons is **partially shipped**: same-primary
-  intra-primary transfers (craft in LEO → Luna, both around Earth) ship
-  in v0.5.7 via `planner.PlanIntraPrimaryHohmann`, with v0.5.9 adding
-  phase correction so the craft actually rendezvous with the target.
-  The reverse direction — craft inside a moon's SOI returning to its
-  parent (Luna → Earth) — slips to v0.6.3 alongside the planner UX
-  work. Wider inter-SOI capture (heliocentric → moon-of-other-planet,
-  Phobos from Mars, Titan from heliocentric) is **not** in v0.6 scope.
+- Transfer planning to/from moons is **shipped both directions**:
+  same-primary intra-primary transfers (craft in LEO → Luna, both
+  around Earth) ship in v0.5.7 via `planner.PlanIntraPrimaryHohmann`,
+  with v0.5.9 adding phase correction so the craft actually
+  rendezvous with the target. The reverse — craft inside a moon's
+  SOI returning to its parent (Luna → Earth) — ships in v0.6.3 via
+  `planner.PlanMoonEscape`: bound transfer ellipse with apolune at
+  the moon's SOI radius, zero-Δv frame marker at SOI exit, player
+  plants their own circularization once they see the post-escape
+  parent-frame trajectory. The departure burn reuses v0.6.2's
+  `IterateForTarget` for finite-burn refinement. Wider inter-SOI
+  capture (heliocentric → moon-of-other-planet, Phobos from Mars,
+  Titan from heliocentric) is **not** in v0.6 scope.
 
 ### Systems loaded
 - **Sol** (playable — craft spawns here).
@@ -197,13 +204,11 @@ by patch — this doc is the snapshot, those are the release notes.
   termination once it lands.
 - **Mission system / objectives** (v0.6 target, see §3). Starter objectives
   such as "achieve a 1000 km circular orbit," "intercept Mars within Δv X."
-- **`PlanTransfer()` moon → parent extension** (v0.6.3 target). v0.5.7's
-  intra-primary path covers parent → moon (LEO → Luna). The reverse —
-  craft in Luna SOI returning to Earth — slips to v0.6.3. Wider
-  inter-SOI capture (heliocentric → moon-of-other-planet) stays out
-  of scope. The v0.6.0 burn-at-next scheduler (now shipped, see §1
-  Planning) is the foundation `PlanTransfer` extensions can compose
-  against — e.g. "fire escape burn at next periapsis."
+- ~~**`PlanTransfer()` moon → parent extension** (v0.6.3 target).~~
+  Shipped in v0.6.3 (`planner.PlanMoonEscape`, dispatch branch in
+  `sim.PlanTransfer` for `target.ID == w.Craft.Primary.ParentID`).
+  Wider inter-SOI capture (heliocentric → moon-of-other-planet)
+  remains out of scope.
 - **Multi-system spacecraft**. The craft is currently locked to Sol. Allowing
   it to enter Alpha Cen / TRAPPIST / Kepler unlocks the system-cycle UX.
   Requires interstellar transfer math (or deus-ex-machina jump for now).
@@ -220,10 +225,17 @@ by patch — this doc is the snapshot, those are the release notes.
   drag below ~150 km to enable reentry / aerobraking gameplay; patched-conic
   two-body stays the primary integrator. Previously on "excluded forever",
   softened here — only *realistic* multi-species drag stays out of scope.
-- **Mouse support** (v0.6 target, see §3). Currently keyboard-only;
-  v0.6 adds click-only selection — click-to-focus on bodies, vessel,
-  maneuver nodes, plus click-to-plant on porkchop cells and click on
-  HUD panels. Drag-to-edit and wheel-zoom stay out of v0.6.
+- **Mouse support + view-mode switcher** (v0.6.4 target, see §3).
+  Currently keyboard-only; v0.6.4 adds click-only selection
+  (click-to-focus on bodies, vessel, maneuver nodes, click-to-plant
+  on porkchop cells, click on HUD panels) and a `v` hot-key that
+  cycles between hard-coded camera presets (equatorial = current
+  default; orbit-perpendicular = camera along the active orbit's
+  angular-momentum vector for clean ellipse rendering on inclined
+  orbits). View-mode plumbing surfaced during v0.6.3 manual play —
+  the equatorial-only projection foreshortens at lunar inclinations
+  and made low-orbit projections hard to size at a glance. Drag-to-
+  edit, wheel-zoom, and free-rotation stay out of v0.6.
 
 ### Visual / UX targets
 - **Maneuver node editing**. Nodes are plant-once today; adding drag/scrub
@@ -283,7 +295,8 @@ by patch — this doc is the snapshot, those are the release notes.
 | **v0.6.0 ✓** | | Burn-at-next scheduler — `ManeuverNode.Event` enum (`Absolute / NextPeri / NextApo / NextAN / NextDN`); event-time helpers in `internal/orbital/events.go`; `World.resolveEventNodes` lazy-freeze resolver hooked into Tick before warp-clamp; `m` form gains `fire at` cycle field (focus 0/1/2/3); save schema bumps v1 → v2 with relaxed version check (v1 saves load with `Event = TriggerAbsolute`). |
 | **v0.6.1 ✓** | | Predicted post-burn orbit HUD + maneuver UX polish — `orbital.OrbitReadout`, `World.PreviewBurnState` (event-aware shadow trajectory), `World.PredictedFinalOrbit` + `PredictedLegs` (chain through nodes, rebase into each node's intended frame so Hohmann arrival reports as Mars-frame). PROJECTED ORBIT HUD blocks on both the orbit screen and `m` form. Per-leg colored trajectory preview (cyan/mint/amber/pink cycle) with matched node-marker colors. `minOrbitPixels` gate hides sub-pixel ellipses + swaps craft chevron for bright `ColorCraftMarker` disk at large zoom. `ColorCurrentOrbit` → pale slate (distinct from any body palette). Default LEO 200 → 500 km, NewWorld spawns with `Focus = FocusCraft`, default burn duration 0 → 10 s. Active-burn guard suppresses projection while live state mutates. |
 | **v0.6.2 ✓** | | Finite-burn-aware iterative planner — `planner.SimulateFiniteBurn` (RK4 + Tsiolkovsky), `planner.IterateForTarget` (Newton iteration on commanded Δv with ±50 % step cap and `ErrFiniteBurnDiverged` fallback), `planner.TargetApoapsis` / `TargetPeriapsis` residual helpers. `sim.refineFiniteDeparture` wires the iterator into `H` auto-plant so Hohmann departures hit the requested apoapsis even on low-TWR loadouts where the impulsive guess loses several percent of energy to gravity-rotation. For S-IVB-1 the iterator converges in 1-2 steps (no-op); for low-TWR profiles it catches errors the impulsive math misses. |
-| **v0.6** | **(in flight) Planner UX + missions + MP design** | Moon → parent escape transfer (v0.6.3), click-only mouse selection (v0.6.4), mission scaffold (v0.6.5), multiplayer design-doc spike (v0.6.6). See `docs/v0.6-plan.md` for slice breakdown. |
+| **v0.6.3 ✓** | | Moon → parent escape transfer — `planner.PlanMoonEscape` (bound transfer ellipse with apolune at the moon's SOI radius, zero-Δv frame marker at SOI exit so the player plants their own circularization in the parent frame). New dispatch branch in `sim.PlanTransfer` for `target.ID == w.Craft.Primary.ParentID`; pre-v0.6.3 this fell through to the heliocentric Hohmann path and quoted nonsense Δv. Departure burn refines through v0.6.2's iterator with `TargetApoapsis(rSOI)`. Maneuver-screen mini-canvas now renders the primary as a sized disk (`FillColoredDisk` + `BodyPixelRadius`) instead of a single pixel, so low-orbit projections read at their real visual scale. |
+| **v0.6** | **(in flight) Planner UX + missions + MP design** | Click-only mouse selection + view-mode switcher (v0.6.4), mission scaffold (v0.6.5), multiplayer design-doc spike (v0.6.6). See `docs/v0.6-plan.md` for slice breakdown + status table. |
 | v0.7 | Custom systems + modding *(speculative)* | Config-file body loader; promote color theme to user-configurable |
 | v0.8+ | Open *(speculative)* | N-body, multi-system spacecraft, multi-rev porkchop, mission editor/scripting, optional drag, maneuver node editing, multiplayer implementation |
 

--- a/docs/v0.6-plan.md
+++ b/docs/v0.6-plan.md
@@ -12,6 +12,18 @@ This doc is the implementation plan. Slices are sequenced so each release
 lands a self-contained capability and the orbital-elements work that
 v0.6.0 introduces is reused by v0.6.1's HUD readout.
 
+## Status (2026-04-27)
+
+| slice  | status   | tag       | notes |
+|--------|----------|-----------|-------|
+| v0.6.0 | shipped  | `v0.6.0`  | Burn-at-next scheduler. |
+| v0.6.1 | shipped  | `v0.6.1`  | Predicted post-burn orbit HUD. |
+| v0.6.2 | shipped  | `v0.6.2`  | Finite-burn-aware iterative planner. |
+| v0.6.3 | shipped  | `v0.6.3`  | Moon → parent escape transfer + maneuver-canvas primary disk render. |
+| v0.6.4 | next     | —         | Mouse selection + view-mode switcher (see scope below). |
+| v0.6.5 | pending  | —         | Mission scaffold. |
+| v0.6.6 | pending  | —         | Multiplayer design-doc spike. |
+
 Scope corrections vs. state-of-game.md (the doc framing was stale in two
 places):
 
@@ -181,6 +193,25 @@ New `PlanTransfer` path for the case `target == craft.Primary.ParentID`
 
 **Estimate.** ~300 LOC + tests.
 
+**Shipped.** PR #38 → tag `v0.6.3`.
+
+- `internal/planner/moon_escape.go` — `PlanMoonEscape(muMoon, rPark,
+  rSOI, minLead, moonID, parentID) (TransferPlan, error)`. Bound
+  transfer ellipse with apolune at SOI; arrival is a zero-Δv frame
+  marker so the player plants their own circularization once they
+  see the post-escape parent-frame trajectory.
+- `internal/sim/maneuver.go` `PlanTransfer` — new dispatch branch
+  when `target.ID == w.Craft.Primary.ParentID`, before the
+  heliocentric Hohmann fallthrough. Departure burn is refined via
+  v0.6.2's `IterateForTarget` with `TargetApoapsis(rSOI)`.
+- `internal/tui/screens/maneuver.go` — mini-canvas primary disk
+  render polish. The pre-v0.6.3 mini-canvas drew the primary as a
+  single pixel at the origin; at lunar-orbit scales this hid the
+  body's surface, making low-orbit projections (e.g. 4× moon-radius
+  apoapsis) read as smaller than they were. Now uses
+  `FillColoredDisk` + `BodyPixelRadius` for visual parity with the
+  main orbit screen.
+
 ### v0.6.4 — mouse selection
 
 Click-only input. No drag, no wheel-zoom.
@@ -205,24 +236,44 @@ Click-only input. No drag, no wheel-zoom.
   Absolute T+ at the projected crossing).
 - Click on HUD panels to set focus (e.g. clicking the "selected
   body" block opens the body-info screen).
+- **View-mode switcher** (added 2026-04-27, surfaced during v0.6.3
+  manual playthrough). Hot-key (`v`) cycles between hard-coded
+  camera presets on both the main orbit canvas and the maneuver
+  mini-canvas:
+  - **Equatorial (default).** Current behaviour — projects (X, Y)
+    in the primary's equatorial frame, ignoring Z.
+  - **Orbit-perpendicular.** Camera oriented along the active
+    orbit's angular-momentum vector (`h = r × v`). Closed orbits
+    project to clean ellipses with no foreshortening — useful for
+    inclined orbits (Luna's 5°, future polar mission profiles).
+  - State lives on `World` (or per-screen) and survives screen
+    swaps so the planner's mini-canvas matches the main view.
+  - Mouse hit-testing in this slice goes through whichever
+    projection is active; `Unproject` accepts a basis matrix.
 
 **Out of scope this release.**
 
 - Drag-to-edit Δv on planted nodes.
 - Wheel-zoom on the orbit canvas.
 - Drag-to-pan camera.
+- Free-rotation / mouse-look. Hard-coded presets only.
 
 **Code surface.**
 
-- `internal/tui/app.go` — add `tea.MouseMsg` handler dispatch.
+- `internal/tui/app.go` — add `tea.MouseMsg` handler dispatch + `v`
+  hot-key for view-mode cycle.
 - `internal/tui/widgets/canvas.go` — reverse-projection from cell →
   body / vessel / node. The v0.5.3 per-cell color tagging is the
   natural extension point (each tagged cell already knows what body
   it belongs to; widen the tag to include vessel and node hits).
+  Add `View` enum + a basis-rotation helper so `Project` /
+  `Unproject` route through the active mode.
 - Per-screen mouse handlers in `internal/tui/screens/*.go` for
-  porkchop and HUD click targets.
+  porkchop and HUD click targets. Maneuver screen also reads the
+  active view so its mini-canvas matches the main orbit view.
 
-**Estimate.** ~150 LOC + tests.
+**Estimate.** ~200 LOC + tests (was ~150 — +50 for view-mode
+plumbing and projection round-trip tests).
 
 ### v0.6.5 — mission scaffold
 
@@ -269,17 +320,17 @@ Pure writing. `docs/multiplayer-design.md`.
 ## Sequencing
 
 ```
-v0.6.0 (scheduler) ──┬──> v0.6.1 (predicted HUD)
-                     ├──> v0.6.2 (finite-burn iter) ──> v0.6.3 (moon escape)
-                     └──> v0.6.3 (moon escape)
-v0.6.4 (mouse)       ─── independent
-v0.6.5 (missions)    ─── independent
-v0.6.6 (MP doc)      ─── independent
+v0.6.0 (scheduler)  ✓──┬──> v0.6.1 (predicted HUD)  ✓
+                       ├──> v0.6.2 (finite-burn iter) ✓──> v0.6.3 (moon escape) ✓
+                       └──> v0.6.3 (moon escape)  ✓
+v0.6.4 (mouse + view modes)   ─── next, independent
+v0.6.5 (missions)             ─── independent
+v0.6.6 (MP doc)               ─── independent
 ```
 
-Recommend ship order: **0 → 1 → 2 → 3 → 4 → 5 → 6**. v0.6.0 and v0.6.1
-ship as a tight pair (shared orbital-elements helper). v0.6.2 unblocks
-v0.6.3. v0.6.4–6 can interleave.
+Shipped: 0–3. **Next up: v0.6.4** — mouse + view-mode switcher.
+Then v0.6.5 (missions) and v0.6.6 (MP design doc); both independent
+and can interleave.
 
 ---
 

--- a/internal/planner/moon_escape.go
+++ b/internal/planner/moon_escape.go
@@ -1,0 +1,83 @@
+package planner
+
+import (
+	"errors"
+	"math"
+	"time"
+)
+
+// PlanMoonEscape constructs a two-impulse plan to escape a moon's SOI
+// and rejoin the parent body's frame. The departure burn is a prograde
+// impulse at the moon-frame parking orbit periapsis sized so the
+// transfer ellipse's apolune kisses the moon's sphere-of-influence
+// boundary. When the craft reaches that apolune it crosses into the
+// parent's frame (via the standard SOI-aware integrator) and inherits
+// the moon's parent-relative velocity plus the small radial
+// component left over from the SOI exit.
+//
+// The arrival node is a zero-Δv marker positioned in the parent's
+// frame at the SOI-exit moment (depOffset + half-period). Its job is
+// to surface the frame transition in the maneuver list / HUD; the
+// player plants their own circularization burn manually after seeing
+// the post-escape parent-frame trajectory.
+//
+// Inputs:
+//   - muMoon: GM of the moon (e.g., Luna's GM).
+//   - rPark:  craft's |R| in the moon's frame at plant time.
+//   - rSOI:   moon's sphere-of-influence radius. Apolune target.
+//   - minLeadSeconds: pad the departure offset so a centered finite
+//     burn fits inside the wait window. Pass 0 to skip padding.
+//   - moonID:    moon's body ID — populates the departure node's
+//     PrimaryID so the HUD renders the burn in the moon's frame.
+//   - parentID:  moon's parent ID — populates the arrival marker's
+//     PrimaryID so the HUD knows the SOI-exit lives in the parent
+//     frame.
+//
+// Phasing isn't enforced. v0.6.3 ships the simplest viable escape:
+// burn at periapsis, drop into parent frame, manual finish. Future
+// cycles can layer in a phasing model so the SOI-exit moment lands at
+// the player's preferred parent-frame angle.
+func PlanMoonEscape(
+	muMoon, rPark, rSOI float64,
+	minLeadSeconds float64,
+	moonID, parentID string,
+) (TransferPlan, error) {
+	if muMoon <= 0 || rPark <= 0 || rSOI <= 0 {
+		return TransferPlan{}, errors.New("planmoonescape: muMoon, rPark, rSOI must be positive")
+	}
+	if rSOI <= rPark {
+		return TransferPlan{}, errors.New("planmoonescape: SOI radius must exceed parking radius")
+	}
+
+	aT := (rPark + rSOI) / 2
+	vCirc := math.Sqrt(muMoon / rPark)
+	vTransAtPeri := math.Sqrt(muMoon * (2/rPark - 1/aT))
+	dvDep := vTransAtPeri - vCirc
+
+	// Half-period of the bound transfer ellipse — periapsis to the
+	// apolune that sits on the SOI boundary.
+	transferTime := math.Pi * math.Sqrt(aT*aT*aT/muMoon)
+
+	var depOffset time.Duration
+	if minLeadSeconds > 0 {
+		depOffset = time.Duration(minLeadSeconds * float64(time.Second))
+	}
+
+	return TransferPlan{
+		Departure: TransferNode{
+			Leg:          LegDeparture,
+			PrimaryID:    moonID,
+			DV:           dvDep,
+			OffsetTime:   depOffset,
+			IsRetrograde: false,
+		},
+		Arrival: TransferNode{
+			Leg:          LegArrival,
+			PrimaryID:    parentID,
+			DV:           0,
+			OffsetTime:   depOffset + time.Duration(transferTime*float64(time.Second)),
+			IsRetrograde: false,
+		},
+		TransferDt: time.Duration(transferTime * float64(time.Second)),
+	}, nil
+}

--- a/internal/planner/moon_escape_test.go
+++ b/internal/planner/moon_escape_test.go
@@ -1,0 +1,132 @@
+package planner
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// muLuna is Luna's gravitational parameter (m³/s²).
+const muLuna = 4.9028e12
+
+// rLunaSOI approximates Luna's sphere-of-influence radius around Earth
+// (a · (m_luna / m_earth)^0.4 ≈ 6.617e7 m). Tests use a constant so the
+// math doesn't drift with body-data changes — what we care about is
+// the planner's algebra against a fixed apolune target.
+const rLunaSOI = 6.617e7
+
+// rLowLunarOrbit is a 100-km-altitude circular orbit around Luna
+// (Luna mean radius ≈ 1737.4 km). Standard test parking orbit.
+const rLowLunarOrbit = 1.7374e6 + 100e3
+
+// TestPlanMoonEscapeApoluneMatchesSOI: the bound-ellipse departure Δv
+// should produce a transfer ellipse whose apolune equals the SOI
+// radius to floating-point precision. This is the load-bearing
+// invariant — if the algebra is wrong, every downstream HUD prediction
+// is wrong.
+func TestPlanMoonEscapeApoluneMatchesSOI(t *testing.T) {
+	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
+	if err != nil {
+		t.Fatalf("PlanMoonEscape: %v", err)
+	}
+
+	// Reconstruct post-burn velocity at periapsis: v_circ + Δv.
+	vCirc := math.Sqrt(muLuna / rLowLunarOrbit)
+	vPeri := vCirc + plan.Departure.DV
+
+	// vis-viva: v² = µ · (2/r − 1/a) → a = 1 / (2/r − v²/µ)
+	a := 1 / (2/rLowLunarOrbit - vPeri*vPeri/muLuna)
+	apoFromBurn := 2*a - rLowLunarOrbit
+
+	if math.Abs(apoFromBurn-rLunaSOI) > 1.0 {
+		t.Errorf("apolune from burn = %.0f m, want %.0f m (SOI radius)",
+			apoFromBurn, rLunaSOI)
+	}
+}
+
+// TestPlanMoonEscapeTransferTimeMatchesHalfPeriod: the planner's
+// TransferDt must equal half the transfer ellipse's period — that's
+// the time between periapsis and the SOI-boundary apolune.
+func TestPlanMoonEscapeTransferTimeMatchesHalfPeriod(t *testing.T) {
+	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
+	if err != nil {
+		t.Fatalf("PlanMoonEscape: %v", err)
+	}
+	aT := (rLowLunarOrbit + rLunaSOI) / 2
+	wantHalf := math.Pi * math.Sqrt(aT*aT*aT/muLuna)
+	gotSecs := plan.TransferDt.Seconds()
+	if math.Abs(gotSecs-wantHalf) > 1.0 {
+		t.Errorf("TransferDt = %.1f s, want %.1f s", gotSecs, wantHalf)
+	}
+}
+
+// TestPlanMoonEscapePrimaryIDsRouteFrames: departure node carries the
+// moon's ID (so the HUD renders the burn in lunar frame), arrival
+// marker carries the parent's ID (so the HUD shows it crossing into
+// Earth frame at SOI exit).
+func TestPlanMoonEscapePrimaryIDsRouteFrames(t *testing.T) {
+	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
+	if err != nil {
+		t.Fatalf("PlanMoonEscape: %v", err)
+	}
+	if plan.Departure.PrimaryID != "moon" {
+		t.Errorf("departure PrimaryID = %q, want %q", plan.Departure.PrimaryID, "moon")
+	}
+	if plan.Arrival.PrimaryID != "earth" {
+		t.Errorf("arrival PrimaryID = %q, want %q", plan.Arrival.PrimaryID, "earth")
+	}
+	if plan.Arrival.DV != 0 {
+		t.Errorf("arrival is a frame-marker — Δv should be 0, got %.3f", plan.Arrival.DV)
+	}
+	if plan.Departure.IsRetrograde {
+		t.Errorf("escape burn should be prograde, got retrograde")
+	}
+}
+
+// TestPlanMoonEscapeMinLeadPadsBoth: when minLeadSeconds is non-zero,
+// the departure offset advances by that amount and the arrival offset
+// rides along (keeping arrival = departure + half-period).
+func TestPlanMoonEscapeMinLeadPadsBoth(t *testing.T) {
+	const lead = 90.0
+	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, lead, "moon", "earth")
+	if err != nil {
+		t.Fatalf("PlanMoonEscape: %v", err)
+	}
+	wantDep := time.Duration(lead * float64(time.Second))
+	if plan.Departure.OffsetTime != wantDep {
+		t.Errorf("departure OffsetTime = %v, want %v", plan.Departure.OffsetTime, wantDep)
+	}
+	gap := plan.Arrival.OffsetTime - plan.Departure.OffsetTime
+	if absDuration(gap-plan.TransferDt) > time.Second {
+		t.Errorf("arrival − departure = %v, want TransferDt = %v", gap, plan.TransferDt)
+	}
+}
+
+// TestPlanMoonEscapeRejectsBadInputs: degenerate inputs (non-positive
+// mu / radii, or SOI inside parking orbit) must surface as errors so
+// the dispatch path falls back instead of planting nonsense.
+func TestPlanMoonEscapeRejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name                string
+		muMoon, rPark, rSOI float64
+	}{
+		{"zero mu", 0, rLowLunarOrbit, rLunaSOI},
+		{"negative rPark", muLuna, -1, rLunaSOI},
+		{"zero rSOI", muLuna, rLowLunarOrbit, 0},
+		{"SOI ≤ rPark", muLuna, rLunaSOI, rLowLunarOrbit},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := PlanMoonEscape(c.muMoon, c.rPark, c.rSOI, 0, "moon", "earth"); err == nil {
+				t.Errorf("expected error for %s, got nil", c.name)
+			}
+		})
+	}
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1013,11 +1013,11 @@ func (w *World) PredictedLegs() []PredictedLeg {
 }
 
 // PreviewBurnState returns the craft state immediately after a
-// hypothetical burn with the given (mode, dv, event) parameters
-// would fire — without mutating world state. Used by the maneuver-
-// planner screen so its shadow trajectory + PROJECTED ORBIT readout
-// reflect where the burn would *actually* fire, not where the craft
-// is sitting right now.
+// hypothetical burn with the given (mode, dv, duration, event)
+// parameters would fire — without mutating world state. Used by the
+// maneuver-planner screen so its shadow trajectory + PROJECTED ORBIT
+// readout reflect where the burn would *actually* fire, not where the
+// craft is sitting right now.
 //
 // For event != Absolute, the helper computes the time-of-flight to
 // the event using the same orbital helpers as the lazy-freeze
@@ -1032,7 +1032,18 @@ func (w *World) PredictedLegs() []PredictedLeg {
 // TriggerTime + Duration/2 in flight; the planner doesn't yet know
 // which TriggerTime the user will choose, so previewing at "now" is
 // the least-surprising default.
-func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, event TriggerEvent) (physics.StateVector, bodies.CelestialBody, bool) {
+//
+// v0.6.3 polish: when duration > 0 the helper routes through
+// `planner.SimulateFiniteBurn` so the preview reflects finite-burn
+// deformation (off-tangential velocity rotation through the burn arc,
+// finite-burn cosine loss, etc.) rather than the impulsive
+// idealisation. The delivered Δv is also capped by the rocket-
+// equation maximum the duration window allows — so a 400 m/s request
+// with the form's default 10 s duration returns a preview reflecting
+// only what 10 s of thrust would actually deliver (≈205 m/s for the
+// S-IVB-1 default loadout), matching what the live integrator does
+// when the burn terminates on duration rather than Δv.
+func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration time.Duration, event TriggerEvent) (physics.StateVector, bodies.CelestialBody, bool) {
 	if w.Craft == nil {
 		return physics.StateVector{}, bodies.CelestialBody{}, false
 	}
@@ -1061,8 +1072,39 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, event Tri
 		}
 	}
 
+	if dv == 0 {
+		return state, primary, true
+	}
+
+	thrust := w.Craft.Thrust
+	isp := w.Craft.Isp
+	useFinite := duration > 0 && thrust > 0 && isp > 0 && state.M > 0
+
+	if useFinite {
+		// Cap delivered Δv by what `duration` actually allows under
+		// the rocket equation. Pre-v0.6.3 the preview used the raw
+		// requested Δv; if the form's duration was too short to
+		// deliver it (the in-flight burn terminates on duration, not
+		// Δv) the projected orbit overshot what the player would see.
+		mdot := thrust / (isp * 9.80665)
+		massAfter := state.M - mdot*duration.Seconds()
+		effectiveDv := dv
+		if massAfter > 0 {
+			maxDv := isp * 9.80665 * math.Log(state.M/massAfter)
+			if effectiveDv > maxDv {
+				effectiveDv = maxDv
+			}
+		}
+		direction := func(r, v orbital.Vec3) orbital.Vec3 {
+			return spacecraft.DirectionUnit(mode, r, v)
+		}
+		mu := primary.GravitationalParameter()
+		state = planner.SimulateFiniteBurn(state, mu, thrust, isp, effectiveDv, direction)
+		return state, primary, true
+	}
+
 	dir := spacecraft.DirectionUnit(mode, state.R, state.V)
-	if dir.Norm() != 0 && dv != 0 {
+	if dir.Norm() != 0 {
 		state.V = state.V.Add(dir.Scale(dv))
 	}
 	return state, primary, true

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -298,6 +298,53 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		return &plan, nil
 	}
 
+	// v0.6.3: target is the craft's primary's parent (e.g., craft in
+	// Luna's SOI, target Earth). The pre-v0.6.3 fallthrough sent these
+	// to the heliocentric Hohmann path, which treated Earth's
+	// heliocentric semimajor axis as the destination radius around
+	// Luna and produced nonsensical Δv. The moon-escape planner instead
+	// targets a bound transfer ellipse whose apolune sits on Luna's
+	// SOI; the SOI-aware integrator then drops the craft into Earth's
+	// frame automatically. The arrival node is a zero-Δv frame marker
+	// — the player plants their own circularization once they see the
+	// post-escape Earth-frame trajectory.
+	if w.Craft.Primary.ParentID != "" && target.ID == w.Craft.Primary.ParentID {
+		moon := w.Craft.Primary
+		moonParent := sys.ParentOf(moon)
+		if moonParent == nil {
+			return nil, errInvalidTransferTarget
+		}
+		muMoon := moon.GravitationalParameter()
+		rSOI := physics.SOIRadius(moon, *moonParent)
+		if rSOI == 0 || rSOI <= rPark {
+			return nil, errInvalidTransferTarget
+		}
+		mass := w.Craft.TotalMass()
+		thrust := w.Craft.Thrust
+		// Pre-size the centered-finite-burn lead pad from the impulsive
+		// estimate, mirroring the intra-primary branch above.
+		aT := (rPark + rSOI) / 2
+		vCirc := math.Sqrt(muMoon / rPark)
+		vTransAtPeri := math.Sqrt(muMoon * (2/rPark - 1/aT))
+		dvEstimate := vTransAtPeri - vCirc
+		var minLead float64
+		if thrust > 0 && mass > 0 && dvEstimate > 0 {
+			minLead = (dvEstimate * mass / thrust) / 2
+		}
+		plan, err := planner.PlanMoonEscape(muMoon, rPark, rSOI, minLead, moon.ID, target.ID)
+		if err != nil {
+			return nil, err
+		}
+		// Reuse v0.6.2's iterator: target the SOI radius as apolune so
+		// finite-burn integration delivers the bound transfer ellipse
+		// the impulsive math designed.
+		refineFiniteDeparture(&plan, muMoon, rPark, mass, thrust, w.Craft.Isp, rSOI)
+		now := w.Clock.SimTime
+		w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
+		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+		return &plan, nil
+	}
+
 	primary := sys.Bodies[0]
 	muSun := primary.GravitationalParameter()
 	rDeparture := w.CraftInertial().Norm()

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -1145,5 +1146,128 @@ func TestRefinePlanUpdatesArrivalAfterPlanTransferAt(t *testing.T) {
 	if len(w.Nodes) != origNodeCount+1 {
 		t.Errorf("node count after refine = %d, want %d (orig + correction)",
 			len(w.Nodes), origNodeCount+1)
+	}
+}
+
+// TestPlanTransferMoonEscapePlantsTwoNodes (v0.6.3): with the craft in
+// low lunar orbit, PlanTransfer(earth) should plant a moon-frame
+// departure burn (Δv > 0, prograde) followed by an Earth-frame
+// zero-Δv SOI-exit marker. Pre-v0.6.3 the dispatch fell through to
+// the heliocentric Hohmann path, which treated Earth's heliocentric
+// semimajor axis as the destination radius around Luna and quoted
+// nonsense Δv.
+func TestPlanTransferMoonEscapePlantsTwoNodes(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	moonIdx, earthIdx := -1, -1
+	for i, b := range sys.Bodies {
+		switch b.ID {
+		case "moon":
+			moonIdx = i
+		case "earth":
+			earthIdx = i
+		}
+	}
+	if moonIdx < 0 || earthIdx < 0 {
+		t.Skip("Earth/Moon missing from loaded Sol")
+	}
+	moon := sys.Bodies[moonIdx]
+	earth := sys.Bodies[earthIdx]
+
+	// Re-seat the craft into a 100-km circular low lunar orbit.
+	rPark := moon.RadiusMeters() + 100e3
+	muMoon := moon.GravitationalParameter()
+	vCirc := math.Sqrt(muMoon / rPark)
+	w.Craft.Primary = moon
+	w.Craft.State.R = orbital.Vec3{X: rPark}
+	w.Craft.State.V = orbital.Vec3{Y: vCirc}
+
+	plan, err := w.PlanTransfer(earthIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer(earth) from lunar orbit: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("PlanTransfer returned nil plan with nil error")
+	}
+	if len(w.Nodes) != 2 {
+		t.Fatalf("expected 2 planted nodes, got %d", len(w.Nodes))
+	}
+	dep, arr := w.Nodes[0], w.Nodes[1]
+	if dep.PrimaryID != moon.ID {
+		t.Errorf("departure PrimaryID = %q, want %q", dep.PrimaryID, moon.ID)
+	}
+	if arr.PrimaryID != earth.ID {
+		t.Errorf("arrival PrimaryID = %q, want %q", arr.PrimaryID, earth.ID)
+	}
+	if dep.DV <= 0 {
+		t.Errorf("departure Δv = %.3f m/s, want > 0", dep.DV)
+	}
+	if dep.Mode != spacecraft.BurnPrograde {
+		t.Errorf("departure Mode = %v, want BurnPrograde", dep.Mode)
+	}
+	if arr.DV != 0 {
+		t.Errorf("arrival is a frame marker — Δv should be 0, got %.3f", arr.DV)
+	}
+
+	// Sanity: planted Δv should match the bound-ellipse impulsive
+	// estimate within ≈5%. The iterator may refine the value; for a
+	// short LLO escape burn (≈30 s on the S-IVB-1) the impulsive
+	// guess is already very close.
+	rSOI := physics.SOIRadius(moon, earth)
+	if rSOI == 0 {
+		t.Fatal("SOIRadius(moon, earth) = 0 — body data missing mass / a")
+	}
+	aT := (rPark + rSOI) / 2
+	vTrans := math.Sqrt(muMoon * (2/rPark - 1/aT))
+	impulsiveDv := vTrans - vCirc
+	rel := math.Abs(dep.DV-impulsiveDv) / impulsiveDv
+	if rel > 0.05 {
+		t.Errorf("departure Δv %.1f m/s deviates >5%% from impulsive %.1f m/s (rel=%.4f)",
+			dep.DV, impulsiveDv, rel)
+	}
+
+	// Arrival's TriggerTime should sit at departure-center +
+	// half-period of the bound transfer ellipse (within 1 s).
+	gap := arr.TriggerTime.Sub(dep.TriggerTime).Seconds()
+	wantGap := math.Pi * math.Sqrt(aT*aT*aT/muMoon)
+	if math.Abs(gap-wantGap) > 1.0 {
+		t.Errorf("arrival − departure gap = %.1f s, want %.1f s (half-period)", gap, wantGap)
+	}
+}
+
+// TestPlanTransferMoonEscapeIntraPrimaryStillFires: regression guard —
+// the new moon-escape branch must not steal dispatch from the
+// intra-primary branch. From LEO targeting Luna (target.ParentID ==
+// craft.Primary.ID), the intra-primary Hohmann path must still fire
+// and plant a non-trivial geocentric departure.
+func TestPlanTransferMoonEscapeIntraPrimaryStillFires(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.ID == "moon" {
+			moonIdx = i
+			break
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	plan, err := w.PlanTransfer(moonIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer(moon) from LEO: %v", err)
+	}
+	if plan.Departure.PrimaryID != "earth" {
+		t.Errorf("intra-primary departure PrimaryID = %q, want %q (LEO→Luna stays geocentric)",
+			plan.Departure.PrimaryID, "earth")
+	}
+	if plan.Arrival.PrimaryID != "moon" {
+		t.Errorf("intra-primary arrival PrimaryID = %q, want %q",
+			plan.Arrival.PrimaryID, "moon")
+	}
+	// Δv should be in TLI ballpark — well above the moon-escape
+	// figure (~30 m/s). Pick a generous lower bound.
+	if plan.Departure.DV < 2000 {
+		t.Errorf("LEO→Luna departure Δv = %.0f m/s, want ≥ 2000 (TLI scale)", plan.Departure.DV)
 	}
 }

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -182,7 +183,7 @@ func TestPreviewBurnStateAtNextApoRaisesPeriapsis(t *testing.T) {
 	// Step 2: preview a 100 m/s prograde at next apoapsis. This must
 	// raise periapsis (perigee-raise = circularise at higher alt) —
 	// NOT raise apoapsis again.
-	state, primary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 100, TriggerNextApo)
+	state, primary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 100, 0, TriggerNextApo)
 	if !ok {
 		t.Fatalf("PreviewBurnState returned ok=false")
 	}
@@ -215,7 +216,7 @@ func TestPreviewBurnStateAtNextApoRaisesPeriapsis(t *testing.T) {
 // pre-v0.6 planner preview semantics.
 func TestPreviewBurnStateAbsolute(t *testing.T) {
 	w := mustWorld(t)
-	state, primary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 50, TriggerAbsolute)
+	state, primary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 50, 0, TriggerAbsolute)
 	if !ok {
 		t.Fatalf("PreviewBurnState(Absolute): ok=false")
 	}
@@ -357,7 +358,7 @@ func TestPredictedFinalOrbitMatchesPreviewForResolvedNode(t *testing.T) {
 	}
 
 	// PreviewBurnState — what the maneuver screen shows.
-	previewState, previewPrimary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 100, TriggerNextApo)
+	previewState, previewPrimary, ok := w.PreviewBurnState(spacecraft.BurnPrograde, 100, 0, TriggerNextApo)
 	if !ok {
 		t.Fatalf("PreviewBurnState ok=false")
 	}
@@ -1232,6 +1233,172 @@ func TestPlanTransferMoonEscapePlantsTwoNodes(t *testing.T) {
 	wantGap := math.Pi * math.Sqrt(aT*aT*aT/muMoon)
 	if math.Abs(gap-wantGap) > 1.0 {
 		t.Errorf("arrival − departure gap = %.1f s, want %.1f s (half-period)", gap, wantGap)
+	}
+}
+
+// seatLunaCaptureOrbit places the craft at apoapsis of a peri-40 km /
+// apo-8000 km moon-frame elliptical orbit — the typical post-Hohmann
+// capture geometry. Returns the moon body, parking peri/apo radii, and
+// peri velocity for follow-on assertions. Apoapsis placement is
+// deliberate: TimeToPeriapsis(state-at-peri) wraps to one full orbital
+// period (≈11 h here), and the velocity-Verlet integrator's drift
+// over that long a coast can mask the burn's actual orbital effect.
+// Apoapsis → next peri is half a period (≈5.5 h), well inside the
+// integrator's accurate regime.
+func seatLunaCaptureOrbit(t *testing.T, w *World) (moon bodies.CelestialBody, rPeri, rApo, vPeri float64, ok bool) {
+	t.Helper()
+	sys := w.System()
+	for _, b := range sys.Bodies {
+		if b.ID == "moon" {
+			moon = b
+			break
+		}
+	}
+	if moon.ID == "" {
+		return moon, 0, 0, 0, false
+	}
+	muMoon := moon.GravitationalParameter()
+	rPeri = moon.RadiusMeters() + 40e3
+	rApo = moon.RadiusMeters() + 8000e3
+	a := (rPeri + rApo) / 2
+	vPeri = math.Sqrt(muMoon * (2/rPeri - 1/a))
+	vApo := math.Sqrt(muMoon * (2/rApo - 1/a))
+	w.Craft.Primary = moon
+	// Apoapsis sits at -X (opposite peri); craft moves in -Y direction
+	// there so the next periapsis return is along +X.
+	w.Craft.State.R = orbital.Vec3{X: -rApo}
+	w.Craft.State.V = orbital.Vec3{Y: -vApo}
+	return moon, rPeri, rApo, vPeri, true
+}
+
+// TestPreviewBurnStateLongRetroAtLunaPeriCapsByDuration (v0.6.3
+// polish): mirrors the Luna-circularization playthrough Jason
+// reported. After a Hohmann + capture, the craft sits in a peri-40 km
+// / apo-~8000 km lunar orbit. Hand-entering 400 m/s retrograde at
+// next peri while leaving the form's default 10 s duration cannot
+// deliver the requested Δv — the in-flight burn terminates on
+// duration, not Δv. The preview must reflect that truncation: the
+// post-burn orbit must match what the live integrator will actually
+// produce, so the player isn't surprised by an AP drop smaller than
+// the projected number suggested.
+//
+// Also confirms that a long retrograde burn centered on periapsis
+// shifts PE by less than the finite-burn arc would predict (well
+// under 100 km for this profile) — Jason's "PE adjusts more than
+// expected" observation, expected to be small in physics.
+func TestPreviewBurnStateLongRetroAtLunaPeriCapsByDuration(t *testing.T) {
+	w := mustWorld(t)
+	moon, rPeri, _, vPeri, seated := seatLunaCaptureOrbit(t, w)
+	if !seated {
+		t.Skip("Moon missing from Sol")
+	}
+	muMoon := moon.GravitationalParameter()
+
+	// Default duration (matches the m form's default).
+	const duration = 10 * time.Second
+
+	// Sanity: max deliverable in 10 s for the S-IVB-1 default.
+	const g0 = 9.80665
+	mdot := w.Craft.Thrust / (w.Craft.Isp * g0)
+	massAfter := w.Craft.State.M - mdot*duration.Seconds()
+	if massAfter <= 0 {
+		t.Fatal("setup: 10 s burn would empty the tank — vessel mass too low for default")
+	}
+	maxDeliverable := w.Craft.Isp * g0 * math.Log(w.Craft.State.M/massAfter)
+	if maxDeliverable > 250 {
+		t.Fatalf("setup: maxDeliverable in %v = %.1f m/s; expected ~205 m/s for S-IVB-1 — vessel parameters changed?",
+			duration, maxDeliverable)
+	}
+
+	// Request 400 m/s — well above what 10 s can deliver.
+	state, primary, ok := w.PreviewBurnState(spacecraft.BurnRetrograde, 400, duration, TriggerNextPeri)
+	if !ok {
+		t.Fatalf("PreviewBurnState returned ok=false")
+	}
+	if primary.ID != moon.ID {
+		t.Fatalf("preview escaped Luna SOI? primary=%q", primary.ID)
+	}
+
+	post := orbital.ElementsFromState(state.R, state.V, muMoon)
+	postPeri := post.Periapsis()
+	postApo := post.Apoapsis()
+
+	// PE should stay close to its pre-burn value. Finite-burn
+	// deformation over a ~10 s arc at 1.2 mrad/s ω only twists the
+	// retrograde direction by ~0.7° — periapsis shift should be
+	// well under 100 km in practice.
+	periShift := math.Abs(postPeri - rPeri)
+	if periShift > 100e3 {
+		t.Errorf("PE shifted %.0f km — finite-burn deformation should be < 100 km; current orbit is symmetric around peri",
+			periShift/1000)
+	}
+
+	// AP must reflect *delivered* Δv, not the requested 400 m/s.
+	// Compute the impulsive AP that 400 m/s would have produced and
+	// the impulsive AP that maxDeliverable would have produced; the
+	// finite preview's AP must sit closer to the latter.
+	impPostV400 := vPeri - 400
+	impEps400 := 0.5*impPostV400*impPostV400 - muMoon/rPeri
+	impA400 := -muMoon / (2 * impEps400)
+	impApo400 := 2*impA400 - rPeri
+
+	impPostVCap := vPeri - maxDeliverable
+	impEpsCap := 0.5*impPostVCap*impPostVCap - muMoon/rPeri
+	impACap := -muMoon / (2 * impEpsCap)
+	impApoCap := 2*impACap - rPeri
+
+	dist400 := math.Abs(postApo - impApo400)
+	distCap := math.Abs(postApo - impApoCap)
+	if dist400 < distCap {
+		t.Errorf("preview AP %.0f km matched 400 m/s impulsive (%.0f km) more closely than truncated %.1f m/s impulsive (%.0f km) — duration cap not applied",
+			postApo/1000, impApo400/1000, maxDeliverable, impApoCap/1000)
+	}
+	// Preview AP should be within 5% of the truncated impulsive
+	// prediction. Finite-burn deformation nudges it slightly but
+	// not by 5%.
+	rel := math.Abs(postApo-impApoCap) / impApoCap
+	if rel > 0.05 {
+		t.Errorf("preview AP %.0f km diverges from truncated-impulsive %.0f km by %.1f%% — expected < 5%%",
+			postApo/1000, impApoCap/1000, rel*100)
+	}
+}
+
+// TestPreviewBurnStateFiniteVsImpulsiveAtLunaPeri (v0.6.3 polish): when
+// the requested Δv fits inside the duration window (200 m/s in 10 s
+// for the S-IVB-1), the finite-burn preview and the impulsive preview
+// should land within a few percent on AP — the burn arc is small
+// enough that the cosine-loss / off-tangential effect is bounded. PE
+// drift between the two should also be small for a burn centered on
+// periapsis. Catches regressions where the finite-burn integration
+// silently produces a wildly different orbit shape.
+func TestPreviewBurnStateFiniteVsImpulsiveAtLunaPeri(t *testing.T) {
+	w := mustWorld(t)
+	moon, _, _, _, seated := seatLunaCaptureOrbit(t, w)
+	if !seated {
+		t.Skip("Moon missing from Sol")
+	}
+	muMoon := moon.GravitationalParameter()
+
+	// 200 m/s in 10 s for S-IVB-1 — deliverable (max ≈ 205).
+	imp, _, ok := w.PreviewBurnState(spacecraft.BurnRetrograde, 200, 0, TriggerNextPeri)
+	if !ok {
+		t.Fatal("impulsive preview ok=false")
+	}
+	fin, _, ok := w.PreviewBurnState(spacecraft.BurnRetrograde, 200, 10*time.Second, TriggerNextPeri)
+	if !ok {
+		t.Fatal("finite preview ok=false")
+	}
+	impEl := orbital.ElementsFromState(imp.R, imp.V, muMoon)
+	finEl := orbital.ElementsFromState(fin.R, fin.V, muMoon)
+
+	apoRel := math.Abs(impEl.Apoapsis()-finEl.Apoapsis()) / impEl.Apoapsis()
+	if apoRel > 0.05 {
+		t.Errorf("AP impulsive vs finite differ by %.1f%% (imp=%.0f km, fin=%.0f km) — expected < 5%% for short burn",
+			apoRel*100, impEl.Apoapsis()/1000, finEl.Apoapsis()/1000)
+	}
+	periDelta := math.Abs(impEl.Periapsis() - finEl.Periapsis())
+	if periDelta > 50e3 {
+		t.Errorf("PE impulsive vs finite differ by %.0f km — expected < 50 km for ~10 s burn at peri", periDelta/1000)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -47,6 +47,13 @@ type App struct {
 	// scheduled tea.Cmd.
 	statusMsg     string
 	statusExpires time.Time
+
+	// confirmingQuit drives the v0.6.3 quit-confirm overlay. When
+	// true, every key except y/Y (confirm) and n/N/esc/q (cancel) is
+	// dropped so accidental keystrokes can't fall through to the
+	// active screen. ctrl+c bypasses this entirely — standard
+	// interrupt convention beats the dialog.
+	confirmingQuit bool
 }
 
 // New builds a root App. Returns an error if systems can't load.
@@ -129,13 +136,34 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.KeyMsg:
-		// Maneuver screen has its own text input that eats most keys; we
-		// still honor global quit, and esc-to-cancel goes through the
-		// screen's handler so it can clean up.
-		if a.active == screenManeuver {
-			if key.Matches(m, a.keys.Quit) {
+		// ctrl+c bypasses the quit-confirm dialog (standard interrupt
+		// convention). Honored from any screen.
+		if key.Matches(m, a.keys.Quit) {
+			a.autosave()
+			return a, tea.Quit
+		}
+		// While confirming a q-quit, intercept everything else: y/Y →
+		// commit, n/N/esc/q → cancel, anything else dropped so a
+		// stray keystroke can't accidentally exit the dialog by
+		// reaching the active screen below.
+		if a.confirmingQuit {
+			switch m.String() {
+			case "y", "Y":
 				a.autosave()
 				return a, tea.Quit
+			case "n", "N", "esc", "q":
+				a.confirmingQuit = false
+				return a, nil
+			}
+			return a, nil
+		}
+		// Maneuver screen has its own text input that eats most keys;
+		// q opens the quit-confirm before delegating, esc-to-cancel
+		// goes through the screen's handler so it can clean up.
+		if a.active == screenManeuver {
+			if key.Matches(m, a.keys.QuitAsk) {
+				a.confirmingQuit = true
+				return a, nil
 			}
 			if key.Matches(m, a.keys.Back) {
 				a.world.Clock.Paused = false
@@ -150,9 +178,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Porkchop: ←/→/↑/↓ navigate cells, Esc returns.
 		if a.active == screenPorkchop {
-			if key.Matches(m, a.keys.Quit) {
-				a.autosave()
-				return a, tea.Quit
+			if key.Matches(m, a.keys.QuitAsk) {
+				a.confirmingQuit = true
+				return a, nil
 			}
 			_, done := a.porkchop.HandleKey(m)
 			if done {
@@ -164,9 +192,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		switch {
-		case key.Matches(m, a.keys.Quit):
-			a.autosave()
-			return a, tea.Quit
+		case key.Matches(m, a.keys.QuitAsk):
+			a.confirmingQuit = true
+			return a, nil
 		case key.Matches(m, a.keys.Help):
 			if a.active == screenHelp {
 				a.active = screenOrbit
@@ -362,6 +390,9 @@ func (a *App) View() string {
 	}
 	if a.statusMsg != "" && time.Now().Before(a.statusExpires) {
 		base += "\n" + a.theme.Footer.Render(a.statusMsg)
+	}
+	if a.confirmingQuit {
+		base += "\n" + a.theme.Warning.Render("Quit and save? [y/N]")
 	}
 	return base
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -6,6 +6,7 @@ import "github.com/charmbracelet/bubbles/key"
 // that need additional keys define them locally.
 type Keymap struct {
 	Quit       key.Binding
+	QuitAsk    key.Binding
 	Help       key.Binding
 	BodyInfo   key.Binding
 	Maneuver   key.Binding
@@ -32,7 +33,8 @@ type Keymap struct {
 
 func DefaultKeymap() Keymap {
 	return Keymap{
-		Quit:       key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+		Quit:       key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit (immediate)")),
+		QuitAsk:    key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit (confirm)")),
 		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 		BodyInfo:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
 		Maneuver:   key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -20,7 +20,8 @@ func (h *Help) Render() string {
 		rows   [][2]string
 	}{
 		{"GLOBAL", [][2]string{
-			{"q / ctrl+c", "quit"},
+			{"q", "quit (confirm prompt)"},
+			{"ctrl+c", "quit (immediate)"},
 			{"?", "toggle this help"},
 			{"esc", "back / close"},
 		}},
@@ -49,7 +50,7 @@ func (h *Help) Render() string {
 		{"PERSISTENCE", [][2]string{
 			{"S", "save game (XDG_STATE_HOME)"},
 			{"L", "load game"},
-			{"q", "quit (autosaves)"},
+			{"q", "quit (confirm + autosave)"},
 		}},
 	}
 

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -216,9 +216,10 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	// craft is nowhere near. Falls back to current-state preview if
 	// the event is unreachable (hyperbolic / equatorial AN/DN).
 	dv := m.parsedDV()
+	dur := m.parsedDuration()
 	mode := spacecraft.AllBurnModes[m.modeIdx]
 	event := sim.AllTriggerEvents[m.fireAtIdx]
-	shadowState, shadowPrimary, ok := w.PreviewBurnState(mode, dv, event)
+	shadowState, shadowPrimary, ok := w.PreviewBurnState(mode, dv, dur, event)
 	if !ok {
 		dir := spacecraft.DirectionUnit(mode, c.State.R, c.State.V)
 		shadowState = physics.StateVector{

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
@@ -239,8 +240,16 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 		m.canvas.Plot(p.Add(primaryGap))
 	}
 
-	// Plot planet (primary) at origin.
-	m.canvas.Plot(orbital.Vec3{})
+	// Plot the primary at origin as a sized disk so its real radius
+	// is visible at the same scale as the orbit. v0.6.3 polish: a
+	// single-pixel marker hid the body's surface and made low-orbit
+	// projections (e.g. low lunar orbit at 4× the moon radius) read
+	// as smaller than they really are. BodyPixelRadius shares the
+	// orbit-screen's size-tier logic so the moon disk on this canvas
+	// is consistent with what the player sees on the main view.
+	primaryColor := render.ColorFor(c.Primary)
+	primaryPxR := BodyPixelRadius(c.Primary, false, m.canvas.Scale())
+	m.canvas.FillColoredDisk(orbital.Vec3{}, primaryPxR, primaryColor)
 	// Plot craft (current position) with a cluster.
 	for i := -4; i <= 4; i++ {
 		step := 1.0 / m.canvas.Scale()

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -244,11 +244,21 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	// is visible at the same scale as the orbit. v0.6.3 polish: a
 	// single-pixel marker hid the body's surface and made low-orbit
 	// projections (e.g. low lunar orbit at 4× the moon radius) read
-	// as smaller than they really are. BodyPixelRadius shares the
-	// orbit-screen's size-tier logic so the moon disk on this canvas
-	// is consistent with what the player sees on the main view.
+	// as smaller than they really are.
+	//
+	// Uses true (radius × scale) projection with a 3-pixel floor and
+	// 64-pixel ceiling — the orbit-screen's BodyPixelRadius drops
+	// Luna-class moons (radius < 3e6 m) to 1 pixel under its size-
+	// tier fallback, which on this canvas reproduces the original
+	// "single dot" issue. Here the primary IS the view's focus, so
+	// always render at true scale.
 	primaryColor := render.ColorFor(c.Primary)
-	primaryPxR := BodyPixelRadius(c.Primary, false, m.canvas.Scale())
+	primaryPxR := int(math.Round(c.Primary.RadiusMeters() * m.canvas.Scale()))
+	if primaryPxR < 3 {
+		primaryPxR = 3
+	} else if primaryPxR > 64 {
+		primaryPxR = 64
+	}
 	m.canvas.FillColoredDisk(orbital.Vec3{}, primaryPxR, primaryColor)
 	// Plot craft (current position) with a cluster.
 	for i := -4; i <= 4; i++ {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -35,6 +35,17 @@ type OrbitView struct {
 	lastSystemIdx int
 	lastFocus     sim.Focus
 	fitted        bool
+
+	// burnFrozenCenter pins the canvas center for the duration of an
+	// active burn. Captured when ActiveBurn becomes non-nil, cleared
+	// when it returns to nil. v0.6.3 fix: focus-on-craft tracks the
+	// craft's live position every tick, and during a burn the craft
+	// is sweeping through periapsis at km/s — every other element
+	// (the selected-body cross, body disks, the live orbit ellipse,
+	// apsidal markers) sweeps the opposite direction in screen space,
+	// reading as the world rotating around the player. Holding the
+	// camera lets the player watch the burn modify the orbit instead.
+	burnFrozenCenter *orbital.Vec3
 }
 
 // minOrbitPixels is the projected apoapsis size below which an orbit
@@ -89,7 +100,17 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	}
 
 	v.canvas.Clear()
-	v.canvas.Center(w.FocusPosition())
+	center := w.FocusPosition()
+	if w.ActiveBurn != nil {
+		if v.burnFrozenCenter == nil {
+			snapshot := center
+			v.burnFrozenCenter = &snapshot
+		}
+		center = *v.burnFrozenCenter
+	} else if v.burnFrozenCenter != nil {
+		v.burnFrozenCenter = nil
+	}
+	v.canvas.Center(center)
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
 	for i := range sys.Bodies {


### PR DESCRIPTION
## Summary
- New `planner.PlanMoonEscape` returns a two-impulse `TransferPlan` whose departure burn raises apolune to the moon's SOI radius and whose arrival node is a zero-Δv frame marker at SOI exit.
- New dispatch branch in `sim.PlanTransfer` fires when `target.ID == w.Craft.Primary.ParentID` (e.g. craft in Luna SOI targeting Earth). Pre-v0.6.3 this case fell through to the heliocentric Hohmann path and quoted nonsense Δv.
- The departure burn reuses the v0.6.2 finite-burn iterator with `TargetApoapsis(rSOI)` so low-TWR loadouts get the same finite-burn refinement as the existing LEO → Luna path.

## Test plan
- [x] `go test ./internal/planner/...` — `PlanMoonEscape` apolune match, half-period transfer time, frame-routing PrimaryIDs, lead-pad propagation, degenerate-input rejection
- [x] `go test ./internal/sim/...` — Luna→Earth plants two nodes (moon-frame departure, Earth-frame zero-Δv marker), departure Δv within 5% of impulsive estimate, half-period gap, intra-primary regression guard for LEO→Luna
- [x] `go test ./...` — full repo green
- [x] `go build ./cmd/terminal-space-program` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)