### PR TITLE
feat(sim,tui): mouse + 5-way view modes (v0.6.4)

### DIFF
--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -22,7 +22,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(app, tea.WithAltScreen())
+	p := tea.NewProgram(app, tea.WithAltScreen(), tea.WithMouseAllMotion())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: %v\n", err)
 		os.Exit(1)

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -212,6 +212,14 @@ by patch — this doc is the snapshot, those are the release notes.
 - **Multi-system spacecraft**. The craft is currently locked to Sol. Allowing
   it to enter Alpha Cen / TRAPPIST / Kepler unlocks the system-cycle UX.
   Requires interstellar transfer math (or deus-ex-machina jump for now).
+- **Multi-craft control selector**. Today the sim exposes one craft
+  (`World.Craft`); UI features that depend on "the active orbit" — focus,
+  the maneuver planner's PROJECTED ORBIT, v0.6.4's orbit-perpendicular
+  view-mode basis — implicitly point at it. When multiple craft come
+  online, those features need a craft-control selector key (e.g. `[`/`]`
+  cycle, or click-to-select on the orbit canvas) so "active craft" is
+  unambiguous and per-screen. Surfaces during v0.6.4 view-mode work as a
+  flagged future requirement.
 - **Inclination-change planner**. Today's burn modes don't expose a clean
   out-of-plane corrector. Adds a third burn at the line-of-nodes.
 - **N-body perturbations**. The sim is strict patched-conic; Lagrangian

--- a/docs/v0.6-plan.md
+++ b/docs/v0.6-plan.md
@@ -20,8 +20,8 @@ v0.6.0 introduces is reused by v0.6.1's HUD readout.
 | v0.6.1 | shipped  | `v0.6.1`  | Predicted post-burn orbit HUD. |
 | v0.6.2 | shipped  | `v0.6.2`  | Finite-burn-aware iterative planner. |
 | v0.6.3 | shipped  | `v0.6.3`  | Moon → parent escape transfer + maneuver-canvas primary disk render. |
-| v0.6.4 | next     | —         | Mouse selection + view-mode switcher (see scope below). |
-| v0.6.5 | pending  | —         | Mission scaffold. |
+| v0.6.4 | branch   | (pending) | Mouse selection + 5-way view-mode switcher with side-view occlusion. |
+| v0.6.5 | next     | —         | Mission scaffold. |
 | v0.6.6 | pending  | —         | Multiplayer design-doc spike. |
 
 Scope corrections vs. state-of-game.md (the doc framing was stale in two
@@ -274,6 +274,52 @@ Click-only input. No drag, no wheel-zoom.
 
 **Estimate.** ~200 LOC + tests (was ~150 — +50 for view-mode
 plumbing and projection round-trip tests).
+
+**Shipped.** Branch `v0.6.4-mouse-and-views` (PR pending).
+
+- Five hard-coded view modes — Top, Right, Bottom, Left, OrbitFlat
+  — replacing the original two-mode (Equatorial / OrbitPerp) draft
+  after a playthrough showed it just rotated the same flat picture.
+  Side views render with back-of-body occlusion via
+  `Canvas.IsBehindBody` + `DrawEllipseOffsetOccluded`, so the
+  spacecraft orbit + craft glyph + apo / peri markers are hidden
+  when occluded by the primary's projected disk. Reads as 3D rather
+  than the orbit punching through the body.
+- `tea.WithMouseAllMotion` enabled. `Canvas.pixelTags` widened from
+  bare `lipgloss.Color` to `CellTag{Color, BodyID, NodeIdx,
+  IsVessel}`; new `Canvas.HitAt(col, row)` aggregates the 2×4
+  pixels of a terminal cell. Tagged variants of FillColoredDisk /
+  RingColoredOutline / PlotArrow / PlotColored let the orbit
+  screen mark body / vessel / node draws for resolution.
+- Click cascade on the orbit screen, most-specific-first: vessel →
+  node → body → empty-canvas → HUD.
+  - **Vessel** → `Focus = FocusCraft`.
+  - **Node** → opens the planner pre-loaded via
+    `Maneuver.LoadNode(idx, node)`. Stores `editingIdx` +
+    `loadedTriggerTime` so Enter replaces the original node in
+    place AND preserves its scheduled fire time. The form's BURN
+    PLAN header shifts to "BURN PLAN — editing node N" in the
+    Warning style; the fire-at line carries an absolute countdown
+    (`T+14m32s` or `next peri (T+3h12m)`) so the schedule is
+    visible.
+  - **Body** → `selectedBody` (same as `←`/`→` cycle).
+  - **Empty canvas** → opens the planner staged at the orbit point
+    nearest the click via `OrbitView.ProjectToOrbit`. Form opens
+    with TriggerAbsolute + the projected TriggerTime + 100 m/s
+    prograde defaults, focus on Δv input.
+  - **HUD** → opens the body-info screen.
+- Porkchop click → `SetSelection(depIdx, tofIdx)` (cursor parity).
+- `BurnExecutedMsg` carries `TriggerTime` + `EditingIdx` so the
+  app can plant with a preserved schedule and remove the original
+  before replanting.
+- Maneuver screen layout switched to horizontal `JoinHorizontal`
+  (canvas left, form right) — pre-fix the form stacked below the
+  canvas, overflowing terminals shorter than ~36 rows and pushing
+  the title off the top.
+- Quit confirm prompt on `q` (`ctrl+c` stays immediate). Camera
+  freeze during active burn so the orbit ellipse + apo / peri
+  markers + selected-body crosshair morph in place rather than
+  sweeping past as focus-on-craft tracks the burning craft.
 
 ### v0.6.5 — mission scaffold
 

--- a/internal/orbital/kepler.go
+++ b/internal/orbital/kepler.go
@@ -169,6 +169,38 @@ func (el Elements) Periapsis() float64 { return el.A * (1 - el.E) }
 // return value is negative (hyperbolic) — callers should check.
 func (el Elements) Apoapsis() float64 { return el.A * (1 + el.E) }
 
+// PerifocalBasis returns the perifocal frame's x̂ and ŷ unit vectors
+// in inertial coordinates, given the orbit's (Ω, i, ω). x̂ points
+// toward periapsis; ŷ is 90° prograde from x̂ in the orbit plane.
+// Together they span the orbit plane — projecting an inertial point
+// onto (x̂, ŷ) gives its in-plane coordinates.
+//
+// v0.6.4+: used by the orbit-perpendicular view mode. Setting the
+// canvas basis to (x̂, ŷ) renders the orbit as a clean ellipse with
+// no foreshortening regardless of inclination. Out-of-plane points
+// project to their in-plane shadow (their orbit-normal component is
+// dropped).
+//
+// Standard reference: Vallado §2.6 perifocal-to-inertial rotation
+// matrix R_perifocal→inertial; the columns are (x̂, ŷ, ẑ_orbit) in
+// inertial coordinates. PerifocalBasis returns the first two columns.
+func PerifocalBasis(el Elements) (Vec3, Vec3) {
+	cosO, sinO := math.Cos(el.Omega), math.Sin(el.Omega)
+	cosI, sinI := math.Cos(el.I), math.Sin(el.I)
+	cosA, sinA := math.Cos(el.Arg), math.Sin(el.Arg)
+	xHat := Vec3{
+		X: cosO*cosA - sinO*cosI*sinA,
+		Y: sinO*cosA + cosO*cosI*sinA,
+		Z: sinI * sinA,
+	}
+	yHat := Vec3{
+		X: -cosO*sinA - sinO*cosI*cosA,
+		Y: -sinO*sinA + cosO*cosI*cosA,
+		Z: sinI * cosA,
+	}
+	return xHat, yHat
+}
+
 // Readout summarises the orbit's headline parameters for HUD use.
 // Distances are in metres from the primary's centre (not altitude);
 // caller subtracts body radius for altitude. Node angles are in

--- a/internal/orbital/kepler_test.go
+++ b/internal/orbital/kepler_test.go
@@ -111,3 +111,82 @@ func TestTrueAnomalyConsistency(t *testing.T) {
 		t.Errorf("|ν| at E=π should be π, got %.12f", ν)
 	}
 }
+
+// TestPerifocalBasisEquatorialIdentity (v0.6.4+): an equatorial
+// circular orbit with Ω = ω = 0 has its perifocal x̂ aligned with
+// world +X and ŷ with world +Y. The basis equals the identity in
+// this degenerate case — equatorial-aligned cases are the frame
+// transformations new readers double-check first.
+func TestPerifocalBasisEquatorialIdentity(t *testing.T) {
+	el := Elements{A: 1e7, E: 0, I: 0, Omega: 0, Arg: 0}
+	xHat, yHat := PerifocalBasis(el)
+	expectPFVec(t, "xHat", xHat, Vec3{X: 1})
+	expectPFVec(t, "yHat", yHat, Vec3{Y: 1})
+}
+
+// TestPerifocalBasisOrthonormal: for arbitrary (Ω, i, ω) the
+// returned basis must be orthonormal. Catches sign / column-mix
+// errors in the rotation-matrix transcription that would foreshorten
+// or skew the orbit-perpendicular projection.
+func TestPerifocalBasisOrthonormal(t *testing.T) {
+	cases := []Elements{
+		{A: 1e7, E: 0.1, I: 30 * math.Pi / 180, Omega: 45 * math.Pi / 180, Arg: 60 * math.Pi / 180},
+		{A: 4e8, E: 0.05, I: 5.145 * math.Pi / 180, Omega: 125.08 * math.Pi / 180, Arg: 318.15 * math.Pi / 180},
+		{A: 1e6, E: 0.7, I: 90 * math.Pi / 180, Omega: 0, Arg: 0}, // polar
+	}
+	for _, el := range cases {
+		xHat, yHat := PerifocalBasis(el)
+		if math.Abs(xHat.Norm()-1) > 1e-9 {
+			t.Errorf("|xHat| = %.10f, want 1 for el=%+v", xHat.Norm(), el)
+		}
+		if math.Abs(yHat.Norm()-1) > 1e-9 {
+			t.Errorf("|yHat| = %.10f, want 1 for el=%+v", yHat.Norm(), el)
+		}
+		dot := xHat.X*yHat.X + xHat.Y*yHat.Y + xHat.Z*yHat.Z
+		if math.Abs(dot) > 1e-9 {
+			t.Errorf("xHat · yHat = %.10f, want 0 for el=%+v", dot, el)
+		}
+	}
+}
+
+// TestPerifocalBasisProjectsOrbitFlat: a point on the orbit at true
+// anomaly ν projects onto the perifocal basis with zero orbit-normal
+// component. The orbit is flat in (xHat, yHat) coords — exactly what
+// the orbit-perpendicular view mode exploits.
+func TestPerifocalBasisProjectsOrbitFlat(t *testing.T) {
+	el := Elements{A: 1e7, E: 0.2, I: 30 * math.Pi / 180, Omega: 45 * math.Pi / 180, Arg: 60 * math.Pi / 180}
+	xHat, yHat := PerifocalBasis(el)
+	// Orbit-normal direction = xHat × yHat.
+	zHat := Vec3{
+		X: xHat.Y*yHat.Z - xHat.Z*yHat.Y,
+		Y: xHat.Z*yHat.X - xHat.X*yHat.Z,
+		Z: xHat.X*yHat.Y - xHat.Y*yHat.X,
+	}
+	for _, nu := range []float64{0, math.Pi / 2, math.Pi, 1.7} {
+		r := PositionAtTrueAnomaly(el, nu)
+		px := r.X*xHat.X + r.Y*xHat.Y + r.Z*xHat.Z
+		py := r.X*yHat.X + r.Y*yHat.Y + r.Z*yHat.Z
+		pz := r.X*zHat.X + r.Y*zHat.Y + r.Z*zHat.Z
+		rMag := r.Norm()
+		if rMag == 0 {
+			continue
+		}
+		if math.Abs(pz)/rMag > 1e-9 {
+			t.Errorf("orbit-normal component at ν=%.2f: %.6f / %.0f m (rel %.2e)",
+				nu, pz, rMag, math.Abs(pz)/rMag)
+		}
+		recon := math.Sqrt(px*px + py*py)
+		if math.Abs(recon-rMag)/rMag > 1e-9 {
+			t.Errorf("ν=%.2f: in-plane projection %.0f m vs |r| %.0f m (rel %.2e)",
+				nu, recon, rMag, math.Abs(recon-rMag)/rMag)
+		}
+	}
+}
+
+func expectPFVec(t *testing.T, name string, got, want Vec3) {
+	t.Helper()
+	const tol = 1e-12
+	if math.Abs(got.X-want.X) > tol || math.Abs(got.Y-want.Y) > tol || math.Abs(got.Z-want.Z) > tol {
+		t.Errorf("%s = %+v, want %+v", name, got, want)
+	}
+}

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -1,42 +1,61 @@
 package sim
 
-// ViewMode selects the canvas projection basis. v0.6.4+. World-level
-// state so the orbit screen and the maneuver-planner mini-canvas
-// share the same camera angle without per-screen coordination.
+// ViewMode selects the canvas projection — which world axes map to
+// canvas X+ and Y+. v0.6.4+. World-level state so the orbit screen
+// and the maneuver-planner mini-canvas share the same camera angle
+// without per-screen coordination.
+//
+// Four hard-coded cardinal views: Top (the pre-v0.6.4 XY drop) plus
+// three side views. Top → Right → Bottom → Left wraps around,
+// matching the player's mental model of rotating the camera around
+// the system.
 type ViewMode int
 
 const (
-	// ViewEquatorial projects (X, Y) in the system / primary's
-	// equatorial frame, dropping Z. The pre-v0.6.4 behaviour and the
-	// zero-value default — v2 saves load with this mode without
-	// schema changes. Inclined orbits foreshorten in this view, but
-	// equatorial alignment matches body-rendered surface features.
-	ViewEquatorial ViewMode = iota
-	// ViewOrbitPerpendicular projects onto the active craft's orbit
-	// plane via the perifocal (P, Q) basis. The orbit renders as a
-	// clean ellipse with no foreshortening regardless of inclination,
-	// useful for inclined transfers and polar mission profiles. Falls
-	// back to ViewEquatorial when the craft's orbit is degenerate
-	// (no craft, hyperbolic, near-rectilinear) so the basis is
-	// well-defined.
-	ViewOrbitPerpendicular
+	// ViewTop is the pre-v0.6.4 default: drop world Z, project onto
+	// world (X, Y). Equatorial orbits read as ellipses; inclined
+	// orbits foreshorten. Zero-value preserves backwards behaviour.
+	ViewTop ViewMode = iota
+	// ViewRight looks at the system from world +X toward origin:
+	// canvas X+ = world Y+, canvas Y+ = world Z+. An equatorial
+	// orbit appears edge-on as a horizontal line passing through
+	// the body's silhouette — useful for "watch the craft swing
+	// around the back of the planet" geometry that Top hides.
+	ViewRight
+	// ViewBottom mirrors ViewTop vertically — looking up from -Z.
+	// Same world-axes projection as Top with canvas Y inverted, so
+	// the same orbit reads with N / S flipped. Useful when the
+	// player wants the moon "below" the apsidal line for spatial
+	// orientation.
+	ViewBottom
+	// ViewLeft mirrors ViewRight horizontally — looking from -X
+	// toward origin. Canvas X+ = world Y-, canvas Y+ = world Z+.
+	ViewLeft
 )
 
 // String returns a short human label for the view mode.
 func (m ViewMode) String() string {
 	switch m {
-	case ViewEquatorial:
-		return "equatorial"
-	case ViewOrbitPerpendicular:
-		return "orbit-perp"
+	case ViewTop:
+		return "top"
+	case ViewRight:
+		return "right"
+	case ViewBottom:
+		return "bottom"
+	case ViewLeft:
+		return "left"
 	}
 	return "?"
 }
 
 // AllViewModes enumerates the modes in canonical cycle order.
+// Top → Right → Bottom → Left → Top — each cycle rotates the camera
+// 90° around the system in a consistent direction.
 var AllViewModes = [...]ViewMode{
-	ViewEquatorial,
-	ViewOrbitPerpendicular,
+	ViewTop,
+	ViewRight,
+	ViewBottom,
+	ViewLeft,
 }
 
 // CycleViewMode advances ViewMode to the next mode in cycle order.

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -1,0 +1,46 @@
+package sim
+
+// ViewMode selects the canvas projection basis. v0.6.4+. World-level
+// state so the orbit screen and the maneuver-planner mini-canvas
+// share the same camera angle without per-screen coordination.
+type ViewMode int
+
+const (
+	// ViewEquatorial projects (X, Y) in the system / primary's
+	// equatorial frame, dropping Z. The pre-v0.6.4 behaviour and the
+	// zero-value default — v2 saves load with this mode without
+	// schema changes. Inclined orbits foreshorten in this view, but
+	// equatorial alignment matches body-rendered surface features.
+	ViewEquatorial ViewMode = iota
+	// ViewOrbitPerpendicular projects onto the active craft's orbit
+	// plane via the perifocal (P, Q) basis. The orbit renders as a
+	// clean ellipse with no foreshortening regardless of inclination,
+	// useful for inclined transfers and polar mission profiles. Falls
+	// back to ViewEquatorial when the craft's orbit is degenerate
+	// (no craft, hyperbolic, near-rectilinear) so the basis is
+	// well-defined.
+	ViewOrbitPerpendicular
+)
+
+// String returns a short human label for the view mode.
+func (m ViewMode) String() string {
+	switch m {
+	case ViewEquatorial:
+		return "equatorial"
+	case ViewOrbitPerpendicular:
+		return "orbit-perp"
+	}
+	return "?"
+}
+
+// AllViewModes enumerates the modes in canonical cycle order.
+var AllViewModes = [...]ViewMode{
+	ViewEquatorial,
+	ViewOrbitPerpendicular,
+}
+
+// CycleViewMode advances ViewMode to the next mode in cycle order.
+// Wraps around — modes are a small finite set.
+func (w *World) CycleViewMode() {
+	w.ViewMode = (w.ViewMode + 1) % ViewMode(len(AllViewModes))
+}

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -5,10 +5,11 @@ package sim
 // and the maneuver-planner mini-canvas share the same camera angle
 // without per-screen coordination.
 //
-// Four hard-coded cardinal views: Top (the pre-v0.6.4 XY drop) plus
-// three side views. Top → Right → Bottom → Left wraps around,
-// matching the player's mental model of rotating the camera around
-// the system.
+// Five modes: four hard-coded cardinal views (Top, Right, Bottom,
+// Left) plus the orbit-flat view that projects onto the active
+// craft's orbit plane regardless of inclination. Cycle order rolls
+// from Top through the cardinals and ends on orbit-flat before
+// wrapping.
 type ViewMode int
 
 const (
@@ -31,6 +32,14 @@ const (
 	// ViewLeft mirrors ViewRight horizontally — looking from -X
 	// toward origin. Canvas X+ = world Y-, canvas Y+ = world Z+.
 	ViewLeft
+	// ViewOrbitFlat projects onto the active craft's orbit plane
+	// via the perifocal (x̂, ŷ) basis. Inclined orbits render as
+	// clean ellipses with no foreshortening — the geometry the
+	// other views can't reveal because they're tied to world axes.
+	// Falls back to ViewTop's basis when the orbit is degenerate
+	// (no craft, e ≥ 1, a ≤ 0). Useful for reading the orbit's
+	// actual shape as if i = 0.
+	ViewOrbitFlat
 )
 
 // String returns a short human label for the view mode.
@@ -44,18 +53,22 @@ func (m ViewMode) String() string {
 		return "bottom"
 	case ViewLeft:
 		return "left"
+	case ViewOrbitFlat:
+		return "orbit-flat"
 	}
 	return "?"
 }
 
 // AllViewModes enumerates the modes in canonical cycle order.
-// Top → Right → Bottom → Left → Top — each cycle rotates the camera
-// 90° around the system in a consistent direction.
+// Top → Right → Bottom → Left → OrbitFlat → Top — cardinal cameras
+// first (each rotates 90° around the system), then the orbit-plane
+// projection as a punctuation mark.
 var AllViewModes = [...]ViewMode{
 	ViewTop,
 	ViewRight,
 	ViewBottom,
 	ViewLeft,
+	ViewOrbitFlat,
 }
 
 // CycleViewMode advances ViewMode to the next mode in cycle order.

--- a/internal/sim/view_test.go
+++ b/internal/sim/view_test.go
@@ -2,21 +2,20 @@ package sim
 
 import "testing"
 
-// TestCycleViewModeWraps: starts at the zero-value (ViewEquatorial),
-// cycles forward through the AllViewModes set and lands back at
-// ViewEquatorial. v0.6.4+.
+// TestCycleViewModeWraps: starts at the zero-value (ViewTop),
+// cycles forward through Top → Right → Bottom → Left → Top in
+// canonical order. v0.6.4+.
 func TestCycleViewModeWraps(t *testing.T) {
 	w := mustWorld(t)
-	if w.ViewMode != ViewEquatorial {
-		t.Fatalf("default ViewMode = %v, want ViewEquatorial", w.ViewMode)
+	if w.ViewMode != ViewTop {
+		t.Fatalf("default ViewMode = %v, want ViewTop", w.ViewMode)
 	}
-	w.CycleViewMode()
-	if w.ViewMode != ViewOrbitPerpendicular {
-		t.Errorf("after one cycle: ViewMode = %v, want ViewOrbitPerpendicular", w.ViewMode)
-	}
-	w.CycleViewMode()
-	if w.ViewMode != ViewEquatorial {
-		t.Errorf("after two cycles: ViewMode = %v, want ViewEquatorial (wrap)", w.ViewMode)
+	want := []ViewMode{ViewRight, ViewBottom, ViewLeft, ViewTop}
+	for i, expect := range want {
+		w.CycleViewMode()
+		if w.ViewMode != expect {
+			t.Errorf("after %d cycles: ViewMode = %v, want %v", i+1, w.ViewMode, expect)
+		}
 	}
 }
 

--- a/internal/sim/view_test.go
+++ b/internal/sim/view_test.go
@@ -1,0 +1,38 @@
+package sim
+
+import "testing"
+
+// TestCycleViewModeWraps: starts at the zero-value (ViewEquatorial),
+// cycles forward through the AllViewModes set and lands back at
+// ViewEquatorial. v0.6.4+.
+func TestCycleViewModeWraps(t *testing.T) {
+	w := mustWorld(t)
+	if w.ViewMode != ViewEquatorial {
+		t.Fatalf("default ViewMode = %v, want ViewEquatorial", w.ViewMode)
+	}
+	w.CycleViewMode()
+	if w.ViewMode != ViewOrbitPerpendicular {
+		t.Errorf("after one cycle: ViewMode = %v, want ViewOrbitPerpendicular", w.ViewMode)
+	}
+	w.CycleViewMode()
+	if w.ViewMode != ViewEquatorial {
+		t.Errorf("after two cycles: ViewMode = %v, want ViewEquatorial (wrap)", w.ViewMode)
+	}
+}
+
+// TestViewModeStringDistinct: each enumerated mode renders a distinct
+// human label. Catches accidental case duplications when new modes
+// land.
+func TestViewModeStringDistinct(t *testing.T) {
+	seen := map[string]bool{}
+	for _, m := range AllViewModes {
+		s := m.String()
+		if s == "" || s == "?" {
+			t.Errorf("ViewMode(%d) returned empty / unknown string %q", m, s)
+		}
+		if seen[s] {
+			t.Errorf("duplicate label %q", s)
+		}
+		seen[s] = true
+	}
+}

--- a/internal/sim/view_test.go
+++ b/internal/sim/view_test.go
@@ -3,14 +3,14 @@ package sim
 import "testing"
 
 // TestCycleViewModeWraps: starts at the zero-value (ViewTop),
-// cycles forward through Top → Right → Bottom → Left → Top in
-// canonical order. v0.6.4+.
+// cycles forward through Top → Right → Bottom → Left → OrbitFlat →
+// Top in canonical order. v0.6.4+.
 func TestCycleViewModeWraps(t *testing.T) {
 	w := mustWorld(t)
 	if w.ViewMode != ViewTop {
 		t.Fatalf("default ViewMode = %v, want ViewTop", w.ViewMode)
 	}
-	want := []ViewMode{ViewRight, ViewBottom, ViewLeft, ViewTop}
+	want := []ViewMode{ViewRight, ViewBottom, ViewLeft, ViewOrbitFlat, ViewTop}
 	for i, expect := range want {
 		w.CycleViewMode()
 		if w.ViewMode != expect {

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -27,6 +27,12 @@ type World struct {
 	// (FocusSystem) matches v0.1.0 behavior.
 	Focus Focus
 
+	// ViewMode selects the canvas projection basis. v0.6.4+. Zero
+	// value (ViewEquatorial) matches the pre-v0.6.4 (X, Y)-drop
+	// projection. Set per-session via the `v` hot-key; not persisted
+	// to save (UI preference, not game state).
+	ViewMode ViewMode
+
 	// Nodes holds planned burns, sorted by TriggerTime. Each fires
 	// automatically when Clock.SimTime reaches its trigger.
 	Nodes []ManeuverNode

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -155,33 +155,45 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseMsg:
 		// v0.6.4: click-only selection. Left-press only; motion /
-		// release / wheel ignored. Hit dispatch order is most-
-		// specific-first: vessel → node → body.
+		// release / wheel ignored. Per-screen routing: orbit's hit
+		// dispatch is most-specific-first (vessel → node → body →
+		// HUD); porkchop click sets the cell selection.
 		if m.Action != tea.MouseActionPress || m.Button != tea.MouseButtonLeft {
 			return a, nil
 		}
-		if a.active != screenOrbit {
-			return a, nil
-		}
-		hit := a.orbitView.HitAt(m.X, m.Y)
-		switch {
-		case hit.IsVessel:
-			if a.world.CraftVisibleHere() {
-				a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
-			}
-		case hit.NodeIdx > 0:
-			idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
-			if idx >= 0 && idx < len(a.world.Nodes) {
-				a.maneuver.LoadNode(idx, a.world.Nodes[idx])
-				a.world.Clock.Paused = true
-				a.active = screenManeuver
-			}
-		case hit.BodyID != "":
-			for i, b := range a.world.System().Bodies {
-				if b.ID == hit.BodyID {
-					a.selectedBody = i
-					break
+		switch a.active {
+		case screenOrbit:
+			hit := a.orbitView.HitAt(m.X, m.Y)
+			switch {
+			case hit.IsVessel:
+				if a.world.CraftVisibleHere() {
+					a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
 				}
+			case hit.NodeIdx > 0:
+				idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
+				if idx >= 0 && idx < len(a.world.Nodes) {
+					a.maneuver.LoadNode(idx, a.world.Nodes[idx])
+					a.world.Clock.Paused = true
+					a.active = screenManeuver
+				}
+			case hit.BodyID != "":
+				for i, b := range a.world.System().Bodies {
+					if b.ID == hit.BodyID {
+						a.selectedBody = i
+						break
+					}
+				}
+			case a.orbitView.IsHudClick(m.X):
+				// HUD click → open body info for the currently
+				// selected body. Coarse: doesn't try to identify
+				// which HUD section was clicked, just routes any
+				// HUD click to the info screen so the user has a
+				// pointer to the same view as `i`.
+				a.active = screenBodyInfo
+			}
+		case screenPorkchop:
+			if depIdx, tofIdx, ok := a.porkchop.HitCell(m.X, m.Y); ok {
+				a.porkchop.SetSelection(depIdx, tofIdx)
 			}
 		}
 		return a, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -183,6 +183,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						break
 					}
 				}
+			case a.orbitView.IsCanvasClick(m.X, m.Y):
+				// Empty-canvas click → stage a new burn at the
+				// orbit point nearest the click. v0.6.4: the user
+				// can place a maneuver at a point along their
+				// trajectory without manually computing a T+
+				// offset. ProjectToOrbit returns time-of-flight
+				// from now to that point's true-anomaly; we open
+				// the form pre-staged with TriggerAbsolute and
+				// that schedule.
+				if dt, ok := a.orbitView.ProjectToOrbit(a.world, m.X, m.Y); ok && a.world.CraftVisibleHere() {
+					a.maneuver.LoadStaged(a.world.Clock.SimTime.Add(dt))
+					a.world.Clock.Paused = true
+					a.active = screenManeuver
+				}
 			case a.orbitView.IsHudClick(m.X):
 				// HUD click → open body info for the currently
 				// selected body. Coarse: doesn't try to identify

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -106,21 +106,38 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case screens.BurnExecutedMsg:
 		if a.world.Craft != nil {
-			// v0.6.0: event-relative nodes go through PlanNode so the
-			// resolver can freeze TriggerTime against the live orbit on
-			// the next Tick. TriggerAbsolute with a finite duration
-			// also routes through PlanNode for consistent finite-burn
-			// dispatch (legacy fast-paths kept for impulsive Absolute
-			// to preserve v0.5 quick-fire semantics).
+			// v0.6.4 click-to-edit: replace the original node before
+			// planting so click → edit → Enter reads as "modify in
+			// place" rather than "duplicate." Removal must come first
+			// so PlanNode's sort handles the new node's position
+			// against the rest of the (post-removal) slice.
+			if m.EditingIdx >= 0 && m.EditingIdx < len(a.world.Nodes) {
+				a.world.Nodes = append(a.world.Nodes[:m.EditingIdx], a.world.Nodes[m.EditingIdx+1:]...)
+			}
 			switch {
+			case !m.TriggerTime.IsZero():
+				// LoadNode preserved a scheduled trigger — plant a real
+				// ManeuverNode at exactly that time, skipping the
+				// legacy "fire now" Absolute path that quick-plant
+				// uses. Event is forwarded so resolved-then-edited
+				// event-relative nodes keep their semantic label.
+				a.world.PlanNode(sim.ManeuverNode{
+					TriggerTime: m.TriggerTime,
+					Mode:        m.Mode,
+					DV:          m.DV,
+					Duration:    m.Duration,
+					Event:       m.Event,
+				})
 			case m.Event != sim.TriggerAbsolute:
-				node := sim.ManeuverNode{
+				// v0.6.0: event-relative nodes go through PlanNode so
+				// the resolver can freeze TriggerTime against the live
+				// orbit on the next Tick.
+				a.world.PlanNode(sim.ManeuverNode{
 					Mode:     m.Mode,
 					DV:       m.DV,
 					Duration: m.Duration,
 					Event:    m.Event,
-				}
-				a.world.PlanNode(node)
+				})
 			case m.Duration == 0:
 				a.world.Craft.ApplyImpulsive(m.Mode, m.DV)
 			default:
@@ -131,6 +148,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		a.maneuver.ResetEditing()
 		a.world.Clock.Paused = false
 		a.active = screenOrbit
 		return a, nil
@@ -154,7 +172,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case hit.NodeIdx > 0:
 			idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
 			if idx >= 0 && idx < len(a.world.Nodes) {
-				a.maneuver.LoadNode(a.world.Nodes[idx])
+				a.maneuver.LoadNode(idx, a.world.Nodes[idx])
 				a.world.Clock.Paused = true
 				a.active = screenManeuver
 			}
@@ -199,6 +217,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return a, nil
 			}
 			if key.Matches(m, a.keys.Back) {
+				a.maneuver.ResetEditing()
 				a.world.Clock.Paused = false
 				a.active = screenOrbit
 				return a, nil
@@ -247,6 +266,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.Maneuver):
 			if a.active == screenOrbit && a.world.CraftVisibleHere() {
+				// Pressing `m` opens for a NEW node — drop any
+				// click-to-edit state that may be lingering from a
+				// previous open.
+				a.maneuver.ResetEditing()
 				a.active = screenManeuver
 				a.world.Clock.Paused = true
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -135,6 +135,28 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.active = screenOrbit
 		return a, nil
 
+	case tea.MouseMsg:
+		// v0.6.4: click-only selection. Body click on the orbit
+		// canvas → focus that body (sets selectedBody index). No
+		// drag, no wheel-zoom — those stay out of v0.6 per the
+		// scoping decisions. Right-click and motion ignored.
+		if m.Action != tea.MouseActionPress || m.Button != tea.MouseButtonLeft {
+			return a, nil
+		}
+		if a.active != screenOrbit {
+			return a, nil
+		}
+		hit := a.orbitView.HitAt(m.X, m.Y)
+		if hit.BodyID != "" {
+			for i, b := range a.world.System().Bodies {
+				if b.ID == hit.BodyID {
+					a.selectedBody = i
+					break
+				}
+			}
+		}
+		return a, nil
+
 	case tea.KeyMsg:
 		// ctrl+c bypasses the quit-confirm dialog (standard interrupt
 		// convention). Honored from any screen.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -136,10 +136,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case tea.MouseMsg:
-		// v0.6.4: click-only selection. Body click on the orbit
-		// canvas → focus that body (sets selectedBody index). No
-		// drag, no wheel-zoom — those stay out of v0.6 per the
-		// scoping decisions. Right-click and motion ignored.
+		// v0.6.4: click-only selection. Left-press only; motion /
+		// release / wheel ignored. Hit dispatch order is most-
+		// specific-first: vessel → node → body.
 		if m.Action != tea.MouseActionPress || m.Button != tea.MouseButtonLeft {
 			return a, nil
 		}
@@ -147,7 +146,19 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		hit := a.orbitView.HitAt(m.X, m.Y)
-		if hit.BodyID != "" {
+		switch {
+		case hit.IsVessel:
+			if a.world.CraftVisibleHere() {
+				a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
+			}
+		case hit.NodeIdx > 0:
+			idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
+			if idx >= 0 && idx < len(a.world.Nodes) {
+				a.maneuver.LoadNode(a.world.Nodes[idx])
+				a.world.Clock.Paused = true
+				a.active = screenManeuver
+			}
+		case hit.BodyID != "":
 			for i, b := range a.world.System().Bodies {
 				if b.ID == hit.BodyID {
 					a.selectedBody = i

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -295,6 +295,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.Load):
 			a.flashStatus("load", a.doLoad())
 			return a, nil
+		case key.Matches(m, a.keys.CycleView):
+			a.world.CycleViewMode()
+			a.statusMsg = fmt.Sprintf("view: %s", a.world.ViewMode)
+			a.statusExpires = time.Now().Add(2 * time.Second)
+			return a, nil
 		case key.Matches(m, a.keys.RefinePlan):
 			if a.world.CraftVisibleHere() {
 				corr, arr, err := a.world.RefinePlan()

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -29,6 +29,7 @@ type Keymap struct {
 	Save          key.Binding
 	Load          key.Binding
 	RefinePlan    key.Binding
+	CycleView     key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -57,5 +58,6 @@ func DefaultKeymap() Keymap {
 		Save:         key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "save game")),
 		Load:         key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "load game")),
 		RefinePlan:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
+		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (equatorial / orbit-perp)")),
 	}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -58,6 +58,6 @@ func DefaultKeymap() Keymap {
 		Save:         key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "save game")),
 		Load:         key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "load game")),
 		RefinePlan:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left)")),
+		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
 	}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -58,6 +58,6 @@ func DefaultKeymap() Keymap {
 		Save:         key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "save game")),
 		Load:         key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "load game")),
 		RefinePlan:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (equatorial / orbit-perp)")),
+		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left)")),
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -34,7 +34,7 @@ func (h *Help) Render() string {
 			{"f", "next focus target"},
 			{"F", "previous focus target"},
 			{"g", "reset to system-wide view"},
-			{"v", "cycle view (equatorial / orbit-perp)"},
+			{"v", "cycle view (top / right / bottom / left)"},
 		}},
 		{"TIME", [][2]string{
 			{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -34,6 +34,7 @@ func (h *Help) Render() string {
 			{"f", "next focus target"},
 			{"F", "previous focus target"},
 			{"g", "reset to system-wide view"},
+			{"v", "cycle view (equatorial / orbit-perp)"},
 		}},
 		{"TIME", [][2]string{
 			{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -34,7 +34,7 @@ func (h *Help) Render() string {
 			{"f", "next focus target"},
 			{"F", "previous focus target"},
 			{"g", "reset to system-wide view"},
-			{"v", "cycle view (top / right / bottom / left)"},
+			{"v", "cycle view (top / right / bottom / left / orbit-flat)"},
 		}},
 		{"TIME", [][2]string{
 			{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -53,6 +53,16 @@ func (h *Help) Render() string {
 			{"L", "load game"},
 			{"q", "quit (confirm + autosave)"},
 		}},
+		{"MOUSE (orbit canvas)", [][2]string{
+			{"click body", "focus body (same as ←/→ to land on it)"},
+			{"click vessel", "focus craft"},
+			{"click node", "open planner pre-loaded for that node (edit-replace)"},
+			{"click empty", "open planner staged at projected orbit point"},
+			{"click HUD", "open body info"},
+		}},
+		{"MOUSE (porkchop)", [][2]string{
+			{"click cell", "select that (dep, tof) — press [enter] to plant"},
+		}},
 	}
 
 	var b strings.Builder

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -80,6 +80,37 @@ func NewManeuver(th Theme) *Maneuver {
 	return m
 }
 
+// LoadNode pre-populates the form fields from an existing planted
+// node — used by the v0.6.4 click-to-edit flow on the orbit canvas.
+// Maps the node's BurnMode + TriggerEvent back to their cycle
+// indices and writes Δv / duration into the text inputs.
+//
+// Does not remove the original node from World.Nodes — opening the
+// form is a navigation aid, and the user's Enter still emits a fresh
+// BurnExecutedMsg that the app plants as a new node. A click → edit
+// → replace workflow is a follow-on (would need an editingIdx field
+// on Maneuver + matching dispatch in BurnExecutedMsg handling).
+func (m *Maneuver) LoadNode(n sim.ManeuverNode) {
+	m.modeIdx = 0
+	for i, mode := range spacecraft.AllBurnModes {
+		if mode == n.Mode {
+			m.modeIdx = i
+			break
+		}
+	}
+	m.fireAtIdx = 0
+	for i, ev := range sim.AllTriggerEvents {
+		if ev == n.Event {
+			m.fireAtIdx = i
+			break
+		}
+	}
+	m.dvInput.SetValue(fmt.Sprintf("%.0f", n.DV))
+	m.durInput.SetValue(fmt.Sprintf("%.1f", n.Duration.Seconds()))
+	m.focus = 0
+	m.applyFocus()
+}
+
 // applyFocus pushes focus state down to the bubbletea text inputs.
 // Focus 0 = mode (cycle), 1 = fire-at (cycle), 2 = Δv, 3 = duration.
 func (m *Maneuver) applyFocus() {

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -339,7 +339,16 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	footer := m.theme.Footer.Render(
 		"[tab] cycle field  [←/→] cycle mode  [enter] commit  [esc] cancel  [digits] edit",
 	)
-	return m.theme.Title.Render("maneuver planner") + "\n" + body + "\n" + footer
+	title := "maneuver planner"
+	if m.editingIdx >= 0 {
+		// v0.6.4 click-to-edit: surface the editing target so the
+		// player knows Enter will replace this node, not duplicate.
+		// Node display index is 1-based to match user expectations
+		// (auto-plant labels nodes "departure" / "arrival" — for
+		// hand-edits we just show the slice position).
+		title = fmt.Sprintf("maneuver planner — editing node %d", m.editingIdx+1)
+	}
+	return m.theme.Title.Render(title) + "\n" + body + "\n" + footer
 }
 
 func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVector, shadowPrimary bodies.CelestialBody, mu float64) string {

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -199,6 +199,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	}
 
 	m.canvas.Clear()
+	m.canvas.SetBasis(viewBasis(w))
 	m.canvas.Center(orbital.Vec3{})
 
 	// Draw current orbit from state elements (white/primary).

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -202,12 +202,30 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	m.canvas.SetBasis(viewBasis(w))
 	m.canvas.Center(orbital.Vec3{})
 
-	// Draw current orbit from state elements (white/primary).
 	c := w.Craft
 	mu := c.Primary.GravitationalParameter()
 	currentEl := orbital.ElementsFromState(c.State.R, c.State.V, mu)
 	m.canvas.FitTo(math.Max(currentEl.Apoapsis(), c.State.R.Norm()) * 1.1)
-	m.canvas.DrawEllipseDotted(currentEl, 360, 4)
+
+	// v0.6.3 disk-render + v0.6.4 side-view occlusion: draw the
+	// primary FIRST so the orbit + shadow + craft cluster can skip
+	// any back-half sample whose screen position falls inside the
+	// disk, leaving a clean gap where the body occludes them.
+	// True-scale radius × scale; 3-pixel floor (so Luna-class moons
+	// always read as a disk) and 64-pixel ceiling (extreme-zoom
+	// guard).
+	primaryColor := render.ColorFor(c.Primary)
+	primaryPxR := int(math.Round(c.Primary.RadiusMeters() * m.canvas.Scale()))
+	if primaryPxR < 3 {
+		primaryPxR = 3
+	} else if primaryPxR > 64 {
+		primaryPxR = 64
+	}
+	m.canvas.FillColoredDisk(orbital.Vec3{}, primaryPxR, primaryColor)
+
+	// Current orbit. Empty colour → uses Plot for back-compat with
+	// the existing white-on-default rendering of this canvas.
+	m.canvas.DrawEllipseOffsetOccluded(currentEl, orbital.Vec3{}, 360, 4, orbital.Vec3{}, primaryPxR, "")
 
 	// Draw shadow trajectory after applying the current (mode, dv,
 	// fire-at) triple. v0.6.1: when fire-at is event-relative, the
@@ -231,42 +249,24 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 		shadowPrimary = c.Primary
 	}
 	shadowMu := shadowPrimary.GravitationalParameter()
-	// Propagate for the new orbital period (or 1 hour if hyperbolic).
 	shadowPeriod := orbitalPeriodOrFallback(shadowState, shadowMu)
 	pts := planner.Predict(shadowState, shadowMu, shadowPeriod, 256)
-	// If the propagation crossed an SOI the shadow is in a different
-	// frame; offset by the body-relative gap so the shadow renders
-	// in the canvas's primary-centred frame.
 	primaryGap := w.BodyPosition(shadowPrimary).Sub(w.BodyPosition(c.Primary))
 	for _, p := range pts {
-		m.canvas.Plot(p.Add(primaryGap))
+		pp := p.Add(primaryGap)
+		if m.canvas.IsBehindBody(pp, orbital.Vec3{}, primaryPxR) {
+			continue
+		}
+		m.canvas.Plot(pp)
 	}
 
-	// Plot the primary at origin as a sized disk so its real radius
-	// is visible at the same scale as the orbit. v0.6.3 polish: a
-	// single-pixel marker hid the body's surface and made low-orbit
-	// projections (e.g. low lunar orbit at 4× the moon radius) read
-	// as smaller than they really are.
-	//
-	// Uses true (radius × scale) projection with a 3-pixel floor and
-	// 64-pixel ceiling — the orbit-screen's BodyPixelRadius drops
-	// Luna-class moons (radius < 3e6 m) to 1 pixel under its size-
-	// tier fallback, which on this canvas reproduces the original
-	// "single dot" issue. Here the primary IS the view's focus, so
-	// always render at true scale.
-	primaryColor := render.ColorFor(c.Primary)
-	primaryPxR := int(math.Round(c.Primary.RadiusMeters() * m.canvas.Scale()))
-	if primaryPxR < 3 {
-		primaryPxR = 3
-	} else if primaryPxR > 64 {
-		primaryPxR = 64
-	}
-	m.canvas.FillColoredDisk(orbital.Vec3{}, primaryPxR, primaryColor)
-	// Plot craft (current position) with a cluster.
-	for i := -4; i <= 4; i++ {
+	// Craft cluster — skip if behind primary in the active view.
+	if !m.canvas.IsBehindBody(c.State.R, orbital.Vec3{}, primaryPxR) {
 		step := 1.0 / m.canvas.Scale()
-		m.canvas.Plot(c.State.R.Add(orbital.Vec3{X: float64(i) * step}))
-		m.canvas.Plot(c.State.R.Add(orbital.Vec3{Y: float64(i) * step}))
+		for i := -4; i <= 4; i++ {
+			m.canvas.Plot(c.State.R.Add(orbital.Vec3{X: float64(i) * step}))
+			m.canvas.Plot(c.State.R.Add(orbital.Vec3{Y: float64(i) * step}))
+		}
 	}
 
 	canvasPanel := m.theme.HUDBox.Render(m.canvas.String())

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -387,11 +387,18 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 	// click-to-edit appends the loaded TriggerTime as a relative
 	// countdown so "T+" alone doesn't read as "fire now" — the user
 	// has the schedule context they need to confirm the edit.
+	// Absolute mode replaces the bare "T+" with the countdown
+	// (which already carries the T+ prefix); event-relative modes
+	// keep the event name and parenthesize the countdown.
 	fireAt := sim.AllTriggerEvents[m.fireAtIdx]
 	fireAtLabel := fireAt.String()
 	if !m.loadedTriggerTime.IsZero() {
-		delta := m.loadedTriggerTime.Sub(w.Clock.SimTime)
-		fireAtLabel = fmt.Sprintf("%s %s", fireAtLabel, formatCountdown(delta))
+		countdown := formatCountdown(m.loadedTriggerTime.Sub(w.Clock.SimTime))
+		if fireAt == sim.TriggerAbsolute {
+			fireAtLabel = countdown
+		} else {
+			fireAtLabel = fmt.Sprintf("%s (%s)", fireAtLabel, countdown)
+		}
 	}
 	if m.focus == 1 {
 		fireAtLabel = m.theme.Warning.Render(fireAtLabel) + "  (←/→ to cycle)"

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -406,8 +406,21 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 			c.Thrust, dur.Seconds(), actual, dv)
 	}
 
+	// v0.6.4 click-to-edit: surface the editing target inline in
+	// the form so the player sees "Enter replaces this node" at the
+	// field they're about to commit. Title-row variants ride above
+	// this and may wrap or get cropped by some renderers; the
+	// form-panel header is the unambiguous spot. Warning style
+	// (orange/yellow) for visual distinction from a fresh-plan
+	// Primary-style header.
+	headerStyle := m.theme.Primary
+	header := "BURN PLAN"
+	if m.editingIdx >= 0 {
+		headerStyle = m.theme.Warning
+		header = fmt.Sprintf("BURN PLAN — editing node %d", m.editingIdx+1)
+	}
 	lines := []string{
-		m.theme.Primary.Render("BURN PLAN"),
+		headerStyle.Render(header),
 		"  mode:     " + modeLabel,
 		"  fire at:  " + fireAtLabel,
 		"  Δv:       " + m.dvInput.View() + " m/s" + warn,

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -30,13 +30,23 @@ import (
 // fires at T+5min (legacy quick-plant default); event-relative modes
 // resolve to the next periapsis/apoapsis/AN/DN at plant time.
 type Maneuver struct {
-	theme      Theme
-	canvas     *widgets.Canvas
-	dvInput    textinput.Model
-	durInput   textinput.Model
-	modeIdx    int
-	fireAtIdx  int
-	focus      int // 0=mode, 1=fireAt, 2=dv, 3=duration
+	theme    Theme
+	canvas   *widgets.Canvas
+	dvInput  textinput.Model
+	durInput textinput.Model
+	modeIdx   int
+	fireAtIdx int
+	focus     int // 0=mode, 1=fireAt, 2=dv, 3=duration
+
+	// editingIdx and loadedTriggerTime carry the v0.6.4 click-to-edit
+	// state. Default editingIdx = -1 (creating a new node). LoadNode
+	// sets them so the next BurnExecutedMsg can replace the original
+	// node in place AND preserve its scheduled trigger time —
+	// otherwise re-planting an Absolute-event node would lose its
+	// future TriggerTime and fall back to the legacy "fire now"
+	// quick-plant path.
+	editingIdx        int
+	loadedTriggerTime time.Time
 }
 
 // BurnExecutedMsg is emitted when the user hits Enter. App consumes it.
@@ -45,11 +55,20 @@ type Maneuver struct {
 // app-side default delay; event-relative modes leave TriggerTime zero
 // and let the World's lazy-freeze resolver compute it from the live
 // orbit on the first Tick after plant.
+//
+// v0.6.4+: TriggerTime non-zero forces the app to plant a real
+// ManeuverNode at exactly that time (skipping the legacy "fire now"
+// path used by quick-plant). Set by LoadNode so a click-to-edit
+// flow preserves the original schedule. EditingIdx ≥ 0 tells the
+// app to remove the original Nodes[idx] before planting, so the
+// edit reads as "replace in place" rather than "duplicate."
 type BurnExecutedMsg struct {
-	Mode     spacecraft.BurnMode
-	DV       float64
-	Duration time.Duration
-	Event    sim.TriggerEvent
+	Mode        spacecraft.BurnMode
+	DV          float64
+	Duration    time.Duration
+	Event       sim.TriggerEvent
+	TriggerTime time.Time
+	EditingIdx  int // -1 = creating a new node; ≥ 0 = replacing world.Nodes[idx]
 }
 
 func NewManeuver(th Theme) *Maneuver {
@@ -71,26 +90,35 @@ func NewManeuver(th Theme) *Maneuver {
 	dur.SetValue("10")
 
 	m := &Maneuver{
-		theme:    th,
-		canvas:   widgets.NewCanvas(60, 20),
-		dvInput:  dv,
-		durInput: dur,
+		theme:      th,
+		canvas:     widgets.NewCanvas(60, 20),
+		dvInput:    dv,
+		durInput:   dur,
+		editingIdx: -1,
 	}
 	m.applyFocus()
 	return m
 }
 
+// ResetEditing clears the click-to-edit state so the next commit
+// plants a fresh node rather than replacing one. Called on `m`-key
+// open (new-node intent) and after every BurnExecutedMsg / Esc so
+// the editingIdx doesn't leak across opens.
+func (m *Maneuver) ResetEditing() {
+	m.editingIdx = -1
+	m.loadedTriggerTime = time.Time{}
+}
+
 // LoadNode pre-populates the form fields from an existing planted
-// node — used by the v0.6.4 click-to-edit flow on the orbit canvas.
-// Maps the node's BurnMode + TriggerEvent back to their cycle
-// indices and writes Δv / duration into the text inputs.
-//
-// Does not remove the original node from World.Nodes — opening the
-// form is a navigation aid, and the user's Enter still emits a fresh
-// BurnExecutedMsg that the app plants as a new node. A click → edit
-// → replace workflow is a follow-on (would need an editingIdx field
-// on Maneuver + matching dispatch in BurnExecutedMsg handling).
-func (m *Maneuver) LoadNode(n sim.ManeuverNode) {
+// node and records the click-to-edit state — used by the v0.6.4
+// orbit-canvas mouse path. Maps the node's BurnMode + TriggerEvent
+// back to their cycle indices, writes Δv / duration into the text
+// inputs, and stores idx + TriggerTime so the next Enter commit
+// emits a BurnExecutedMsg with EditingIdx = idx + TriggerTime
+// = original schedule. The app then removes Nodes[idx] before
+// planting so the edit replaces in place AND preserves the
+// node's future trigger time.
+func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 	m.modeIdx = 0
 	for i, mode := range spacecraft.AllBurnModes {
 		if mode == n.Mode {
@@ -108,6 +136,8 @@ func (m *Maneuver) LoadNode(n sim.ManeuverNode) {
 	m.dvInput.SetValue(fmt.Sprintf("%.0f", n.DV))
 	m.durInput.SetValue(fmt.Sprintf("%.1f", n.Duration.Seconds()))
 	m.focus = 0
+	m.editingIdx = idx
+	m.loadedTriggerTime = n.TriggerTime
 	m.applyFocus()
 }
 
@@ -183,14 +213,15 @@ func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		dur := m.parsedDuration()
 		event := sim.AllTriggerEvents[m.fireAtIdx]
-		return func() tea.Msg {
-			return BurnExecutedMsg{
-				Mode:     spacecraft.AllBurnModes[m.modeIdx],
-				DV:       dv,
-				Duration: dur,
-				Event:    event,
-			}
-		}, true
+		msg := BurnExecutedMsg{
+			Mode:        spacecraft.AllBurnModes[m.modeIdx],
+			DV:          dv,
+			Duration:    dur,
+			Event:       event,
+			TriggerTime: m.loadedTriggerTime,
+			EditingIdx:  m.editingIdx,
+		}
+		return func() tea.Msg { return msg }, true
 	}
 	var cmd tea.Cmd
 	switch m.focus {

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -157,6 +158,12 @@ func (m *Maneuver) applyFocus() {
 // Resize handles terminal-size changes. Keep the maneuver canvas ≤ 60 cols
 // wide so the form panel sits cleanly alongside it.
 func (m *Maneuver) Resize(cols, rows int) {
+	// Horizontal layout (v0.6.4 fix): canvas on the left, form panel
+	// on the right. Sized so canvas + form sit side-by-side under
+	// the title and footer rather than stacking vertically — pre-fix
+	// the form's ~14 rows added on top of canvas rows-6 overflowed
+	// any terminal under ~36 rows tall, scrolling the title off the
+	// top in some renderers.
 	canvasCols := cols * 6 / 10
 	if canvasCols < 20 {
 		canvasCols = 20
@@ -164,7 +171,13 @@ func (m *Maneuver) Resize(cols, rows int) {
 	if canvasCols > 80 {
 		canvasCols = 80
 	}
-	m.canvas.Resize(canvasCols, rows-6)
+	// Reserve 3 rows for title (1) + footer (1) + a 1-row gap between
+	// title and the canvas-panel border.
+	canvasRows := rows - 3
+	if canvasRows < 6 {
+		canvasRows = 6
+	}
+	m.canvas.Resize(canvasCols, canvasRows)
 }
 
 // HandleKey routes planner-local keys. Returns (cmd, done) where done=true
@@ -334,7 +347,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	canvasPanel := m.theme.HUDBox.Render(m.canvas.String())
 
 	form := m.renderForm(w, dv, shadowState, shadowPrimary, shadowMu)
-	body := strings.Join([]string{canvasPanel, form}, "\n")
+	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, "  ", form)
 
 	footer := m.theme.Footer.Render(
 		"[tab] cycle field  [←/→] cycle mode  [enter] commit  [esc] cancel  [digits] edit",

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -383,9 +383,16 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		modeLabel = m.theme.Dim.Render(modeLabel)
 	}
 
-	// Fire-at line — highlight if focused, otherwise dim.
+	// Fire-at line — highlight if focused, otherwise dim. v0.6.4
+	// click-to-edit appends the loaded TriggerTime as a relative
+	// countdown so "T+" alone doesn't read as "fire now" — the user
+	// has the schedule context they need to confirm the edit.
 	fireAt := sim.AllTriggerEvents[m.fireAtIdx]
 	fireAtLabel := fireAt.String()
+	if !m.loadedTriggerTime.IsZero() {
+		delta := m.loadedTriggerTime.Sub(w.Clock.SimTime)
+		fireAtLabel = fmt.Sprintf("%s %s", fireAtLabel, formatCountdown(delta))
+	}
 	if m.focus == 1 {
 		fireAtLabel = m.theme.Warning.Render(fireAtLabel) + "  (←/→ to cycle)"
 	} else {
@@ -467,6 +474,37 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// formatCountdown renders a relative duration as "T+1d3h", "T+14m32s",
+// or "T-5s" (past, in case the node is overdue). v0.6.4 click-to-
+// edit uses this to qualify the fire-at label so the player sees
+// when the loaded burn is scheduled. Two-component precision keeps
+// the line short — "1d3h" not "1d3h45m12s".
+func formatCountdown(d time.Duration) string {
+	prefix := "T+"
+	if d < 0 {
+		d = -d
+		prefix = "T-"
+	}
+	totalSecs := int64(d.Seconds())
+	if totalSecs == 0 {
+		return prefix + "0s"
+	}
+	days := totalSecs / 86400
+	hours := (totalSecs % 86400) / 3600
+	mins := (totalSecs % 3600) / 60
+	secs := totalSecs % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%s%dd%dh", prefix, days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%s%dh%dm", prefix, hours, mins)
+	case mins > 0:
+		return fmt.Sprintf("%s%dm%ds", prefix, mins, secs)
+	default:
+		return fmt.Sprintf("%s%ds", prefix, secs)
+	}
 }
 
 // normalizeManeuverDeg wraps an angle in degrees into [0, 360). Local

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -110,6 +110,27 @@ func (m *Maneuver) ResetEditing() {
 	m.loadedTriggerTime = time.Time{}
 }
 
+// LoadStaged opens the form for a NEW node staged at a specific
+// trigger time — used by the v0.6.4 empty-canvas mouse path to
+// "click a point on the orbit, plant a burn there." Distinct from
+// LoadNode in that there's no original to replace (editingIdx
+// stays at -1); the form simply previews and commits with the
+// staged TriggerTime so the new node fires at the click's
+// projected orbit position. Mode / fire-at fall back to defaults
+// (prograde / Absolute); Δv defaults to "100" so the form is
+// immediately usable, focus jumps to the Δv field so the player
+// can type a value without tabbing.
+func (m *Maneuver) LoadStaged(triggerTime time.Time) {
+	m.editingIdx = -1
+	m.loadedTriggerTime = triggerTime
+	m.modeIdx = 0   // prograde — the most common new-burn intent
+	m.fireAtIdx = 0 // TriggerAbsolute — the staged TriggerTime IS the absolute schedule
+	m.dvInput.SetValue("100")
+	m.durInput.SetValue("10")
+	m.focus = 2 // Δv input — player typically wants to set magnitude first
+	m.applyFocus()
+}
+
 // LoadNode pre-populates the form fields from an existing planted
 // node and records the click-to-edit state — used by the v0.6.4
 // orbit-canvas mouse path. Maps the node's BurnMode + TriggerEvent

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -581,31 +581,45 @@ func normalizeDeg(d float64) float64 {
 
 // viewBasis returns the canvas projection basis for the world's
 // current ViewMode. Four cardinal cases — Top (XY drop), Right (YZ),
-// Bottom (XY mirrored), Left (YZ mirrored). Each rotates the camera
-// 90° around the system; together they let the player see an
-// otherwise edge-on orbit from a side angle so the trajectory's
-// in-front-of / behind-the-body geometry reads at a glance.
+// Bottom (XY mirrored), Left (YZ mirrored) — plus orbit-flat, which
+// projects onto the active craft's orbit plane via the perifocal
+// (x̂, ŷ) basis so the orbit reads as a clean ellipse regardless of
+// inclination. Falls back to Top's basis when the orbit is degenerate
+// (no craft, e ≥ 1, a ≤ 0).
+//
+// Single-craft today; multi-craft will need an active-craft selector
+// to disambiguate "the active orbit" (state-of-game.md §2 backlog).
 func viewBasis(w *sim.World) widgets.Basis {
 	switch w.ViewMode {
 	case sim.ViewRight:
-		// Camera at +X looking -X. Canvas X+ = world Y+, Y+ = world Z+.
 		return widgets.Basis{
 			X: orbital.Vec3{Y: 1},
 			Y: orbital.Vec3{Z: 1},
 		}
 	case sim.ViewBottom:
-		// Camera at -Z looking +Z. Canvas X+ = world X+, Y+ = world Y-
-		// (vertical mirror of Top).
 		return widgets.Basis{
 			X: orbital.Vec3{X: 1},
 			Y: orbital.Vec3{Y: -1},
 		}
 	case sim.ViewLeft:
-		// Camera at -X looking +X. Canvas X+ = world Y-, Y+ = world Z+.
 		return widgets.Basis{
 			X: orbital.Vec3{Y: -1},
 			Y: orbital.Vec3{Z: 1},
 		}
+	case sim.ViewOrbitFlat:
+		if w.Craft == nil {
+			return widgets.DefaultBasis()
+		}
+		mu := w.Craft.Primary.GravitationalParameter()
+		if mu <= 0 {
+			return widgets.DefaultBasis()
+		}
+		el := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+		if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+			return widgets.DefaultBasis()
+		}
+		xHat, yHat := orbital.PerifocalBasis(el)
+		return widgets.Basis{X: xHat, Y: yHat}
 	}
 	return widgets.DefaultBasis() // ViewTop or any future mode
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -246,10 +246,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		}
 		craftInertial := w.CraftInertial()
 		if !v.canvas.IsBehindBody(craftInertial, primaryPos, primaryPxR) {
+			vesselTag := widgets.CellTag{Color: render.ColorCraftMarker, IsVessel: true}
 			if orbitVisible {
-				v.canvas.PlotArrow(craftInertial, c.State.V, 5)
+				v.canvas.PlotArrowTagged(craftInertial, c.State.V, 5, vesselTag)
 			} else {
-				v.canvas.FillColoredDisk(craftInertial, 1, render.ColorCraftMarker)
+				v.canvas.FillColoredDiskTagged(craftInertial, 1, vesselTag)
 			}
 		}
 	}
@@ -335,10 +336,18 @@ func (v *OrbitView) plotCluster(center orbital.Vec3, n int) {
 // their resulting orbit leg, so the player sees node N at the
 // position where the post-burn orbit (also color N) begins.
 func (v *OrbitView) plotClusterColored(center orbital.Vec3, n int, color lipgloss.Color) {
+	v.plotClusterTagged(center, n, widgets.CellTag{Color: color})
+}
+
+// plotClusterTagged is plotClusterColored that records the supplied
+// CellTag (color + hit-test metadata) on every pixel it sets. v0.6.4+
+// — node draws use this with NodeIdx so HitAt can resolve a click
+// back to the planted node it lands on.
+func (v *OrbitView) plotClusterTagged(center orbital.Vec3, n int, tag widgets.CellTag) {
 	step := 1.0 / v.canvas.Scale()
 	for i := -n / 2; i <= n/2; i++ {
-		v.canvas.PlotColored(center.Add(orbital.Vec3{X: float64(i) * step}), color)
-		v.canvas.PlotColored(center.Add(orbital.Vec3{Y: float64(i) * step}), color)
+		v.canvas.PlotColoredTagged(center.Add(orbital.Vec3{X: float64(i) * step}), tag)
+		v.canvas.PlotColoredTagged(center.Add(orbital.Vec3{Y: float64(i) * step}), tag)
 	}
 }
 
@@ -365,7 +374,10 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 		// v0.6.1: each node's marker matches the color of its
 		// resulting orbit leg, so the cluster glyph and the
 		// post-burn dashed orbit read as a matched pair.
-		v.plotClusterColored(w.NodeInertialPosition(n), size, render.ManeuverSegmentColor(i))
+		v.plotClusterTagged(w.NodeInertialPosition(n), size, widgets.CellTag{
+			Color:   render.ManeuverSegmentColor(i),
+			NodeIdx: i + 1, // 0 = none; planted node i is 1+i in the tag.
+		})
 	}
 
 	// v0.6.1: while a finite burn is firing the live craft state is

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -83,6 +83,16 @@ func (v *OrbitView) Resize(totalCols, totalRows int) {
 func (v *OrbitView) ZoomIn()  { v.canvas.ZoomBy(1.25) }
 func (v *OrbitView) ZoomOut() { v.canvas.ZoomBy(1.0 / 1.25) }
 
+// HitAt translates a screen-space mouse coordinate (col, row) into a
+// CellTag from the orbit canvas. The orbit screen renders title (1
+// row) + canvasPanel (rounded border = 1 row top, 1 col left)
+// before the canvas content, so we offset (col-1, row-2). Returns a
+// zero-value CellTag when the click lands outside the canvas
+// content area, which the caller treats as "no hit." v0.6.4+.
+func (v *OrbitView) HitAt(screenCol, screenRow int) widgets.CellTag {
+	return v.canvas.HitAt(screenCol-1, screenRow-2)
+}
+
 // Render composes the frame: canvas on the left, HUD on the right.
 // selectedIdx is the index of the cursor-selected body in system.Bodies.
 func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows int) string {
@@ -136,11 +146,14 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		pos := w.BodyPosition(b)
 		r := BodyPixelRadius(b, i == 0, scale)
 		color := render.ColorFor(b)
+		// v0.6.4: tag body pixels with BodyID so HitAt resolves
+		// mouse clicks back to the body for click-to-focus.
+		bodyTag := widgets.CellTag{Color: color, BodyID: b.ID}
 		if i == 0 {
-			v.canvas.RingColoredOutline(pos, r, color)
-			v.canvas.FillColoredDisk(pos, 1, color)
+			v.canvas.RingColoredOutlineTagged(pos, r, bodyTag)
+			v.canvas.FillColoredDiskTagged(pos, 1, bodyTag)
 		} else {
-			v.canvas.FillColoredDisk(pos, r, color)
+			v.canvas.FillColoredDiskTagged(pos, r, bodyTag)
 		}
 		// Draw rings for ringed bodies (v0.5.11). World-scale ring
 		// radii project to pixel radii via the canvas scale; only

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -106,6 +107,59 @@ func (v *OrbitView) IsCanvasClick(col, row int) bool {
 // panel (right of the canvas + its border).
 func (v *OrbitView) IsHudClick(col int) bool {
 	return col > v.canvas.Cols()+1
+}
+
+// ProjectToOrbit maps a screen-space click to the time-of-flight at
+// which the active craft reaches the orbit point nearest the click.
+// Used by the v0.6.4 empty-canvas mouse path to stage a new burn at
+// "this point along my orbit."
+//
+// Algorithm: sample 360 true-anomalies on the live craft orbit,
+// project each to canvas pixels, take the smallest screen distance
+// to the click pixel; convert that ν to a time-of-flight via
+// orbital.TimeToTrueAnomaly. ok=false for hyperbolic / no-craft
+// states or when no sample lands on-canvas.
+func (v *OrbitView) ProjectToOrbit(w *sim.World, screenCol, screenRow int) (time.Duration, bool) {
+	if w.Craft == nil {
+		return 0, false
+	}
+	mu := w.Craft.Primary.GravitationalParameter()
+	el := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+	if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return 0, false
+	}
+	currentNu := orbital.TrueAnomalyFromState(w.Craft.State.R, w.Craft.State.V, mu, el)
+	primaryPos := w.BodyPosition(w.Craft.Primary)
+
+	clickCanvasCol := screenCol - 1 // strip border / title offsets
+	clickCanvasRow := screenRow - 2
+	bestNu := 0.0
+	bestDist := math.MaxFloat64
+	const samples = 360
+	for i := 0; i < samples; i++ {
+		nu := 2 * math.Pi * float64(i) / float64(samples)
+		p := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, nu))
+		px, py, ok := v.canvas.Project(p)
+		if !ok {
+			continue
+		}
+		col, row := px/2, py/4
+		dx := float64(col - clickCanvasCol)
+		dy := float64(row - clickCanvasRow)
+		d := dx*dx + dy*dy
+		if d < bestDist {
+			bestDist = d
+			bestNu = nu
+		}
+	}
+	if bestDist == math.MaxFloat64 {
+		return 0, false
+	}
+	dtSecs := orbital.TimeToTrueAnomaly(currentNu, bestNu, el.A, el.E, mu)
+	if dtSecs < 0 {
+		return 0, false
+	}
+	return time.Duration(dtSecs * float64(time.Second)), true
 }
 
 // Render composes the frame: canvas on the left, HUD on the right.

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -93,6 +93,21 @@ func (v *OrbitView) HitAt(screenCol, screenRow int) widgets.CellTag {
 	return v.canvas.HitAt(screenCol-1, screenRow-2)
 }
 
+// IsCanvasClick reports whether a screen-space (col, row) lands
+// inside the canvas content area (i.e. between the rounded-border
+// edges). v0.6.4 mouse dispatch uses this to distinguish "click on
+// orbit canvas" from "click on HUD" when no body / vessel / node
+// hit lands.
+func (v *OrbitView) IsCanvasClick(col, row int) bool {
+	return col >= 1 && col <= v.canvas.Cols() && row >= 2 && row <= v.canvas.Rows()+1
+}
+
+// IsHudClick reports whether a screen-space col lands on the HUD
+// panel (right of the canvas + its border).
+func (v *OrbitView) IsHudClick(col int) bool {
+	return col > v.canvas.Cols()+1
+}
+
 // Render composes the frame: canvas on the left, HUD on the right.
 // selectedIdx is the index of the cursor-selected body in system.Bodies.
 func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows int) string {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -212,32 +212,32 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		primaryPos := w.BodyPosition(c.Primary)
 		scale := v.canvas.Scale()
 		orbitVisible := el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) && el.Apoapsis()*scale >= minOrbitPixels
+		// v0.6.4: in side views, the spacecraft orbit can pass behind
+		// the primary body. The canvas's IsBehindBody / occluded-
+		// ellipse helpers skip back-half samples that fall inside
+		// the primary's projected disk — since the body disk has
+		// already been drawn (line ~115), the gap reads as natural
+		// occlusion. Apo / peri markers + the craft chevron use the
+		// same check.
+		primaryPxR := BodyPixelRadius(c.Primary, false, scale)
 		if orbitVisible {
-			v.canvas.DrawEllipseOffsetDottedColored(el, primaryPos, 360, 3, render.ColorCurrentOrbit)
-			// Apoapsis / periapsis markers — render even for low-e
-			// orbits so the player sees WHERE the two extremes are
-			// when the ellipse shape alone is near-circular. Apoapsis
-			// gets a larger disk, periapsis smaller; distinct sizes
-			// read at a glance.
+			v.canvas.DrawEllipseOffsetOccluded(el, primaryPos, 360, 3, primaryPos, primaryPxR, render.ColorCurrentOrbit)
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
-			v.canvas.FillDisk(peri, 2)
-			v.canvas.FillDisk(apo, 3)
+			if !v.canvas.IsBehindBody(peri, primaryPos, primaryPxR) {
+				v.canvas.FillDisk(peri, 2)
+			}
+			if !v.canvas.IsBehindBody(apo, primaryPos, primaryPxR) {
+				v.canvas.FillDisk(apo, 3)
+			}
 		}
-		// Vessel marker. When the orbit ellipse is rendering at a
-		// useful size, draw a directional chevron so the player reads
-		// "which way am I going" off the velocity frame. When the
-		// orbit's collapsed below minOrbitPixels (heliocentric zoom on
-		// a LEO craft), the chevron's 5-pixel spread sprawls across
-		// the parent body and reads as noise — replace it with a
-		// single bright disk that says "vehicle here." The disk color
-		// is distinct from every body palette entry and every
-		// maneuver-leg color so multi-craft views (future) stay
-		// disambiguable per craft.
-		if orbitVisible {
-			v.canvas.PlotArrow(w.CraftInertial(), c.State.V, 5)
-		} else {
-			v.canvas.FillColoredDisk(w.CraftInertial(), 1, render.ColorCraftMarker)
+		craftInertial := w.CraftInertial()
+		if !v.canvas.IsBehindBody(craftInertial, primaryPos, primaryPxR) {
+			if orbitVisible {
+				v.canvas.PlotArrow(craftInertial, c.State.V, 5)
+			} else {
+				v.canvas.FillColoredDisk(craftInertial, 1, render.ColorCraftMarker)
+			}
 		}
 	}
 
@@ -580,24 +580,32 @@ func normalizeDeg(d float64) float64 {
 }
 
 // viewBasis returns the canvas projection basis for the world's
-// current ViewMode. Equatorial → DefaultBasis (drop Z). Orbit-
-// perpendicular → perifocal (x̂, ŷ) of the active craft's orbit.
-// Falls back to DefaultBasis when the orbit is degenerate (no craft,
-// e ≥ 1, a ≤ 0) so the projection stays well-defined. Single-craft
-// today; multi-craft will need an active-craft selector to
-// disambiguate (state-of-game.md §2 backlog).
+// current ViewMode. Four cardinal cases — Top (XY drop), Right (YZ),
+// Bottom (XY mirrored), Left (YZ mirrored). Each rotates the camera
+// 90° around the system; together they let the player see an
+// otherwise edge-on orbit from a side angle so the trajectory's
+// in-front-of / behind-the-body geometry reads at a glance.
 func viewBasis(w *sim.World) widgets.Basis {
-	if w.ViewMode != sim.ViewOrbitPerpendicular || w.Craft == nil {
-		return widgets.DefaultBasis()
+	switch w.ViewMode {
+	case sim.ViewRight:
+		// Camera at +X looking -X. Canvas X+ = world Y+, Y+ = world Z+.
+		return widgets.Basis{
+			X: orbital.Vec3{Y: 1},
+			Y: orbital.Vec3{Z: 1},
+		}
+	case sim.ViewBottom:
+		// Camera at -Z looking +Z. Canvas X+ = world X+, Y+ = world Y-
+		// (vertical mirror of Top).
+		return widgets.Basis{
+			X: orbital.Vec3{X: 1},
+			Y: orbital.Vec3{Y: -1},
+		}
+	case sim.ViewLeft:
+		// Camera at -X looking +X. Canvas X+ = world Y-, Y+ = world Z+.
+		return widgets.Basis{
+			X: orbital.Vec3{Y: -1},
+			Y: orbital.Vec3{Z: 1},
+		}
 	}
-	mu := w.Craft.Primary.GravitationalParameter()
-	if mu <= 0 {
-		return widgets.DefaultBasis()
-	}
-	el := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
-	if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
-		return widgets.DefaultBasis()
-	}
-	xHat, yHat := orbital.PerifocalBasis(el)
-	return widgets.Basis{X: xHat, Y: yHat}
+	return widgets.DefaultBasis() // ViewTop or any future mode
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -100,6 +100,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	}
 
 	v.canvas.Clear()
+	v.canvas.SetBasis(viewBasis(w))
 	center := w.FocusPosition()
 	if w.ActiveBurn != nil {
 		if v.burnFrozenCenter == nil {
@@ -576,4 +577,27 @@ func normalizeDeg(d float64) float64 {
 		d += 360
 	}
 	return d
+}
+
+// viewBasis returns the canvas projection basis for the world's
+// current ViewMode. Equatorial → DefaultBasis (drop Z). Orbit-
+// perpendicular → perifocal (x̂, ŷ) of the active craft's orbit.
+// Falls back to DefaultBasis when the orbit is degenerate (no craft,
+// e ≥ 1, a ≤ 0) so the projection stays well-defined. Single-craft
+// today; multi-craft will need an active-craft selector to
+// disambiguate (state-of-game.md §2 backlog).
+func viewBasis(w *sim.World) widgets.Basis {
+	if w.ViewMode != sim.ViewOrbitPerpendicular || w.Craft == nil {
+		return widgets.DefaultBasis()
+	}
+	mu := w.Craft.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return widgets.DefaultBasis()
+	}
+	el := orbital.ElementsFromState(w.Craft.State.R, w.Craft.State.V, mu)
+	if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return widgets.DefaultBasis()
+	}
+	xHat, yHat := orbital.PerifocalBasis(el)
+	return widgets.Basis{X: xHat, Y: yHat}
 }

--- a/internal/tui/screens/porkchop.go
+++ b/internal/tui/screens/porkchop.go
@@ -116,6 +116,42 @@ func (p *Porkchop) PendingPlant() (targetIdx int, depDay, tofDay float64, ok boo
 	return p.targetIdx, p.depDays[p.selDep], p.tofDays[p.selTof], true
 }
 
+// HitCell maps a screen-space (col, row) onto the porkchop grid's
+// (depIdx, tofIdx). Title + blank line take rows 0 and 1; grid
+// starts at row 2. Each row begins with "tof XXXd │" = 10 chars
+// (gridLead) before the first cell. Returns ok=false when the
+// click lands outside the grid's pixel rectangle. v0.6.4 mouse
+// dispatch sets selDep / selTof from the result.
+func (p *Porkchop) HitCell(col, row int) (depIdx, tofIdx int, ok bool) {
+	const gridLead = 10 // matches Render's gridLead constant
+	if p.grid == nil {
+		return 0, 0, false
+	}
+	depIdx = col - gridLead
+	tofIdx = row - 2
+	if depIdx < 0 || depIdx >= len(p.depDays) {
+		return 0, 0, false
+	}
+	if tofIdx < 0 || tofIdx >= len(p.tofDays) {
+		return 0, 0, false
+	}
+	return depIdx, tofIdx, true
+}
+
+// SetSelection moves the cursor to (depIdx, tofIdx) — used by the
+// v0.6.4 mouse dispatch on click. Bounds-checked; out-of-range
+// indices are ignored.
+func (p *Porkchop) SetSelection(depIdx, tofIdx int) {
+	if depIdx < 0 || depIdx >= len(p.depDays) {
+		return
+	}
+	if tofIdx < 0 || tofIdx >= len(p.tofDays) {
+		return
+	}
+	p.selDep = depIdx
+	p.selTof = tofIdx
+}
+
 // Render draws the grid + axes + selection readout.
 func (p *Porkchop) Render(w *sim.World, cols, rows int) string {
 	if p.errMsg != "" {

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -565,6 +565,14 @@ func (c *Canvas) RingOutline(center orbital.Vec3, pxRadius int) {
 // pixels (total arrow width is roughly 2×size). Velocity magnitude is
 // irrelevant — only the direction is used.
 func (c *Canvas) PlotArrow(center, velocity orbital.Vec3, size int) {
+	c.PlotArrowTagged(center, velocity, size, CellTag{})
+}
+
+// PlotArrowTagged is PlotArrow that records `tag` on every pixel
+// it sets. v0.6.4+: callers pass IsVessel = true so HitAt resolves
+// chevron pixels back to "vessel was clicked." Tag's Color drives
+// per-cell colorization the same way as the other tagged helpers.
+func (c *Canvas) PlotArrowTagged(center, velocity orbital.Vec3, size int, tag CellTag) {
 	vMag := velocity.Norm()
 	if vMag == 0 || size < 1 {
 		return
@@ -587,17 +595,22 @@ func (c *Canvas) PlotArrow(center, velocity orbital.Vec3, size int) {
 	if wingLen < 1 {
 		wingLen = 1
 	}
+	tagSet := tag != (CellTag{})
+	if tagSet && c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	setPixel := func(px, py int) {
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			return
+		}
+		c.dc.Set(px, py)
+		if tagSet {
+			c.pixelTags[[2]int{px, py}] = tag
+		}
+	}
 	for t := 0; t <= wingLen; t++ {
-		plx := tipX + int(math.Round(lx*float64(t)))
-		ply := tipY + int(math.Round(ly*float64(t)))
-		if plx >= 0 && plx < c.pxW && ply >= 0 && ply < c.pxH {
-			c.dc.Set(plx, ply)
-		}
-		prx := tipX + int(math.Round(rx*float64(t)))
-		pry := tipY + int(math.Round(ry*float64(t)))
-		if prx >= 0 && prx < c.pxW && pry >= 0 && pry < c.pxH {
-			c.dc.Set(prx, pry)
-		}
+		setPixel(tipX+int(math.Round(lx*float64(t))), tipY+int(math.Round(ly*float64(t))))
+		setPixel(tipX+int(math.Round(rx*float64(t))), tipY+int(math.Round(ry*float64(t))))
 	}
 }
 

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -18,11 +18,35 @@ import (
 // World coordinates are inertial meters. The projection is ortho: drop Z,
 // map (x_world, y_world) → (px, py) via a single scale and the cached
 // center (panning is out-of-scope for v0.1 per plan C8 commit body).
+// Basis selects the world-space unit vectors that map to canvas X+
+// and Y+ on render. A point's screen position is:
+//
+//	screen.x = (world − center) · basis.X
+//	screen.y = (world − center) · basis.Y
+//
+// DefaultBasis (X = (1,0,0), Y = (0,1,0)) is the v0.1 equatorial
+// projection — drop Z, plot (X, Y). v0.6.4+ uses orbit-perpendicular
+// bases (perifocal x̂/ŷ from a craft's elements) so inclined orbits
+// project without foreshortening.
+type Basis struct {
+	X, Y orbital.Vec3
+}
+
+// DefaultBasis is the equatorial projection: world X axis maps to
+// canvas X+, world Y axis to canvas Y+. Z drops.
+func DefaultBasis() Basis {
+	return Basis{
+		X: orbital.Vec3{X: 1},
+		Y: orbital.Vec3{Y: 1},
+	}
+}
+
 type Canvas struct {
 	cols, rows int          // terminal cells
 	pxW, pxH   int          // pixel grid (cols*2, rows*4)
 	centerW    orbital.Vec3 // world coord at pixel center
 	scale      float64      // pixels per meter
+	basis      Basis        // world axes mapped to canvas X+/Y+ (v0.6.4+)
 	dc         drawille.Canvas
 
 	// pixelTags maps a pixel coord (px, py) → its render color. Set by
@@ -65,9 +89,15 @@ func NewCanvas(cols, rows int) *Canvas {
 		pxW:   cols * 2,
 		pxH:   rows * 4,
 		scale: 1,
+		basis: DefaultBasis(),
 		dc:    drawille.NewCanvas(),
 	}
 }
+
+// SetBasis swaps the projection basis. Called per-frame by render
+// code that wants a non-equatorial view; pass DefaultBasis() to
+// restore. v0.6.4+.
+func (c *Canvas) SetBasis(b Basis) { c.basis = b }
 
 // Resize updates the terminal-cell dimensions. Does not clear the canvas.
 func (c *Canvas) Resize(cols, rows int) {
@@ -236,12 +266,30 @@ func (c *Canvas) ZoomBy(factor float64) {
 // pixel location and ok=false if the point is off-canvas.
 func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
 	rel := w.Sub(c.centerW)
-	px := int(math.Round(rel.X*c.scale)) + c.pxW/2
-	py := c.pxH/2 - int(math.Round(rel.Y*c.scale))
+	relX := rel.X*c.basis.X.X + rel.Y*c.basis.X.Y + rel.Z*c.basis.X.Z
+	relY := rel.X*c.basis.Y.X + rel.Y*c.basis.Y.Y + rel.Z*c.basis.Y.Z
+	px := int(math.Round(relX*c.scale)) + c.pxW/2
+	py := c.pxH/2 - int(math.Round(relY*c.scale))
 	if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
 		return px, py, false
 	}
 	return px, py, true
+}
+
+// Unproject returns the world coord whose Project would land at the
+// given pixel — assuming the world point lies in the basis plane
+// through centerW. v0.6.4+: paired with Project for view-aware mouse
+// hit-testing in v0.6.4's mouse work. The Z axis (out of screen) is
+// implicitly the orbit-normal direction in orbit-perpendicular mode
+// or world Z in equatorial mode; Unproject doesn't disambiguate, so
+// callers that need a 3D world point on a specific surface must do
+// their own ray-cast.
+func (c *Canvas) Unproject(px, py int) orbital.Vec3 {
+	relX := float64(px-c.pxW/2) / c.scale
+	relY := float64(c.pxH/2-py) / c.scale
+	return c.centerW.
+		Add(c.basis.X.Scale(relX)).
+		Add(c.basis.Y.Scale(relY))
 }
 
 // Plot sets the pixel at the given world coord. No-op if off-canvas.

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -32,6 +32,19 @@ type Basis struct {
 	X, Y orbital.Vec3
 }
 
+// CellTag is the per-pixel record set by the *Colored* / *Tagged*
+// draw helpers. Color drives String()'s per-cell colorization;
+// BodyID / NodeIdx / IsVessel let HitAt resolve mouse clicks back
+// to a sim object. v0.6.4+. Zero value = untagged (no color, no
+// hit). NodeIdx 0 means "not a node" — planted nodes are 1-indexed
+// in the tag and decoded by callers.
+type CellTag struct {
+	Color    lipgloss.Color
+	BodyID   string
+	NodeIdx  int  // 0 = no node; otherwise 1 + Nodes-slice index
+	IsVessel bool
+}
+
 // DefaultBasis is the top-down projection: world X axis maps to
 // canvas X+, world Y axis to canvas Y+. Z drops. Pre-v0.6.4 the
 // only projection.
@@ -64,20 +77,24 @@ type Canvas struct {
 	basis      Basis        // world axes mapped to canvas X+/Y+ (v0.6.4+)
 	dc         drawille.Canvas
 
-	// pixelTags maps a pixel coord (px, py) → its render color. Set by
-	// the *Colored* draw helpers (FillColoredDisk, RingColoredOutline);
-	// the plain Plot / FillDisk / RingOutline / DrawEllipse / PlotArrow
-	// helpers leave pixels untagged. At String() time, each terminal
-	// cell picks its color from the most-common tag among its 2×4
-	// pixels; cells with no tagged pixels render in the default
-	// terminal color.
+	// pixelTags maps a pixel coord (px, py) → CellTag. Set by the
+	// *Colored* / *Tagged* draw helpers; plain Plot / FillDisk /
+	// RingOutline / DrawEllipse / PlotArrow leave pixels untagged.
+	//
+	// At String() time, each terminal cell picks its color from the
+	// most-common Color among its 2×4 pixels (cells with no tagged
+	// pixels render in the default terminal color). v0.6.4+: HitAt
+	// aggregates the same cell-level pixel set to answer "what's
+	// under cursor (col, row)?" for mouse hit-testing — bodies,
+	// vessel, planted nodes — using BodyID / NodeIdx / IsVessel
+	// fields on CellTag.
 	//
 	// v0.5.10+: replaces the v0.5.3 cell-rectangle approach, which
 	// colored a body's entire bounding box of cells — bleeding into
 	// orbit lines, craft glyphs, and apo/peri markers near a body.
 	// Per-pixel tagging keeps body color confined to the body's own
 	// pixels.
-	pixelTags map[[2]int]lipgloss.Color
+	pixelTags map[[2]int]CellTag
 
 	// cellOverlays maps a cell coord → a Unicode glyph that replaces
 	// the drawille-derived char at String() time. v0.5.12+ — used by
@@ -164,13 +181,22 @@ func (c *Canvas) SetCellOverlay(w orbital.Vec3, glyph rune) {
 // Replaces the v0.5.3 AddColoredDisk approach which painted the
 // body's entire cell-bounding-box, bleeding into nearby content.
 func (c *Canvas) FillColoredDisk(center orbital.Vec3, pxRadius int, color lipgloss.Color) {
+	c.FillColoredDiskTagged(center, pxRadius, CellTag{Color: color})
+}
+
+// FillColoredDiskTagged is FillColoredDisk that records the supplied
+// CellTag (color + body / node / vessel hit fields) on every pixel
+// it sets. v0.6.4+: callers pass a tag with BodyID set so HitAt can
+// resolve mouse clicks back to bodies. Tag values default to "no
+// hit" so older draw paths that just need color stay untouched.
+func (c *Canvas) FillColoredDiskTagged(center orbital.Vec3, pxRadius int, tag CellTag) {
 	if pxRadius < 1 {
 		pxRadius = 1
 	}
 	cx, cy, _ := c.Project(center)
 	r2 := pxRadius * pxRadius
 	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]lipgloss.Color)
+		c.pixelTags = make(map[[2]int]CellTag)
 	}
 	for dy := -pxRadius; dy <= pxRadius; dy++ {
 		for dx := -pxRadius; dx <= pxRadius; dx++ {
@@ -182,7 +208,7 @@ func (c *Canvas) FillColoredDisk(center orbital.Vec3, pxRadius int, color lipglo
 				continue
 			}
 			c.dc.Set(px, py)
-			c.pixelTags[[2]int{px, py}] = color
+			c.pixelTags[[2]int{px, py}] = tag
 		}
 	}
 }
@@ -198,6 +224,13 @@ func (c *Canvas) FillColoredDisk(center orbital.Vec3, pxRadius int, color lipglo
 // The cap still produces dense enough sampling for the ring to look
 // smooth at any radius that contributes visible pixels to the canvas.
 func (c *Canvas) RingColoredOutline(center orbital.Vec3, pxRadius int, color lipgloss.Color) {
+	c.RingColoredOutlineTagged(center, pxRadius, CellTag{Color: color})
+}
+
+// RingColoredOutlineTagged is RingColoredOutline that records the
+// supplied CellTag on every pixel it sets. v0.6.4+ — same role as
+// FillColoredDiskTagged for ring-system bodies.
+func (c *Canvas) RingColoredOutlineTagged(center orbital.Vec3, pxRadius int, tag CellTag) {
 	if pxRadius < 1 {
 		pxRadius = 1
 	}
@@ -211,7 +244,7 @@ func (c *Canvas) RingColoredOutline(center orbital.Vec3, pxRadius int, color lip
 		samples = maxSamples
 	}
 	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]lipgloss.Color)
+		c.pixelTags = make(map[[2]int]CellTag)
 	}
 	for i := 0; i < samples; i++ {
 		theta := 2 * math.Pi * float64(i) / float64(samples)
@@ -221,21 +254,28 @@ func (c *Canvas) RingColoredOutline(center orbital.Vec3, pxRadius int, color lip
 			continue
 		}
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = color
+		c.pixelTags[[2]int{px, py}] = tag
 	}
 }
 
 // PlotColored sets a single pixel and tags it with the given color.
-// Used by callers that want a tagged dot (currently unused — Plot
-// stays untagged, which is what most callers want for orbit lines
-// and trail samples).
+// Used by callers that want a tagged dot (e.g. v0.6.1 maneuver-leg
+// preview). v0.6.4+: routed through PlotColoredTagged so tagged
+// variants of node-cluster / vessel-glyph plots can land hit-test
+// metadata while reusing the same path.
 func (c *Canvas) PlotColored(w orbital.Vec3, color lipgloss.Color) {
+	c.PlotColoredTagged(w, CellTag{Color: color})
+}
+
+// PlotColoredTagged is PlotColored with the full CellTag (color +
+// hit-test metadata) preserved on the pixel. v0.6.4+.
+func (c *Canvas) PlotColoredTagged(w orbital.Vec3, tag CellTag) {
 	if px, py, ok := c.Project(w); ok {
 		c.dc.Set(px, py)
 		if c.pixelTags == nil {
-			c.pixelTags = make(map[[2]int]lipgloss.Color)
+			c.pixelTags = make(map[[2]int]CellTag)
 		}
-		c.pixelTags[[2]int{px, py}] = color
+		c.pixelTags[[2]int{px, py}] = tag
 	}
 }
 
@@ -304,6 +344,84 @@ func (c *Canvas) Unproject(px, py int) orbital.Vec3 {
 	return c.centerW.
 		Add(c.basis.X.Scale(relX)).
 		Add(c.basis.Y.Scale(relY))
+}
+
+// HitAt aggregates the CellTag fields recorded on the 2×4 pixels
+// of the terminal cell at (col, row). Returns the most-common
+// non-empty BodyID among those pixels (with first-seen as the tie-
+// breaker). NodeIdx and IsVessel resolve the same way (most common
+// non-zero / true wins). Color falls out of the existing String()
+// aggregation and is not returned here. v0.6.4+: paired with the
+// app's MouseMsg dispatch so a click resolves to "what sim object
+// is this cell rendering?"
+//
+// (col, row) outside the canvas → zero-value CellTag (no hit).
+// Cells whose pixel set is entirely untagged also return zero —
+// the caller treats this as "click on empty canvas" and may then
+// Unproject for an in-orbit-plane world coord.
+func (c *Canvas) HitAt(col, row int) CellTag {
+	if col < 0 || col >= c.cols || row < 0 || row >= c.rows {
+		return CellTag{}
+	}
+	if len(c.pixelTags) == 0 {
+		return CellTag{}
+	}
+	bodyCounts := map[string]int{}
+	nodeCounts := map[int]int{}
+	vesselCount := 0
+	pxStart, pyStart := col*2, row*4
+	for dx := 0; dx < 2; dx++ {
+		for dy := 0; dy < 4; dy++ {
+			tag, ok := c.pixelTags[[2]int{pxStart + dx, pyStart + dy}]
+			if !ok {
+				continue
+			}
+			if tag.BodyID != "" {
+				bodyCounts[tag.BodyID]++
+			}
+			if tag.NodeIdx != 0 {
+				nodeCounts[tag.NodeIdx]++
+			}
+			if tag.IsVessel {
+				vesselCount++
+			}
+		}
+	}
+	hit := CellTag{}
+	if vesselCount > 0 {
+		hit.IsVessel = true
+	}
+	if best, n := mostCommonString(bodyCounts); n > 0 {
+		hit.BodyID = best
+	}
+	if best, n := mostCommonInt(nodeCounts); n > 0 {
+		hit.NodeIdx = best
+	}
+	return hit
+}
+
+func mostCommonString(counts map[string]int) (string, int) {
+	var best string
+	bestN := 0
+	for k, n := range counts {
+		if n > bestN {
+			bestN = n
+			best = k
+		}
+	}
+	return best, bestN
+}
+
+func mostCommonInt(counts map[int]int) (int, int) {
+	var best int
+	bestN := 0
+	for k, n := range counts {
+		if n > bestN {
+			bestN = n
+			best = k
+		}
+	}
+	return best, bestN
 }
 
 // IsBehindBody reports whether a world point `samplePos` is occluded
@@ -557,13 +675,16 @@ func (c *Canvas) String() string {
 	// since collisions are rare).
 	cellColor := make(map[[2]int]lipgloss.Color)
 	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
-	for coord, color := range c.pixelTags {
+	for coord, tag := range c.pixelTags {
+		if tag.Color == "" {
+			continue
+		}
 		cellX, cellY := coord[0]/2, coord[1]/4
 		key := [2]int{cellX, cellY}
 		if cellCounts[key] == nil {
 			cellCounts[key] = make(map[lipgloss.Color]int)
 		}
-		cellCounts[key][color]++
+		cellCounts[key][tag.Color]++
 	}
 	for key, counts := range cellCounts {
 		var bestColor lipgloss.Color

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -32,12 +32,27 @@ type Basis struct {
 	X, Y orbital.Vec3
 }
 
-// DefaultBasis is the equatorial projection: world X axis maps to
-// canvas X+, world Y axis to canvas Y+. Z drops.
+// DefaultBasis is the top-down projection: world X axis maps to
+// canvas X+, world Y axis to canvas Y+. Z drops. Pre-v0.6.4 the
+// only projection.
 func DefaultBasis() Basis {
 	return Basis{
 		X: orbital.Vec3{X: 1},
 		Y: orbital.Vec3{Y: 1},
+	}
+}
+
+// DepthAxis returns the unit vector pointing toward the camera, i.e.
+// "out of screen." Points with positive (world − center)·DepthAxis()
+// are in front of the basis plane through center; negative is
+// behind. Computed as basis.X × basis.Y so the cardinal-view axes
+// derive consistently from the X / Y choice. v0.6.4+: orbit-screen
+// uses this for back-of-body occlusion in side views.
+func (b Basis) DepthAxis() orbital.Vec3 {
+	return orbital.Vec3{
+		X: b.X.Y*b.Y.Z - b.X.Z*b.Y.Y,
+		Y: b.X.Z*b.Y.X - b.X.X*b.Y.Z,
+		Z: b.X.X*b.Y.Y - b.X.Y*b.Y.X,
 	}
 }
 
@@ -280,8 +295,7 @@ func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
 // given pixel — assuming the world point lies in the basis plane
 // through centerW. v0.6.4+: paired with Project for view-aware mouse
 // hit-testing in v0.6.4's mouse work. The Z axis (out of screen) is
-// implicitly the orbit-normal direction in orbit-perpendicular mode
-// or world Z in equatorial mode; Unproject doesn't disambiguate, so
+// implicitly the depth direction; Unproject doesn't disambiguate, so
 // callers that need a 3D world point on a specific surface must do
 // their own ray-cast.
 func (c *Canvas) Unproject(px, py int) orbital.Vec3 {
@@ -290,6 +304,73 @@ func (c *Canvas) Unproject(px, py int) orbital.Vec3 {
 	return c.centerW.
 		Add(c.basis.X.Scale(relX)).
 		Add(c.basis.Y.Scale(relY))
+}
+
+// IsBehindBody reports whether a world point `samplePos` is occluded
+// by a body at `bodyPos` with screen-projected radius `bodyPxR`,
+// under the canvas's active basis. Two conditions must hold:
+//
+//  1. Negative depth: (samplePos − bodyPos) · DepthAxis() < 0 — the
+//     sample is on the camera-far side of the body's plane.
+//  2. Inside disk: the sample's projected pixel coord lies within
+//     `bodyPxR` pixels of the body's projected pixel coord.
+//
+// Used by the orbit + maneuver renders (v0.6.4+) to skip plots
+// behind a body in side views, so the body disk reads as opaque
+// and the orbit visibly passes around — not through — it.
+func (c *Canvas) IsBehindBody(samplePos, bodyPos orbital.Vec3, bodyPxR int) bool {
+	depthAxis := c.basis.DepthAxis()
+	rel := samplePos.Sub(bodyPos)
+	depth := rel.X*depthAxis.X + rel.Y*depthAxis.Y + rel.Z*depthAxis.Z
+	if depth >= 0 {
+		return false
+	}
+	spx, spy, ok := c.Project(samplePos)
+	if !ok {
+		return false
+	}
+	bpx, bpy, _ := c.Project(bodyPos)
+	dx := spx - bpx
+	dy := spy - bpy
+	return dx*dx+dy*dy <= bodyPxR*bodyPxR
+}
+
+// DrawEllipseOffsetOccluded plots a dotted ellipse but skips any
+// sample IsBehindBody-occluded by the supplied (bodyPos, bodyPxR).
+// Same shape as DrawEllipseOffsetDotted; v0.6.4+ side-view variant.
+// Pass an untagged stride to keep the existing colour helpers; this
+// helper writes through PlotColored when `color` is non-empty,
+// otherwise plain Plot.
+func (c *Canvas) DrawEllipseOffsetOccluded(
+	el orbital.Elements,
+	offset orbital.Vec3,
+	samples int,
+	stride int,
+	bodyPos orbital.Vec3,
+	bodyPxR int,
+	color lipgloss.Color,
+) {
+	if samples < 16 {
+		samples = 16
+	}
+	if stride < 1 {
+		stride = 1
+	}
+	for i := 0; i < samples; i++ {
+		if i%stride != 0 {
+			continue
+		}
+		nu := 2 * math.Pi * float64(i) / float64(samples)
+		p := offset.Add(orbital.PositionAtTrueAnomaly(el, nu))
+		if c.IsBehindBody(p, bodyPos, bodyPxR) {
+			continue
+		}
+		if color == "" {
+			c.Plot(p)
+		} else {
+			c.PlotColored(p, color)
+		}
+	}
 }
 
 // Plot sets the pixel at the given world coord. No-op if off-canvas.

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -287,6 +287,57 @@ func abs(x float64) float64 {
 	return x
 }
 
+// TestHitAtResolvesBodyTag (v0.6.4+): a tagged disk drawn at a known
+// world coord is recoverable by HitAt at the cell containing the
+// disk's center. The test sets a 5-pixel disk and asserts the
+// center cell hits with the supplied BodyID.
+func TestHitAtResolvesBodyTag(t *testing.T) {
+	c := NewCanvas(40, 20) // pixel grid 80 × 80
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.FillColoredDiskTagged(orbital.Vec3{}, 5, CellTag{
+		Color:  lipgloss.Color("#FF0000"),
+		BodyID: "moon",
+	})
+	// Disk center maps to canvas pixel (40, 40), terminal cell (20, 10).
+	hit := c.HitAt(20, 10)
+	if hit.BodyID != "moon" {
+		t.Errorf("center cell hit BodyID = %q, want %q", hit.BodyID, "moon")
+	}
+}
+
+// TestHitAtUntaggedReturnsZero: a cell whose covered pixels carry
+// only color tags (no BodyID / NodeIdx / IsVessel) returns the
+// zero-value CellTag — used by the orbit screen to differentiate
+// "click on a sim object" from "click on empty canvas."
+func TestHitAtUntaggedReturnsZero(t *testing.T) {
+	c := NewCanvas(40, 20)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	// PlotColored only sets Color — no BodyID / NodeIdx / IsVessel.
+	c.PlotColored(orbital.Vec3{}, lipgloss.Color("#00FF00"))
+	hit := c.HitAt(20, 10)
+	if hit.BodyID != "" || hit.NodeIdx != 0 || hit.IsVessel {
+		t.Errorf("untagged cell hit non-zero CellTag: %+v", hit)
+	}
+}
+
+// TestHitAtOutOfBoundsReturnsZero: clicks outside the canvas
+// content area must not panic and must return zero. The mouse
+// dispatch uses this guard for clicks that fall on the title /
+// border / HUD regions.
+func TestHitAtOutOfBoundsReturnsZero(t *testing.T) {
+	c := NewCanvas(40, 20)
+	for _, p := range [][2]int{
+		{-1, 5}, {5, -1}, {40, 5}, {5, 20}, {1000, 1000},
+	} {
+		hit := c.HitAt(p[0], p[1])
+		if hit.BodyID != "" || hit.NodeIdx != 0 || hit.IsVessel {
+			t.Errorf("HitAt(%d, %d) = %+v, want zero", p[0], p[1], hit)
+		}
+	}
+}
+
 // TestIsBehindBodyDepthAndDisk (v0.6.4+): the helper returns true
 // only when both conditions hold — sample is behind the body's
 // camera-perpendicular plane AND the projected pixel coord falls

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -211,6 +211,82 @@ func TestPerPixelTagDoesNotBleed(t *testing.T) {
 	}
 }
 
+// TestUnprojectRoundTripDefaultBasis: Project(world) → (px, py); the
+// pixel-rounding cost is at most one half-pixel of world distance,
+// so Unproject(Project(w)) ≈ w within that bound. Default basis case.
+// v0.6.4+.
+func TestUnprojectRoundTripDefaultBasis(t *testing.T) {
+	c := NewCanvas(60, 30)
+	c.SetScale(0.01)               // pixels per metre — 1 m ≈ 0.01 px
+	c.Center(orbital.Vec3{X: 1000}) // off-origin to exercise centerW
+	cases := []orbital.Vec3{
+		{X: 1000, Y: 0},
+		{X: 1500, Y: 250},
+		{X: 750, Y: -500},
+	}
+	for _, w := range cases {
+		px, py, ok := c.Project(w)
+		if !ok {
+			t.Errorf("project(%v) off-canvas — expected on-canvas for round-trip", w)
+			continue
+		}
+		got := c.Unproject(px, py)
+		// Tolerance: half-pixel of world distance = (1 / scale) / 2.
+		halfPxWorld := 0.5 / c.scale
+		if abs(got.X-w.X) > halfPxWorld || abs(got.Y-w.Y) > halfPxWorld {
+			t.Errorf("round-trip %v → (%d, %d) → %v exceeds %.1f tolerance",
+				w, px, py, got, halfPxWorld)
+		}
+	}
+}
+
+// TestUnprojectRoundTripPerifocalBasis: same round-trip invariant
+// against an arbitrary basis (orbit-perpendicular case). World
+// points are in the basis plane (xHat / yHat span); Project drops
+// the orbit-normal component, so the round-trip is exact-ish on the
+// (xHat, yHat) plane.
+func TestUnprojectRoundTripPerifocalBasis(t *testing.T) {
+	c := NewCanvas(60, 30)
+	c.SetScale(0.01)
+	c.Center(orbital.Vec3{})
+	// Inclined orbit: i = 30°, Ω = 45°, ω = 60°.
+	el := orbital.Elements{A: 1e6, E: 0.2, I: 30 * 3.14159265 / 180,
+		Omega: 45 * 3.14159265 / 180, Arg: 60 * 3.14159265 / 180}
+	xHat, yHat := orbital.PerifocalBasis(el)
+	c.SetBasis(Basis{X: xHat, Y: yHat})
+
+	// Test points are linear combinations of xHat and yHat (i.e.,
+	// they lie in the orbit plane).
+	combos := []struct{ a, b float64 }{
+		{1000, 0},
+		{500, 250},
+		{-300, 750},
+	}
+	for _, lc := range combos {
+		w := xHat.Scale(lc.a).Add(yHat.Scale(lc.b))
+		px, py, ok := c.Project(w)
+		if !ok {
+			continue
+		}
+		got := c.Unproject(px, py)
+		// `got` should equal w to within rounding. The basis is
+		// orthonormal, so the (a, b) coords are recovered exactly.
+		halfPxWorld := 0.5 / c.scale
+		dx := got.Sub(w)
+		if abs(dx.X) > halfPxWorld || abs(dx.Y) > halfPxWorld || abs(dx.Z) > halfPxWorld {
+			t.Errorf("round-trip in perifocal basis (%v) → got %v (diff %v) exceeds %.1f",
+				w, got, dx, halfPxWorld)
+		}
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 func onlyWhitespace(s string) bool {
 	for _, r := range s {
 		if r != ' ' && r != '\n' && r != '\t' && r != '⠀' {

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -287,6 +287,83 @@ func abs(x float64) float64 {
 	return x
 }
 
+// TestIsBehindBodyDepthAndDisk (v0.6.4+): the helper returns true
+// only when both conditions hold — sample is behind the body's
+// camera-perpendicular plane AND the projected pixel coord falls
+// inside the body's disk. Two of three failure modes (in front, or
+// behind but outside the disk) must return false.
+func TestIsBehindBodyDepthAndDisk(t *testing.T) {
+	c := NewCanvas(60, 30)
+	c.SetScale(0.001) // 1 m → 0.001 px
+	c.Center(orbital.Vec3{})
+	// Right-view basis: depth axis = +X (toward camera).
+	c.SetBasis(Basis{X: orbital.Vec3{Y: 1}, Y: orbital.Vec3{Z: 1}})
+
+	// Body at origin with 100 px projected radius (= 100 km world).
+	body := orbital.Vec3{}
+	const bodyPxR = 100
+
+	cases := []struct {
+		name    string
+		sample  orbital.Vec3
+		want    bool
+		comment string
+	}{
+		{
+			name:    "front, on screen-axis with body",
+			sample:  orbital.Vec3{X: 50_000}, // depth +50 km → in front
+			want:    false,
+			comment: "depth ≥ 0 → never occluded",
+		},
+		{
+			name:    "behind, screen-coincident with body",
+			sample:  orbital.Vec3{X: -50_000}, // depth -50 km → behind
+			want:    true,
+			comment: "behind + same screen pos = inside disk",
+		},
+		{
+			name:    "behind, screen-far-from body",
+			sample:  orbital.Vec3{X: -50_000, Y: 200_000}, // off-disk laterally
+			want:    false,
+			comment: "behind but screen pos outside disk",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.IsBehindBody(tc.sample, body, bodyPxR)
+			if got != tc.want {
+				t.Errorf("got %v, want %v — %s", got, tc.want, tc.comment)
+			}
+		})
+	}
+}
+
+// TestDepthAxisCardinalBases (v0.6.4+): each cardinal-view basis
+// produces the expected camera-toward axis. Top → +Z, Right → +X,
+// Bottom → -Z, Left → -X. Catches sign / cross-product errors that
+// would silently invert the in-front / behind decision in side
+// views.
+func TestDepthAxisCardinalBases(t *testing.T) {
+	cases := []struct {
+		name string
+		b    Basis
+		want orbital.Vec3
+	}{
+		{"top", Basis{X: orbital.Vec3{X: 1}, Y: orbital.Vec3{Y: 1}}, orbital.Vec3{Z: 1}},
+		{"right", Basis{X: orbital.Vec3{Y: 1}, Y: orbital.Vec3{Z: 1}}, orbital.Vec3{X: 1}},
+		{"bottom", Basis{X: orbital.Vec3{X: 1}, Y: orbital.Vec3{Y: -1}}, orbital.Vec3{Z: -1}},
+		{"left", Basis{X: orbital.Vec3{Y: -1}, Y: orbital.Vec3{Z: 1}}, orbital.Vec3{X: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.b.DepthAxis()
+			if abs(got.X-tc.want.X) > 1e-12 || abs(got.Y-tc.want.Y) > 1e-12 || abs(got.Z-tc.want.Z) > 1e-12 {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func onlyWhitespace(s string) bool {
 	for _, r := range s {
 		if r != ' ' && r != '\n' && r != '\t' && r != '⠀' {


### PR DESCRIPTION
## Summary
- **5-way view-mode switcher** (`v` key) — Top, Right, Bottom, Left, OrbitFlat. Side views render with back-of-body occlusion via `Canvas.IsBehindBody` + `DrawEllipseOffsetOccluded`, so the orbit + craft glyph + apo/peri markers visibly pass behind the primary disk instead of through it. OrbitFlat projects onto the active craft's orbit plane via `orbital.PerifocalBasis` so inclined orbits read as clean ellipses.
- **Click-only mouse**. `Canvas.pixelTags` widens to `CellTag{Color, BodyID, NodeIdx, IsVessel}`; new `Canvas.HitAt(col, row)` aggregates per cell. Click cascade on the orbit screen: vessel → node → body → empty-canvas → HUD. Porkchop cells are clickable (cursor parity).
- **Click-to-edit nodes**. `Maneuver.LoadNode(idx, node)` records `editingIdx` + `loadedTriggerTime`; `BurnExecutedMsg` carries them so Enter replaces the original node in place AND preserves its scheduled fire time. Form's BURN PLAN header switches to "BURN PLAN — editing node N" (warning style); fire-at line shows an absolute countdown.
- **Empty-canvas click** → opens the planner staged at the orbit point nearest the click via `OrbitView.ProjectToOrbit`.
- **Quit confirm prompt** on `q` (`ctrl+c` stays immediate). **Burn camera freeze** so the orbit ellipse morphs in place during active burns.
- **Horizontal layout fix** for the maneuver screen — canvas left, form right.

## Test plan
- [x] `go test ./...` — full suite green
- [x] `go build ./cmd/terminal-space-program` — clean
- [x] Manual: 5 view-mode cycle, side-view occlusion against Luna, click body / vessel / node / empty / HUD, porkchop cell click, click-to-edit replaces in place + preserves T+, empty-click stages at orbit point, `q` confirm prompt, burn-camera freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)