### PR TITLE
feat(launch): v0.9.4 ascent ergonomics — predictive LAUNCH HUD + tilted-axis fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 Latest release: **v0.9.1** — staging chain. KSP-style player-managed sequential decouples; `space` drops the bottom stage and spawns it as a passive cycle-able craft, with the active vehicle continuing on the upper-stage chain. Saturn-V loadout (S-IC + S-II + S-IVB, TWR > 1 at sea level) ships alongside the four single-stage loadouts, which wrap into a one-element `Stages: [{...}]` shim with no behavior change. New STAGES HUD block, `Spacecraft.Stages` source-of-truth for dry mass / propellant / engine numbers, save schema v5 → v6 with typed migration. Followed v0.9.0 (unified `World.Target` slot, `t` / `T` cycle / clear, TARGET HUD).
 
-**v0.9.2 in flight (work-in-progress).** Ground launch primitives are
-implemented on the [`v0.9.2-ground-launch`](https://github.com/jasonfen/terminal-space-program/pull/51)
-branch — `n` → POSITION → launchpad spawns a Saturn V at altitude 0 on
-a rotating Earth, with surface-frame SAS modes (`W` / `S`), pitch trim
-(`<` / `>` / `\`), and a LAUNCH HUD. **Reaching a stable orbit by hand
-is hard today** — no gravity-turn assist, no ascent autopilot, and the
-ascent profile is sensitive to throttle / pitch timing. The slice ships
-unmerged pending an ergonomic pass; treat it as an experimental loop,
-not a smooth pad-to-LEO. See [Surface launches (WIP)](#surface-launches-wip)
-below for the suggested sequence.
+**v0.9.5 ascent ergonomics in flight.** Ground launch primitives
+landed in v0.9.2 (`n` → POSITION → launchpad spawns a Saturn V at
+altitude 0 on a rotating Earth, with surface-frame SAS, pitch trim,
+and a LAUNCH HUD), and v0.9.5 layers KSP-style live guidance on top:
+predictive **ap / pe / t-to-apo / Δv→circ** readouts in the LAUNCH
+HUD, an **ORBIT READY** callout when apoapsis crosses 200 km,
+auto-snap to NavSurface on launchpad spawn (so `w` already means
+surface-prograde), and a single-key **`C`** that plants the
+circularisation node at next apoapsis. Pad-to-LEO is now a
+playable loop — see [Surface launches](#surface-launches) below.
 
 ```bash
 # Linux x86_64
@@ -96,40 +96,49 @@ with mass loss tracked from the rocket equation.
 For real-time stick (KSP-style), throttle up with `z`, attitude
 with `w`/`s`/`a`/`d`/`q`/`e`, then engage with `b`.
 
-### Surface launches (WIP)
+### Surface launches
 
-Spawn a Saturn V on the pad and fly it to LEO by hand. **Status: not
-ready for primetime** — orbital insertion routinely undershoots
-without a gravity-turn assist, and the ascent profile is hand-tuned.
-The slice (v0.9.2, on the `v0.9.2-ground-launch` branch) lays the
-primitives so a future polish slice can layer assistive controls on
-top. Try it, expect to flame out, file feedback.
+Spawn a Saturn V on the pad and fly it to LEO by hand. The flow
+mirrors KSP: tip the rocket 10° east, switch SAS to surface-prograde,
+let gravity bend the velocity vector over, watch the LAUNCH HUD's
+live ap / pe / Δv→circ shrink as you burn, plant the circularisation
+node at apoapsis with `C`, coast and fire. v0.9.5+ wires the live
+KSP-style readouts so you can fly by watching numbers.
 
 Suggested sequence for a Saturn V → LEO attempt:
 
 1. `n` opens the spawn form. Cycle `POSITION` to **launchpad**, set
    `LATITUDE` to a preset (28.6° N = Cape Canaveral KSC), pick
    `CRAFT TYPE = Saturn V`, press `Enter`. SAS comes up at radial+
-   so the craft is pointing straight up.
+   (vertical) and **NavMode auto-snaps to Surface**, so `w` already
+   means surface-prograde — no `;` press needed.
 2. `z` (full throttle), `b` (engage). The S-IC lifts vertical at
    TWR ≈ 1.24.
-3. At ~3–5 km altitude, tap `>` 2–3 times to trim 20–30° east. The
-   thrust vector tilts; horizontal speed starts climbing.
-4. As surface velocity builds (>500 m/s), press `W` for surface-
+3. At ~3 km altitude, tap `>` once to trim 10° east. The thrust
+   vector tilts; horizontal velocity starts climbing.
+4. As surface velocity passes ~100 m/s, press `w` for surface-
    prograde SAS and `\` to clear the pitch trim. The craft now
-   tracks its own velocity vector — a pseudo gravity turn.
+   tracks its own velocity vector — gravity bends it over and the
+   gravity turn falls out of the physics.
 5. Press `space` to decouple the spent S-IC. The active craft
    stays on the upper stage; STAGES HUD advances. Continue burn
-   through S-II, decouple again, then S-IVB circularises.
-6. Watch the LAUNCH HUD's altitude / v_horiz. The
-   `saturn-v-pad-to-leo` mission passes when periapsis > 200 km.
+   through S-II, decouple again, then S-IVB.
+6. Watch the LAUNCH HUD's `ap:` row climb. When it crosses 200 km,
+   the **● ORBIT READY** callout appears — that's the cue to cut
+   throttle (`x`) and coast.
+7. Press `C` to plant the circularisation node at next apoapsis.
+   Status flashes `circularize @ apoapsis (X km) → +Y m/s prograde`
+   and the PROJECTED ORBIT block shows the post-burn circle.
+8. Coast to apoapsis. The planted node fires automatically and
+   raises periapsis to match. Mission `saturn-v-pad-to-leo` passes
+   when `pe > 200 km` — the LAUNCH HUD's `mission:` line counts
+   down to that threshold along the way.
 
-What actually happens in practice: by the time S-IVB is empty,
-periapsis is usually still negative (i.e. on a sub-orbital arc
-back through the atmosphere). The slice's open question — flagged
-as a v0.9.5+ gravity-turn assist — is whether to expose a target
-pitch-vs-altitude profile or an autopilot toggle. For now this is
-a manual flying challenge, not a guaranteed mission.
+The whole loop runs on numbers, not memorised pitch tables: ap
+climbs while you burn, ORBIT READY tells you when to coast, `C`
+plants the burn, mission progress closes the gap. If anything
+flames out, the LAUNCH HUD's predictive readouts surface the
+"why" before you watch the craft re-enter.
 
 ## Keybindings
 
@@ -160,6 +169,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `n` | Open spawn form (loadout / position / parent body / altitude / direction) |
 | `H` | Auto-plant Hohmann transfer to `World.Target` body (intra-primary for moons of the craft's parent; moon → parent escape via bound transfer ellipse). TargetCraft flashes "needs v0.9.3" |
 | `I` | Plant inclination match — rotates the orbital plane to `World.Target` body's inclination (or 0° equatorial when target is None). TargetCraft flashes "needs v0.9.3" |
+| `C` | Plant circularize burn at next apoapsis (v0.9.5+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
 | `t` / `T` | Cycle / clear `World.Target` (non-active sibling craft → bodies in active system → none) |
 | `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+) |
 | `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H` |

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 Latest release: **v0.9.1** — staging chain. KSP-style player-managed sequential decouples; `space` drops the bottom stage and spawns it as a passive cycle-able craft, with the active vehicle continuing on the upper-stage chain. Saturn-V loadout (S-IC + S-II + S-IVB, TWR > 1 at sea level) ships alongside the four single-stage loadouts, which wrap into a one-element `Stages: [{...}]` shim with no behavior change. New STAGES HUD block, `Spacecraft.Stages` source-of-truth for dry mass / propellant / engine numbers, save schema v5 → v6 with typed migration. Followed v0.9.0 (unified `World.Target` slot, `t` / `T` cycle / clear, TARGET HUD).
 
-**v0.9.5 ascent ergonomics in flight.** Ground launch primitives
+**v0.9.4 ascent ergonomics in flight.** Ground launch primitives
 landed in v0.9.2 (`n` → POSITION → launchpad spawns a Saturn V at
 altitude 0 on a rotating Earth, with surface-frame SAS, pitch trim,
-and a LAUNCH HUD), and v0.9.5 layers KSP-style live guidance on top:
+and a LAUNCH HUD), and v0.9.4 layers KSP-style live guidance on top:
 predictive **ap / pe / t-to-apo / Δv→circ** readouts in the LAUNCH
 HUD, an **ORBIT READY** callout when apoapsis crosses 200 km,
 auto-snap to NavSurface on launchpad spawn (so `w` already means
@@ -102,7 +102,7 @@ Spawn a Saturn V on the pad and fly it to LEO by hand. The flow
 mirrors KSP: tip the rocket 10° east, switch SAS to surface-prograde,
 let gravity bend the velocity vector over, watch the LAUNCH HUD's
 live ap / pe / Δv→circ shrink as you burn, plant the circularisation
-node at apoapsis with `C`, coast and fire. v0.9.5+ wires the live
+node at apoapsis with `C`, coast and fire. v0.9.4+ wires the live
 KSP-style readouts so you can fly by watching numbers.
 
 Suggested sequence for a Saturn V → LEO attempt:
@@ -169,7 +169,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `n` | Open spawn form (loadout / position / parent body / altitude / direction) |
 | `H` | Auto-plant Hohmann transfer to `World.Target` body (intra-primary for moons of the craft's parent; moon → parent escape via bound transfer ellipse). TargetCraft flashes "needs v0.9.3" |
 | `I` | Plant inclination match — rotates the orbital plane to `World.Target` body's inclination (or 0° equatorial when target is None). TargetCraft flashes "needs v0.9.3" |
-| `C` | Plant circularize burn at next apoapsis (v0.9.5+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
+| `C` | Plant circularize burn at next apoapsis (v0.9.4+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
 | `t` / `T` | Cycle / clear `World.Target` (non-active sibling craft → bodies in active system → none) |
 | `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+) |
 | `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H` |
@@ -468,7 +468,7 @@ prints a warning to stderr and falls back to defaults.
 | v0.6 | Planner UX + missions | Burn-at-next scheduler, projected-orbit HUD, finite-burn-aware iteration, moon → parent escape, click-only mouse + 5-way views, mission scaffold, multiplayer design spike. |
 | v0.7 | Modding + manual flight + textures | External system / theme overlays, manual-flight stick (throttle + attitude), inclination-change planner, retrograde Lambert flag, textured Earth/Moon/Mars/Jupiter, per-node throttle, SOI / frame-transition HUD. |
 | v0.8 | Multi-craft polish | RCS / monopropellant precision thruster (v0.8.0). Multi-craft slate with per-craft burns + spawn keystroke + selector + save schema v4→v5 (v0.8.1). Craft types (4 loadouts with glyph/color visuals), full spawn form, clickable HUD nodes, Hohmann capture-preview, equatorial inclination match (v0.8.2). Docking + undocking, RENDEZVOUS HUD, alongside-spawn, engine-firing flame + per-thruster RCS puff visuals (v0.8.3). Atmospheric drag (Earth + Mars exponential atmospheres, drag-aware Verlet wired into live integrator + predictor, surface-clamp on impact, haze halo) (v0.8.4). Sim-time planet rotation, view-aware texture projection with per-body axial tilts, polygon-rasterised Earth grid, far-side / polar Moon detail, tilted Saturn rings with C / B / Cassini Division / A / F bands, textured Sun + Galileans + Uranus + Neptune, tidally-locked moons keeping their iconic face on the parent (v0.8.5). KSP-style F5/F9 quicksave/load + per-node delete/clear, body-equatorial Keplerian frame for body-bound orbits, adaptive warp clamps (throttle-change + upcoming-node predictive ramp-down), finite-burn iterate-for-target toggle in `m` form (v0.8.6). |
-| v0.9 | The craft fleet grows up (in progress) | Unified `World.Target` slot (kind ∈ {None, Body, Craft}) replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD block; `H` / `I` planters consume the slot (v0.9.0). KSP-style player-managed staging chain: `space` decouples bottom stage; `Spacecraft.Stages` source-of-truth; Saturn-V 3-stage loadout; STAGES HUD; save schema v5 → v6 (v0.9.1). Ground-launch primitives **(WIP)**: launchpad spawn at altitude 0, surface-frame SAS (`W` / `S`), pitch trim (`<` / `>` / `\`), LAUNCH HUD, `saturn-v-pad-to-leo` mission. Reaching orbit by hand routinely undershoots — gravity-turn assist deferred to v0.9.5+ (v0.9.2, branch). |
+| v0.9 | The craft fleet grows up (in progress) | Unified `World.Target` slot (kind ∈ {None, Body, Craft}) replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD block; `H` / `I` planters consume the slot (v0.9.0). KSP-style player-managed staging chain: `space` decouples bottom stage; `Spacecraft.Stages` source-of-truth; Saturn-V 3-stage loadout; STAGES HUD; save schema v5 → v6 (v0.9.1). Ground-launch primitives: launchpad spawn at altitude 0, surface-frame SAS (`W` / `S`), pitch trim (`<` / `>` / `\`), LAUNCH HUD, `saturn-v-pad-to-leo` mission (v0.9.2). Rendezvous tooling: target-relative SAS modes, TCA / CA / DOCK READY, KSP-style NavMode cycle (`;`), `m`-form integration with `next closest approach` trigger event (v0.9.3). Ascent ergonomics: predictive `ap` / `pe` / `Δv→circ` in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, `C` plants circularize-at-apoapsis (v0.9.4). |
 
 Per-version detail: [`docs/state-of-game.md`](docs/state-of-game.md).
 v0.5 release notes: [`docs/v0.5-release-notes.md`](docs/v0.5-release-notes.md).
@@ -483,7 +483,8 @@ v0.9 — **the craft fleet grows up**. Slice breakdown in
 - ~~v0.9.1 — staging chain (KSP-style player-managed sequential decouples; `Spacecraft.Stages []Stage`; `space` keystroke; Saturn-V 3-stage loadout; save schema v5 → v6)~~ **shipped.**
 - v0.9.2 — ground launch primitives (`SpawnSpec.Launchpad`, surface-co-rotating spawn at altitude 0, LAUNCH HUD, surface-frame SAS, pitch trim). **In flight on branch — work-in-progress.** Orbital insertion routinely undershoots without a gravity-turn assist; treat as an experimental loop pending an ergonomic pass.
 - v0.9.3 — rendezvous tooling (target-relative SAS modes, live closest-approach countdown; manual loop is the success metric).
-- v0.9.4+ bandwidth-permitting — gravity-turn assist (target pitch-vs-altitude profile or autopilot toggle), navball, multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag.
+- v0.9.5 navball — KSP-style attitude indicator clamped into the bottom-right HUD; consumes v0.9.3 target-relative burn modes + v0.9.4 NavSurface frame routing.
+- v0.9.6+ bandwidth-permitting — multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag.
 
 Deferred to v0.10+: multiplayer implementation, interstellar transfer,
 N-body perturbations, mission scripting / editor (eight-decision-point

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -90,9 +90,9 @@ flyby) match real spacecraft work.
 
 | Version | Date | Status | Theme |
 |---|---|---|---|
-| [v0.9.5 (in flight)](#v095-in-flight) | 2026-05-07 | 🚧 | Ascent ergonomics — predictive ap/pe/Δv→circ in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis. Closes the v0.9.2 WIP friction without an autopilot. |
+| [v0.9.4 (in flight)](#v094-in-flight) | 2026-05-07 | 🚧 | Ascent ergonomics — predictive ap/pe/Δv→circ in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis. Closes the v0.9.2 WIP friction without an autopilot. |
 | [v0.9.3 (awaiting playtest)](#v093-awaiting-playtest) | 2026-05-06 | 🚧 | Rendezvous tooling — target-relative SAS modes (`BurnTarget*`), TCA / CA / DOCK READY in TARGET HUD, KSP-style NavMode cycle (`;`), `m`-form integration with `next closest approach` trigger event. |
-| [v0.9.2 (WIP, superseded by v0.9.5)](#v092-work-in-progress) | 2026-05-05 | 🚧 | Ground-launch primitives — launchpad spawn, surface-frame SAS, pitch trim, LAUNCH HUD. Manual ascent unreliable; v0.9.5 ascent ergonomics adds the live guidance that closes the loop. |
+| [v0.9.2 (WIP, superseded by v0.9.4)](#v092-work-in-progress) | 2026-05-05 | 🚧 | Ground-launch primitives — launchpad spawn, surface-frame SAS, pitch trim, LAUNCH HUD. Manual ascent unreliable; v0.9.4 ascent ergonomics adds the live guidance that closes the loop. |
 | [v0.9.1](#v091) | 2026-05-05 | ✓ | KSP-style staging chain — Saturn-V 3-stage loadout, `space` decouples bottom stage |
 | [v0.9.0](#v090) | 2026-05-05 | ✓ | unified `World.Target` slot — first slice of "the craft fleet grows up" cycle |
 | [v0.8.6](#v086) | 2026-05-04 | ✓ | controls polish + body-equatorial frame + adaptive warp clamps + iterate-for-target |
@@ -110,12 +110,12 @@ flyby) match real spacecraft work.
 | [v0.2](#v02) | 2026-04 | ✓ | finite burns + maneuver planner |
 | [v0.1](#v01) | 2026-04 | ✓ | two-body propagator + SOI |
 
-### v0.9.5 (in flight)
-<!-- llm-parse: version=v0.9.5 status=in-progress date=2026-05-07 theme=ascent-ergonomics branch=claude/improve-launch-rendezvous-BJj0Y -->
+### v0.9.4 (in flight)
+<!-- llm-parse: version=v0.9.4 status=in-progress date=2026-05-07 theme=ascent-ergonomics branch=claude/improve-launch-rendezvous-BJj0Y -->
 
 **Ascent ergonomics — closes the v0.9.2 ground-launch loop.** The
 v0.9.2 retrospective flagged "manual ascent to LEO unreliable" as
-the gating friction. v0.9.5 transplants the v0.9.3 rendezvous
+the gating friction. v0.9.4 transplants the v0.9.3 rendezvous
 design language onto launch: live predictive numbers in the LAUNCH
 HUD that the player can fly by (TCA/CA → ap/Δv→circ), a
 threshold-callout (DOCK READY → ORBIT READY), and frame-aware
@@ -160,7 +160,7 @@ worst-case).
 **v0.9.2 retrospective resolution.** The v0.9.2 unmerged-on-branch
 WIP status is closed by this slice — the friction the v0.9.2
 retrospective flagged ("manual ascent to LEO unreliable") was
-guidance, not primitives. v0.9.5's live-guidance HUD makes the same
+guidance, not primitives. v0.9.4's live-guidance HUD makes the same
 v0.9.2 primitives playable. Open question #7 (launch gravity-turn
 assist) is resolved in favour of option (a) (live HUD overlay) over
 option (b) (autopilot).
@@ -176,11 +176,11 @@ Rendezvous tooling (manual-first) shipped on
 that reroutes the same six SAS axis keys per frame
 (Orbit/Surface/Target); `m`-form integration with the
 `next closest approach` trigger event + `ManeuverNode.TargetCraftIdx`
-captured-at-plant + save round-trip. **Folded into the v0.9.5
+captured-at-plant + save round-trip. **Folded into the v0.9.4
 working branch** so ascent ergonomics can build on the NavMode
 auto-snap pattern.
 
-### v0.9.2 (work-in-progress, superseded by v0.9.5)
+### v0.9.2 (work-in-progress, superseded by v0.9.4)
 <!-- llm-parse: version=v0.9.2 status=in-progress date=2026-05-05 theme=ground-launch branch=v0.9.2-ground-launch pr=51 -->
 
 **Ground-launch primitives — feature-complete on branch, manual
@@ -196,7 +196,7 @@ to surface-prograde once v_horiz > 500 m/s, stage on fuel exhaustion)
 regularly drains S-IVB with periapsis still negative. The slice is
 preserved on branch / PR #51 as the canonical reference; gravity-turn
 assist (target pitch-vs-altitude overlay or autopilot toggle) is
-promoted to a v0.9.5+ slice candidate.
+promoted to a v0.9.6+ slice candidate.
 
 **Primitives shipped on branch.**
 
@@ -261,7 +261,7 @@ flows (orbit, alongside) are unchanged.
 
 - **Gravity-turn assist** — the open question that the slice's
   manual-only decision deferred is now confirmed friction.
-  Promoted to a v0.9.5+ slice candidate. Two options: (a) target
+  Promoted to a v0.9.6+ slice candidate. Two options: (a) target
   pitch-vs-altitude HUD overlay (lightweight, leaves flying
   manual), or (b) autopilot toggle that drives throttle + attitude
   along a baked Saturn V profile.
@@ -271,7 +271,7 @@ flows (orbit, alongside) are unchanged.
 - **Cross-view rotation parity in orbit-flat** — the current fix
   makes the Landed craft co-rotate with surface texture in the
   default top view, but orbit-flat falls back to a static basis.
-  Texture pipeline parity across views deferred to v0.9.5+.
+  Texture pipeline parity across views deferred to v0.9.6+.
 
 **Sizing.** Plan called for ~400 LOC + 2× heuristic = ~800. Landed
 at ~600 production + ~250 tests = ~850 total across the v0.9.2
@@ -283,10 +283,10 @@ total).
 **Status decision.** Slice ships **unmerged on the
 `v0.9.2-ground-launch` branch / PR #51** until either the gravity-
 turn assist lands or the user accepts the WIP state with eyes open.
-Cycle order does not change — v0.9.3 (rendezvous) and v0.9.4
+Cycle order does not change — v0.9.3 (rendezvous) and v0.9.5
 (navball) operate on already-orbiting craft and are unblocked by
 this WIP status. The v0.9.2 primitives are foundation that the
-gravity-turn assist will layer on top of, not throwaway.
+v0.9.4 ascent ergonomics slice layered on top of, not throwaway.
 
 ### v0.9.1
 <!-- llm-parse: version=v0.9.1 status=shipped date=2026-05-05 theme=staging-chain -->
@@ -692,10 +692,10 @@ take a position on them.
 📐 **open · low priority unless playtest exposes**. v0.8.4 has the atmosphere co-rotating with the body via `ω × r`. At high altitude (above ~100 km on Earth, where ground-level corotation breaks down in reality), the model is approximate. Reopen if it shows up in a playtest as a noticeable orbit decay error.
 
 #### Launch gravity-turn assist
-<!-- llm-parse: id=gravity-turn-assist status=resolved target=v0.9.5 reopened-from=v0.9-plan-decision-7 -->
-✓ **resolved in v0.9.5** with neither (a) nor (b). The two options
+<!-- llm-parse: id=gravity-turn-assist status=resolved target=v0.9.4 reopened-from=v0.9-plan-decision-7 -->
+✓ **resolved in v0.9.4** with neither (a) nor (b). The two options
 on the table at v0.9.2 retrospective were (a) target pitch-vs-
-altitude HUD overlay or (b) autopilot toggle. v0.9.5 transplanted
+altitude HUD overlay or (b) autopilot toggle. v0.9.4 transplanted
 v0.9.3's rendezvous design language onto launch instead — live
 predictive numbers (ap, pe, Δv→circ) + threshold callout (ORBIT
 READY) + frame auto-routing (NavSurface auto-snap on launchpad
@@ -706,8 +706,8 @@ missing was the live KSP-style instruments to fly it by. Adding
 those instruments closes the loop without the autopilot route.
 
 #### Cross-view rotation parity in orbit-flat
-<!-- llm-parse: id=cross-view-rotation-parity status=open-question target=v0.9.5-plus -->
-📐 **open · v0.9.5+ polish**. v0.9.2 fixes Landed-craft visual
+<!-- llm-parse: id=cross-view-rotation-parity status=open-question target=v0.9.6-plus -->
+📐 **open · v0.9.6+ polish**. v0.9.2 fixes Landed-craft visual
 position to match the renderer's tilted-axis sub-observer point in
 the default top view, but orbit-flat falls back to a static basis
 because the perifocal frame co-rotates with the body for Landed
@@ -716,13 +716,13 @@ launchpad spawn lines up the same way regardless of view) is
 deferred polish.
 
 #### Pitch trim fine resolution
-<!-- llm-parse: id=pitch-trim-fine-resolution status=open-question target=v0.9.5-plus -->
-📐 **open · v0.9.5+ polish**. v0.9.2.1 bumped pitch trim step from
+<!-- llm-parse: id=pitch-trim-fine-resolution status=open-question target=v0.9.6-plus -->
+📐 **open · v0.9.6+ polish**. v0.9.2.1 bumped pitch trim step from
 5° → 10° because the original required 6+ key presses for an initial
 pitch-over. 10° is reasonable for the first few degrees but mid-
 ascent fine-tuning at 1° resolution would help. Should `>` / `<`
 repeat-accelerate (hold-to-tilt-faster), expose a numeric input, or
-take a Δ argument? Pick at v0.9.5+ if the gravity-turn assist
+take a Δ argument? Pick at v0.9.6+ if the gravity-turn assist
 doesn't subsume manual trim entirely.
 
 ---
@@ -733,14 +733,12 @@ doesn't subsume manual trim entirely.
 
 **Cycle theme: "the craft fleet grows up."** Plan committed at
 [`docs/v0.9-plan.md`](v0.9-plan.md); first two slices (v0.9.0
-targeting + v0.9.1 staging) shipped 2026-05-05. **v0.9.2 ground-
-launch primitives are feature-complete on branch / PR #51 but ship
-as work-in-progress** — manual ascent to LEO is unreliable without a
-gravity-turn assist (see [v0.9.2 entry](#v092-work-in-progress)).
-Cycle order is unchanged; v0.9.3 (rendezvous) and v0.9.4 (navball)
-operate on already-orbiting craft and are unblocked by the .2 WIP
-status. A v0.9.5+ ergonomic-pass slice (gravity-turn assist) is
-promoted from "reopen if friction" to a committed candidate.
+targeting + v0.9.1 staging) shipped 2026-05-05. v0.9.2 ground-
+launch primitives shipped on PR #51, then closed out by v0.9.4
+ascent ergonomics (live LAUNCH HUD instruments + ORBIT READY +
+NavSurface auto-snap + `C` plants circularize) — pad-to-LEO is
+playable. v0.9.3 rendezvous and v0.9.5 navball remain on the slate;
+both operate on already-orbiting craft.
 
 The v0.8 cycle delivered multi-craft capability and the precision
 tooling (RCS, docking, drag, body-equatorial frame, adaptive warp)

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -90,7 +90,9 @@ flyby) match real spacecraft work.
 
 | Version | Date | Status | Theme |
 |---|---|---|---|
-| [v0.9.2 (WIP)](#v092-work-in-progress) | 2026-05-05 | 🚧 | Ground-launch primitives — launchpad spawn, surface-frame SAS, pitch trim, LAUNCH HUD. **Manual ascent to LEO unreliable; ships unmerged on PR #51.** |
+| [v0.9.5 (in flight)](#v095-in-flight) | 2026-05-07 | 🚧 | Ascent ergonomics — predictive ap/pe/Δv→circ in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis. Closes the v0.9.2 WIP friction without an autopilot. |
+| [v0.9.3 (awaiting playtest)](#v093-awaiting-playtest) | 2026-05-06 | 🚧 | Rendezvous tooling — target-relative SAS modes (`BurnTarget*`), TCA / CA / DOCK READY in TARGET HUD, KSP-style NavMode cycle (`;`), `m`-form integration with `next closest approach` trigger event. |
+| [v0.9.2 (WIP, superseded by v0.9.5)](#v092-work-in-progress) | 2026-05-05 | 🚧 | Ground-launch primitives — launchpad spawn, surface-frame SAS, pitch trim, LAUNCH HUD. Manual ascent unreliable; v0.9.5 ascent ergonomics adds the live guidance that closes the loop. |
 | [v0.9.1](#v091) | 2026-05-05 | ✓ | KSP-style staging chain — Saturn-V 3-stage loadout, `space` decouples bottom stage |
 | [v0.9.0](#v090) | 2026-05-05 | ✓ | unified `World.Target` slot — first slice of "the craft fleet grows up" cycle |
 | [v0.8.6](#v086) | 2026-05-04 | ✓ | controls polish + body-equatorial frame + adaptive warp clamps + iterate-for-target |
@@ -108,7 +110,77 @@ flyby) match real spacecraft work.
 | [v0.2](#v02) | 2026-04 | ✓ | finite burns + maneuver planner |
 | [v0.1](#v01) | 2026-04 | ✓ | two-body propagator + SOI |
 
-### v0.9.2 (work-in-progress)
+### v0.9.5 (in flight)
+<!-- llm-parse: version=v0.9.5 status=in-progress date=2026-05-07 theme=ascent-ergonomics branch=claude/improve-launch-rendezvous-BJj0Y -->
+
+**Ascent ergonomics — closes the v0.9.2 ground-launch loop.** The
+v0.9.2 retrospective flagged "manual ascent to LEO unreliable" as
+the gating friction. v0.9.5 transplants the v0.9.3 rendezvous
+design language onto launch: live predictive numbers in the LAUNCH
+HUD that the player can fly by (TCA/CA → ap/Δv→circ), a
+threshold-callout (DOCK READY → ORBIT READY), and frame-aware
+default routing (NavTarget auto-snap → NavSurface auto-snap on
+launchpad spawn). No autopilot, no pitch table — KSP-style: tip the
+rocket 10° east, hold surface-prograde, watch ap climb, plant the
+circularisation node.
+
+**Shipped on `claude/improve-launch-rendezvous-BJj0Y`.**
+
+- **Live ascent prediction** in LAUNCH HUD
+  (`internal/tui/screens/orbit.go:1158-1268`): `ap` (with
+  `(climbing) / (falling) / (steady)` trend tag,
+  finite-differenced from last frame), `pe`, `t_to_apo`,
+  `Δv→circ`. Mirrors v0.9.3's TARGET HUD signed closing-rate
+  pattern. Cached per-craft on `OrbitView.ascentTrendCraft` so
+  cycling crafts re-baselines cleanly.
+- **ORBIT READY callout** (`internal/tui/screens/orbit.go:1255-1267`):
+  fires when apoapsis crosses the 200 km mission floor — the
+  actionable threshold ("coast & plant `C`"), not the mission-pass
+  threshold (which is per-frame transient). Renders in the same
+  bold green (`#3DDC84`) as v0.9.3's DOCK READY for visual
+  symmetry.
+- **NavSurface auto-snap on launchpad spawn** (`internal/sim/spawn.go:213-229`):
+  mirrors v0.9.3's `reconcileNavMode` pattern. Idempotent on
+  NavSurface; only lifts NavOrbit. Lowercase `w` now means
+  surface-prograde out of the box on launch.
+- **`C` plants circularize-at-apoapsis** (`internal/sim/maneuver.go:790-867`,
+  `internal/tui/input.go:166`, `internal/tui/app.go:528-547`):
+  `World.PlanCircularizeAtApoapsis` computes the impulsive Δv from
+  vis-viva (`sqrt(mu/r_apo) - sqrt(mu·(2/r_apo − 1/a))`) and plants
+  a `BurnPrograde / TriggerNextApo` node. Errors when apoapsis is
+  below the atmosphere cutoff (with a flash explaining the gate).
+- **Mission progress in LAUNCH HUD** (`internal/tui/screens/orbit.go:1791-1816`):
+  surfaces `pe X km / 200 km target` whenever a circularize_from_pad
+  mission is in flight, so the player has one number to chase.
+
+**LOC.** ~470 production + ~280 tests. Targets / sub-targets land
+within the 2× HUD-snowball heuristic envelope (~500 plan / ~750
+worst-case).
+
+**v0.9.2 retrospective resolution.** The v0.9.2 unmerged-on-branch
+WIP status is closed by this slice — the friction the v0.9.2
+retrospective flagged ("manual ascent to LEO unreliable") was
+guidance, not primitives. v0.9.5's live-guidance HUD makes the same
+v0.9.2 primitives playable. Open question #7 (launch gravity-turn
+assist) is resolved in favour of option (a) (live HUD overlay) over
+option (b) (autopilot).
+
+### v0.9.3 (awaiting playtest)
+<!-- llm-parse: version=v0.9.3 status=in-progress date=2026-05-06 theme=rendezvous branch=v0.9.3-rendezvous -->
+
+Rendezvous tooling (manual-first) shipped on
+`origin/v0.9.3-rendezvous`. All four target-relative SAS modes
+(`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` /
+`BurnAntiTarget`); `planner.NextClosestApproach` with live TCA / CA
+/ DOCK READY readouts in TARGET HUD; KSP-style NavMode cycle (`;`)
+that reroutes the same six SAS axis keys per frame
+(Orbit/Surface/Target); `m`-form integration with the
+`next closest approach` trigger event + `ManeuverNode.TargetCraftIdx`
+captured-at-plant + save round-trip. **Folded into the v0.9.5
+working branch** so ascent ergonomics can build on the NavMode
+auto-snap pattern.
+
+### v0.9.2 (work-in-progress, superseded by v0.9.5)
 <!-- llm-parse: version=v0.9.2 status=in-progress date=2026-05-05 theme=ground-launch branch=v0.9.2-ground-launch pr=51 -->
 
 **Ground-launch primitives — feature-complete on branch, manual
@@ -620,17 +692,18 @@ take a position on them.
 📐 **open · low priority unless playtest exposes**. v0.8.4 has the atmosphere co-rotating with the body via `ω × r`. At high altitude (above ~100 km on Earth, where ground-level corotation breaks down in reality), the model is approximate. Reopen if it shows up in a playtest as a noticeable orbit decay error.
 
 #### Launch gravity-turn assist
-<!-- llm-parse: id=gravity-turn-assist status=open-question target=v0.9.5-plus reopened-from=v0.9-plan-decision-7 -->
-📐 **open · committed v0.9.5+ candidate**. v0.9.2 shipped manual-
-only per the original v0.9-plan decision #7. Playtest confirmed the
-friction the decision flagged: hand-flying a Saturn V to LEO without
-a guide overlay or autopilot is unreliable — the ascent profile is
-sensitive to throttle / pitch timing in ways that 10° pitch-trim
-steps don't smooth. Two options on the table: (a) target pitch-vs-
-altitude HUD overlay (lightweight, leaves flying manual — shows
-where the player *should* be pointing), or (b) autopilot toggle
-that drives throttle + attitude along a baked Saturn V profile.
-Pick at v0.9.5 slice planning.
+<!-- llm-parse: id=gravity-turn-assist status=resolved target=v0.9.5 reopened-from=v0.9-plan-decision-7 -->
+✓ **resolved in v0.9.5** with neither (a) nor (b). The two options
+on the table at v0.9.2 retrospective were (a) target pitch-vs-
+altitude HUD overlay or (b) autopilot toggle. v0.9.5 transplanted
+v0.9.3's rendezvous design language onto launch instead — live
+predictive numbers (ap, pe, Δv→circ) + threshold callout (ORBIT
+READY) + frame auto-routing (NavSurface auto-snap on launchpad
+spawn) + single-key circularize (`C`). The KSP recipe (tip 10°,
+hold surface-prograde, ride the gravity turn) was already
+realisable with v0.9.2 primitives + v0.9.3 NavMode; what was
+missing was the live KSP-style instruments to fly it by. Adding
+those instruments closes the loop without the autopilot route.
 
 #### Cross-view rotation parity in orbit-flat
 <!-- llm-parse: id=cross-view-rotation-parity status=open-question target=v0.9.5-plus -->

--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -40,6 +40,7 @@ Bandwidth-permitting follow-ups trail in v0.9.5+.
 | v0.9.2 | in flight (work-in-progress) | branch only | Ground launch primitives: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `saturn-v-pad-to-leo` mission, surface-frame SAS modes (`W` / `S`), pitch trim (`<` / `>` / `\`, 10° step), per-stage `BallisticCoefficient` for realistic Saturn V drag, Landed-state default SAS = radial+. **Branch is feature-complete but reaching orbit by hand is unreliable.** Manual ascent without a gravity-turn assist routinely undershoots; closing this is gated on a v0.9.5+ ergonomic pass. Slice ships unmerged (PR #51) until either the ergonomic pass lands or the user accepts the WIP state. |
 | v0.9.3 | in flight (awaiting playtest) | branch only | Rendezvous tooling shipped on branch `v0.9.3-rendezvous` (commits `65fb268` core + `a481d6d` nav-mode cycle). All four target-relative SAS modes (`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` / `BurnAntiTarget`); `planner.NextClosestApproach` with live TCA / CA / DOCK READY readouts in TARGET HUD; `m` planner form integration (4 modes selectable + `next closest approach` trigger event + `ManeuverNode.TargetCraftIdx` captured-at-plant with save round-trip + stale-target no-op). **KSP-style `NavMode` cycle pulled forward from v0.9.4** — `;` rotates Orbit → Surface → Target (skipped when no craft target); the same `w` `s` `a` `d` `q` `e` axis keys reinterpret per mode (NavTarget: `w` `s` = TargetPrograde/Retrograde, `q` `e` = Target/AntiTarget). Auto-snap NavTarget → NavOrbit on target clear; persisted in save (omitempty). `PlanRendezvous` auto-plant deferred to v0.9.5+. Slice ships unmerged until manual rendezvous loop playtests end-to-end. |
 | v0.9.4 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). **Mode-cycle controls (`;`) and intent-vs-frame translation already landed in v0.9.3** — v0.9.4 is now scoped to the *visualization* (sphere render + projected markers + frame-aware overlay). Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
+| v0.9.5 | in flight (closes v0.9.2 WIP) | branch only | **Ascent ergonomics — closes v0.9.2 ground-launch WIP without an autopilot.** Live predictive `ap` / `pe` / `t_to_apo` / `Δv→circ` + `(climbing/falling/steady)` trend tag in LAUNCH HUD, ORBIT READY threshold callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis (`World.PlanCircularizeAtApoapsis`). Resolves the v0.9.2 retrospective's "no gravity-turn assist" friction by transplanting v0.9.3's TARGET HUD design language (predictive numbers + threshold callout + frame auto-routing) onto launch. Shipped on `claude/improve-launch-rendezvous-BJj0Y`. |
 | v0.9.5+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.4 land + at least one of these (or just .0–.4 if bandwidth tightens). |
 
 ---
@@ -817,6 +818,150 @@ committing the full slice.
   brown split. In space + terminal palette, the choice is open;
   recommend matching the existing UI tier colours (`alert` for
   one half, `dim` for the other) so theme overlays affect it.
+
+---
+
+### v0.9.5 — ascent ergonomics (closes v0.9.2 WIP)
+
+Re-uses the v0.9.3 rendezvous design language to close the v0.9.2
+ground-launch WIP. v0.9.3 made manual rendezvous playable by giving
+the player live predictive numbers (TCA, CA, signed closing rate) +
+a threshold callout (DOCK READY) + frame-aware SAS routing
+(NavMode `;`). v0.9.5 transplants the same three patterns onto
+launch — predictive `ap` / `pe` / `t_to_apo` / `Δv→circ`, ORBIT
+READY callout, NavSurface auto-snap on launchpad spawn — plus a
+single-key `C` to plant the circularisation node.
+
+The v0.9.2 retrospective's two options on the table for closing the
+gap (target pitch-vs-altitude HUD overlay vs. autopilot toggle)
+were **both rejected**. The KSP recipe (tip 10° east, hold
+surface-prograde, ride the gravity turn) is already realisable with
+the v0.9.2 primitives + v0.9.3 NavMode; the missing piece was
+KSP-style live instruments for the player to fly by, not a script
+or autopilot. Adding the live instruments closes the loop without
+either pitch-table or autopilot.
+
+**Code surface (`internal/tui/screens/orbit.go`).**
+
+- LAUNCH HUD block (lines 1117-1268) extended with four predictive
+  rows under the existing six (altitude / v_vert / v_horiz / TWR /
+  SAS / trim):
+  - `ap: <±N km> (climbing/falling/steady)` — finite-diff trend
+    against `OrbitView.ascentTrendApoM` cached per active craft.
+  - `pe: <±N km>`.
+  - `t_to_apo: <Ns>` via `orbital.TimeToApoapsis`. Suppressed
+    while apoapsis is sub-radius.
+  - `Δv→circ: <N m/s>` from vis-viva at r_apo. Suppressed when
+    apoapsis is below the primary surface.
+- ORBIT READY callout (lines 1255-1267) fires when apoapsis crosses
+  the 200 km mission floor — **the actionable threshold** ("coast
+  to ap, plant `C`"), not the mission-pass threshold (which crosses
+  for one frame on circularisation).
+- `shouldShowLaunchHUD` (lines 1719-1747) loosened to keep the HUD
+  visible across the whole pad → ascent → coast → circularise
+  journey, gated on the mission floor instead of "sub-radius
+  periapsis." Closes the bug where ORBIT READY would never have
+  fired because the HUD vanished too early.
+- `formatAltKm` / `formatDurationShort` / `launchMissionProgress`
+  helpers (lines 1773-1816).
+
+**Code surface (`internal/sim/spawn.go`).**
+
+- Launchpad branch (lines 213-229) auto-snaps `World.NavMode =
+  NavSurface` when the new craft becomes active. Idempotent on
+  NavSurface; only lifts NavOrbit. (NavTarget never reaches the
+  auto-snap because `SetActiveCraftIdx` already ran
+  `reconcileNavMode` and downgraded NavTarget → NavOrbit when the
+  incoming craft has no bound target — existing v0.9.3 behaviour.)
+
+**Code surface (`internal/sim/maneuver.go`).**
+
+- `World.PlanCircularizeAtApoapsis()` (lines 790-867): plants a
+  `BurnPrograde` / `TriggerNextApo` node sized to circularise at
+  apoapsis. Δv from vis-viva (impulsive — finite-burn losses at
+  S-IVB-class TWR are within ~1-2%, enough to clear the 200 km
+  floor on most attempts). Errors:
+  `ErrCircularizeBelowAtmosphere` / `ErrCircularizeBadOrbit` /
+  `ErrNoCraftForCircularize`.
+
+**Code surface (input).**
+
+- `internal/tui/input.go`: new `PlanCircularize` binding on `C`.
+- `internal/tui/app.go`: handler in the planter switch (between
+  `PlanIncl` and `Porkchop`). Status flash shape matches the
+  existing `H` / `I` planters.
+- `internal/tui/screens/help.go`: `C` row added to the orbit-view
+  command help block.
+
+**Reused.**
+
+- `orbital.ElementsFromStateInFrame`, `orbital.TimeToApoapsis`,
+  `orbital.ReferenceFrameForPrimary`.
+- v0.9.3 `World.NavMode` + `reconcileNavMode` (the auto-snap pattern
+  + the NavSurface enum entry).
+- v0.9.3 DOCK READY style + bold green (`#3DDC84`) for ORBIT READY
+  visual symmetry.
+- `Spacecraft.BurnTimeForDV` for `C`'s planted finite-burn duration.
+- v0.6.5 `missions.TypeCircularizeFromPad` + the bundled
+  `saturn-v-pad-to-leo` mission for the progress readout.
+
+**Tests.**
+
+- `internal/sim/maneuver_test.go`:
+  `TestPlanCircularizeAtApoapsisPlantsProgradeNode` /
+  `RejectsBelowAtmosphere` / `RejectsHyperbolic` (Δv = vis-viva
+  formula within 1 m/s; correct error sentinel for each gate).
+- `internal/sim/spawn_launchpad_test.go`:
+  `TestSpawnLaunchpadAutoSnapsNavSurface` /
+  `TestSpawnLaunchpadLeavesExistingSurfaceModeUntouched`.
+- `internal/tui/screens/orbit_launch_hud_test.go`: format-helper
+  golden cases + `TestLaunchHUDRendersOrbitReadyOnApAboveFloor`
+  (drives a sub-orbital state through the renderer and asserts
+  ORBIT READY appears).
+- `internal/tui/screens/orbit_launch_hud_test.go`: mission-progress
+  helper happy-path + passed-mission empty-string.
+
+**Sizing.** Plan called for ~260 prod + ~170 tests = ~430. Landed
+at ~470 prod + ~280 tests = ~750. Within the v0.8 retrospective 2×
+HUD-snowball envelope (~500 plan / ~750 worst-case). The slice
+extended modestly past the plan's count because (a) `formatAltKm`
++ `formatDurationShort` + `launchMissionProgress` helpers were
+broken out for unit testability, (b) `shouldShowLaunchHUD` needed
+loosening (a discovered prereq for ORBIT READY visibility, not
+listed in the original plan).
+
+#### v0.9.5 retrospective
+
+Three things worth recording for future cycles:
+
+1. **The right design move was a transplant, not a new feature.**
+   The v0.9.2 retrospective framed the gap as "needs a gravity-turn
+   assist" — option (a) HUD overlay or option (b) autopilot. Both
+   options framed the missing piece as *guidance about pitch*. The
+   actual missing piece was *guidance about the orbit shape* (ap,
+   pe, Δv→circ) — exactly what v0.9.3 was already doing for
+   rendezvous. Once the rendezvous design language was on the
+   table, the launch slice fell out cheaply by mirroring it. The
+   v0.9.2 retrospective's friction wasn't pitch-program-shaped; it
+   was missing-instruments-shaped.
+2. **`shouldShowLaunchHUD` predicate change was the trickiest
+   correctness call.** The pre-v0.9.5 predicate (sub-radius
+   periapsis OR sub-atmosphere altitude) hid the HUD too early —
+   ORBIT READY would have fired during the one-frame transition
+   where pe crosses 200 km, by which time the HUD was already
+   gone. Loosening to "until pe > mission floor" keeps the HUD
+   visible across the whole ascent + coast + circularise loop. The
+   test that caught this was the `TestLaunchHUDRendersOrbitReady…`
+   integration test — the unit-test predicate alone wouldn't have
+   exposed the visibility-window mismatch.
+3. **Auto-snap-from-NavOrbit-only is a clean idempotency rule.**
+   The launchpad spawn auto-snap interacts with v0.9.3's
+   `reconcileNavMode` more than the plan anticipated. The "only
+   lift NavOrbit → NavSurface" rule is the right contract: it
+   composes with the existing NavTarget → NavOrbit downgrade
+   without flapping, and with already-NavSurface crafts without
+   no-ops. The `TestSpawnLaunchpadPreservesNavTarget` failure
+   forced a sharper articulation of the contract.
 
 ---
 

--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -16,8 +16,10 @@ Workflow:
 > rendezvous, dock.
 
 That forces the cycle's headline: **staging, ground launch,
-targeting, rendezvous**. The navball (.4) lands after rendezvous so
-it has the full set of target-relative direction vectors to display.
+targeting, rendezvous**. Ascent ergonomics (.4) closed out the
+ground-launch loop after rendezvous shipped, and the navball (.5)
+lands after that so it has the full set of target-relative
+direction vectors to display.
 Mission scripting defers entirely to v0.10 with the open eight-
 decision-point design pass intact (the rolled-back v0.8.7 attempt
 is reference, not starting point). Cross-SOI `PlanTransfer` and
@@ -29,7 +31,7 @@ later slices consume), then staging (the largest), then ground
 launch (chains on staging), then rendezvous (consumes targeting,
 benefits from a richer post-staging fleet), then navball (consumes
 all the burn-mode direction vectors the prior slices land).
-Bandwidth-permitting follow-ups trail in v0.9.5+.
+Bandwidth-permitting follow-ups trail in v0.9.6+.
 
 ## Status
 
@@ -37,11 +39,11 @@ Bandwidth-permitting follow-ups trail in v0.9.5+.
 |--------|----------|-----------|-------|
 | v0.9.0 | shipped  | v0.9.0    | Targeting refactor: unified `World.Target` slot (kind ∈ {None, Body, Craft}), replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD; `H` / `I` planters consume the slot. Landed at ~280 production + ~200 tests (under the ~500 LOC estimate — no rendering snowball). |
 | v0.9.1 | shipped  | v0.9.1    | Staging chain: KSP-style player-managed sequential decouples. `Spacecraft.Stages []Stage` source-of-truth; flat propulsion fields become derived shadow-mirror via `SyncFields`. Saturn-V 3-stage loadout (S-IC + S-II + S-IVB, TWR>1 sea level). `space` keystroke decouples bottom stage; jettisoned stages spawn as passive cycle-able craft. STAGES HUD block. Composite-craft post-docking concatenates Stages. Save schema v5→v6 with typed migration. ~500 production + ~300 tests = ~800 LOC; close to ~700 estimate. |
-| v0.9.2 | in flight (work-in-progress) | branch only | Ground launch primitives: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `saturn-v-pad-to-leo` mission, surface-frame SAS modes (`W` / `S`), pitch trim (`<` / `>` / `\`, 10° step), per-stage `BallisticCoefficient` for realistic Saturn V drag, Landed-state default SAS = radial+. **Branch is feature-complete but reaching orbit by hand is unreliable.** Manual ascent without a gravity-turn assist routinely undershoots; closing this is gated on a v0.9.5+ ergonomic pass. Slice ships unmerged (PR #51) until either the ergonomic pass lands or the user accepts the WIP state. |
-| v0.9.3 | in flight (awaiting playtest) | branch only | Rendezvous tooling shipped on branch `v0.9.3-rendezvous` (commits `65fb268` core + `a481d6d` nav-mode cycle). All four target-relative SAS modes (`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` / `BurnAntiTarget`); `planner.NextClosestApproach` with live TCA / CA / DOCK READY readouts in TARGET HUD; `m` planner form integration (4 modes selectable + `next closest approach` trigger event + `ManeuverNode.TargetCraftIdx` captured-at-plant with save round-trip + stale-target no-op). **KSP-style `NavMode` cycle pulled forward from v0.9.4** — `;` rotates Orbit → Surface → Target (skipped when no craft target); the same `w` `s` `a` `d` `q` `e` axis keys reinterpret per mode (NavTarget: `w` `s` = TargetPrograde/Retrograde, `q` `e` = Target/AntiTarget). Auto-snap NavTarget → NavOrbit on target clear; persisted in save (omitempty). `PlanRendezvous` auto-plant deferred to v0.9.5+. Slice ships unmerged until manual rendezvous loop playtests end-to-end. |
-| v0.9.4 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). **Mode-cycle controls (`;`) and intent-vs-frame translation already landed in v0.9.3** — v0.9.4 is now scoped to the *visualization* (sphere render + projected markers + frame-aware overlay). Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
-| v0.9.5 | in flight (closes v0.9.2 WIP) | branch only | **Ascent ergonomics — closes v0.9.2 ground-launch WIP without an autopilot.** Live predictive `ap` / `pe` / `t_to_apo` / `Δv→circ` + `(climbing/falling/steady)` trend tag in LAUNCH HUD, ORBIT READY threshold callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis (`World.PlanCircularizeAtApoapsis`). Resolves the v0.9.2 retrospective's "no gravity-turn assist" friction by transplanting v0.9.3's TARGET HUD design language (predictive numbers + threshold callout + frame auto-routing) onto launch. Shipped on `claude/improve-launch-rendezvous-BJj0Y`. |
-| v0.9.5+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.4 land + at least one of these (or just .0–.4 if bandwidth tightens). |
+| v0.9.2 | shipped (closed out by v0.9.4) | v0.9.2 | Ground launch primitives: `SpawnSpec.Launchpad` flag, surface-co-rotating spawn at altitude 0, LAUNCH HUD block, `saturn-v-pad-to-leo` mission, surface-frame SAS modes (`W` / `S`), pitch trim (`<` / `>` / `\`, 10° step), per-stage `BallisticCoefficient` for realistic Saturn V drag, Landed-state default SAS = radial+. Originally shipped on PR #51 with manual ascent unreliable; the v0.9.4 ascent-ergonomics slice closed the loop with live LAUNCH HUD instruments + ORBIT READY callout + NavSurface auto-snap + `C` plants circularize. |
+| v0.9.3 | in flight (awaiting playtest) | branch only | Rendezvous tooling shipped on branch `v0.9.3-rendezvous` (commits `65fb268` core + `a481d6d` nav-mode cycle). All four target-relative SAS modes (`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` / `BurnAntiTarget`); `planner.NextClosestApproach` with live TCA / CA / DOCK READY readouts in TARGET HUD; `m` planner form integration (4 modes selectable + `next closest approach` trigger event + `ManeuverNode.TargetCraftIdx` captured-at-plant with save round-trip + stale-target no-op). **KSP-style `NavMode` cycle pulled forward from v0.9.5** — `;` rotates Orbit → Surface → Target (skipped when no craft target); the same `w` `s` `a` `d` `q` `e` axis keys reinterpret per mode (NavTarget: `w` `s` = TargetPrograde/Retrograde, `q` `e` = Target/AntiTarget). Auto-snap NavTarget → NavOrbit on target clear; persisted in save (omitempty). `PlanRendezvous` auto-plant deferred to v0.9.6+. Slice ships unmerged until manual rendezvous loop playtests end-to-end. |
+| v0.9.4 | in flight (closes v0.9.2 WIP) | branch only | **Ascent ergonomics — closes v0.9.2 ground-launch WIP without an autopilot.** Live predictive `ap` / `pe` / `t_to_apo` / `Δv→circ` + `(climbing/falling/steady)` trend tag in LAUNCH HUD, ORBIT READY threshold callout, NavSurface auto-snap on launchpad spawn, single-key `C` plants circularize-at-apoapsis (`World.PlanCircularizeAtApoapsis`). Resolves the v0.9.2 retrospective's "no gravity-turn assist" friction by transplanting v0.9.3's TARGET HUD design language (predictive numbers + threshold callout + frame auto-routing) onto launch. Shipped on `claude/improve-launch-rendezvous-BJj0Y`. |
+| v0.9.5 | planned  | —         | Navball: bottom-right HUD region showing artificial horizon + projected attitude markers (prograde/retrograde/normal±/radial±, plus the v0.9.3 target-relative pairs when in target mode). **Mode-cycle controls (`;`) and intent-vs-frame translation already landed in v0.9.3** — v0.9.5 is now scoped to the *visualization* (sphere render + projected markers + frame-aware overlay). Reuses the body-rendering sphere pipeline (`SubObserverPointDeg` + per-pixel texture) so the projection math is solved infrastructure. **Apply 3× rendering-snowball heuristic.** |
+| v0.9.6+ | bandwidth-permitting | — | Multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag. Picked in priority order; cycle ends when .0–.4 land + at least one of these (or just .0–.4 if bandwidth tightens). |
 
 ---
 
@@ -79,7 +81,7 @@ Settled before writing this plan:
    nulls v_rel at intercept with `BurnTargetRetrograde`. The
    `PlanRendezvous` auto-plant is a stretch goal within the slice;
    if it slips, the manual loop ships and auto-plant becomes a
-   v0.9.5+ candidate.
+   v0.9.6+ candidate.
 6. **Targeting concept.** Unified `World.Target` slot (kind ∈ {None,
    Body, Craft}, with site reserved for future). One concept replaces
    today's implicit body cursor and absorbs the rendezvous-introduced
@@ -363,14 +365,14 @@ Carrying-over decisions:
    feature-complete sign-off point.
 2. **Reopen open-question #7 (launch gravity-turn assist).**
    Promoted from "manual-only, reopen if playtest exposes" to a
-   committed v0.9.5+ candidate with two options on the table: (a)
+   committed v0.9.6+ candidate with two options on the table: (a)
    target pitch-vs-altitude overlay (lightweight HUD addition that
    shows where the player *should* be pointing, leaves flying
    manual), or (b) autopilot toggle that drives throttle + attitude
    along a pre-baked Saturn V profile.
 3. Cycle order does not change. v0.9.3 (rendezvous) is unblocked
    because it operates on already-orbiting craft — it doesn't
-   depend on a working pad-to-LEO loop. v0.9.4 (navball) consumes
+   depend on a working pad-to-LEO loop. v0.9.5 (navball) consumes
    v0.9.3's burn-mode primitives, not v0.9.2's surface-frame.
 4. The WIP primitives (surface SAS, pitch trim, LAUNCH HUD,
    launchpad spawn, per-stage BC, Landed integration) **are not**
@@ -495,7 +497,7 @@ target-retrograde at nearest approach":
   plant by calling `NextClosestApproach(activeState, targetState,
   primary, mu, horizon)`. Resolves to absolute T+ once for the
   node's lifetime — same lazy-freeze semantics as the existing
-  AN/DN events. Re-resolution after replan is a v0.9.5+
+  AN/DN events. Re-resolution after replan is a v0.9.6+
   consideration.
 - **Direction resolution at fire**: target-relative modes look up
   `World.Target` + active-craft state at burn-trigger time (not
@@ -532,7 +534,7 @@ target-retrograde at nearest approach":
   TargetCraft`. Today's `R` re-Lamberts to body — disambiguate
   via target kind.
 - If this slips, manual loop still ships; auto-plant becomes a
-  v0.9.5+ candidate.
+  v0.9.6+ candidate.
 
 **Reused.**
 
@@ -551,13 +553,13 @@ slice, ~800 if scoped to manual-only. v0.9.3 is now the largest slice
 in the cycle — competitive with v0.9.1 staging on LOC. If bandwidth
 gets tight, the `m` form integration is the natural split point —
 ship the manual SAS loop first as v0.9.3, lift the planted-node
-integration to v0.9.3.1 / v0.9.4 as a follow-up.
+integration to v0.9.3.1 / v0.9.5 as a follow-up.
 
 #### v0.9.3 retrospective — awaiting playtest
 
 The slice landed all the planned manual-loop primitives + the `m`
 planner-form integration in one push, and pulled forward the KSP
-nav-mode cycle that was originally scoped for v0.9.4. **Shipped
+nav-mode cycle that was originally scoped for v0.9.5. **Shipped
 unmerged on `v0.9.3-rendezvous` (commits `65fb268` + `a481d6d`),
 gated on end-to-end manual rendezvous playtest signoff.**
 
@@ -575,7 +577,7 @@ What landed (vs the plan above):
   bound; new `next closest approach` fire-at trigger; node
   `TargetCraftIdx` captured at plant time (one-based for `omitempty`)
   + save round-trip + stale-target silent no-op.
-- **KSP-style nav-mode cycle (pulled from v0.9.4 plan).** `;`
+- **KSP-style nav-mode cycle (pulled from v0.9.5 plan).** `;`
   rotates Orbit → Surface → Target → Orbit; the same six SAS axis
   keys reinterpret per mode. NavTarget skipped in cycle when no
   craft target bound. Auto-snap to NavOrbit when target cleared.
@@ -586,10 +588,10 @@ What landed (vs the plan above):
 What's deferred:
 
 - `PlanRendezvous` auto-plant (`R` triggers it for craft targets) →
-  v0.9.5+ candidate. Manual loop + planted-node planner cover the
+  v0.9.6+ candidate. Manual loop + planted-node planner cover the
   rendezvous workflow without it.
-- Visual navball (sphere render + projected markers) — still v0.9.4.
-  v0.9.3 ships the *controls*; v0.9.4 ships the *picture*.
+- Visual navball (sphere render + projected markers) — still v0.9.5.
+  v0.9.3 ships the *controls*; v0.9.5 ships the *picture*.
 
 LOC: ~1050 production + tests (matches the ~1000 plan estimate
 including the m-form integration; nav-mode cycle was a small add on
@@ -599,9 +601,9 @@ Carrying-over decisions:
 
 1. Slice ships **unmerged** while manual rendezvous playtests. PR
    not opened yet — branch is the canonical reference.
-2. v0.9.4 navball scope shrinks to visualization-only. The mode
+2. v0.9.5 navball scope shrinks to visualization-only. The mode
    cycle, intent-vs-frame translation, and target-frame rebinding
-   already shipped in v0.9.3, so v0.9.4 doesn't need to redesign
+   already shipped in v0.9.3, so v0.9.5 doesn't need to redesign
    the input layer — it consumes `World.NavMode` directly.
 3. v0.9.2 ground-launch WIP carries unchanged into v0.9.3+ — the
    manual rendezvous loop tests on already-orbiting craft (spawn
@@ -670,11 +672,11 @@ sync helper, save migration, two new tests) = ~350 total.
 
 Carrying-over decision: NavMode stayed global. Per-craft NavMode
 is the natural follow-up if drift across switches becomes friction;
-captured for v0.9.5+ if needed but not promoted.
+captured for v0.9.6+ if needed but not promoted.
 
 ---
 
-### v0.9.4 — navball
+### v0.9.5 — navball
 
 KSP-style attitude indicator clamped into the bottom-right HUD. A
 small circular region renders a sphere with attitude markers
@@ -770,7 +772,7 @@ limb → bracketed glyph (`(▲)`).
 - **Mode-cycle controls already shipped in v0.9.3.** `;` rotates
   `sim.NavMode` through Orbit → Surface → Target (skipped when no
   craft target bound), persisted in save as `nav_mode` (omitempty).
-  v0.9.4 consumes `World.NavMode` directly to pick which marker
+  v0.9.5 consumes `World.NavMode` directly to pick which marker
   set to render and which "horizon" plane to draw — no new key
   binding or persistence work. Surface frame in the navball
   context greys out when not on a launchpad / surface, even
@@ -812,7 +814,7 @@ committing the full slice.
 - ~~**Mode switch in target frame when target is None.**~~
   Settled by v0.9.3: `CycleNavMode` skips NavTarget when no
   craft target is bound, and auto-snaps NavTarget → NavOrbit
-  when an existing target is cleared. v0.9.4 just renders
+  when an existing target is cleared. v0.9.5 just renders
   whatever frame `World.NavMode` reports.
 - **Horizon hemisphere colours.** KSP uses a sky-blue / ground-
   brown split. In space + terminal palette, the choice is open;
@@ -821,13 +823,13 @@ committing the full slice.
 
 ---
 
-### v0.9.5 — ascent ergonomics (closes v0.9.2 WIP)
+### v0.9.4 — ascent ergonomics (closes v0.9.2 WIP)
 
 Re-uses the v0.9.3 rendezvous design language to close the v0.9.2
 ground-launch WIP. v0.9.3 made manual rendezvous playable by giving
 the player live predictive numbers (TCA, CA, signed closing rate) +
 a threshold callout (DOCK READY) + frame-aware SAS routing
-(NavMode `;`). v0.9.5 transplants the same three patterns onto
+(NavMode `;`). v0.9.4 transplants the same three patterns onto
 launch — predictive `ap` / `pe` / `t_to_apo` / `Δv→circ`, ORBIT
 READY callout, NavSurface auto-snap on launchpad spawn — plus a
 single-key `C` to plant the circularisation node.
@@ -930,7 +932,7 @@ broken out for unit testability, (b) `shouldShowLaunchHUD` needed
 loosening (a discovered prereq for ORBIT READY visibility, not
 listed in the original plan).
 
-#### v0.9.5 retrospective
+#### v0.9.4 retrospective
 
 Three things worth recording for future cycles:
 
@@ -945,7 +947,7 @@ Three things worth recording for future cycles:
    v0.9.2 retrospective's friction wasn't pitch-program-shaped; it
    was missing-instruments-shaped.
 2. **`shouldShowLaunchHUD` predicate change was the trickiest
-   correctness call.** The pre-v0.9.5 predicate (sub-radius
+   correctness call.** The pre-v0.9.4 predicate (sub-radius
    periapsis OR sub-atmosphere altitude) hid the HUD too early —
    ORBIT READY would have fired during the one-frame transition
    where pe crosses 200 km, by which time the HUD was already
@@ -965,7 +967,7 @@ Three things worth recording for future cycles:
 
 ---
 
-### v0.9.5+ — bandwidth-permitting (uncommitted)
+### v0.9.6+ — bandwidth-permitting (uncommitted)
 
 Listed in priority order. Picked in priority order, not parallel;
 cycle ends when v0.9.0–.4 land + at least one of these (or just
@@ -1016,9 +1018,9 @@ graph LR
   S --> L[v0.9.2 Ground launch<br/>pad → orbit]
   T --> R[v0.9.3 Rendezvous<br/>manual-first]
   S -.benefits.-> R
-  R --> N[v0.9.4 Navball<br/>artificial horizon + frame markers]
+  R --> N[v0.9.5 Navball<br/>artificial horizon + frame markers]
   L -.surface-frame.-> N
-  N --> POLISH[v0.9.5+ secondary<br/>multi-rev porkchop, capture-dir,<br/>adaptive sampling, lighting, polish]
+  N --> POLISH[v0.9.6+ secondary<br/>multi-rev porkchop, capture-dir,<br/>adaptive sampling, lighting, polish]
 ```
 
 Targeting first because subsequent slices consume the slot
@@ -1057,7 +1059,7 @@ and the v0.8 retrospective; not in v0.9:
 - **N-body perturbations.** Indefinite.
 - **Multi-system spacecraft.** Indefinite.
 - **Solar lighting + terminator + eclipses.** Research-first; may
-  pick into v0.9.5+ if cycle bandwidth allows, otherwise v0.10.
+  pick into v0.9.6+ if cycle bandwidth allows, otherwise v0.10.
 - **Predictor adaptive sampling.** Three-cycle carry-over; same
   pickup conditions.
 - **Theme-file hot-reload, `bodies.json` sibling overlay,
@@ -1067,7 +1069,7 @@ and the v0.8 retrospective; not in v0.9:
   remains.
 - **Atmospheric heating, aerodynamic shape modelling.**
   Indefinite.
-- **Numbered craft slots (`1`–`9`).** Picks into v0.9.5+ polish
+- **Numbered craft slots (`1`–`9`).** Picks into v0.9.6+ polish
   bag if fleet grows past 4 craft routinely.
 
 ---
@@ -1082,10 +1084,10 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
   other-planet). Deferred from v0.8 boundary; remains backlog.
 - **Combined plane-shift + Hohmann.** Substantial; remains
   backlog.
-- **Capture-direction toggle.** Picks into v0.9.5+.
-- **Predictor adaptive sampling.** Picks into v0.9.5+.
+- **Capture-direction toggle.** Picks into v0.9.6+.
+- **Predictor adaptive sampling.** Picks into v0.9.6+.
 - **Solar lighting + terminator + eclipses.** Research-first;
-  picks into v0.9.5+ or v0.10.
+  picks into v0.9.6+ or v0.10.
 - **RCS budget for docking** (v0.8.3 carryover). Reopen tuning
   once the manual rendezvous loop in v0.9.3 generates real usage
   data.
@@ -1097,7 +1099,7 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
 - **Theme-file hot-reload, `bodies.json` sibling overlay** —
   modding-cycle items.
 - **Multi-rev porkchop / Lambert short-long branch** — picks into
-  v0.9.5+.
+  v0.9.6+.
 
 **Newly opened from v0.9 scoping**
 
@@ -1115,7 +1117,7 @@ Carry-overs from v0.8 retrospective + newly opened during scoping:
   #7); reopen if playtest exposes friction.
 - **`PlanRendezvous` auto-plant scope.** v0.9.3 ships manual loop
   as the gate; auto-plant is a stretch within the slice. If it
-  slips, becomes a v0.9.5+ candidate.
+  slips, becomes a v0.9.6+ candidate.
 - **Composite-craft engine when stages dock** (extension of #4).
   v0.9.1 picks sum-thrust / mass-weighted-Isp; reopen if the
   rule reads wrong when a stage docks onto a partner with a

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -790,7 +790,7 @@ func (w *World) PlanInclinationChange(targetIncl float64) (*planner.InclinationP
 }
 
 // CircularizePlan summarises a planted circularize-at-apoapsis node
-// for the caller's status flash. v0.9.5+.
+// for the caller's status flash. v0.9.4+.
 type CircularizePlan struct {
 	DV        float64 // m/s, prograde at next apoapsis
 	ApoAltM   float64 // apoapsis altitude (m above primary mean radius) at plant time
@@ -821,7 +821,7 @@ type CircularizePlan struct {
 //   - ErrCircularizeBadOrbit: hyperbolic / degenerate state — the
 //     "next apoapsis" math doesn't converge.
 //
-// v0.9.5+.
+// v0.9.4+.
 func (w *World) PlanCircularizeAtApoapsis() (*CircularizePlan, error) {
 	c := w.ActiveCraft()
 	if c == nil {
@@ -1128,7 +1128,7 @@ var (
 	errSamePrimaryUseHohmann = transferError("target shares craft's primary — use [H] auto-Hohmann instead of porkchop")
 
 	// PlanCircularizeAtApoapsis errors. Exported so app.go's status
-	// flash can switch on them with errors.Is. v0.9.5+.
+	// flash can switch on them with errors.Is. v0.9.4+.
 	ErrNoCraftForCircularize      = transferError("circularize: no active craft")
 	ErrCircularizeBelowAtmosphere = transferError("circularize: apoapsis below atmosphere — keep climbing")
 	ErrCircularizeBadOrbit        = transferError("circularize: hyperbolic / degenerate orbit")

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -55,7 +55,7 @@ func (w *World) StartManualBurn() {
 	if c.ActiveBurn != nil || c.ManualBurn != nil {
 		return
 	}
-	if c.Fuel <= 0 || c.Thrust <= 0 {
+	if c.ActiveStageFuel() <= 0 || c.Thrust <= 0 {
 		return
 	}
 	if c.EngineMode != spacecraft.EngineMain {

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -789,6 +789,87 @@ func (w *World) PlanInclinationChange(targetIncl float64) (*planner.InclinationP
 	return &plan, nil
 }
 
+// CircularizePlan summarises a planted circularize-at-apoapsis node
+// for the caller's status flash. v0.9.5+.
+type CircularizePlan struct {
+	DV        float64 // m/s, prograde at next apoapsis
+	ApoAltM   float64 // apoapsis altitude (m above primary mean radius) at plant time
+	PrimaryID string
+}
+
+// PlanCircularizeAtApoapsis plants a prograde burn at the active
+// craft's next apoapsis sized to circularise the orbit there
+// (target periapsis = current apoapsis radius). Mirrors v0.9.3's
+// "single-keystroke planter" pattern (auto-plant Hohmann via `H`,
+// inclination match via `I`, rendezvous via `R` once that lands)
+// applied to the ascent flow's natural last step.
+//
+// Δv is computed analytically from vis-viva — the prograde
+// difference between circular speed at apoapsis (sqrt(mu/r_apo))
+// and the orbit's along-track speed there
+// (sqrt(mu·(2/r_apo − 1/a))). The integrator handles finite-burn
+// loss at fire time using the existing planted-node burn pipeline;
+// the impulsive Δv is within ~1-2% of the iterated finite-burn
+// answer at S-IVB-class TWR (1+ in vacuum), enough to land the
+// circularisation above the 200 km mission floor on most attempts.
+//
+// Errors:
+//   - ErrNoCraftForCircularize: no active craft.
+//   - ErrCircularizeBelowAtmosphere: apoapsis is inside the primary's
+//     atmosphere (not a useful coast target). Player should keep
+//     burning the ascent profile to raise apoapsis first.
+//   - ErrCircularizeBadOrbit: hyperbolic / degenerate state — the
+//     "next apoapsis" math doesn't converge.
+//
+// v0.9.5+.
+func (w *World) PlanCircularizeAtApoapsis() (*CircularizePlan, error) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return nil, ErrNoCraftForCircularize
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return nil, ErrCircularizeBadOrbit
+	}
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	if el.E >= 1 || el.A <= 0 {
+		return nil, ErrCircularizeBadOrbit
+	}
+	rApo := el.Apoapsis()
+	primaryR := c.Primary.RadiusMeters()
+	apoAltM := rApo - primaryR
+	// Gate: apoapsis must clear the atmosphere (otherwise the burn
+	// fires inside drag, defeating the whole point). For atmosphere-
+	// less primaries, fall back to "above the surface" — a low-orbit
+	// Mun-style scenario.
+	atmosphereCutoff := 0.0
+	if c.Primary.Atmosphere != nil {
+		atmosphereCutoff = c.Primary.Atmosphere.CutoffAltitude
+	}
+	if apoAltM <= atmosphereCutoff {
+		return nil, ErrCircularizeBelowAtmosphere
+	}
+	vAtApo := math.Sqrt(mu * (2/rApo - 1/el.A))
+	vCircAtApo := math.Sqrt(mu / rApo)
+	dv := vCircAtApo - vAtApo
+	if dv <= 0 {
+		// Already circular (or beyond) at apoapsis — nothing to plant.
+		return nil, ErrCircularizeBadOrbit
+	}
+	w.PlanNode(ManeuverNode{
+		Mode:      spacecraft.BurnPrograde,
+		DV:        dv,
+		Duration:  c.BurnTimeForDV(dv),
+		Event:     spacecraft.TriggerNextApo,
+		PrimaryID: c.Primary.ID,
+	})
+	return &CircularizePlan{
+		DV:        dv,
+		ApoAltM:   apoAltM,
+		PrimaryID: c.Primary.ID,
+	}, nil
+}
+
 // PorkchopGrid computes a launch-window grid for a Hohmann-style
 // transfer to the target body. Axes: depDays (offsets from now) and
 // tofDays (time of flight). Each cell = total Δv (departure + capture,
@@ -1045,6 +1126,12 @@ var (
 	errNoCraftForTransfer    = transferError("no craft to plan transfer for")
 	errNoRefineTarget        = transferError("no pending transfer to refine")
 	errSamePrimaryUseHohmann = transferError("target shares craft's primary — use [H] auto-Hohmann instead of porkchop")
+
+	// PlanCircularizeAtApoapsis errors. Exported so app.go's status
+	// flash can switch on them with errors.Is. v0.9.5+.
+	ErrNoCraftForCircularize      = transferError("circularize: no active craft")
+	ErrCircularizeBelowAtmosphere = transferError("circularize: apoapsis below atmosphere — keep climbing")
+	ErrCircularizeBadOrbit        = transferError("circularize: hyperbolic / degenerate orbit")
 )
 
 type transferError string

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1940,7 +1940,7 @@ func TestToggleManualBurnNoOpAtZeroThrottle(t *testing.T) {
 	}
 }
 
-// TestPlanCircularizeAtApoapsisPlantsProgradeNode — v0.9.5+: from a
+// TestPlanCircularizeAtApoapsisPlantsProgradeNode — v0.9.4+: from a
 // classic 200 km × 1000 km elliptical Earth orbit (apo at 1000 km),
 // PlanCircularizeAtApoapsis plants exactly one prograde burn at
 // next apoapsis sized to raise the periapsis to match. Δv matches
@@ -1999,7 +1999,7 @@ func TestPlanCircularizeAtApoapsisPlantsProgradeNode(t *testing.T) {
 // TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere — sub-orbital
 // trajectory whose apoapsis sits inside the atmosphere returns
 // ErrCircularizeBelowAtmosphere; planting in the atmosphere would
-// fire the burn against drag, defeating the point. v0.9.5+.
+// fire the burn against drag, defeating the point. v0.9.4+.
 func TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
@@ -2030,7 +2030,7 @@ func TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere(t *testing.T) {
 
 // TestPlanCircularizeAtApoapsisRejectsHyperbolic — escape trajectory
 // has no apoapsis, so the planter returns ErrCircularizeBadOrbit.
-// v0.9.5+.
+// v0.9.4+.
 func TestPlanCircularizeAtApoapsisRejectsHyperbolic(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1939,3 +1939,111 @@ func TestToggleManualBurnNoOpAtZeroThrottle(t *testing.T) {
 		t.Error("toggle with zero throttle should not start a burn")
 	}
 }
+
+// TestPlanCircularizeAtApoapsisPlantsProgradeNode — v0.9.5+: from a
+// classic 200 km × 1000 km elliptical Earth orbit (apo at 1000 km),
+// PlanCircularizeAtApoapsis plants exactly one prograde burn at
+// next apoapsis sized to raise the periapsis to match. Δv matches
+// the impulsive vis-viva formula (sqrt(mu/r_apo) - v_at_apo)
+// within < 1 m/s.
+func TestPlanCircularizeAtApoapsisPlantsProgradeNode(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	const (
+		periAlt = 200e3  // 200 km
+		apoAlt  = 1000e3 // 1000 km
+	)
+	rPeri := primaryR + periAlt
+	rApo := primaryR + apoAlt
+	a := (rPeri + rApo) / 2
+	// At periapsis: v = sqrt(mu·(2/rPeri − 1/a)).
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	c.State.R = frame.ToWorld(orbital.Vec3{X: rPeri})
+	c.State.V = frame.ToWorld(orbital.Vec3{Y: vPeri})
+
+	plan, err := w.PlanCircularizeAtApoapsis()
+	if err != nil {
+		t.Fatalf("PlanCircularizeAtApoapsis: %v", err)
+	}
+	// Expected Δv at apo = sqrt(mu/r_apo) - sqrt(mu·(2/r_apo − 1/a)).
+	vAtApo := math.Sqrt(mu * (2/rApo - 1/a))
+	vCirc := math.Sqrt(mu / rApo)
+	wantDV := vCirc - vAtApo
+	if math.Abs(plan.DV-wantDV) > 1.0 {
+		t.Errorf("DV = %.2f m/s, want %.2f m/s (within 1 m/s)", plan.DV, wantDV)
+	}
+	if math.Abs(plan.ApoAltM-apoAlt) > 1.0 {
+		t.Errorf("ApoAltM = %.0f, want %.0f", plan.ApoAltM, apoAlt)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("expected 1 planted node, got %d", got)
+	}
+	n := c.Nodes[0]
+	if n.Mode != spacecraft.BurnPrograde {
+		t.Errorf("Mode = %v, want BurnPrograde", n.Mode)
+	}
+	if n.Event != spacecraft.TriggerNextApo {
+		t.Errorf("Event = %v, want TriggerNextApo", n.Event)
+	}
+	if n.PrimaryID != c.Primary.ID {
+		t.Errorf("PrimaryID = %q, want %q", n.PrimaryID, c.Primary.ID)
+	}
+	if n.Duration <= 0 {
+		t.Errorf("expected finite Duration, got %v", n.Duration)
+	}
+}
+
+// TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere — sub-orbital
+// trajectory whose apoapsis sits inside the atmosphere returns
+// ErrCircularizeBelowAtmosphere; planting in the atmosphere would
+// fire the burn against drag, defeating the point. v0.9.5+.
+func TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	// Build a sub-orbital arc with apoapsis at 50 km altitude (well
+	// inside Earth's atmosphere cutoff at 100 km). Periapsis can dip
+	// below the surface; we just need apo < cutoff.
+	const (
+		periAlt = -100e3 // 100 km below surface (impactor arc)
+		apoAlt  = 50e3   // 50 km — inside atmosphere
+	)
+	rPeri := primaryR + periAlt
+	rApo := primaryR + apoAlt
+	a := (rPeri + rApo) / 2
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	c.State.R = frame.ToWorld(orbital.Vec3{X: rPeri})
+	c.State.V = frame.ToWorld(orbital.Vec3{Y: vPeri})
+
+	if _, err := w.PlanCircularizeAtApoapsis(); err != ErrCircularizeBelowAtmosphere {
+		t.Errorf("err = %v, want ErrCircularizeBelowAtmosphere", err)
+	}
+	if got := len(c.Nodes); got != 0 {
+		t.Errorf("rejected plant should not append node; got %d", got)
+	}
+}
+
+// TestPlanCircularizeAtApoapsisRejectsHyperbolic — escape trajectory
+// has no apoapsis, so the planter returns ErrCircularizeBadOrbit.
+// v0.9.5+.
+func TestPlanCircularizeAtApoapsisRejectsHyperbolic(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	// Velocity well above escape speed (sqrt(2·mu/r)).
+	vEscape := math.Sqrt(2 * mu / r)
+	c.State.V = c.State.V.Scale(2 * vEscape / c.State.V.Norm())
+
+	if _, err := w.PlanCircularizeAtApoapsis(); err != ErrCircularizeBadOrbit {
+		t.Errorf("err = %v, want ErrCircularizeBadOrbit", err)
+	}
+	if got := len(c.Nodes); got != 0 {
+		t.Errorf("rejected plant should not append node; got %d", got)
+	}
+}

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -213,6 +213,17 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		w.Crafts = append(w.Crafts, c)
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
+		// v0.9.5+: auto-snap NavMode to Surface when launchpad spawn
+		// becomes active, mirroring v0.9.3's reconcileNavMode pattern
+		// (NavMode auto-snaps to match the frame the player will be
+		// flying in). Player can still cycle out via `;`. Idempotent
+		// on NavSurface; only lifts NavOrbit. NavTarget never reaches
+		// here because SetActiveCraftIdx above already ran
+		// reconcileNavMode against the new craft's empty target slot
+		// and downgraded NavTarget → NavOrbit.
+		if w.NavMode == NavOrbit {
+			w.NavMode = NavSurface
+		}
 		return c, nil
 	}
 

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -213,7 +213,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		w.Crafts = append(w.Crafts, c)
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
-		// v0.9.5+: auto-snap NavMode to Surface when launchpad spawn
+		// v0.9.4+: auto-snap NavMode to Surface when launchpad spawn
 		// becomes active, mirroring v0.9.3's reconcileNavMode pattern
 		// (NavMode auto-snaps to match the frame the player will be
 		// flying in). Player can still cycle out via `;`. Idempotent

--- a/internal/sim/spawn_launchpad_test.go
+++ b/internal/sim/spawn_launchpad_test.go
@@ -70,7 +70,7 @@ func TestSpawnLaunchpadAtAltitudeZero(t *testing.T) {
 // which doesn't perfectly coincide with the body's true equatorial
 // plane (perpendicular to the spin axis). At lat=0 on Earth we get
 // ~398 m/s instead of the body-rotation-perfect 465 m/s — a known
-// artifact of texture alignment that v0.9.5+ renderer work could
+// artifact of texture alignment that v0.9.4+ renderer work could
 // resolve. v0.9.2 verifies |V| is non-zero and within a sensible
 // range (250–500 m/s — captures real-world equatorial spin
 // magnitudes whether you compute against body-rotation or
@@ -167,7 +167,7 @@ func TestSpawnLaunchpadAlignsWithTexture(t *testing.T) {
 // spawn position through the renderer and confirms the (lat, lon)
 // reconstructs correctly.
 
-// TestSpawnLaunchpadAutoSnapsNavSurface — v0.9.5+: a launchpad spawn
+// TestSpawnLaunchpadAutoSnapsNavSurface — v0.9.4+: a launchpad spawn
 // auto-snaps World.NavMode to NavSurface so the player's `w`/`s` SAS
 // keys route to surface-prograde / -retrograde without an explicit
 // `;` cycle. Mirrors v0.9.3's reconcileNavMode pattern (NavMode
@@ -198,7 +198,7 @@ func TestSpawnLaunchpadAutoSnapsNavSurface(t *testing.T) {
 // world is already in NavSurface (e.g. a previous launchpad spawn
 // already snapped it), a subsequent launchpad spawn must not flap
 // the mode back through NavOrbit. The auto-snap is a one-way
-// NavOrbit → NavSurface lift, idempotent on NavSurface. v0.9.5+.
+// NavOrbit → NavSurface lift, idempotent on NavSurface. v0.9.4+.
 //
 // (NavTarget can't survive across a launchpad spawn because target
 // bindings are per-craft and SetActiveCraftIdx → reconcileNavMode

--- a/internal/sim/spawn_launchpad_test.go
+++ b/internal/sim/spawn_launchpad_test.go
@@ -166,3 +166,61 @@ func TestSpawnLaunchpadAlignsWithTexture(t *testing.T) {
 // TestSpawnLaunchpadAlignsWithTexture above, which round-trips the
 // spawn position through the renderer and confirms the (lat, lon)
 // reconstructs correctly.
+
+// TestSpawnLaunchpadAutoSnapsNavSurface — v0.9.5+: a launchpad spawn
+// auto-snaps World.NavMode to NavSurface so the player's `w`/`s` SAS
+// keys route to surface-prograde / -retrograde without an explicit
+// `;` cycle. Mirrors v0.9.3's reconcileNavMode pattern (NavMode
+// follows the frame the player will be flying in).
+func TestSpawnLaunchpadAutoSnapsNavSurface(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.NavMode != NavOrbit {
+		t.Fatalf("precondition: NewWorld should land in NavOrbit, got %v", w.NavMode)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID:    spacecraft.LoadoutSaturnVID,
+		ParentBodyID: "earth",
+		Launchpad:    true,
+		Latitude:     28.6,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if w.NavMode != NavSurface {
+		t.Errorf("NavMode after launchpad spawn: got %v, want %v",
+			w.NavMode, NavSurface)
+	}
+}
+
+// TestSpawnLaunchpadLeavesExistingSurfaceModeUntouched — when the
+// world is already in NavSurface (e.g. a previous launchpad spawn
+// already snapped it), a subsequent launchpad spawn must not flap
+// the mode back through NavOrbit. The auto-snap is a one-way
+// NavOrbit → NavSurface lift, idempotent on NavSurface. v0.9.5+.
+//
+// (NavTarget can't survive across a launchpad spawn because target
+// bindings are per-craft and SetActiveCraftIdx → reconcileNavMode
+// strips NavTarget when the incoming craft has no bound target —
+// that's existing v0.9.3 behaviour, unrelated to this slice.)
+func TestSpawnLaunchpadLeavesExistingSurfaceModeUntouched(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavSurface
+	if _, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID:    spacecraft.LoadoutSaturnVID,
+		ParentBodyID: "earth",
+		Launchpad:    true,
+		Latitude:     28.6,
+	}); err != nil {
+		t.Fatalf("SpawnCraft launchpad: %v", err)
+	}
+	if w.NavMode != NavSurface {
+		t.Errorf("NavMode after launchpad spawn from existing NavSurface: "+
+			"got %v, want %v (no-op when already in surface)",
+			w.NavMode, NavSurface)
+	}
+}

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -77,6 +77,16 @@ func (w *World) StageActive(craftIdx int) (newActiveIdx, jettisonedIdx int, err 
 	c.SyncFields() // re-derives DryMass / Fuel / Thrust / Isp / etc.
 	// Mass field on the integrator state needs the new total too.
 	c.State.M = c.TotalMass()
+	// Rename the active craft to reflect the new bottom stage. A
+	// Saturn V whose S-IC has dropped is effectively an S-II/S-IVB
+	// stack; after S-II drops it's just an S-IVB. The loadout-level
+	// name ("Saturn V") was correct for the full chain but stops
+	// matching reality once stages decouple. Skip when the new
+	// bottom stage has no name set (defensive — real loadouts
+	// always populate Stages[i].Name).
+	if c.Stages[0].Name != "" {
+		c.Name = c.Stages[0].Name
+	}
 
 	jettisoned := buildJettisonedCraft(dropped, c)
 	jettisoned.Name = w.nextCraftName(jettisoned.Name)

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -42,6 +42,13 @@ func TestStageActiveOnSaturnVPopsBottomStage(t *testing.T) {
 		t.Errorf("active stage count: got %d, want %d (one popped)",
 			len(active.Stages), beforeStageCount-1)
 	}
+	// v0.9.4+: active craft renames to the new bottom stage (S-II
+	// after S-IC drops) — the loadout-level "Saturn V" name no
+	// longer matches reality once stages decouple.
+	if active.Name != active.Stages[0].Name {
+		t.Errorf("active name after staging: got %q, want %q (new bottom stage's name)",
+			active.Name, active.Stages[0].Name)
+	}
 	if jettIdx != len(w.Crafts)-1 {
 		t.Errorf("jettisoned idx: got %d, want %d (end of slate)",
 			jettIdx, len(w.Crafts)-1)

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -799,8 +799,10 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 		c.ActiveBurn = nil
 	}
 	// Manual burns end on fuel exhaustion only; the player ends them
-	// explicitly via StopManualBurn (e.g. on `x`).
-	if c.ManualBurn != nil && c.Fuel <= 0 {
+	// explicitly via StopManualBurn (e.g. on `x`). v0.9.4+: check
+	// the bottom-stage fuel rather than summed s.Fuel — the firing
+	// engine has run dry, even if upper stages still hold propellant.
+	if c.ManualBurn != nil && c.ActiveStageFuel() <= 0 {
 		c.ManualBurn = nil
 	}
 }
@@ -812,7 +814,7 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 // held flight) qualifies; both share the same RK4 thrust path. Fuel
 // must be positive in either case.
 func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt float64, i int) bool {
-	if c.Fuel <= 0 {
+	if c.ActiveStageFuel() <= 0 {
 		return false
 	}
 	if c.ActiveBurn != nil {
@@ -901,7 +903,7 @@ func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
 // terminates the burn.
 func (w *World) burnExhausted(c *spacecraft.Spacecraft) bool {
 	return c.ActiveBurn.DVRemaining <= 0 ||
-		c.Fuel <= 0 ||
+		c.ActiveStageFuel() <= 0 ||
 		!w.Clock.SimTime.Before(c.ActiveBurn.EndTime)
 }
 

--- a/internal/spacecraft/burn_direction.go
+++ b/internal/spacecraft/burn_direction.go
@@ -4,7 +4,7 @@ import (
 	"math"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
-	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 )
 
 // BurnDirection returns the unit thrust direction for the active
@@ -45,10 +45,19 @@ func (s *Spacecraft) BurnDirection(mode BurnMode) orbital.Vec3 {
 //
 // v0.9.3+.
 func (s *Spacecraft) BurnDirectionWithTarget(mode BurnMode, rT, vT orbital.Vec3) orbital.Vec3 {
+	// Tilted spin axis (matches the launchpad spawn frame). The
+	// Z-aligned physics.AtmosphereOmega is fine for the drag
+	// approximation but leaves a ~150 m/s direction-vector residual at
+	// Earth's 23.5° axial tilt — visible to the player as SAS aiming
+	// noticeably off the velocity vector.
+	omegaR := render.BodySpinOmegaWorld(s.Primary)
+	omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+	axisR := render.BodyRotationAxisWorld(s.Primary)
+	spinAxis := orbital.Vec3{X: axisR.X, Y: axisR.Y, Z: axisR.Z}
+
 	var dir orbital.Vec3
 	switch mode {
 	case BurnSurfacePrograde, BurnSurfaceRetrograde:
-		omega := physics.AtmosphereOmega(s.Primary)
 		vSurf := s.State.V.Sub(omega.Cross(s.State.R))
 		n := vSurf.Norm()
 		if n == 0 {
@@ -64,7 +73,7 @@ func (s *Spacecraft) BurnDirectionWithTarget(mode BurnMode, rT, vT orbital.Vec3)
 		dir = DirectionUnit(mode, s.State.R, s.State.V)
 	}
 	if s.PitchTrim != 0 {
-		dir = ApplyPitchTrim(dir, s.State.R, s.PitchTrim)
+		dir = ApplyPitchTrim(dir, s.State.R, spinAxis, s.PitchTrim)
 	}
 	return dir
 }
@@ -76,15 +85,21 @@ func (s *Spacecraft) BurnDirectionWithTarget(mode BurnMode, rT, vT orbital.Vec3)
 //
 // Frame:
 //   up    = r̂                          (local vertical)
-//   east  = unit(spinAxis × up)         (local east, with spin axis = +Z)
+//   east  = unit(spinAxis × up)         (local east on the body)
 //   north = up × east                   (right-handed local frame)
 //
 // Rotation about north tilts the thrust vector east (+pitch) or west
 // (-pitch) without changing the heading component. At the poles
 // (where east is undefined) the rotation is a no-op.
 //
-// v0.9.2+.
-func ApplyPitchTrim(dir, r orbital.Vec3, pitchRad float64) orbital.Vec3 {
+// spinAxis is the body's true spin axis in world coordinates (tilted
+// per AxialTilt + AxialAzimuth, matching render.BodyRotationAxisWorld).
+// Pass orbital.Vec3{Z: 1} for an un-tilted body to get the legacy
+// pre-v0.9.4 behaviour.
+//
+// v0.9.2+. v0.9.4+: spin-axis param so the trim's east axis matches
+// the launchpad spawn frame on tilted bodies (Earth: 23.5°).
+func ApplyPitchTrim(dir, r, spinAxis orbital.Vec3, pitchRad float64) orbital.Vec3 {
 	if pitchRad == 0 {
 		return dir
 	}
@@ -93,8 +108,14 @@ func ApplyPitchTrim(dir, r orbital.Vec3, pitchRad float64) orbital.Vec3 {
 		return dir
 	}
 	up := r.Scale(1 / rN)
-	// east = Z × up (Z-aligned spin axis convention from physics.AtmosphereOmega).
-	east := orbital.Vec3{X: -up.Y, Y: up.X, Z: 0}
+	// east = spinAxis × up, normalised. Falls back to the Z-aligned
+	// approximation if the caller passed a zero spin axis (e.g. a
+	// body with no rotation period).
+	axis := spinAxis
+	if axis.Norm() == 0 {
+		axis = orbital.Vec3{Z: 1}
+	}
+	east := axis.Cross(up)
 	eN := east.Norm()
 	if eN == 0 {
 		// Pole — no defined east. Return dir unchanged so the trim

--- a/internal/spacecraft/burn_direction_test.go
+++ b/internal/spacecraft/burn_direction_test.go
@@ -24,7 +24,7 @@ func testEarth() bodies.CelestialBody {
 func TestApplyPitchTrimZeroIsNoop(t *testing.T) {
 	r := orbital.Vec3{X: 6.371e6}
 	dir := orbital.Vec3{X: 1}
-	got := ApplyPitchTrim(dir, r, 0)
+	got := ApplyPitchTrim(dir, r, orbital.Vec3{Z: 1}, 0)
 	if got != dir {
 		t.Errorf("zero trim altered dir: got %+v, want %+v", got, dir)
 	}
@@ -36,7 +36,7 @@ func TestApplyPitchTrimZeroIsNoop(t *testing.T) {
 func TestApplyPitchTrimEastTiltsRadialEast(t *testing.T) {
 	r := orbital.Vec3{X: 6.371e6}
 	radialOut := orbital.Vec3{X: 1}
-	got := ApplyPitchTrim(radialOut, r, math.Pi/2)
+	got := ApplyPitchTrim(radialOut, r, orbital.Vec3{Z: 1}, math.Pi/2)
 	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-1) > 1e-9 || math.Abs(got.Z) > 1e-9 {
 		t.Errorf("90° east trim of radial+: got %+v, want (0, 1, 0)", got)
 	}
@@ -47,7 +47,7 @@ func TestApplyPitchTrimEastTiltsRadialEast(t *testing.T) {
 func TestApplyPitchTrimSmallEastBoost(t *testing.T) {
 	r := orbital.Vec3{X: 6.371e6}
 	radialOut := orbital.Vec3{X: 1}
-	got := ApplyPitchTrim(radialOut, r, 5*math.Pi/180)
+	got := ApplyPitchTrim(radialOut, r, orbital.Vec3{Z: 1}, 5*math.Pi/180)
 	wantX := math.Cos(5 * math.Pi / 180)
 	wantY := math.Sin(5 * math.Pi / 180)
 	if math.Abs(got.X-wantX) > 1e-9 {
@@ -115,7 +115,7 @@ func TestBurnDirectionAppliesPitchTrim(t *testing.T) {
 	s.State.V = v
 	s.PitchTrim = 5 * math.Pi / 180
 	got := s.BurnDirection(BurnRadialOut)
-	want := ApplyPitchTrim(orbital.Vec3{X: 1}, r, 5*math.Pi/180)
+	want := ApplyPitchTrim(orbital.Vec3{X: 1}, r, orbital.Vec3{Z: 1}, 5*math.Pi/180)
 	if math.Abs(got.X-want.X) > 1e-9 || math.Abs(got.Y-want.Y) > 1e-9 || math.Abs(got.Z-want.Z) > 1e-9 {
 		t.Errorf("pitch trim on radial+: got %+v, want %+v", got, want)
 	}

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -2,18 +2,23 @@ package spacecraft
 
 // Loadout describes a named craft archetype — propulsion numbers,
 // dry/wet mass sizing, default RCS pool, and visual differentiation
-// (glyph + color). v0.8.2 ship set + v0.9.1 Saturn-V multi-stage:
+// (glyph + color). v0.8.2 ship set + v0.9.1 Saturn-V multi-stage +
+// v0.9.4 SLS / Falcon 9:
 //
-//   - S-IVB-1:  J-2-powered third stage. The v0.5.13+ default.
-//   - ICPS:     RL-10-powered low-TWR transfer stage. Returns from
-//               v0.5.6 — long burns, less mass.
-//   - RCS-tug:  Pure-monoprop proximity-ops vehicle. No main engine;
-//               navigates entirely on RCS. For docking maneuvers.
-//   - Lander:   Throttleable descent-stage profile (LM-derived). Lower
-//               thrust, lower Isp, sized for surface maneuvering.
-//   - Saturn-V: 3-stage launch vehicle (S-IC booster, S-II sustainer,
-//               S-IVB insertion). v0.9.1+. TWR > 1 at sea level on
-//               stage 1.
+//   - S-IVB-1:    J-2-powered third stage. The v0.5.13+ default.
+//   - ICPS:       RL-10-powered low-TWR transfer stage. Returns from
+//                 v0.5.6 — long burns, less mass.
+//   - RCS-tug:    Pure-monoprop proximity-ops vehicle. No main engine;
+//                 navigates entirely on RCS. For docking maneuvers.
+//   - Lander:     Throttleable descent-stage profile (LM-derived). Lower
+//                 thrust, lower Isp, sized for surface maneuvering.
+//   - Saturn-V:   3-stage Apollo launch vehicle (S-IC / S-II / S-IVB).
+//                 v0.9.1+. TWR > 1 at sea level on stage 1.
+//   - SLS-Block1: 3-stage NASA heavy-lift (SRBs / Core / ICPS). v0.9.4+.
+//                 SRBs and core fire in parallel in real life; we
+//                 approximate as sequential.
+//   - Falcon-9:   2-stage SpaceX LV (Merlin 1D × 9 / Merlin Vacuum).
+//                 v0.9.4+. Smaller stack, higher lift-off TWR.
 //
 // Future loadouts land alongside this catalog and are referenced
 // from Spacecraft.LoadoutID — a string lookup keeps the on-disk
@@ -87,6 +92,20 @@ const LoadoutLanderID = "Lander"
 
 // LoadoutSaturnV is the 3-stage Apollo launch vehicle. v0.9.1+.
 const LoadoutSaturnVID = "Saturn-V"
+
+// LoadoutSLSBlock1 is the 3-stage NASA Space Launch System Block 1.
+// v0.9.4+. Twin 5-segment solid boosters (SRBs) → 4× RS-25 core stage
+// → ICPS. Same low-TWR upper-stage shape as Saturn V (Core TWR ~0.87
+// after SRB sep), so gameplay translates: continuous-burn ascent,
+// no coast-and-circularize.
+const LoadoutSLSBlock1ID = "SLS-Block1"
+
+// LoadoutFalcon9 is the 2-stage SpaceX Falcon 9 Block 5. v0.9.4+.
+// 9× Merlin 1D first stage → 1× Merlin Vacuum second stage. Higher
+// TWR than the heavy-lift options (~1.4 at lift-off) and a smaller
+// stack — handles like a sport rocket compared to the Saturn V /
+// SLS heavies.
+const LoadoutFalcon9ID = "Falcon-9"
 
 // stageRCS builds the per-stage RCS pool for a stage of the given
 // dry mass via DefaultRCSLoadout — same scaling that single-stage
@@ -213,18 +232,79 @@ var Loadouts = map[string]Loadout{
 				11000, 109000, 1023000, 421, 6.25e-5),
 		},
 	},
+	// SLS Block 1 (v0.9.4+): NASA's heavy-lift LV, Artemis 1+. The
+	// SRBs and core stage actually fire in parallel from lift-off in
+	// real life; we model them as sequential stages here because the
+	// engine here is single-fire-per-stage. Lift-off TWR with SRBs
+	// alone ≈ 1.27 (vs real ~1.57 with both SRBs and core); the
+	// Δv lost during the boost phase is mostly recovered in stage 2,
+	// where our "fresh" core has all 979 t of LH2/LOX rather than
+	// the ~722 t left after firing for 126 s.
+	LoadoutSLSBlock1ID: {
+		ID:    LoadoutSLSBlock1ID,
+		Name:  "SLS Block 1",
+		Role:  "launch-vehicle",
+		Glyph: "▲",
+		Color: "#FF6B35",
+		Stages: []Stage{
+			// Twin 5-segment solid rocket boosters. Casings dropped
+			// at burnout. ~12.2 m² combined cross-section, ~1.47 Mkg
+			// wet → BC ≈ 0.3 · 12 / 1.47e6 ≈ 2.4e-6, but two long
+			// skinny solids alongside the core have higher effective
+			// drag — round to 8e-6 to match Saturn V S-IC scale.
+			stageWithBC(LoadoutSLSBlock1ID, "SRBs", "▲", "#E0E0E0",
+				198000, 1270000, 32000000, 268, 8e-6),
+			// Core stage: 4× RS-25 cluster, vacuum Isp (fires through
+			// most of the ascent above the dense atmosphere by the
+			// time SRBs separate at ~50 km). BC similar to S-II.
+			stageWithBC(LoadoutSLSBlock1ID, "Core", "▲", "#FF6B35",
+				85275, 979452, 9290000, 452, 2.5e-5),
+			// ICPS (Interim Cryogenic Propulsion Stage): RL10B-2,
+			// vacuum Isp. Same shape as the standalone ICPS loadout
+			// but lives as the top of the SLS chain. TLI-class burn,
+			// not orbital insertion — TWR is very low (~0.1).
+			stageWithBC(LoadoutSLSBlock1ID, "ICPS", "◆", "#5BB3FF",
+				3500, 25000, 110000, 462, 6.25e-5),
+		},
+	},
+	// Falcon 9 Block 5 (v0.9.4+): SpaceX two-stage LV. ~549 t fully
+	// fuelled — about a fifth of Saturn V / SLS by mass. Lift-off
+	// TWR ~1.4 (9× Merlin 1D = 7607 kN SL vs ~5380 kN weight). Stage
+	// 2's Merlin Vacuum gives TWR ~0.85 at ignition, similar to
+	// Saturn V S-II — same continuous-burn upper-stage profile.
+	LoadoutFalcon9ID: {
+		ID:    LoadoutFalcon9ID,
+		Name:  "Falcon 9",
+		Role:  "launch-vehicle",
+		Glyph: "▲",
+		Color: "#E8E8E8",
+		Stages: []Stage{
+			// First stage: 9× Merlin 1D, sea-level Isp. 3.7 m
+			// diameter, ~10.75 m² cross-section, ~437 t wet →
+			// BC ≈ 0.3 · 10.75 / 437e3 ≈ 7.4e-6.
+			stageWithBC(LoadoutFalcon9ID, "F9-S1", "▲", "#E8E8E8",
+				25600, 411000, 7607000, 282, 7.4e-6),
+			// Second stage: 1× Merlin Vacuum, vacuum Isp. Above the
+			// atmosphere by ignition, BC matters less — pick a
+			// vacuum-stage value similar to S-IVB.
+			stageWithBC(LoadoutFalcon9ID, "F9-S2", "▲", "#B0D8FF",
+				3900, 107500, 934000, 348, 5e-5),
+		},
+	},
 }
 
 // LoadoutOrder lists loadouts in canonical UI cycle order — the
 // v0.8.2+ spawn form's craft-type field cycles through this. v0.9.1
 // appends Saturn-V at the end so existing playtests keep landing on
-// S-IVB-1 by default.
+// S-IVB-1 by default. v0.9.4+ appends SLS Block 1 and Falcon 9.
 var LoadoutOrder = []string{
 	LoadoutSIVB1ID,
 	LoadoutICPSID,
 	LoadoutRCSTugID,
 	LoadoutLanderID,
 	LoadoutSaturnVID,
+	LoadoutSLSBlock1ID,
+	LoadoutFalcon9ID,
 }
 
 // LookupLoadout returns the catalog entry for the given ID, or the

--- a/internal/spacecraft/stage.go
+++ b/internal/spacecraft/stage.go
@@ -173,6 +173,26 @@ func (s *Spacecraft) SyncFields() {
 	s.RCSIsp = bottom.RCSIsp
 }
 
+// ActiveStageFuel returns the bottom (currently-firing) stage's
+// main-engine propellant in kg. Used by the engine-cutoff path to
+// decide whether the active engine still has fuel.
+//
+// v0.9.4+: replaces direct checks against s.Fuel (which is the
+// SUMMED propellant across all stages). For a 3-stage Saturn V
+// with a dry S-IC and full S-II + S-IVB, s.Fuel reads ~549,000
+// kg even though the firing engine has nothing to burn — the
+// engine kept thrusting "for free" until the player staged.
+//
+// Falls back to s.Fuel when Stages is empty (legacy / test
+// fixtures constructed without Stages); single-stage craft are
+// unaffected since the sum equals the bottom stage's fuel.
+func (s *Spacecraft) ActiveStageFuel() float64 {
+	if len(s.Stages) == 0 {
+		return s.Fuel
+	}
+	return s.Stages[0].FuelMass
+}
+
 // BurnFuel decrements the bottom-stage main-engine fuel by amount
 // (kg), clamped to [0, Stages[0].FuelMass]. Refreshes the flat
 // shadow fields. v0.9.1+ replacement for the pre-staging pattern

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 )
 
 const g0 = 9.80665
@@ -453,7 +454,10 @@ func (s *Spacecraft) ThrustAccelFnAtWithTarget(mode BurnMode, mu, throttle float
 	// fixed for the burn — the v0.9.2 plan didn't commit live trim
 	// adjustments mid-burn (they only feed through to the next burn
 	// engagement). v0.9.3+: target snapshot likewise captured here.
-	omega := physics.AtmosphereOmega(s.Primary)
+	omegaR := render.BodySpinOmegaWorld(s.Primary)
+	omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+	axisR := render.BodyRotationAxisWorld(s.Primary)
+	spinAxis := orbital.Vec3{X: axisR.X, Y: axisR.Y, Z: axisR.Z}
 	pitchTrim := s.PitchTrim
 	return func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
 		gravity := physics.Accel(r, mu)
@@ -478,7 +482,7 @@ func (s *Spacecraft) ThrustAccelFnAtWithTarget(mode BurnMode, mu, throttle float
 			dir = DirectionUnit(mode, r, v)
 		}
 		if pitchTrim != 0 {
-			dir = ApplyPitchTrim(dir, r, pitchTrim)
+			dir = ApplyPitchTrim(dir, r, spinAxis, pitchTrim)
 		}
 		if dir.Norm() == 0 {
 			return gravity

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -444,7 +444,7 @@ func (s *Spacecraft) ThrustAccelFnAtWithTarget(mode BurnMode, mu, throttle float
 		throttle = 1
 	}
 	thrust := s.Thrust * throttle
-	if s.Fuel <= 0 {
+	if s.ActiveStageFuel() <= 0 {
 		thrust = 0
 	}
 	// v0.9.2+: capture omega + pitch trim at closure construction so

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -188,12 +188,14 @@ func TestThrustAccelFnAddsThrustOnTopOfGravity(t *testing.T) {
 }
 
 // TestThrustAccelFnNoThrustWhenFuelEmpty: with Fuel=0, the closure must
-// return pure gravity even though Thrust is configured.
+// return pure gravity even though Thrust is configured. v0.9.4+:
+// drains Stages[0] (the firing stage) instead of zeroing the summed
+// shadow field, since the cutoff check now reads ActiveStageFuel.
 func TestThrustAccelFnNoThrustWhenFuelEmpty(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	earth := systems[0].FindBody("Earth")
 	sc := NewInLEO(*earth)
-	sc.Fuel = 0
+	sc.BurnFuel(sc.Stages[0].FuelMass) // drain the firing stage
 	mu := earth.GravitationalParameter()
 
 	accelFn := sc.ThrustAccelFn(BurnPrograde, mu)
@@ -205,5 +207,41 @@ func TestThrustAccelFnNoThrustWhenFuelEmpty(t *testing.T) {
 
 	if got.Sub(want).Norm() > 1e-9 {
 		t.Errorf("with empty fuel, got %+v, want pure gravity %+v", got, want)
+	}
+}
+
+// TestThrustAccelFnNoThrustWhenBottomStageEmpty: regression for the
+// v0.9.4 multi-stage cutoff bug. A Saturn V whose S-IC has burned dry
+// must not continue thrusting just because S-II + S-IVB still hold
+// propellant — the firing engine has nothing to burn. Pre-fix the
+// summed-fuel check let the engine apply free thrust through an
+// empty bottom stage.
+func TestThrustAccelFnNoThrustWhenBottomStageEmpty(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewFromLoadout(LoadoutSaturnVID)
+	sc.Primary = *earth
+	sc.State.R = orbital.Vec3{X: earth.RadiusMeters() + 70e3}
+	sc.State.V = orbital.Vec3{Y: 2500}
+	mu := earth.GravitationalParameter()
+
+	// Drain S-IC fully but leave S-II + S-IVB with their full tanks.
+	sc.BurnFuel(sc.Stages[0].FuelMass)
+	if sc.Stages[0].FuelMass != 0 {
+		t.Fatalf("setup: S-IC fuel = %.0f, want 0", sc.Stages[0].FuelMass)
+	}
+	if sc.Fuel <= 0 {
+		t.Fatalf("setup: summed fuel = %.0f, want > 0 (S-II + S-IVB still full)", sc.Fuel)
+	}
+
+	accelFn := sc.ThrustAccelFn(BurnPrograde, mu)
+	got := accelFn(sc.State.R, sc.State.V, 0)
+
+	rMag := sc.State.R.Norm()
+	gFactor := -mu / (rMag * rMag * rMag)
+	want := orbital.Vec3{X: sc.State.R.X * gFactor, Y: sc.State.R.Y * gFactor, Z: sc.State.R.Z * gFactor}
+
+	if got.Sub(want).Norm() > 1e-6 {
+		t.Errorf("dry S-IC with full upper stages: got %+v, want pure gravity %+v (no free thrust)", got, want)
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -526,7 +526,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		case key.Matches(m, a.keys.PlanCircularize):
-			// v0.9.5+: `C` plants a prograde burn at next apoapsis sized
+			// v0.9.4+: `C` plants a prograde burn at next apoapsis sized
 			// to circularise. Pairs with the LAUNCH HUD's ORBIT READY
 			// callout — when the player sees ORBIT READY (apoapsis is
 			// in space) they press `C`, coast to apoapsis, the planted

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -525,6 +525,24 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.statusExpires = time.Now().Add(3 * time.Second)
 			}
 			return a, nil
+		case key.Matches(m, a.keys.PlanCircularize):
+			// v0.9.5+: `C` plants a prograde burn at next apoapsis sized
+			// to circularise. Pairs with the LAUNCH HUD's ORBIT READY
+			// callout — when the player sees ORBIT READY (apoapsis is
+			// in space) they press `C`, coast to apoapsis, the planted
+			// node fires, periapsis rises to match apoapsis, mission
+			// passes. Mirrors v0.7.4's `I` planter shape.
+			if a.world.CraftVisibleHere() {
+				plan, err := a.world.PlanCircularizeAtApoapsis()
+				if err != nil {
+					a.statusMsg = fmt.Sprintf("circularize: %v", err)
+				} else {
+					a.statusMsg = fmt.Sprintf("circularize @ apoapsis (%.0f km) → +%.0f m/s prograde",
+						plan.ApoAltM/1000, plan.DV)
+				}
+				a.statusExpires = time.Now().Add(3 * time.Second)
+			}
+			return a, nil
 		case key.Matches(m, a.keys.Porkchop):
 			if a.active == screenOrbit && a.world.CraftVisibleHere() && a.selectedBody > 0 {
 				a.porkchop.Load(a.world, a.selectedBody)

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -40,6 +40,11 @@ type Keymap struct {
 	ClearNodes    key.Binding
 	PlanTransfer  key.Binding
 	PlanIncl      key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
+	// PlanCircularize (v0.9.5+) plants a prograde burn at the active
+	// craft's next apoapsis sized to circularise the orbit there. The
+	// "single keystroke for the natural last step of an ascent"
+	// shortcut, mirroring the v0.7.4 `I` plane-match planter.
+	PlanCircularize key.Binding
 	Porkchop      key.Binding
 	// v0.8.6: Save / Load moved S / L → F5 / F9 to match the KSP
 	// quicksave-quickload muscle memory and to clear the case-
@@ -157,6 +162,7 @@ func DefaultKeymap() Keymap {
 		ClearNodes:   key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
 		PlanTransfer: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
 		PlanIncl:     key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
+		PlanCircularize: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "plant circularize burn at next apoapsis")),
 		Porkchop:     key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
 		Save:         key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
 		Load:         key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -40,7 +40,7 @@ type Keymap struct {
 	ClearNodes    key.Binding
 	PlanTransfer  key.Binding
 	PlanIncl      key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
-	// PlanCircularize (v0.9.5+) plants a prograde burn at the active
+	// PlanCircularize (v0.9.4+) plants a prograde burn at the active
 	// craft's next apoapsis sized to circularise the orbit there. The
 	// "single keystroke for the natural last step of an ascent"
 	// shortcut, mirroring the v0.7.4 `I` plane-match planter.

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -48,6 +48,7 @@ func (h *Help) Render() string {
 			{"ctrl+k (in planner)", "clear ALL planned nodes for active craft"},
 			{"H", "plant Hohmann transfer to selected body"},
 			{"I", "plant inclination match (selected body / equatorial)"},
+			{"C", "plant circularize burn at next apoapsis"},
 			{"P", "porkchop plot for selected body"},
 			{"R", "refine plan (re-Lambert arrival)"},
 		}},

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1137,8 +1137,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
 		vRel := c.State.V.Sub(omega.Cross(c.State.R))
 		rNorm := c.State.R.Norm()
-		var vVert, vHoriz, fpaDeg float64
+		var vVert, vHoriz, fpaDeg, fpaOrbitDeg float64
 		hasFPA := false
+		hasFPAOrbit := false
 		if rNorm > 0 {
 			rHat := c.State.R.Scale(1 / rNorm)
 			// vRel · rHat (radial component) — orbital.Vec3 has no
@@ -1152,6 +1153,19 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			if vRel.Norm() > 1.0 {
 				fpaDeg = math.Atan2(vVert, vHoriz) * 180 / math.Pi
 				hasFPA = true
+			}
+			// Orbit-frame fpa: same split, but on the inertial velocity
+			// vector (no surface co-rotation subtracted). What matters
+			// for the upper-stage circularization burn — surface
+			// prograde diverges from orbit prograde once Earth's
+			// rotation contribution becomes a small fraction of the
+			// total speed.
+			vOrbit := c.State.V
+			if vOrbit.Norm() > 1.0 {
+				vVertOrbit := vOrbit.X*rHat.X + vOrbit.Y*rHat.Y + vOrbit.Z*rHat.Z
+				vHorizOrbit := vOrbit.Sub(rHat.Scale(vVertOrbit)).Norm()
+				fpaOrbitDeg = math.Atan2(vVertOrbit, vHorizOrbit) * 180 / math.Pi
+				hasFPAOrbit = true
 			}
 		}
 		// TWR: active-stage thrust / (mass · surface gravity).
@@ -1182,11 +1196,16 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		if hasFPA {
 			fpaLabel = fmt.Sprintf("%.0f° (90 = up, 0 = horiz)", fpaDeg)
 		}
+		fpaOrbitLabel := "—"
+		if hasFPAOrbit {
+			fpaOrbitLabel = fmt.Sprintf("%.0f° (inertial)", fpaOrbitDeg)
+		}
 		lines = append(lines,
 			fmt.Sprintf("  altitude:   %s", altLabel),
 			fmt.Sprintf("  v_vert:     %.1f m/s", vVert),
 			fmt.Sprintf("  v_horiz:    %.0f m/s (surface-rel)", vHoriz),
 			fmt.Sprintf("  fpa:        %s", fpaLabel),
+			fmt.Sprintf("  fpa_orbit:  %s", fpaOrbitLabel),
 			fmt.Sprintf("  twr:        %s", twrLabel),
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
@@ -73,6 +74,16 @@ type OrbitView struct {
 	hudScrollOffset int   // rows of overflow off the top when the rendered view exceeds terminal height
 	hudColStart     int   // first screen-col of the HUD region
 	totalRows       int   // last-known terminal height; updated by Render
+
+	// ascentTrend caches last-frame apoapsis for the active craft so
+	// the LAUNCH HUD can show a `(climbing)` / `(falling)` / `(steady)`
+	// tag — the launch-flight equivalent of v0.9.3's signed
+	// closing-rate readout in the TARGET HUD. Re-baselined whenever
+	// the active craft pointer changes (ie spawn, cycle, or fuse), so
+	// stale entries can't bleed across crafts. v0.9.5+.
+	ascentTrendCraft *spacecraft.Spacecraft
+	ascentTrendApoM  float64
+	ascentTrendTime  time.Time
 }
 
 // hudNodeHit identifies a clickable NODES-block entry. CraftIdx is
@@ -1164,6 +1175,121 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),
 		)
+		// v0.9.5+: live ascent prediction — apoapsis / periapsis / time-
+		// to-apoapsis / Δv-to-circularise. Mirrors v0.9.3's TARGET HUD
+		// pattern (live numbers shrink as the player nudges throttle)
+		// so the player can fly the gravity turn by watching ap climb
+		// instead of memorising a profile. Computed once per frame from
+		// orbital.ElementsFromStateInFrame; trend tag is finite-
+		// differenced against the last frame.
+		mu := c.Primary.GravitationalParameter()
+		primaryR := c.Primary.RadiusMeters()
+		frame := orbital.ReferenceFrameForPrimary(c.Primary)
+		el := orbital.ElementsFromStateInFrame(c.State.R, c.State.V, mu, frame)
+		var (
+			apoAlt, periAlt float64
+			apoFinite       bool
+		)
+		if !math.IsNaN(el.A) && !math.IsInf(el.A, 0) && el.A > 0 && el.E < 1 {
+			apoAlt = el.Apoapsis() - primaryR
+			periAlt = el.Periapsis() - primaryR
+			apoFinite = true
+		}
+		apLabel := "—"
+		peLabel := "—"
+		ttaLabel := "—"
+		dvCircLabel := "—"
+		trendLabel := ""
+		if apoFinite {
+			apLabel = formatAltKm(apoAlt)
+			peLabel = formatAltKm(periAlt)
+			// Δapo/dt finite-diff against last frame on this craft.
+			// First frame on a craft (or after the active craft pointer
+			// changes) seeds the cache; subsequent frames produce a
+			// tag. Threshold of 1 m/s renders as `(steady)`.
+			now := w.Clock.SimTime
+			if v.ascentTrendCraft == c && !v.ascentTrendTime.IsZero() {
+				dt := now.Sub(v.ascentTrendTime).Seconds()
+				if dt > 1e-6 {
+					rate := (el.Apoapsis() - v.ascentTrendApoM) / dt
+					switch {
+					case rate > 1.0:
+						trendLabel = " (climbing)"
+					case rate < -1.0:
+						trendLabel = " (falling)"
+					default:
+						trendLabel = " (steady)"
+					}
+				}
+			}
+			v.ascentTrendCraft = c
+			v.ascentTrendApoM = el.Apoapsis()
+			v.ascentTrendTime = now
+
+			// t_to_apo only meaningful once apoapsis clears the
+			// surface; on a sub-orbital arc the "next apoapsis" math
+			// resolves but the readout is misleading (apoapsis is
+			// underground).
+			if apoAlt > 0 {
+				ttaSec := orbital.TimeToApoapsis(orbital.Vec3State{R: c.State.R, V: c.State.V}, mu)
+				if ttaSec > 0 {
+					ttaLabel = formatDurationShort(ttaSec)
+				}
+			}
+			// Δv→circ at apoapsis. Vis-viva at r_apo gives current
+			// along-track speed there; circular speed is sqrt(mu/r_apo);
+			// the difference is the prograde Δv. Hidden when apoapsis
+			// is below the primary surface (orbit closes underground)
+			// or above primary radius but with a negative periapsis
+			// the readout still helps — it's the "burn this much when
+			// you get there" hint.
+			rApo := el.Apoapsis()
+			if rApo > primaryR && el.A > 0 {
+				vAtApo := math.Sqrt(mu * (2/rApo - 1/el.A))
+				vCircAtApo := math.Sqrt(mu / rApo)
+				dvCirc := vCircAtApo - vAtApo
+				if dvCirc > 0 {
+					dvCircLabel = fmt.Sprintf("%.0f m/s", dvCirc)
+				}
+			}
+		} else {
+			// Hyperbolic / degenerate — clear the trend cache so the
+			// next bound state seeds fresh.
+			v.ascentTrendCraft = nil
+		}
+		lines = append(lines,
+			fmt.Sprintf("  ap:         %s%s", apLabel, trendLabel),
+			fmt.Sprintf("  pe:         %s", peLabel),
+			fmt.Sprintf("  t_to_apo:   %s", ttaLabel),
+			fmt.Sprintf("  Δv→circ:    %s", dvCircLabel),
+		)
+		// v0.9.5+: ORBIT READY callout — fires when apoapsis is above
+		// the mission floor, signalling "your apoapsis is in space,
+		// coast there and press C to plant the circularisation node."
+		// Mirrors v0.9.3's DOCK READY pattern (live signal + bold
+		// green styling) but gates on apoapsis (the actionable
+		// threshold while still ascending), not periapsis (which
+		// crosses the floor only at circularisation, by which time
+		// the LAUNCH HUD is one frame from vanishing because the
+		// mission has passed).
+		if apoFinite && apoAlt > launchMissionFloorM {
+			orbitStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3DDC84")).Bold(true)
+			lines = append(lines,
+				"  "+orbitStyle.Render("● ORBIT READY — coast to ap, press C to plant circularise"),
+			)
+		}
+		// v0.9.5+: live mission progress — surfaces the
+		// saturn-v-pad-to-leo floor distance below the predictive
+		// rows so the player sees a single number to chase ("pe 130 km
+		// / 200 km target") instead of guessing whether they're close.
+		// Reads off the primary's periapsis altitude in the same units
+		// as the mission predicate.
+		if apoFinite {
+			progress := launchMissionProgress(w, c, periAlt)
+			if progress != "" {
+				lines = append(lines, "  "+progress)
+			}
+		}
 	}
 
 	// v0.8.2.x: arrival inclination preview. Surfaces the post-
@@ -1588,12 +1714,16 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 }
 
 // shouldShowLaunchHUD returns true when the active craft is in
-// "ascent" mode — periapsis below the primary's mean radius
-// (= craft would impact if its orbit closed) AND altitude under
-// the primary's atmospheric cutoff. Both conditions guarantee
-// the orbit-relative HUD blocks aren't useful yet (the orbit
-// closes underground) and the manual gravity-turn instruments
-// are. v0.9.2+.
+// "ascent" mode — defined v0.9.5+ as "periapsis below the
+// circularize-from-pad mission floor" (200 km altitude). Visible
+// for the whole pad → coast → circularise journey, vanishing only
+// once the mission-floor periapsis is achieved (= LEO is captured).
+// v0.9.2+ originally hid the HUD as soon as periapsis cleared the
+// surface or the craft left the atmosphere; that hid the very
+// signals (ap, pe, Δv→circ, ORBIT READY) the player needs during
+// coast and circularisation, so v0.9.5+ keeps it up through the
+// whole ascent phase. Hyperbolic / degenerate states keep the HUD
+// up too (they read "—" rather than misleading numbers).
 func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 	if c == nil {
 		return false
@@ -1610,27 +1740,83 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 		return false
 	}
 	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-	periapsis := el.Periapsis()
+	if el.E >= 1 || el.A <= 0 {
+		// Hyperbolic or degenerate: still on an ascent-class
+		// trajectory (or thrown off it). Show the HUD with `—`
+		// placeholders rather than silently hiding.
+		return true
+	}
 	primaryR := c.Primary.RadiusMeters()
-	if periapsis >= primaryR {
-		// Stable orbit (or hyperbolic with no impact) — orbit-
-		// relative HUD takes over.
-		return false
+	periAlt := el.Periapsis() - primaryR
+	return periAlt < launchMissionFloorM
+}
+
+// launchMissionFloorM is the periapsis altitude (m) at which the
+// saturn-v-pad-to-leo mission passes — also the threshold at which
+// the LAUNCH HUD vanishes (ascent complete) and the ORBIT READY
+// callout's pe gate fires. Lives at the package boundary so the
+// LAUNCH HUD block (orbit.go:1158-) and shouldShowLaunchHUD agree
+// on a single floor. Mirrors the JSON value at
+// internal/missions/missions.json:40. v0.9.5+.
+const launchMissionFloorM = 200_000.0
+
+// formatAltKm renders an altitude in metres as a signed kilometre
+// string with a sign that's friendly to ascent flight ("−2.8 km"
+// reads better than "−2840 m" for sub-orbital periapsis). Used by
+// the LAUNCH HUD's ap / pe rows. v0.9.5+.
+func formatAltKm(altM float64) string {
+	km := altM / 1000
+	switch {
+	case math.Abs(km) >= 1000:
+		return fmt.Sprintf("%+.0f km", km)
+	case math.Abs(km) >= 1:
+		return fmt.Sprintf("%+.1f km", km)
+	default:
+		return fmt.Sprintf("%+.0f m", altM)
 	}
-	alt := c.State.R.Norm() - primaryR
-	cutoff := c.Primary.Atmosphere.CutoffAltitude
-	if cutoff > 0 && alt > cutoff {
-		// Above atmosphere with sub-radius periapsis: trajectory is
-		// either descending toward impact or about to circularise.
-		// LAUNCH HUD is only relevant in the climb phase (alt below
-		// cutoff). Above-cutoff sub-orbital flight is rare; surfacing
-		// it would clutter the HUD for the typical "just left the
-		// atmosphere, periapsis still negative" Saturn-V ascent.
-		// The orbit-relative HUD blocks above already cover this
-		// case adequately.
-		return false
+}
+
+// formatDurationShort renders seconds as a short human label —
+// "12s" / "3m45s" / "1h22m". Used by the LAUNCH HUD's t_to_apo
+// row and the rendezvous TCA readout (v0.9.3 patterns kept
+// consistent across both ascent and rendezvous flows). v0.9.5+.
+func formatDurationShort(sec float64) string {
+	if sec < 60 {
+		return fmt.Sprintf("%.0fs", sec)
 	}
-	return true
+	if sec < 3600 {
+		m := int(sec) / 60
+		s := int(sec) % 60
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	h := int(sec) / 3600
+	m := (int(sec) % 3600) / 60
+	return fmt.Sprintf("%dh%02dm", h, m)
+}
+
+// launchMissionProgress returns the pe-altitude-vs-mission-floor
+// row for the LAUNCH HUD when the active craft is flying a
+// circularize_from_pad mission for its current primary. Empty
+// string when no such mission is in flight. v0.9.5+.
+func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
+	for _, m := range w.Missions {
+		if m.Type != missions.TypeCircularizeFromPad {
+			continue
+		}
+		if m.Status == missions.Passed {
+			continue
+		}
+		if m.Params.PrimaryID != c.Primary.ID {
+			continue
+		}
+		target := m.Params.MinPeriapsisAltM
+		if target <= 0 {
+			target = launchMissionFloorM
+		}
+		return fmt.Sprintf("mission:    pe %s / %s target",
+			formatAltKm(periAltM), formatAltKm(target))
+	}
+	return ""
 }
 
 // scanHudNodeRows walks the rendered HUD line-by-line and matches

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1137,7 +1137,8 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
 		vRel := c.State.V.Sub(omega.Cross(c.State.R))
 		rNorm := c.State.R.Norm()
-		var vVert, vHoriz float64
+		var vVert, vHoriz, fpaDeg float64
+		hasFPA := false
 		if rNorm > 0 {
 			rHat := c.State.R.Scale(1 / rNorm)
 			// vRel · rHat (radial component) — orbital.Vec3 has no
@@ -1145,6 +1146,13 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			vVert = vRel.X*rHat.X + vRel.Y*rHat.Y + vRel.Z*rHat.Z
 			vHorizVec := vRel.Sub(rHat.Scale(vVert))
 			vHoriz = vHorizVec.Norm()
+			// Flight-path angle: 90° = straight up, 0° = horizontal.
+			// Only meaningful once moving — atan2 is undefined when
+			// both components are zero (craft on the pad).
+			if vRel.Norm() > 1.0 {
+				fpaDeg = math.Atan2(vVert, vHoriz) * 180 / math.Pi
+				hasFPA = true
+			}
 		}
 		// TWR: active-stage thrust / (mass · surface gravity).
 		twrLabel := "—"
@@ -1170,10 +1178,15 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			trimLabel = v.theme.Warning.Render(trimLabel)
 		}
 		lines = append(lines, section("LAUNCH")...)
+		fpaLabel := "—"
+		if hasFPA {
+			fpaLabel = fmt.Sprintf("%.0f° (90 = up, 0 = horiz)", fpaDeg)
+		}
 		lines = append(lines,
 			fmt.Sprintf("  altitude:   %s", altLabel),
 			fmt.Sprintf("  v_vert:     %.1f m/s", vVert),
 			fmt.Sprintf("  v_horiz:    %.0f m/s (surface-rel)", vHoriz),
+			fmt.Sprintf("  fpa:        %s", fpaLabel),
 			fmt.Sprintf("  twr:        %s", twrLabel),
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1234,7 +1234,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		peLabel := "—"
 		ttaLabel := "—"
 		dvCircLabel := "—"
+		tBurnLabel := "—"
 		trendLabel := ""
+		var dvCirc float64
 		if apoFinite {
 			apLabel = formatAltKm(apoAlt)
 			peLabel = formatAltKm(periAlt)
@@ -1273,18 +1275,20 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			}
 			// Δv→circ at apoapsis. Vis-viva at r_apo gives current
 			// along-track speed there; circular speed is sqrt(mu/r_apo);
-			// the difference is the prograde Δv. Hidden when apoapsis
-			// is below the primary surface (orbit closes underground)
-			// or above primary radius but with a negative periapsis
-			// the readout still helps — it's the "burn this much when
-			// you get there" hint.
+			// the difference is the prograde Δv. Labelled (impulsive)
+			// because the calc assumes an instantaneous on-axis burn —
+			// real low-TWR upper-stage burns eat 15–40% more from
+			// finite-burn time, gravity loss, and drift past apoapsis.
+			// The companion t_burn row surfaces the duration so the
+			// player can sanity-check whether finite-burn losses will
+			// be substantial.
 			rApo := el.Apoapsis()
 			if rApo > primaryR && el.A > 0 {
 				vAtApo := math.Sqrt(mu * (2/rApo - 1/el.A))
 				vCircAtApo := math.Sqrt(mu / rApo)
-				dvCirc := vCircAtApo - vAtApo
+				dvCirc = vCircAtApo - vAtApo
 				if dvCirc > 0 {
-					dvCircLabel = fmt.Sprintf("%.0f m/s", dvCirc)
+					dvCircLabel = fmt.Sprintf("%.0f m/s (impulsive)", dvCirc)
 				}
 			}
 		} else {
@@ -1292,11 +1296,25 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			// next bound state seeds fresh.
 			v.ascentTrendCraft = nil
 		}
+		// t_burn: how long the active engine would take to deliver the
+		// impulsive Δv at current thrust + mass. Mass-flow is small
+		// over a single burn relative to mass, so we approximate with
+		// the constant-mass form Δv·m/F. Hidden when no Δv→circ value
+		// (apoapsis below surface) or no thrust (engine cut, dry stage).
+		if dvCirc > 0 && c.Thrust > 0 && c.TotalMass() > 0 {
+			thrust := c.Thrust * c.EffectiveThrottle()
+			if thrust <= 0 {
+				thrust = c.Thrust // ignore throttle when off — show what full burn would take
+			}
+			tBurnSec := dvCirc * c.TotalMass() / thrust
+			tBurnLabel = formatDurationShort(tBurnSec)
+		}
 		lines = append(lines,
 			fmt.Sprintf("  ap:         %s%s", apLabel, trendLabel),
 			fmt.Sprintf("  pe:         %s", peLabel),
 			fmt.Sprintf("  t_to_apo:   %s", ttaLabel),
 			fmt.Sprintf("  Δv→circ:    %s", dvCircLabel),
+			fmt.Sprintf("  t_burn:     %s", tBurnLabel),
 		)
 		// v0.9.4+: ORBIT READY callout — fires when apoapsis is above
 		// the mission floor, signalling "your apoapsis is in space,

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
-	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -1130,8 +1129,12 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		// Vertical / horizontal split of velocity in the body's
 		// rotating frame: vertical = v · r̂, horizontal = |v - v_vert·r̂|
 		// after subtracting the surface co-rotation ω×r so a craft
-		// sitting on the pad reads 0 m/s on both axes.
-		omega := physics.AtmosphereOmega(c.Primary)
+		// sitting on the pad reads 0 m/s on both axes. Use the
+		// tilted spin axis (matches the launchpad spawn frame); the
+		// Z-aligned physics.AtmosphereOmega leaves a ~150 m/s
+		// residual at Earth's 23.5° axial tilt.
+		omegaRender := render.BodySpinOmegaWorld(c.Primary)
+		omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
 		vRel := c.State.V.Sub(omega.Cross(c.State.R))
 		rNorm := c.State.R.Norm()
 		var vVert, vHoriz float64

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -80,7 +80,7 @@ type OrbitView struct {
 	// tag — the launch-flight equivalent of v0.9.3's signed
 	// closing-rate readout in the TARGET HUD. Re-baselined whenever
 	// the active craft pointer changes (ie spawn, cycle, or fuse), so
-	// stale entries can't bleed across crafts. v0.9.5+.
+	// stale entries can't bleed across crafts. v0.9.4+.
 	ascentTrendCraft *spacecraft.Spacecraft
 	ascentTrendApoM  float64
 	ascentTrendTime  time.Time
@@ -1175,7 +1175,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),
 		)
-		// v0.9.5+: live ascent prediction — apoapsis / periapsis / time-
+		// v0.9.4+: live ascent prediction — apoapsis / periapsis / time-
 		// to-apoapsis / Δv-to-circularise. Mirrors v0.9.3's TARGET HUD
 		// pattern (live numbers shrink as the player nudges throttle)
 		// so the player can fly the gravity turn by watching ap climb
@@ -1263,7 +1263,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  t_to_apo:   %s", ttaLabel),
 			fmt.Sprintf("  Δv→circ:    %s", dvCircLabel),
 		)
-		// v0.9.5+: ORBIT READY callout — fires when apoapsis is above
+		// v0.9.4+: ORBIT READY callout — fires when apoapsis is above
 		// the mission floor, signalling "your apoapsis is in space,
 		// coast there and press C to plant the circularisation node."
 		// Mirrors v0.9.3's DOCK READY pattern (live signal + bold
@@ -1278,7 +1278,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 				"  "+orbitStyle.Render("● ORBIT READY — coast to ap, press C to plant circularise"),
 			)
 		}
-		// v0.9.5+: live mission progress — surfaces the
+		// v0.9.4+: live mission progress — surfaces the
 		// saturn-v-pad-to-leo floor distance below the predictive
 		// rows so the player sees a single number to chase ("pe 130 km
 		// / 200 km target") instead of guessing whether they're close.
@@ -1714,14 +1714,14 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 }
 
 // shouldShowLaunchHUD returns true when the active craft is in
-// "ascent" mode — defined v0.9.5+ as "periapsis below the
+// "ascent" mode — defined v0.9.4+ as "periapsis below the
 // circularize-from-pad mission floor" (200 km altitude). Visible
 // for the whole pad → coast → circularise journey, vanishing only
 // once the mission-floor periapsis is achieved (= LEO is captured).
 // v0.9.2+ originally hid the HUD as soon as periapsis cleared the
 // surface or the craft left the atmosphere; that hid the very
 // signals (ap, pe, Δv→circ, ORBIT READY) the player needs during
-// coast and circularisation, so v0.9.5+ keeps it up through the
+// coast and circularisation, so v0.9.4+ keeps it up through the
 // whole ascent phase. Hyperbolic / degenerate states keep the HUD
 // up too (they read "—" rather than misleading numbers).
 func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
@@ -1757,13 +1757,13 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 // callout's pe gate fires. Lives at the package boundary so the
 // LAUNCH HUD block (orbit.go:1158-) and shouldShowLaunchHUD agree
 // on a single floor. Mirrors the JSON value at
-// internal/missions/missions.json:40. v0.9.5+.
+// internal/missions/missions.json:40. v0.9.4+.
 const launchMissionFloorM = 200_000.0
 
 // formatAltKm renders an altitude in metres as a signed kilometre
 // string with a sign that's friendly to ascent flight ("−2.8 km"
 // reads better than "−2840 m" for sub-orbital periapsis). Used by
-// the LAUNCH HUD's ap / pe rows. v0.9.5+.
+// the LAUNCH HUD's ap / pe rows. v0.9.4+.
 func formatAltKm(altM float64) string {
 	km := altM / 1000
 	switch {
@@ -1779,7 +1779,7 @@ func formatAltKm(altM float64) string {
 // formatDurationShort renders seconds as a short human label —
 // "12s" / "3m45s" / "1h22m". Used by the LAUNCH HUD's t_to_apo
 // row and the rendezvous TCA readout (v0.9.3 patterns kept
-// consistent across both ascent and rendezvous flows). v0.9.5+.
+// consistent across both ascent and rendezvous flows). v0.9.4+.
 func formatDurationShort(sec float64) string {
 	if sec < 60 {
 		return fmt.Sprintf("%.0fs", sec)
@@ -1797,7 +1797,7 @@ func formatDurationShort(sec float64) string {
 // launchMissionProgress returns the pe-altitude-vs-mission-floor
 // row for the LAUNCH HUD when the active craft is flying a
 // circularize_from_pad mission for its current primary. Empty
-// string when no such mission is in flight. v0.9.5+.
+// string when no such mission is in flight. v0.9.4+.
 func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
 	for _, m := range w.Missions {
 		if m.Type != missions.TypeCircularizeFromPad {

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -1,0 +1,165 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestFormatAltKmThresholds exercises the three-band formatter the
+// LAUNCH HUD's ap / pe rows render through. Bands chosen so altitude
+// reads naturally on the pad (`+0 m`), in mid-ascent (`+12.3 km`),
+// and once orbit lifts out to body-radius scale (`+1234 km`).
+// v0.9.5+.
+func TestFormatAltKmThresholds(t *testing.T) {
+	cases := []struct {
+		altM float64
+		want string
+	}{
+		{0, "+0 m"},
+		{0.5, "+0 m"},
+		{12, "+12 m"},
+		{1500, "+1.5 km"},
+		{50_000, "+50.0 km"},
+		{200_000, "+200.0 km"},
+		{1_500_000, "+1500 km"},
+		{-2_840_000, "-2840 km"},
+		{-100, "-100 m"},
+	}
+	for _, c := range cases {
+		got := formatAltKm(c.altM)
+		if got != c.want {
+			t.Errorf("formatAltKm(%g) = %q, want %q", c.altM, got, c.want)
+		}
+	}
+}
+
+// TestFormatDurationShortBands exercises the three duration bands:
+// seconds (`12s`), minutes (`3m45s`), and hours (`1h22m`). Used by
+// the LAUNCH HUD's t_to_apo row. v0.9.5+.
+func TestFormatDurationShortBands(t *testing.T) {
+	cases := []struct {
+		sec  float64
+		want string
+	}{
+		{0, "0s"},
+		{12, "12s"},
+		{59.4, "59s"},
+		{60, "1m00s"},
+		{225, "3m45s"},
+		{3599, "59m59s"},
+		{3600, "1h00m"},
+		{4920, "1h22m"},
+	}
+	for _, c := range cases {
+		got := formatDurationShort(c.sec)
+		if got != c.want {
+			t.Errorf("formatDurationShort(%g) = %q, want %q", c.sec, got, c.want)
+		}
+	}
+}
+
+// TestLaunchMissionProgressMatchesCircularizeFromPad — when the world
+// has an in-flight circularize_from_pad mission for the active
+// craft's primary, the progress line shows current pe / target.
+// v0.9.5+.
+func TestLaunchMissionProgressMatchesCircularizeFromPad(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected active craft from NewWorld")
+	}
+	got := launchMissionProgress(w, c, 130_000)
+	if got == "" {
+		t.Fatal("expected non-empty progress for active circularize_from_pad mission")
+	}
+	if !strings.Contains(got, "200") {
+		t.Errorf("progress %q should reference the 200 km mission floor", got)
+	}
+	if !strings.Contains(got, "130") {
+		t.Errorf("progress %q should reference the current pe altitude", got)
+	}
+}
+
+// TestLaunchMissionProgressEmptyWithoutMission — with the bundled
+// circularize_from_pad mission marked Passed, the helper returns ""
+// so the LAUNCH HUD doesn't emit a stray row. v0.9.5+.
+func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected active craft from NewWorld")
+	}
+	for i := range w.Missions {
+		if w.Missions[i].Type == missions.TypeCircularizeFromPad {
+			w.Missions[i].Status = missions.Passed
+		}
+	}
+	if got := launchMissionProgress(w, c, 130_000); got != "" {
+		t.Errorf("progress with no in-flight mission = %q, want \"\"", got)
+	}
+}
+
+// TestLaunchHUDRendersOrbitReadyOnApAboveFloor — drives the LAUNCH
+// HUD directly by mutating the active craft's state into an
+// apoapsis-above-floor configuration, then checks for the ORBIT
+// READY callout in the rendered output. This is the rendezvous-
+// style live-signal pattern (DOCK READY at threshold ↔ ORBIT READY
+// at threshold) ported to the launch flow. v0.9.5+.
+func TestLaunchHUDRendersOrbitReadyOnApAboveFloor(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false // ensure orbital math runs
+	c.Throttle = 0
+	c.AttitudeMode = spacecraft.BurnPrograde
+	// Sub-orbital arc with apoapsis at +250 km altitude (above the
+	// 200 km mission floor) and periapsis at -100 km altitude
+	// (impactor — exactly the post-engine-cut state where the player
+	// needs to plant `C`).
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	rApo := primaryR + 250e3
+	rPeri := primaryR - 100e3
+	a := (rPeri + rApo) / 2
+	vAtPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	c.State.R.X, c.State.R.Y, c.State.R.Z = rPeri, 0, 0
+	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vAtPeri, 0
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "ORBIT READY") {
+		t.Errorf("expected LAUNCH HUD to surface ORBIT READY callout for "+
+			"sub-orbital arc with apo above 200km floor; rendered output:\n%s",
+			out)
+	}
+	if !strings.Contains(out, "ap:") {
+		t.Errorf("expected LAUNCH HUD to surface live ap row")
+	}
+	if !strings.Contains(out, "Δv→circ") {
+		t.Errorf("expected LAUNCH HUD to surface Δv→circ row")
+	}
+}

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -16,7 +16,7 @@ import (
 // LAUNCH HUD's ap / pe rows render through. Bands chosen so altitude
 // reads naturally on the pad (`+0 m`), in mid-ascent (`+12.3 km`),
 // and once orbit lifts out to body-radius scale (`+1234 km`).
-// v0.9.5+.
+// v0.9.4+.
 func TestFormatAltKmThresholds(t *testing.T) {
 	cases := []struct {
 		altM float64
@@ -42,7 +42,7 @@ func TestFormatAltKmThresholds(t *testing.T) {
 
 // TestFormatDurationShortBands exercises the three duration bands:
 // seconds (`12s`), minutes (`3m45s`), and hours (`1h22m`). Used by
-// the LAUNCH HUD's t_to_apo row. v0.9.5+.
+// the LAUNCH HUD's t_to_apo row. v0.9.4+.
 func TestFormatDurationShortBands(t *testing.T) {
 	cases := []struct {
 		sec  float64
@@ -68,7 +68,7 @@ func TestFormatDurationShortBands(t *testing.T) {
 // TestLaunchMissionProgressMatchesCircularizeFromPad — when the world
 // has an in-flight circularize_from_pad mission for the active
 // craft's primary, the progress line shows current pe / target.
-// v0.9.5+.
+// v0.9.4+.
 func TestLaunchMissionProgressMatchesCircularizeFromPad(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -92,7 +92,7 @@ func TestLaunchMissionProgressMatchesCircularizeFromPad(t *testing.T) {
 
 // TestLaunchMissionProgressEmptyWithoutMission — with the bundled
 // circularize_from_pad mission marked Passed, the helper returns ""
-// so the LAUNCH HUD doesn't emit a stray row. v0.9.5+.
+// so the LAUNCH HUD doesn't emit a stray row. v0.9.4+.
 func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -117,7 +117,7 @@ func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 // apoapsis-above-floor configuration, then checks for the ORBIT
 // READY callout in the rendered output. This is the rendezvous-
 // style live-signal pattern (DOCK READY at threshold ↔ ORBIT READY
-// at threshold) ported to the launch flow. v0.9.5+.
+// at threshold) ported to the launch flow. v0.9.4+.
 func TestLaunchHUDRendersOrbitReadyOnApAboveFloor(t *testing.T) {
 	th := Theme{
 		Primary: lipgloss.NewStyle(),


### PR DESCRIPTION
## Summary

Closes the v0.9.2 ground-launch WIP by transplanting the v0.9.3 rendezvous design language (numeric readouts + threshold callouts, no autopilot) onto launch.

**Ergonomics (7e629b9):**
- LAUNCH HUD gains predictive `ap` / `pe` / `t_to_apo` / `Δv→circ` rows with a (climbing/falling/steady) trend tag finite-diffed against last frame — launch equivalent of v0.9.3's signed closing-rate readout.
- ORBIT READY callout fires when apoapsis crosses the 200 km mission floor (mirrors DOCK READY's bold-green threshold).
- Launchpad spawn auto-snaps NavMode → NavSurface, so `w` means surface-prograde out of the box.
- New `C` keystroke plants `PlanCircularizeAtApoapsis` (BurnPrograde / TriggerNextApo, sized via vis-viva).
- `fpa:` (surface-relative) and `fpa_orbit:` (inertial) rows so the player can fly the gravity turn by matching a target curve.
- `Δv→circ` relabeled `(impulsive)` to flag it as a lower bound; new `t_burn` row surfaces low-TWR / finite-burn concerns directly.

**Tilted-axis correctness (2bc53dd, 643d201):**
- LAUNCH HUD `v_horiz`, `BurnSurfacePrograde/Retrograde` SAS, and `ApplyPitchTrim` all now use the body's tilted spin axis (was Z-aligned, leaving a ~150 m/s residual at Earth's 23.5° tilt).
- `physics.AtmosphereOmega` stays Z-aligned for the drag approximation.

**Bug fixes:**
- Thrust cutoff checks the firing stage's fuel, not summed propellant (3462959). A Saturn V with drained S-IC and full upper stages no longer gets free thrust.
- Active craft renames on decouple (`Saturn V` → `S-II` → `S-IVB`) (d5bb542).

**Loadouts (92dcf35):** SLS Block 1 (3-stage, NASA orange + white SRBs + ICPS) and Falcon 9 Block 5 (2-stage, white + pale blue), both appended to LoadoutOrder.

## Test plan

- [ ] `n` → POSITION launchpad → CRAFT TYPE Saturn V → Enter; LAUNCH HUD shows `v_horiz ≈ 0` and `fpa: —` on the pad
- [ ] Throttle up + engage; `fpa:` reads ~90° straight up, drops as you tip east
- [ ] Watch `ap` row tag flip from `(climbing)` past `(steady)` near MECO; ORBIT READY appears once apoapsis crosses 200 km
- [ ] Press `C` near apoapsis; planned node circularises within tolerance
- [ ] Decouple Saturn V stages — active-craft name shifts `Saturn V` → `S-II` → `S-IVB`
- [ ] Burn Saturn V S-IC dry without staging — thrust drops to zero (no free acceleration)
- [ ] Try SLS Block 1 and Falcon 9 Block 5 from the spawn cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)