### PR TITLE
docs(v0.9-plan): add position-relative target burn modes to v0.9.3

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -31,7 +31,7 @@ follow-ups trail.
 | v0.9.0 | shipped  | v0.9.0    | Targeting refactor: unified `World.Target` slot (kind ∈ {None, Body, Craft}), replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD; `H` / `I` planters consume the slot. Landed at ~280 production + ~200 tests (under the ~500 LOC estimate — no rendering snowball). |
 | v0.9.1 | planned  | —         | Staging chain: KSP-style player-managed sequential decouples. `Spacecraft.Stages []Stage`; jettisoned stages spawn as passive cycle-able craft. Save schema v5→v6. |
 | v0.9.2 | planned  | —         | Ground launch: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `circularize-from-pad` mission predicate. Reuses v0.8.4 atmosphere + surface clamp. |
-| v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): `BurnTargetPrograde`/`BurnTargetRetrograde` SAS modes, `NextClosestApproach` with live time + distance countdown in TARGET HUD. `PlanRendezvous` auto-plant is a stretch within the slice. |
+| v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): four target-relative SAS modes — `BurnTargetPrograde`/`BurnTargetRetrograde` (velocity-relative, close / open v_rel) and `BurnTarget`/`BurnAntiTarget` (position-relative, proximity-ops nudges). `NextClosestApproach` with live time + distance countdown in TARGET HUD. `PlanRendezvous` auto-plant is a stretch within the slice. |
 | v0.9.4+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.3 land + at least one of these. |
 
 ---
@@ -338,20 +338,33 @@ manual; no node planting required.
 
 **Code surface (manual loop — the gating work).**
 
-- `internal/spacecraft/thrust.go` — extend `BurnMode` enum:
+- `internal/spacecraft/thrust.go` — extend `BurnMode` enum with two
+  pairs (KSP SAS naming):
 
   ```go
   const (
       // ...existing six modes
-      BurnTargetPrograde
-      BurnTargetRetrograde
+
+      // Velocity-relative (close / open relative velocity). The
+      // primary tool for the manual rendezvous loop — close v_rel
+      // on approach, null at closest approach.
+      BurnTargetPrograde   // direction: (v_target − v_active).Unit()
+      BurnTargetRetrograde // direction: (v_active − v_target).Unit()
+
+      // Position-relative (push toward / away from target's
+      // current position). Useful for sub-m/s proximity-ops nudges
+      // after v_rel is nulled — drift in, fine-tune docking offset.
+      BurnTarget     // direction: (r_target − r_active).Unit()
+      BurnAntiTarget // direction: (r_active − r_target).Unit()
   )
   ```
 
-  Direction unit vector along `v_active − v_target` (retrograde)
-  or `v_target − v_active` (prograde). SAS holds these the same
-  way it holds today's prograde / retrograde. Modes degrade to
-  no-op when `World.Target.Kind != TargetCraft`.
+  All four SAS-hold the same way today's prograde / retrograde
+  hold. All four degrade to no-op when `World.Target.Kind !=
+  TargetCraft` (body targets reuse `H` / `I`; position-relative on
+  a body would just be radial-out / radial-in toward the body
+  centre, which the existing `BurnRadialOut` / `BurnRadialIn`
+  already cover relative to the active craft's primary).
 - `internal/planner/rendezvous.go` (new) —
 
   ```go
@@ -401,9 +414,11 @@ manual; no node planting required.
 - v0.6.2 `planner.IterateForTarget` (auto-plant convergence).
 - Predictor segment cache.
 
-**Estimate.** ~350 LOC for the manual loop alone; ~500 with
-auto-plant. **Apply 2× heuristic** (planner UX + HUD): plan ~700
-for the full slice, ~500 if scoped to manual-only.
+**Estimate.** ~400 LOC for the manual loop (was ~350 — +~50 for the
+position-relative SAS pair: two enum values, two direction-vector
+branches in `thrust.go`, two SAS-hold paths); ~550 with auto-plant.
+**Apply 2× heuristic** (planner UX + HUD): plan ~800 for the full
+slice, ~600 if scoped to manual-only.
 
 ---
 


### PR DESCRIPTION
## Summary

KSP exposes four target-relative SAS modes; the original v0.9.3 spec only committed the velocity-relative pair. Adds the position-relative pair so the manual-rendezvous slice covers all four:

- \`BurnTargetPrograde\` / \`BurnTargetRetrograde\` — velocity-relative; close / open \`v_rel\`. (Already in plan.)
- \`BurnTarget\` / \`BurnAntiTarget\` — **new**; position-relative; push toward / away from target's current position. Useful for sub-m/s proximity-ops nudges after \`v_rel\` is nulled.

Estimate bumped 350→400 (manual loop) / 700→800 (full slice) to absorb the extra pair.

## Test plan

- [x] Doc-only change; CI go-test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)