### PR TITLE
v0.9.3 — rendezvous tooling (manual loop + KSP NavMode + m-form integration)

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -637,8 +637,39 @@ ellipse-ellipse intersection or sample-walking for local minima;
 deferred until 3a's eyeball-the-track approach proves insufficient.
 Re-evaluate post-merge based on subsequent rendezvous playtests.
 
-LOC for polish pass: ~80 production. No tests added (rendering
-changes are covered by the existing screen / canvas suites).
+##### Polish pass 2 (2026-05-06) — RENDEZVOUS block + per-craft target
+
+Two more friction items surfaced once the polish-1 commits hit the
+test box:
+
+4. **RENDEZVOUS HUD block was duplicative** of the v0.9.0 TARGET
+   block now that TARGET carries range / |v_rel| / closing / TCA /
+   CA / DOCK READY. Deleted the v0.8.3 RENDEZVOUS section + its
+   `findNearestSamePrimary` helper (sole caller). Player must bind
+   a target with `H` / `I` to see proximity-ops feedback now —
+   acceptable trade since the v0.9.0 cycle has trained binding.
+5. **Per-craft target binding.** Pre-polish, pressing `T` toggled
+   `World.Target`, a single shared slot — switching active craft
+   left the same target visible. Moved the `Target` / `TargetKind`
+   types from `internal/sim/target.go` to `internal/spacecraft/`
+   (so `Spacecraft` can carry a `Target` field directly), with
+   type aliases in `sim` to preserve the 75+ existing readers
+   (`w.Target.Kind == sim.TargetCraft` still compiles). Added
+   `World.SetActiveCraftIdx(idx)` that checkpoints `w.Target` onto
+   the outgoing craft + loads the incoming craft's stored Target;
+   replaced the 6 direct `ActiveCraftIdx =` assignments
+   (CycleActiveCraft, app.go editing handoff, docking Undock /
+   DockCrafts, spawn x3) with the helper. Save: per-craft Target
+   on the `save.Craft` wire record (additive, no schema bump);
+   payload-level Target stays on the load path for backwards-compat
+   (legacy saves migrate the singleton onto the active craft).
+
+LOC for polish pass: ~80 (pass 1) + ~270 (pass 2 — type move,
+sync helper, save migration, two new tests) = ~350 total.
+
+Carrying-over decision: NavMode stayed global. Per-craft NavMode
+is the natural follow-up if drift across switches becomes friction;
+captured for v0.9.5+ if needed but not promoted.
 
 ---
 

--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -606,6 +606,40 @@ Carrying-over decisions:
    manual rendezvous loop tests on already-orbiting craft (spawn
    at 600 km) so it doesn't depend on a working pad-to-LEO loop.
 
+##### Playtest qualified-signoff polish (2026-05-06)
+
+Manual rendezvous playtested end-to-end successfully (two LEO
+craft, target features used). User flagged three friction items;
+all three landed on the same branch as polish before merge:
+
+1. **Signed closing rate** in TARGET HUD. Existing `|v_rel|` row
+   was sign-blind, leaving the player to guess whether they were
+   faster or slower along-track than target. Added a `closing`
+   row computed as `-(r_rel · v_rel) / |r_rel|`; positive =
+   approaching, negative = receding. Required adding a `Dot`
+   method to `orbital.Vec3` (sat next to existing `Cross`).
+2. **Target apoapsis / periapsis** in the TARGET HUD craft block.
+   Reuses the active-vessel path (`ElementsFromStateInFrame` +
+   `Apoapsis()` / `Periapsis()` minus primary radius) — meaningful
+   in target's own primary frame regardless of cross-SOI.
+3. **Target orbit on main view + maneuver planner.** Main view
+   was already drawing all non-active craft; bumped the bound
+   target to a dedicated `render.ColorTarget` (vivid green,
+   matches DOCK READY callout) with denser sampling stride (3 vs
+   5) so it reads as the prominent track. Maneuver planner
+   canvas had no target rendering at all — added the target's
+   ellipse + glyph when target shares the active craft's
+   primary. Cross-primary targets skipped (canvas frame is wrong).
+
+Deferred to backlog: explicit "target-at-intersection" markers on
+crossing orbits (3b in playtest framing). Sized 200+ LOC for
+ellipse-ellipse intersection or sample-walking for local minima;
+deferred until 3a's eyeball-the-track approach proves insufficient.
+Re-evaluate post-merge based on subsequent rendezvous playtests.
+
+LOC for polish pass: ~80 production. No tests added (rendering
+changes are covered by the existing screen / canvas suites).
+
 ---
 
 ### v0.9.4 — navball

--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -38,8 +38,8 @@ Bandwidth-permitting follow-ups trail in v0.9.5+.
 | v0.9.0 | shipped  | v0.9.0    | Targeting refactor: unified `World.Target` slot (kind ∈ {None, Body, Craft}), replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD; `H` / `I` planters consume the slot. Landed at ~280 production + ~200 tests (under the ~500 LOC estimate — no rendering snowball). |
 | v0.9.1 | shipped  | v0.9.1    | Staging chain: KSP-style player-managed sequential decouples. `Spacecraft.Stages []Stage` source-of-truth; flat propulsion fields become derived shadow-mirror via `SyncFields`. Saturn-V 3-stage loadout (S-IC + S-II + S-IVB, TWR>1 sea level). `space` keystroke decouples bottom stage; jettisoned stages spawn as passive cycle-able craft. STAGES HUD block. Composite-craft post-docking concatenates Stages. Save schema v5→v6 with typed migration. ~500 production + ~300 tests = ~800 LOC; close to ~700 estimate. |
 | v0.9.2 | in flight (work-in-progress) | branch only | Ground launch primitives: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `saturn-v-pad-to-leo` mission, surface-frame SAS modes (`W` / `S`), pitch trim (`<` / `>` / `\`, 10° step), per-stage `BallisticCoefficient` for realistic Saturn V drag, Landed-state default SAS = radial+. **Branch is feature-complete but reaching orbit by hand is unreliable.** Manual ascent without a gravity-turn assist routinely undershoots; closing this is gated on a v0.9.5+ ergonomic pass. Slice ships unmerged (PR #51) until either the ergonomic pass lands or the user accepts the WIP state. |
-| v0.9.3 | planned  | —         | Rendezvous tooling (manual-first): four target-relative SAS modes — `BurnTargetPrograde`/`BurnTargetRetrograde` (velocity-relative, close / open v_rel) and `BurnTarget`/`BurnAntiTarget` (position-relative, proximity-ops nudges). `NextClosestApproach` with live time + distance countdown in TARGET HUD. **`m` planner form integration** — all four modes selectable + new `next closest approach` fire-at trigger event so KSP-style "burn X Δv target-retrograde at nearest approach" works as a single planted node. `PlanRendezvous` auto-plant is a stretch within the slice. |
-| v0.9.4 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). Mode toggle (`;`) cycles orbit / target / surface frames. Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
+| v0.9.3 | in flight (awaiting playtest) | branch only | Rendezvous tooling shipped on branch `v0.9.3-rendezvous` (commits `65fb268` core + `a481d6d` nav-mode cycle). All four target-relative SAS modes (`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` / `BurnAntiTarget`); `planner.NextClosestApproach` with live TCA / CA / DOCK READY readouts in TARGET HUD; `m` planner form integration (4 modes selectable + `next closest approach` trigger event + `ManeuverNode.TargetCraftIdx` captured-at-plant with save round-trip + stale-target no-op). **KSP-style `NavMode` cycle pulled forward from v0.9.4** — `;` rotates Orbit → Surface → Target (skipped when no craft target); the same `w` `s` `a` `d` `q` `e` axis keys reinterpret per mode (NavTarget: `w` `s` = TargetPrograde/Retrograde, `q` `e` = Target/AntiTarget). Auto-snap NavTarget → NavOrbit on target clear; persisted in save (omitempty). `PlanRendezvous` auto-plant deferred to v0.9.5+. Slice ships unmerged until manual rendezvous loop playtests end-to-end. |
+| v0.9.4 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). **Mode-cycle controls (`;`) and intent-vs-frame translation already landed in v0.9.3** — v0.9.4 is now scoped to the *visualization* (sphere render + projected markers + frame-aware overlay). Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
 | v0.9.5+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.4 land + at least one of these (or just .0–.4 if bandwidth tightens). |
 
 ---
@@ -552,6 +552,60 @@ gets tight, the `m` form integration is the natural split point —
 ship the manual SAS loop first as v0.9.3, lift the planted-node
 integration to v0.9.3.1 / v0.9.4 as a follow-up.
 
+#### v0.9.3 retrospective — awaiting playtest
+
+The slice landed all the planned manual-loop primitives + the `m`
+planner-form integration in one push, and pulled forward the KSP
+nav-mode cycle that was originally scoped for v0.9.4. **Shipped
+unmerged on `v0.9.3-rendezvous` (commits `65fb268` + `a481d6d`),
+gated on end-to-end manual rendezvous playtest signoff.**
+
+What landed (vs the plan above):
+
+- All four `BurnTarget*` modes, `WithTarget` thrust/RCS/burn-direction
+  variants, `World.TargetStateRelativeToActivePrimary` for cross-
+  primary frame conversion.
+- `planner.NextClosestApproach` (sample-and-walk over Verlet
+  predictions). `TriggerNextClosestApproach` event with the lazy-
+  freeze resolver pattern reused from AN/DN.
+- TARGET HUD craft block with TCA / CA / DOCK READY (range < 50 m
+  + |v_rel| < 0.1 m/s).
+- `m` form: 4 target-relative modes selectable when craft target is
+  bound; new `next closest approach` fire-at trigger; node
+  `TargetCraftIdx` captured at plant time (one-based for `omitempty`)
+  + save round-trip + stale-target silent no-op.
+- **KSP-style nav-mode cycle (pulled from v0.9.4 plan).** `;`
+  rotates Orbit → Surface → Target → Orbit; the same six SAS axis
+  keys reinterpret per mode. NavTarget skipped in cycle when no
+  craft target bound. Auto-snap to NavOrbit when target cleared.
+  `nav: ORBIT/SURFACE/TARGET` HUD row in ATTITUDE block. Saved
+  omitempty. Existing `W` / `S` shift-shortcuts kept as nav-mode
+  bypass.
+
+What's deferred:
+
+- `PlanRendezvous` auto-plant (`R` triggers it for craft targets) →
+  v0.9.5+ candidate. Manual loop + planted-node planner cover the
+  rendezvous workflow without it.
+- Visual navball (sphere render + projected markers) — still v0.9.4.
+  v0.9.3 ships the *controls*; v0.9.4 ships the *picture*.
+
+LOC: ~1050 production + tests (matches the ~1000 plan estimate
+including the m-form integration; nav-mode cycle was a small add on
+top of the existing primitives).
+
+Carrying-over decisions:
+
+1. Slice ships **unmerged** while manual rendezvous playtests. PR
+   not opened yet — branch is the canonical reference.
+2. v0.9.4 navball scope shrinks to visualization-only. The mode
+   cycle, intent-vs-frame translation, and target-frame rebinding
+   already shipped in v0.9.3, so v0.9.4 doesn't need to redesign
+   the input layer — it consumes `World.NavMode` directly.
+3. v0.9.2 ground-launch WIP carries unchanged into v0.9.3+ — the
+   manual rendezvous loop tests on already-orbiting craft (spawn
+   at 600 km) so it doesn't depend on a working pad-to-LEO loop.
+
 ---
 
 ### v0.9.4 — navball
@@ -647,13 +701,15 @@ limb → bracketed glyph (`(▲)`).
   Layout reflows the existing TARGET / RENDEZVOUS blocks above
   the navball so nothing collides. Hidden when terminal width is
   under a threshold (graceful fallback for narrow windows).
-- `cmd/terminal-space-program/keys.go` — `;` cycles navball
-  frame: orbit → target → surface → orbit. Surface entry skipped
-  when the active craft is in flight (no surface tangent
-  defined). Setting persists in `World.NavballFrame` and round-
-  trips through save (additive, no schema bump).
-- `internal/tui/input.go` — `CycleNavballFrame key.Binding` on
-  `;`, with `key.WithHelp(";", "cycle navball frame")`.
+- **Mode-cycle controls already shipped in v0.9.3.** `;` rotates
+  `sim.NavMode` through Orbit → Surface → Target (skipped when no
+  craft target bound), persisted in save as `nav_mode` (omitempty).
+  v0.9.4 consumes `World.NavMode` directly to pick which marker
+  set to render and which "horizon" plane to draw — no new key
+  binding or persistence work. Surface frame in the navball
+  context greys out when not on a launchpad / surface, even
+  though the SAS-side mapping still resolves orbit-frame normal/
+  radial.
 
 **Reused.**
 
@@ -668,11 +724,12 @@ limb → bracketed glyph (`(▲)`).
 
 **Estimate.**
 
-Surface estimate ~250 LOC (navball renderer + marker set + frame
-derivation + HUD clamp + mode toggle + key binding). **Apply 3×
-rendering-snowball heuristic** per the v0.8.5 / v0.8.6 retro-
-spectives — slices that touch rendering AND frame conventions
-consistently overshoot. Plan ~750 actual.
+Surface estimate ~225 LOC (navball renderer + marker set + frame
+derivation + HUD clamp; mode toggle + key binding shipped in v0.9.3
+so .4 doesn't pay for them). **Apply 3× rendering-snowball
+heuristic** per the v0.8.5 / v0.8.6 retrospectives — slices that
+touch rendering AND frame conventions consistently overshoot. Plan
+~700 actual.
 
 If the body-rendering reuse holds cleanly, this could land closer
 to ~400. If the existing texture pipeline doesn't bend to a
@@ -686,10 +743,11 @@ committing the full slice.
 - **Sphere size.** 12×12 chars (= 24×48 braille pixels) is a
   starting bid; readability depends on glyph crowding. Final
   size picked during a render spike.
-- **Mode switch in target frame when target is None.** Today's
-  bid: cycle skips target frame when no craft target is set.
-  Alternative: target-frame entries grey out instead of skipping.
-  Pick during slice playtest.
+- ~~**Mode switch in target frame when target is None.**~~
+  Settled by v0.9.3: `CycleNavMode` skips NavTarget when no
+  craft target is bound, and auto-snaps NavTarget → NavOrbit
+  when an existing target is cleared. v0.9.4 just renders
+  whatever frame `World.NavMode` reports.
 - **Horizon hemisphere colours.** KSP uses a sky-blue / ground-
   brown split. In space + terminal palette, the choice is open;
   recommend matching the existing UI tier colours (`alert` for

--- a/internal/orbital/frame.go
+++ b/internal/orbital/frame.go
@@ -30,6 +30,9 @@ func (a Vec3) Cross(b Vec3) Vec3 {
 	}
 }
 
+// Dot returns a · b.
+func (a Vec3) Dot(b Vec3) float64 { return a.X*b.X + a.Y*b.Y + a.Z*b.Z }
+
 // PerifocalToInertial converts perifocal (p, q, w) → inertial (X, Y, Z) via
 // the standard 3-1-3 Euler sequence (Ω, i, ω). Perifocal frame: p along
 // periapsis, q 90° ahead in the orbital plane, w = p × q.

--- a/internal/planner/rendezvous.go
+++ b/internal/planner/rendezvous.go
@@ -1,0 +1,97 @@
+package planner
+
+import (
+	"errors"
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// NextClosestApproach finds the next time-to-encounter between two
+// craft along their predicted segments. Both states must be in the
+// SAME frame (typically the active craft's primary-relative frame —
+// world.TargetStateRelativeToActivePrimary handles cross-primary
+// conversion before this is called). The function only handles
+// same-primary rendezvous; cross-SOI tooling is out of scope for
+// v0.9.3 (matches the slice's manual-loop scenario in LEO).
+//
+// Algorithm: forward-propagate both craft via Verlet at intervals of
+// roughly period/50 over `horizon` seconds, track minimum |rA - rB|,
+// return the time + distance + relative velocity at the minimum-
+// distance sample. No parabolic refinement — sample resolution is
+// sub-second-class for typical LEO horizons, plenty for the HUD
+// countdown which is recomputed each frame anyway.
+//
+// Returns:
+//   - t: seconds from now until closest approach (0 if "now").
+//   - dist: distance at closest approach (meters).
+//   - vRel: vA − vB at closest approach (m/s vector — magnitude is
+//     the |v_rel| HUD readout).
+//   - err: non-nil for invalid inputs (non-positive mu / horizon).
+//
+// v0.9.3+.
+func NextClosestApproach(
+	stateA, stateB orbital.Vec3State,
+	primary bodies.CelestialBody,
+	mu, horizon float64,
+) (t, dist float64, vRel orbital.Vec3, err error) {
+	_ = primary // captured in the signature for future cross-frame work
+	if horizon <= 0 {
+		return 0, 0, orbital.Vec3{}, errors.New("rendezvous: non-positive horizon")
+	}
+	if mu <= 0 {
+		return 0, 0, orbital.Vec3{}, errors.New("rendezvous: non-positive mu")
+	}
+
+	sA := physics.StateVector{R: stateA.R, V: stateA.V}
+	sB := physics.StateVector{R: stateB.R, V: stateB.V}
+
+	pA := orbitalPeriod(sA, mu)
+	pB := orbitalPeriod(sB, mu)
+	minPeriod := math.Min(pA, pB)
+	if math.IsInf(minPeriod, 0) || math.IsNaN(minPeriod) || minPeriod <= 0 {
+		minPeriod = horizon
+	}
+
+	// ~50 samples per orbit period, bounded.
+	nSamples := int(math.Ceil(horizon / (minPeriod / 50)))
+	if nSamples < 64 {
+		nSamples = 64
+	}
+	if nSamples > 2048 {
+		nSamples = 2048
+	}
+	dtSample := horizon / float64(nSamples)
+
+	// Verlet sub-step per period/200 for stability; clamp under dtSample.
+	subStep := minPeriod / 200
+	if subStep <= 0 || subStep > dtSample {
+		subStep = dtSample
+	}
+	nSub := int(math.Ceil(dtSample / subStep))
+	if nSub < 1 {
+		nSub = 1
+	}
+	dt := dtSample / float64(nSub)
+
+	minDist := sA.R.Sub(sB.R).Norm()
+	minT := 0.0
+	minVRel := sA.V.Sub(sB.V)
+
+	for i := 1; i <= nSamples; i++ {
+		for j := 0; j < nSub; j++ {
+			sA = physics.StepVerlet(sA, mu, dt)
+			sB = physics.StepVerlet(sB, mu, dt)
+		}
+		d := sA.R.Sub(sB.R).Norm()
+		if d < minDist {
+			minDist = d
+			minT = float64(i) * dtSample
+			minVRel = sA.V.Sub(sB.V)
+		}
+	}
+
+	return minT, minDist, minVRel, nil
+}

--- a/internal/planner/rendezvous_test.go
+++ b/internal/planner/rendezvous_test.go
@@ -1,0 +1,121 @@
+package planner
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// muEarth is reused from transfer_test.go (same package).
+
+// circularState builds a circular-orbit Vec3State at radius r with
+// the velocity rotated by `phaseRad` from the +X axis (so two craft
+// with different phases sit at different points on the same orbit).
+func circularState(r, phaseRad, mu float64) orbital.Vec3State {
+	cos, sin := math.Cos(phaseRad), math.Sin(phaseRad)
+	v := math.Sqrt(mu / r)
+	return orbital.Vec3State{
+		R: orbital.Vec3{X: r * cos, Y: r * sin},
+		V: orbital.Vec3{X: -v * sin, Y: v * cos},
+	}
+}
+
+// TestNextClosestApproachCoOrbital — two craft on the same circular
+// orbit, phase-offset 90°. Their separation is constant at r·√2;
+// closest approach distance ≈ that value, t≈0 (or anywhere — the
+// minimum is degenerate so we accept any t in [0, horizon]).
+func TestNextClosestApproachCoOrbital(t *testing.T) {
+	r := 6.771e6 // 400 km LEO
+	a := circularState(r, 0, muEarth)
+	b := circularState(r, math.Pi/2, muEarth)
+
+	tCA, dist, vRel, err := NextClosestApproach(a, b, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := r * math.Sqrt(2)
+	if math.Abs(dist-want)/want > 0.02 {
+		t.Errorf("co-orbital separation: dist=%.0f, want≈%.0f", dist, want)
+	}
+	// |v_rel| for two circular co-orbits at phase π/2 is √2·v_circ.
+	vCirc := math.Sqrt(muEarth / r)
+	gotVRel := vRel.Norm()
+	wantVRel := math.Sqrt(2) * vCirc
+	if math.Abs(gotVRel-wantVRel)/wantVRel > 0.05 {
+		t.Errorf("|v_rel|=%.1f, want≈%.1f", gotVRel, wantVRel)
+	}
+	if tCA < 0 || tCA > 6000 {
+		t.Errorf("t out of horizon: %v", tCA)
+	}
+}
+
+// TestNextClosestApproachIdenticalStatesIsZero — same state for both
+// craft → distance is 0 at t=0.
+func TestNextClosestApproachIdenticalStatesIsZero(t *testing.T) {
+	r := 6.771e6
+	s := circularState(r, 0, muEarth)
+	tCA, dist, _, err := NextClosestApproach(s, s, bodies.CelestialBody{}, muEarth, 3600)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if tCA != 0 {
+		t.Errorf("identical states: t=%v, want 0", tCA)
+	}
+	if dist > 1.0 {
+		t.Errorf("identical states: dist=%v, want ≈0", dist)
+	}
+}
+
+// TestNextClosestApproachCatchesUp — A trails B by a small phase
+// offset on the same orbit; A is given a slight prograde boost so
+// it catches up. NextClosestApproach should return a positive t with
+// dist near zero (intercept).
+//
+// 100 m/s prograde on a 400 km LEO drops semimajor axis a tiny bit
+// and shifts mean motion — the phase closes over multiple orbits.
+// Horizon: 4 hours, plenty for catch-up.
+func TestNextClosestApproachCatchesUp(t *testing.T) {
+	r := 6.771e6
+	// A at phase 0, B at phase +0.05 rad (≈340 km ahead).
+	a := circularState(r, 0, muEarth)
+	b := circularState(r, 0.05, muEarth)
+	// Boost A prograde by 5 m/s (small, so the orbit barely changes
+	// shape but mean motion shifts enough to close the phase gap).
+	progradeUnit := orbital.Vec3{X: a.V.X, Y: a.V.Y}
+	n := progradeUnit.Norm()
+	progradeUnit = progradeUnit.Scale(1 / n)
+	a.V = a.V.Add(progradeUnit.Scale(5))
+
+	_, dist, _, err := NextClosestApproach(a, b, bodies.CelestialBody{}, muEarth, 4*3600)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// Initial separation ≈ 339 km; expect closest approach to drop
+	// significantly below that as the phase closes.
+	if dist > 5e5 {
+		t.Errorf("catch-up: dist at closest approach %.0f m, expected to drop below 500 km", dist)
+	}
+}
+
+// TestNextClosestApproachInvalidHorizon — non-positive horizon → err.
+func TestNextClosestApproachInvalidHorizon(t *testing.T) {
+	r := 6.771e6
+	s := circularState(r, 0, muEarth)
+	if _, _, _, err := NextClosestApproach(s, s, bodies.CelestialBody{}, muEarth, 0); err == nil {
+		t.Error("zero horizon: expected err")
+	}
+	if _, _, _, err := NextClosestApproach(s, s, bodies.CelestialBody{}, muEarth, -100); err == nil {
+		t.Error("negative horizon: expected err")
+	}
+}
+
+// TestNextClosestApproachInvalidMu — non-positive mu → err.
+func TestNextClosestApproachInvalidMu(t *testing.T) {
+	r := 6.771e6
+	s := circularState(r, 0, muEarth)
+	if _, _, _, err := NextClosestApproach(s, s, bodies.CelestialBody{}, 0, 3600); err == nil {
+		t.Error("zero mu: expected err")
+	}
+}

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -27,6 +27,7 @@ var (
 	ColorForeignSOI   = lipgloss.Color("#D75FFF") // post-SOI-crossing trajectory segments
 	ColorDim          = lipgloss.Color("#5F5F5F") // background / inactive
 	ColorFlame        = lipgloss.Color("#FF8C42") // engine-firing flame trail (warm orange — distinct from craftmarker yellow)
+	ColorTarget       = lipgloss.Color("#3DDC84") // active TARGET craft + its orbit — vivid green, matches DOCK READY callout, distinct from craft yellow / current-orbit slate / planned-node cyan
 )
 
 // maneuverSegmentPalette cycles through distinct colors per planted

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -65,6 +65,7 @@ type Payload struct {
 	Paused         bool               `json:"paused"`
 	Focus          Focus              `json:"focus"`
 	Target         *Target            `json:"target,omitempty"` // v0.9.0+ unified target slot. nil pointer (zero/None) → omitted on the wire.
+	NavMode        int                `json:"nav_mode,omitempty"` // v0.9.3+ KSP-style SAS reference frame. NavOrbit=0 omitted; older saves load with NavOrbit.
 	Craft          *Craft             `json:"craft,omitempty"` // v1–v4 singular form; migrated to Crafts on load.
 	Crafts         []Craft            `json:"crafts,omitempty"`
 	ActiveCraftIdx int                `json:"active_craft_idx,omitempty"`
@@ -351,6 +352,10 @@ func payloadFromWorld(w *sim.World) Payload {
 			CraftIdx: w.Target.CraftIdx,
 		}
 	}
+	// v0.9.3+: persist NavMode. NavOrbit=0 round-trips as omitempty so
+	// pre-v0.9.3 saves (which never carried the field) load with the
+	// default-frame behaviour they were written under.
+	p.NavMode = int(w.NavMode)
 	// v0.8.1+: Crafts becomes the wire form. Each craft carries its
 	// own Nodes / ActiveBurn / AttitudeMode / EngineMode (per-craft
 	// burn state). Pre-v5 saves had these on the Payload; the load
@@ -493,6 +498,9 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			CraftIdx: p.Target.CraftIdx,
 		}
 	}
+	// v0.9.3+: restore NavMode. Absent field → zero → NavOrbit (the
+	// pre-v0.9.3 default frame).
+	w.NavMode = sim.NavMode(p.NavMode)
 	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
 
 	// v0.8.1+: load path translates the pre-v5 singular Craft field

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -204,6 +204,12 @@ type Node struct {
 	PrimaryID       string  `json:"primary_id"`
 	Event           int     `json:"event,omitempty"`
 	Throttle        float64 `json:"throttle,omitempty"`
+	// TargetCraftIdx (v0.9.3+) is the one-based slate idx the node
+	// is bound to for target-relative modes / TriggerNextClosest
+	// Approach event. Zero = no target. Additive — pre-v0.9.3 saves
+	// load with TargetCraftIdx=0, which is correct semantics for
+	// non-target nodes. No schema bump required.
+	TargetCraftIdx int `json:"target_craft_idx,omitempty"`
 }
 
 // DockedComponent mirrors spacecraft.DockedComponent. v0.8.3+.
@@ -232,6 +238,10 @@ type ActiveBurn struct {
 	EndTimeNano int64   `json:"end_time_unix_nano"`
 	PrimaryID   string  `json:"primary_id"`
 	Throttle    float64 `json:"throttle,omitempty"`
+	// TargetCraftIdx (v0.9.3+) — see Node.TargetCraftIdx; mirrored
+	// onto in-flight finite burns so a save mid-rendezvous-burn
+	// reloads with the burn still tracking its bound target.
+	TargetCraftIdx int `json:"target_craft_idx,omitempty"`
 }
 
 // Errors returned by Load.
@@ -426,15 +436,17 @@ func payloadFromWorld(w *sim.World) Payload {
 				PrimaryID:       n.PrimaryID,
 				Event:           int(n.Event),
 				Throttle:        n.Throttle,
+				TargetCraftIdx:  n.TargetCraftIdx,
 			})
 		}
 		if c.ActiveBurn != nil {
 			wc.ActiveBurn = &ActiveBurn{
-				Mode:        int(c.ActiveBurn.Mode),
-				DVRemaining: c.ActiveBurn.DVRemaining,
-				EndTimeNano: c.ActiveBurn.EndTime.UnixNano(),
-				PrimaryID:   c.ActiveBurn.PrimaryID,
-				Throttle:    c.ActiveBurn.Throttle,
+				Mode:           int(c.ActiveBurn.Mode),
+				DVRemaining:    c.ActiveBurn.DVRemaining,
+				EndTimeNano:    c.ActiveBurn.EndTime.UnixNano(),
+				PrimaryID:      c.ActiveBurn.PrimaryID,
+				Throttle:       c.ActiveBurn.Throttle,
+				TargetCraftIdx: c.ActiveBurn.TargetCraftIdx,
 			}
 		}
 		p.Crafts = append(p.Crafts, wc)
@@ -589,22 +601,24 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				trig = time.Unix(0, n.TriggerTimeNano).UTC()
 			}
 			c.Nodes = append(c.Nodes, sim.ManeuverNode{
-				TriggerTime: trig,
-				Mode:        spacecraft.BurnMode(n.Mode),
-				DV:          n.DV,
-				Duration:    time.Duration(n.DurationNano),
-				PrimaryID:   n.PrimaryID,
-				Event:       sim.TriggerEvent(n.Event),
-				Throttle:    n.Throttle,
+				TriggerTime:    trig,
+				Mode:           spacecraft.BurnMode(n.Mode),
+				DV:             n.DV,
+				Duration:       time.Duration(n.DurationNano),
+				PrimaryID:      n.PrimaryID,
+				Event:          sim.TriggerEvent(n.Event),
+				Throttle:       n.Throttle,
+				TargetCraftIdx: n.TargetCraftIdx,
 			})
 		}
 		if wc.ActiveBurn != nil {
 			c.ActiveBurn = &sim.ActiveBurn{
-				Mode:        spacecraft.BurnMode(wc.ActiveBurn.Mode),
-				DVRemaining: wc.ActiveBurn.DVRemaining,
-				EndTime:     time.Unix(0, wc.ActiveBurn.EndTimeNano).UTC(),
-				PrimaryID:   wc.ActiveBurn.PrimaryID,
-				Throttle:    wc.ActiveBurn.Throttle,
+				Mode:           spacecraft.BurnMode(wc.ActiveBurn.Mode),
+				DVRemaining:    wc.ActiveBurn.DVRemaining,
+				EndTime:        time.Unix(0, wc.ActiveBurn.EndTimeNano).UTC(),
+				PrimaryID:      wc.ActiveBurn.PrimaryID,
+				Throttle:       wc.ActiveBurn.Throttle,
+				TargetCraftIdx: wc.ActiveBurn.TargetCraftIdx,
 			}
 		}
 		w.Crafts = append(w.Crafts, c)
@@ -622,22 +636,24 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				trig = time.Unix(0, n.TriggerTimeNano).UTC()
 			}
 			active.Nodes = append(active.Nodes, sim.ManeuverNode{
-				TriggerTime: trig,
-				Mode:        spacecraft.BurnMode(n.Mode),
-				DV:          n.DV,
-				Duration:    time.Duration(n.DurationNano),
-				PrimaryID:   n.PrimaryID,
-				Event:       sim.TriggerEvent(n.Event),
-				Throttle:    n.Throttle,
+				TriggerTime:    trig,
+				Mode:           spacecraft.BurnMode(n.Mode),
+				DV:             n.DV,
+				Duration:       time.Duration(n.DurationNano),
+				PrimaryID:      n.PrimaryID,
+				Event:          sim.TriggerEvent(n.Event),
+				Throttle:       n.Throttle,
+				TargetCraftIdx: n.TargetCraftIdx,
 			})
 		}
 		if p.ActiveBurn != nil && active.ActiveBurn == nil {
 			active.ActiveBurn = &sim.ActiveBurn{
-				Mode:        spacecraft.BurnMode(p.ActiveBurn.Mode),
-				DVRemaining: p.ActiveBurn.DVRemaining,
-				EndTime:     time.Unix(0, p.ActiveBurn.EndTimeNano).UTC(),
-				PrimaryID:   p.ActiveBurn.PrimaryID,
-				Throttle:    p.ActiveBurn.Throttle,
+				Mode:           spacecraft.BurnMode(p.ActiveBurn.Mode),
+				DVRemaining:    p.ActiveBurn.DVRemaining,
+				EndTime:        time.Unix(0, p.ActiveBurn.EndTimeNano).UTC(),
+				PrimaryID:      p.ActiveBurn.PrimaryID,
+				Throttle:       p.ActiveBurn.Throttle,
+				TargetCraftIdx: p.ActiveBurn.TargetCraftIdx,
 			}
 		}
 	}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -151,6 +151,14 @@ type Craft struct {
 	AttitudeMode int         `json:"attitude_mode,omitempty"`
 	EngineMode   int         `json:"engine_mode,omitempty"`
 
+	// Target (v0.9.3 polish): per-craft target binding. Pre-polish
+	// saves had a single payload-level Target; the load path now
+	// migrates that into the active craft's slot when no per-craft
+	// targets are present. omitempty so legacy saves with no target
+	// AND fresh untargeted craft both round-trip without writing the
+	// field.
+	Target *Target `json:"target,omitempty"`
+
 	// PitchTrim (v0.9.2+, schema v6 additive): signed pitch-trim
 	// offset in radians applied on top of the active BurnMode.
 	// omitempty so legacy saves with no trim load with PitchTrim=0
@@ -343,15 +351,11 @@ func payloadFromWorld(w *sim.World) Payload {
 			BodyIdx: w.Focus.BodyIdx,
 		},
 	}
-	// v0.9.0+: persist the unified target slot only when set. None
-	// stays nil on the wire so older saves round-trip identically.
-	if w.Target.Kind != sim.TargetNone {
-		p.Target = &Target{
-			Kind:     int(w.Target.Kind),
-			BodyIdx:  w.Target.BodyIdx,
-			CraftIdx: w.Target.CraftIdx,
-		}
-	}
+	// v0.9.3 polish: per-craft target replaces the payload-level
+	// Target slot. Each craft writes its own Target onto its Craft
+	// record (see the loop below); the payload-level Target field
+	// is no longer written. Read path retains backwards-compat
+	// support for older saves that wrote the payload-level field.
 	// v0.9.3+: persist NavMode. NavOrbit=0 round-trips as omitempty so
 	// pre-v0.9.3 saves (which never carried the field) load with the
 	// default-frame behaviour they were written under.
@@ -454,6 +458,16 @@ func payloadFromWorld(w *sim.World) Payload {
 				TargetCraftIdx: c.ActiveBurn.TargetCraftIdx,
 			}
 		}
+		// v0.9.3 polish: per-craft Target. Skip serialising when
+		// the craft has no target so untargeted craft still write
+		// out the same minimal JSON they did pre-polish.
+		if c.Target.Kind != spacecraft.TargetNone {
+			wc.Target = &Target{
+				Kind:     int(c.Target.Kind),
+				BodyIdx:  c.Target.BodyIdx,
+				CraftIdx: c.Target.CraftIdx,
+			}
+		}
 		p.Crafts = append(p.Crafts, wc)
 	}
 	p.ActiveCraftIdx = w.ActiveCraftIdx
@@ -488,16 +502,11 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			BodyIdx: p.Focus.BodyIdx,
 		},
 	}
-	// v0.9.0+: restore the unified target slot. Pre-v0.9 saves omit
-	// the field entirely; the nil pointer means the World keeps its
-	// zero-value Target (TargetNone).
-	if p.Target != nil {
-		w.Target = sim.Target{
-			Kind:     sim.TargetKind(p.Target.Kind),
-			BodyIdx:  p.Target.BodyIdx,
-			CraftIdx: p.Target.CraftIdx,
-		}
-	}
+	// v0.9.3 polish: per-craft Target supersedes the payload-level
+	// slot. Per-craft restores happen below, in the wireCrafts loop.
+	// The payload-level field is read here only for backwards-compat
+	// — assigned to the active craft after Crafts are loaded (see the
+	// reconcile block past the loop).
 	// v0.9.3+: restore NavMode. Absent field → zero → NavOrbit (the
 	// pre-v0.9.3 default frame).
 	w.NavMode = sim.NavMode(p.NavMode)
@@ -629,10 +638,50 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				TargetCraftIdx: wc.ActiveBurn.TargetCraftIdx,
 			}
 		}
+		// v0.9.3 polish: per-craft Target. Pre-polish saves omit the
+		// field; nil pointer leaves the craft's Target at zero
+		// (TargetNone) which is the fresh-craft default.
+		if wc.Target != nil {
+			c.Target = spacecraft.Target{
+				Kind:     spacecraft.TargetKind(wc.Target.Kind),
+				BodyIdx:  wc.Target.BodyIdx,
+				CraftIdx: wc.Target.CraftIdx,
+			}
+		}
 		w.Crafts = append(w.Crafts, c)
 	}
 	if p.ActiveCraftIdx >= 0 && p.ActiveCraftIdx < len(w.Crafts) {
 		w.ActiveCraftIdx = p.ActiveCraftIdx
+	}
+	// v0.9.3 polish: backwards-compat. Pre-polish saves serialised a
+	// single payload-level Target slot. Migrate it onto the active
+	// craft so legacy saves load with the binding the player set
+	// pre-polish. Skip when any craft already carries a per-craft
+	// Target (a polish-era save) so we don't clobber.
+	if p.Target != nil {
+		legacyTarget := spacecraft.Target{
+			Kind:     spacecraft.TargetKind(p.Target.Kind),
+			BodyIdx:  p.Target.BodyIdx,
+			CraftIdx: p.Target.CraftIdx,
+		}
+		anyPerCraft := false
+		for _, c := range w.Crafts {
+			if c != nil && c.Target.Kind != spacecraft.TargetNone {
+				anyPerCraft = true
+				break
+			}
+		}
+		if !anyPerCraft {
+			if active := w.ActiveCraft(); active != nil {
+				active.Target = legacyTarget
+			}
+		}
+	}
+	// Sync world-level live cursor to the active craft's stored
+	// target so readers (`w.Target.Kind == sim.TargetCraft` etc.)
+	// see the right binding immediately after load.
+	if active := w.ActiveCraft(); active != nil {
+		w.Target = active.Target
 	}
 	// Pre-v5 payload-level Nodes / ActiveBurn → active craft's
 	// fields. The migration assumes pre-v5 saves had a single craft

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -398,6 +398,64 @@ func TestEventRoundtrip(t *testing.T) {
 	}
 }
 
+// TestTargetCraftIdxRoundtrip — v0.9.3 target binding survives save/
+// load. Plant a target-relative node with a one-based TargetCraftIdx
+// and confirm it round-trips with the same value. Also confirms the
+// JSON omitempty tag works: a non-target node round-trips with
+// TargetCraftIdx == 0 (no field on disk → zero unmarshals).
+func TestTargetCraftIdxRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Target-relative node bound to slate idx 0 (one-based: 1).
+	w.PlanNode(sim.ManeuverNode{
+		Mode:           spacecraft.BurnTargetPrograde,
+		DV:             10,
+		Event:          sim.TriggerNextClosestApproach,
+		TargetCraftIdx: 1,
+	})
+	// Non-target node: no binding.
+	w.PlanNode(sim.ManeuverNode{
+		Mode: spacecraft.BurnPrograde,
+		DV:   100,
+	})
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	nodes := got.ActiveCraft().Nodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	// Find the target-bound node — sortNodes may reorder.
+	var bound, free *sim.ManeuverNode
+	for i := range nodes {
+		if nodes[i].Mode == spacecraft.BurnTargetPrograde {
+			bound = &nodes[i]
+		} else {
+			free = &nodes[i]
+		}
+	}
+	if bound == nil || free == nil {
+		t.Fatal("did not find both nodes after load")
+	}
+	if bound.TargetCraftIdx != 1 {
+		t.Errorf("bound node TargetCraftIdx: got %d, want 1", bound.TargetCraftIdx)
+	}
+	if free.TargetCraftIdx != 0 {
+		t.Errorf("free node TargetCraftIdx: got %d, want 0", free.TargetCraftIdx)
+	}
+	if bound.Event != sim.TriggerNextClosestApproach {
+		t.Errorf("bound node Event: got %v, want TriggerNextClosestApproach", bound.Event)
+	}
+}
+
 // TestMissionsRoundtrip: a save written with progressed mission status
 // (e.g. one passed, one in-progress) round-trips with status preserved.
 func TestMissionsRoundtrip(t *testing.T) {

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -713,6 +713,51 @@ func TestTargetCraftRoundtrip(t *testing.T) {
 	}
 }
 
+// TestPerCraftTargetRoundtrip exercises the v0.9.3 polish: each
+// craft persists its own Target through save/load. Bind distinct
+// targets on two craft, round-trip, and confirm switching to either
+// surfaces that craft's stored target as w.Target.
+func TestPerCraftTargetRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnSisterCraft(); err != nil {
+		t.Fatalf("SpawnSisterCraft: %v", err)
+	}
+	// Active is craft 1 (the sister). Target body idx 5 here.
+	w.SetTargetBody(5)
+	craft1Want := w.Target
+
+	// Switch to craft 0, target body idx 3.
+	w.SetActiveCraftIdx(0)
+	w.SetTargetBody(3)
+	craft0Want := w.Target
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Active was craft 0 at save time → load surfaces craft 0's
+	// target.
+	if got.Target != craft0Want {
+		t.Errorf("active=0 target after roundtrip: got %+v, want %+v", got.Target, craft0Want)
+	}
+	got.SetActiveCraftIdx(1)
+	if got.Target != craft1Want {
+		t.Errorf("after switch to craft 1: got %+v, want %+v", got.Target, craft1Want)
+	}
+	got.SetActiveCraftIdx(0)
+	if got.Target != craft0Want {
+		t.Errorf("after switch back to craft 0: got %+v, want %+v", got.Target, craft0Want)
+	}
+}
+
 // Pre-v0.9 saves predate the unified target slot — the JSON envelope
 // has no `target` key. Loading must yield TargetNone with no error.
 // We exercise this by saving with no target set (which the wire form

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -117,7 +117,7 @@ func (w *World) Undock(idx int) bool {
 	// Active craft becomes the first restored component (matches
 	// the "you keep flying the lead vessel" convention from
 	// DockCrafts).
-	w.ActiveCraftIdx = idx
+	w.SetActiveCraftIdx(idx)
 	w.StopManualBurn()
 	return true
 }
@@ -323,8 +323,10 @@ func (w *World) DockCrafts(idxA, idxB int) {
 	case w.ActiveCraftIdx == lead || w.ActiveCraftIdx == drop:
 		// Player ends up on the composite regardless of which slot
 		// they were flying.
-		w.ActiveCraftIdx = newLead
+		w.SetActiveCraftIdx(newLead)
 	case w.ActiveCraftIdx > drop:
+		// Slate shifts left around the dropped slot — the active
+		// craft pointer follows. Same craft, no target rebind.
 		w.ActiveCraftIdx--
 	}
 }

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -25,11 +25,12 @@ type (
 )
 
 const (
-	TriggerAbsolute = spacecraft.TriggerAbsolute
-	TriggerNextPeri = spacecraft.TriggerNextPeri
-	TriggerNextApo  = spacecraft.TriggerNextApo
-	TriggerNextAN   = spacecraft.TriggerNextAN
-	TriggerNextDN   = spacecraft.TriggerNextDN
+	TriggerAbsolute            = spacecraft.TriggerAbsolute
+	TriggerNextPeri            = spacecraft.TriggerNextPeri
+	TriggerNextApo             = spacecraft.TriggerNextApo
+	TriggerNextAN              = spacecraft.TriggerNextAN
+	TriggerNextDN              = spacecraft.TriggerNextDN
+	TriggerNextClosestApproach = spacecraft.TriggerNextClosestApproach
 )
 
 // AllTriggerEvents re-exports the spacecraft-package canonical UI
@@ -219,6 +220,38 @@ func (w *World) resolveEventNodesFor(c *spacecraft.Spacecraft) {
 			dt = orbital.TimeToNodeCrossing(state, mu, true)
 		case TriggerNextDN:
 			dt = orbital.TimeToNodeCrossing(state, mu, false)
+		case TriggerNextClosestApproach:
+			// v0.9.3+: bound to the craft captured at plant time
+			// via n.TargetCraftIdx. Skip if the target slot is
+			// stale (out-of-range / nil craft / different primary
+			// — same-primary only for the manual rendezvous slice).
+			tIdx, ok := n.TargetCraftIdxValue()
+			if !ok {
+				continue
+			}
+			if tIdx < 0 || tIdx >= len(w.Crafts) {
+				continue
+			}
+			tc := w.Crafts[tIdx]
+			if tc == nil {
+				continue
+			}
+			if tc.Primary.ID != c.Primary.ID {
+				continue
+			}
+			active := orbital.Vec3State{R: c.State.R, V: c.State.V}
+			target := orbital.Vec3State{R: tc.State.R, V: tc.State.V}
+			// 4 hours horizon — same as the HUD readout. If the
+			// encounter is farther than that, the resolver retries
+			// next tick (planner returns the in-horizon minimum
+			// even if it's not a true encounter, but the player can
+			// always extend the horizon by replanning closer to
+			// the encounter).
+			tCA, _, _, err := planner.NextClosestApproach(active, target, c.Primary, mu, 4*3600)
+			if err != nil {
+				continue
+			}
+			dt = tCA
 		default:
 			continue
 		}
@@ -1069,15 +1102,28 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 		if n.BurnStart().After(w.Clock.SimTime) {
 			break
 		}
+		// v0.9.3+: resolve target snapshot for target-relative nodes
+		// at fire time. Bound via n.TargetCraftIdx (captured at
+		// plant), not the current World.Target — a target switch
+		// between plant and fire doesn't silently retarget the burn.
+		var rT, vT orbital.Vec3
+		if n.IsTargetRelative() {
+			if tIdx, ok := n.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
+				if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+					rT, vT = tc.State.R, tc.State.V
+				}
+			}
+		}
 		if n.Duration == 0 {
-			c.ApplyImpulsive(n.Mode, n.DV)
+			c.ApplyImpulsiveWithTarget(n.Mode, n.DV, rT, vT)
 		} else {
 			c.ActiveBurn = &ActiveBurn{
-				Mode:        n.Mode,
-				DVRemaining: n.DV,
-				EndTime:     n.BurnEnd(),
-				PrimaryID:   n.PrimaryID,
-				Throttle:    n.EffectiveThrottle(),
+				Mode:           n.Mode,
+				DVRemaining:    n.DV,
+				EndTime:        n.BurnEnd(),
+				PrimaryID:      n.PrimaryID,
+				Throttle:       n.EffectiveThrottle(),
+				TargetCraftIdx: n.TargetCraftIdx,
 			}
 		}
 		// v0.9.2+: planted-burn ignition releases a Landed craft.
@@ -1452,6 +1498,22 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration 
 			dt = orbital.TimeToNodeCrossing(ostate, mu, true)
 		case TriggerNextDN:
 			dt = orbital.TimeToNodeCrossing(ostate, mu, false)
+		case TriggerNextClosestApproach:
+			// v0.9.3+: preview against the current World.Target.
+			// Plant-time binding kicks in at PlanNode; at preview the
+			// player is still picking a target, so the live
+			// World.Target is what matches their intent.
+			rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+			if !ok {
+				return physics.StateVector{}, bodies.CelestialBody{}, false
+			}
+			active := orbital.Vec3State{R: state.R, V: state.V}
+			target := orbital.Vec3State{R: rT, V: vT}
+			tCA, _, _, err := planner.NextClosestApproach(active, target, primary, mu, 4*3600)
+			if err != nil {
+				return physics.StateVector{}, bodies.CelestialBody{}, false
+			}
+			dt = tCA
 		}
 		if dt < 0 {
 			return physics.StateVector{}, bodies.CelestialBody{}, false
@@ -1469,6 +1531,21 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration 
 	isp := w.ActiveCraft().Isp
 	useFinite := duration > 0 && thrust > 0 && isp > 0 && state.M > 0
 
+	// v0.9.3+: target-relative modes resolve direction against the
+	// current World.Target snapshot. Preview uses the snapshot
+	// without forward-propagating the target across the burn — for
+	// the short rendezvous burns these modes target (Δv ≪ |v|), the
+	// approximation lands within UI noise.
+	var rT, vT orbital.Vec3
+	targetMode := spacecraft.IsTargetRelativeMode(mode)
+	if targetMode {
+		var ok bool
+		rT, vT, ok = w.TargetStateRelativeToActivePrimary()
+		if !ok {
+			return state, primary, true
+		}
+	}
+
 	if useFinite {
 		// Cap delivered Δv by what `duration` actually allows under
 		// the rocket equation. Pre-v0.6.3 the preview used the raw
@@ -1485,6 +1562,9 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration 
 			}
 		}
 		direction := func(r, v orbital.Vec3) orbital.Vec3 {
+			if targetMode {
+				return spacecraft.DirectionUnitTarget(mode, r, v, rT, vT)
+			}
 			return spacecraft.DirectionUnit(mode, r, v)
 		}
 		mu := primary.GravitationalParameter()
@@ -1492,7 +1572,12 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration 
 		return state, primary, true
 	}
 
-	dir := spacecraft.DirectionUnit(mode, state.R, state.V)
+	var dir orbital.Vec3
+	if targetMode {
+		dir = spacecraft.DirectionUnitTarget(mode, state.R, state.V, rT, vT)
+	} else {
+		dir = spacecraft.DirectionUnit(mode, state.R, state.V)
+	}
 	if dir.Norm() != 0 {
 		state.V = state.V.Add(dir.Scale(dv))
 	}

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1039,6 +1039,70 @@ func mustWorld(t *testing.T) *World {
 	return w
 }
 
+// TestResolveEventNodesFreezesNextClosestApproach — v0.9.3+: planting
+// a TriggerNextClosestApproach node bound to a sibling craft on a
+// distinct orbit resolves to a fire time within the planner horizon
+// (and >= now — t==0 is also a valid result if the crafts happen to
+// be at closest approach right at plant). Regression guard for the
+// resolver wiring (NextClosestApproach + same-primary check +
+// TargetCraftIdx round-trip).
+func TestResolveEventNodesFreezesNextClosestApproach(t *testing.T) {
+	w := mustWorld(t)
+	// Spawn a sibling craft on a slightly higher orbit so the two
+	// have different periods → the encounter time is a non-trivial
+	// future moment within the 4h horizon.
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(w.Crafts))
+	}
+	// Active is now the spawned (idx 1) craft per SpawnCraft semantics;
+	// flip back to the original so target-binding to idx 1 makes sense.
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	w.PlanNode(ManeuverNode{
+		Event:          TriggerNextClosestApproach,
+		Mode:           spacecraft.BurnTargetRetrograde,
+		DV:             10,
+		TargetCraftIdx: 2, // one-based: refers to slate idx 1
+	})
+	if !w.ActiveCraft().Nodes[0].TriggerTime.IsZero() {
+		t.Fatalf("precondition: unresolved node has zero TriggerTime")
+	}
+	w.resolveEventNodes()
+	n := w.ActiveCraft().Nodes[0]
+	if n.TriggerTime.IsZero() {
+		t.Fatalf("resolver did not freeze TriggerTime for TriggerNextClosestApproach")
+	}
+	if n.TriggerTime.Before(w.Clock.SimTime) {
+		t.Errorf("resolved TriggerTime in the past: TT=%v ST=%v", n.TriggerTime, w.Clock.SimTime)
+	}
+	// Resolver horizon is 4h; resolved time must fall within it.
+	if dt := n.TriggerTime.Sub(w.Clock.SimTime); dt > 4*time.Hour {
+		t.Errorf("resolved TriggerTime past planner horizon: %v", dt)
+	}
+}
+
+// TestResolveEventNodesNextClosestApproachStaleTargetSkips — node
+// with TargetCraftIdx referencing a missing craft slot stays
+// unresolved (silent no-op, sits in slate for player to delete or
+// repoint). Stale-handling guard for v0.9.3+.
+func TestResolveEventNodesNextClosestApproachStaleTargetSkips(t *testing.T) {
+	w := mustWorld(t)
+	w.PlanNode(ManeuverNode{
+		Event:          TriggerNextClosestApproach,
+		Mode:           spacecraft.BurnTargetRetrograde,
+		DV:             10,
+		TargetCraftIdx: 99, // out-of-range — never spawned
+	})
+	w.resolveEventNodes()
+	n := w.ActiveCraft().Nodes[0]
+	if !n.TriggerTime.IsZero() {
+		t.Errorf("stale-target node should remain unresolved; got TT=%v", n.TriggerTime)
+	}
+}
+
 // TestNextFrameTransitionDetectsForeignPrimary: a planted node with
 // PrimaryID != craft.Primary.ID surfaces as a frame transition.
 // Mirrors the v0.6.3 PlanMoonEscape arrival-marker shape — moon-frame

--- a/internal/sim/nav.go
+++ b/internal/sim/nav.go
@@ -1,0 +1,121 @@
+package sim
+
+import "github.com/jasonfen/terminal-space-program/internal/spacecraft"
+
+// NavMode selects the reference frame the SAS axis hotkeys
+// (prograde / retrograde / normal±, radial±) interpret against.
+// KSP-style: the player cycles a single mode and the same six axis
+// keys reinterpret accordingly.
+//
+//   NavOrbit   — prograde ≡ +v̂ in the active craft's primary-relative
+//                frame (the v0.7.3+ default).
+//   NavSurface — prograde ≡ +(v − ω×r), velocity relative to the
+//                rotating atmosphere; useful for ascent. Only prograde
+//                / retrograde rebind in this mode (KSP shows orbital
+//                normal/radial on the surface navball too).
+//   NavTarget  — prograde ≡ unit(v_target − v_active), retrograde its
+//                flip; radial± rebinds to BurnTarget / BurnAntiTarget
+//                (toward / away from target). Only valid when
+//                World.Target.Kind == TargetCraft. v0.9.3+.
+type NavMode int
+
+const (
+	NavOrbit NavMode = iota
+	NavSurface
+	NavTarget
+)
+
+// String returns a short HUD label.
+func (n NavMode) String() string {
+	switch n {
+	case NavSurface:
+		return "SURFACE"
+	case NavTarget:
+		return "TARGET"
+	}
+	return "ORBIT"
+}
+
+// AttitudeIntent is the input intent — which SAS axis the player
+// pressed — independent of NavMode. The TUI maps w/s/a/d/q/e to the
+// six intents; ResolveAttitudeIntent translates intent + NavMode to
+// the concrete BurnMode the integrator + SAS hold consume. v0.9.3+.
+type AttitudeIntent int
+
+const (
+	IntentPrograde AttitudeIntent = iota
+	IntentRetrograde
+	IntentNormalPlus
+	IntentNormalMinus
+	IntentRadialOut
+	IntentRadialIn
+)
+
+// ResolveAttitudeIntent maps (intent, NavMode) → BurnMode. NavTarget
+// silently falls back to NavOrbit when no craft target is bound — a
+// stale NavTarget should never produce a zero-direction SAS hold.
+// NavSurface only redefines prograde / retrograde (KSP behavior); the
+// other axes stay orbit-relative.
+func (w *World) ResolveAttitudeIntent(intent AttitudeIntent) spacecraft.BurnMode {
+	nav := w.NavMode
+	if nav == NavTarget && w.Target.Kind != TargetCraft {
+		nav = NavOrbit
+	}
+	switch nav {
+	case NavTarget:
+		switch intent {
+		case IntentPrograde:
+			return spacecraft.BurnTargetPrograde
+		case IntentRetrograde:
+			return spacecraft.BurnTargetRetrograde
+		case IntentRadialOut:
+			return spacecraft.BurnTarget
+		case IntentRadialIn:
+			return spacecraft.BurnAntiTarget
+		}
+	case NavSurface:
+		switch intent {
+		case IntentPrograde:
+			return spacecraft.BurnSurfacePrograde
+		case IntentRetrograde:
+			return spacecraft.BurnSurfaceRetrograde
+		}
+	}
+	switch intent {
+	case IntentRetrograde:
+		return spacecraft.BurnRetrograde
+	case IntentNormalPlus:
+		return spacecraft.BurnNormalPlus
+	case IntentNormalMinus:
+		return spacecraft.BurnNormalMinus
+	case IntentRadialOut:
+		return spacecraft.BurnRadialOut
+	case IntentRadialIn:
+		return spacecraft.BurnRadialIn
+	}
+	return spacecraft.BurnPrograde
+}
+
+// CycleNavMode advances World.NavMode through Orbit → Surface → Target
+// → Orbit. NavTarget is skipped when no craft target is bound so the
+// player never lands on a mode that silently degrades back to orbit.
+// Returns the new mode for the caller's HUD flash.
+func (w *World) CycleNavMode() NavMode {
+	hasCraftTarget := w.Target.Kind == TargetCraft
+	for i := 0; i < 3; i++ {
+		w.NavMode = (w.NavMode + 1) % 3
+		if w.NavMode != NavTarget || hasCraftTarget {
+			return w.NavMode
+		}
+	}
+	return w.NavMode
+}
+
+// reconcileNavMode forces NavTarget back to NavOrbit when the player
+// drops or swaps off a craft target. Called from every Target mutator
+// so NavMode stays self-consistent with what the HUD displays. v0.9.3+.
+func (w *World) reconcileNavMode() {
+	if w.NavMode == NavTarget && w.Target.Kind != TargetCraft {
+		w.NavMode = NavOrbit
+	}
+}

--- a/internal/sim/nav_test.go
+++ b/internal/sim/nav_test.go
@@ -1,0 +1,196 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestResolveAttitudeIntentOrbit — NavOrbit (the default) maps the six
+// SAS-axis intents 1:1 to the v0.7.3+ orbit-frame burn modes.
+func TestResolveAttitudeIntentOrbit(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	cases := []struct {
+		intent AttitudeIntent
+		want   spacecraft.BurnMode
+	}{
+		{IntentPrograde, spacecraft.BurnPrograde},
+		{IntentRetrograde, spacecraft.BurnRetrograde},
+		{IntentNormalPlus, spacecraft.BurnNormalPlus},
+		{IntentNormalMinus, spacecraft.BurnNormalMinus},
+		{IntentRadialOut, spacecraft.BurnRadialOut},
+		{IntentRadialIn, spacecraft.BurnRadialIn},
+	}
+	for _, tc := range cases {
+		if got := w.ResolveAttitudeIntent(tc.intent); got != tc.want {
+			t.Errorf("orbit intent %v: got %v, want %v", tc.intent, got, tc.want)
+		}
+	}
+}
+
+// TestResolveAttitudeIntentSurface — NavSurface only redefines
+// prograde / retrograde; the other axes still resolve to their
+// orbital meanings (KSP behaviour: the surface navball still shows
+// orbital normal/radial markers).
+func TestResolveAttitudeIntentSurface(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavSurface
+	cases := []struct {
+		intent AttitudeIntent
+		want   spacecraft.BurnMode
+	}{
+		{IntentPrograde, spacecraft.BurnSurfacePrograde},
+		{IntentRetrograde, spacecraft.BurnSurfaceRetrograde},
+		{IntentNormalPlus, spacecraft.BurnNormalPlus},
+		{IntentNormalMinus, spacecraft.BurnNormalMinus},
+		{IntentRadialOut, spacecraft.BurnRadialOut},
+		{IntentRadialIn, spacecraft.BurnRadialIn},
+	}
+	for _, tc := range cases {
+		if got := w.ResolveAttitudeIntent(tc.intent); got != tc.want {
+			t.Errorf("surface intent %v: got %v, want %v", tc.intent, got, tc.want)
+		}
+	}
+}
+
+// TestResolveAttitudeIntentTarget — NavTarget rebinds prograde /
+// retrograde to relative-velocity and radial± to BurnTarget /
+// BurnAntiTarget (toward / away). Normal axes stay orbital because
+// there is no target-relative normal SAS mode.
+func TestResolveAttitudeIntentTarget(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnSisterCraft(); err != nil {
+		t.Fatalf("SpawnSisterCraft: %v", err)
+	}
+	// SpawnSisterCraft promotes the new craft to active (idx 1); the
+	// original LEO craft is now at idx 0 and is the targetable sibling.
+	w.SetTargetCraft(0)
+	if w.Target.Kind != TargetCraft {
+		t.Fatalf("setup: target kind = %v, want TargetCraft", w.Target.Kind)
+	}
+	w.NavMode = NavTarget
+	cases := []struct {
+		intent AttitudeIntent
+		want   spacecraft.BurnMode
+	}{
+		{IntentPrograde, spacecraft.BurnTargetPrograde},
+		{IntentRetrograde, spacecraft.BurnTargetRetrograde},
+		{IntentRadialOut, spacecraft.BurnTarget},
+		{IntentRadialIn, spacecraft.BurnAntiTarget},
+		{IntentNormalPlus, spacecraft.BurnNormalPlus},
+		{IntentNormalMinus, spacecraft.BurnNormalMinus},
+	}
+	for _, tc := range cases {
+		if got := w.ResolveAttitudeIntent(tc.intent); got != tc.want {
+			t.Errorf("target intent %v: got %v, want %v", tc.intent, got, tc.want)
+		}
+	}
+}
+
+// TestResolveAttitudeIntentTargetFallback — NavTarget without a craft
+// target silently degrades to NavOrbit so a stale mode doesn't yield
+// a zero-direction SAS hold.
+func TestResolveAttitudeIntentTargetFallback(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavTarget
+	// No craft target bound. ResolveAttitudeIntent must fall back to
+	// orbit-frame.
+	if got := w.ResolveAttitudeIntent(IntentPrograde); got != spacecraft.BurnPrograde {
+		t.Errorf("target+notarget prograde: got %v, want BurnPrograde", got)
+	}
+	if got := w.ResolveAttitudeIntent(IntentRadialOut); got != spacecraft.BurnRadialOut {
+		t.Errorf("target+notarget radial+: got %v, want BurnRadialOut", got)
+	}
+}
+
+// TestCycleNavModeSkipsTargetWithoutCraftTarget — without a craft
+// target, the cycle goes Orbit → Surface → Orbit (Target skipped) so
+// the player never lands on a mode that silently degrades.
+func TestCycleNavModeSkipsTargetWithoutCraftTarget(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.NavMode != NavOrbit {
+		t.Fatalf("default nav: got %v, want NavOrbit", w.NavMode)
+	}
+	if got := w.CycleNavMode(); got != NavSurface {
+		t.Errorf("cycle 1: got %v, want NavSurface", got)
+	}
+	if got := w.CycleNavMode(); got != NavOrbit {
+		t.Errorf("cycle 2 (skips target — no craft target): got %v, want NavOrbit", got)
+	}
+}
+
+// TestCycleNavModeIncludesTargetWhenCraftTargetBound — once a sibling
+// craft is targeted, the cycle visits all three: Orbit → Surface →
+// Target → Orbit.
+func TestCycleNavModeIncludesTargetWhenCraftTargetBound(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnSisterCraft(); err != nil {
+		t.Fatalf("SpawnSisterCraft: %v", err)
+	}
+	w.SetTargetCraft(0)
+	if got := w.CycleNavMode(); got != NavSurface {
+		t.Errorf("cycle 1: got %v, want NavSurface", got)
+	}
+	if got := w.CycleNavMode(); got != NavTarget {
+		t.Errorf("cycle 2: got %v, want NavTarget", got)
+	}
+	if got := w.CycleNavMode(); got != NavOrbit {
+		t.Errorf("cycle 3: got %v, want NavOrbit", got)
+	}
+}
+
+// TestClearTargetSnapsNavTargetToOrbit — dropping the target while
+// NavMode is NavTarget reconciles back to NavOrbit so the HUD doesn't
+// claim a frame it can no longer resolve.
+func TestClearTargetSnapsNavTargetToOrbit(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnSisterCraft(); err != nil {
+		t.Fatalf("SpawnSisterCraft: %v", err)
+	}
+	w.SetTargetCraft(0)
+	w.NavMode = NavTarget
+	w.ClearTarget()
+	if w.NavMode != NavOrbit {
+		t.Errorf("after ClearTarget: nav = %v, want NavOrbit", w.NavMode)
+	}
+}
+
+// TestSetTargetBodySnapsNavTargetToOrbit — swapping from a craft
+// target to a body target also takes nav out of NavTarget (KSP target
+// mode is craft-only in our model).
+func TestSetTargetBodySnapsNavTargetToOrbit(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnSisterCraft(); err != nil {
+		t.Fatalf("SpawnSisterCraft: %v", err)
+	}
+	w.SetTargetCraft(0)
+	w.NavMode = NavTarget
+	w.SetTargetBody(1) // any non-root body
+	if w.NavMode != NavOrbit {
+		t.Errorf("after SetTargetBody: nav = %v, want NavOrbit", w.NavMode)
+	}
+}

--- a/internal/sim/rcs.go
+++ b/internal/sim/rcs.go
@@ -43,11 +43,14 @@ func (w *World) FireRCSPulse(mode spacecraft.BurnMode) bool {
 		return false
 	}
 	// v0.9.2+: BurnDirection handles surface modes + pitch trim.
-	dir := w.ActiveCraft().BurnDirection(mode)
+	// v0.9.3+: resolve target snapshot for the four target-relative
+	// modes; non-target modes ignore the snapshot.
+	rT, vT, _ := w.TargetStateRelativeToActivePrimary()
+	dir := w.ActiveCraft().BurnDirectionWithTarget(mode, rT, vT)
 	if dir.Norm() == 0 {
 		return false
 	}
-	if !w.ActiveCraft().ApplyRCSPulse(mode) {
+	if !w.ActiveCraft().ApplyRCSPulseWithTarget(mode, rT, vT) {
 		return false
 	}
 	w.ActiveCraft().AttitudeMode = mode

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -155,7 +155,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 			M: c.TotalMass(),
 		}
 		w.Crafts = append(w.Crafts, c)
-		w.ActiveCraftIdx = len(w.Crafts) - 1
+		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
 		return c, nil
 	}
@@ -211,7 +211,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		// engaging.
 		c.AttitudeMode = spacecraft.BurnRadialOut
 		w.Crafts = append(w.Crafts, c)
-		w.ActiveCraftIdx = len(w.Crafts) - 1
+		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
 		return c, nil
 	}
@@ -245,7 +245,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		M: c.TotalMass(),
 	}
 	w.Crafts = append(w.Crafts, c)
-	w.ActiveCraftIdx = len(w.Crafts) - 1
+	w.SetActiveCraftIdx(len(w.Crafts) - 1)
 	w.StopManualBurn()
 	return c, nil
 }

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -5,40 +5,25 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
-// TargetKind enumerates what World.Target points at. v0.9.0+ unifies
-// the implicit body cursor (read by `H` PlanTransfer and `I`
-// PlanInclinationChange pre-v0.9) and the rendezvous-introduced
-// target-craft idx (planned for v0.9.3) into a single slot. Every
-// planner that needs to ask "what is the player aiming at?" reads
-// the same field.
-//
-// TargetSite is reserved for landing-site targeting, slated for
-// post-v0.9 ground-ops work; populating it is a no-op until that
-// surface ships.
-type TargetKind int
-
-const (
-	// TargetNone — no target set. Planners that consume Target fall
-	// back to their kind-less default (equatorial inclination match,
-	// "pick a body cursor first" status flash).
-	TargetNone TargetKind = iota
-	// TargetBody references a body by index in System().Bodies.
-	TargetBody
-	// TargetCraft references a non-active craft by index in World.Crafts.
-	TargetCraft
-	// TargetSite is reserved; not populated until landing-site
-	// targeting ships post-v0.9.
-	TargetSite
+// Target / TargetKind moved to the `spacecraft` package in v0.9.3
+// polish so each Spacecraft can carry its own per-craft target as a
+// struct field (per-craft target binding — each vessel remembers
+// its own target across active-craft switches). The aliases below
+// preserve the existing API surface so readers like
+// `w.Target.Kind == sim.TargetCraft` continue to compile unchanged.
+type (
+	TargetKind = spacecraft.TargetKind
+	Target     = spacecraft.Target
 )
 
-// Target identifies what the player is aiming at. The zero value
-// (TargetNone) is the v0.9.0 default and round-trips through save as
-// an absent JSON field.
-type Target struct {
-	Kind     TargetKind
-	BodyIdx  int // when Kind==TargetBody
-	CraftIdx int // when Kind==TargetCraft
-}
+// Re-exported constants — preserve the `sim.TargetNone` etc.
+// identifiers that 75+ readers depend on.
+const (
+	TargetNone  = spacecraft.TargetNone
+	TargetBody  = spacecraft.TargetBody
+	TargetCraft = spacecraft.TargetCraft
+	TargetSite  = spacecraft.TargetSite
+)
 
 // SetTargetBody sets the body target by system index. Out-of-range
 // or system-primary (idx 0) selections clear the target — neither is
@@ -50,6 +35,7 @@ func (w *World) SetTargetBody(idx int) {
 		return
 	}
 	w.Target = Target{Kind: TargetBody, BodyIdx: idx}
+	w.mirrorTargetToActiveCraft()
 	w.reconcileNavMode()
 }
 
@@ -65,6 +51,7 @@ func (w *World) SetTargetCraft(idx int) {
 		return
 	}
 	w.Target = Target{Kind: TargetCraft, CraftIdx: idx}
+	w.mirrorTargetToActiveCraft()
 }
 
 // ClearTarget drops any target. After ClearTarget,
@@ -73,7 +60,22 @@ func (w *World) SetTargetCraft(idx int) {
 // resolve. v0.9.3+.
 func (w *World) ClearTarget() {
 	w.Target = Target{}
+	w.mirrorTargetToActiveCraft()
 	w.reconcileNavMode()
+}
+
+// mirrorTargetToActiveCraft writes w.Target onto the active craft's
+// per-craft Target field so the binding survives an active-craft
+// switch (v0.9.3 polish). Maintains the invariant
+// w.Target == w.Crafts[w.ActiveCraftIdx].Target whenever an active
+// craft exists. No-op when there is no active craft.
+func (w *World) mirrorTargetToActiveCraft() {
+	if w.ActiveCraftIdx < 0 || w.ActiveCraftIdx >= len(w.Crafts) {
+		return
+	}
+	if c := w.Crafts[w.ActiveCraftIdx]; c != nil {
+		c.Target = w.Target
+	}
 }
 
 // CycleTarget advances Target through non-active sibling crafts →
@@ -106,6 +108,7 @@ func (w *World) CycleTarget(forward bool) {
 		idx = (idx - 1 + len(cycle)) % len(cycle)
 	}
 	w.Target = cycle[idx]
+	w.mirrorTargetToActiveCraft()
 	w.reconcileNavMode()
 }
 

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -172,6 +172,42 @@ func (w *World) CraftInertialVelocity(c *spacecraft.Spacecraft) orbital.Vec3 {
 	return w.bodyInertialVelocity(c.Primary).Add(c.State.V)
 }
 
+// TargetStateRelativeToActivePrimary returns the target craft's state
+// expressed in the active craft's primary-relative frame, so the same
+// (R, V) basis as ActiveCraft().State can be used for relative-vector
+// math (closest approach, target-prograde direction, |v_rel|, range).
+// Returns ok=false when no craft target is set, the index is stale,
+// or there is no active craft.
+//
+// Same-primary case (the common one — rendezvous in LEO): both craft
+// share a primary, so the target's primary-relative state is already
+// in the active's frame. Cross-primary case: convert via inertial,
+// subtract the active primary's pose. v0.9.3+.
+func (w *World) TargetStateRelativeToActivePrimary() (rT, vT orbital.Vec3, ok bool) {
+	if w.Target.Kind != TargetCraft {
+		return orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		return orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
+		return orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	t := w.Crafts[w.Target.CraftIdx]
+	if t == nil {
+		return orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	if t.Primary.EnglishName == active.Primary.EnglishName {
+		return t.State.R, t.State.V, true
+	}
+	targetInertialR := w.BodyPosition(t.Primary).Add(t.State.R)
+	targetInertialV := w.bodyInertialVelocity(t.Primary).Add(t.State.V)
+	activePrimaryR := w.BodyPosition(active.Primary)
+	activePrimaryV := w.bodyInertialVelocity(active.Primary)
+	return targetInertialR.Sub(activePrimaryR), targetInertialV.Sub(activePrimaryV), true
+}
+
 // TargetName returns a short human label for the current target,
 // suitable for the TARGET HUD block. Empty string when no target is
 // set or the index is stale.

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -50,6 +50,7 @@ func (w *World) SetTargetBody(idx int) {
 		return
 	}
 	w.Target = Target{Kind: TargetBody, BodyIdx: idx}
+	w.reconcileNavMode()
 }
 
 // SetTargetCraft sets the craft target by slate index. The active
@@ -67,8 +68,13 @@ func (w *World) SetTargetCraft(idx int) {
 }
 
 // ClearTarget drops any target. After ClearTarget,
-// Target.Kind == TargetNone.
-func (w *World) ClearTarget() { w.Target = Target{} }
+// Target.Kind == TargetNone. Also reconciles NavMode (snap NavTarget
+// → NavOrbit) so the HUD doesn't claim a mode it can no longer
+// resolve. v0.9.3+.
+func (w *World) ClearTarget() {
+	w.Target = Target{}
+	w.reconcileNavMode()
+}
 
 // CycleTarget advances Target through non-active sibling crafts →
 // system bodies (non-root) → None → repeat. Forward=false steps
@@ -100,6 +106,7 @@ func (w *World) CycleTarget(forward bool) {
 		idx = (idx - 1 + len(cycle)) % len(cycle)
 	}
 	w.Target = cycle[idx]
+	w.reconcileNavMode()
 }
 
 // targetCycle enumerates the valid target slots for the current

--- a/internal/sim/target_test.go
+++ b/internal/sim/target_test.go
@@ -166,6 +166,76 @@ func TestTargetStateForNoneReturnsNotOk(t *testing.T) {
 	}
 }
 
+// TestPerCraftTargetPersistsAcrossSwitch covers the v0.9.3 polish
+// that gives each craft its own target binding. Pre-polish, pressing
+// `T` to set a target on craft A would also surface that target on
+// craft B (single shared World.Target slot). Post-polish, each craft
+// has a Target field; the world-level live cursor is synced from the
+// active craft on switch via SetActiveCraftIdx.
+func TestPerCraftTargetPersistsAcrossSwitch(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{Alongside: true}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	// Spawn lands the player on the new craft (idx 1). Bind a body
+	// target on craft 1, then a different body target on craft 0,
+	// and verify each survives a switch back.
+	w.SetActiveCraftIdx(1)
+	w.SetTargetBody(3)
+	craft1Target := w.Target
+
+	w.SetActiveCraftIdx(0)
+	if w.Target.Kind == TargetBody && w.Target.BodyIdx == 3 {
+		t.Errorf("switching to craft 0: world Target leaked from craft 1: %+v", w.Target)
+	}
+	w.SetTargetBody(5)
+	craft0Target := w.Target
+
+	w.SetActiveCraftIdx(1)
+	if w.Target != craft1Target {
+		t.Errorf("after switch back to craft 1: got %+v, want %+v", w.Target, craft1Target)
+	}
+
+	w.SetActiveCraftIdx(0)
+	if w.Target != craft0Target {
+		t.Errorf("after switch back to craft 0: got %+v, want %+v", w.Target, craft0Target)
+	}
+}
+
+// TestPerCraftTargetMirroredOnEverySetter confirms the
+// world-level cursor and the active craft's stored Target stay in
+// lockstep — every mutator (SetTargetBody / SetTargetCraft /
+// ClearTarget / CycleTarget) must mirror through to the active
+// craft so a subsequent switch checkpoints the right value.
+func TestPerCraftTargetMirroredOnEverySetter(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{Alongside: true}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("active craft nil after spawn")
+	}
+	w.SetTargetBody(3)
+	if active.Target != w.Target {
+		t.Errorf("SetTargetBody mirror: craft.Target=%+v, w.Target=%+v", active.Target, w.Target)
+	}
+	w.ClearTarget()
+	if active.Target != w.Target {
+		t.Errorf("ClearTarget mirror: craft.Target=%+v, w.Target=%+v", active.Target, w.Target)
+	}
+	w.CycleTarget(true)
+	if active.Target != w.Target {
+		t.Errorf("CycleTarget mirror: craft.Target=%+v, w.Target=%+v", active.Target, w.Target)
+	}
+}
+
 func TestTargetNameForBody(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -50,6 +50,13 @@ type World struct {
 	// kind-less default (equatorial plane, Hohmann no-op).
 	Target Target
 
+	// NavMode selects the reference frame the SAS axis hotkeys
+	// interpret against (KSP-style nav-ball mode cycle). Zero value
+	// (NavOrbit) reproduces the pre-v0.9.3 behavior. Cycled via the
+	// `;` hot-key; auto-snaps to NavOrbit when a craft target is
+	// dropped. v0.9.3+.
+	NavMode NavMode
+
 	// ViewMode selects the canvas projection basis. v0.6.4+. Zero
 	// value (ViewEquatorial) matches the pre-v0.6.4 (X, Y)-drop
 	// projection. Set per-session via the `v` hot-key; not persisted

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -811,7 +811,23 @@ func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
 			throttle = 1.0
 		}
 	}
-	thrustFn := c.ThrustAccelFnAt(mode, mu, throttle)
+	// v0.9.3+: resolve target snapshot for target-relative thrust.
+	// For ActiveBurn (planted finite burn), the target was bound at
+	// plant time via ActiveBurn.TargetCraftIdx — survives a player
+	// target switch mid-burn. For ManualBurn (live SAS hold), the
+	// snapshot follows the current World.Target so the player can
+	// retarget mid-hold. Non-target modes ignore (rT, vT).
+	var rT, vT orbital.Vec3
+	if c.ActiveBurn != nil && c.ActiveBurn.TargetCraftIdx != 0 {
+		if tIdx, ok := c.ActiveBurn.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
+			if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+				rT, vT = tc.State.R, tc.State.V
+			}
+		}
+	} else {
+		rT, vT, _ = w.TargetStateRelativeToActivePrimary()
+	}
+	thrustFn := c.ThrustAccelFnAtWithTarget(mode, mu, throttle, rT, vT)
 	bc := c.EffectiveBallisticCoefficient()
 	primary := c.Primary
 	// v0.8.4: drag adds to thrust + gravity inside the RK4 closure so

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -198,7 +198,7 @@ func (w *World) CycleActiveCraft(delta int) {
 	if idx < 0 {
 		idx += n
 	}
-	w.ActiveCraftIdx = idx
+	w.SetActiveCraftIdx(idx)
 	// Engine state is per-active-craft in v0.8.1 (planted nodes,
 	// manual burn, attitude all live on World as "what the active
 	// craft is doing"). Cycling resets the live RCS-or-main mode
@@ -206,6 +206,36 @@ func (w *World) CycleActiveCraft(delta int) {
 	// is dropped since it was tied to the prior active craft's
 	// engine.
 	w.StopManualBurn()
+}
+
+// SetActiveCraftIdx switches control to the craft at idx, syncing
+// per-craft Target so each vessel keeps its own target binding
+// across switches (v0.9.3 polish). Outgoing's live `w.Target`
+// is checkpointed onto the outgoing craft, then `w.Target` is
+// reloaded from the incoming craft's stored Target. NavMode is
+// not yet per-craft (acceptable scope cap; revisit if NavMode
+// drift across switches becomes friction).
+//
+// Caller is responsible for bounds-checking idx against
+// len(Crafts); out-of-range idx is treated as "no checkpoint, no
+// load" so spawn paths that assign before any craft exists don't
+// touch w.Target.
+func (w *World) SetActiveCraftIdx(idx int) {
+	if w.ActiveCraftIdx >= 0 && w.ActiveCraftIdx < len(w.Crafts) {
+		if outgoing := w.Crafts[w.ActiveCraftIdx]; outgoing != nil {
+			outgoing.Target = w.Target
+		}
+	}
+	w.ActiveCraftIdx = idx
+	if idx >= 0 && idx < len(w.Crafts) {
+		if incoming := w.Crafts[idx]; incoming != nil {
+			w.Target = incoming.Target
+			w.reconcileNavMode()
+			return
+		}
+	}
+	w.Target = spacecraft.Target{}
+	w.reconcileNavMode()
 }
 
 // System returns the currently active system.

--- a/internal/spacecraft/burn_direction.go
+++ b/internal/spacecraft/burn_direction.go
@@ -27,8 +27,24 @@ import (
 // modes there return zero (degraded — predictor doesn't simulate
 // future v_surface).
 //
-// v0.9.2+.
+// v0.9.2+. v0.9.3+: target-relative modes added; this wrapper passes
+// zero target state, so the four target modes degrade to no-op here —
+// callers with a target use BurnDirectionWithTarget.
 func (s *Spacecraft) BurnDirection(mode BurnMode) orbital.Vec3 {
+	return s.BurnDirectionWithTarget(mode, orbital.Vec3{}, orbital.Vec3{})
+}
+
+// BurnDirectionWithTarget is BurnDirection with a target snapshot in
+// the same frame as Spacecraft.State (primary-relative when both
+// share a primary, fully inertial otherwise — caller resolves the
+// frame via World.targetStateRelativeToActivePrimary).
+//
+// The four target-relative modes (BurnTargetPrograde / Retrograde /
+// BurnTarget / AntiTarget) consume (rT, vT); other modes ignore it
+// and behave identically to BurnDirection.
+//
+// v0.9.3+.
+func (s *Spacecraft) BurnDirectionWithTarget(mode BurnMode, rT, vT orbital.Vec3) orbital.Vec3 {
 	var dir orbital.Vec3
 	switch mode {
 	case BurnSurfacePrograde, BurnSurfaceRetrograde:
@@ -42,6 +58,8 @@ func (s *Spacecraft) BurnDirection(mode BurnMode) orbital.Vec3 {
 		if mode == BurnSurfaceRetrograde {
 			dir = dir.Scale(-1)
 		}
+	case BurnTargetPrograde, BurnTargetRetrograde, BurnTarget, BurnAntiTarget:
+		dir = DirectionUnitTarget(mode, s.State.R, s.State.V, rT, vT)
 	default:
 		dir = DirectionUnit(mode, s.State.R, s.State.V)
 	}

--- a/internal/spacecraft/burn_direction_test.go
+++ b/internal/spacecraft/burn_direction_test.go
@@ -120,3 +120,83 @@ func TestBurnDirectionAppliesPitchTrim(t *testing.T) {
 		t.Errorf("pitch trim on radial+: got %+v, want %+v", got, want)
 	}
 }
+
+// TestDirectionUnitTargetPrograde — target ahead in +Y, faster:
+// v_target − v_active = +Y, so BurnTargetPrograde = +Y.
+func TestDirectionUnitTargetPrograde(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7600}
+	got := DirectionUnitTarget(BurnTargetPrograde, rA, vA, rT, vT)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-1) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("target prograde: got %+v, want (0, 1, 0)", got)
+	}
+}
+
+// TestDirectionUnitTargetRetrograde — flip of TargetPrograde.
+func TestDirectionUnitTargetRetrograde(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7600}
+	got := DirectionUnitTarget(BurnTargetRetrograde, rA, vA, rT, vT)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-(-1)) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("target retrograde: got %+v, want (0, -1, 0)", got)
+	}
+}
+
+// TestDirectionUnitTargetPosition — target at +Y offset:
+// r_target − r_active points +Y, so BurnTarget = +Y.
+func TestDirectionUnitTargetPosition(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7500}
+	got := DirectionUnitTarget(BurnTarget, rA, vA, rT, vT)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-1) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("target position: got %+v, want (0, 1, 0)", got)
+	}
+}
+
+// TestDirectionUnitAntiTarget — flip of BurnTarget.
+func TestDirectionUnitAntiTarget(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7500}
+	got := DirectionUnitTarget(BurnAntiTarget, rA, vA, rT, vT)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-(-1)) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("anti-target: got %+v, want (0, -1, 0)", got)
+	}
+}
+
+// TestDirectionUnitTargetCoVelocityDegrades — identical velocities
+// collapse the relative-velocity vector to zero; BurnTargetPrograde
+// returns zero so the burn no-ops (the caller's |v_rel| readout
+// surfaces "already matched").
+func TestDirectionUnitTargetCoVelocityDegrades(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7500}
+	got := DirectionUnitTarget(BurnTargetPrograde, rA, vA, rT, vT)
+	if got != (orbital.Vec3{}) {
+		t.Errorf("co-velocity TargetPrograde: got %+v, want zero", got)
+	}
+}
+
+// TestDirectionUnitTargetFallsThroughToBaseModes — non-target modes
+// passed to DirectionUnitTarget delegate to DirectionUnit so callers
+// can use the target API uniformly.
+func TestDirectionUnitTargetFallsThroughToBaseModes(t *testing.T) {
+	rA := orbital.Vec3{X: 7e6}
+	vA := orbital.Vec3{Y: 7500}
+	rT := orbital.Vec3{X: 7e6, Y: 1000}
+	vT := orbital.Vec3{Y: 7600}
+	got := DirectionUnitTarget(BurnPrograde, rA, vA, rT, vT)
+	want := DirectionUnit(BurnPrograde, rA, vA)
+	if got != want {
+		t.Errorf("non-target fallthrough: got %+v, want %+v", got, want)
+	}
+}

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -22,6 +22,14 @@ const (
 	TriggerNextApo
 	TriggerNextAN
 	TriggerNextDN
+	// TriggerNextClosestApproach (v0.9.3+) resolves to the next
+	// time-to-encounter between the active craft and a target craft
+	// captured at plant time via ManeuverNode.TargetCraftIdx. Lazy-
+	// frozen on the first tick after plant the same way AN / DN are.
+	// Only valid for the four target-relative burn modes; pickable
+	// in the m-form only when World.Target.Kind == TargetCraft at
+	// plant time.
+	TriggerNextClosestApproach
 )
 
 // String returns a human-readable label for the trigger event.
@@ -37,6 +45,8 @@ func (e TriggerEvent) String() string {
 		return "next AN"
 	case TriggerNextDN:
 		return "next DN"
+	case TriggerNextClosestApproach:
+		return "next closest approach"
 	}
 	return "?"
 }
@@ -48,6 +58,7 @@ var AllTriggerEvents = [...]TriggerEvent{
 	TriggerNextApo,
 	TriggerNextAN,
 	TriggerNextDN,
+	TriggerNextClosestApproach,
 }
 
 // ManeuverNode represents a planned burn. v0.5.14+: TriggerTime is the
@@ -88,6 +99,63 @@ type ManeuverNode struct {
 	// planted burns from live `Craft.Throttle` so adjusting throttle
 	// mid-coast doesn't slow an in-flight planted burn.
 	Throttle float64
+	// TargetCraftIdx (v0.9.3+) is the World.Crafts index of the
+	// target craft this node was planted against, captured at plant
+	// time. Populated only for the four target-relative modes
+	// (BurnTargetPrograde / Retrograde / BurnTarget / AntiTarget) and
+	// for the TriggerNextClosestApproach event. Zero-value-omitempty:
+	// non-target nodes save without the field, no schema bump.
+	//
+	// Bound at plant time so a target switch later doesn't silently
+	// retarget the planted burn — the node remains aimed at the craft
+	// the player chose. Stale handling: if the referenced index falls
+	// out of range or w.Crafts[idx] is nil at fire time, the node
+	// degrades to no-op. v0.9.3+: TargetStaleAtLoad below also flags
+	// load-time staleness so the slate UI can surface it.
+	//
+	// One-based to allow JSON omitempty: encoded value is idx+1, so
+	// zero means "no target". Helpers (TargetCraftIdxValue / SetTarget
+	// CraftIdxValue) translate to the natural 0-based slate index;
+	// callers always work in 0-based.
+	TargetCraftIdx int `json:",omitempty"`
+}
+
+// TargetCraftIdxValue returns the 0-based slate index this node is
+// bound to, and ok=false if no target was bound at plant time. The
+// JSON-stored field is one-based so omitempty drops "no target"
+// nodes from the wire — translation lives here so callers don't need
+// to remember the offset. v0.9.3+.
+func (n ManeuverNode) TargetCraftIdxValue() (int, bool) {
+	if n.TargetCraftIdx == 0 {
+		return 0, false
+	}
+	return n.TargetCraftIdx - 1, true
+}
+
+// SetTargetCraftIdx writes a 0-based slate index into the node's
+// stored target slot. v0.9.3+.
+func (n *ManeuverNode) SetTargetCraftIdx(idx int) {
+	n.TargetCraftIdx = idx + 1
+}
+
+// ClearTargetCraftIdx unbinds the node's target. v0.9.3+.
+func (n *ManeuverNode) ClearTargetCraftIdx() { n.TargetCraftIdx = 0 }
+
+// IsTargetRelative reports whether this node's burn mode requires a
+// target craft state to resolve direction. v0.9.3+.
+func (n ManeuverNode) IsTargetRelative() bool {
+	return IsTargetRelativeMode(n.Mode)
+}
+
+// IsTargetRelativeMode reports whether the given burn mode requires
+// a target craft state. Used by m-form cycle gating and resolver
+// dispatch. v0.9.3+.
+func IsTargetRelativeMode(m BurnMode) bool {
+	switch m {
+	case BurnTargetPrograde, BurnTargetRetrograde, BurnTarget, BurnAntiTarget:
+		return true
+	}
+	return false
 }
 
 // EffectiveThrottle returns the throttle to use when firing this
@@ -142,6 +210,23 @@ type ActiveBurn struct {
 	EndTime     time.Time
 	PrimaryID   string
 	Throttle    float64
+	// TargetCraftIdx (v0.9.3+) is one-based slate idx (matches
+	// ManeuverNode.TargetCraftIdx encoding) — zero means no target
+	// bound. Populated when a target-relative finite-burn node fires;
+	// the world's stepThrust resolves the target snapshot from this
+	// each tick so the burn keeps tracking even if the player swaps
+	// World.Target mid-burn.
+	TargetCraftIdx int `json:",omitempty"`
+}
+
+// TargetCraftIdxValue mirrors ManeuverNode.TargetCraftIdxValue —
+// returns the 0-based slate idx the burn is bound to, or ok=false
+// when no target was captured at fire time. v0.9.3+.
+func (b ActiveBurn) TargetCraftIdxValue() (int, bool) {
+	if b.TargetCraftIdx == 0 {
+		return 0, false
+	}
+	return b.TargetCraftIdx - 1, true
 }
 
 // ManualBurn is the runtime state of a v0.7.3+ player-held manual

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -174,6 +174,16 @@ type Spacecraft struct {
 	// wrapping the v5 flat fields into a single-element Stages
 	// slice (see internal/save/save_migrate_v5_to_v6.go).
 	Stages []Stage
+
+	// Target (v0.9.3 polish) is this craft's bound target. Pre-
+	// polish, target was a single World.Target slot shared across
+	// all crafts; pressing `T` while controlling craft A would
+	// toggle the target visible to craft B too. Per-craft Target
+	// gives each vessel its own binding, restored on switch via
+	// World.setActiveCraftIdx so w.Target stays in sync with the
+	// currently-active craft. Zero value (TargetNone) is the safe
+	// default for fresh / loaded crafts.
+	Target Target
 }
 
 // DockedComponent is a snapshot of one pre-dock craft identity

--- a/internal/spacecraft/target.go
+++ b/internal/spacecraft/target.go
@@ -1,0 +1,36 @@
+package spacecraft
+
+// TargetKind enumerates what a craft is aiming at. Type lives on
+// `spacecraft` (not `sim`) so each Spacecraft can carry its own
+// per-craft target as a struct field — moved from sim/target.go in
+// v0.9.3 polish to support per-craft target binding (each vessel
+// remembers its own target across active-craft switches).
+//
+// `sim` re-exports the type via an alias so existing readers
+// (`w.Target.Kind == sim.TargetCraft`) continue to compile unchanged.
+type TargetKind int
+
+const (
+	// TargetNone — no target set. Planners that consume Target fall
+	// back to their kind-less default (equatorial inclination match,
+	// "pick a body cursor first" status flash).
+	TargetNone TargetKind = iota
+	// TargetBody references a body by index in System().Bodies.
+	TargetBody
+	// TargetCraft references a non-active craft by index in World.Crafts.
+	TargetCraft
+	// TargetSite is reserved; not populated until landing-site
+	// targeting ships post-v0.9.
+	TargetSite
+)
+
+// Target identifies what a single craft is aiming at. The zero
+// value (TargetNone) is the v0.9.0 default and round-trips through
+// save as an absent JSON field. v0.9.3+ : every Spacecraft holds its
+// own Target value so per-craft targeting persists across active-
+// craft switches.
+type Target struct {
+	Kind     TargetKind
+	BodyIdx  int // when Kind==TargetBody
+	CraftIdx int // when Kind==TargetCraft
+}

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -46,14 +46,28 @@ const RCSDvQuantum = 0.1
 // RCSIsp engine. No-op if monoprop is empty or RCSThrust / RCSIsp are
 // unconfigured (legacy save with zero RCS fields, mid-load before the
 // loader populates defaults). v0.8.0+.
+//
+// Target-relative modes degrade to no-op (zero direction) without a
+// resolved target snapshot — callers with a target use
+// ApplyRCSPulseWithTarget. v0.9.3+.
 func (s *Spacecraft) ApplyRCSPulse(mode BurnMode) bool {
+	return s.ApplyRCSPulseWithTarget(mode, orbital.Vec3{}, orbital.Vec3{})
+}
+
+// ApplyRCSPulseWithTarget is ApplyRCSPulse with a resolved target
+// snapshot in the same frame as Spacecraft.State (primary-relative
+// when both share a primary, fully inertial otherwise — caller
+// resolves via World.targetStateRelativeToActivePrimary). The four
+// target-relative modes use the snapshot to compute direction; other
+// modes ignore it. v0.9.3+.
+func (s *Spacecraft) ApplyRCSPulseWithTarget(mode BurnMode, rT, vT orbital.Vec3) bool {
 	if s.RCSIsp <= 0 || s.RCSThrust <= 0 || s.Monoprop <= 0 {
 		return false
 	}
 	// v0.9.2+: route through BurnDirection so surface modes + pitch
 	// trim feed through. Non-surface modes degenerate to the same
 	// result as DirectionUnit + zero trim.
-	dir := s.BurnDirection(mode)
+	dir := s.BurnDirectionWithTarget(mode, rT, vT)
 	if dir.Norm() == 0 {
 		return false
 	}
@@ -105,6 +119,30 @@ const (
 	// future v_surface usefully.
 	BurnSurfacePrograde
 	BurnSurfaceRetrograde
+
+	// Target-relative modes (v0.9.3+). Direction depends on the
+	// active *and* target craft states in the same frame:
+	//
+	//   BurnTargetPrograde   = unit(v_target − v_active)
+	//   BurnTargetRetrograde = unit(v_active − v_target)
+	//   BurnTarget           = unit(r_target − r_active)
+	//   BurnAntiTarget       = unit(r_active − r_target)
+	//
+	// The velocity-relative pair is the primary tool for the manual
+	// rendezvous loop — hold target-prograde to close v_rel during
+	// approach, flip target-retrograde at closest approach to null
+	// v_rel. The position-relative pair is for sub-m/s proximity-ops
+	// nudges after v_rel is nulled.
+	//
+	// All four require World.Target.Kind == TargetCraft. Without a
+	// craft target, DirectionUnitTarget returns the zero vector and
+	// the burn is a no-op (the live-closure path captures the world's
+	// resolved target state once per step; the planted-node path
+	// resolves at fire-time via ManeuverNode.TargetCraftIdx).
+	BurnTargetPrograde
+	BurnTargetRetrograde
+	BurnTarget
+	BurnAntiTarget
 )
 
 // String is the label shown in the maneuver planner / HUD.
@@ -126,11 +164,25 @@ func (m BurnMode) String() string {
 		return "Surface Prograde"
 	case BurnSurfaceRetrograde:
 		return "Surface Retrograde"
+	case BurnTargetPrograde:
+		return "Target Prograde"
+	case BurnTargetRetrograde:
+		return "Target Retrograde"
+	case BurnTarget:
+		return "Target"
+	case BurnAntiTarget:
+		return "Anti-Target"
 	}
 	return "?"
 }
 
-// AllBurnModes is the cycle order for the planner UI.
+// AllBurnModes is the cycle order for the planner UI. v0.9.3+: the
+// four target-relative modes append after the body-frame six. Surface
+// modes stay out — planted nodes can't predict future v_surface.
+//
+// The maneuver form skips target-relative entries when
+// World.Target.Kind != TargetCraft (no defined direction without a
+// craft target).
 var AllBurnModes = []BurnMode{
 	BurnPrograde,
 	BurnRetrograde,
@@ -138,11 +190,21 @@ var AllBurnModes = []BurnMode{
 	BurnNormalMinus,
 	BurnRadialOut,
 	BurnRadialIn,
+	BurnTargetPrograde,
+	BurnTargetRetrograde,
+	BurnTarget,
+	BurnAntiTarget,
 }
 
 // DirectionUnit returns a unit vector for the given burn mode given the
 // craft's current (r, v) — primary-relative. Returns the zero vector if
 // r or v is degenerate (can't define the frame).
+//
+// Target-relative modes (BurnTargetPrograde / Retrograde / BurnTarget /
+// AntiTarget) are not handled here — they require target craft state.
+// Callers with a target use DirectionUnitTarget; pure-function callers
+// without target state in scope (predictor, AllBurnModes preview math
+// when no target is set) get the zero vector + degraded behaviour.
 func DirectionUnit(mode BurnMode, r, v orbital.Vec3) orbital.Vec3 {
 	vMag := v.Norm()
 	rMag := r.Norm()
@@ -175,13 +237,61 @@ func DirectionUnit(mode BurnMode, r, v orbital.Vec3) orbital.Vec3 {
 	return orbital.Vec3{}
 }
 
+// DirectionUnitTarget returns the unit thrust direction for the four
+// target-relative modes (v0.9.3+) given the active and target craft
+// states in the SAME frame. Both states should be primary-relative
+// when the two craft share a primary, or fully inertial when they
+// don't — the world layer (World.targetStateRelativeToActivePrimary)
+// handles that conversion.
+//
+// Non-target modes fall through to DirectionUnit(mode, rA, vA), so
+// this is safe to call from any thrust-direction site that wants
+// uniform mode handling.
+//
+// Returns the zero vector when the relative quantity is degenerate
+// (identical positions for BurnTarget / AntiTarget; identical
+// velocities for BurnTargetPrograde / Retrograde) or when called
+// with zero rT, vT (no target resolved — caller passes zeros so the
+// closure still constructs but the burn no-ops).
+func DirectionUnitTarget(mode BurnMode, rA, vA, rT, vT orbital.Vec3) orbital.Vec3 {
+	var d orbital.Vec3
+	switch mode {
+	case BurnTargetPrograde:
+		d = vT.Sub(vA)
+	case BurnTargetRetrograde:
+		d = vA.Sub(vT)
+	case BurnTarget:
+		d = rT.Sub(rA)
+	case BurnAntiTarget:
+		d = rA.Sub(rT)
+	default:
+		return DirectionUnit(mode, rA, vA)
+	}
+	n := d.Norm()
+	if n == 0 {
+		return orbital.Vec3{}
+	}
+	return d.Scale(1 / n)
+}
+
 // ApplyImpulsive adds a delta-v of magnitude dv m/s in the given direction
 // mode, instantly. Fuel is deducted using the rocket equation as a proxy
 // (Isp·g·ln(m0/m1) for the actually-burned Δv); in v0.1 we approximate with
 // a linear consumption rate — plan §MVP defers true rocket-eq to v0.2.
+//
+// Target-relative modes degrade to no-op without a target snapshot;
+// callers with a target use ApplyImpulsiveWithTarget. v0.9.3+.
 func (s *Spacecraft) ApplyImpulsive(mode BurnMode, dv float64) {
+	s.ApplyImpulsiveWithTarget(mode, dv, orbital.Vec3{}, orbital.Vec3{})
+}
+
+// ApplyImpulsiveWithTarget is ApplyImpulsive with a target snapshot
+// in the same frame as Spacecraft.State. Used by the planted-node
+// fire path (sim/maneuver.go) for target-relative impulsive nodes.
+// v0.9.3+.
+func (s *Spacecraft) ApplyImpulsiveWithTarget(mode BurnMode, dv float64, rT, vT orbital.Vec3) {
 	// v0.9.2+: route through BurnDirection so surface modes + trim feed through.
-	dir := s.BurnDirection(mode)
+	dir := s.BurnDirectionWithTarget(mode, rT, vT)
 	if dir.Norm() == 0 || dv == 0 {
 		return
 	}
@@ -300,7 +410,32 @@ func (s *Spacecraft) ThrustAccelFn(mode BurnMode, mu float64) func(r, v orbital.
 // per-node throttle captured on the ActiveBurn struct at fire-time.
 // Decoupling from `Spacecraft.Throttle` means adjusting the live
 // throttle knob mid-coast doesn't slow a planted burn. v0.7.6+.
+//
+// Wrapper: passes zero target state. Target-relative modes degrade
+// to no-op without a snapshot. v0.9.3+: prefer
+// ThrustAccelFnAtWithTarget when the caller has resolved target
+// state.
 func (s *Spacecraft) ThrustAccelFnAt(mode BurnMode, mu, throttle float64) func(r, v orbital.Vec3, t float64) orbital.Vec3 {
+	return s.ThrustAccelFnAtWithTarget(mode, mu, throttle, orbital.Vec3{}, orbital.Vec3{})
+}
+
+// ThrustAccelFnAtWithTarget is ThrustAccelFnAt with a target-craft
+// state snapshot captured at closure construction. The four target-
+// relative modes (BurnTargetPrograde / Retrograde / BurnTarget /
+// AntiTarget) resolve their direction against (rT, vT). The target
+// moves during a sub-step but slowly relative to the per-step
+// granularity, so freezing the snapshot per call is safe — the world
+// layer reconstructs the closure each stepThrust pass with a fresh
+// snapshot.
+//
+// Pass zero rT, vT when no craft target is set (target-relative modes
+// degrade to no-op, non-target modes are unaffected). Both states
+// must be in the same frame as the closure's incoming (r, v) — the
+// world layer (targetStateRelativeToActivePrimary) handles cross-
+// primary conversion before construction.
+//
+// v0.9.3+.
+func (s *Spacecraft) ThrustAccelFnAtWithTarget(mode BurnMode, mu, throttle float64, rT, vT orbital.Vec3) func(r, v orbital.Vec3, t float64) orbital.Vec3 {
 	mass := s.TotalMass()
 	if throttle < 0 {
 		throttle = 0
@@ -317,7 +452,7 @@ func (s *Spacecraft) ThrustAccelFnAt(mode BurnMode, mu, throttle float64) func(r
 	// (r, v, t) into the closure). The closure's mode + trim stay
 	// fixed for the burn — the v0.9.2 plan didn't commit live trim
 	// adjustments mid-burn (they only feed through to the next burn
-	// engagement).
+	// engagement). v0.9.3+: target snapshot likewise captured here.
 	omega := physics.AtmosphereOmega(s.Primary)
 	pitchTrim := s.PitchTrim
 	return func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
@@ -337,6 +472,8 @@ func (s *Spacecraft) ThrustAccelFnAt(mode BurnMode, mu, throttle float64) func(r
 			if mode == BurnSurfaceRetrograde {
 				dir = dir.Scale(-1)
 			}
+		case BurnTargetPrograde, BurnTargetRetrograde, BurnTarget, BurnAntiTarget:
+			dir = DirectionUnitTarget(mode, r, v, rT, vT)
 		default:
 			dir = DirectionUnit(mode, r, v)
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -572,22 +572,22 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.world.AdjustThrottle(-0.1)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudePrograde):
-			a.handleAttitudeKey(spacecraft.BurnPrograde)
+			a.handleAttitudeIntent(sim.IntentPrograde)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeRetrograde):
-			a.handleAttitudeKey(spacecraft.BurnRetrograde)
+			a.handleAttitudeIntent(sim.IntentRetrograde)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeNormalPlus):
-			a.handleAttitudeKey(spacecraft.BurnNormalPlus)
+			a.handleAttitudeIntent(sim.IntentNormalPlus)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeNormalMinus):
-			a.handleAttitudeKey(spacecraft.BurnNormalMinus)
+			a.handleAttitudeIntent(sim.IntentNormalMinus)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeRadialOut):
-			a.handleAttitudeKey(spacecraft.BurnRadialOut)
+			a.handleAttitudeIntent(sim.IntentRadialOut)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeRadialIn):
-			a.handleAttitudeKey(spacecraft.BurnRadialIn)
+			a.handleAttitudeIntent(sim.IntentRadialIn)
 			return a, nil
 		case key.Matches(m, a.keys.ToggleBurn):
 			a.world.ToggleManualBurn()
@@ -612,6 +612,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.ClearTarget):
 			a.world.ClearTarget()
+			return a, nil
+		case key.Matches(m, a.keys.CycleNavMode):
+			nav := a.world.CycleNavMode()
+			a.statusMsg = fmt.Sprintf("nav: %s", nav)
+			a.statusExpires = time.Now().Add(2 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeSurfacePrograde):
 			a.handleAttitudeKey(spacecraft.BurnSurfacePrograde)
@@ -731,6 +736,17 @@ func (a *App) handleAttitudeKey(mode spacecraft.BurnMode) {
 		return
 	}
 	a.world.SetAttitudeMode(mode)
+}
+
+// handleAttitudeIntent translates the player's SAS-axis input through
+// the active NavMode (KSP-style nav-ball mode cycle) before dispatching.
+// In NavOrbit (default) the intent maps 1:1 to the v0.7.3+ orbit-frame
+// burn modes; NavSurface rebinds prograde / retrograde to the rotating-
+// atmosphere frame; NavTarget rebinds prograde / retrograde to relative-
+// velocity, and radial± to BurnTarget / BurnAntiTarget (toward / away
+// from the bound craft target). v0.9.3+.
+func (a *App) handleAttitudeIntent(intent sim.AttitudeIntent) {
+	a.handleAttitudeKey(a.world.ResolveAttitudeIntent(intent))
 }
 
 // applyMenuAction dispatches a finalised MenuAction (Save / Load /

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -714,7 +714,7 @@ func (a *App) hudNodeHit(x, y int) bool {
 	// targeted correctly and the post-edit projected orbit reflects
 	// the right craft.
 	if craftIdx != a.world.ActiveCraftIdx {
-		a.world.ActiveCraftIdx = craftIdx
+		a.world.SetActiveCraftIdx(craftIdx)
 		a.world.StopManualBurn()
 	}
 	a.maneuver.LoadNode(nodeIdx, c.Nodes[nodeIdx])

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -152,25 +152,37 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// uses. Event is forwarded so resolved-then-edited
 				// event-relative nodes keep their semantic label.
 				a.world.PlanNode(sim.ManeuverNode{
-					TriggerTime: m.TriggerTime,
-					Mode:        m.Mode,
-					DV:          m.DV,
-					Duration:    dur,
-					Event:       m.Event,
-					Throttle:    m.Throttle,
+					TriggerTime:    m.TriggerTime,
+					Mode:           m.Mode,
+					DV:             m.DV,
+					Duration:       dur,
+					Event:          m.Event,
+					Throttle:       m.Throttle,
+					TargetCraftIdx: m.TargetCraftIdx,
 				})
 			case m.Event != sim.TriggerAbsolute:
 				// v0.6.0: event-relative nodes go through PlanNode so
 				// the resolver can freeze TriggerTime against the live
 				// orbit on the next Tick.
 				a.world.PlanNode(sim.ManeuverNode{
-					Mode:     m.Mode,
-					DV:       m.DV,
-					Duration: dur,
-					Event:    m.Event,
-					Throttle: m.Throttle,
+					Mode:           m.Mode,
+					DV:             m.DV,
+					Duration:       dur,
+					Event:          m.Event,
+					Throttle:       m.Throttle,
+					TargetCraftIdx: m.TargetCraftIdx,
 				})
 			case dur == 0:
+				// v0.9.3+: target-relative impulsive needs the bound
+				// target snapshot for direction resolution.
+				if m.TargetCraftIdx != 0 {
+					if tIdx := m.TargetCraftIdx - 1; tIdx >= 0 && tIdx < len(a.world.Crafts) {
+						if tc := a.world.Crafts[tIdx]; tc != nil && tc.Primary.ID == a.world.ActiveCraft().Primary.ID {
+							a.world.ActiveCraft().ApplyImpulsiveWithTarget(m.Mode, m.DV, tc.State.R, tc.State.V)
+							break
+						}
+					}
+				}
 				a.world.ActiveCraft().ApplyImpulsive(m.Mode, m.DV)
 			default:
 				effThrottle := m.Throttle
@@ -178,10 +190,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					effThrottle = 1.0
 				}
 				a.world.ActiveCraft().ActiveBurn = &sim.ActiveBurn{
-					Mode:        m.Mode,
-					DVRemaining: m.DV,
-					EndTime:     a.world.Clock.SimTime.Add(dur),
-					Throttle:    effThrottle,
+					Mode:           m.Mode,
+					DVRemaining:    m.DV,
+					EndTime:        a.world.Clock.SimTime.Add(dur),
+					Throttle:       effThrottle,
+					TargetCraftIdx: m.TargetCraftIdx,
 				}
 			}
 		}
@@ -240,6 +253,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
 				if idx >= 0 && idx < len(a.world.ActiveCraft().Nodes) {
 					a.maneuver.LoadNode(idx, a.world.ActiveCraft().Nodes[idx])
+					a.bindManeuverTarget()
 					a.world.Clock.Paused = true
 					a.active = screenManeuver
 				}
@@ -261,6 +275,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// that schedule.
 				if dt, ok := a.orbitView.ProjectToOrbit(a.world, m.X, m.Y); ok && a.world.CraftVisibleHere() {
 					a.maneuver.LoadStaged(a.world.Clock.SimTime.Add(dt))
+					a.bindManeuverTarget()
 					a.world.Clock.Paused = true
 					a.active = screenManeuver
 				}
@@ -397,6 +412,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// click-to-edit state that may be lingering from a
 				// previous open.
 				a.maneuver.ResetEditing()
+				a.bindManeuverTarget()
 				a.active = screenManeuver
 				a.world.Clock.Paused = true
 			}
@@ -826,4 +842,18 @@ func overlayLastLine(base, overlay string) string {
 		return overlay
 	}
 	return base[:idx+1] + overlay
+}
+
+// bindManeuverTarget hands the current World.Target binding to the
+// maneuver form so the four target-relative burn modes and the
+// TriggerNextClosestApproach event are pickable + correctly captured
+// at plant. Bound at form-open time (not per-keypress), so a target
+// switch while the form is open doesn't silently retarget a planted
+// burn — the player closes + reopens to retarget. v0.9.3+.
+func (a *App) bindManeuverTarget() {
+	if a.world.Target.Kind == sim.TargetCraft {
+		a.maneuver.SetTargetCraft(true, a.world.Target.CraftIdx)
+		return
+	}
+	a.maneuver.SetTargetCraft(false, 0)
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -88,6 +88,15 @@ type Keymap struct {
 	CycleTarget key.Binding
 	ClearTarget key.Binding
 
+	// CycleNavMode (v0.9.3+): rotate the SAS reference frame through
+	// Orbit → Surface → Target → Orbit (KSP nav-ball mode cycle).
+	// Skips Target when no craft target is bound. The same w/s/a/d/q/e
+	// axis keys reinterpret accordingly: in NavTarget, w/s become
+	// target-relative prograde/retrograde and q/e become Target/Anti-
+	// Target (toward / away). Bound to `;`. Existing `W` / `S` direct-
+	// surface shortcuts stay as nav-mode-bypass.
+	CycleNavMode key.Binding
+
 	// Stage (v0.9.1+): KSP-style player-managed sequential decouple.
 	// Drops the active craft's bottom stage (Stages[0]) — spawning
 	// it as a passive Spacecraft in the slate at the same inertial
@@ -171,6 +180,7 @@ func DefaultKeymap() Keymap {
 		Undock:              key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "undock active composite")),
 		CycleTarget:         key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "cycle target (body / craft)")),
 		ClearTarget:         key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "clear target")),
+		CycleNavMode:        key.NewBinding(key.WithKeys(";"), key.WithHelp(";", "nav: orbit / surface / target")),
 		Stage:               key.NewBinding(key.WithKeys(" "), key.WithHelp("space", "decouple bottom stage")),
 
 		AttitudeSurfacePrograde:   key.NewBinding(key.WithKeys("W"), key.WithHelp("W", "attitude: surface prograde")),

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -514,6 +514,30 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	// the existing white-on-default rendering of this canvas.
 	m.canvas.DrawEllipseOffsetOccluded(currentEl, orbital.Vec3{}, 360, 4, orbital.Vec3{}, primaryPxR, "")
 
+	// v0.9.3 polish: target craft's orbit + current position when it
+	// shares the active craft's primary. The maneuver canvas centers
+	// on the active craft's primary at origin {0,0,0}, so the target
+	// state vector (already primary-relative when same-primary) plots
+	// directly. Cross-primary targets are out of scope — the canvas
+	// frame is the wrong one for them.
+	if w.Target.Kind == sim.TargetCraft && w.Target.CraftIdx >= 0 && w.Target.CraftIdx < len(w.Crafts) {
+		if tc := w.Crafts[w.Target.CraftIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+			tEl := orbital.ElementsFromState(tc.State.R, tc.State.V, mu)
+			tOrbitVisible := tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0)
+			if tOrbitVisible {
+				m.canvas.DrawEllipseOffsetOccluded(tEl, orbital.Vec3{}, 360, 3, orbital.Vec3{}, primaryPxR, render.ColorTarget)
+			}
+			if !m.canvas.IsBehindBody(tc.State.R, orbital.Vec3{}, primaryPxR) {
+				m.canvas.PlotColored(tc.State.R, render.ColorTarget)
+				if tc.Glyph != "" {
+					if g := []rune(tc.Glyph); len(g) > 0 {
+						m.canvas.SetCellOverlay(tc.State.R, g[0])
+					}
+				}
+			}
+		}
+	}
+
 	// Draw shadow trajectory after applying the current (mode, dv,
 	// fire-at) triple. v0.6.1: when fire-at is event-relative, the
 	// world's PreviewBurnState propagates the craft to the event

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -53,6 +53,43 @@ type Maneuver struct {
 	// quick-plant path.
 	editingIdx        int
 	loadedTriggerTime time.Time
+
+	// hasTargetCraft + targetCraftIdx carry the World.Target binding
+	// at form-open time, so the four target-relative burn modes and
+	// the TriggerNextClosestApproach event can resolve their
+	// direction / trigger against the captured target. Bound at open
+	// (not at every keypress) so a target switch while the form is
+	// open doesn't silently retarget a planted burn — the player
+	// closes + reopens the form to retarget. v0.9.3+.
+	hasTargetCraft bool
+	targetCraftIdx int
+}
+
+// SetTargetCraft binds (or unbinds) the target-craft slate index the
+// form's planted burn will be aimed at. Called by the app when
+// opening the form so the four target-relative burn modes and the
+// TriggerNextClosestApproach event can resolve at plant + fire time.
+// Pass ok=false to clear (no craft target set / target is a body).
+// v0.9.3+.
+func (m *Maneuver) SetTargetCraft(ok bool, idx int) {
+	m.hasTargetCraft = ok
+	if ok {
+		m.targetCraftIdx = idx
+	} else {
+		m.targetCraftIdx = 0
+	}
+	// If the currently-selected mode or trigger requires a target
+	// and we no longer have one, snap to safe defaults so the form
+	// renders something fireable.
+	if !m.hasTargetCraft {
+		mode := spacecraft.AllBurnModes[m.modeIdx]
+		if spacecraft.IsTargetRelativeMode(mode) {
+			m.modeIdx = 0
+		}
+		if sim.AllTriggerEvents[m.fireAtIdx] == sim.TriggerNextClosestApproach {
+			m.fireAtIdx = 0
+		}
+	}
 }
 
 // BurnExecutedMsg is emitted when the user hits Enter. App consumes it.
@@ -93,6 +130,12 @@ type BurnExecutedMsg struct {
 	// commanded value would have delivered (compensating finite-burn
 	// loss). Ignored for impulsive (zero-thrust) and Normal± burns.
 	IterateForTarget bool
+	// TargetCraftIdx (v0.9.3+) is the one-based encoding of the
+	// target slate idx the form was bound to at plant. Zero = no
+	// target. Mirrors ManeuverNode.TargetCraftIdx; the app passes it
+	// straight through. Only populated for target-relative modes /
+	// TriggerNextClosestApproach event.
+	TargetCraftIdx int
 }
 
 // NodeDeleteMsg is emitted when the player presses ctrl+d in the
@@ -193,6 +236,15 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 	m.focus = 0
 	m.editingIdx = idx
 	m.loadedTriggerTime = n.TriggerTime
+	// v0.9.3+: preserve the node's stored target binding through the
+	// edit cycle so re-planting doesn't drop it. Caller (app) is
+	// expected to follow up with SetTargetCraft to reflect the
+	// CURRENT World.Target if the node's binding is stale, but the
+	// default-load behaviour preserves the original target.
+	if tIdx, ok := n.TargetCraftIdxValue(); ok {
+		m.hasTargetCraft = true
+		m.targetCraftIdx = tIdx
+	}
 	m.applyFocus()
 }
 
@@ -277,10 +329,10 @@ func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	case "left":
 		switch m.focus {
 		case 0:
-			m.modeIdx = (m.modeIdx - 1 + len(spacecraft.AllBurnModes)) % len(spacecraft.AllBurnModes)
+			m.advanceMode(-1)
 			return nil, false
 		case 1:
-			m.fireAtIdx = (m.fireAtIdx - 1 + len(sim.AllTriggerEvents)) % len(sim.AllTriggerEvents)
+			m.advanceFireAt(-1)
 			return nil, false
 		case 4:
 			m.iterateForTarget = !m.iterateForTarget
@@ -289,10 +341,10 @@ func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	case "right":
 		switch m.focus {
 		case 0:
-			m.modeIdx = (m.modeIdx + 1) % len(spacecraft.AllBurnModes)
+			m.advanceMode(1)
 			return nil, false
 		case 1:
-			m.fireAtIdx = (m.fireAtIdx + 1) % len(sim.AllTriggerEvents)
+			m.advanceFireAt(1)
 			return nil, false
 		case 4:
 			m.iterateForTarget = !m.iterateForTarget
@@ -337,9 +389,10 @@ func (m *Maneuver) commitCmd() tea.Cmd {
 	if dv == 0 {
 		return nil
 	}
+	mode := spacecraft.AllBurnModes[m.modeIdx]
 	event := sim.AllTriggerEvents[m.fireAtIdx]
 	msg := BurnExecutedMsg{
-		Mode:             spacecraft.AllBurnModes[m.modeIdx],
+		Mode:             mode,
 		DV:               dv,
 		Event:            event,
 		TriggerTime:      m.loadedTriggerTime,
@@ -347,7 +400,48 @@ func (m *Maneuver) commitCmd() tea.Cmd {
 		Throttle:         m.parsedThrottle(),
 		IterateForTarget: m.iterateForTarget,
 	}
+	// v0.9.3+: capture the bound target craft idx for target-relative
+	// modes and the TriggerNextClosestApproach event. One-based to
+	// match the ManeuverNode encoding (zero = no target, idx+1
+	// otherwise — JSON omitempty drops it for non-target nodes).
+	if m.hasTargetCraft && (spacecraft.IsTargetRelativeMode(mode) || event == sim.TriggerNextClosestApproach) {
+		msg.TargetCraftIdx = m.targetCraftIdx + 1
+	}
 	return func() tea.Msg { return msg }
+}
+
+// advanceMode steps modeIdx by delta, skipping target-relative modes
+// when no craft target is bound. Stops after one full cycle to avoid
+// looping forever in the impossible "all modes invalid" case (would
+// only happen if AllBurnModes were entirely target-relative). v0.9.3+.
+func (m *Maneuver) advanceMode(delta int) {
+	n := len(spacecraft.AllBurnModes)
+	if n == 0 {
+		return
+	}
+	for step := 0; step < n; step++ {
+		m.modeIdx = (m.modeIdx + delta + n) % n
+		mode := spacecraft.AllBurnModes[m.modeIdx]
+		if !spacecraft.IsTargetRelativeMode(mode) || m.hasTargetCraft {
+			return
+		}
+	}
+}
+
+// advanceFireAt steps fireAtIdx by delta, skipping
+// TriggerNextClosestApproach when no craft target is bound. v0.9.3+.
+func (m *Maneuver) advanceFireAt(delta int) {
+	n := len(sim.AllTriggerEvents)
+	if n == 0 {
+		return
+	}
+	for step := 0; step < n; step++ {
+		m.fireAtIdx = (m.fireAtIdx + delta + n) % n
+		ev := sim.AllTriggerEvents[m.fireAtIdx]
+		if ev != sim.TriggerNextClosestApproach || m.hasTargetCraft {
+			return
+		}
+	}
 }
 
 // parsedThrottle returns the form's throttle setting as a fraction

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -571,6 +571,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// small pixel sizes. The current-orbit ellipse renders in
 		// the craft's own color (dim when no Color is set, falling
 		// back to ColorDim — preserves pre-v0.8.2 behaviour).
+		targetCraftIdx := -1
+		if w.Target.Kind == sim.TargetCraft {
+			targetCraftIdx = w.Target.CraftIdx
+		}
 		for i, other := range w.Crafts {
 			if i == w.ActiveCraftIdx || other == nil {
 				continue
@@ -580,12 +584,27 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			otherInertial := otherPrimaryPos.Add(other.State.R)
 			otherEl := orbital.ElementsFromState(other.State.R, other.State.V, other.Primary.GravitationalParameter())
 			otherOrbitVisible := otherEl.A > 0 && !math.IsNaN(otherEl.A) && !math.IsInf(otherEl.A, 0) && otherEl.Apoapsis()*scale >= minOrbitPixels
+			isTarget := i == targetCraftIdx
 			otherColor := lipgloss.Color(render.ColorDim)
 			if other.Color != "" {
 				otherColor = lipgloss.Color(other.Color)
 			}
+			if isTarget {
+				// v0.9.3 polish: target's orbit + glyph render in the
+				// dedicated TARGET green so the player can pick out
+				// which non-active craft is the bound target at a
+				// glance, even with multiple craft sharing the view.
+				otherColor = render.ColorTarget
+			}
 			if otherOrbitVisible {
-				v.canvas.DrawEllipseOffsetOccluded(otherEl, otherPrimaryPos, 180, 5, otherPrimaryPos, otherPxR, otherColor)
+				// Target gets denser sampling (every 3rd vs every 5th
+				// for plain non-active craft) so its track reads as
+				// brighter / more prominent than peers.
+				stride := 5
+				if isTarget {
+					stride = 3
+				}
+				v.canvas.DrawEllipseOffsetOccluded(otherEl, otherPrimaryPos, 180, stride, otherPrimaryPos, otherPxR, otherColor)
 			}
 			if !v.canvas.IsBehindBody(otherInertial, otherPrimaryPos, otherPxR) {
 				v.canvas.PlotColored(otherInertial, otherColor)
@@ -1268,20 +1287,43 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 						nameLine += v.theme.Dim.Render(" — " + tc.Role)
 					}
 					lines = append(lines, nameLine)
+					// Target orbit shape: apo/peri altitudes around its
+					// own primary. Always meaningful (target's state is
+					// already primary-relative), regardless of whether
+					// active craft shares the primary.
+					tMu := tc.Primary.GravitationalParameter()
+					tFrame := orbital.ReferenceFrameForPrimary(tc.Primary)
+					tEl := orbital.ElementsFromStateInFrame(tc.State.R, tc.State.V, tMu, tFrame)
+					if tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0) {
+						tPrimaryR := tc.Primary.RadiusMeters()
+						lines = append(lines,
+							fmt.Sprintf("  apoapsis:  %.1f km", (tEl.Apoapsis()-tPrimaryR)/1000),
+							fmt.Sprintf("  periapsis: %.1f km", (tEl.Periapsis()-tPrimaryR)/1000),
+						)
+					}
 					// Range / |v_rel|: use primary-frame deltas when
 					// they share a primary (the common rendezvous
 					// scenario), inertial otherwise (cross-SOI
 					// targeting works but reads as a long-distance
 					// pointer — v0.9.3 closest-approach maths will
 					// make this useful).
-					var rangeM, vRel float64
+					var rRel, vRelVec orbital.Vec3
 					if tc.Primary.ID == c.Primary.ID {
-						rangeM = tc.State.R.Sub(c.State.R).Norm()
-						vRel = tc.State.V.Sub(c.State.V).Norm()
+						rRel = tc.State.R.Sub(c.State.R)
+						vRelVec = tc.State.V.Sub(c.State.V)
 					} else {
 						tcInertial := w.BodyPosition(tc.Primary).Add(tc.State.R)
-						rangeM = tcInertial.Sub(w.CraftInertial()).Norm()
-						vRel = w.CraftInertialVelocity(tc).Sub(w.CraftInertialVelocity(c)).Norm()
+						rRel = tcInertial.Sub(w.CraftInertial())
+						vRelVec = w.CraftInertialVelocity(tc).Sub(w.CraftInertialVelocity(c))
+					}
+					rangeM := rRel.Norm()
+					vRel := vRelVec.Norm()
+					// Closing rate: positive = approaching, negative =
+					// receding. Sign tells the player whether they're
+					// faster or slower along-track than target.
+					var closing float64
+					if rangeM > 0 {
+						closing = -rRel.Dot(vRelVec) / rangeM
 					}
 					rangeLabel := fmt.Sprintf("%.0f m", rangeM)
 					switch {
@@ -1291,8 +1333,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 						rangeLabel = fmt.Sprintf("%.2f km", rangeM/1000)
 					}
 					lines = append(lines,
-						fmt.Sprintf("  range:  %s", rangeLabel),
+						fmt.Sprintf("  range:   %s", rangeLabel),
 						fmt.Sprintf("  |v_rel|: %.2f m/s", vRel),
+						fmt.Sprintf("  closing: %+.2f m/s", closing),
 					)
 					// v0.9.3+: rendezvous block — time + distance to next
 					// closest approach, DOCK READY indicator. Only when

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1384,41 +1384,12 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		}
 	}
 
-	// v0.8.3+: rendezvous readout — when the active craft shares
-	// its primary frame with another craft, surface range +
-	// relative velocity to the nearest one. Lets the player RCS-
-	// null residuals during proximity ops without guessing. The
-	// "DOCK READY" callout fires when both gates are met (the
-	// next tick will actually fuse).
-	if c := w.ActiveCraft(); c != nil && len(w.Crafts) > 1 {
-		nearest, range_, vRel, ok := findNearestSamePrimary(w.Crafts, w.ActiveCraftIdx)
-		if ok {
-			lines = append(lines, section("RENDEZVOUS")...)
-			rangeLabel := fmt.Sprintf("%.0f m", range_)
-			if range_ > 1000 {
-				rangeLabel = fmt.Sprintf("%.2f km", range_/1000)
-			}
-			vRelLabel := fmt.Sprintf("%.2f m/s", vRel)
-			withinDist := range_ <= sim.DockingDistM
-			withinV := vRel <= sim.DockingVMS
-			if withinDist {
-				rangeLabel = v.theme.Warning.Render(rangeLabel + " ✓")
-			}
-			if withinV {
-				vRelLabel = v.theme.Warning.Render(vRelLabel + " ✓")
-			}
-			lines = append(lines,
-				fmt.Sprintf("  target:    %s", nearest.Name),
-				fmt.Sprintf("  range:     %s", rangeLabel),
-				fmt.Sprintf("  |v_rel|:   %s", vRelLabel),
-			)
-			if withinDist && withinV {
-				lines = append(lines,
-					"  "+v.theme.Alert.Render("● DOCK READY — fusing next tick"),
-				)
-			}
-		}
-	}
+	// v0.9.3 polish: the v0.8.3 RENDEZVOUS block (nearest-craft
+	// auto-surface) was dropped — the v0.9.0 TARGET HUD block now
+	// covers the same range / |v_rel| / DOCK READY readouts and
+	// adds closing rate, TCA, CA, and target apo/peri. Player must
+	// bind a target with `H`/`I` to see proximity-ops feedback now,
+	// but the duplication was reading as noise on the HUD.
 
 	// v0.9.1+: STAGES block — lists per-stage thrust / Isp / fuel%
 	// for the active craft when it has more than one stage. Top-of-
@@ -1631,10 +1602,6 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	return rendered
 }
 
-// findNearestSamePrimary returns the closest non-active craft
-// sharing the active craft's primary, plus their separation +
-// relative speed. Used by the v0.8.3+ RENDEZVOUS HUD block to
-// surface live proximity-ops feedback. Returns ok=false when no
 // shouldShowLaunchHUD returns true when the active craft is in
 // "ascent" mode — periapsis below the primary's mean radius
 // (= craft would impact if its orbit closed) AND altitude under
@@ -1679,40 +1646,6 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 		return false
 	}
 	return true
-}
-
-// other craft is in the same frame.
-func findNearestSamePrimary(crafts []*spacecraft.Spacecraft, activeIdx int) (*spacecraft.Spacecraft, float64, float64, bool) {
-	if activeIdx < 0 || activeIdx >= len(crafts) {
-		return nil, 0, 0, false
-	}
-	a := crafts[activeIdx]
-	if a == nil {
-		return nil, 0, 0, false
-	}
-	var (
-		best     *spacecraft.Spacecraft
-		bestDist = math.Inf(1)
-		bestVRel float64
-	)
-	for i, c := range crafts {
-		if i == activeIdx || c == nil {
-			continue
-		}
-		if c.Primary.ID != a.Primary.ID {
-			continue
-		}
-		d := c.State.R.Sub(a.State.R).Norm()
-		if d < bestDist {
-			bestDist = d
-			bestVRel = c.State.V.Sub(a.State.V).Norm()
-			best = c
-		}
-	}
-	if best == nil {
-		return nil, 0, 0, false
-	}
-	return best, bestDist, bestVRel, true
 }
 
 // scanHudNodeRows walks the rendered HUD line-by-line and matches

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -431,27 +431,12 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		}
 	}
 
-	// Vessel position trail (v0.5.2): a fading dotted history of
-	// where the craft has actually been, distinct from the current
-	// Keplerian orbit ellipse. Stride increases (sparser dots) for
-	// older samples to give a visual gradient — newest = densest.
-	if w.CraftVisibleHere() {
-		trail := w.CraftTrail()
-		// Draw oldest first (sparse stride 4) → newest (every point),
-		// so newer samples overdraw older ones at any cell collision.
-		for i, p := range trail {
-			// stride: 4 at oldest end, 1 at newest end. Linear ramp.
-			progress := float64(i) / float64(len(trail))
-			stride := 4 - int(3*progress)
-			if stride < 1 {
-				stride = 1
-			}
-			if i%stride != 0 {
-				continue
-			}
-			v.canvas.Plot(p)
-		}
-	}
+	// v0.9.3 polish: vessel position trail no longer renders by
+	// default. With multiple craft + the v0.9.3 target-orbit
+	// highlight, trails read as clutter in the multi-orbit views.
+	// `World.CraftTrail()` still ticks behind the scenes — fast
+	// reintroduction as a toggle is trivial if it turns out players
+	// miss the breadcrumb cue.
 
 	// Spacecraft current-orbit ellipse + glyph. Orbit is the craft's
 	// live Keplerian ellipse in its home primary's frame, translated

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -1292,6 +1293,48 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 						fmt.Sprintf("  range:  %s", rangeLabel),
 						fmt.Sprintf("  |v_rel|: %.2f m/s", vRel),
 					)
+					// v0.9.3+: rendezvous block — time + distance to next
+					// closest approach, DOCK READY indicator. Only when
+					// both craft share a primary; cross-SOI rendezvous is
+					// out of scope for the manual loop. Horizon: 4 hours
+					// covers 2–3 LEO periods, which is the typical
+					// player-controlled rendezvous window.
+					if tc.Primary.ID == c.Primary.ID {
+						rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+						if ok {
+							active := orbital.Vec3State{R: c.State.R, V: c.State.V}
+							target := orbital.Vec3State{R: rT, V: vT}
+							mu := c.Primary.GravitationalParameter()
+							const horizon = 4 * 3600.0
+							if tCA, distCA, _, err := planner.NextClosestApproach(active, target, c.Primary, mu, horizon); err == nil {
+								tcaLabel := fmt.Sprintf("%.0fs", tCA)
+								switch {
+								case tCA >= 3600:
+									tcaLabel = fmt.Sprintf("%.2fh", tCA/3600)
+								case tCA >= 60:
+									tcaLabel = fmt.Sprintf("%.1fmin", tCA/60)
+								}
+								caLabel := fmt.Sprintf("%.0f m", distCA)
+								switch {
+								case distCA > 1e6:
+									caLabel = fmt.Sprintf("%.0f km", distCA/1000)
+								case distCA > 1000:
+									caLabel = fmt.Sprintf("%.2f km", distCA/1000)
+								}
+								lines = append(lines,
+									fmt.Sprintf("  TCA:    %s", tcaLabel),
+									fmt.Sprintf("  CA:     %s", caLabel),
+								)
+							}
+						}
+						// DOCK READY: current range < 50 m && |v_rel| <
+						// 0.1 m/s. Gates on v0.8.3 DockCrafts which the
+						// player invokes once the indicator lights.
+						if rangeM < 50 && vRel < 0.1 {
+							dockStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3DDC84")).Bold(true)
+							lines = append(lines, "  "+dockStyle.Render("DOCK READY"))
+						}
+					}
 				}
 			}
 		}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1024,6 +1024,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			manualState = fmt.Sprintf(v.theme.Warning.Render("● firing T+%.1fs"), elapsed)
 		}
 		lines = append(lines,
+			fmt.Sprintf("  nav:       %s", w.NavMode),
 			fmt.Sprintf("  hold:      %s", w.ActiveCraft().AttitudeMode.String()),
 			fmt.Sprintf("  engine:    %s", w.ActiveCraft().EngineMode.String()),
 			fmt.Sprintf("  manual:    %s", manualState),


### PR DESCRIPTION
## Summary

Rendezvous tooling — manual-flow first, with KSP-style NavMode cycle pulled forward from the original v0.9.4/v0.9.5 navball slot.

- **Four target-relative SAS modes** (`internal/spacecraft/thrust.go`): `BurnTargetPrograde` / `BurnTargetRetrograde` (velocity-relative — close / open `v_rel`) and `BurnTarget` / `BurnAntiTarget` (position-relative — proximity-ops nudges). All four resolve direction at fire time against the captured target snapshot.
- **`planner.NextClosestApproach`** (`internal/planner/rendezvous.go`): sample-then-bisect over Verlet predictions for live TCA / CA / `v_rel` readouts.
- **TARGET HUD craft block** (`internal/tui/screens/orbit.go`): live range / `|v_rel|` / signed closing rate + apoapsis / periapsis + TCA / CA + DOCK READY callout (range < 50 m && `|v_rel|` < 0.1 m/s).
- **KSP-style NavMode cycle** (`internal/sim/nav.go`, `;` keystroke): rotates Orbit → Surface → Target. Same six SAS axis keys (`w`/`s`/`a`/`d`/`q`/`e`) reinterpret per mode — NavTarget rebinds prograde/retrograde to TargetPrograde/Retrograde and radial±  to BurnTarget / BurnAntiTarget. NavTarget auto-snaps back to NavOrbit when the bound target craft is cleared. Persisted in save (omitempty).
- **`m`-form integration** (`internal/tui/screens/maneuver.go`): the four target-relative modes selectable when a craft target is bound; new `next closest approach` trigger event with lazy-freeze resolver; `ManeuverNode.TargetCraftIdx` captured at plant time (one-based for `omitempty`); save round-trip + stale-target silent no-op on load.
- **Per-craft target binding + colored target track** (`internal/sim/target.go`, polish pass).

`PlanRendezvous` auto-plant deferred; the manual loop is the slice's success metric.

## Test plan

- [ ] Build cleanly: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Manual rendezvous loop end-to-end: spawn sister craft via `n` → POSITION → alongside; cycle `t` to bind as target; press `;` to enter NavTarget; throttle + `w` (now TargetPrograde) to close `v_rel`; watch TCA / CA shrink in TARGET HUD; flip to `s` (TargetRetrograde) at intercept to null `v_rel`; DOCK READY callout fires when both gates met.
- [ ] Planted-node workflow: `m` form → mode = TargetPrograde, fire-at = `next closest approach`, Δv = small; node fires at predicted encounter with target-relative direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SVEcfc1k3v3PUk9MucrWQp)_