### PR TITLE
feat(missions,sim,save,tui): mission scaffold (v0.6.5)

### DIFF
--- a/docs/v0.6-plan.md
+++ b/docs/v0.6-plan.md
@@ -20,9 +20,9 @@ v0.6.0 introduces is reused by v0.6.1's HUD readout.
 | v0.6.1 | shipped  | `v0.6.1`  | Predicted post-burn orbit HUD. |
 | v0.6.2 | shipped  | `v0.6.2`  | Finite-burn-aware iterative planner. |
 | v0.6.3 | shipped  | `v0.6.3`  | Moon → parent escape transfer + maneuver-canvas primary disk render. |
-| v0.6.4 | branch   | (pending) | Mouse selection + 5-way view-mode switcher with side-view occlusion. |
-| v0.6.5 | next     | —         | Mission scaffold. |
-| v0.6.6 | pending  | —         | Multiplayer design-doc spike. |
+| v0.6.4 | shipped  | `v0.6.4`  | Mouse selection + 5-way view-mode switcher with side-view occlusion. |
+| v0.6.5 | branch   | (pending) | Mission scaffold + save schema v3. |
+| v0.6.6 | next     | —         | Multiplayer design-doc spike. |
 
 Scope corrections vs. state-of-game.md (the doc framing was stale in two
 places):
@@ -340,6 +340,44 @@ Pass/fail objectives evaluated against `World` state each Tick.
 
 **Estimate.** ~250 LOC + JSON + tests.
 
+**Shipped.** Branch `v0.6.5-missions` (PR pending).
+
+- `internal/missions/missions.go` — `Mission{ID, Name, Description,
+  Type, Params, Status}` with three predicate kinds dispatched on
+  `Type`: `circularize` (target altitude, ±tol on |a−target|/target,
+  eccentricity cap), `orbit_insertion` (craft.Primary == named body
+  AND e < 1), `soi_flyby` (craft.Primary.ID == named body). Status
+  is a three-state machine (`InProgress` / `Passed` / `Failed`)
+  whose terminal states are sticky — `Mission.Evaluate(ctx)` is
+  idempotent on Passed/Failed so the per-tick caller can blindly
+  walk the slice.
+- `internal/missions/missions.json` — three starters with body IDs
+  matching `internal/bodies/systems/sol.json` (`earth`, `moon`,
+  `mars`). Embedded via `go:embed missions.json` →
+  `DefaultCatalog()`.
+- `EvalContext` lifts the minimum World state a predicate needs
+  (primary ID / radius / μ, craft state, sim time) so the missions
+  package depends only on `orbital` + `physics` and `sim` can
+  import it cleanly.
+- Schema bump `SchemaVersion` v2 → v3. `Payload.Missions
+  []missions.Mission` is `omitempty`. v1/v2 saves wire-out as nil
+  Missions and get the embedded starter catalog seeded fresh in
+  `worldFromPayload` for backward compatibility (older saves gain
+  the new feature without a manual edit). v3 saves with explicit
+  mission state round-trip status verbatim.
+- `World.Missions` lives next to `Nodes` / `ActiveBurn`; `NewWorld`
+  seeds the default catalog at construction. `Tick` calls
+  `evaluateMissions` after `executeDueNodes` /
+  `maybeRecordTrail` — predicates run after the integrator has
+  applied this tick's burn dispatch, so freshly-completed
+  circularizations can pass on the same tick. `World.ActiveMission`
+  returns the first `InProgress` entry for the HUD.
+- Orbit screen HUD gains a `MISSION` section under the active-burn
+  block. Renders the active mission's name + status, or
+  `N/total complete` in the Primary style once every mission
+  reaches a terminal state. Hidden entirely when no missions are
+  loaded.
+
 ### v0.6.6 — multiplayer design-doc spike
 
 Pure writing. `docs/multiplayer-design.md`.
@@ -374,9 +412,8 @@ v0.6.5 (missions)             ─── independent
 v0.6.6 (MP doc)               ─── independent
 ```
 
-Shipped: 0–3. **Next up: v0.6.4** — mouse + view-mode switcher.
-Then v0.6.5 (missions) and v0.6.6 (MP design doc); both independent
-and can interleave.
+Shipped: 0–4. v0.6.5 (missions) on branch awaiting playthrough +
+merge. **Next up: v0.6.6** — multiplayer design-doc spike.
 
 ---
 

--- a/internal/missions/embed.go
+++ b/internal/missions/embed.go
@@ -1,0 +1,11 @@
+package missions
+
+import _ "embed"
+
+//go:embed missions.json
+var defaultCatalogJSON []byte
+
+// DefaultCatalog returns the embedded v0.6.5 starter catalog.
+func DefaultCatalog() (Catalog, error) {
+	return LoadCatalog(defaultCatalogJSON)
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -1,0 +1,202 @@
+// Package missions defines pass/fail objectives evaluated against the
+// live sim state each Tick. v0.6.5+.
+//
+// A Mission is a typed predicate over the spacecraft's current
+// (primary, state, sim-time) tuple. Three predicate kinds ship in the
+// v0.6.5 starter catalog:
+//
+//   - Circularize: craft is in the named primary's frame, orbit is
+//     bound, eccentricity ≤ cap, and semimajor axis is within ±tol of
+//     target altitude (radius + altitude_m).
+//   - OrbitInsertion: craft is in the named primary's frame on a
+//     bound orbit (e < 1).
+//   - SOIFlyby: any tick where the craft's current primary ID matches
+//     the named body.
+//
+// Status is a three-state machine (InProgress → Passed | Failed).
+// Terminal states are sticky: Evaluate is idempotent on Passed/Failed
+// missions, so the per-tick caller can blindly walk all missions
+// without filtering.
+package missions
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// Status is the mission state machine.
+type Status int
+
+const (
+	InProgress Status = iota
+	Passed
+	Failed
+)
+
+// String returns a human-readable label for the status.
+func (s Status) String() string {
+	switch s {
+	case InProgress:
+		return "in progress"
+	case Passed:
+		return "passed"
+	case Failed:
+		return "failed"
+	}
+	return "?"
+}
+
+// Type discriminates the predicate kind. Stored in JSON as a string
+// so the catalog stays human-editable without leaking enum integers.
+type Type string
+
+const (
+	TypeCircularize    Type = "circularize"
+	TypeOrbitInsertion Type = "orbit_insertion"
+	TypeSOIFlyby       Type = "soi_flyby"
+)
+
+// Params is the union of parameters across all predicate kinds. Each
+// kind reads only the fields it cares about; the rest stay zero.
+type Params struct {
+	// PrimaryID is the body whose frame the predicate evaluates in
+	// (Circularize / OrbitInsertion) or whose SOI counts as a flyby
+	// (SOIFlyby).
+	PrimaryID string `json:"primary_id,omitempty"`
+
+	// AltitudeM is the target altitude above the primary's mean
+	// radius, in metres. Circularize only.
+	AltitudeM float64 `json:"altitude_m,omitempty"`
+
+	// AltitudeTolPct is the fractional tolerance on |a − target|/target.
+	// 0.05 = ±5%. Circularize only.
+	AltitudeTolPct float64 `json:"altitude_tol_pct,omitempty"`
+
+	// EccentricityCap is the upper bound on eccentricity. Circularize
+	// only. 0.005 ≈ ≤0.5% radial swing.
+	EccentricityCap float64 `json:"eccentricity_cap,omitempty"`
+}
+
+// Mission groups the catalog metadata, the predicate parameters, and
+// the runtime status. JSON-serialisable for both the catalog and the
+// save file.
+type Mission struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Type        Type   `json:"type"`
+	Params      Params `json:"params"`
+	Status      Status `json:"status,omitempty"`
+}
+
+// EvalContext is the minimum slice of World state a mission predicate
+// needs. Lifted out of sim so the missions package can depend only on
+// orbital/physics and avoid an import cycle.
+type EvalContext struct {
+	PrimaryID      string              // craft's current primary ID
+	PrimaryRadiusM float64             // craft primary's mean radius
+	PrimaryMu      float64             // craft primary's GM
+	State          physics.StateVector // craft state in primary frame
+	SimTime        time.Time           // current sim time
+}
+
+// Evaluate steps the predicate one tick and returns the new status.
+// Idempotent on terminal states (Passed/Failed return immediately).
+func (m Mission) Evaluate(ctx EvalContext) Status {
+	if m.Status != InProgress {
+		return m.Status
+	}
+	switch m.Type {
+	case TypeCircularize:
+		return evalCircularize(m.Params, ctx)
+	case TypeOrbitInsertion:
+		return evalOrbitInsertion(m.Params, ctx)
+	case TypeSOIFlyby:
+		return evalSOIFlyby(m.Params, ctx)
+	}
+	return InProgress
+}
+
+func evalCircularize(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.PrimaryMu == 0 {
+		return InProgress
+	}
+	el := orbital.ElementsFromState(ctx.State.R, ctx.State.V, ctx.PrimaryMu)
+	if el.A <= 0 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return InProgress
+	}
+	if el.E >= 1 {
+		return InProgress
+	}
+	if el.E > p.EccentricityCap {
+		return InProgress
+	}
+	target := ctx.PrimaryRadiusM + p.AltitudeM
+	if target <= 0 {
+		return InProgress
+	}
+	if math.Abs(el.A-target)/target > p.AltitudeTolPct {
+		return InProgress
+	}
+	return Passed
+}
+
+func evalOrbitInsertion(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.PrimaryMu == 0 {
+		return InProgress
+	}
+	el := orbital.ElementsFromState(ctx.State.R, ctx.State.V, ctx.PrimaryMu)
+	if el.A <= 0 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return InProgress
+	}
+	if el.E >= 1 {
+		return InProgress
+	}
+	return Passed
+}
+
+func evalSOIFlyby(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID == p.PrimaryID {
+		return Passed
+	}
+	return InProgress
+}
+
+// Catalog is a list of missions, persisted to JSON. The starter
+// catalog ships embedded in the binary; future config-file work could
+// supply user-authored catalogs through the same shape.
+type Catalog struct {
+	Missions []Mission `json:"missions"`
+}
+
+// LoadCatalog parses JSON bytes into a Catalog.
+func LoadCatalog(data []byte) (Catalog, error) {
+	var c Catalog
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Catalog{}, fmt.Errorf("missions: parse catalog: %w", err)
+	}
+	return c, nil
+}
+
+// Clone returns a deep copy of the mission slice. Used when seeding
+// World.Missions from the embedded catalog so per-session status
+// progression doesn't mutate the shared template.
+func Clone(missions []Mission) []Mission {
+	if len(missions) == 0 {
+		return nil
+	}
+	out := make([]Mission, len(missions))
+	copy(out, missions)
+	return out
+}

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -1,0 +1,34 @@
+{
+  "missions": [
+    {
+      "id": "leo-circularize-1000",
+      "name": "Circularize at 1000 km LEO",
+      "description": "Reach a circular orbit around Earth at 1000 km altitude (±5%, e ≤ 0.005).",
+      "type": "circularize",
+      "params": {
+        "primary_id": "earth",
+        "altitude_m": 1000000,
+        "altitude_tol_pct": 0.05,
+        "eccentricity_cap": 0.005
+      }
+    },
+    {
+      "id": "luna-orbit-insertion",
+      "name": "Luna orbit insertion",
+      "description": "Capture into a bound orbit around Earth's Moon.",
+      "type": "orbit_insertion",
+      "params": {
+        "primary_id": "moon"
+      }
+    },
+    {
+      "id": "mars-soi-flyby",
+      "name": "Mars SOI flyby",
+      "description": "Cross into Mars' sphere of influence.",
+      "type": "soi_flyby",
+      "params": {
+        "primary_id": "mars"
+      }
+    }
+  ]
+}

--- a/internal/missions/missions_test.go
+++ b/internal/missions/missions_test.go
@@ -1,0 +1,307 @@
+package missions
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+const (
+	earthMu     = 3.986004418e14
+	earthRadius = 6.371e6
+	moonMu      = 4.9028e12
+	moonRadius  = 1.7374e6
+)
+
+// circularState builds a state vector for a circular prograde orbit
+// at altitude alt over a body of radius r and gravitational parameter
+// mu. Returned in (X, Y) with V along +Y so the orbit lies in the
+// equatorial plane.
+func circularState(r, mu, alt float64) physics.StateVector {
+	radius := r + alt
+	v := math.Sqrt(mu / radius)
+	return physics.StateVector{
+		R: orbital.Vec3{X: radius},
+		V: orbital.Vec3{Y: v},
+		M: 1000,
+	}
+}
+
+func TestCircularizeStartsInProgress(t *testing.T) {
+	m := Mission{
+		Type: TypeCircularize,
+		Params: Params{
+			PrimaryID:       "earth",
+			AltitudeM:       1_000_000,
+			AltitudeTolPct:  0.05,
+			EccentricityCap: 0.005,
+		},
+	}
+	// Craft in 500 km LEO — way short of 1000 km target.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 500e3),
+	}
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Fatalf("at 500 km, expected InProgress, got %v", got)
+	}
+}
+
+func TestCircularizePassesAtTarget(t *testing.T) {
+	m := Mission{
+		Type: TypeCircularize,
+		Params: Params{
+			PrimaryID:       "earth",
+			AltitudeM:       1_000_000,
+			AltitudeTolPct:  0.05,
+			EccentricityCap: 0.005,
+		},
+	}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 1_000_000),
+	}
+	if got := m.Evaluate(ctx); got != Passed {
+		t.Fatalf("at 1000 km circular, expected Passed, got %v", got)
+	}
+}
+
+func TestCircularizeTolerance(t *testing.T) {
+	m := Mission{
+		Type: TypeCircularize,
+		Params: Params{
+			PrimaryID:       "earth",
+			AltitudeM:       1_000_000,
+			AltitudeTolPct:  0.05, // ±5% on |a − target|
+			EccentricityCap: 0.005,
+		},
+	}
+	target := earthRadius + 1_000_000
+	// Inside tolerance: a within 5% of target.
+	insideAlt := 1_000_000 - 0.04*target // 4% under target
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, insideAlt),
+	}
+	if got := m.Evaluate(ctx); got != Passed {
+		t.Errorf("inside tolerance, expected Passed, got %v", got)
+	}
+	// Outside tolerance: 10% under.
+	outsideAlt := 1_000_000 - 0.10*target
+	ctx.State = circularState(earthRadius, earthMu, outsideAlt)
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Errorf("outside tolerance, expected InProgress, got %v", got)
+	}
+}
+
+func TestCircularizeEccentricityCap(t *testing.T) {
+	m := Mission{
+		Type: TypeCircularize,
+		Params: Params{
+			PrimaryID:       "earth",
+			AltitudeM:       1_000_000,
+			AltitudeTolPct:  0.05,
+			EccentricityCap: 0.005,
+		},
+	}
+	// Build an elliptical orbit with a == target but e = 0.05 (well
+	// over the cap). Using vis-viva at a periapsis chosen to give the
+	// right semimajor axis.
+	a := earthRadius + 1_000_000
+	e := 0.05
+	rp := a * (1 - e)
+	vp := math.Sqrt(earthMu * (2/rp - 1/a))
+	state := physics.StateVector{
+		R: orbital.Vec3{X: rp},
+		V: orbital.Vec3{Y: vp},
+		M: 1000,
+	}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          state,
+	}
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Fatalf("e=0.05 over cap=0.005, expected InProgress, got %v", got)
+	}
+}
+
+func TestCircularizeWrongPrimary(t *testing.T) {
+	m := Mission{
+		Type: TypeCircularize,
+		Params: Params{
+			PrimaryID:       "earth",
+			AltitudeM:       1_000_000,
+			AltitudeTolPct:  0.05,
+			EccentricityCap: 0.005,
+		},
+	}
+	// Craft is at the right altitude but around the moon — predicate
+	// doesn't apply.
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 1_000_000),
+	}
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Fatalf("primary mismatch, expected InProgress, got %v", got)
+	}
+}
+
+func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
+	m := Mission{
+		Type:   TypeOrbitInsertion,
+		Params: Params{PrimaryID: "moon"},
+	}
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 100e3),
+	}
+	if got := m.Evaluate(ctx); got != Passed {
+		t.Fatalf("bound moon orbit, expected Passed, got %v", got)
+	}
+}
+
+func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
+	m := Mission{
+		Type:   TypeOrbitInsertion,
+		Params: Params{PrimaryID: "moon"},
+	}
+	// Velocity well above escape — hyperbolic.
+	radius := moonRadius + 100e3
+	vEsc := math.Sqrt(2 * moonMu / radius)
+	state := physics.StateVector{
+		R: orbital.Vec3{X: radius},
+		V: orbital.Vec3{Y: vEsc * 1.5},
+		M: 1000,
+	}
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          state,
+	}
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Fatalf("hyperbolic, expected InProgress, got %v", got)
+	}
+}
+
+func TestSOIFlybyPassesOnPrimaryMatch(t *testing.T) {
+	m := Mission{
+		Type:   TypeSOIFlyby,
+		Params: Params{PrimaryID: "mars"},
+	}
+	ctx := EvalContext{PrimaryID: "mars"}
+	if got := m.Evaluate(ctx); got != Passed {
+		t.Fatalf("inside Mars SOI, expected Passed, got %v", got)
+	}
+}
+
+func TestSOIFlybyInProgressOtherwise(t *testing.T) {
+	m := Mission{
+		Type:   TypeSOIFlyby,
+		Params: Params{PrimaryID: "mars"},
+	}
+	ctx := EvalContext{PrimaryID: "earth"}
+	if got := m.Evaluate(ctx); got != InProgress {
+		t.Fatalf("not in Mars SOI, expected InProgress, got %v", got)
+	}
+}
+
+func TestEvaluateIdempotentOnTerminal(t *testing.T) {
+	m := Mission{
+		Type:   TypeSOIFlyby,
+		Params: Params{PrimaryID: "mars"},
+		Status: Passed,
+	}
+	// Even though we're back at Earth, a Passed mission stays Passed.
+	ctx := EvalContext{PrimaryID: "earth"}
+	if got := m.Evaluate(ctx); got != Passed {
+		t.Fatalf("Passed mission should stay Passed, got %v", got)
+	}
+}
+
+func TestDefaultCatalogLoads(t *testing.T) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	if len(cat.Missions) != 3 {
+		t.Fatalf("expected 3 starter missions, got %d", len(cat.Missions))
+	}
+	wantIDs := map[string]bool{
+		"leo-circularize-1000": false,
+		"luna-orbit-insertion": false,
+		"mars-soi-flyby":       false,
+	}
+	for _, m := range cat.Missions {
+		if _, ok := wantIDs[m.ID]; !ok {
+			t.Errorf("unexpected mission id %q", m.ID)
+			continue
+		}
+		wantIDs[m.ID] = true
+	}
+	for id, found := range wantIDs {
+		if !found {
+			t.Errorf("missing mission id %q", id)
+		}
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		s    Status
+		want string
+	}{
+		{InProgress, "in progress"},
+		{Passed, "passed"},
+		{Failed, "failed"},
+	}
+	for _, tc := range cases {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("Status(%d).String() = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestCloneIsIndependent(t *testing.T) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	dup := Clone(cat.Missions)
+	dup[0].Status = Passed
+	if cat.Missions[0].Status == Passed {
+		t.Fatal("Clone shares backing memory with source")
+	}
+}
+
+// Sanity check that EvalContext's SimTime field is wired but not
+// currently consumed — guards against accidentally tying behaviour
+// to wall-clock during the v0.6.5 scaffold.
+func TestEvalIgnoresSimTime(t *testing.T) {
+	m := Mission{
+		Type:   TypeSOIFlyby,
+		Params: Params{PrimaryID: "mars"},
+	}
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+	ctx1 := EvalContext{PrimaryID: "earth", SimTime: t1}
+	ctx2 := EvalContext{PrimaryID: "earth", SimTime: t2}
+	if m.Evaluate(ctx1) != m.Evaluate(ctx2) {
+		t.Fatal("SimTime should not affect predicate outcome in v0.6.5")
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -25,12 +26,14 @@ import (
 
 // SchemaVersion is the on-disk version that Save writes today. v0.4.0
 // shipped v1; v0.6.0 bumped to v2 to add ManeuverNode.Event for the
-// burn-at-next scheduler. Load accepts any version in [1,
+// burn-at-next scheduler; v0.6.5 bumped to v3 to add Payload.Missions
+// for the mission-scaffold slice. Load accepts any version in [1,
 // SchemaVersion]; missing fields on older saves deserialise to their
-// zero values, which match the v1 semantics (Event = TriggerAbsolute,
-// no Missions). Bumps that need real migration logic should add a
-// dedicated upgrade pass keyed off File.Version.
-const SchemaVersion = 2
+// zero values, which match the legacy semantics (Event =
+// TriggerAbsolute, Missions = nil → seeded from default catalog post-
+// load). Bumps that need real migration logic should add a dedicated
+// upgrade pass keyed off File.Version.
+const SchemaVersion = 3
 
 // File is the on-disk envelope.
 type File struct {
@@ -44,15 +47,16 @@ type File struct {
 // Payload carries the live simulation state. Anything derivable from
 // the catalog (Systems, Calculator) is reconstructed on Load.
 type Payload struct {
-	SystemIdx    int         `json:"system_idx"`
-	SimTimeNano  int64       `json:"sim_time_unix_nano"`
-	BaseStepNano int64       `json:"base_step_nano"`
-	WarpIdx      int         `json:"warp_idx"`
-	Paused       bool        `json:"paused"`
-	Focus        Focus       `json:"focus"`
-	Craft        *Craft      `json:"craft,omitempty"`
-	Nodes        []Node      `json:"nodes,omitempty"`
-	ActiveBurn   *ActiveBurn `json:"active_burn,omitempty"`
+	SystemIdx    int                `json:"system_idx"`
+	SimTimeNano  int64              `json:"sim_time_unix_nano"`
+	BaseStepNano int64              `json:"base_step_nano"`
+	WarpIdx      int                `json:"warp_idx"`
+	Paused       bool               `json:"paused"`
+	Focus        Focus              `json:"focus"`
+	Craft        *Craft             `json:"craft,omitempty"`
+	Nodes        []Node             `json:"nodes,omitempty"`
+	ActiveBurn   *ActiveBurn        `json:"active_burn,omitempty"`
+	Missions     []missions.Mission `json:"missions,omitempty"`
 }
 
 // Focus mirrors sim.Focus by value.
@@ -242,6 +246,7 @@ func payloadFromWorld(w *sim.World) Payload {
 			PrimaryID:   w.ActiveBurn.PrimaryID,
 		}
 	}
+	p.Missions = missions.Clone(w.Missions)
 	return p
 }
 
@@ -311,6 +316,16 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			EndTime:     time.Unix(0, p.ActiveBurn.EndTimeNano).UTC(),
 			PrimaryID:   p.ActiveBurn.PrimaryID,
 		}
+	}
+	// v0.6.5: missions persist with status. v3+ saves carry an explicit
+	// (possibly-empty) Missions slice; v1/v2 saves wire-out as nil and
+	// get the embedded starter catalog seeded fresh so older saves
+	// gain the new feature without a manual edit. A failed catalog
+	// load is non-fatal — missions are additive.
+	if p.Missions != nil {
+		w.Missions = missions.Clone(p.Missions)
+	} else if cat, err := missions.DefaultCatalog(); err == nil {
+		w.Missions = missions.Clone(cat.Missions)
 	}
 	return w, nil
 }

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/save"
@@ -386,6 +387,76 @@ func TestEventRoundtrip(t *testing.T) {
 	}
 	if !got.Nodes[0].TriggerTime.IsZero() {
 		t.Errorf("expected zero TriggerTime on unresolved node, got %v", got.Nodes[0].TriggerTime)
+	}
+}
+
+// TestMissionsRoundtrip: a save written with progressed mission status
+// (e.g. one passed, one in-progress) round-trips with status preserved.
+func TestMissionsRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if len(w.Missions) == 0 {
+		t.Fatal("NewWorld did not seed default missions")
+	}
+	// Force the first mission into Passed so we can verify status
+	// persists across save/load.
+	w.Missions[0].Status = missions.Passed
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Missions) != len(w.Missions) {
+		t.Fatalf("missions count: got %d, want %d", len(got.Missions), len(w.Missions))
+	}
+	if got.Missions[0].Status != missions.Passed {
+		t.Errorf("first mission status: got %v, want Passed", got.Missions[0].Status)
+	}
+	if got.Missions[0].ID != w.Missions[0].ID {
+		t.Errorf("first mission ID: got %q, want %q", got.Missions[0].ID, w.Missions[0].ID)
+	}
+}
+
+// TestV2SaveLoadsAsV3: a pre-v0.6.5 save (no missions field on the
+// wire) loads cleanly under SchemaVersion = 3 with the default
+// catalog seeded by NewWorld preserved.
+func TestV2SaveLoadsAsV3(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Forge a v2 envelope: drop the missions field by zeroing it on
+	// the in-memory File and re-marshalling.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	f.Version = 2
+	f.Payload.Missions = nil
+	rewritten, _ := json.Marshal(f)
+	if err := os.WriteFile(path, rewritten, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load v2 save: %v", err)
+	}
+	if len(got.Missions) == 0 {
+		t.Fatal("v2 save loaded with no missions; expected default-catalog seed from NewWorld")
 	}
 }
 

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -270,10 +270,12 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		mass := w.Craft.TotalMass()
 		thrust := w.Craft.Thrust
 		dvDepEstimate := estimateIntraPrimaryDepDv(muShared, rPark, rArrival)
-		var minLead float64
-		if thrust > 0 && mass > 0 {
-			minLead = (dvDepEstimate * mass / thrust) / 2
-		}
+		// minLead = half the centred-finite-burn duration so the planner's
+		// OffsetTime sits ≥ Duration/2 ahead of now (BurnStart can't be
+		// retroactive). v0.6.5: rocket-equation form via BurnTimeForDV
+		// instead of constant-mass `Δv·m/F` so this matches the duration
+		// transferNodeToManeuver will actually plant.
+		minLead := w.Craft.BurnTimeForDV(dvDepEstimate).Seconds() / 2
 		plan, err := planner.PlanIntraPrimaryHohmann(
 			muShared, rPark, rArrival,
 			craftAngle, targetAngle, minLead,
@@ -293,8 +295,8 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		// falls back to the impulsive guess.
 		refineFiniteDeparture(&plan, muShared, rPark, mass, thrust, w.Craft.Isp, rArrival)
 		now := w.Clock.SimTime
-		w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
-		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+		w.PlanNode(transferNodeToManeuver(plan.Departure, now, w.Craft))
+		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, w.Craft))
 		return &plan, nil
 	}
 
@@ -327,10 +329,7 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		vCirc := math.Sqrt(muMoon / rPark)
 		vTransAtPeri := math.Sqrt(muMoon * (2/rPark - 1/aT))
 		dvEstimate := vTransAtPeri - vCirc
-		var minLead float64
-		if thrust > 0 && mass > 0 && dvEstimate > 0 {
-			minLead = (dvEstimate * mass / thrust) / 2
-		}
+		minLead := w.Craft.BurnTimeForDV(dvEstimate).Seconds() / 2
 		plan, err := planner.PlanMoonEscape(muMoon, rPark, rSOI, minLead, moon.ID, target.ID)
 		if err != nil {
 			return nil, err
@@ -340,8 +339,8 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		// the impulsive math designed.
 		refineFiniteDeparture(&plan, muMoon, rPark, mass, thrust, w.Craft.Isp, rSOI)
 		now := w.Clock.SimTime
-		w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
-		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+		w.PlanNode(transferNodeToManeuver(plan.Departure, now, w.Craft))
+		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, w.Craft))
 		return &plan, nil
 	}
 
@@ -362,10 +361,8 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 	}
 
 	now := w.Clock.SimTime
-	mass := w.Craft.TotalMass()
-	thrust := w.Craft.Thrust
-	w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
-	w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+	w.PlanNode(transferNodeToManeuver(plan.Departure, now, w.Craft))
+	w.PlanNode(transferNodeToManeuver(plan.Arrival, now, w.Craft))
 	return &plan, nil
 }
 
@@ -459,21 +456,16 @@ func (w *World) RefinePlan() (correctionDv, arrivalDv float64, err error) {
 		return 0, 0, err
 	}
 
-	mass := w.Craft.TotalMass()
-	thrust := w.Craft.Thrust
-
 	// Plant the correction burn at now (tiny offset to avoid firing the
-	// same tick it lands if executeDueNodes has already run).
-	var correctionDur time.Duration
-	if thrust > 0 && mass > 0 && correctionDv > 0 {
-		correctionDur = time.Duration(correctionDv * mass / thrust * float64(time.Second))
-	}
+	// same tick it lands if executeDueNodes has already run). v0.6.5:
+	// duration via the rocket-equation form so it matches the
+	// transferNodeToManeuver path.
 	if correctionDv > 0 {
 		w.PlanNode(ManeuverNode{
 			TriggerTime: now.Add(time.Second),
 			Mode:        correctionMode,
 			DV:          correctionDv,
-			Duration:    correctionDur,
+			Duration:    w.Craft.BurnTimeForDV(correctionDv),
 			PrimaryID:   w.Craft.Primary.ID,
 		})
 	}
@@ -483,10 +475,8 @@ func (w *World) RefinePlan() (correctionDv, arrivalDv float64, err error) {
 		TriggerTime: arrNode.TriggerTime,
 		Mode:        arrNode.Mode,
 		DV:          arrivalDv,
+		Duration:    w.Craft.BurnTimeForDV(arrivalDv),
 		PrimaryID:   arrNode.PrimaryID,
-	}
-	if thrust > 0 && mass > 0 && arrivalDv > 0 {
-		newArrival.Duration = time.Duration(arrivalDv * mass / thrust * float64(time.Second))
 	}
 	// Find arrNode again by index after PlanNode sorted the slice.
 	for i, n := range w.Nodes {
@@ -561,10 +551,8 @@ func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.
 	}
 
 	now := w.Clock.SimTime
-	mass := w.Craft.TotalMass()
-	thrust := w.Craft.Thrust
-	w.PlanNode(transferNodeToManeuver(plan.Departure, now, mass, thrust))
-	w.PlanNode(transferNodeToManeuver(plan.Arrival, now, mass, thrust))
+	w.PlanNode(transferNodeToManeuver(plan.Departure, now, w.Craft))
+	w.PlanNode(transferNodeToManeuver(plan.Arrival, now, w.Craft))
 	return &plan, nil
 }
 
@@ -784,10 +772,10 @@ func (w *World) bodyHelioStateAt(b bodies.CelestialBody, epoch float64) (orbital
 }
 
 // transferNodeToManeuver converts a planner.TransferNode into a
-// sim.ManeuverNode, adding a realistic burn duration based on the
-// craft's thrust and current mass (Δt = Δv · m / F). If thrust is
-// zero or inputs are degenerate the node stays impulsive (Duration=0),
-// matching the legacy behavior.
+// sim.ManeuverNode, deriving a realistic burn duration from the
+// craft's current mass + thrust + Isp via the rocket equation
+// (spacecraft.BurnTimeForDV). Zero-thrust craft yield Duration = 0,
+// preserving the legacy impulsive path.
 //
 // TriggerTime is set to the planner's intended firing moment — i.e.,
 // the burn-CENTER per ManeuverNode's v0.5.14+ semantics. The
@@ -800,21 +788,20 @@ func (w *World) bodyHelioStateAt(b bodies.CelestialBody, epoch float64) (orbital
 // to fire a node retroactively) must pad the planner's OffsetTime by
 // ≥ Duration/2 in advance — for the intra-primary path that's done
 // via PlanIntraPrimaryHohmann's minLeadSeconds.
-func transferNodeToManeuver(tn planner.TransferNode, now time.Time, mass, thrust float64) ManeuverNode {
+//
+// v0.6.5: switched from constant-mass `Δv·m/F` to the rocket-equation
+// form. Single source of truth — same call the maneuver planner UX
+// uses — so player-input and auto-plant burns size identically.
+func transferNodeToManeuver(tn planner.TransferNode, now time.Time, craft *spacecraft.Spacecraft) ManeuverNode {
 	mode := spacecraft.BurnPrograde
 	if tn.IsRetrograde {
 		mode = spacecraft.BurnRetrograde
-	}
-	var duration time.Duration
-	if thrust > 0 && mass > 0 && tn.DV > 0 {
-		secs := tn.DV * mass / thrust
-		duration = time.Duration(secs * float64(time.Second))
 	}
 	return ManeuverNode{
 		TriggerTime: now.Add(tn.OffsetTime),
 		Mode:        mode,
 		DV:          tn.DV,
-		Duration:    duration,
+		Duration:    craft.BurnTimeForDV(tn.DV),
 		PrimaryID:   tn.PrimaryID,
 	}
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -41,6 +42,11 @@ type World struct {
 	// Set by executeDueNodes when a Duration>0 node fires; cleared by
 	// integrateSpacecraft when DVRemaining hits zero or SimTime ≥ EndTime.
 	ActiveBurn *ActiveBurn
+
+	// Missions are pass/fail objectives evaluated against World state
+	// each Tick. Seeded from the embedded starter catalog at NewWorld
+	// time; Status fields progress as the player flies. v0.6.5+.
+	Missions []missions.Mission
 
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
@@ -94,6 +100,13 @@ func NewWorld() (*World, error) {
 		Clock:     NewClock(bodies.J2000, 50*time.Millisecond),
 	}
 	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+
+	// v0.6.5: seed missions from the embedded starter catalog. A failure
+	// to load the catalog is non-fatal — missions are an additive
+	// feature and shouldn't block worldgen if the JSON is malformed.
+	if cat, err := missions.DefaultCatalog(); err == nil {
+		w.Missions = missions.Clone(cat.Missions)
+	}
 
 	// Spawn spacecraft in LEO. v0.1: craft is always in Sol.
 	earth := w.Systems[0].FindBody("Earth")
@@ -215,7 +228,40 @@ func (w *World) Tick() {
 			w.maybeSwitchPrimary()
 		}
 		w.maybeRecordTrail(simDelta.Seconds())
+		w.evaluateMissions()
 	}
+}
+
+// evaluateMissions steps each mission's predicate against the live
+// craft state. Terminal-state missions are evaluated too, but their
+// status is sticky in missions.Mission.Evaluate. v0.6.5+.
+func (w *World) evaluateMissions() {
+	if len(w.Missions) == 0 || w.Craft == nil {
+		return
+	}
+	ctx := missions.EvalContext{
+		PrimaryID:      w.Craft.Primary.ID,
+		PrimaryRadiusM: w.Craft.Primary.RadiusMeters(),
+		PrimaryMu:      w.Craft.Primary.GravitationalParameter(),
+		State:          w.Craft.State,
+		SimTime:        w.Clock.SimTime,
+	}
+	for i := range w.Missions {
+		w.Missions[i].Status = w.Missions[i].Evaluate(ctx)
+	}
+}
+
+// ActiveMission returns the first in-progress mission, or nil if all
+// missions are passed/failed (or none are loaded). v0.6.5+. Used by
+// the HUD to surface a single-line status — multi-mission UX is a
+// follow-up.
+func (w *World) ActiveMission() *missions.Mission {
+	for i := range w.Missions {
+		if w.Missions[i].Status == missions.InProgress {
+			return &w.Missions[i]
+		}
+	}
+	return nil
 }
 
 // nextFiniteBurnTrigger returns the BurnStart sim-time of the soonest

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
@@ -255,5 +256,76 @@ func TestPausedTickDoesNothing(t *testing.T) {
 	}
 	if !w.Clock.SimTime.Equal(t0) {
 		t.Errorf("paused: sim-time advanced from %v to %v", t0, w.Clock.SimTime)
+	}
+}
+
+// TestNewWorldSeedsMissions: NewWorld populates World.Missions from
+// the embedded starter catalog with every mission InProgress.
+func TestNewWorldSeedsMissions(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if len(w.Missions) == 0 {
+		t.Fatal("NewWorld did not seed missions from default catalog")
+	}
+	for _, m := range w.Missions {
+		if m.Status != missions.InProgress {
+			t.Errorf("mission %q: expected InProgress at spawn, got %v", m.ID, m.Status)
+		}
+	}
+}
+
+// TestTickPassesCircularizeAtTarget: pumping the craft into a perfect
+// 1000 km circular Earth orbit and ticking once should mark the
+// circularize mission Passed via the Tick → evaluateMissions path.
+func TestTickPassesCircularizeAtTarget(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Force the craft into an exact 1000 km circular orbit.
+	mu := w.Craft.Primary.GravitationalParameter()
+	r := w.Craft.Primary.RadiusMeters() + 1_000_000
+	v := math.Sqrt(mu / r)
+	w.Craft.State = physics.StateVector{
+		R: orbital.Vec3{X: r},
+		V: orbital.Vec3{Y: v},
+		M: w.Craft.TotalMass(),
+	}
+	w.Tick()
+
+	var found *missions.Mission
+	for i := range w.Missions {
+		if w.Missions[i].Type == missions.TypeCircularize {
+			found = &w.Missions[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("circularize mission not present in default catalog")
+	}
+	if found.Status != missions.Passed {
+		t.Errorf("circularize at 1000 km: got %v, want Passed", found.Status)
+	}
+}
+
+// TestActiveMissionPicksFirstInProgress: ActiveMission walks the
+// mission slice in order and returns the first non-terminal entry.
+func TestActiveMissionPicksFirstInProgress(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if len(w.Missions) < 2 {
+		t.Skip("default catalog has fewer than 2 missions")
+	}
+	w.Missions[0].Status = missions.Passed
+	got := w.ActiveMission()
+	if got == nil {
+		t.Fatal("ActiveMission returned nil with one InProgress mission left")
+	}
+	if got.ID != w.Missions[1].ID {
+		t.Errorf("ActiveMission returned %q, want %q (first InProgress)", got.ID, w.Missions[1].ID)
 	}
 }

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -2,6 +2,7 @@ package spacecraft
 
 import (
 	"math"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
@@ -131,6 +132,39 @@ func (s *Spacecraft) MassFlowRate() float64 {
 		return 0
 	}
 	return s.Thrust / (s.Isp * g0)
+}
+
+// BurnTimeForDV returns the engine-on duration required to deliver dv
+// at the craft's current mass + thrust + Isp, using the rocket-equation
+// form t = (m0/ṁ)·(1 − exp(−Δv/(Isp·g0))). Accounts for the mass loss
+// during the burn — at high Δv-fraction of the budget, a constant-mass
+// approximation underestimates the time by the integral of mass /
+// thrust, which matters for low-TWR vessels burning a large share of
+// their fuel.
+//
+// Returns 0 when no finite burn is possible: zero or non-positive Δv,
+// no thrust, no Isp, or Δv exceeding what the available fuel can
+// support (caller's exceeds-budget warning fires; the integrator caps
+// delivery at fuel exhaustion regardless of the duration the form
+// committed). v0.6.5+: replaces the prior UI-set duration field; the
+// planner now derives this so the player only specifies Δv.
+func (s *Spacecraft) BurnTimeForDV(dv float64) time.Duration {
+	if dv <= 0 || s.Isp <= 0 || s.Thrust <= 0 {
+		return 0
+	}
+	mDot := s.MassFlowRate()
+	if mDot <= 0 {
+		return 0
+	}
+	mass0 := s.TotalMass()
+	if mass0 <= 0 {
+		return 0
+	}
+	secs := (mass0 / mDot) * (1 - math.Exp(-dv/(s.Isp*g0)))
+	if secs <= 0 || math.IsNaN(secs) || math.IsInf(secs, 0) {
+		return 0
+	}
+	return time.Duration(secs * float64(time.Second))
 }
 
 // ThrustAccelFn returns an RK4-compatible accel closure that adds engine

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -111,6 +111,50 @@ func TestMassFlowRateZeroWhenNoThrust(t *testing.T) {
 	}
 }
 
+// TestBurnTimeForDVRocketEquation: at S-IVB-1 specs (51000 kg total,
+// 1023 kN thrust, Isp 421 s) a 100 m/s Δv requires
+//
+//	t = (m0/ṁ) · (1 - exp(-Δv/(Isp·g0)))
+//	  = (51000 / 247.84) · (1 - exp(-100/(421·9.80665)))
+//	  ≈ 4.92 s
+//
+// Validates the rocket-equation form vs a constant-mass approximation
+// (which would give 51000·100/1023000 ≈ 4.99 s — slightly higher).
+func TestBurnTimeForDVRocketEquation(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	got := sc.BurnTimeForDV(100).Seconds()
+	mDot := 1023000.0 / (421.0 * 9.80665)
+	want := (51000.0 / mDot) * (1 - math.Exp(-100.0/(421.0*9.80665)))
+	if math.Abs(got-want) > 1e-3 {
+		t.Errorf("BurnTimeForDV(100) = %.3f s, want %.3f s", got, want)
+	}
+}
+
+// TestBurnTimeForDVZeroDV: zero Δv input must yield zero duration so
+// the form's enter-on-empty / planner zero-Δv paths fall through to
+// the impulsive branch.
+func TestBurnTimeForDVZeroDV(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	if got := sc.BurnTimeForDV(0); got != 0 {
+		t.Errorf("BurnTimeForDV(0) = %v, want 0", got)
+	}
+}
+
+// TestBurnTimeForDVZeroThrust: a thrust-less craft must return 0 so
+// the App's switch falls into the impulsive branch (legacy path
+// preserved through the API even though the form no longer surfaces
+// it).
+func TestBurnTimeForDVZeroThrust(t *testing.T) {
+	sc := &Spacecraft{Thrust: 0, Isp: 421, Fuel: 100, DryMass: 1000}
+	if got := sc.BurnTimeForDV(50); got != 0 {
+		t.Errorf("BurnTimeForDV with zero thrust = %v, want 0", got)
+	}
+}
+
 // TestThrustAccelFnAddsThrustOnTopOfGravity: at LEO with prograde mode,
 // the thrust component should equal Thrust/mass along the velocity unit
 // vector. Gravity component should match physics.Accel.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -106,6 +106,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case screens.BurnExecutedMsg:
 		if a.world.Craft != nil {
+			// v0.6.5: derive burn duration from Δv using the rocket
+			// equation against the live craft state, so the planner UX
+			// only has to specify Δv. Zero-thrust craft fall back to the
+			// legacy impulsive path (Duration = 0) — the API still
+			// supports that branch, just no longer through the form.
+			dur := a.world.Craft.BurnTimeForDV(m.DV)
 			// v0.6.4 click-to-edit: replace the original node before
 			// planting so click → edit → Enter reads as "modify in
 			// place" rather than "duplicate." Removal must come first
@@ -125,7 +131,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					TriggerTime: m.TriggerTime,
 					Mode:        m.Mode,
 					DV:          m.DV,
-					Duration:    m.Duration,
+					Duration:    dur,
 					Event:       m.Event,
 				})
 			case m.Event != sim.TriggerAbsolute:
@@ -135,16 +141,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.world.PlanNode(sim.ManeuverNode{
 					Mode:     m.Mode,
 					DV:       m.DV,
-					Duration: m.Duration,
+					Duration: dur,
 					Event:    m.Event,
 				})
-			case m.Duration == 0:
+			case dur == 0:
 				a.world.Craft.ApplyImpulsive(m.Mode, m.DV)
 			default:
 				a.world.ActiveBurn = &sim.ActiveBurn{
 					Mode:        m.Mode,
 					DVRemaining: m.DV,
-					EndTime:     a.world.Clock.SimTime.Add(m.Duration),
+					EndTime:     a.world.Clock.SimTime.Add(dur),
 				}
 			}
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -379,8 +379,6 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.CycleView):
 			a.world.CycleViewMode()
-			a.statusMsg = fmt.Sprintf("view: %s", a.world.ViewMode)
-			a.statusExpires = time.Now().Add(2 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.RefinePlan):
 			if a.world.CraftVisibleHere() {

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -26,18 +26,21 @@ import (
 //
 // Per plan §C20: live preview = shadow trajectory on a miniature canvas.
 // v0.2.1: three fields — mode / Δv / duration. v0.6.0: four fields —
-// mode / fire-at / Δv / duration. Duration zero = impulsive (legacy
-// v0.1 path); duration > 0 = finite burn. Fire-at = TriggerAbsolute
-// fires at T+5min (legacy quick-plant default); event-relative modes
-// resolve to the next periapsis/apoapsis/AN/DN at plant time.
+// mode / fire-at / Δv / duration. v0.6.5: three fields again — mode /
+// fire-at / Δv. Duration is no longer an independent input; the planner
+// derives it from Δv via the rocket equation at commit time, since at
+// fixed thrust + mass the two are the same dial — letting the player
+// set both was over-determined and the only effect of mismatch was a
+// truncated burn (planned Δv undelivered if duration was too short).
+// KSP-style: specify Δv, the engine takes as long as it takes.
 type Maneuver struct {
-	theme    Theme
-	canvas   *widgets.Canvas
-	dvInput  textinput.Model
-	durInput textinput.Model
+	theme   Theme
+	canvas  *widgets.Canvas
+	dvInput textinput.Model
+
 	modeIdx   int
 	fireAtIdx int
-	focus     int // 0=mode, 1=fireAt, 2=dv, 3=duration
+	focus     int // 0=mode, 1=fireAt, 2=dv
 
 	// editingIdx and loadedTriggerTime carry the v0.6.4 click-to-edit
 	// state. Default editingIdx = -1 (creating a new node). LoadNode
@@ -51,8 +54,7 @@ type Maneuver struct {
 }
 
 // BurnExecutedMsg is emitted when the user hits Enter. App consumes it.
-// Duration zero = impulsive (legacy path); >0 = finite burn. Event
-// (v0.6.0+) selects the trigger model — TriggerAbsolute uses the
+// Event (v0.6.0+) selects the trigger model — TriggerAbsolute uses the
 // app-side default delay; event-relative modes leave TriggerTime zero
 // and let the World's lazy-freeze resolver compute it from the live
 // orbit on the first Tick after plant.
@@ -63,10 +65,18 @@ type Maneuver struct {
 // flow preserves the original schedule. EditingIdx ≥ 0 tells the
 // app to remove the original Nodes[idx] before planting, so the
 // edit reads as "replace in place" rather than "duplicate."
+//
+// v0.6.5: Duration dropped from this message — the App computes it
+// on receipt via spacecraft.BurnTimeForDV(DV) using the live craft's
+// thrust + Isp + mass. Letting the player set both Δv AND duration
+// was over-determined: at fixed thrust + mass the two are the same
+// dial, and the only effect of mismatch was a truncated burn
+// (planned Δv undelivered if the duration was too short). Zero-thrust
+// craft return Duration = 0 from BurnTimeForDV, preserving the
+// impulsive code path even though the form no longer exposes it.
 type BurnExecutedMsg struct {
 	Mode        spacecraft.BurnMode
 	DV          float64
-	Duration    time.Duration
 	Event       sim.TriggerEvent
 	TriggerTime time.Time
 	EditingIdx  int // -1 = creating a new node; ≥ 0 = replacing world.Nodes[idx]
@@ -79,22 +89,10 @@ func NewManeuver(th Theme) *Maneuver {
 	dv.Width = 10
 	dv.SetValue("100")
 
-	dur := textinput.New()
-	dur.Placeholder = "0"
-	dur.CharLimit = 6
-	dur.Width = 10
-	// v0.6.1: default to a 10 s finite burn rather than impulsive.
-	// Impulsive Δv is unphysical for a chemical engine and the
-	// PROJECTED ORBIT readout reflects a more realistic plan when
-	// the player picks a duration up front. They can still set 0 to
-	// fall back to the legacy impulsive path.
-	dur.SetValue("10")
-
 	m := &Maneuver{
 		theme:      th,
 		canvas:     widgets.NewCanvas(60, 20),
 		dvInput:    dv,
-		durInput:   dur,
 		editingIdx: -1,
 	}
 	m.applyFocus()
@@ -126,7 +124,6 @@ func (m *Maneuver) LoadStaged(triggerTime time.Time) {
 	m.modeIdx = 0   // prograde — the most common new-burn intent
 	m.fireAtIdx = 0 // TriggerAbsolute — the staged TriggerTime IS the absolute schedule
 	m.dvInput.SetValue("100")
-	m.durInput.SetValue("10")
 	m.focus = 2 // Δv input — player typically wants to set magnitude first
 	m.applyFocus()
 }
@@ -156,7 +153,6 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 		}
 	}
 	m.dvInput.SetValue(fmt.Sprintf("%.0f", n.DV))
-	m.durInput.SetValue(fmt.Sprintf("%.1f", n.Duration.Seconds()))
 	m.focus = 0
 	m.editingIdx = idx
 	m.loadedTriggerTime = n.TriggerTime
@@ -164,15 +160,13 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 }
 
 // applyFocus pushes focus state down to the bubbletea text inputs.
-// Focus 0 = mode (cycle), 1 = fire-at (cycle), 2 = Δv, 3 = duration.
+// Focus 0 = mode (cycle), 1 = fire-at (cycle), 2 = Δv. v0.6.5 dropped
+// the duration field; the planner now derives burn time from Δv at
+// commit, so the form has one fewer focus stop.
 func (m *Maneuver) applyFocus() {
 	m.dvInput.Blur()
-	m.durInput.Blur()
-	switch m.focus {
-	case 2:
+	if m.focus == 2 {
 		m.dvInput.Focus()
-	case 3:
-		m.durInput.Focus()
 	}
 }
 
@@ -205,14 +199,14 @@ func (m *Maneuver) Resize(cols, rows int) {
 // means the app should exit the maneuver screen (commit or cancel).
 //
 // Key bindings:
-//   tab / shift+tab        — cycle focus across mode / fire-at / Δv / duration fields
+//   tab / shift+tab        — cycle focus across mode / fire-at / Δv fields
 //   ←/→ (mode focused)     — cycle direction modes
 //   ←/→ (fire-at focused)  — cycle trigger events (Absolute / NextPeri / NextApo / NextAN / NextDN)
-//   enter                  — commit burn → emits BurnExecutedMsg
+//   enter                  — commit burn → emits BurnExecutedMsg with rocket-equation duration
 //   esc                    — cancel → plain exit (app handles)
 //   digits/backspace       — forwarded to focused text input
 func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
-	const focusFields = 4
+	const focusFields = 3
 	switch msg.String() {
 	case "tab":
 		m.focus = (m.focus + 1) % focusFields
@@ -241,30 +235,42 @@ func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 			return nil, false
 		}
 	case "enter":
-		dv := m.parsedDV()
-		if dv == 0 {
-			return nil, false // ignore — user needs to type a number
+		// dv drives both the BurnExecutedMsg's Δv field AND its derived
+		// Duration via the rocket equation. Zero-thrust craft return
+		// Duration = 0 from BurnTimeForDV, falling back to the legacy
+		// impulsive path — preserving the impulsive capability through
+		// the API even though the form no longer exposes it directly.
+		cmd := m.commitCmd()
+		if cmd == nil {
+			return nil, false // zero Δv — ignore, user needs to type a number
 		}
-		dur := m.parsedDuration()
-		event := sim.AllTriggerEvents[m.fireAtIdx]
-		msg := BurnExecutedMsg{
-			Mode:        spacecraft.AllBurnModes[m.modeIdx],
-			DV:          dv,
-			Duration:    dur,
-			Event:       event,
-			TriggerTime: m.loadedTriggerTime,
-			EditingIdx:  m.editingIdx,
-		}
-		return func() tea.Msg { return msg }, true
+		return cmd, true
 	}
 	var cmd tea.Cmd
-	switch m.focus {
-	case 2:
+	if m.focus == 2 {
 		m.dvInput, cmd = m.dvInput.Update(msg)
-	case 3:
-		m.durInput, cmd = m.durInput.Update(msg)
 	}
 	return cmd, false
+}
+
+// commitCmd builds a BurnExecutedMsg from the current form values.
+// Caller (HandleKey on Enter) returns nil cmd to ignore commits with
+// zero Δv. Split out so the burn-time derivation lives in one place
+// and the form panel can preview the same number.
+func (m *Maneuver) commitCmd() tea.Cmd {
+	dv := m.parsedDV()
+	if dv == 0 {
+		return nil
+	}
+	event := sim.AllTriggerEvents[m.fireAtIdx]
+	msg := BurnExecutedMsg{
+		Mode:        spacecraft.AllBurnModes[m.modeIdx],
+		DV:          dv,
+		Event:       event,
+		TriggerTime: m.loadedTriggerTime,
+		EditingIdx:  m.editingIdx,
+	}
+	return func() tea.Msg { return msg }
 }
 
 func (m *Maneuver) parsedDV() float64 {
@@ -278,15 +284,6 @@ func (m *Maneuver) parsedDV() float64 {
 	return dv
 }
 
-// parsedDuration returns the duration field as a time.Duration. The field
-// is in seconds; zero means impulsive.
-func (m *Maneuver) parsedDuration() time.Duration {
-	var secs float64
-	if _, err := fmt.Sscanf(m.durInput.Value(), "%f", &secs); err != nil || secs <= 0 {
-		return 0
-	}
-	return time.Duration(secs * float64(time.Second))
-}
 
 // Render composes the preview canvas + form panel.
 func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
@@ -331,7 +328,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	// craft is nowhere near. Falls back to current-state preview if
 	// the event is unreachable (hyperbolic / equatorial AN/DN).
 	dv := m.parsedDV()
-	dur := m.parsedDuration()
+	dur := c.BurnTimeForDV(dv)
 	mode := spacecraft.AllBurnModes[m.modeIdx]
 	event := sim.AllTriggerEvents[m.fireAtIdx]
 	shadowState, shadowPrimary, ok := w.PreviewBurnState(mode, dv, dur, event)
@@ -389,7 +386,9 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 	c := w.Craft
 	mode := spacecraft.AllBurnModes[m.modeIdx]
 	budget := c.RemainingDeltaV()
-	dur := m.parsedDuration()
+	// v0.6.5: duration is derived from Δv at render time (and again at
+	// commit), so the form preview matches what the App will plant.
+	dur := c.BurnTimeForDV(dv)
 
 	warn := ""
 	if dv > budget {
@@ -427,18 +426,14 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		fireAtLabel = m.theme.Dim.Render(fireAtLabel)
 	}
 
+	// v0.6.5: burn description shows the rocket-equation-derived
+	// duration. Zero-thrust craft fall back to "impulsive" since
+	// BurnTimeForDV returns 0 in that case; otherwise we surface
+	// the engine-on time the App will plant.
 	burnDescr := "impulsive"
 	if dur > 0 {
-		// At constant thrust the analytical estimate is dv = thrust/mass × dur.
-		// Show what the engine actually *can* deliver in the requested duration.
-		mass := c.TotalMass()
-		var estDv float64
-		if mass > 0 {
-			estDv = c.Thrust / mass * dur.Seconds()
-		}
-		actual := math.Min(dv, estDv)
-		burnDescr = fmt.Sprintf("finite burn (%.0f N × %.1fs → est %.1f m/s, target %.0f m/s)",
-			c.Thrust, dur.Seconds(), actual, dv)
+		burnDescr = fmt.Sprintf("finite burn — %.1fs at %.0f kN, Isp %.0f s",
+			dur.Seconds(), c.Thrust/1000, c.Isp)
 	}
 
 	// v0.6.4 click-to-edit: surface the editing target inline in
@@ -459,7 +454,6 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		"  mode:     " + modeLabel,
 		"  fire at:  " + fireAtLabel,
 		"  Δv:       " + m.dvInput.View() + " m/s" + warn,
-		"  duration: " + m.durInput.View() + " s",
 		"  → " + burnDescr,
 		"",
 		"  Δv budget remaining: " + fmt.Sprintf("%.0f m/s", budget),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -527,6 +527,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	}
 	lines = append(lines, section("FOCUS")...)
 	lines = append(lines, "  "+w.FocusName())
+	lines = append(lines, "  view: "+w.ViewMode.String())
 
 	// Spacecraft block — only in Sol per plan §MVP.
 	if w.CraftVisibleHere() {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -574,6 +575,30 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  Δv-to-go: %.1f m/s", w.ActiveBurn.DVRemaining),
 			fmt.Sprintf("  T-%.1fs remaining", remaining),
 		)
+	}
+
+	// v0.6.5: mission status. Surfaces the first in-progress mission, or
+	// a "ALL CLEAR" line when every loaded mission is in a terminal
+	// state. Hidden entirely when no missions are loaded (e.g. a future
+	// "free play" toggle, or a config-load failure).
+	if len(w.Missions) > 0 {
+		lines = append(lines, section("MISSION")...)
+		if active := w.ActiveMission(); active != nil {
+			lines = append(lines,
+				"  "+active.Name,
+				v.theme.Dim.Render("  "+active.Status.String()),
+			)
+		} else {
+			passed := 0
+			for _, m := range w.Missions {
+				if m.Status == missions.Passed {
+					passed++
+				}
+			}
+			lines = append(lines,
+				v.theme.Primary.Render(fmt.Sprintf("  %d/%d complete", passed, len(w.Missions))),
+			)
+		}
 	}
 
 	if len(w.Nodes) > 0 {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -527,7 +527,8 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	}
 	lines = append(lines, section("FOCUS")...)
 	lines = append(lines, "  "+w.FocusName())
-	lines = append(lines, "  view: "+w.ViewMode.String())
+	lines = append(lines, v.theme.Primary.Render("VIEW"))
+	lines = append(lines, "  "+w.ViewMode.String())
 
 	// Spacecraft block — only in Sol per plan §MVP.
 	if w.CraftVisibleHere() {


### PR DESCRIPTION
## Summary

- **New `internal/missions` package** with three predicate kinds dispatched on `Type`: `circularize` (target altitude, ±tol on |a − target|/target, eccentricity cap), `orbit_insertion` (craft primary matches AND bound orbit), `soi_flyby` (craft primary matches a named body). Three-state machine (`InProgress` / `Passed` / `Failed`) with sticky terminal states; `Evaluate` is idempotent on terminals so the per-tick caller blindly walks the slice.
- **`EvalContext`** lifts the minimum World state a predicate needs (primary id / radius / μ, craft state, sim time) so missions depends only on `orbital` + `physics` and `sim` can import it without a cycle.
- **Embedded starter catalog** (`internal/missions/missions.json` via `go:embed`) ships three starters: "Circularize at 1000 km LEO" (e ≤ 0.005, ±5% on a), "Luna orbit insertion" (bound orbit around moon), "Mars SOI flyby". Body IDs match `internal/bodies/systems/sol.json` (`earth`, `moon`, `mars`).
- **`World.Missions` seeded at `NewWorld`**; `Tick` calls `evaluateMissions` after `executeDueNodes` so a burn that completes a circularization passes on the same tick. `World.ActiveMission` returns the first `InProgress` entry for the HUD.
- **Save schema v2 → v3.** `Payload.Missions []missions.Mission` is `omitempty`. v1/v2 saves wire-out nil and get the embedded catalog seeded fresh in `worldFromPayload` (older saves gain the feature without a manual edit); v3 saves round-trip status verbatim.
- **Orbit screen HUD** gains a `MISSION` section under the active-burn block: active mission name + status, or `N/total complete` once every mission reaches a terminal state. Hidden when no missions are loaded.

## Test plan

- [x] `go test ./internal/missions/...` — predicate transitions for all three kinds (start in progress, pass at target, tolerance bounds, eccentricity cap, primary mismatch, hyperbolic insertion, idempotence on terminals, default-catalog load).
- [x] `go test ./internal/save/...` — missions round-trip with progressed status; v2 saves load with the default catalog seeded.
- [x] `go test ./internal/sim/...` — `NewWorld` seeds missions in InProgress; pumping the craft into a 1000 km circular orbit and ticking once flips the circularize mission to Passed via the Tick path; `ActiveMission` skips terminal entries.
- [x] `go test ./...` — full suite green (no regressions in planner / orbital / tui screens).
- [ ] Manual playthrough: spawn → see "Circularize at 1000 km LEO" in HUD → run an auto-Hohmann to 1000 km → verify status flips to Passed and HUD picks up the next mission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)