### PR TITLE
docs(v0.9-plan): commit v0.9.4 navball as a fifth slice

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -4,25 +4,32 @@
 
 `docs/state-of-game.md` §"Upcoming — v0.9 cycle plans" framed v0.9
 as eleven candidate slices in priority order. This doc narrows that
-menu to a committed cycle anchored on four slices the player can
-exercise as one continuous workflow:
+menu to a committed cycle anchored on **four workflow slices** the
+player can exercise as one continuous workflow plus **one operational-
+support slice** (a navball) that lands once the workflow primitives
+exist for it to display.
+
+Workflow:
 
 > Roll a launch vehicle to the pad, fly it to LEO through staged
 > ascent, target another craft already on orbit, fly to a manual
 > rendezvous, dock.
 
-That workflow forces the cycle's headline: **staging, ground launch,
-targeting, rendezvous**. Mission scripting defers entirely to v0.10
-with the open eight-decision-point design pass intact (the rolled-
-back v0.8.7 attempt is reference, not starting point). Cross-SOI
-`PlanTransfer` and combined plane-shift + Hohmann remain L-tier
-backlog — they're real work, just not in this cycle's path.
+That forces the cycle's headline: **staging, ground launch,
+targeting, rendezvous**. The navball (.4) lands after rendezvous so
+it has the full set of target-relative direction vectors to display.
+Mission scripting defers entirely to v0.10 with the open eight-
+decision-point design pass intact (the rolled-back v0.8.7 attempt
+is reference, not starting point). Cross-SOI `PlanTransfer` and
+combined plane-shift + Hohmann remain L-tier backlog — they're real
+work, just not in this cycle's path.
 
 Slice ordering threads targeting first (small refactor that the
 later slices consume), then staging (the largest), then ground
 launch (chains on staging), then rendezvous (consumes targeting,
-benefits from a richer post-staging fleet). Bandwidth-permitting
-follow-ups trail.
+benefits from a richer post-staging fleet), then navball (consumes
+all the burn-mode direction vectors the prior slices land).
+Bandwidth-permitting follow-ups trail in v0.9.5+.
 
 ## Status
 
@@ -32,7 +39,8 @@ follow-ups trail.
 | v0.9.1 | planned  | —         | Staging chain: KSP-style player-managed sequential decouples. `Spacecraft.Stages []Stage`; jettisoned stages spawn as passive cycle-able craft. Save schema v5→v6. |
 | v0.9.2 | planned  | —         | Ground launch: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `circularize-from-pad` mission predicate. Reuses v0.8.4 atmosphere + surface clamp. |
 | v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): four target-relative SAS modes — `BurnTargetPrograde`/`BurnTargetRetrograde` (velocity-relative, close / open v_rel) and `BurnTarget`/`BurnAntiTarget` (position-relative, proximity-ops nudges). `NextClosestApproach` with live time + distance countdown in TARGET HUD. **`m` planner form integration** — all four modes selectable + new `next closest approach` fire-at trigger event so KSP-style "burn X Δv target-retrograde at nearest approach" works as a single planted node. `PlanRendezvous` auto-plant is a stretch within the slice. |
-| v0.9.4+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.3 land + at least one of these. |
+| v0.9.4 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). Mode toggle (`;`) cycles orbit / target / surface frames. Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
+| v0.9.5+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.4 land + at least one of these (or just .0–.4 if bandwidth tightens). |
 
 ---
 
@@ -70,7 +78,7 @@ Settled before writing this plan:
    nulls v_rel at intercept with `BurnTargetRetrograde`. The
    `PlanRendezvous` auto-plant is a stretch goal within the slice;
    if it slips, the manual loop ships and auto-plant becomes a
-   v0.9.4+ candidate.
+   v0.9.5+ candidate.
 6. **Targeting concept.** Unified `World.Target` slot (kind ∈ {None,
    Body, Craft}, with site reserved for future). One concept replaces
    today's implicit body cursor and absorbs the rendezvous-introduced
@@ -85,11 +93,12 @@ Settled before writing this plan:
 8. **Cross-SOI `PlanTransfer` and plane-shift + Hohmann remain
    backlog.** Both are L-tier and explicitly out of scope for v0.9.
 9. **Cadence.** Foundation-first: targeting → staging → launch →
-   rendezvous. Targeting first because subsequent slices consume the
-   slot; staging before launch because the launch vehicle is multi-
-   stage; rendezvous last because it benefits from the richer
-   post-staging fleet (manual loop tests against a recently
-   jettisoned stage are the cheap success-metric scenario).
+   rendezvous → navball. Targeting first because subsequent slices
+   consume the slot; staging before launch because the launch
+   vehicle is multi-stage; rendezvous before navball because the
+   navball's target-frame markers consume the v0.9.3 target-relative
+   `BurnMode` directions; navball last so the surface-frame branch
+   has v0.9.2 ground-launch primitives to display.
 10. **v0.8.7 stays vacant.** Per the pre-cycle checklist; the rolled-
     back attempt's tag is not reused.
 
@@ -424,7 +433,7 @@ target-retrograde at nearest approach":
   plant by calling `NextClosestApproach(activeState, targetState,
   primary, mu, horizon)`. Resolves to absolute T+ once for the
   node's lifetime — same lazy-freeze semantics as the existing
-  AN/DN events. Re-resolution after replan is a v0.9.4+
+  AN/DN events. Re-resolution after replan is a v0.9.5+
   consideration.
 - **Direction resolution at fire**: target-relative modes look up
   `World.Target` + active-craft state at burn-trigger time (not
@@ -461,7 +470,7 @@ target-retrograde at nearest approach":
   TargetCraft`. Today's `R` re-Lamberts to body — disambiguate
   via target kind.
 - If this slips, manual loop still ships; auto-plant becomes a
-  v0.9.4+ candidate.
+  v0.9.5+ candidate.
 
 **Reused.**
 
@@ -484,11 +493,155 @@ integration to v0.9.3.1 / v0.9.4 as a follow-up.
 
 ---
 
-### v0.9.4+ — bandwidth-permitting (uncommitted)
+### v0.9.4 — navball
+
+KSP-style attitude indicator clamped into the bottom-right HUD. A
+small circular region renders a sphere with attitude markers
+projected onto it; the markers reflect the active craft's nose
+direction relative to a chosen frame (orbit / target / surface).
+Players reach for it on muscle memory, and right now nothing in
+the HUD shows where the craft is pointing in a body-frame /
+velocity-frame / target-frame view.
+
+**Why this slot.** v0.9.3 lands all four target-relative burn
+modes; the navball needs each of those direction vectors to render
+its target-mode markers. Building before .3 would force a re-pass
+once the modes existed. The "operational support" framing keeps
+.0–.3 as the workflow and .4 as the indicator that lights up once
+the workflow primitives exist.
+
+**Code surface (renderer reuse).**
+
+The body-rendering pipeline (`render.SubObserverPointDeg` +
+per-pixel sphere texture, shipped v0.8.5) is the right shape for
+the navball: a unit sphere, a sub-observer point driven by craft
+attitude instead of camera direction, a "texture" that paints the
+horizon hemisphere split + the lat/lon grid + marker glyphs at
+fixed body-frame positions.
+
+- `internal/render/navball.go` (new) — entry point.
+  `RenderNavball(canvas, region, craft, frame, target)` paints
+  the navball into the supplied terminal region. Reuses
+  `SubObserverPointDeg` to compute which face of the unit sphere
+  the player sees; reuses the existing per-pixel disk shader to
+  fill the circle with horizon-hemisphere colour + grid lines +
+  marker overlays.
+- The "horizon" is the local horizontal plane: in orbit frame,
+  perpendicular to the radial-from-primary vector; in target
+  frame, perpendicular to the line to target; in surface frame
+  (v0.9.2 ground-launch), the actual surface tangent plane.
+  Northern hemisphere fills with a "sky" tint, southern with a
+  "ground" tint — per KSP convention even in space.
+- Lat/lon grid: 8 meridians × 8 parallels, dimmed on the back
+  hemisphere (Z < 0 in the navball's view-from-craft frame) and
+  rendered solid on the front. Cardinal headings (N, E, S, W in
+  surface frame; or 0/90/180/270 in orbit frame) labelled at the
+  equator front quadrant.
+
+**Code surface (markers).**
+
+Each marker is a glyph plotted at a unit-direction projected onto
+the sphere. Behind the sphere → dimmed; in front → solid; on the
+limb → bracketed glyph (`(▲)`).
+
+- `internal/render/navball_markers.go` (new) —
+  `MarkerSet(world, craft, frame)` returns a `[]Marker` with each
+  marker's body-frame unit direction + glyph + colour for the
+  current frame. Frame switch toggles which markers are present:
+  - **Orbit frame** — prograde / retrograde / normal+ / normal- /
+    radial+ / radial- (the existing six `BurnMode` directions
+    relative to the craft's heliocentric or primary-frame orbit).
+  - **Target frame** — target-prograde / target-retrograde /
+    target / anti-target (the four v0.9.3 modes). Hidden when
+    `World.Target.Kind != TargetCraft`.
+  - **Surface frame** — N/E/S/W cardinal ticks (only meaningful
+    after v0.9.2 ground launch lands; for orbiting craft this
+    frame greys out and falls back to orbit).
+  - **Maneuver-node marker** — when a planted node exists, the
+    node's burn direction unit vector renders as a node-coloured
+    glyph that sweeps across the sphere as the craft rotates
+    toward burn alignment. (Reuses the per-leg trajectory
+    palette so the marker matches the predicted-orbit leg.)
+- Glyphs (mirroring KSP's symbols): `⊕` prograde, `⊖` retrograde,
+  `△` normal+, `▽` normal-, `◇` radial+ / radial-, `◈` target,
+  `◉` anti-target. Final glyph picks during slice — ANSI fallback
+  for terminals without unicode coverage TBD.
+
+**Code surface (frame derivation).**
+
+- `internal/sim/frame.go` (new or extended) —
+  `BurnDirection(world, craft, mode) orbital.Vec3`: returns the
+  unit direction for any `BurnMode` given the active craft's
+  state and `World.Target`. Single source of truth for both the
+  navball renderer and the existing SAS-hold path. Replaces the
+  current direction-vector logic scattered across `thrust.go`
+  consumers (refactor lift, not new logic — the v0.9.3 work
+  introduces the four target-relative modes, this slice
+  consolidates the lookup).
+
+**Code surface (HUD layout + mode toggle).**
+
+- `internal/tui/screens/orbit.go` — clamp a fixed-size navball
+  region (e.g. 12×12 chars) into the bottom-right HUD column.
+  Layout reflows the existing TARGET / RENDEZVOUS blocks above
+  the navball so nothing collides. Hidden when terminal width is
+  under a threshold (graceful fallback for narrow windows).
+- `cmd/terminal-space-program/keys.go` — `;` cycles navball
+  frame: orbit → target → surface → orbit. Surface entry skipped
+  when the active craft is in flight (no surface tangent
+  defined). Setting persists in `World.NavballFrame` and round-
+  trips through save (additive, no schema bump).
+- `internal/tui/input.go` — `CycleNavballFrame key.Binding` on
+  `;`, with `key.WithHelp(";", "cycle navball frame")`.
+
+**Reused.**
+
+- v0.8.5 `render.SubObserverPointDeg` + per-pixel sphere texture
+  pipeline — the projection math is already solved.
+- v0.6.1 per-leg trajectory palette (for the maneuver-node
+  marker on the ball).
+- v0.9.0 `World.Target` for the target-frame branch.
+- v0.9.3 target-relative `BurnMode` enum entries.
+- v0.7.3 `Spacecraft.Throttle` + `World.AttitudeMode` (already
+  the source of truth for craft pointing).
+
+**Estimate.**
+
+Surface estimate ~250 LOC (navball renderer + marker set + frame
+derivation + HUD clamp + mode toggle + key binding). **Apply 3×
+rendering-snowball heuristic** per the v0.8.5 / v0.8.6 retro-
+spectives — slices that touch rendering AND frame conventions
+consistently overshoot. Plan ~750 actual.
+
+If the body-rendering reuse holds cleanly, this could land closer
+to ~400. If the existing texture pipeline doesn't bend to a
+"render in the craft's body frame instead of the camera frame"
+shape, this slice grows — flag the renderer reuse as the slice's
+single biggest sizing risk and validate it as a spike before
+committing the full slice.
+
+**Open scoping questions (settle during slice planning).**
+
+- **Sphere size.** 12×12 chars (= 24×48 braille pixels) is a
+  starting bid; readability depends on glyph crowding. Final
+  size picked during a render spike.
+- **Mode switch in target frame when target is None.** Today's
+  bid: cycle skips target frame when no craft target is set.
+  Alternative: target-frame entries grey out instead of skipping.
+  Pick during slice playtest.
+- **Horizon hemisphere colours.** KSP uses a sky-blue / ground-
+  brown split. In space + terminal palette, the choice is open;
+  recommend matching the existing UI tier colours (`alert` for
+  one half, `dim` for the other) so theme overlays affect it.
+
+---
+
+### v0.9.5+ — bandwidth-permitting (uncommitted)
 
 Listed in priority order. Picked in priority order, not parallel;
-cycle ends when v0.9.0–.3 land + at least one of these. **Not
-committed slices.** Each gets its own scoping pass at pick time.
+cycle ends when v0.9.0–.4 land + at least one of these (or just
+.0–.4 if bandwidth tightens). **Not committed slices.** Each gets
+its own scoping pass at pick time.
 
 | Slice | Tier | Notes |
 |---|---|---|
@@ -534,8 +687,9 @@ graph LR
   S --> L[v0.9.2 Ground launch<br/>pad → orbit]
   T --> R[v0.9.3 Rendezvous<br/>manual-first]
   S -.benefits.-> R
-  L --> POLISH[v0.9.4+ secondary<br/>multi-rev porkchop, capture-dir,<br/>adaptive sampling, lighting, polish]
-  R --> POLISH
+  R --> N[v0.9.4 Navball<br/>artificial horizon + frame markers]
+  L -.surface-frame.-> N
+  N --> POLISH[v0.9.5+ secondary<br/>multi-rev porkchop, capture-dir,<br/>adaptive sampling, lighting, polish]
 ```
 
 Targeting first because subsequent slices consume the slot
@@ -545,13 +699,17 @@ consumes the targeting slot and benefits from a richer post-
 staging fleet (the cheap success-metric scenario is "rendezvous
 with the stage I just jettisoned"), but does not strictly depend
 on staging — the slice could ship before .1 / .2 if cycle order
-shifts.
+shifts. Navball lands after rendezvous so its target-frame
+markers have all four target-relative `BurnMode` directions to
+display; the surface-frame branch lights up retroactively once
+the v0.9.2 ground-launch primitives exist.
 
 **Suggested cadence.** Targeting (.0) ships first as foundation.
 Staging (.1) is the heaviest slice and lands next. Launch (.2)
 chains immediately on staging. Rendezvous (.3) closes the
-headline. Bandwidth-permitting picks (.4+) trail in priority
-order, one at a time.
+workflow headline. Navball (.4) lands once the burn-mode
+direction vectors are all in place. Bandwidth-permitting picks
+(.5+) trail in priority order, one at a time.
 
 ---
 
@@ -570,7 +728,7 @@ and the v0.8 retrospective; not in v0.9:
 - **N-body perturbations.** Indefinite.
 - **Multi-system spacecraft.** Indefinite.
 - **Solar lighting + terminator + eclipses.** Research-first; may
-  pick into v0.9.4+ if cycle bandwidth allows, otherwise v0.10.
+  pick into v0.9.5+ if cycle bandwidth allows, otherwise v0.10.
 - **Predictor adaptive sampling.** Three-cycle carry-over; same
   pickup conditions.
 - **Theme-file hot-reload, `bodies.json` sibling overlay,
@@ -580,7 +738,7 @@ and the v0.8 retrospective; not in v0.9:
   remains.
 - **Atmospheric heating, aerodynamic shape modelling.**
   Indefinite.
-- **Numbered craft slots (`1`–`9`).** Picks into v0.9.4+ polish
+- **Numbered craft slots (`1`–`9`).** Picks into v0.9.5+ polish
   bag if fleet grows past 4 craft routinely.
 
 ---
@@ -595,10 +753,10 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
   other-planet). Deferred from v0.8 boundary; remains backlog.
 - **Combined plane-shift + Hohmann.** Substantial; remains
   backlog.
-- **Capture-direction toggle.** Picks into v0.9.4+.
-- **Predictor adaptive sampling.** Picks into v0.9.4+.
+- **Capture-direction toggle.** Picks into v0.9.5+.
+- **Predictor adaptive sampling.** Picks into v0.9.5+.
 - **Solar lighting + terminator + eclipses.** Research-first;
-  picks into v0.9.4+ or v0.10.
+  picks into v0.9.5+ or v0.10.
 - **RCS budget for docking** (v0.8.3 carryover). Reopen tuning
   once the manual rendezvous loop in v0.9.3 generates real usage
   data.
@@ -610,7 +768,7 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
 - **Theme-file hot-reload, `bodies.json` sibling overlay** —
   modding-cycle items.
 - **Multi-rev porkchop / Lambert short-long branch** — picks into
-  v0.9.4+.
+  v0.9.5+.
 
 **Newly opened from v0.9 scoping**
 
@@ -628,7 +786,7 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
   #7); reopen if playtest exposes friction.
 - **`PlanRendezvous` auto-plant scope.** v0.9.3 ships manual loop
   as the gate; auto-plant is a stretch within the slice. If it
-  slips, becomes a v0.9.4+ candidate.
+  slips, becomes a v0.9.5+ candidate.
 - **Composite-craft engine when stages dock** (extension of #4).
   v0.9.1 picks sum-thrust / mass-weighted-Isp; reopen if the
   rule reads wrong when a stage docks onto a partner with a


### PR DESCRIPTION
## Summary

Promotes the KSP-style navball from \"could be a v0.9.4+ pick\" to a committed slice. Bandwidth-permitting bucket shifts to v0.9.5+.

**Why this slot:**
- v0.9.3 lands the four target-relative \`BurnMode\` directions the navball needs to render its target-mode markers. Building before .3 would force a re-pass.
- The body-rendering pipeline (\`SubObserverPointDeg\` + per-pixel sphere texture, v0.8.5) is the right shape — a unit sphere with craft-attitude sub-observer point and a horizon/grid/marker texture. Real reuse, not a stretch.
- Operational support: prograde/retrograde/normal±/radial± in orbit frame, target-prograde/retrograde/target/anti-target in target frame, N/E/S/W cardinals in surface frame (post-v0.9.2). Mode toggle on \`;\`.

**Sizing:** surface ~250 LOC; **apply 3× rendering-snowball heuristic** per v0.8.5 / v0.8.6 retrospectives → plan ~750 actual. Renderer reuse flagged as the biggest sizing risk — validate as a spike before committing the full slice.

**Plan changes:** new §v0.9.4 navball section (code surface, reused, estimate, three open scoping questions); status table extended; sequencing diagram + cadence updated; global v0.9.4+ → v0.9.5+ rename for the bandwidth-permitting references.

## Test plan

- [x] Doc-only change; CI go-test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)