### PR TITLE
fix(targeting): t cycles crafts before bodies — v0.9.0.1

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -127,7 +127,10 @@ body cursor.
 - `World.Target Target` field. `World.SetTarget`,
   `World.CycleTarget`, `World.ClearTarget` mirror
   `World.SetFocus` / `World.CycleFocus` / `World.ResetFocus`.
-  Cycle order: bodies in active SOI → sibling craft → none → repeat.
+  Cycle order (revised post-v0.9.0 hotfix): non-active sibling craft
+  → bodies in active system → none → repeat. Crafts come first because
+  Sol's 19-body catalog made the originally-planned bodies-first order
+  unworkable (you'd press `t` 19 times to reach a spawned craft).
 - `World.TargetState() (orbital.Vec3State, ok bool)` — resolves a
   target to its current heliocentric (or primary-frame, when
   `World.ActiveCraft()` is body-bound) state. Used by every

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -70,16 +70,18 @@ func (w *World) SetTargetCraft(idx int) {
 // Target.Kind == TargetNone.
 func (w *World) ClearTarget() { w.Target = Target{} }
 
-// CycleTarget advances Target through the system's targetable bodies
-// (non-root bodies in the active system) → non-active sibling crafts
-// → None → repeat. Forward=false steps backwards through the same
-// cycle. No-op when no targetable entry exists.
+// CycleTarget advances Target through non-active sibling crafts →
+// system bodies (non-root) → None → repeat. Forward=false steps
+// backwards through the same cycle. No-op when no targetable entry
+// exists.
 //
-// Cycle order: bodies in current system (idx 1 .. n-1, skipping the
-// system primary which has no orbital radius), then every non-active
-// craft in the slate (sibling-frame restriction is intentionally not
-// enforced here so the player can pre-select a target before
-// transferring into its frame), then TargetNone, then repeat.
+// Cycle order: every non-active craft in the slate first (the small
+// set the player most often wants to target after spawning a sister
+// craft), then bodies in the current system (idx 1 .. n-1, skipping
+// the system primary which has no orbital radius), then TargetNone,
+// then repeat. Sibling-frame restriction is intentionally not
+// enforced on the craft branch so the player can pre-select a target
+// before transferring into its frame.
 func (w *World) CycleTarget(forward bool) {
 	cycle := w.targetCycle()
 	if len(cycle) == 0 {
@@ -106,14 +108,14 @@ func (w *World) CycleTarget(forward bool) {
 // requiring a cache invalidation.
 func (w *World) targetCycle() []Target {
 	cycle := []Target{{Kind: TargetNone}}
-	for i := 1; i < len(w.System().Bodies); i++ {
-		cycle = append(cycle, Target{Kind: TargetBody, BodyIdx: i})
-	}
 	for i, c := range w.Crafts {
 		if c == nil || i == w.ActiveCraftIdx {
 			continue
 		}
 		cycle = append(cycle, Target{Kind: TargetCraft, CraftIdx: i})
+	}
+	for i := 1; i < len(w.System().Bodies); i++ {
+		cycle = append(cycle, Target{Kind: TargetBody, BodyIdx: i})
 	}
 	return cycle
 }

--- a/internal/sim/target_test.go
+++ b/internal/sim/target_test.go
@@ -68,9 +68,9 @@ func TestSetTargetCraftRejectsActiveAndOutOfRange(t *testing.T) {
 	}
 }
 
-// CycleTarget walks: None → body 1 → … → body n-1 → (no other crafts
-// in NewWorld's solo slate) → None. Verify forward pass lands at
-// every non-root body in order before wrapping.
+// CycleTarget walks: None → (no sibling crafts in NewWorld's solo
+// slate) → body 1 → … → body n-1 → None. Verify forward pass lands
+// at every non-root body in order before wrapping.
 func TestCycleTargetForwardWalksBodiesThenNone(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -113,9 +113,11 @@ func TestCycleTargetBackwardFromNoneLandsOnLastEntry(t *testing.T) {
 	}
 }
 
-// CycleTarget should include every non-active craft in the slate.
-// Spawn an alongside sister craft so the cycle has two entries to
-// walk through.
+// CycleTarget should include every non-active craft in the slate
+// AND visit them BEFORE any system body (the small list comes first
+// so spawn-then-target lands in one keypress on Sol's 19-body
+// catalog). Spawn an alongside sister craft and assert the very
+// first cycle from None is a TargetCraft entry.
 func TestCycleTargetIncludesSiblingCrafts(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -125,26 +127,12 @@ func TestCycleTargetIncludesSiblingCrafts(t *testing.T) {
 		t.Fatalf("SpawnCraft: %v", err)
 	}
 	// SpawnCraft makes the new craft active — original at idx 0,
-	// new at idx 1, ActiveCraftIdx==1. Cycle target until we hit a
-	// TargetCraft entry; assert it points at idx 0 (the only
-	// non-active sibling).
+	// new at idx 1, ActiveCraftIdx==1. First forward cycle from None
+	// must land on TargetCraft idx 0 (crafts before bodies).
 	w.ClearTarget()
-	saw := false
-	for i := 0; i < 200; i++ { // generous loop bound; cycle has ≪200 entries.
-		w.CycleTarget(true)
-		if w.Target.Kind == TargetCraft {
-			if w.Target.CraftIdx != 0 {
-				t.Errorf("TargetCraft idx: got %d, want 0 (the non-active sibling)", w.Target.CraftIdx)
-			}
-			saw = true
-			break
-		}
-		if w.Target.Kind == TargetNone && i > 0 {
-			break // wrapped without seeing TargetCraft → fail below
-		}
-	}
-	if !saw {
-		t.Errorf("CycleTarget never visited a TargetCraft entry — cycle missing sibling-craft branch")
+	w.CycleTarget(true)
+	if w.Target.Kind != TargetCraft || w.Target.CraftIdx != 0 {
+		t.Errorf("first CycleTarget after spawn: got %+v, want {TargetCraft, 0} (crafts must come before bodies)", w.Target)
 	}
 }
 


### PR DESCRIPTION
## Summary

Hotfix for v0.9.0. The originally-planned cycle order (bodies →
crafts → None) is unworkable on Sol: the body catalog has 19 entries,
so spawning a sister craft and pressing \`t\` once landed on Mercury,
not the craft. The player had to press \`t\` 19 times to reach the
only entry they cared about.

Reorders to: **None → non-active crafts → bodies → repeat**. Single
\`t\` press now lands on the first sibling craft when one exists.
Bodies still cycle (just after crafts).

- \`internal/sim/target.go\`: \`targetCycle\` builds craft entries before body
  entries; \`CycleTarget\` docstring updated.
- \`internal/sim/target_test.go\`: \`TestCycleTargetIncludesSiblingCrafts\`
  tightened to assert \"first forward cycle from None is TargetCraft idx 0\"
  — locks in the new order. Other tests unchanged (NewWorld has one
  craft, so the bodies-only walk in \`TestCycleTargetForwardWalksBodiesThenNone\`
  still holds).
- \`docs/v0.9-plan.md\`: \"Cycle order\" line documents the revision +
  rationale (Sol's 19-body catalog).

## Test plan

- [x] \`go test ./internal/sim/...\` (CI)
- [x] Spawn alongside craft, press \`t\` once, land on the craft

🤖 Generated with [Claude Code](https://claude.com/claude-code)