### PR TITLE
docs(v0.9-plan): m-form integration + closest-approach trigger in v0.9.3

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -31,7 +31,7 @@ follow-ups trail.
 | v0.9.0 | shipped  | v0.9.0    | Targeting refactor: unified `World.Target` slot (kind ∈ {None, Body, Craft}), replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD; `H` / `I` planters consume the slot. Landed at ~280 production + ~200 tests (under the ~500 LOC estimate — no rendering snowball). |
 | v0.9.1 | planned  | —         | Staging chain: KSP-style player-managed sequential decouples. `Spacecraft.Stages []Stage`; jettisoned stages spawn as passive cycle-able craft. Save schema v5→v6. |
 | v0.9.2 | planned  | —         | Ground launch: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `circularize-from-pad` mission predicate. Reuses v0.8.4 atmosphere + surface clamp. |
-| v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): four target-relative SAS modes — `BurnTargetPrograde`/`BurnTargetRetrograde` (velocity-relative, close / open v_rel) and `BurnTarget`/`BurnAntiTarget` (position-relative, proximity-ops nudges). `NextClosestApproach` with live time + distance countdown in TARGET HUD. `PlanRendezvous` auto-plant is a stretch within the slice. |
+| v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): four target-relative SAS modes — `BurnTargetPrograde`/`BurnTargetRetrograde` (velocity-relative, close / open v_rel) and `BurnTarget`/`BurnAntiTarget` (position-relative, proximity-ops nudges). `NextClosestApproach` with live time + distance countdown in TARGET HUD. **`m` planner form integration** — all four modes selectable + new `next closest approach` fire-at trigger event so KSP-style "burn X Δv target-retrograde at nearest approach" works as a single planted node. `PlanRendezvous` auto-plant is a stretch within the slice. |
 | v0.9.4+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.3 land + at least one of these. |
 
 ---
@@ -336,6 +336,15 @@ countdown shrink in real time. At intercept they flip SAS to
 `BurnTargetRetrograde` and null v_rel. Approach + null-out is fully
 manual; no node planting required.
 
+**Secondary metric (planted-node workflow).** The manual SAS loop
+above is the gating work, but the same primitives expose to the
+`m` planner form: the player picks any of the four target-relative
+modes, picks `next closest approach` as the fire-at trigger, sets a
+Δv, and the node fires at the encounter with the target-relative
+direction resolved at fire-time. KSP-style "burn 3.4 m/s target-
+retrograde at nearest approach" works as a single planted node,
+not a real-time stick exercise.
+
 **Code surface (manual loop — the gating work).**
 
 - `internal/spacecraft/thrust.go` — extend `BurnMode` enum with two
@@ -391,6 +400,53 @@ manual; no node planting required.
   - "DOCK READY" indicator (range < 50 m + |v_rel| < 0.1 m/s —
     gates on v0.8.3 `DockCrafts`).
 
+**Code surface (`m` planner-form integration).**
+
+The four target-relative modes and a new `next closest approach`
+trigger event also expose through the existing maneuver planner so
+the player can plant a deferred-fire node like KSP's "burn 3.4 m/s
+target-retrograde at nearest approach":
+
+- **Mode field cycle** (`internal/tui/screens/maneuver.go`): the
+  four `BurnTarget*` modes appear after the existing six in the
+  `←`/`→`-cycled mode list. When `World.Target.Kind != TargetCraft`
+  these entries skip in cycle (or render greyed with a "needs
+  craft target" footer flash) — they have no defined direction
+  vector without a craft target.
+- **Fire-at field cycle**: extend the existing trigger-event list
+  (`absolute T+ / next peri / next apo / next AN / next DN`) with
+  one entry — `next closest approach`. Available only when both
+  the active craft and target craft share resolvable orbital
+  states (any kind of target degrades to "needs craft target"
+  flash if picked without a craft target slotted).
+- **Trigger-event resolver** (`internal/planner/triggers.go`):
+  `next closest approach` resolves lazily on the first tick after
+  plant by calling `NextClosestApproach(activeState, targetState,
+  primary, mu, horizon)`. Resolves to absolute T+ once for the
+  node's lifetime — same lazy-freeze semantics as the existing
+  AN/DN events. Re-resolution after replan is a v0.9.4+
+  consideration.
+- **Direction resolution at fire**: target-relative modes look up
+  `World.Target` + active-craft state at burn-trigger time (not
+  plant time), so if either craft maneuvers between plant and
+  fire the burn still points the correct direction. The node
+  carries `TargetCraftIdx` captured at plant so a target switch
+  doesn't silently retarget the planted burn — the node remains
+  bound to the craft the player aimed it at. If the target craft
+  is gone at fire (undocked + recombined, or save loaded without
+  it), the node degrades to no-op + status-flash.
+- **PROJECTED ORBIT preview**: target-relative modes resolve a
+  direction the same way at preview time as at fire time, so the
+  `m` form's live apo / peri / AN / inclination readout works for
+  these nodes too — assuming the target's predicted state is
+  cached (it is, for `NextClosestApproach`).
+- **Save round-trip**: `ManeuverNode` extends with
+  `TargetCraftIdx int` (`omitempty`, only populated for the four
+  target-relative modes). v5 schema absorbs additively. Load-time
+  validation: if `TargetCraftIdx` references a now-missing craft,
+  the node loads with a flagged-stale state (still in the slate
+  for the player to delete or repoint, just doesn't fire).
+
 **Code surface (auto-plant — stretch).**
 
 - `PlanRendezvous(active, target, primary, mu) []ManeuverNode` —
@@ -414,11 +470,17 @@ manual; no node planting required.
 - v0.6.2 `planner.IterateForTarget` (auto-plant convergence).
 - Predictor segment cache.
 
-**Estimate.** ~400 LOC for the manual loop (was ~350 — +~50 for the
-position-relative SAS pair: two enum values, two direction-vector
-branches in `thrust.go`, two SAS-hold paths); ~550 with auto-plant.
-**Apply 2× heuristic** (planner UX + HUD): plan ~800 for the full
-slice, ~600 if scoped to manual-only.
+**Estimate.** ~600 LOC for the manual loop (was ~400 — +~200 for the
+`m` planner-form integration: mode-field cycle entries, new fire-at
+trigger event with lazy `NextClosestApproach` resolve, direction
+resolution at fire-time, PROJECTED ORBIT preview, `ManeuverNode.TargetCraftIdx`
++ save round-trip + stale-target load handling); ~750 with auto-plant.
+**Apply 2× heuristic** (planner UX + HUD): plan ~1000 for the full
+slice, ~800 if scoped to manual-only. v0.9.3 is now the largest slice
+in the cycle — competitive with v0.9.1 staging on LOC. If bandwidth
+gets tight, the `m` form integration is the natural split point —
+ship the manual SAS loop first as v0.9.3, lift the planted-node
+integration to v0.9.3.1 / v0.9.4 as a follow-up.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the planted-node workflow to v0.9.3 alongside the manual SAS loop. KSP-style \"burn 3.4 m/s target-retrograde at nearest approach\" becomes a single planted node.

**New code surface (m planner-form integration):**
- Mode field cycle: four \`BurnTarget*\` modes appear after the existing six. Skip when target isn't a craft.
- Fire-at field cycle: new \`next closest approach\` trigger event. Lazy-resolves via \`NextClosestApproach\` on first tick post-plant.
- Direction resolution at fire-time (not plant-time) so target-relative direction stays correct if either craft maneuvers between plant and fire.
- \`ManeuverNode.TargetCraftIdx\` captures target at plant — target-switch doesn't silently retarget. Stale-target load → flagged-stale, no-op + status flash, still in slate.
- PROJECTED ORBIT preview works for target-relative nodes.
- Save: additive to v5 schema.

**Sizing impact:** manual loop 400→600 LOC, full slice 800→1000 (with auto-plant). v0.9.3 now competitive with v0.9.1 staging. Natural split point if bandwidth tightens — manual SAS loop ships as v0.9.3, planted-node integration lifts to v0.9.3.1 / v0.9.4.

## Test plan

- [x] Doc-only change; CI go-test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)