### PR TITLE
v0.10.0 — rate-limited attitude (slew) + manual-flight fidelity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Terminal-native orbital-mechanics rocket simulator (a KSP-in-the-terminal),
+shipped as a single static Go binary. Bubble Tea TUI on top of a
+patched-conic physics core. Go 1.24+, no CGO.
+
+## Commands
+
+```bash
+go build ./cmd/terminal-space-program        # build the binary
+./terminal-space-program                     # run it
+./terminal-space-program --version           # version + commit
+
+go test ./... -race -count=1                 # full suite (matches CI)
+go test ./internal/sim -run TestWarp         # single package / test (regex)
+go vet ./...                                 # CI runs this before tests
+```
+
+CI (`.github/workflows/test.yml`) runs `go vet ./...` then
+`go test ./... -race -count=1` on every push/PR — keep both green.
+Releases are tag-driven via GoReleaser (`v*` SemVer tags only;
+four-part `vX.Y.Z.N` tags are checkpoint markers and do **not** trigger
+a release).
+
+There is no Makefile and no lint config beyond `go vet`; the codebase
+is test-heavy (almost every `.go` has a sibling `_test.go`) — add tests
+alongside changes.
+
+## Architecture
+
+The dependency flow is one-directional: **physics → orbital → planner /
+spacecraft → sim → tui**. Lower layers never import upward.
+
+- **`internal/physics`** — integrators and force models, stateless and
+  unit-tested in isolation: symplectic `verlet` (free flight), `rk4`
+  (active thrust), `kepler_step` (warp-locked analytic propagation),
+  `drag`, `soi` (sphere-of-influence transitions), `surface` (ground
+  contact), `state` (position/velocity state vector).
+- **`internal/orbital`** — Keplerian element conversions (`kepler`),
+  the `Calculator` for body ephemerides, reference-frame transforms
+  (`frame` — ecliptic vs. body-equatorial), apsis/node `events`.
+- **`internal/bodies`** — body catalog + multi-system data, loaded from
+  embedded `systems/*.json` plus user overlays. `LoadAllWithWarnings`
+  is the entrypoint; user files in `$XDG_CONFIG_HOME` win on
+  `systemName` match. Save files carry a `body_catalog_hash` so a save
+  rejects if the catalog changed.
+- **`internal/planner`** — burn/transfer math: `lambert` (Stumpff
+  universal-variable, Curtis Alg 5.2), `hohmann`, `porkchop`,
+  `inclination`, `moon_escape`, `finiteburn` (iterate-for-target),
+  `predictor` (projected post-burn orbit, frame-rebased per node).
+- **`internal/spacecraft`** — vessel state: `Spacecraft`, `Stages`
+  (player-managed decouple chain), `thrust`, `rcs`, `slew`
+  (rate-limited attitude), `maneuver` nodes, `loadouts` (the launch
+  catalog), `target`.
+- **`internal/sim`** — the simulation orchestrator. **`world.go`**
+  (`World`) is the central mutable state: loaded systems, the craft
+  slate (`Crafts []*Spacecraft` + `ActiveCraftIdx`), `Clock`, `Focus`,
+  `Target` (unified body/craft aim slot), `NavMode`, `ViewMode`,
+  `Missions`. `tick.go` drives the Bubble Tea physics loop via
+  `TickMsg`/`TickCmd`. Other files are feature slices over `World`
+  (`maneuver.go` is the largest — node firing/integration; plus
+  `staging`, `docking`, `landed`, `navball`, `nav`, `predict`,
+  `warp`, `spawn`, `target`).
+- **`internal/save`** — versioned JSON envelope (`SchemaVersion = 6`,
+  at `$XDG_STATE_HOME/terminal-space-program/save.json`). Accepts
+  `[1, SchemaVersion]`; older envelopes auto-migrate via typed
+  `save_migrate_v*` functions. Bump the version + add a migration
+  whenever persisted state shape changes.
+- **`internal/tui`** — Bubble Tea root. `app.go` (`App`) is the root
+  `tea.Model`: owns `world`, theme, keymap, and the active screen.
+  **Screens read from the shared world; they don't mutate it** —
+  state changes go through `sim` methods. `input.go` is the keymap.
+  `tui/screens/*` are screen sub-models (orbit / maneuver / porkchop /
+  bodyinfo / missions / menu / spawn / help); `tui/widgets/canvas.go`
+  is the drawille braille renderer.
+- **`internal/render`** — per-pixel body textures + the navball;
+  pure pixel/color math, view-aware projection with axial tilts.
+
+## Conventions
+
+- **Integrator switch**: free flight uses Verlet (symplectic); an
+  active burn switches to RK4 with rocket-equation mass loss. Warp is
+  clamped to ≤10× during burns and ramps down approaching a planted
+  node so the integrator can't alias past it. Preserve these clamps
+  when touching warp or burn code.
+- **Frames matter**: body-bound orbits read Keplerian elements in the
+  primary's *equatorial* frame; heliocentric orbits stay
+  ecliptic-relative. Don't mix them — `internal/orbital/frame.go` is
+  the boundary.
+- The in-game `?` help overlay is the source of truth for keybindings;
+  `README.md` mirrors it. Update both when changing input.
+- `docs/state-of-game.md` is the running per-version changelog/backlog;
+  `docs/vX.Y-plan.md` are the cycle plans. Read the current plan before
+  starting feature work — scope for a cycle is committed there.
+- Version strings live in `internal/version`; don't hand-edit (set via
+  ldflags at release).

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `q` / `e` | Attitude radial+ / radial- |
 | `b` | Engage / cut manual burn (main engine, throttle > 0) |
 | `r` | Engine: main / RCS (v0.8.0+) |
+| `k` | SAS model: slew / instant — MANUAL (rate-limited, default) vs AUTO (legacy instant snap); navball `[MAN]`/`[AUT]` tag mirrors it (v0.10.0+) |
 | `W` / `S` | Attitude surface-prograde / surface-retrograde — track velocity in the rotating-atmosphere frame (v - ω × r). For ascent gravity turn (v0.9.2+) |
 | `>` / `<` | Pitch trim ±10° east / west — rotate thrust vector about local-north axis on top of current SAS mode (v0.9.2+) |
 | `\` | Reset pitch trim to 0 (v0.9.2+) |

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -1,6 +1,6 @@
 # v0.10 — the fleet flies for real
 
-<!-- llm-parse: cycle=v0.10 status=planning anchor=manual-flight-fidelity -->
+<!-- llm-parse: cycle=v0.10 status=in-progress anchor=manual-flight-fidelity -->
 
 ## Context
 
@@ -34,7 +34,7 @@ is picked up. Mission scripting stays design-pass-first and is
 
 | slice   | status   | tag      | notes |
 |---------|----------|----------|-------|
-| v0.10.0 | designed | —        | Manual flight: rate-limited attitude (slew) + attitude save-persistence rider. Decision (b) lead-compensated locked. |
+| v0.10.0 | in-test  | branch `v0.10.0-slew` | Slew + attitude save-persistence **built and playtest-validated** on branch (not yet tagged / merged to `main`). Lead-compensated nodes in. Unplanned scope folded in: full roll DOF + body-frame navball. `InstantSAS` surfacing **now wired** (`k` key + navball `[MAN]`/`[AUT]` tag); no remaining slice blockers (see slice note). |
 | v0.10.1 | candidate| —        | Staging chain (L) — the standing #1; multi-tier fleet. |
 | v0.10.2 | candidate| —        | Rendezvous tooling (M) — consumes staging fleet; gains depth from v0.10.0. |
 | v0.10.3 | candidate| —        | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. |
@@ -71,7 +71,7 @@ is picked up. Mission scripting stays design-pass-first and is
 
 ### v0.10.0 — manual flight: rate-limited attitude (+ persistence rider)
 
-<!-- llm-parse: slice=v0.10.0 weight=M scope=sim status=designed pair=attitude-save -->
+<!-- llm-parse: slice=v0.10.0 weight=M scope=sim status=in-test pair=attitude-save -->
 
 **Problem.** The nose is recomputed from `AttitudeMode` every tick
 (`NavballSubObserver` / `stepThrust` both call
@@ -135,6 +135,30 @@ literals left unset = default this slice). Surfacing = new key +
 navball `[MODE]` MANUAL/AUTO tag. **Still open (slice-time, non-
 blocking):** the richer "slewing — N s to align" HUD readout and
 its high-warp-collapsed state — app/render slice, not sim.
+
+**Built (2026-05-18, branch `v0.10.0-slew`).** Shipped on branch
+and playtest-validated (slew at 15°/s holding up in flight); not
+yet tagged or merged to `main`. Implemented: `CurrentAttitudeDir`
++ per-loadout `SlewRate`, per-tick slew integrator, consumers on
+actual-not-commanded direction, lead-compensated nodes, save/load
+round-trip of attitude, `World.InstantSAS` + `ToggleInstantSAS()`
+with byte-identical legacy branch. Unplanned scope folded in this
+slice: **full roll degree of freedom + body-frame navball**
+(commits `4a01dc8`, `c106c10`, `174a825`; surface-launch nose-sync
+fixes `7d350a0` / `eb32136`) — not in the original design above.
+**InstantSAS surfacing — done (2026-05-18).** The locked-decision
+keybinding and navball tag are now wired in `internal/tui`: `k`
+toggles `World.ToggleInstantSAS()` with a `SAS: MANUAL (slew) /
+AUTO (instant)` toast, and a dedicated clickable `[SAS]` tag
+(`NavballControlSAS`, `[MAN]`/`[AUT]`, Warning-styled when AUTO)
+sits between `[MODE]` and `RCS` in the navball toggle row — kept
+separate from the `[MODE]` NavMode button to avoid the
+control-collision noted earlier. The non-default (instant) model
+is never silent, satisfying the locked decision. Help/README
+updated; tests added (panel tag flip, click dispatch, box count);
+full `-race` suite green. **Slice has no remaining blockers** —
+only the non-blocking "slewing — N s to align" HUD readout stays
+deferred to a later app/render polish pass.
 
 ### v0.10.1+ — carry-over candidates
 

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -128,7 +128,8 @@ node aligned at T0; save/load round-trips attitude; instant mode
 unchanged (golden).
 
 **Resolved (2026-05-17).** `SlewRate` = a single global
-`DefaultSlewRateDegPerSec = 5.0` (~36 s for a 180° flip) with a
+`DefaultSlewRateDegPerSec = 15.0` (~12 s for a 180° flip; raised
+from 5.0 after playtest) with a
 per-loadout `Loadout.SlewRateDegPerSec` override (all loadout
 literals left unset = default this slice). Surfacing = new key +
 navball `[MODE]` MANUAL/AUTO tag. **Still open (slice-time, non-
@@ -189,7 +190,8 @@ design-pass-first, its own future cycle.
 ## Open questions for v0.10
 
 - ~~`SlewRate` value(s) per loadout~~ — **resolved 2026-05-17:**
-  global `DefaultSlewRateDegPerSec = 5.0` + per-loadout
+  global `DefaultSlewRateDegPerSec = 15.0` (raised from 5.0 after
+  playtest) + per-loadout
   `Loadout.SlewRateDegPerSec` override.
 - ~~Manual-flight mode surfacing~~ — **resolved 2026-05-17:** new
   key + navball `[MODE]` MANUAL/AUTO tag (not folded into

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -50,9 +50,16 @@ is picked up. Mission scripting stays design-pass-first and is
   node Δv accuracy and its existing test surface. The punishing
   "naive — fire at T0, eat the misalignment" behaviour is a
   deferred later toggle, not this slice.
-- **Slew is mode-gated, opt-in.** Instant "magic SAS" stays the
-  default; the new manual-flight mode enables slew + its
-  consequences. No silent behaviour change for existing play.
+- **Slew is the default; instant "magic SAS" is the opt-in
+  toggle.** *(Reversed 2026-05-17 — was "mode-gated, opt-in;
+  instant stays default".)* Slew + its consequences are the
+  v0.10 default flight model; a manual toggle (`World.InstantSAS`,
+  surfaced as a new key + navball `[MODE]` tag) opts back into the
+  legacy instant path. This is a **deliberate, accepted behaviour
+  change for existing play** — not silent: the navball `[MODE]`
+  indicator shows MANUAL (slew) vs AUTO (instant). The instant
+  path is preserved byte-identical behind the toggle and is the
+  regression baseline.
 - **RCS pulses stay instant.** Discrete attitude nudges are not
   rate-limited; only held-attitude (SAS preset) commands slew.
 - **Slew rate is per-loadout, sim-time.** Constant angular-rate
@@ -89,10 +96,12 @@ instantly — there is no stored physical orientation.
   **animates for free** as the craft slews; burning before
   alignment bleeds Δv to cosine loss — the intended consequence.
   RCS pulse path is left on the instant commanded direction.
-- **Mode gate.** A manual-flight toggle (sits naturally beside
-  `EngineMode` / NavMode, and the navball `[MODE]`/`RCS` toggle
-  row has the real estate) selects slew vs the legacy instant
-  path. Default = instant.
+- **Mode gate.** `World.InstantSAS` (default `false` = slew on)
+  toggles back to the legacy instant path; surfaced as a new key
+  + a navball `[MODE]` MANUAL/AUTO tag. **Default = slew.** The
+  instant branch is preserved byte-identical as the regression
+  baseline. The flag is a UI preference (like `ViewMode`) — **not
+  persisted**; a reload returns to the slew default.
 - **Lead-compensated nodes.** Maneuver-node execution computes
   lead time `= angleTo(target) / SlewRate` and begins orienting
   before `BurnStart()` so attitude is converged at ignition.
@@ -118,9 +127,13 @@ persistence" backlog item; it ships *in* this slice, not separately.
 node aligned at T0; save/load round-trips attitude; instant mode
 unchanged (golden).
 
-**Open question.** Surface/HUD affordance for "slewing — N s to
-align" and the chosen `SlewRate` per loadout value(s) — pick during
-slice, not blocking the plan.
+**Resolved (2026-05-17).** `SlewRate` = a single global
+`DefaultSlewRateDegPerSec = 5.0` (~36 s for a 180° flip) with a
+per-loadout `Loadout.SlewRateDegPerSec` override (all loadout
+literals left unset = default this slice). Surfacing = new key +
+navball `[MODE]` MANUAL/AUTO tag. **Still open (slice-time, non-
+blocking):** the richer "slewing — N s to align" HUD readout and
+its high-warp-collapsed state — app/render slice, not sim.
 
 ### v0.10.1+ — carry-over candidates
 
@@ -175,7 +188,10 @@ design-pass-first, its own future cycle.
 
 ## Open questions for v0.10
 
-- `SlewRate` value(s) per loadout, and whether it's a single
-  global default with per-loadout overrides.
-- Manual-flight mode surfacing: new key + navball toggle vs
-  folding into the existing NavMode/Engine toggle vocabulary.
+- ~~`SlewRate` value(s) per loadout~~ — **resolved 2026-05-17:**
+  global `DefaultSlewRateDegPerSec = 5.0` + per-loadout
+  `Loadout.SlewRateDegPerSec` override.
+- ~~Manual-flight mode surfacing~~ — **resolved 2026-05-17:** new
+  key + navball `[MODE]` MANUAL/AUTO tag (not folded into
+  NavMode/Engine vocabulary). Slew is the default; instant is the
+  opt-in. Key binding itself is the app/render slice's call.

--- a/internal/orbital/frame.go
+++ b/internal/orbital/frame.go
@@ -33,6 +33,35 @@ func (a Vec3) Cross(b Vec3) Vec3 {
 // Dot returns a · b.
 func (a Vec3) Dot(b Vec3) float64 { return a.X*b.X + a.Y*b.Y + a.Z*b.Z }
 
+// Unit returns a / |a|. A zero vector returns the zero vector (callers
+// already interpret a zero direction as "undefined" — see BurnDirection).
+func (a Vec3) Unit() Vec3 {
+	n := a.Norm()
+	if n == 0 {
+		return Vec3{}
+	}
+	return a.Scale(1 / n)
+}
+
+// Rotate rotates v about axis by theta radians (right-hand rule),
+// via Rodrigues' formula:
+//
+//	v·cosθ + (axis×v)·sinθ + axis·(axis·v)·(1−cosθ)
+//
+// axis is assumed to be a unit vector; the caller is responsible for
+// normalizing it (the v0.10.0 slew integrator picks a unit perpendicular
+// before calling). This is the only general axis-angle rotation in the
+// tree — PerifocalToInertial is a fixed Euler matrix and ApplyPitchTrim
+// is a 2-D local-frame rotation, neither reusable here.
+//
+// v0.10.0+ (rate-limited attitude).
+func Rotate(v, axis Vec3, theta float64) Vec3 {
+	c, s := math.Cos(theta), math.Sin(theta)
+	return v.Scale(c).
+		Add(axis.Cross(v).Scale(s)).
+		Add(axis.Scale(axis.Dot(v) * (1 - c)))
+}
+
 // PerifocalToInertial converts perifocal (p, q, w) → inertial (X, Y, Z) via
 // the standard 3-1-3 Euler sequence (Ω, i, ω). Perifocal frame: p along
 // periapsis, q 90° ahead in the orbital plane, w = p × q.

--- a/internal/orbital/frame_test.go
+++ b/internal/orbital/frame_test.go
@@ -239,3 +239,53 @@ func TestCircularOrbitVelocity(t *testing.T) {
 		t.Errorf("circular-orbit v=%.3f m/s, want %.3f m/s (rel err %.2e)", v, want, d)
 	}
 }
+
+// --- v0.10.0 rate-limited attitude: Unit + Rodrigues Rotate ---
+
+func vecClose(a, b Vec3, tol float64) bool { return a.Sub(b).Norm() <= tol }
+
+func TestUnitNormalizesAndZeroSafe(t *testing.T) {
+	if got := (Vec3{3, 0, 4}).Unit(); !vecClose(got, Vec3{0.6, 0, 0.8}, 1e-12) {
+		t.Errorf("Unit() = %+v, want {0.6 0 0.8}", got)
+	}
+	if got := (Vec3{}).Unit(); got != (Vec3{}) {
+		t.Errorf("Unit() of zero = %+v, want zero", got)
+	}
+}
+
+func TestRotateIdentityAtZeroTheta(t *testing.T) {
+	v := Vec3{1, 2, 3}
+	if got := Rotate(v, Vec3{0, 0, 1}, 0); !vecClose(got, v, 1e-12) {
+		t.Errorf("Rotate(θ=0) = %+v, want %+v", got, v)
+	}
+}
+
+func TestRotate90AboutZMapsXToY(t *testing.T) {
+	got := Rotate(Vec3{1, 0, 0}, Vec3{0, 0, 1}, math.Pi/2)
+	if !vecClose(got, Vec3{0, 1, 0}, 1e-12) {
+		t.Errorf("Rotate(X, +Z, 90°) = %+v, want {0 1 0}", got)
+	}
+}
+
+func TestRotate180Antiparallel(t *testing.T) {
+	got := Rotate(Vec3{1, 0, 0}, Vec3{0, 1, 0}, math.Pi)
+	if !vecClose(got, Vec3{-1, 0, 0}, 1e-12) {
+		t.Errorf("Rotate(X, +Y, 180°) = %+v, want {-1 0 0}", got)
+	}
+}
+
+func TestRotateAboutOwnAxisIsNoop(t *testing.T) {
+	axis := (Vec3{1, 1, 1}).Unit()
+	if got := Rotate(axis, axis, 1.234); !vecClose(got, axis, 1e-12) {
+		t.Errorf("rotating axis about itself changed it: %+v != %+v", got, axis)
+	}
+}
+
+func TestRotatePreservesNorm(t *testing.T) {
+	v := Vec3{2, -3, 5}
+	axis := (Vec3{0, 1, 2}).Unit()
+	got := Rotate(v, axis, 0.7)
+	if d := math.Abs(got.Norm()-v.Norm()) / v.Norm(); d > 1e-12 {
+		t.Errorf("Rotate changed norm: |got|=%.9f |v|=%.9f (rel %.2e)", got.Norm(), v.Norm(), d)
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -175,6 +175,14 @@ type Craft struct {
 	// persisted — it is re-derived from the loadout on load.
 	CurrentAttitudeDir Vec3 `json:"current_attitude_dir,omitempty"`
 
+	// CommandedRollDeg / CurrentRollDeg (v0.10.0+, schema v6
+	// additive): the craft's roll about the nose axis (degrees,
+	// heads-up = 0). Both round-trip so a banked / mid-roll craft
+	// restores correctly. omitempty → pre-v0.10.0 saves load as 0
+	// (heads-up), the prior implicit behaviour. No schema bump.
+	CommandedRollDeg float64 `json:"commanded_roll_deg,omitempty"`
+	CurrentRollDeg   float64 `json:"current_roll_deg,omitempty"`
+
 	// Landed (v0.9.2+, schema v6 additive): true when the craft is
 	// parked on its primary's surface co-rotating with the ground.
 	// Pre-v0.9.2 saves load with Landed=false (= normal integration,
@@ -401,6 +409,8 @@ func payloadFromWorld(w *sim.World) Payload {
 			Color:              c.Color,
 			PitchTrim:          c.PitchTrim,
 			CurrentAttitudeDir: vec3From(c.CurrentAttitudeDir),
+			CommandedRollDeg:   c.CommandedRollDeg,
+			CurrentRollDeg:     c.CurrentRollDeg,
 			Landed:             c.Landed,
 			LaunchLatDeg:       c.LaunchLatDeg,
 			LaunchLonDeg:       c.LaunchLonDeg,
@@ -582,6 +592,8 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			Color:              wc.Color,
 			PitchTrim:          wc.PitchTrim,
 			CurrentAttitudeDir: vec3To(wc.CurrentAttitudeDir),
+			CommandedRollDeg:   wc.CommandedRollDeg,
+			CurrentRollDeg:     wc.CurrentRollDeg,
 			Landed:             wc.Landed,
 			LaunchLatDeg:       wc.LaunchLatDeg,
 			LaunchLonDeg:       wc.LaunchLonDeg,

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -175,14 +175,6 @@ type Craft struct {
 	// persisted — it is re-derived from the loadout on load.
 	CurrentAttitudeDir Vec3 `json:"current_attitude_dir,omitempty"`
 
-	// CommandedRollDeg / CurrentRollDeg (v0.10.0+, schema v6
-	// additive): the craft's roll about the nose axis (degrees,
-	// heads-up = 0). Both round-trip so a banked / mid-roll craft
-	// restores correctly. omitempty → pre-v0.10.0 saves load as 0
-	// (heads-up), the prior implicit behaviour. No schema bump.
-	CommandedRollDeg float64 `json:"commanded_roll_deg,omitempty"`
-	CurrentRollDeg   float64 `json:"current_roll_deg,omitempty"`
-
 	// Landed (v0.9.2+, schema v6 additive): true when the craft is
 	// parked on its primary's surface co-rotating with the ground.
 	// Pre-v0.9.2 saves load with Landed=false (= normal integration,
@@ -409,8 +401,6 @@ func payloadFromWorld(w *sim.World) Payload {
 			Color:              c.Color,
 			PitchTrim:          c.PitchTrim,
 			CurrentAttitudeDir: vec3From(c.CurrentAttitudeDir),
-			CommandedRollDeg:   c.CommandedRollDeg,
-			CurrentRollDeg:     c.CurrentRollDeg,
 			Landed:             c.Landed,
 			LaunchLatDeg:       c.LaunchLatDeg,
 			LaunchLonDeg:       c.LaunchLonDeg,
@@ -592,8 +582,6 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			Color:              wc.Color,
 			PitchTrim:          wc.PitchTrim,
 			CurrentAttitudeDir: vec3To(wc.CurrentAttitudeDir),
-			CommandedRollDeg:   wc.CommandedRollDeg,
-			CurrentRollDeg:     wc.CurrentRollDeg,
 			Landed:             wc.Landed,
 			LaunchLatDeg:       wc.LaunchLatDeg,
 			LaunchLonDeg:       wc.LaunchLonDeg,

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -64,9 +64,9 @@ type Payload struct {
 	WarpIdx        int                `json:"warp_idx"`
 	Paused         bool               `json:"paused"`
 	Focus          Focus              `json:"focus"`
-	Target         *Target            `json:"target,omitempty"` // v0.9.0+ unified target slot. nil pointer (zero/None) → omitted on the wire.
+	Target         *Target            `json:"target,omitempty"`   // v0.9.0+ unified target slot. nil pointer (zero/None) → omitted on the wire.
 	NavMode        int                `json:"nav_mode,omitempty"` // v0.9.3+ KSP-style SAS reference frame. NavOrbit=0 omitted; older saves load with NavOrbit.
-	Craft          *Craft             `json:"craft,omitempty"` // v1–v4 singular form; migrated to Crafts on load.
+	Craft          *Craft             `json:"craft,omitempty"`    // v1–v4 singular form; migrated to Crafts on load.
 	Crafts         []Craft            `json:"crafts,omitempty"`
 	ActiveCraftIdx int                `json:"active_craft_idx,omitempty"`
 	Nodes          []Node             `json:"nodes,omitempty"`
@@ -164,6 +164,16 @@ type Craft struct {
 	// omitempty so legacy saves with no trim load with PitchTrim=0
 	// (= no trim, the v0.9.2-pre behaviour).
 	PitchTrim float64 `json:"pitch_trim,omitempty"`
+
+	// CurrentAttitudeDir (v0.10.0+, schema v6 additive): the craft's
+	// physical nose unit vector. Slew makes attitude load-bearing —
+	// a craft can be caught mid-slew — so the real nose must round-
+	// trip or a reload teleports it. Pre-v0.10.0 saves lack the key →
+	// decodes to a zero Vec3 → the slew integrator's first-tick snap
+	// guard seeds it from the commanded direction (no teleport, no
+	// slew-from-garbage). No schema bump (additive). SlewRate is NOT
+	// persisted — it is re-derived from the loadout on load.
+	CurrentAttitudeDir Vec3 `json:"current_attitude_dir,omitempty"`
 
 	// Landed (v0.9.2+, schema v6 additive): true when the craft is
 	// parked on its primary's surface co-rotating with the ground.
@@ -370,29 +380,30 @@ func payloadFromWorld(w *sim.World) Payload {
 			continue
 		}
 		wc := Craft{
-			Name:             c.Name,
-			DryMass:          c.DryMass,
-			Fuel:             c.Fuel,
-			Isp:              c.Isp,
-			Thrust:           c.Thrust,
-			PrimaryID:        c.Primary.ID,
-			R:                vec3From(c.State.R),
-			V:                vec3From(c.State.V),
-			M:                c.State.M,
-			Monoprop:         c.Monoprop,
-			MonopropCapacity: c.MonopropCapacity,
-			RCSThrust:        c.RCSThrust,
-			RCSIsp:           c.RCSIsp,
-			AttitudeMode:     int(c.AttitudeMode),
-			EngineMode:       int(c.EngineMode),
-			LoadoutID:        c.LoadoutID,
-			Role:             c.Role,
-			Glyph:            c.Glyph,
-			Color:            c.Color,
-			PitchTrim:        c.PitchTrim,
-			Landed:           c.Landed,
-			LaunchLatDeg:     c.LaunchLatDeg,
-			LaunchLonDeg:     c.LaunchLonDeg,
+			Name:               c.Name,
+			DryMass:            c.DryMass,
+			Fuel:               c.Fuel,
+			Isp:                c.Isp,
+			Thrust:             c.Thrust,
+			PrimaryID:          c.Primary.ID,
+			R:                  vec3From(c.State.R),
+			V:                  vec3From(c.State.V),
+			M:                  c.State.M,
+			Monoprop:           c.Monoprop,
+			MonopropCapacity:   c.MonopropCapacity,
+			RCSThrust:          c.RCSThrust,
+			RCSIsp:             c.RCSIsp,
+			AttitudeMode:       int(c.AttitudeMode),
+			EngineMode:         int(c.EngineMode),
+			LoadoutID:          c.LoadoutID,
+			Role:               c.Role,
+			Glyph:              c.Glyph,
+			Color:              c.Color,
+			PitchTrim:          c.PitchTrim,
+			CurrentAttitudeDir: vec3From(c.CurrentAttitudeDir),
+			Landed:             c.Landed,
+			LaunchLatDeg:       c.LaunchLatDeg,
+			LaunchLonDeg:       c.LaunchLonDeg,
 		}
 		// v0.9.1+: serialize Stages so v6 saves carry per-stage
 		// detail. Single-stage craft still wire out a one-element
@@ -563,16 +574,17 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				V: vec3To(wc.V),
 				M: wc.M,
 			},
-			AttitudeMode: spacecraft.BurnMode(wc.AttitudeMode),
-			EngineMode:   spacecraft.EngineMode(wc.EngineMode),
-			LoadoutID:    wc.LoadoutID,
-			Role:         wc.Role,
-			Glyph:        wc.Glyph,
-			Color:        wc.Color,
-			PitchTrim:    wc.PitchTrim,
-			Landed:       wc.Landed,
-			LaunchLatDeg: wc.LaunchLatDeg,
-			LaunchLonDeg: wc.LaunchLonDeg,
+			AttitudeMode:       spacecraft.BurnMode(wc.AttitudeMode),
+			EngineMode:         spacecraft.EngineMode(wc.EngineMode),
+			LoadoutID:          wc.LoadoutID,
+			Role:               wc.Role,
+			Glyph:              wc.Glyph,
+			Color:              wc.Color,
+			PitchTrim:          wc.PitchTrim,
+			CurrentAttitudeDir: vec3To(wc.CurrentAttitudeDir),
+			Landed:             wc.Landed,
+			LaunchLatDeg:       wc.LaunchLatDeg,
+			LaunchLonDeg:       wc.LaunchLonDeg,
 		}
 		c.SyncFields()
 		// v0.8.2+: pre-v0.8.2 saves carry no Glyph/Color; backfill

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -937,6 +937,30 @@ func TestCurrentAttitudeDirRoundtrip(t *testing.T) {
 	}
 }
 
+// v0.10.0: roll about the nose axis must round-trip so a banked /
+// mid-roll craft restores correctly.
+func TestRollRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.ActiveCraft().CommandedRollDeg = 72
+	w.ActiveCraft().CurrentRollDeg = 41.5
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c := got.ActiveCraft(); c.CommandedRollDeg != 72 || c.CurrentRollDeg != 41.5 {
+		t.Errorf("roll round-trip: commanded=%g current=%g, want 72 / 41.5",
+			c.CommandedRollDeg, c.CurrentRollDeg)
+	}
+}
+
 // A pre-v0.10.0 save has no current_attitude_dir key → decodes to a
 // zero Vec3. The craft must NOT teleport its nose; the slew
 // integrator's first-tick snap seeds it from the commanded direction.

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -912,3 +912,71 @@ func TestSaturnVStagesRoundtrip(t *testing.T) {
 		}
 	}
 }
+
+// v0.10.0: the physical nose (CurrentAttitudeDir) must round-trip so a
+// craft caught mid-slew doesn't teleport its nose on reload.
+func TestCurrentAttitudeDirRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	want := orbital.Vec3{X: 0.36, Y: -0.48, Z: 0.8}.Unit() // non-axis-aligned unit
+	w.ActiveCraft().CurrentAttitudeDir = want
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if d := got.ActiveCraft().CurrentAttitudeDir.Sub(want).Norm(); d > 1e-12 {
+		t.Errorf("CurrentAttitudeDir round-trip off by %.3e: got %+v want %+v",
+			d, got.ActiveCraft().CurrentAttitudeDir, want)
+	}
+}
+
+// A pre-v0.10.0 save has no current_attitude_dir key → decodes to a
+// zero Vec3. The craft must NOT teleport its nose; the slew
+// integrator's first-tick snap seeds it from the commanded direction.
+func TestLegacySaveNoAttitudeDirSnapsNoTeleport(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Strip the field to simulate a pre-v0.10.0 save.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var f save.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	f.Payload.Crafts[0].CurrentAttitudeDir = save.Vec3{} // legacy: absent → zero
+	stripped, _ := json.Marshal(f)
+	if err := os.WriteFile(path, stripped, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	c := got.ActiveCraft()
+	if c.CurrentAttitudeDir.Norm() != 0 {
+		t.Fatalf("legacy save should load with zero CurrentAttitudeDir, got %+v",
+			c.CurrentAttitudeDir)
+	}
+	// One tick: the first-tick snap guard must seed (not slew-from-
+	// garbage, not leave zero) the physical nose.
+	got.Tick()
+	if n := c.CurrentAttitudeDir.Norm(); n < 0.999 || n > 1.001 {
+		t.Errorf("first-tick snap did not seed a unit nose: |dir|=%.6f", n)
+	}
+}

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -937,30 +937,6 @@ func TestCurrentAttitudeDirRoundtrip(t *testing.T) {
 	}
 }
 
-// v0.10.0: roll about the nose axis must round-trip so a banked /
-// mid-roll craft restores correctly.
-func TestRollRoundtrip(t *testing.T) {
-	w, err := sim.NewWorld()
-	if err != nil {
-		t.Fatalf("NewWorld: %v", err)
-	}
-	w.ActiveCraft().CommandedRollDeg = 72
-	w.ActiveCraft().CurrentRollDeg = 41.5
-
-	path := filepath.Join(t.TempDir(), "save.json")
-	if err := save.Save(w, path); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-	got, err := save.Load(path)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if c := got.ActiveCraft(); c.CommandedRollDeg != 72 || c.CurrentRollDeg != 41.5 {
-		t.Errorf("roll round-trip: commanded=%g current=%g, want 72 / 41.5",
-			c.CommandedRollDeg, c.CurrentRollDeg)
-	}
-}
-
 // A pre-v0.10.0 save has no current_attitude_dir key → decodes to a
 // zero Vec3. The craft must NOT teleport its nose; the slew
 // integrator's first-tick snap seeds it from the commanded direction.

--- a/internal/sim/landed.go
+++ b/internal/sim/landed.go
@@ -51,4 +51,18 @@ func integrateLanded(w *World, c *spacecraft.Spacecraft, simDelta time.Duration)
 	omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
 	c.State.V = omega.Cross(c.State.R)
 	c.State.M = c.TotalMass()
+
+	// v0.10.0: a landed craft is rigidly bolted to the pad pointing
+	// per its AttitudeMode; as it co-rotates with the body its nose
+	// co-rotates too. The slew integrator is skipped while Landed
+	// (this function returns before it), so without this sync a long
+	// warp on the pad leaves CurrentAttitudeDir frozen at the spawn-
+	// time vector — on liftoff the engine then thrusts along that
+	// stale (now sideways / sub-horizon) nose and the craft can't
+	// leave the pad. Track the commanded direction instead; skip a
+	// zero/undefined commanded (e.g. surface mode pre-liftoff) so we
+	// hold the last good nose rather than blanking it.
+	if cmd := w.commandedDirFor(c); cmd.Norm() != 0 {
+		c.CurrentAttitudeDir = cmd
+	}
 }

--- a/internal/sim/landed.go
+++ b/internal/sim/landed.go
@@ -65,4 +65,7 @@ func integrateLanded(w *World, c *spacecraft.Spacecraft, simDelta time.Duration)
 	if cmd := w.commandedDirFor(c); cmd.Norm() != 0 {
 		c.CurrentAttitudeDir = cmd
 	}
+	// A bolted-down craft isn't rolling — keep CurrentRollDeg synced
+	// to the command so liftoff begins at the intended roll.
+	c.CurrentRollDeg = c.CommandedRollDeg
 }

--- a/internal/sim/landed.go
+++ b/internal/sim/landed.go
@@ -65,7 +65,4 @@ func integrateLanded(w *World, c *spacecraft.Spacecraft, simDelta time.Duration)
 	if cmd := w.commandedDirFor(c); cmd.Norm() != 0 {
 		c.CurrentAttitudeDir = cmd
 	}
-	// A bolted-down craft isn't rolling — keep CurrentRollDeg synced
-	// to the command so liftoff begins at the intended roll.
-	c.CurrentRollDeg = c.CommandedRollDeg
 }

--- a/internal/sim/landed_test.go
+++ b/internal/sim/landed_test.go
@@ -118,3 +118,64 @@ func TestEngineIgnitionClearsLanded(t *testing.T) {
 		t.Error("StartManualBurn should engage ManualBurn")
 	}
 }
+
+// TestLandedNoseTracksLocalUpThroughWarp — regression for the v0.10.0
+// slew bug the player hit: warping on the pad (watching inclination)
+// then pressing `b` would not lift off. Cause: the slew integrator is
+// skipped while Landed, so CurrentAttitudeDir stayed frozen at the
+// spawn-time radial-out vector while the craft co-rotated; on liftoff
+// the engine thrust followed that stale (now sub-horizon) nose.
+// Fix: integrateLanded keeps CurrentAttitudeDir synced to the
+// commanded direction so the nose co-rotates with the pad.
+func TestLandedNoseTracksLocalUpThroughWarp(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        28.6083,
+		LongitudeOffset: -80.604,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: launchpad spawn should set Landed=true")
+	}
+	spawnNose := c.CurrentAttitudeDir
+	if a := slewAngle(spawnNose, c.State.R.Unit()); a > 1e-3 {
+		t.Fatalf("setup: spawn nose not radial-out (%.4f rad off)", a)
+	}
+
+	// Warp on the pad: the body rotates, local up moves.
+	w.Clock.SimTime = w.Clock.SimTime.Add(6 * time.Hour)
+	integrateLanded(w, c, time.Hour)
+	upNow := c.State.R.Unit()
+	if a := slewAngle(spawnNose, upNow); a < 5*math.Pi/180 {
+		t.Fatalf("setup: body did not rotate enough to exercise the bug (%.2f°)",
+			a*180/math.Pi)
+	}
+	// The nose must track the *current* local up, not the stale
+	// spawn vector.
+	if a := slewAngle(c.CurrentAttitudeDir, upNow); a > 1e-3 {
+		t.Errorf("landed nose did not track local up through warp: %.3f° off",
+			a*180/math.Pi)
+	}
+
+	// Liftoff: with the nose correct the craft must actually rise.
+	alt0 := c.Altitude()
+	w.StartManualBurn()
+	for i := 0; i < 60; i++ { // ~3 s at 1× / 50 ms base step
+		w.Tick()
+	}
+	if c.Altitude() <= alt0+1.0 {
+		t.Errorf("craft did not lift off the pad: altitude %.2f → %.2f m",
+			alt0, c.Altitude())
+	}
+	if vUp := c.State.V.Dot(c.State.R.Unit()); vUp <= 0 {
+		t.Errorf("post-ignition vertical velocity not positive: %.3f m/s", vUp)
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1226,6 +1226,59 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 	}
 }
 
+// nodeLeadSlack pads the computed lead time so a commanded direction
+// that drifts during the lead window (e.g. prograde rotating in a low
+// orbit) still converges before ignition. 1.25 = 25% slack. v0.10.0+.
+const nodeLeadSlack = 1.25
+
+// nodeLeadActive reports the upcoming node's ignition direction when
+// the craft should already be slewing toward it — i.e. BurnStart is
+// within nodeLeadSlack·angle/SlewRate sim-seconds of now. This is the
+// lead-compensation that keeps planted-node Δv accurate under rate-
+// limited attitude: the craft auto-orients ahead of T0 so it is
+// converged at ignition (the node's Δv math + IsResolved/BurnStart
+// gating in executeDueNodesFor are untouched — only attitude timing
+// changes). Only the next-to-fire (first) node matters; nodes are
+// sorted trigger-ascending with unresolved at the end.
+//
+// v0.10.0+.
+func (w *World) nodeLeadActive(c *spacecraft.Spacecraft) (orbital.Vec3, bool) {
+	if len(c.Nodes) == 0 {
+		return orbital.Vec3{}, false
+	}
+	n := c.Nodes[0]
+	if !n.IsResolved() {
+		return orbital.Vec3{}, false
+	}
+	// Node's commanded ignition direction, evaluated against current
+	// state + the target bound at plant (mirrors executeDueNodesFor).
+	var rT, vT orbital.Vec3
+	if n.IsTargetRelative() {
+		if tIdx, ok := n.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
+			if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+				rT, vT = tc.State.R, tc.State.V
+			}
+		}
+	}
+	dir := c.BurnDirectionWithTarget(n.Mode, rT, vT)
+	if dir.Norm() == 0 {
+		return orbital.Vec3{}, false
+	}
+	cosA := c.CurrentAttitudeDir.Unit().Dot(dir.Unit())
+	if cosA > 1 {
+		cosA = 1
+	} else if cosA < -1 {
+		cosA = -1
+	}
+	ang := math.Acos(cosA)
+	leadSecs := nodeLeadSlack * ang / c.SlewRateRad()
+	leadWindowStart := n.BurnStart().Add(-time.Duration(leadSecs * float64(time.Second)))
+	if w.Clock.SimTime.Before(leadWindowStart) {
+		return orbital.Vec3{}, false // not yet in the lead window
+	}
+	return dir, true
+}
+
 // NodeInertialPosition returns the inertial (system-primary-centered)
 // position where the node will fire. Forward-integrates the craft state
 // from now to the node's trigger time using SOI-aware Verlet sub-

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -7,155 +7,68 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // NavballBasis is the orthonormal world-frame basis the navball is
 // painted in. The ball's "lat = 0, lon = 0" point lies along EX;
-// "lat = +90" (north pole) along EZ; "lon = +90, lat = 0" along EY
-// (right-handed completion).
+// "lat = +90" along EZ; "lon = +90, lat = 0" along EY.
 //
-// EX is always the active NavMode's prograde direction so that when
-// the craft's nose points along prograde, the prograde marker sits
-// at the disk centre — matching KSP's "ball rotates so prograde stays
-// in front of you" behaviour.
-//
-// EZ is the orbital normal in all modes (KSP convention: even in
-// surface mode the navball's "north" stays orbital, since the local
-// "up" is already covered by the radial-out marker).
-//
-// v0.9.5+.
+// v0.10.0+: this is the active craft's **body frame** — EX = nose,
+// EZ = body up (dorsal), EY = body right — so the navball is the
+// world as seen from the craft. The nose is always the disc centre
+// and a non-zero roll banks the whole ball. NavballBasis() builds it
+// from the body frame; see that method's doc. (Pre-v0.10 this was a
+// velocity frame with EX = prograde, EZ = orbital normal.)
 type NavballBasis struct {
 	EX, EY, EZ orbital.Vec3
 }
 
-// NavballBasis returns the orthonormal basis for the active craft +
-// current NavMode. ok=false when the basis is degenerate — zero
-// velocity (NavOrbit), zero surface velocity (NavSurface, e.g.
-// stationary on the launchpad before liftoff), missing or coincident
-// target velocity (NavTarget), or a craft state with zero r / a
-// rectilinear orbit (no defined orbital plane).
+// NavballBasis returns the active craft's **body frame** as the
+// navball basis (v0.10.0+): the navball is the world as seen from the
+// craft, so it is the craft's own orientation, not a velocity frame.
 //
-// NavOrbit / NavTarget are velocity-framed (the sphere's pole is the
-// orbital normal):
+//   - EX (lat 0, lon 0): nose / thrust axis (CurrentAttitudeDir)
+//   - EZ (lat +90):      body up (dorsal) — the heads-up reference
+//     (local vertical projected ⟂ nose) rotated about the nose by the
+//     roll, so banking rolls the whole ball
+//   - EY:                body right (= nose × up)
 //
-//   - EX (lat 0, lon 0): +v̂ (orbit) or +(v_target − v_active)̂ (target)
-//   - EZ (lat +90):      orbital normal (r × v)̂, re-orthogonalised
-//     against EX (target-prograde isn't generally ⟂ the orbit plane)
-//   - EY = EZ × EX
+// The disc centre is therefore always the nose (NavballSubObserver
+// returns (0,0)); prograde/retrograde/normal/radial/target/node and
+// the surface compass ticks are world directions projected into this
+// frame, so they sit exactly where they are *relative to the craft* —
+// and with roll 0 (heads-up) the local vertical is screen-up and East
+// is screen-right, the compass sense the player expects, with no pole
+// singularity (body up/right are explicit, always orthonormal).
 //
-// NavSurface is a **local-horizon** sphere (KSP surface navball): the
-// pole is the local vertical so the sky/ground hemispheres read true.
-// This is velocity-independent, so it is well-defined on the launchpad
-// (a craft sitting on the pad pointing radial-out reads at the sky
-// pole, not the horizon band):
-//
-//   - EZ (lat +90, sky pole): local up = r̂
-//   - EX (lon 0):             local north
-//   - EY = EZ × EX            (= −local east)
-//
-// The surface navball is a **zenith-centred, North-up compass rose**:
-// NavballSubObserver pins the disc centre to the zenith (lat +90) with
-// a fixed 180° roll, not the nose. Under that fixed view this basis
-// projects North→screen-up, East→screen-right, South→down, West→left
-// (see TestNavballSurfaceEastIsScreenRight), and the nose rides as a
-// marker that slides toward East (right) when the player trims `>`.
-// Velocity-framed orbit/target basis below is unaffected.
+// ok=false only when the nose is uninitialised (zero) and there is no
+// commanded direction to fall back to — the caller degrades to a
+// static navball. NavMode no longer changes the basis; it still
+// selects which markers/labels are shown (see NavballMarkers).
 func (w *World) NavballBasis() (NavballBasis, bool) {
 	active := w.ActiveCraft()
 	if active == nil {
 		return NavballBasis{}, false
 	}
-	r := active.State.R
-	v := active.State.V
-	if r.Norm() == 0 {
+	nose, roll := w.navballNoseRoll(active)
+	bNose, bUp, bRight, ok := active.BodyFrameFor(nose, roll)
+	if !ok {
 		return NavballBasis{}, false
 	}
+	return NavballBasis{EX: bNose, EY: bRight, EZ: bUp}, true
+}
 
-	nav := w.NavMode
-	if nav == NavTarget && w.Target.Kind != TargetCraft {
-		nav = NavOrbit
+// navballNoseRoll picks the nose direction and roll the navball body
+// frame is built from: the physical CurrentAttitudeDir / CurrentRollDeg
+// under slew, or the commanded direction / CommandedRollDeg under
+// InstantSAS or before the first slew tick (CurrentAttitudeDir still
+// zero). Mirrors the stepThrust / consumer gating. v0.10.0+.
+func (w *World) navballNoseRoll(active *spacecraft.Spacecraft) (nose orbital.Vec3, rollDeg float64) {
+	if !w.InstantSAS && active.CurrentAttitudeDir.Norm() != 0 {
+		return active.CurrentAttitudeDir, active.CurrentRollDeg
 	}
-
-	// NavSurface: local-horizon sphere — pole = local up (r̂),
-	// lon-0 = local north. Velocity-independent so it is valid on
-	// the launchpad: the craft pointing radial-out reads at the sky
-	// pole (lat +90), not the horizon. North is undefined at a
-	// geographic pole or on a non-rotating primary — fall back to
-	// any horizontal axis (world +Z projected off up, else +X) so
-	// the basis stays defined rather than blanking the navball.
-	if nav == NavSurface {
-		rN := r.Norm()
-		up := r.Scale(1 / rN)
-		spinR := render.BodyRotationAxisWorld(active.Primary)
-		spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
-		var north orbital.Vec3
-		east := spinAxis.Cross(up)
-		if spinAxis.Norm() > 0 && east.Norm() > 1e-12 {
-			east = east.Scale(1 / east.Norm())
-			north = up.Cross(east)
-		} else {
-			ref := orbital.Vec3{Z: 1}
-			horiz := ref.Sub(up.Scale(up.Dot(ref)))
-			if horiz.Norm() < 1e-9 {
-				ref = orbital.Vec3{X: 1}
-				horiz = ref.Sub(up.Scale(up.Dot(ref)))
-			}
-			north = horiz.Scale(1 / horiz.Norm())
-		}
-		// EY = EZ × EX (= −east). Right-handed; the desired
-		// East-is-screen-right comes from the fixed zenith-centred
-		// 180°-roll view that NavballSubObserver feeds for surface
-		// mode, not from the basis handedness (see the type doc).
-		eX := north
-		eZ := up
-		eY := eZ.Cross(eX)
-		return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
-	}
-
-	h := r.Cross(v)
-	hN := h.Norm()
-	if hN == 0 {
-		return NavballBasis{}, false
-	}
-	eZ := h.Scale(1 / hN)
-
-	var eX orbital.Vec3
-	switch nav {
-	case NavTarget:
-		_, vT, ok := w.TargetStateRelativeToActivePrimary()
-		if !ok {
-			return NavballBasis{}, false
-		}
-		dv := vT.Sub(v)
-		n := dv.Norm()
-		if n == 0 {
-			return NavballBasis{}, false
-		}
-		eX = dv.Scale(1 / n)
-	default:
-		vN := v.Norm()
-		if vN == 0 {
-			return NavballBasis{}, false
-		}
-		eX = v.Scale(1 / vN)
-	}
-
-	// Orthogonalise eZ against eX. Required because surface-prograde
-	// and target-prograde aren't generally perpendicular to the orbital
-	// normal, so the raw (h, eX) pair isn't an orthogonal basis.
-	d := eZ.Dot(eX)
-	eZ = eZ.Sub(eX.Scale(d))
-	zN := eZ.Norm()
-	if zN < 1e-9 {
-		// eX is parallel to orbital normal — physically odd (would
-		// require the craft's surface or relative velocity to coincide
-		// with the orbit normal). Fall back to undefined basis; caller
-		// degrades gracefully.
-		return NavballBasis{}, false
-	}
-	eZ = eZ.Scale(1 / zN)
-	eY := eZ.Cross(eX)
-	return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
+	return w.commandedDirFor(active), active.CommandedRollDeg
 }
 
 // SubObserver projects a unit world-frame direction onto the basis
@@ -179,52 +92,16 @@ func (b NavballBasis) SubObserver(dir orbital.Vec3) (latDeg, lonDeg float64) {
 	return latDeg, lonDeg
 }
 
-// NavballSubObserver returns (lat, lon, ok) on the navball for the
-// active craft's nose direction (s.AttitudeMode → world-frame unit
-// vector via BurnDirectionWithTarget) projected into the active
-// NavMode's basis.
-//
-// ok=false when the basis is degenerate or the craft has no defined
-// nose direction (e.g. surface-prograde before liftoff). Caller
-// degrades to a static / blank navball.
+// NavballSubObserver returns the disc-centre (lat, lon) for the
+// navball. The basis IS the craft body frame (EX = nose), so the nose
+// is by construction at (0, 0) — the disc centre is always "where the
+// craft points". ok=false only when the body frame is undefined (no
+// nose and no commanded direction). v0.10.0+.
 func (w *World) NavballSubObserver() (latDeg, lonDeg float64, ok bool) {
-	active := w.ActiveCraft()
-	if active == nil {
+	if _, basisOK := w.NavballBasis(); !basisOK {
 		return 0, 0, false
 	}
-	basis, basisOK := w.NavballBasis()
-	if !basisOK {
-		return 0, 0, false
-	}
-	// v0.10.0: NavSurface is a zenith-centred, North-up compass rose.
-	// The disc centre is pinned to the local zenith (basis EZ = up →
-	// lat +90), NOT the nose; the 180° roll (subLon = 180 at the pole,
-	// where subLon *is* the screen roll) orients the fixed basis so
-	// North→up, East→right, South→down, West→left. The nose is shown
-	// as a marker (NavballMarkers) that slides toward East (right) as
-	// the player trims `>`. This is stable on the launchpad (no
-	// gimbal: the centre doesn't depend on where the nose points).
-	if w.NavMode == NavSurface {
-		return 90, 180, true
-	}
-	// v0.10.0: in slew mode the disk centre is the craft's PHYSICAL
-	// nose (CurrentAttitudeDir) so it animates as the craft slews;
-	// the cardinal/node markers (NavballMarkers) stay on the
-	// commanded directions, so nose vs targets visibly diverge during
-	// a slew. Pre-first-tick (CurrentAttitudeDir still zero) or under
-	// InstantSAS, fall back to the commanded direction.
-	var dir orbital.Vec3
-	if !w.InstantSAS && active.CurrentAttitudeDir.Norm() != 0 {
-		dir = active.CurrentAttitudeDir
-	} else {
-		rT, vT, _ := w.TargetStateRelativeToActivePrimary()
-		dir = active.BurnDirectionWithTarget(active.AttitudeMode, rT, vT)
-	}
-	if dir.Norm() == 0 {
-		return 0, 0, false
-	}
-	lat, lon := basis.SubObserver(dir)
-	return lat, lon, true
+	return 0, 0, true
 }
 
 // Navball glyphs. Mirroring KSP's symbol vocabulary so muscle memory
@@ -253,15 +130,15 @@ const (
 // axis key would steer toward, resolved via ResolveAttitudeIntent +
 // BurnDirectionWithTarget. So:
 //
-//   NavOrbit   — orbit-frame prograde / retrograde / normal± / radial±
-//                (six cardinals using the radial-diamond glyphs ◇ ◆)
-//   NavSurface — prograde / retrograde swap to surface-relative
-//                velocity; normal± / radial± stay orbit-frame
-//                (matches ResolveAttitudeIntent's NavSurface fallthrough)
-//   NavTarget  — prograde / retrograde swap to target-relative velocity;
-//                radial+ / radial- swap to BurnTarget / BurnAntiTarget
-//                (toward / away from target) and use the target glyphs
-//                ◉ ◌ in target color so the swap is visible at a glance
+//	NavOrbit   — orbit-frame prograde / retrograde / normal± / radial±
+//	             (six cardinals using the radial-diamond glyphs ◇ ◆)
+//	NavSurface — prograde / retrograde swap to surface-relative
+//	             velocity; normal± / radial± stay orbit-frame
+//	             (matches ResolveAttitudeIntent's NavSurface fallthrough)
+//	NavTarget  — prograde / retrograde swap to target-relative velocity;
+//	             radial+ / radial- swap to BurnTarget / BurnAntiTarget
+//	             (toward / away from target) and use the target glyphs
+//	             ◉ ◌ in target color so the swap is visible at a glance
 //
 // This makes the marker set match the SAS hold semantics exactly:
 // each glyph sits at the direction the corresponding axis key would
@@ -363,25 +240,6 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 				pushCompass(north.Scale(-1), 'S')
 				pushCompass(east.Scale(-1), 'W')
 			}
-		}
-		// Nose marker. The surface navball is zenith-centred (the
-		// disc centre is local up, not the nose), so the craft's
-		// actual pointing is shown as a glyph that sits at centre on
-		// the pad and slides toward East (screen right) as the player
-		// trims `>`. Physical nose in slew mode (tracks the slew +
-		// pitch-trim); commanded otherwise / pre-first-tick.
-		noseDir := active.CurrentAttitudeDir
-		if w.InstantSAS || noseDir.Norm() == 0 {
-			noseDir = w.commandedDirFor(active)
-		}
-		if noseDir.Norm() != 0 {
-			lat, lon := basis.SubObserver(noseDir)
-			out = append(out, render.NavballMarker{
-				LatDeg: lat,
-				LonDeg: lon,
-				Glyph:  NavballGlyphNose,
-				Color:  render.ColorNavballMarkerNoseFront,
-			})
 		}
 	}
 

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -7,68 +7,146 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
-	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // NavballBasis is the orthonormal world-frame basis the navball is
 // painted in. The ball's "lat = 0, lon = 0" point lies along EX;
-// "lat = +90" along EZ; "lon = +90, lat = 0" along EY.
+// "lat = +90" (north pole) along EZ; "lon = +90, lat = 0" along EY
+// (right-handed completion).
 //
-// v0.10.0+: this is the active craft's **body frame** — EX = nose,
-// EZ = body up (dorsal), EY = body right — so the navball is the
-// world as seen from the craft. The nose is always the disc centre
-// and a non-zero roll banks the whole ball. NavballBasis() builds it
-// from the body frame; see that method's doc. (Pre-v0.10 this was a
-// velocity frame with EX = prograde, EZ = orbital normal.)
+// EX is always the active NavMode's prograde direction so that when
+// the craft's nose points along prograde, the prograde marker sits
+// at the disk centre — matching KSP's "ball rotates so prograde stays
+// in front of you" behaviour.
+//
+// EZ is the orbital normal in all modes (KSP convention: even in
+// surface mode the navball's "north" stays orbital, since the local
+// "up" is already covered by the radial-out marker).
+//
+// v0.9.5+.
 type NavballBasis struct {
 	EX, EY, EZ orbital.Vec3
 }
 
-// NavballBasis returns the active craft's **body frame** as the
-// navball basis (v0.10.0+): the navball is the world as seen from the
-// craft, so it is the craft's own orientation, not a velocity frame.
+// NavballBasis returns the orthonormal basis for the active craft +
+// current NavMode. ok=false when the basis is degenerate — zero
+// velocity (NavOrbit), zero surface velocity (NavSurface, e.g.
+// stationary on the launchpad before liftoff), missing or coincident
+// target velocity (NavTarget), or a craft state with zero r / a
+// rectilinear orbit (no defined orbital plane).
 //
-//   - EX (lat 0, lon 0): nose / thrust axis (CurrentAttitudeDir)
-//   - EZ (lat +90):      body up (dorsal) — the heads-up reference
-//     (local vertical projected ⟂ nose) rotated about the nose by the
-//     roll, so banking rolls the whole ball
-//   - EY:                body right (= nose × up)
+// NavOrbit / NavTarget are velocity-framed (the sphere's pole is the
+// orbital normal):
 //
-// The disc centre is therefore always the nose (NavballSubObserver
-// returns (0,0)); prograde/retrograde/normal/radial/target/node and
-// the surface compass ticks are world directions projected into this
-// frame, so they sit exactly where they are *relative to the craft* —
-// and with roll 0 (heads-up) the local vertical is screen-up and East
-// is screen-right, the compass sense the player expects, with no pole
-// singularity (body up/right are explicit, always orthonormal).
+//   - EX (lat 0, lon 0): +v̂ (orbit) or +(v_target − v_active)̂ (target)
+//   - EZ (lat +90):      orbital normal (r × v)̂, re-orthogonalised
+//     against EX (target-prograde isn't generally ⟂ the orbit plane)
+//   - EY = EZ × EX
 //
-// ok=false only when the nose is uninitialised (zero) and there is no
-// commanded direction to fall back to — the caller degrades to a
-// static navball. NavMode no longer changes the basis; it still
-// selects which markers/labels are shown (see NavballMarkers).
+// NavSurface is a **local-horizon** sphere (KSP surface navball): the
+// pole is the local vertical so the sky/ground hemispheres read true.
+// This is velocity-independent, so it is well-defined on the launchpad
+// (a craft sitting on the pad pointing radial-out reads at the sky
+// pole, not the horizon band):
+//
+//   - EZ (lat +90, sky pole): local up = r̂
+//   - EX (lon 0):             local north
+//   - EY = EZ × EX            (= −local east)
+//
+// so radial-out → lat +90 (zenith / sky), the horizon → lat 0, and
+// the N/E/S/W compass ticks ring the lat-0 equator at their bearings.
 func (w *World) NavballBasis() (NavballBasis, bool) {
 	active := w.ActiveCraft()
 	if active == nil {
 		return NavballBasis{}, false
 	}
-	nose, roll := w.navballNoseRoll(active)
-	bNose, bUp, bRight, ok := active.BodyFrameFor(nose, roll)
-	if !ok {
+	r := active.State.R
+	v := active.State.V
+	if r.Norm() == 0 {
 		return NavballBasis{}, false
 	}
-	return NavballBasis{EX: bNose, EY: bRight, EZ: bUp}, true
-}
 
-// navballNoseRoll picks the nose direction and roll the navball body
-// frame is built from: the physical CurrentAttitudeDir / CurrentRollDeg
-// under slew, or the commanded direction / CommandedRollDeg under
-// InstantSAS or before the first slew tick (CurrentAttitudeDir still
-// zero). Mirrors the stepThrust / consumer gating. v0.10.0+.
-func (w *World) navballNoseRoll(active *spacecraft.Spacecraft) (nose orbital.Vec3, rollDeg float64) {
-	if !w.InstantSAS && active.CurrentAttitudeDir.Norm() != 0 {
-		return active.CurrentAttitudeDir, active.CurrentRollDeg
+	nav := w.NavMode
+	if nav == NavTarget && w.Target.Kind != TargetCraft {
+		nav = NavOrbit
 	}
-	return w.commandedDirFor(active), active.CommandedRollDeg
+
+	// NavSurface: local-horizon sphere — pole = local up (r̂),
+	// lon-0 = local north. Velocity-independent so it is valid on
+	// the launchpad: the craft pointing radial-out reads at the sky
+	// pole (lat +90), not the horizon. North is undefined at a
+	// geographic pole or on a non-rotating primary — fall back to
+	// any horizontal axis (world +Z projected off up, else +X) so
+	// the basis stays defined rather than blanking the navball.
+	if nav == NavSurface {
+		rN := r.Norm()
+		up := r.Scale(1 / rN)
+		spinR := render.BodyRotationAxisWorld(active.Primary)
+		spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
+		var north orbital.Vec3
+		east := spinAxis.Cross(up)
+		if spinAxis.Norm() > 0 && east.Norm() > 1e-12 {
+			east = east.Scale(1 / east.Norm())
+			north = up.Cross(east)
+		} else {
+			ref := orbital.Vec3{Z: 1}
+			horiz := ref.Sub(up.Scale(up.Dot(ref)))
+			if horiz.Norm() < 1e-9 {
+				ref = orbital.Vec3{X: 1}
+				horiz = ref.Sub(up.Scale(up.Dot(ref)))
+			}
+			north = horiz.Scale(1 / horiz.Norm())
+		}
+		eX := north
+		eZ := up
+		eY := eZ.Cross(eX)
+		return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
+	}
+
+	h := r.Cross(v)
+	hN := h.Norm()
+	if hN == 0 {
+		return NavballBasis{}, false
+	}
+	eZ := h.Scale(1 / hN)
+
+	var eX orbital.Vec3
+	switch nav {
+	case NavTarget:
+		_, vT, ok := w.TargetStateRelativeToActivePrimary()
+		if !ok {
+			return NavballBasis{}, false
+		}
+		dv := vT.Sub(v)
+		n := dv.Norm()
+		if n == 0 {
+			return NavballBasis{}, false
+		}
+		eX = dv.Scale(1 / n)
+	default:
+		vN := v.Norm()
+		if vN == 0 {
+			return NavballBasis{}, false
+		}
+		eX = v.Scale(1 / vN)
+	}
+
+	// Orthogonalise eZ against eX. Required because surface-prograde
+	// and target-prograde aren't generally perpendicular to the orbital
+	// normal, so the raw (h, eX) pair isn't an orthogonal basis.
+	d := eZ.Dot(eX)
+	eZ = eZ.Sub(eX.Scale(d))
+	zN := eZ.Norm()
+	if zN < 1e-9 {
+		// eX is parallel to orbital normal — physically odd (would
+		// require the craft's surface or relative velocity to coincide
+		// with the orbit normal). Fall back to undefined basis; caller
+		// degrades gracefully.
+		return NavballBasis{}, false
+	}
+	eZ = eZ.Scale(1 / zN)
+	eY := eZ.Cross(eX)
+	return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
 }
 
 // SubObserver projects a unit world-frame direction onto the basis
@@ -92,16 +170,41 @@ func (b NavballBasis) SubObserver(dir orbital.Vec3) (latDeg, lonDeg float64) {
 	return latDeg, lonDeg
 }
 
-// NavballSubObserver returns the disc-centre (lat, lon) for the
-// navball. The basis IS the craft body frame (EX = nose), so the nose
-// is by construction at (0, 0) — the disc centre is always "where the
-// craft points". ok=false only when the body frame is undefined (no
-// nose and no commanded direction). v0.10.0+.
+// NavballSubObserver returns (lat, lon, ok) on the navball for the
+// active craft's nose direction (s.AttitudeMode → world-frame unit
+// vector via BurnDirectionWithTarget) projected into the active
+// NavMode's basis.
+//
+// ok=false when the basis is degenerate or the craft has no defined
+// nose direction (e.g. surface-prograde before liftoff). Caller
+// degrades to a static / blank navball.
 func (w *World) NavballSubObserver() (latDeg, lonDeg float64, ok bool) {
-	if _, basisOK := w.NavballBasis(); !basisOK {
+	active := w.ActiveCraft()
+	if active == nil {
 		return 0, 0, false
 	}
-	return 0, 0, true
+	basis, basisOK := w.NavballBasis()
+	if !basisOK {
+		return 0, 0, false
+	}
+	// v0.10.0: in slew mode the disk centre is the craft's PHYSICAL
+	// nose (CurrentAttitudeDir) so it animates as the craft slews;
+	// the cardinal/node markers (NavballMarkers) stay on the
+	// commanded directions, so nose vs targets visibly diverge during
+	// a slew. Pre-first-tick (CurrentAttitudeDir still zero) or under
+	// InstantSAS, fall back to the commanded direction.
+	var dir orbital.Vec3
+	if !w.InstantSAS && active.CurrentAttitudeDir.Norm() != 0 {
+		dir = active.CurrentAttitudeDir
+	} else {
+		rT, vT, _ := w.TargetStateRelativeToActivePrimary()
+		dir = active.BurnDirectionWithTarget(active.AttitudeMode, rT, vT)
+	}
+	if dir.Norm() == 0 {
+		return 0, 0, false
+	}
+	lat, lon := basis.SubObserver(dir)
+	return lat, lon, true
 }
 
 // Navball glyphs. Mirroring KSP's symbol vocabulary so muscle memory
@@ -117,7 +220,6 @@ const (
 	NavballGlyphTarget      = '◉'
 	NavballGlyphAntiTarget  = '◌'
 	NavballGlyphNode        = '◎' // planted maneuver node burn direction
-	NavballGlyphNose        = '⌖' // craft nose (surface compass-rose mode)
 )
 
 // NavballMarkers returns the marker set the painter should overlay
@@ -130,15 +232,15 @@ const (
 // axis key would steer toward, resolved via ResolveAttitudeIntent +
 // BurnDirectionWithTarget. So:
 //
-//	NavOrbit   — orbit-frame prograde / retrograde / normal± / radial±
-//	             (six cardinals using the radial-diamond glyphs ◇ ◆)
-//	NavSurface — prograde / retrograde swap to surface-relative
-//	             velocity; normal± / radial± stay orbit-frame
-//	             (matches ResolveAttitudeIntent's NavSurface fallthrough)
-//	NavTarget  — prograde / retrograde swap to target-relative velocity;
-//	             radial+ / radial- swap to BurnTarget / BurnAntiTarget
-//	             (toward / away from target) and use the target glyphs
-//	             ◉ ◌ in target color so the swap is visible at a glance
+//   NavOrbit   — orbit-frame prograde / retrograde / normal± / radial±
+//                (six cardinals using the radial-diamond glyphs ◇ ◆)
+//   NavSurface — prograde / retrograde swap to surface-relative
+//                velocity; normal± / radial± stay orbit-frame
+//                (matches ResolveAttitudeIntent's NavSurface fallthrough)
+//   NavTarget  — prograde / retrograde swap to target-relative velocity;
+//                radial+ / radial- swap to BurnTarget / BurnAntiTarget
+//                (toward / away from target) and use the target glyphs
+//                ◉ ◌ in target color so the swap is visible at a glance
 //
 // This makes the marker set match the SAS hold semantics exactly:
 // each glyph sits at the direction the corresponding axis key would

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -51,16 +51,15 @@ type NavballBasis struct {
 //
 //   - EZ (lat +90, sky pole): local up = r̂
 //   - EX (lon 0):             local north
-//   - EY (lon +90):           local **east**
+//   - EY = EZ × EX            (= −local east)
 //
-// so radial-out → lat +90 (zenith / sky), the horizon → lat 0, and
-// longitude increases *eastward*: East projects to lon +90 (screen
-// right), West to lon −90 (left), matching a real compass — pitching
-// the nose east with the `>` trim key moves the heading rightward on
-// the navball. (This makes the surface triple left-handed; the
-// renderer is internally consistent — handedness only sets the
-// mirror sense, deliberately picked so east = right. The velocity-
-// framed orbit/target basis below is unaffected.)
+// The surface navball is a **zenith-centred, North-up compass rose**:
+// NavballSubObserver pins the disc centre to the zenith (lat +90) with
+// a fixed 180° roll, not the nose. Under that fixed view this basis
+// projects North→screen-up, East→screen-right, South→down, West→left
+// (see TestNavballSurfaceEastIsScreenRight), and the nose rides as a
+// marker that slides toward East (right) when the player trims `>`.
+// Velocity-framed orbit/target basis below is unaffected.
 func (w *World) NavballBasis() (NavballBasis, bool) {
 	active := w.ActiveCraft()
 	if active == nil {
@@ -103,14 +102,13 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 			}
 			north = horiz.Scale(1 / horiz.Norm())
 		}
-		// EY = +east so longitude increases eastward (East → lon +90
-		// = screen right), the compass/trim sense the player expects.
-		// north × up == geographic east in the spin-axis branch
-		// (= the `east` computed above); in the pole/non-rotating
-		// fallback it is just a consistent horizontal axis.
+		// EY = EZ × EX (= −east). Right-handed; the desired
+		// East-is-screen-right comes from the fixed zenith-centred
+		// 180°-roll view that NavballSubObserver feeds for surface
+		// mode, not from the basis handedness (see the type doc).
 		eX := north
 		eZ := up
-		eY := north.Cross(up)
+		eY := eZ.Cross(eX)
 		return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
 	}
 
@@ -198,6 +196,17 @@ func (w *World) NavballSubObserver() (latDeg, lonDeg float64, ok bool) {
 	if !basisOK {
 		return 0, 0, false
 	}
+	// v0.10.0: NavSurface is a zenith-centred, North-up compass rose.
+	// The disc centre is pinned to the local zenith (basis EZ = up →
+	// lat +90), NOT the nose; the 180° roll (subLon = 180 at the pole,
+	// where subLon *is* the screen roll) orients the fixed basis so
+	// North→up, East→right, South→down, West→left. The nose is shown
+	// as a marker (NavballMarkers) that slides toward East (right) as
+	// the player trims `>`. This is stable on the launchpad (no
+	// gimbal: the centre doesn't depend on where the nose points).
+	if w.NavMode == NavSurface {
+		return 90, 180, true
+	}
 	// v0.10.0: in slew mode the disk centre is the craft's PHYSICAL
 	// nose (CurrentAttitudeDir) so it animates as the craft slews;
 	// the cardinal/node markers (NavballMarkers) stay on the
@@ -231,6 +240,7 @@ const (
 	NavballGlyphTarget      = '◉'
 	NavballGlyphAntiTarget  = '◌'
 	NavballGlyphNode        = '◎' // planted maneuver node burn direction
+	NavballGlyphNose        = '⌖' // craft nose (surface compass-rose mode)
 )
 
 // NavballMarkers returns the marker set the painter should overlay
@@ -353,6 +363,25 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 				pushCompass(north.Scale(-1), 'S')
 				pushCompass(east.Scale(-1), 'W')
 			}
+		}
+		// Nose marker. The surface navball is zenith-centred (the
+		// disc centre is local up, not the nose), so the craft's
+		// actual pointing is shown as a glyph that sits at centre on
+		// the pad and slides toward East (screen right) as the player
+		// trims `>`. Physical nose in slew mode (tracks the slew +
+		// pitch-trim); commanded otherwise / pre-first-tick.
+		noseDir := active.CurrentAttitudeDir
+		if w.InstantSAS || noseDir.Norm() == 0 {
+			noseDir = w.commandedDirFor(active)
+		}
+		if noseDir.Norm() != 0 {
+			lat, lon := basis.SubObserver(noseDir)
+			out = append(out, render.NavballMarker{
+				LatDeg: lat,
+				LonDeg: lon,
+				Glyph:  NavballGlyphNose,
+				Color:  render.ColorNavballMarkerNoseFront,
+			})
 		}
 	}
 

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -51,10 +51,16 @@ type NavballBasis struct {
 //
 //   - EZ (lat +90, sky pole): local up = r̂
 //   - EX (lon 0):             local north
-//   - EY = EZ × EX            (= −local east)
+//   - EY (lon +90):           local **east**
 //
 // so radial-out → lat +90 (zenith / sky), the horizon → lat 0, and
-// the N/E/S/W compass ticks ring the lat-0 equator at their bearings.
+// longitude increases *eastward*: East projects to lon +90 (screen
+// right), West to lon −90 (left), matching a real compass — pitching
+// the nose east with the `>` trim key moves the heading rightward on
+// the navball. (This makes the surface triple left-handed; the
+// renderer is internally consistent — handedness only sets the
+// mirror sense, deliberately picked so east = right. The velocity-
+// framed orbit/target basis below is unaffected.)
 func (w *World) NavballBasis() (NavballBasis, bool) {
 	active := w.ActiveCraft()
 	if active == nil {
@@ -97,9 +103,14 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 			}
 			north = horiz.Scale(1 / horiz.Norm())
 		}
+		// EY = +east so longitude increases eastward (East → lon +90
+		// = screen right), the compass/trim sense the player expects.
+		// north × up == geographic east in the spin-axis branch
+		// (= the `east` computed above); in the pole/non-rotating
+		// fallback it is just a consistent horizontal axis.
 		eX := north
 		eZ := up
-		eY := eZ.Cross(eX)
+		eY := north.Cross(up)
 		return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
 	}
 

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -154,8 +154,19 @@ func (w *World) NavballSubObserver() (latDeg, lonDeg float64, ok bool) {
 	if !basisOK {
 		return 0, 0, false
 	}
-	rT, vT, _ := w.TargetStateRelativeToActivePrimary()
-	dir := active.BurnDirectionWithTarget(active.AttitudeMode, rT, vT)
+	// v0.10.0: in slew mode the disk centre is the craft's PHYSICAL
+	// nose (CurrentAttitudeDir) so it animates as the craft slews;
+	// the cardinal/node markers (NavballMarkers) stay on the
+	// commanded directions, so nose vs targets visibly diverge during
+	// a slew. Pre-first-tick (CurrentAttitudeDir still zero) or under
+	// InstantSAS, fall back to the commanded direction.
+	var dir orbital.Vec3
+	if !w.InstantSAS && active.CurrentAttitudeDir.Norm() != 0 {
+		dir = active.CurrentAttitudeDir
+	} else {
+		rT, vT, _ := w.TargetStateRelativeToActivePrimary()
+		dir = active.BurnDirectionWithTarget(active.AttitudeMode, rT, vT)
+	}
 	if dir.Norm() == 0 {
 		return 0, 0, false
 	}

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -35,17 +35,26 @@ type NavballBasis struct {
 // target velocity (NavTarget), or a craft state with zero r / a
 // rectilinear orbit (no defined orbital plane).
 //
-// EX (lat = 0, lon = 0):
-//   - NavOrbit   — +v̂                          (orbit-frame velocity)
-//   - NavSurface — +(v − ω×r)̂                  (surface-relative velocity)
-//   - NavTarget  — +(v_target − v_active)̂      (relative velocity, target-prograde)
+// NavOrbit / NavTarget are velocity-framed (the sphere's pole is the
+// orbital normal):
 //
-// EZ (lat = +90, north pole) — orbital normal (r × v)̂ in all modes;
-// re-orthogonalised against EX to handle modes where prograde is
-// not perpendicular to the orbit plane (NavSurface near the launchpad,
-// NavTarget when relative motion has a radial component).
+//   - EX (lat 0, lon 0): +v̂ (orbit) or +(v_target − v_active)̂ (target)
+//   - EZ (lat +90):      orbital normal (r × v)̂, re-orthogonalised
+//     against EX (target-prograde isn't generally ⟂ the orbit plane)
+//   - EY = EZ × EX
 //
-// EY = EZ × EX, completing the right-handed basis.
+// NavSurface is a **local-horizon** sphere (KSP surface navball): the
+// pole is the local vertical so the sky/ground hemispheres read true.
+// This is velocity-independent, so it is well-defined on the launchpad
+// (a craft sitting on the pad pointing radial-out reads at the sky
+// pole, not the horizon band):
+//
+//   - EZ (lat +90, sky pole): local up = r̂
+//   - EX (lon 0):             local north
+//   - EY = EZ × EX            (= −local east)
+//
+// so radial-out → lat +90 (zenith / sky), the horizon → lat 0, and
+// the N/E/S/W compass ticks ring the lat-0 equator at their bearings.
 func (w *World) NavballBasis() (NavballBasis, bool) {
 	active := w.ActiveCraft()
 	if active == nil {
@@ -56,6 +65,44 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 	if r.Norm() == 0 {
 		return NavballBasis{}, false
 	}
+
+	nav := w.NavMode
+	if nav == NavTarget && w.Target.Kind != TargetCraft {
+		nav = NavOrbit
+	}
+
+	// NavSurface: local-horizon sphere — pole = local up (r̂),
+	// lon-0 = local north. Velocity-independent so it is valid on
+	// the launchpad: the craft pointing radial-out reads at the sky
+	// pole (lat +90), not the horizon. North is undefined at a
+	// geographic pole or on a non-rotating primary — fall back to
+	// any horizontal axis (world +Z projected off up, else +X) so
+	// the basis stays defined rather than blanking the navball.
+	if nav == NavSurface {
+		rN := r.Norm()
+		up := r.Scale(1 / rN)
+		spinR := render.BodyRotationAxisWorld(active.Primary)
+		spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
+		var north orbital.Vec3
+		east := spinAxis.Cross(up)
+		if spinAxis.Norm() > 0 && east.Norm() > 1e-12 {
+			east = east.Scale(1 / east.Norm())
+			north = up.Cross(east)
+		} else {
+			ref := orbital.Vec3{Z: 1}
+			horiz := ref.Sub(up.Scale(up.Dot(ref)))
+			if horiz.Norm() < 1e-9 {
+				ref = orbital.Vec3{X: 1}
+				horiz = ref.Sub(up.Scale(up.Dot(ref)))
+			}
+			north = horiz.Scale(1 / horiz.Norm())
+		}
+		eX := north
+		eZ := up
+		eY := eZ.Cross(eX)
+		return NavballBasis{EX: eX, EY: eY, EZ: eZ}, true
+	}
+
 	h := r.Cross(v)
 	hN := h.Norm()
 	if hN == 0 {
@@ -63,22 +110,8 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 	}
 	eZ := h.Scale(1 / hN)
 
-	nav := w.NavMode
-	if nav == NavTarget && w.Target.Kind != TargetCraft {
-		nav = NavOrbit
-	}
-
 	var eX orbital.Vec3
 	switch nav {
-	case NavSurface:
-		omegaR := render.BodySpinOmegaWorld(active.Primary)
-		omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
-		vSurf := v.Sub(omega.Cross(r))
-		n := vSurf.Norm()
-		if n == 0 {
-			return NavballBasis{}, false
-		}
-		eX = vSurf.Scale(1 / n)
 	case NavTarget:
 		_, vT, ok := w.TargetStateRelativeToActivePrimary()
 		if !ok {

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -421,6 +421,45 @@ func TestNavballMarkersIncludeNode(t *testing.T) {
 	}
 }
 
+// TestNavballSurfaceEastIsScreenRight: in NavSurface the longitude
+// must increase eastward so East projects to lon +90 (screen right),
+// West to −90, North to 0 — the compass sense the player expects, and
+// what makes the `>` (east) pitch-trim move the heading rightward on
+// the navball.
+func TestNavballSurfaceEastIsScreenRight(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavSurface
+	c := w.ActiveCraft()
+	basis, ok := w.NavballBasis()
+	if !ok {
+		t.Fatal("NavballBasis: ok=false in surface mode")
+	}
+
+	rN := c.State.R.Norm()
+	up := c.State.R.Scale(1 / rN)
+	spinR := render.BodyRotationAxisWorld(c.Primary)
+	spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
+	east := spinAxis.Cross(up)
+	east = east.Scale(1 / east.Norm())
+	north := up.Cross(east)
+
+	if _, lon := basis.SubObserver(north); math.Abs(lon) > 1e-3 {
+		t.Errorf("North should be lon 0; got %g", lon)
+	}
+	if _, lon := basis.SubObserver(east); math.Abs(lon-90) > 1e-3 {
+		t.Errorf("East should be lon +90 (screen right); got %g", lon)
+	}
+	if _, lon := basis.SubObserver(east.Scale(-1)); math.Abs(lon+90) > 1e-3 {
+		t.Errorf("West should be lon −90 (screen left); got %g", lon)
+	}
+	if lat, _ := basis.SubObserver(up); math.Abs(lat-90) > 1e-3 {
+		t.Errorf("up should be the sky pole lat +90; got %g", lat)
+	}
+}
+
 // TestNavballMarkersSurfaceCompassTicks: in NavSurface mode the
 // marker set includes four compass ticks (N / E / S / W) painted in
 // the grid color, in addition to the cardinal SAS markers. NavOrbit

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -19,9 +19,10 @@ func vec3Eq(a, b orbital.Vec3) bool {
 		math.Abs(a.Z-b.Z) < navballEps
 }
 
-// TestNavballBasisOrthonormal checks the spawn-state LEO basis is
-// orthonormal and right-handed: EX·EX = EY·EY = EZ·EZ = 1, off-
-// diagonals zero, EZ = EX × EY.
+// TestNavballBasisOrthonormal checks the spawn-state LEO body-frame
+// basis is orthonormal: unit axes, zero off-diagonals. The navball
+// basis is the craft body frame (EX=nose, EZ=up, EY=right=nose×up),
+// so EX×EY = −EZ (i.e. EZ = EY×EX).
 func TestNavballBasisOrthonormal(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -49,20 +50,22 @@ func TestNavballBasisOrthonormal(t *testing.T) {
 			t.Errorf("%s = %g, want 0", name, d)
 		}
 	}
-	cross := basis.EX.Cross(basis.EY)
-	if !vec3Eq(cross, basis.EZ) {
+	// Body frame: right = up×nose ⇒ right-handed, EX×EY = EZ.
+	if cross := basis.EX.Cross(basis.EY); !vec3Eq(cross, basis.EZ) {
 		t.Errorf("EX × EY = %v, want EZ = %v", cross, basis.EZ)
 	}
 }
 
-// TestNavballBasisOrbitMode checks NavOrbit produces EX = +v̂ and
-// EZ = (r × v)̂ on the spawn-state LEO craft.
-func TestNavballBasisOrbitMode(t *testing.T) {
+// TestNavballBasisBodyFrame: on a fresh LEO craft (default
+// AttitudeMode = prograde, roll 0, pre-first-tick so the commanded
+// nose is used) the body-frame basis is EX = nose = +v̂ and EZ = body
+// up = the heads-up reference = radial-out r̂ (⟂ the prograde nose in
+// a circular orbit). NavMode does not change the basis.
+func TestNavballBasisBodyFrame(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	w.NavMode = NavOrbit
 	c := w.ActiveCraft()
 	basis, ok := w.NavballBasis()
 	if !ok {
@@ -70,23 +73,22 @@ func TestNavballBasisOrbitMode(t *testing.T) {
 	}
 	progradeUnit := c.State.V.Scale(1 / c.State.V.Norm())
 	if !vec3Eq(basis.EX, progradeUnit) {
-		t.Errorf("EX = %v, want prograde %v", basis.EX, progradeUnit)
+		t.Errorf("EX (nose) = %v, want prograde %v", basis.EX, progradeUnit)
 	}
-	hUnit := c.State.R.Cross(c.State.V)
-	hUnit = hUnit.Scale(1 / hUnit.Norm())
-	if !vec3Eq(basis.EZ, hUnit) {
-		t.Errorf("EZ = %v, want orbital normal %v", basis.EZ, hUnit)
+	radialOut := c.State.R.Scale(1 / c.State.R.Norm())
+	if !vec3Eq(basis.EZ, radialOut) {
+		t.Errorf("EZ (body up) = %v, want radial-out %v", basis.EZ, radialOut)
 	}
 }
 
 // TestNavballSubObserverProjectsCardinals checks the cardinal-axis
-// projection table for an orbit-mode basis. With EX = prograde,
-// EZ = normal+, EY = EZ × EX:
-//   - prograde         → (0,    0)
-//   - retrograde       → (0,  ±180)
-//   - normal+          → (90,   _)
-//   - normal-          → (-90,  _)
-//   - radial-related   → (0, ±90)
+// projection in the body-frame basis. Default LEO craft: nose = +v̂
+// (prograde), body up = r̂ (radial-out), right = v̂×r̂ = −normal. So:
+//   - prograde   → (0,   0)     (the nose = disc centre)
+//   - retrograde → (0, ±180)
+//   - radial-out → (+90, _)     (body up = the +lat pole)
+//   - radial-in  → (−90, _)
+//   - normal±    → (0, ∓90)     (on the equator, ±90 lon)
 func TestNavballSubObserverProjectsCardinals(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -104,59 +106,28 @@ func TestNavballSubObserverProjectsCardinals(t *testing.T) {
 	radialOut := spacecraft.DirectionUnit(spacecraft.BurnRadialOut, c.State.R, c.State.V)
 	radialIn := spacecraft.DirectionUnit(spacecraft.BurnRadialIn, c.State.R, c.State.V)
 
-	checks := []struct {
-		name     string
-		dir      orbital.Vec3
-		wantLat  float64
-		wantLon  float64
-		ignoreLon bool // true for poles where lon is undefined
-	}{
-		{"prograde", progradeDir, 0, 0, false},
-		{"retrograde", retrogradeDir, 0, 180, true /* ±180 both valid */},
-		{"normal+", normalPlus, 90, 0, true},
-		{"normal-", normalMinus, -90, 0, true},
-		{"radial-related ±90 lon", radialOut, 0, 0, false},
-		{"radial-related ∓90 lon", radialIn, 0, 0, false},
+	if lat, lon := basis.SubObserver(progradeDir); math.Abs(lat) > 1e-4 || math.Abs(lon) > 1e-4 {
+		t.Errorf("prograde (nose) → (%g,%g), want (0,0)", lat, lon)
 	}
-	for _, tc := range checks {
-		t.Run(tc.name, func(t *testing.T) {
-			lat, lon := basis.SubObserver(tc.dir)
-			if math.Abs(lat-tc.wantLat) > 1e-4 {
-				t.Errorf("lat = %g, want %g", lat, tc.wantLat)
-			}
-			switch tc.name {
-			case "retrograde":
-				absLon := math.Abs(lon)
-				if math.Abs(absLon-180) > 1e-4 {
-					t.Errorf("|lon| = %g, want 180", absLon)
-				}
-			case "radial-related ±90 lon", "radial-related ∓90 lon":
-				absLon := math.Abs(lon)
-				if math.Abs(absLon-90) > 1e-4 {
-					t.Errorf("|lon| = %g, want 90", absLon)
-				}
-			default:
-				if !tc.ignoreLon && math.Abs(lon-tc.wantLon) > 1e-4 {
-					t.Errorf("lon = %g, want %g", lon, tc.wantLon)
-				}
-			}
-		})
+	if lat, lon := basis.SubObserver(retrogradeDir); math.Abs(lat) > 1e-4 || math.Abs(math.Abs(lon)-180) > 1e-4 {
+		t.Errorf("retrograde → (%g,%g), want (0,±180)", lat, lon)
 	}
-	// radialOut and radialIn must land on opposite longitudes.
-	latOut, lonOut := basis.SubObserver(radialOut)
-	latIn, lonIn := basis.SubObserver(radialIn)
-	if math.Abs(latOut) > 1e-4 || math.Abs(latIn) > 1e-4 {
-		t.Errorf("radial markers should sit on equator (lat≈0); got %g, %g", latOut, latIn)
+	if lat, _ := basis.SubObserver(radialOut); math.Abs(lat-90) > 1e-4 {
+		t.Errorf("radial-out lat = %g, want +90 (body-up pole)", lat)
 	}
-	wrap := lonOut + lonIn
-	for wrap > 180 {
-		wrap -= 360
+	if lat, _ := basis.SubObserver(radialIn); math.Abs(lat+90) > 1e-4 {
+		t.Errorf("radial-in lat = %g, want −90", lat)
 	}
-	for wrap < -180 {
-		wrap += 360
+	latNP, lonNP := basis.SubObserver(normalPlus)
+	latNM, lonNM := basis.SubObserver(normalMinus)
+	if math.Abs(latNP) > 1e-4 || math.Abs(math.Abs(lonNP)-90) > 1e-4 {
+		t.Errorf("normal+ → (%g,%g), want (0,±90)", latNP, lonNP)
 	}
-	if math.Abs(wrap) > 1e-4 && math.Abs(math.Abs(wrap)-360) > 1e-4 {
-		t.Errorf("radial+ and radial- should be antipodal in lon; got %g + %g = %g", lonOut, lonIn, wrap)
+	if math.Abs(latNM) > 1e-4 || math.Abs(math.Abs(lonNM)-90) > 1e-4 {
+		t.Errorf("normal- → (%g,%g), want (0,±90)", latNM, lonNM)
+	}
+	if math.Abs(lonNP+lonNM) > 1e-4 { // antipodal: +90 / −90
+		t.Errorf("normal± should be antipodal in lon; got %g, %g", lonNP, lonNM)
 	}
 }
 
@@ -179,24 +150,20 @@ func TestNavballSubObserverNoseDirection(t *testing.T) {
 	}
 }
 
-// TestNavballSubObserverNoseRetrograde: when the craft holds
-// retrograde, the nose maps to (0, ±180).
-func TestNavballSubObserverNoseRetrograde(t *testing.T) {
+// TestNavballSubObserverIsAlwaysCentre: the basis is the body frame
+// (EX = nose), so the disc centre is always the nose — (0, 0) —
+// regardless of which way the craft holds attitude.
+func TestNavballSubObserverIsAlwaysCentre(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	w.NavMode = NavOrbit
-	w.ActiveCraft().AttitudeMode = spacecraft.BurnRetrograde
-	lat, lon, ok := w.NavballSubObserver()
-	if !ok {
-		t.Fatal("NavballSubObserver: ok=false")
-	}
-	if math.Abs(lat) > 1e-4 {
-		t.Errorf("retrograde lat = %g, want 0", lat)
-	}
-	if math.Abs(math.Abs(lon)-180) > 1e-4 {
-		t.Errorf("retrograde |lon| = %g, want 180", math.Abs(lon))
+	for _, mode := range []spacecraft.BurnMode{spacecraft.BurnPrograde, spacecraft.BurnRetrograde, spacecraft.BurnNormalPlus} {
+		w.ActiveCraft().AttitudeMode = mode
+		lat, lon, ok := w.NavballSubObserver()
+		if !ok || math.Abs(lat) > 1e-9 || math.Abs(lon) > 1e-9 {
+			t.Errorf("mode %v: sub-observer = (%g,%g,%v), want (0,0,true)", mode, lat, lon, ok)
+		}
 	}
 }
 
@@ -230,45 +197,28 @@ func TestNavballMarkersOrbitMode(t *testing.T) {
 	for i, m := range got {
 		byGlyph[m.Glyph] = i
 	}
-	checks := []struct {
-		glyph    rune
-		wantLat  float64
-		wantLon  float64
-		ignoreLon bool
-	}{
-		{NavballGlyphPrograde, 0, 0, false},
-		{NavballGlyphRetrograde, 0, 180, true},
-		{NavballGlyphNormalPlus, 90, 0, true},
-		{NavballGlyphNormalMinus, -90, 0, true},
-		{NavballGlyphRadialOut, 0, 0, true},  // ±90 lon
-		{NavballGlyphRadialIn, 0, 0, true},
+	// Body frame (nose=prograde, up=radial-out): prograde at centre,
+	// retrograde antipodal, radial-out/in at the ±lat poles, normal±
+	// on the equator at ±90 lon.
+	if m := got[byGlyph[NavballGlyphPrograde]]; math.Abs(m.LatDeg) > 1e-4 || math.Abs(m.LonDeg) > 1e-4 {
+		t.Errorf("prograde → (%g,%g), want (0,0)", m.LatDeg, m.LonDeg)
 	}
-	for _, c := range checks {
-		idx, ok := byGlyph[c.glyph]
-		if !ok {
-			t.Errorf("missing marker glyph %c", c.glyph)
-			continue
-		}
-		m := got[idx]
-		if math.Abs(m.LatDeg-c.wantLat) > 1e-4 {
-			t.Errorf("%c lat = %g, want %g", c.glyph, m.LatDeg, c.wantLat)
-		}
-		if !c.ignoreLon && math.Abs(m.LonDeg-c.wantLon) > 1e-4 {
-			t.Errorf("%c lon = %g, want %g", c.glyph, m.LonDeg, c.wantLon)
-		}
+	if m := got[byGlyph[NavballGlyphRetrograde]]; math.Abs(m.LatDeg) > 1e-4 || math.Abs(math.Abs(m.LonDeg)-180) > 1e-4 {
+		t.Errorf("retrograde → (%g,%g), want (0,±180)", m.LatDeg, m.LonDeg)
 	}
-	// retrograde lon must be ±180 exactly.
-	if m := got[byGlyph[NavballGlyphRetrograde]]; math.Abs(math.Abs(m.LonDeg)-180) > 1e-4 {
-		t.Errorf("retrograde |lon| = %g, want 180", math.Abs(m.LonDeg))
+	if m := got[byGlyph[NavballGlyphRadialOut]]; math.Abs(m.LatDeg-90) > 1e-4 {
+		t.Errorf("radial-out lat = %g, want +90", m.LatDeg)
 	}
-	// radial markers sit on the equator with antipodal lons.
-	rOut := got[byGlyph[NavballGlyphRadialOut]]
-	rIn := got[byGlyph[NavballGlyphRadialIn]]
-	if math.Abs(rOut.LatDeg) > 1e-4 || math.Abs(rIn.LatDeg) > 1e-4 {
-		t.Errorf("radial markers should be on equator, got %g and %g", rOut.LatDeg, rIn.LatDeg)
+	if m := got[byGlyph[NavballGlyphRadialIn]]; math.Abs(m.LatDeg+90) > 1e-4 {
+		t.Errorf("radial-in lat = %g, want −90", m.LatDeg)
 	}
-	if math.Abs(math.Abs(rOut.LonDeg)-90) > 1e-4 {
-		t.Errorf("radialOut |lon| = %g, want 90", math.Abs(rOut.LonDeg))
+	np := got[byGlyph[NavballGlyphNormalPlus]]
+	nm := got[byGlyph[NavballGlyphNormalMinus]]
+	if math.Abs(np.LatDeg) > 1e-4 || math.Abs(math.Abs(np.LonDeg)-90) > 1e-4 {
+		t.Errorf("normal+ → (%g,%g), want (0,±90)", np.LatDeg, np.LonDeg)
+	}
+	if math.Abs(nm.LatDeg) > 1e-4 || math.Abs(np.LonDeg+nm.LonDeg) > 1e-4 {
+		t.Errorf("normal- → (%g,%g), want antipodal to normal+", nm.LatDeg, nm.LonDeg)
 	}
 }
 
@@ -421,76 +371,60 @@ func TestNavballMarkersIncludeNode(t *testing.T) {
 	}
 }
 
-// TestNavballSurfaceEastIsScreenRight: NavSurface is a zenith-centred,
-// North-up compass rose. NavballSubObserver pins the disc to the
-// zenith with a 180° roll; under that fixed view North→screen-up,
-// East→screen-right, South→down, West→left, and the nose marker slides
-// right as the player trims `>` (east). Asserted end-to-end by
-// replicating the renderer's pole projection at the pinned
-// (subLat=90, subLon=180) view.
+// TestNavballSurfaceEastIsScreenRight: on the launchpad the nose
+// points radial-out and roll is 0 (heads-up). The body-frame navball
+// is fed (0,0), so screen-right ∝ d·EY and screen-up ∝ d·EZ. With
+// heads-up roll the world East must read screen-right, West left,
+// North up, and the nose (radial-out) sits at the disc centre — the
+// behaviour the player asked for, now singularity-free.
 func TestNavballSurfaceEastIsScreenRight(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	w.NavMode = NavSurface
-	c := w.ActiveCraft()
+	c, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID: spacecraft.LoadoutSaturnVID, ParentBodyID: "earth",
+		Launchpad: true, Latitude: 28.6083, LongitudeOffset: -80.604,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
 	basis, ok := w.NavballBasis()
 	if !ok {
-		t.Fatal("NavballBasis: ok=false in surface mode")
+		t.Fatal("NavballBasis: ok=false on the pad")
+	}
+	if sl, so, sok := w.NavballSubObserver(); !sok || math.Abs(sl) > 1e-9 || math.Abs(so) > 1e-9 {
+		t.Fatalf("body-frame sub-observer = (%g,%g,%v), want (0,0,true)", sl, so, sok)
 	}
 
-	// The disc must be pinned to the zenith with the compass roll.
-	sLat, sLon, sok := w.NavballSubObserver()
-	if !sok || math.Abs(sLat-90) > 1e-9 || math.Abs(sLon-180) > 1e-9 {
-		t.Fatalf("surface sub-observer = (%g,%g,%v), want (90,180,true)", sLat, sLon, sok)
-	}
-
-	// render.projectLatLonToPixel at (subLat=90, subLon=180) reduces
-	// to: screenRight ∝ −cos(lat)·sin(lon), screenUp ∝ cos(lat)·cos(lon)
-	// (lat,lon from basis.SubObserver). Mirror it to assert the
-	// on-screen quadrant of each direction.
+	// Body-frame navball fed (0,0): screen-right = d·EY, up = d·EZ.
 	screen := func(dir orbital.Vec3) (right, up float64) {
-		lat, lon := basis.SubObserver(dir)
-		la, lo := lat*math.Pi/180, lon*math.Pi/180
-		return -math.Cos(la) * math.Sin(lo), math.Cos(la) * math.Cos(lo)
+		return dir.Dot(basis.EY), dir.Dot(basis.EZ)
 	}
 
-	rN := c.State.R.Norm()
-	upv := c.State.R.Scale(1 / rN)
+	upv := c.State.R.Scale(1 / c.State.R.Norm()) // radial-out = nose
 	spinR := render.BodyRotationAxisWorld(c.Primary)
 	spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
 	east := spinAxis.Cross(upv)
 	east = east.Scale(1 / east.Norm())
-	north := upv.Cross(east)
 
-	if r, u := screen(north); math.Abs(r) > 1e-6 || u <= 0 {
-		t.Errorf("North should be screen-up; got right=%.3f up=%.3f", r, u)
-	}
 	if r, u := screen(east); r <= 0 || math.Abs(u) > 1e-6 {
 		t.Errorf("East should be screen-right; got right=%.3f up=%.3f", r, u)
 	}
 	if r, _ := screen(east.Scale(-1)); r >= 0 {
 		t.Errorf("West should be screen-left; got right=%.3f", r)
 	}
-	if _, u := screen(north.Scale(-1)); u >= 0 {
-		t.Errorf("South should be screen-down; got up=%.3f", u)
-	}
-	if r, u := screen(upv); math.Abs(r) > 1e-6 || math.Abs(u) > 1e-6 {
-		t.Errorf("zenith should be disc centre; got right=%.3f up=%.3f", r, u)
+	if r, u := screen(basis.EX); math.Abs(r) > 1e-6 || math.Abs(u) > 1e-6 {
+		t.Errorf("nose should be the disc centre; got right=%.3f up=%.3f", r, u)
 	}
 
-	// Trimming `>` (east) tilts the nose from radial-out toward east;
-	// its marker must move to screen-right (positive, from ~0).
-	noseUp := upv // radial-out at launch
-	noseTrimmed := orbital.Rotate(upv, north, 12*math.Pi/180) // 12° toward east
-	r0, _ := screen(noseUp)
-	r1, _ := screen(noseTrimmed)
-	if math.Abs(r0) > 1e-6 {
-		t.Errorf("untrimmed nose (radial-out) should sit at centre; got right=%.3f", r0)
-	}
-	if r1 <= r0 {
-		t.Errorf("east trim should move the nose screen-right; right %.3f → %.3f", r0, r1)
+	// Roll 90° must rotate the ball: East moves off screen-right.
+	c.CommandedRollDeg = 90
+	c.CurrentRollDeg = 90
+	rb, _ := w.NavballBasis()
+	if r := east.Dot(rb.EY); r > 0.2 {
+		t.Errorf("after 90° roll East should leave screen-right; got right=%.3f", r)
 	}
 }
 

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -349,27 +349,46 @@ func TestNavballMarkersTargetModeProgradeIsTargetRelative(t *testing.T) {
 	t.Errorf("missing prograde marker in target mode")
 }
 
-// TestNavballMarkersSurfaceModeProgradeIsSurface: in NavSurface
-// mode, EX is surface-relative velocity, and the prograde marker
-// direction is the same — landing at the disk centre. Confirms
-// orbit-frame prograde isn't leaking into surface-mode output.
-func TestNavballMarkersSurfaceModeProgradeIsSurface(t *testing.T) {
+// TestNavballMarkersSurfaceModeLocalHorizon: NavSurface is a local-
+// horizon sphere (sky pole = local up). Radial-out must read at the
+// sky pole (lat +90), radial-in at the nadir (lat −90), and surface-
+// prograde on the horizon band (lat ≈ 0) — not re-centred on prograde
+// the way the pre-v0.10 orbital-normal-pole basis did. This is the
+// "launching shows the sky, not the horizon" fix.
+func TestNavballMarkersSurfaceModeLocalHorizon(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	w.NavMode = NavSurface
 	got := w.NavballMarkers()
-	for _, m := range got {
-		if m.Glyph != NavballGlyphPrograde {
-			continue
+
+	find := func(glyph rune) (render.NavballMarker, bool) {
+		for _, m := range got {
+			if m.Glyph == glyph {
+				return m, true
+			}
 		}
-		if math.Abs(m.LatDeg) > 1e-4 || math.Abs(m.LonDeg) > 1e-4 {
-			t.Errorf("surface-mode prograde lands at (%g, %g), want (0, 0)", m.LatDeg, m.LonDeg)
-		}
-		return
+		return render.NavballMarker{}, false
 	}
-	t.Errorf("missing prograde marker in surface mode")
+
+	if m, ok := find(NavballGlyphRadialOut); !ok {
+		t.Error("missing radial-out marker in surface mode")
+	} else if math.Abs(m.LatDeg-90) > 1e-3 {
+		t.Errorf("radial-out should sit at the sky pole (lat +90); got lat=%g", m.LatDeg)
+	}
+
+	if m, ok := find(NavballGlyphRadialIn); !ok {
+		t.Error("missing radial-in marker in surface mode")
+	} else if math.Abs(m.LatDeg+90) > 1e-3 {
+		t.Errorf("radial-in should sit at the nadir (lat −90); got lat=%g", m.LatDeg)
+	}
+
+	if m, ok := find(NavballGlyphPrograde); !ok {
+		t.Error("missing prograde marker in surface mode")
+	} else if math.Abs(m.LatDeg) > 1.0 {
+		t.Errorf("surface-prograde should ride the horizon (lat ≈ 0); got lat=%g", m.LatDeg)
+	}
 }
 
 // TestNavballMarkersIncludeNode: a planted BurnPrograde node adds

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -421,11 +421,13 @@ func TestNavballMarkersIncludeNode(t *testing.T) {
 	}
 }
 
-// TestNavballSurfaceEastIsScreenRight: in NavSurface the longitude
-// must increase eastward so East projects to lon +90 (screen right),
-// West to −90, North to 0 — the compass sense the player expects, and
-// what makes the `>` (east) pitch-trim move the heading rightward on
-// the navball.
+// TestNavballSurfaceEastIsScreenRight: NavSurface is a zenith-centred,
+// North-up compass rose. NavballSubObserver pins the disc to the
+// zenith with a 180° roll; under that fixed view North→screen-up,
+// East→screen-right, South→down, West→left, and the nose marker slides
+// right as the player trims `>` (east). Asserted end-to-end by
+// replicating the renderer's pole projection at the pinned
+// (subLat=90, subLon=180) view.
 func TestNavballSurfaceEastIsScreenRight(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -438,25 +440,57 @@ func TestNavballSurfaceEastIsScreenRight(t *testing.T) {
 		t.Fatal("NavballBasis: ok=false in surface mode")
 	}
 
+	// The disc must be pinned to the zenith with the compass roll.
+	sLat, sLon, sok := w.NavballSubObserver()
+	if !sok || math.Abs(sLat-90) > 1e-9 || math.Abs(sLon-180) > 1e-9 {
+		t.Fatalf("surface sub-observer = (%g,%g,%v), want (90,180,true)", sLat, sLon, sok)
+	}
+
+	// render.projectLatLonToPixel at (subLat=90, subLon=180) reduces
+	// to: screenRight ∝ −cos(lat)·sin(lon), screenUp ∝ cos(lat)·cos(lon)
+	// (lat,lon from basis.SubObserver). Mirror it to assert the
+	// on-screen quadrant of each direction.
+	screen := func(dir orbital.Vec3) (right, up float64) {
+		lat, lon := basis.SubObserver(dir)
+		la, lo := lat*math.Pi/180, lon*math.Pi/180
+		return -math.Cos(la) * math.Sin(lo), math.Cos(la) * math.Cos(lo)
+	}
+
 	rN := c.State.R.Norm()
-	up := c.State.R.Scale(1 / rN)
+	upv := c.State.R.Scale(1 / rN)
 	spinR := render.BodyRotationAxisWorld(c.Primary)
 	spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
-	east := spinAxis.Cross(up)
+	east := spinAxis.Cross(upv)
 	east = east.Scale(1 / east.Norm())
-	north := up.Cross(east)
+	north := upv.Cross(east)
 
-	if _, lon := basis.SubObserver(north); math.Abs(lon) > 1e-3 {
-		t.Errorf("North should be lon 0; got %g", lon)
+	if r, u := screen(north); math.Abs(r) > 1e-6 || u <= 0 {
+		t.Errorf("North should be screen-up; got right=%.3f up=%.3f", r, u)
 	}
-	if _, lon := basis.SubObserver(east); math.Abs(lon-90) > 1e-3 {
-		t.Errorf("East should be lon +90 (screen right); got %g", lon)
+	if r, u := screen(east); r <= 0 || math.Abs(u) > 1e-6 {
+		t.Errorf("East should be screen-right; got right=%.3f up=%.3f", r, u)
 	}
-	if _, lon := basis.SubObserver(east.Scale(-1)); math.Abs(lon+90) > 1e-3 {
-		t.Errorf("West should be lon −90 (screen left); got %g", lon)
+	if r, _ := screen(east.Scale(-1)); r >= 0 {
+		t.Errorf("West should be screen-left; got right=%.3f", r)
 	}
-	if lat, _ := basis.SubObserver(up); math.Abs(lat-90) > 1e-3 {
-		t.Errorf("up should be the sky pole lat +90; got %g", lat)
+	if _, u := screen(north.Scale(-1)); u >= 0 {
+		t.Errorf("South should be screen-down; got up=%.3f", u)
+	}
+	if r, u := screen(upv); math.Abs(r) > 1e-6 || math.Abs(u) > 1e-6 {
+		t.Errorf("zenith should be disc centre; got right=%.3f up=%.3f", r, u)
+	}
+
+	// Trimming `>` (east) tilts the nose from radial-out toward east;
+	// its marker must move to screen-right (positive, from ~0).
+	noseUp := upv // radial-out at launch
+	noseTrimmed := orbital.Rotate(upv, north, 12*math.Pi/180) // 12° toward east
+	r0, _ := screen(noseUp)
+	r1, _ := screen(noseTrimmed)
+	if math.Abs(r0) > 1e-6 {
+		t.Errorf("untrimmed nose (radial-out) should sit at centre; got right=%.3f", r0)
+	}
+	if r1 <= r0 {
+		t.Errorf("east trim should move the nose screen-right; right %.3f → %.3f", r0, r1)
 	}
 }
 

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -19,10 +19,9 @@ func vec3Eq(a, b orbital.Vec3) bool {
 		math.Abs(a.Z-b.Z) < navballEps
 }
 
-// TestNavballBasisOrthonormal checks the spawn-state LEO body-frame
-// basis is orthonormal: unit axes, zero off-diagonals. The navball
-// basis is the craft body frame (EX=nose, EZ=up, EY=right=nose×up),
-// so EX×EY = −EZ (i.e. EZ = EY×EX).
+// TestNavballBasisOrthonormal checks the spawn-state LEO basis is
+// orthonormal and right-handed: EX·EX = EY·EY = EZ·EZ = 1, off-
+// diagonals zero, EZ = EX × EY.
 func TestNavballBasisOrthonormal(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -50,22 +49,20 @@ func TestNavballBasisOrthonormal(t *testing.T) {
 			t.Errorf("%s = %g, want 0", name, d)
 		}
 	}
-	// Body frame: right = up×nose ⇒ right-handed, EX×EY = EZ.
-	if cross := basis.EX.Cross(basis.EY); !vec3Eq(cross, basis.EZ) {
+	cross := basis.EX.Cross(basis.EY)
+	if !vec3Eq(cross, basis.EZ) {
 		t.Errorf("EX × EY = %v, want EZ = %v", cross, basis.EZ)
 	}
 }
 
-// TestNavballBasisBodyFrame: on a fresh LEO craft (default
-// AttitudeMode = prograde, roll 0, pre-first-tick so the commanded
-// nose is used) the body-frame basis is EX = nose = +v̂ and EZ = body
-// up = the heads-up reference = radial-out r̂ (⟂ the prograde nose in
-// a circular orbit). NavMode does not change the basis.
-func TestNavballBasisBodyFrame(t *testing.T) {
+// TestNavballBasisOrbitMode checks NavOrbit produces EX = +v̂ and
+// EZ = (r × v)̂ on the spawn-state LEO craft.
+func TestNavballBasisOrbitMode(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
+	w.NavMode = NavOrbit
 	c := w.ActiveCraft()
 	basis, ok := w.NavballBasis()
 	if !ok {
@@ -73,22 +70,23 @@ func TestNavballBasisBodyFrame(t *testing.T) {
 	}
 	progradeUnit := c.State.V.Scale(1 / c.State.V.Norm())
 	if !vec3Eq(basis.EX, progradeUnit) {
-		t.Errorf("EX (nose) = %v, want prograde %v", basis.EX, progradeUnit)
+		t.Errorf("EX = %v, want prograde %v", basis.EX, progradeUnit)
 	}
-	radialOut := c.State.R.Scale(1 / c.State.R.Norm())
-	if !vec3Eq(basis.EZ, radialOut) {
-		t.Errorf("EZ (body up) = %v, want radial-out %v", basis.EZ, radialOut)
+	hUnit := c.State.R.Cross(c.State.V)
+	hUnit = hUnit.Scale(1 / hUnit.Norm())
+	if !vec3Eq(basis.EZ, hUnit) {
+		t.Errorf("EZ = %v, want orbital normal %v", basis.EZ, hUnit)
 	}
 }
 
 // TestNavballSubObserverProjectsCardinals checks the cardinal-axis
-// projection in the body-frame basis. Default LEO craft: nose = +v̂
-// (prograde), body up = r̂ (radial-out), right = v̂×r̂ = −normal. So:
-//   - prograde   → (0,   0)     (the nose = disc centre)
-//   - retrograde → (0, ±180)
-//   - radial-out → (+90, _)     (body up = the +lat pole)
-//   - radial-in  → (−90, _)
-//   - normal±    → (0, ∓90)     (on the equator, ±90 lon)
+// projection table for an orbit-mode basis. With EX = prograde,
+// EZ = normal+, EY = EZ × EX:
+//   - prograde         → (0,    0)
+//   - retrograde       → (0,  ±180)
+//   - normal+          → (90,   _)
+//   - normal-          → (-90,  _)
+//   - radial-related   → (0, ±90)
 func TestNavballSubObserverProjectsCardinals(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -106,28 +104,59 @@ func TestNavballSubObserverProjectsCardinals(t *testing.T) {
 	radialOut := spacecraft.DirectionUnit(spacecraft.BurnRadialOut, c.State.R, c.State.V)
 	radialIn := spacecraft.DirectionUnit(spacecraft.BurnRadialIn, c.State.R, c.State.V)
 
-	if lat, lon := basis.SubObserver(progradeDir); math.Abs(lat) > 1e-4 || math.Abs(lon) > 1e-4 {
-		t.Errorf("prograde (nose) → (%g,%g), want (0,0)", lat, lon)
+	checks := []struct {
+		name     string
+		dir      orbital.Vec3
+		wantLat  float64
+		wantLon  float64
+		ignoreLon bool // true for poles where lon is undefined
+	}{
+		{"prograde", progradeDir, 0, 0, false},
+		{"retrograde", retrogradeDir, 0, 180, true /* ±180 both valid */},
+		{"normal+", normalPlus, 90, 0, true},
+		{"normal-", normalMinus, -90, 0, true},
+		{"radial-related ±90 lon", radialOut, 0, 0, false},
+		{"radial-related ∓90 lon", radialIn, 0, 0, false},
 	}
-	if lat, lon := basis.SubObserver(retrogradeDir); math.Abs(lat) > 1e-4 || math.Abs(math.Abs(lon)-180) > 1e-4 {
-		t.Errorf("retrograde → (%g,%g), want (0,±180)", lat, lon)
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			lat, lon := basis.SubObserver(tc.dir)
+			if math.Abs(lat-tc.wantLat) > 1e-4 {
+				t.Errorf("lat = %g, want %g", lat, tc.wantLat)
+			}
+			switch tc.name {
+			case "retrograde":
+				absLon := math.Abs(lon)
+				if math.Abs(absLon-180) > 1e-4 {
+					t.Errorf("|lon| = %g, want 180", absLon)
+				}
+			case "radial-related ±90 lon", "radial-related ∓90 lon":
+				absLon := math.Abs(lon)
+				if math.Abs(absLon-90) > 1e-4 {
+					t.Errorf("|lon| = %g, want 90", absLon)
+				}
+			default:
+				if !tc.ignoreLon && math.Abs(lon-tc.wantLon) > 1e-4 {
+					t.Errorf("lon = %g, want %g", lon, tc.wantLon)
+				}
+			}
+		})
 	}
-	if lat, _ := basis.SubObserver(radialOut); math.Abs(lat-90) > 1e-4 {
-		t.Errorf("radial-out lat = %g, want +90 (body-up pole)", lat)
+	// radialOut and radialIn must land on opposite longitudes.
+	latOut, lonOut := basis.SubObserver(radialOut)
+	latIn, lonIn := basis.SubObserver(radialIn)
+	if math.Abs(latOut) > 1e-4 || math.Abs(latIn) > 1e-4 {
+		t.Errorf("radial markers should sit on equator (lat≈0); got %g, %g", latOut, latIn)
 	}
-	if lat, _ := basis.SubObserver(radialIn); math.Abs(lat+90) > 1e-4 {
-		t.Errorf("radial-in lat = %g, want −90", lat)
+	wrap := lonOut + lonIn
+	for wrap > 180 {
+		wrap -= 360
 	}
-	latNP, lonNP := basis.SubObserver(normalPlus)
-	latNM, lonNM := basis.SubObserver(normalMinus)
-	if math.Abs(latNP) > 1e-4 || math.Abs(math.Abs(lonNP)-90) > 1e-4 {
-		t.Errorf("normal+ → (%g,%g), want (0,±90)", latNP, lonNP)
+	for wrap < -180 {
+		wrap += 360
 	}
-	if math.Abs(latNM) > 1e-4 || math.Abs(math.Abs(lonNM)-90) > 1e-4 {
-		t.Errorf("normal- → (%g,%g), want (0,±90)", latNM, lonNM)
-	}
-	if math.Abs(lonNP+lonNM) > 1e-4 { // antipodal: +90 / −90
-		t.Errorf("normal± should be antipodal in lon; got %g, %g", lonNP, lonNM)
+	if math.Abs(wrap) > 1e-4 && math.Abs(math.Abs(wrap)-360) > 1e-4 {
+		t.Errorf("radial+ and radial- should be antipodal in lon; got %g + %g = %g", lonOut, lonIn, wrap)
 	}
 }
 
@@ -150,20 +179,24 @@ func TestNavballSubObserverNoseDirection(t *testing.T) {
 	}
 }
 
-// TestNavballSubObserverIsAlwaysCentre: the basis is the body frame
-// (EX = nose), so the disc centre is always the nose — (0, 0) —
-// regardless of which way the craft holds attitude.
-func TestNavballSubObserverIsAlwaysCentre(t *testing.T) {
+// TestNavballSubObserverNoseRetrograde: when the craft holds
+// retrograde, the nose maps to (0, ±180).
+func TestNavballSubObserverNoseRetrograde(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	for _, mode := range []spacecraft.BurnMode{spacecraft.BurnPrograde, spacecraft.BurnRetrograde, spacecraft.BurnNormalPlus} {
-		w.ActiveCraft().AttitudeMode = mode
-		lat, lon, ok := w.NavballSubObserver()
-		if !ok || math.Abs(lat) > 1e-9 || math.Abs(lon) > 1e-9 {
-			t.Errorf("mode %v: sub-observer = (%g,%g,%v), want (0,0,true)", mode, lat, lon, ok)
-		}
+	w.NavMode = NavOrbit
+	w.ActiveCraft().AttitudeMode = spacecraft.BurnRetrograde
+	lat, lon, ok := w.NavballSubObserver()
+	if !ok {
+		t.Fatal("NavballSubObserver: ok=false")
+	}
+	if math.Abs(lat) > 1e-4 {
+		t.Errorf("retrograde lat = %g, want 0", lat)
+	}
+	if math.Abs(math.Abs(lon)-180) > 1e-4 {
+		t.Errorf("retrograde |lon| = %g, want 180", math.Abs(lon))
 	}
 }
 
@@ -197,28 +230,45 @@ func TestNavballMarkersOrbitMode(t *testing.T) {
 	for i, m := range got {
 		byGlyph[m.Glyph] = i
 	}
-	// Body frame (nose=prograde, up=radial-out): prograde at centre,
-	// retrograde antipodal, radial-out/in at the ±lat poles, normal±
-	// on the equator at ±90 lon.
-	if m := got[byGlyph[NavballGlyphPrograde]]; math.Abs(m.LatDeg) > 1e-4 || math.Abs(m.LonDeg) > 1e-4 {
-		t.Errorf("prograde → (%g,%g), want (0,0)", m.LatDeg, m.LonDeg)
+	checks := []struct {
+		glyph    rune
+		wantLat  float64
+		wantLon  float64
+		ignoreLon bool
+	}{
+		{NavballGlyphPrograde, 0, 0, false},
+		{NavballGlyphRetrograde, 0, 180, true},
+		{NavballGlyphNormalPlus, 90, 0, true},
+		{NavballGlyphNormalMinus, -90, 0, true},
+		{NavballGlyphRadialOut, 0, 0, true},  // ±90 lon
+		{NavballGlyphRadialIn, 0, 0, true},
 	}
-	if m := got[byGlyph[NavballGlyphRetrograde]]; math.Abs(m.LatDeg) > 1e-4 || math.Abs(math.Abs(m.LonDeg)-180) > 1e-4 {
-		t.Errorf("retrograde → (%g,%g), want (0,±180)", m.LatDeg, m.LonDeg)
+	for _, c := range checks {
+		idx, ok := byGlyph[c.glyph]
+		if !ok {
+			t.Errorf("missing marker glyph %c", c.glyph)
+			continue
+		}
+		m := got[idx]
+		if math.Abs(m.LatDeg-c.wantLat) > 1e-4 {
+			t.Errorf("%c lat = %g, want %g", c.glyph, m.LatDeg, c.wantLat)
+		}
+		if !c.ignoreLon && math.Abs(m.LonDeg-c.wantLon) > 1e-4 {
+			t.Errorf("%c lon = %g, want %g", c.glyph, m.LonDeg, c.wantLon)
+		}
 	}
-	if m := got[byGlyph[NavballGlyphRadialOut]]; math.Abs(m.LatDeg-90) > 1e-4 {
-		t.Errorf("radial-out lat = %g, want +90", m.LatDeg)
+	// retrograde lon must be ±180 exactly.
+	if m := got[byGlyph[NavballGlyphRetrograde]]; math.Abs(math.Abs(m.LonDeg)-180) > 1e-4 {
+		t.Errorf("retrograde |lon| = %g, want 180", math.Abs(m.LonDeg))
 	}
-	if m := got[byGlyph[NavballGlyphRadialIn]]; math.Abs(m.LatDeg+90) > 1e-4 {
-		t.Errorf("radial-in lat = %g, want −90", m.LatDeg)
+	// radial markers sit on the equator with antipodal lons.
+	rOut := got[byGlyph[NavballGlyphRadialOut]]
+	rIn := got[byGlyph[NavballGlyphRadialIn]]
+	if math.Abs(rOut.LatDeg) > 1e-4 || math.Abs(rIn.LatDeg) > 1e-4 {
+		t.Errorf("radial markers should be on equator, got %g and %g", rOut.LatDeg, rIn.LatDeg)
 	}
-	np := got[byGlyph[NavballGlyphNormalPlus]]
-	nm := got[byGlyph[NavballGlyphNormalMinus]]
-	if math.Abs(np.LatDeg) > 1e-4 || math.Abs(math.Abs(np.LonDeg)-90) > 1e-4 {
-		t.Errorf("normal+ → (%g,%g), want (0,±90)", np.LatDeg, np.LonDeg)
-	}
-	if math.Abs(nm.LatDeg) > 1e-4 || math.Abs(np.LonDeg+nm.LonDeg) > 1e-4 {
-		t.Errorf("normal- → (%g,%g), want antipodal to normal+", nm.LatDeg, nm.LonDeg)
+	if math.Abs(math.Abs(rOut.LonDeg)-90) > 1e-4 {
+		t.Errorf("radialOut |lon| = %g, want 90", math.Abs(rOut.LonDeg))
 	}
 }
 
@@ -368,63 +418,6 @@ func TestNavballMarkersIncludeNode(t *testing.T) {
 	}
 	if math.Abs(node.LatDeg) > 1e-4 || math.Abs(node.LonDeg) > 1e-4 {
 		t.Errorf("BurnPrograde node should project to (0, 0); got (%g, %g)", node.LatDeg, node.LonDeg)
-	}
-}
-
-// TestNavballSurfaceEastIsScreenRight: on the launchpad the nose
-// points radial-out and roll is 0 (heads-up). The body-frame navball
-// is fed (0,0), so screen-right ∝ d·EY and screen-up ∝ d·EZ. With
-// heads-up roll the world East must read screen-right, West left,
-// North up, and the nose (radial-out) sits at the disc centre — the
-// behaviour the player asked for, now singularity-free.
-func TestNavballSurfaceEastIsScreenRight(t *testing.T) {
-	w, err := NewWorld()
-	if err != nil {
-		t.Fatalf("NewWorld: %v", err)
-	}
-	w.NavMode = NavSurface
-	c, err := w.SpawnCraft(SpawnSpec{
-		LoadoutID: spacecraft.LoadoutSaturnVID, ParentBodyID: "earth",
-		Launchpad: true, Latitude: 28.6083, LongitudeOffset: -80.604,
-	})
-	if err != nil {
-		t.Fatalf("SpawnCraft: %v", err)
-	}
-	basis, ok := w.NavballBasis()
-	if !ok {
-		t.Fatal("NavballBasis: ok=false on the pad")
-	}
-	if sl, so, sok := w.NavballSubObserver(); !sok || math.Abs(sl) > 1e-9 || math.Abs(so) > 1e-9 {
-		t.Fatalf("body-frame sub-observer = (%g,%g,%v), want (0,0,true)", sl, so, sok)
-	}
-
-	// Body-frame navball fed (0,0): screen-right = d·EY, up = d·EZ.
-	screen := func(dir orbital.Vec3) (right, up float64) {
-		return dir.Dot(basis.EY), dir.Dot(basis.EZ)
-	}
-
-	upv := c.State.R.Scale(1 / c.State.R.Norm()) // radial-out = nose
-	spinR := render.BodyRotationAxisWorld(c.Primary)
-	spinAxis := orbital.Vec3{X: spinR.X, Y: spinR.Y, Z: spinR.Z}
-	east := spinAxis.Cross(upv)
-	east = east.Scale(1 / east.Norm())
-
-	if r, u := screen(east); r <= 0 || math.Abs(u) > 1e-6 {
-		t.Errorf("East should be screen-right; got right=%.3f up=%.3f", r, u)
-	}
-	if r, _ := screen(east.Scale(-1)); r >= 0 {
-		t.Errorf("West should be screen-left; got right=%.3f", r)
-	}
-	if r, u := screen(basis.EX); math.Abs(r) > 1e-6 || math.Abs(u) > 1e-6 {
-		t.Errorf("nose should be the disc centre; got right=%.3f up=%.3f", r, u)
-	}
-
-	// Roll 90° must rotate the ball: East moves off screen-right.
-	c.CommandedRollDeg = 90
-	c.CurrentRollDeg = 90
-	rb, _ := w.NavballBasis()
-	if r := east.Dot(rb.EY); r > 0.2 {
-		t.Errorf("after 90° roll East should leave screen-right; got right=%.3f", r)
 	}
 }
 

--- a/internal/sim/slew_world_test.go
+++ b/internal/sim/slew_world_test.go
@@ -245,50 +245,6 @@ func TestLeadCompNodeAlignedAtT0(t *testing.T) {
 	}
 }
 
-// Roll is rate-limited under slew (default) and snapped under
-// InstantSAS — same SlewRate budget as pitch/yaw.
-func TestRollSlewsThenSnapsUnderInstant(t *testing.T) {
-	w, _ := NewWorld()
-	c := w.Crafts[0]
-	c.SlewRateDegPerSec = 10
-	c.CommandedRollDeg = 90
-
-	// One short integrate: must move toward 90 but NOT reach it.
-	w.integrateOneCraft(c, 1*time.Second) // 10°/s × 1 s = 10°
-	if c.CurrentRollDeg <= 0 || c.CurrentRollDeg >= 90 {
-		t.Fatalf("roll should be slewing (0 < r < 90); got %.3f", c.CurrentRollDeg)
-	}
-	if math.Abs(c.CurrentRollDeg-10) > 1e-6 {
-		t.Errorf("expected ~10° after 1 s at 10°/s; got %.3f", c.CurrentRollDeg)
-	}
-
-	// InstantSAS: snap to command.
-	w.InstantSAS = true
-	w.integrateOneCraft(c, 1*time.Second)
-	if math.Abs(c.CurrentRollDeg-90) > 1e-9 {
-		t.Errorf("InstantSAS should snap roll to 90; got %.3f", c.CurrentRollDeg)
-	}
-}
-
-// A landed craft keeps CurrentRollDeg synced to the command (no
-// rolling on the pad; liftoff starts at the intended roll).
-func TestLandedSnapsRoll(t *testing.T) {
-	w, _ := NewWorld()
-	c, err := w.SpawnCraft(SpawnSpec{
-		LoadoutID: spacecraft.LoadoutSaturnVID, ParentBodyID: "earth", Launchpad: true,
-	})
-	if err != nil {
-		t.Fatalf("SpawnCraft: %v", err)
-	}
-	c.CommandedRollDeg = 45
-	c.CurrentRollDeg = 0
-	w.Clock.SimTime = w.Clock.SimTime.Add(time.Hour)
-	w.Tick() // Landed bypass
-	if math.Abs(c.CurrentRollDeg-45) > 1e-9 {
-		t.Errorf("landed craft should snap roll to command 45; got %.3f", c.CurrentRollDeg)
-	}
-}
-
 // InstantSAS opt-out must skip the slew integrator entirely (legacy
 // behaviour: CurrentAttitudeDir untouched by the integrator).
 func TestInstantSASSkipsSlew(t *testing.T) {

--- a/internal/sim/slew_world_test.go
+++ b/internal/sim/slew_world_test.go
@@ -245,6 +245,50 @@ func TestLeadCompNodeAlignedAtT0(t *testing.T) {
 	}
 }
 
+// Roll is rate-limited under slew (default) and snapped under
+// InstantSAS — same SlewRate budget as pitch/yaw.
+func TestRollSlewsThenSnapsUnderInstant(t *testing.T) {
+	w, _ := NewWorld()
+	c := w.Crafts[0]
+	c.SlewRateDegPerSec = 10
+	c.CommandedRollDeg = 90
+
+	// One short integrate: must move toward 90 but NOT reach it.
+	w.integrateOneCraft(c, 1*time.Second) // 10°/s × 1 s = 10°
+	if c.CurrentRollDeg <= 0 || c.CurrentRollDeg >= 90 {
+		t.Fatalf("roll should be slewing (0 < r < 90); got %.3f", c.CurrentRollDeg)
+	}
+	if math.Abs(c.CurrentRollDeg-10) > 1e-6 {
+		t.Errorf("expected ~10° after 1 s at 10°/s; got %.3f", c.CurrentRollDeg)
+	}
+
+	// InstantSAS: snap to command.
+	w.InstantSAS = true
+	w.integrateOneCraft(c, 1*time.Second)
+	if math.Abs(c.CurrentRollDeg-90) > 1e-9 {
+		t.Errorf("InstantSAS should snap roll to 90; got %.3f", c.CurrentRollDeg)
+	}
+}
+
+// A landed craft keeps CurrentRollDeg synced to the command (no
+// rolling on the pad; liftoff starts at the intended roll).
+func TestLandedSnapsRoll(t *testing.T) {
+	w, _ := NewWorld()
+	c, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID: spacecraft.LoadoutSaturnVID, ParentBodyID: "earth", Launchpad: true,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	c.CommandedRollDeg = 45
+	c.CurrentRollDeg = 0
+	w.Clock.SimTime = w.Clock.SimTime.Add(time.Hour)
+	w.Tick() // Landed bypass
+	if math.Abs(c.CurrentRollDeg-45) > 1e-9 {
+		t.Errorf("landed craft should snap roll to command 45; got %.3f", c.CurrentRollDeg)
+	}
+}
+
 // InstantSAS opt-out must skip the slew integrator entirely (legacy
 // behaviour: CurrentAttitudeDir untouched by the integrator).
 func TestInstantSASSkipsSlew(t *testing.T) {

--- a/internal/sim/slew_world_test.go
+++ b/internal/sim/slew_world_test.go
@@ -179,8 +179,8 @@ func TestInstantSASIgnoresCurrentAttitudeDir(t *testing.T) {
 // auto-orient BEFORE BurnStart so it is aligned at ignition and the
 // planted node delivers its full Δv (no cosine loss) — i.e. the slew
 // outcome matches the legacy instant path. A 180° flip (prograde →
-// retrograde node) at the 5°/s default needs 36 s; the lead window
-// (1.25·36 ≈ 45 s) opens well before BurnStart.
+// retrograde node) at the 15°/s default needs 12 s; the lead window
+// (1.25·12 ≈ 15 s) opens well before BurnStart.
 func TestLeadCompNodeAlignedAtT0(t *testing.T) {
 	mk := func(instant bool) *World {
 		w, _ := NewWorld()

--- a/internal/sim/slew_world_test.go
+++ b/internal/sim/slew_world_test.go
@@ -1,0 +1,264 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+func slewAngle(a, b orbital.Vec3) float64 {
+	c := a.Unit().Dot(b.Unit())
+	if c > 1 {
+		c = 1
+	} else if c < -1 {
+		c = -1
+	}
+	return math.Acos(c)
+}
+
+// Slew must integrate the same total attitude per total sim-time
+// regardless of how that sim-time is delivered (one big tick vs many
+// small ticks) — the warp-invariance guarantee. Uses BurnNormalPlus on
+// the default equatorial circular orbit, whose orbit normal is an
+// inertially-fixed commanded direction, so the only variable is
+// elapsed sim-time.
+func TestSlewWarpInvariant(t *testing.T) {
+	mkCraft := func() (*World, *spacecraft.Spacecraft) {
+		w, err := NewWorld()
+		if err != nil {
+			t.Fatalf("NewWorld: %v", err)
+		}
+		c := w.Crafts[0]
+		c.AttitudeMode = spacecraft.BurnNormalPlus
+		c.SlewRateDegPerSec = 2                 // 2°/s → 20° over 10 s (won't converge)
+		c.CurrentAttitudeDir = c.State.V.Unit() // ⟂ orbit normal: 90° off
+		return w, c
+	}
+
+	wA, cA := mkCraft()
+	wA.integrateOneCraft(cA, 10*time.Second)
+
+	wB, cB := mkCraft()
+	for i := 0; i < 10; i++ {
+		wB.integrateOneCraft(cB, 1*time.Second)
+	}
+
+	if d := slewAngle(cA.CurrentAttitudeDir, cB.CurrentAttitudeDir); d > 1e-6 {
+		t.Errorf("warp-variant slew: 1×10s vs 10×1s differ by %.3e rad\n  A=%+v\n  B=%+v",
+			d, cA.CurrentAttitudeDir, cB.CurrentAttitudeDir)
+	}
+	// Sanity: it actually slewed but did NOT converge (still rate-limited).
+	moved := math.Pi/2 - slewAngle(cA.CurrentAttitudeDir, normalOf(cA))
+	if moved < 0.30 || moved > 0.40 { // ~20° ≈ 0.349 rad
+		t.Errorf("expected ~0.349 rad of slew over 10 s, got %.4f", moved)
+	}
+}
+
+func normalOf(c *spacecraft.Spacecraft) orbital.Vec3 {
+	return c.State.R.Cross(c.State.V).Unit()
+}
+
+// The slew integrator must run BEFORE the Kepler fast-path gate: a
+// coasting craft at warp>1 takes the analytic early-return, so a slew
+// integrator placed after the sub-step loop would never run and the
+// nose would freeze mid-slew. This locks the placement.
+func TestSlewRunsDuringKeplerCoast(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.Crafts[0]
+	w.Clock.WarpIdx = 2 // 100× → Warp() > 1, no burn ⇒ canKeplerStep true
+
+	if !w.canKeplerStep(c, 10*time.Second) {
+		t.Fatal("precondition failed: expected canKeplerStep true (coasting, warp>1)")
+	}
+
+	c.AttitudeMode = spacecraft.BurnNormalPlus
+	c.SlewRateDegPerSec = 2
+	c.CurrentAttitudeDir = c.State.V.Unit() // 90° off the orbit normal
+	before := slewAngle(c.CurrentAttitudeDir, normalOf(c))
+
+	w.integrateOneCraft(c, 10*time.Second) // takes the Kepler early-return
+
+	after := slewAngle(c.CurrentAttitudeDir, normalOf(c))
+	if after >= before-1e-6 {
+		t.Fatalf("slew did not run on the Kepler coast path: angle %.4f -> %.4f", before, after)
+	}
+	if after < 1e-6 {
+		t.Fatalf("slew snapped (not rate-limited) on coast path: angle %.4f", after)
+	}
+	// ~20° of progress (2°/s × 10 s), not a snap.
+	if d := (before - after) - 0.349; math.Abs(d) > 0.02 {
+		t.Errorf("coast slew progress %.4f rad, want ≈0.349 (20°)", before-after)
+	}
+}
+
+// thrustDV isolates the thrust contribution over one integrate by
+// subtracting a gravity-only baseline run of an identical craft.
+func thrustDV(t *testing.T, dir orbital.Vec3, instant bool, dt time.Duration) orbital.Vec3 {
+	t.Helper()
+	// Burning craft.
+	wB, _ := NewWorld()
+	cB := wB.Crafts[0]
+	wB.InstantSAS = instant
+	cB.AttitudeMode = spacecraft.BurnPrograde
+	cB.SlewRateDegPerSec = 1e-9 // freeze: nose stays put for the tick
+	cB.CurrentAttitudeDir = dir.Unit()
+	v0 := cB.State.V
+	wB.StartManualBurn()
+	wB.integrateOneCraft(cB, dt)
+	dvBurn := cB.State.V.Sub(v0)
+
+	// Gravity-only baseline (no burn), identical start.
+	wG, _ := NewWorld()
+	cG := wG.Crafts[0]
+	vg0 := cG.State.V
+	wG.integrateOneCraft(cG, dt)
+	dvGrav := cG.State.V.Sub(vg0)
+
+	return dvBurn.Sub(dvGrav)
+}
+
+// Default (slew) thrust must follow the craft's physical nose
+// (CurrentAttitudeDir), not the commanded BurnMode — set the nose
+// orthogonal to prograde and confirm Δv goes along the nose.
+func TestBurnThrustsAlongCurrentAttitudeDir(t *testing.T) {
+	w, _ := NewWorld()
+	c := w.Crafts[0]
+	nose := c.State.R.Cross(c.State.V).Unit() // orbit normal ⟂ prograde
+
+	dv := thrustDV(t, nose, false, 1*time.Second)
+	if dv.Norm() < 1.0 {
+		t.Fatalf("no measurable thrust Δv: %+v", dv)
+	}
+	if a := slewAngle(dv, nose); a > 0.02 { // ≈1°
+		t.Errorf("thrust Δv not along nose: %.4f rad off (dv=%+v nose=%+v)", a, dv, nose)
+	}
+}
+
+// Burning while the nose lags the commanded direction bleeds Δv to
+// cosine loss: along-commanded component scales as cos(lag).
+func TestCosineLossWhenNoseLags(t *testing.T) {
+	w, _ := NewWorld()
+	c := w.Crafts[0]
+	pro := c.State.V.Unit()
+	nrm := c.State.R.Cross(c.State.V).Unit()
+	// 60° off prograde, in the prograde–normal plane.
+	lag := orbital.Rotate(pro, nrm, 60*math.Pi/180)
+
+	aligned := thrustDV(t, pro, false, 1*time.Second).Dot(pro)
+	lagged := thrustDV(t, lag, false, 1*time.Second).Dot(pro)
+
+	want := aligned * math.Cos(60*math.Pi/180) // ≈ 0.5 × aligned
+	if math.Abs(lagged-want) > 0.02*aligned {
+		t.Errorf("cosine loss off: lagged along-prograde=%.3f, want ≈%.3f (aligned=%.3f)",
+			lagged, want, aligned)
+	}
+}
+
+// InstantSAS must ignore CurrentAttitudeDir and thrust along the
+// commanded mode (legacy behaviour) even when the nose points
+// elsewhere.
+func TestInstantSASIgnoresCurrentAttitudeDir(t *testing.T) {
+	w, _ := NewWorld()
+	c := w.Crafts[0]
+	pro := c.State.V.Unit()
+	nrm := c.State.R.Cross(c.State.V).Unit() // bogus nose ⟂ prograde
+
+	dv := thrustDV(t, nrm, true /*InstantSAS*/, 1*time.Second)
+	if a := slewAngle(dv, pro); a > 0.02 {
+		t.Errorf("InstantSAS thrust not along commanded prograde: %.4f rad off", a)
+	}
+}
+
+// Lead-compensated node firing: with rate-limited slew the craft must
+// auto-orient BEFORE BurnStart so it is aligned at ignition and the
+// planted node delivers its full Δv (no cosine loss) — i.e. the slew
+// outcome matches the legacy instant path. A 180° flip (prograde →
+// retrograde node) at the 5°/s default needs 36 s; the lead window
+// (1.25·36 ≈ 45 s) opens well before BurnStart.
+func TestLeadCompNodeAlignedAtT0(t *testing.T) {
+	mk := func(instant bool) *World {
+		w, _ := NewWorld()
+		w.InstantSAS = instant
+		c := w.Crafts[0]
+		c.CurrentAttitudeDir = c.State.V.Unit() // start prograde (180° off retro)
+		now := w.Clock.SimTime
+		w.PlanNode(ManeuverNode{
+			TriggerTime: now.Add(200 * time.Second),
+			Mode:        spacecraft.BurnRetrograde,
+			DV:          30,
+			Duration:    20 * time.Second,
+			PrimaryID:   c.Primary.ID,
+		})
+		w.Clock.WarpIdx = 2 // 100× → ~5 s/tick
+		return w
+	}
+
+	wSlew := mk(false)
+	wInst := mk(true)
+
+	var atFireAngle = math.Pi // sentinel
+	firedSlew := false
+	for i := 0; i < 400; i++ {
+		// Capture the slew craft's nose-vs-retrograde angle on the
+		// tick the burn first becomes active (ignition).
+		cs := wSlew.Crafts[0]
+		preActive := cs.ActiveBurn != nil
+		wSlew.Tick()
+		wInst.Tick()
+		if !preActive && cs.ActiveBurn != nil && !firedSlew {
+			retro := cs.State.V.Unit().Scale(-1)
+			atFireAngle = slewAngle(cs.CurrentAttitudeDir, retro)
+			firedSlew = true
+		}
+		if wSlew.Crafts[0].Nodes == nil && wInst.Crafts[0].Nodes == nil &&
+			wSlew.Crafts[0].ActiveBurn == nil && wInst.Crafts[0].ActiveBurn == nil &&
+			firedSlew && i > 20 {
+			break
+		}
+	}
+
+	if !firedSlew {
+		t.Fatal("node never fired within tick budget")
+	}
+	if atFireAngle > 6*math.Pi/180 { // converged within ~6° at ignition
+		t.Errorf("not lead-aligned at ignition: %.2f° off retrograde",
+			atFireAngle*180/math.Pi)
+	}
+
+	// Δv preserved: the slew outcome must match the legacy instant
+	// (perfectly-aligned) burn. Compare specific orbital energy.
+	en := func(w *World) float64 {
+		c := w.Crafts[0]
+		mu := c.Primary.GravitationalParameter()
+		return c.State.V.Norm()*c.State.V.Norm()/2 - mu/c.State.R.Norm()
+	}
+	eS, eI := en(wSlew), en(wInst)
+	if rel := math.Abs(eS-eI) / math.Abs(eI); rel > 2e-3 {
+		t.Errorf("lead-comp Δv not preserved vs instant baseline: "+
+			"energy rel diff %.2e (slew=%.1f instant=%.1f)", rel, eS, eI)
+	}
+}
+
+// InstantSAS opt-out must skip the slew integrator entirely (legacy
+// behaviour: CurrentAttitudeDir untouched by the integrator).
+func TestInstantSASSkipsSlew(t *testing.T) {
+	w, _ := NewWorld()
+	c := w.Crafts[0]
+	w.InstantSAS = true
+	c.AttitudeMode = spacecraft.BurnNormalPlus
+	c.SlewRateDegPerSec = 2
+	start := c.State.V.Unit()
+	c.CurrentAttitudeDir = start
+
+	w.integrateOneCraft(c, 10*time.Second)
+
+	if d := c.CurrentAttitudeDir.Sub(start).Norm(); d > 1e-12 {
+		t.Errorf("InstantSAS still slewed CurrentAttitudeDir (Δ=%.3e)", d)
+	}
+}

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -62,16 +62,16 @@ func surfaceSpawnPosVel(
 
 // SpawnSpec describes a craft to spawn. v0.8.2 ships these axes:
 //   - LoadoutID:    propulsion archetype. Empty → round-robin via
-//                   nextLoadoutID().
+//     nextLoadoutID().
 //   - ParentBodyID: which body to orbit. Empty → active craft's
-//                   current primary.
+//     current primary.
 //   - AltitudeM:    altitude above the parent's mean radius (m).
-//                   Zero → 500 km default.
+//     Zero → 500 km default.
 //   - Retrograde:   spawn going retrograde rather than prograde.
 //   - Alongside:    spawn within the docking gate of the active
-//                   craft, matching its velocity. Overrides
-//                   ParentBodyID + AltitudeM + Retrograde.
-//                   (v0.8.3+ — for docking testing.)
+//     craft, matching its velocity. Overrides
+//     ParentBodyID + AltitudeM + Retrograde.
+//     (v0.8.3+ — for docking testing.)
 //
 // Future patches may add inclination, a phase-angle offset, etc.
 type SpawnSpec struct {
@@ -157,6 +157,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		w.Crafts = append(w.Crafts, c)
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
+		w.initCraftAttitude(c)
 		return c, nil
 	}
 
@@ -224,6 +225,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		if w.NavMode == NavOrbit {
 			w.NavMode = NavSurface
 		}
+		w.initCraftAttitude(c)
 		return c, nil
 	}
 
@@ -258,6 +260,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 	w.Crafts = append(w.Crafts, c)
 	w.SetActiveCraftIdx(len(w.Crafts) - 1)
 	w.StopManualBurn()
+	w.initCraftAttitude(c)
 	return c, nil
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -743,6 +743,9 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	// stepThrust / the navball read commanded directly in that mode).
 	if !w.InstantSAS {
 		c.SlewToward(w.slewTargetFor(c), secs)
+		c.RollToward(secs)
+	} else {
+		c.CurrentRollDeg = c.CommandedRollDeg // instant: snap roll too
 	}
 
 	// Warp-lock fast path: analytic Kepler propagation in chunks small

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -743,9 +743,6 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	// stepThrust / the navball read commanded directly in that mode).
 	if !w.InstantSAS {
 		c.SlewToward(w.slewTargetFor(c), secs)
-		c.RollToward(secs)
-	} else {
-		c.CurrentRollDeg = c.CommandedRollDeg // instant: snap roll too
 	}
 
 	// Warp-lock fast path: analytic Kepler propagation in chunks small

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -63,13 +63,23 @@ type World struct {
 	// to save (UI preference, not game state).
 	ViewMode ViewMode
 
+	// InstantSAS opts back into the legacy instantaneous-attitude
+	// path. v0.10.0+ makes rate-limited slew the DEFAULT (zero value
+	// = false = slew on); toggling this true restores the pre-v0.10
+	// "magic SAS" snap (the byte-identical regression baseline). Like
+	// ViewMode it is a per-session UI preference — NOT persisted; a
+	// reload returns to the slew default. Surfaced as a new hot-key +
+	// navball [MODE] MANUAL/AUTO tag (binding is the app/render
+	// slice's call).
+	InstantSAS bool
+
 	// rcsPuffs is a small ring of recent RCS pulses, surfaced by the
 	// orbit canvas as a fading marker for visual feedback. v0.8.0
 	// ships a placeholder visual; v0.8.2 replaces it with per-thruster
 	// glyphs once craft visual differentiation lands.
-	rcsPuffs    [rcsPuffCap]rcsPuff
-	rcsPuffIdx  int
-	rcsPuffLen  int
+	rcsPuffs   [rcsPuffCap]rcsPuff
+	rcsPuffIdx int
+	rcsPuffLen int
 
 	// Missions are pass/fail objectives evaluated against World state
 	// each Tick. Seeded from the embedded starter catalog at NewWorld
@@ -393,9 +403,9 @@ func (w *World) Tick() {
 		// stashed on World.LastDockEvent for the HUD flash.
 		if a, b, ok := w.checkDocking(); ok {
 			w.LastDockEvent = &DockEvent{
-				When:    w.Clock.SimTime,
-				CraftIdx: a,
-				PartnerIdx: b,
+				When:          w.Clock.SimTime,
+				CraftIdx:      a,
+				PartnerIdx:    b,
 				CompositeName: w.ActiveCraft().Name,
 			}
 		}
@@ -405,10 +415,10 @@ func (w *World) Tick() {
 
 // DockEvent records the latest fuse for HUD-side messaging. v0.8.3+.
 type DockEvent struct {
-	When           time.Time
-	CraftIdx       int    // active partner's index (becomes the composite slot)
-	PartnerIdx     int    // index of the partner that was removed
-	CompositeName  string // name of the resulting composite craft
+	When          time.Time
+	CraftIdx      int    // active partner's index (becomes the composite slot)
+	PartnerIdx    int    // index of the partner that was removed
+	CompositeName string // name of the resulting composite craft
 }
 
 // evaluateMissions steps each mission's predicate against the live
@@ -721,6 +731,20 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	period := orbitalPeriod(c.State, mu)
 	secs := simDelta.Seconds()
 
+	// v0.10.0: rate-limited attitude. Slew the physical nose toward
+	// the commanded direction once per tick, BEFORE the Kepler
+	// fast-path gate below — otherwise a coasting craft (the common
+	// warp case, which early-returns at the gate) would never
+	// converge and the navball would freeze mid-slew. dt is the
+	// whole-tick warp-scaled sim seconds (constant angular velocity
+	// in sim-time; collapses to ~instant at very high warp — accepted).
+	// Landed craft are already out (they co-rotate; nose is cosmetic).
+	// InstantSAS opts back into the legacy snap (the consumers in
+	// stepThrust / the navball read commanded directly in that mode).
+	if !w.InstantSAS {
+		c.SlewToward(w.slewTargetFor(c), secs)
+	}
+
 	// Warp-lock fast path: analytic Kepler propagation in chunks small
 	// enough that the craft can't outrun any other body's SOI per
 	// chunk. Falls back to Verlet sub-stepping if the gate rejects
@@ -837,26 +861,28 @@ func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt fl
 // v0.7.6+: planted burns honour their per-node throttle rather than
 // the live craft setting, so the player can tweak the throttle knob
 // during a coast without slowing an in-flight planted burn.
-func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
-	mode := c.AttitudeMode
-	throttle := c.EffectiveThrottle()
+// ToggleInstantSAS flips the legacy instant-attitude opt-out. Default
+// (false) is rate-limited slew (v0.10.0+); true restores the pre-v0.10
+// instant snap. Session UI preference — not persisted (see the
+// InstantSAS field doc).
+func (w *World) ToggleInstantSAS() { w.InstantSAS = !w.InstantSAS }
+
+// attitudeContext resolves the burn mode and target snapshot the
+// craft's attitude is driven by this tick. Extracted from stepThrust
+// (v0.10.0) so the slew integrator, the thrust closure, and the
+// navball sub-observer all agree on the *commanded* direction.
+//
+//   - mode: ActiveBurn.Mode (planted finite burn, fixed at fire) when
+//     a burn is in flight, else the live c.AttitudeMode (SAS hold).
+//   - (rT, vT): for ActiveBurn the target bound at plant time
+//     (survives a mid-burn target switch); otherwise the live
+//     World.Target snapshot so a manual hold can retarget. Non-target
+//     modes ignore it. v0.9.3+ logic, unchanged — just relocated.
+func (w *World) attitudeContext(c *spacecraft.Spacecraft) (mode spacecraft.BurnMode, rT, vT orbital.Vec3) {
+	mode = c.AttitudeMode
 	if c.ActiveBurn != nil {
 		mode = c.ActiveBurn.Mode
-		throttle = c.ActiveBurn.Throttle
-		if throttle <= 0 {
-			// Defensive fallback: legacy v3-save ActiveBurn with no
-			// captured throttle (loaded with zero) → treat as full
-			// open, matching the pre-v0.7.6 universal behaviour.
-			throttle = 1.0
-		}
 	}
-	// v0.9.3+: resolve target snapshot for target-relative thrust.
-	// For ActiveBurn (planted finite burn), the target was bound at
-	// plant time via ActiveBurn.TargetCraftIdx — survives a player
-	// target switch mid-burn. For ManualBurn (live SAS hold), the
-	// snapshot follows the current World.Target so the player can
-	// retarget mid-hold. Non-target modes ignore (rT, vT).
-	var rT, vT orbital.Vec3
 	if c.ActiveBurn != nil && c.ActiveBurn.TargetCraftIdx != 0 {
 		if tIdx, ok := c.ActiveBurn.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
 			if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
@@ -866,7 +892,64 @@ func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
 	} else {
 		rT, vT, _ = w.TargetStateRelativeToActivePrimary()
 	}
-	thrustFn := c.ThrustAccelFnAtWithTarget(mode, mu, throttle, rT, vT)
+	return mode, rT, vT
+}
+
+// commandedDirFor is the world-unit nose direction the craft's
+// attitude is *commanded* toward this tick (recomputed from mode +
+// live state). The slew integrator chases it; with InstantSAS the
+// craft is pinned to it. v0.10.0+.
+func (w *World) commandedDirFor(c *spacecraft.Spacecraft) orbital.Vec3 {
+	mode, rT, vT := w.attitudeContext(c)
+	return c.BurnDirectionWithTarget(mode, rT, vT)
+}
+
+// slewTargetFor is the direction the slew integrator chases this tick.
+// Normally the live commanded direction; Step 6 (lead-compensated
+// nodes) overrides it with an upcoming node's ignition direction so
+// the craft is converged at BurnStart. v0.10.0+.
+// initCraftAttitude seeds a freshly-spawned craft's physical nose with
+// its commanded direction so the navball is correct on the first frame
+// (before any Tick runs the slew integrator). The integrator's
+// zero-init snap guard already covers correctness — this is HUD
+// polish. No-op if already set (defensive). v0.10.0+.
+func (w *World) initCraftAttitude(c *spacecraft.Spacecraft) {
+	if c == nil || c.CurrentAttitudeDir.Norm() != 0 {
+		return
+	}
+	c.CurrentAttitudeDir = w.commandedDirFor(c)
+}
+
+func (w *World) slewTargetFor(c *spacecraft.Spacecraft) orbital.Vec3 {
+	if dir, ok := w.nodeLeadActive(c); ok {
+		return dir
+	}
+	return w.commandedDirFor(c)
+}
+
+func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
+	mode, rT, vT := w.attitudeContext(c)
+	throttle := c.EffectiveThrottle()
+	if c.ActiveBurn != nil {
+		throttle = c.ActiveBurn.Throttle
+		if throttle <= 0 {
+			// Defensive fallback: legacy v3-save ActiveBurn with no
+			// captured throttle (loaded with zero) → treat as full
+			// open, matching the pre-v0.7.6 universal behaviour.
+			throttle = 1.0
+		}
+	}
+	// v0.10.0: by default thrust along the craft's physical nose
+	// (CurrentAttitudeDir, slewed at the tick top) so burning before
+	// alignment bleeds Δv to cosine loss. InstantSAS restores the
+	// legacy per-k-step recompute from the commanded mode (byte-
+	// identical to pre-v0.10).
+	var thrustFn func(r, v orbital.Vec3, t float64) orbital.Vec3
+	if w.InstantSAS {
+		thrustFn = c.ThrustAccelFnAtWithTarget(mode, mu, throttle, rT, vT)
+	} else {
+		thrustFn = c.ThrustAccelFnFixedDir(c.CurrentAttitudeDir, mu, throttle)
+	}
 	bc := c.EffectiveBallisticCoefficient()
 	primary := c.Primary
 	// v0.8.4: drag adds to thrust + gravity inside the RK4 closure so

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -53,10 +53,11 @@ type Loadout struct {
 
 // DefaultSlewRateDegPerSec is the attitude slew-rate cap applied to
 // any loadout that does not override it (Loadout.SlewRateDegPerSec
-// == 0) and to legacy/test craft built without a loadout. 5°/s ≈ 36 s
-// for a 180° flip — deliberate, SAS-like; makes cosine loss a real
-// consequence the player times burns around. v0.10.0+.
-const DefaultSlewRateDegPerSec = 5.0
+// == 0) and to legacy/test craft built without a loadout. 15°/s ≈ 12 s
+// for a 180° flip — visible and deliberate, but snappy enough not to
+// be tedious (raised from 5°/s after v0.10.0 playtest). Cosine loss
+// is still a real consequence the player times burns around. v0.10.0+.
+const DefaultSlewRateDegPerSec = 15.0
 
 // DryMass returns the bottom stage's dry mass (single-stage
 // equivalent for pre-v0.9.1 readers; sum-across-stages is via

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -42,7 +42,21 @@ type Loadout struct {
 	// (must be non-empty); a one-element Stages declares a
 	// single-stage craft.
 	Stages []Stage
+	// SlewRateDegPerSec (v0.10.0+) is the per-loadout attitude
+	// angular-rate cap (deg/s, sim-time). Zero => the global
+	// DefaultSlewRateDegPerSec. Loadout-level (not per-stage):
+	// staging does not change the slew rate this cycle (attitude
+	// dynamics are deferred). All catalog literals leave this unset
+	// in v0.10.0; per-vehicle tuning is a follow-up dial.
+	SlewRateDegPerSec float64
 }
+
+// DefaultSlewRateDegPerSec is the attitude slew-rate cap applied to
+// any loadout that does not override it (Loadout.SlewRateDegPerSec
+// == 0) and to legacy/test craft built without a loadout. 5°/s ≈ 36 s
+// for a 180° flip — deliberate, SAS-like; makes cosine loss a real
+// consequence the player times burns around. v0.10.0+.
+const DefaultSlewRateDegPerSec = 5.0
 
 // DryMass returns the bottom stage's dry mass (single-stage
 // equivalent for pre-v0.9.1 readers; sum-across-stages is via
@@ -341,6 +355,7 @@ func NewFromLoadout(loadoutID string) *Spacecraft {
 		Throttle:             1.0,
 		BallisticCoefficient: DefaultBallisticCoefficient,
 		Stages:               stages,
+		SlewRateDegPerSec:    l.SlewRateDegPerSec,
 	}
 	c.SyncFields()
 	return c

--- a/internal/spacecraft/slew.go
+++ b/internal/spacecraft/slew.go
@@ -1,0 +1,82 @@
+package spacecraft
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// slewAngleEps is the angular tolerance (radians) below which the nose
+// is considered already aligned — snap to the commanded direction
+// rather than emit a sub-nanoradian residual.
+const slewAngleEps = 1e-9
+
+// SlewRateRad returns the craft's attitude slew-rate cap in rad/s,
+// falling back to DefaultSlewRateDegPerSec when the per-craft value is
+// unset (zero). This is why legacy saves and bare Spacecraft{} test
+// fixtures get a sane rate without a persisted field — the rate is a
+// loadout/catalog property, re-applied on construction.
+func (s *Spacecraft) SlewRateRad() float64 {
+	deg := s.SlewRateDegPerSec
+	if deg <= 0 {
+		deg = DefaultSlewRateDegPerSec
+	}
+	return deg * math.Pi / 180
+}
+
+// SlewToward rotates CurrentAttitudeDir toward the commanded unit
+// direction by at most SlewRate·dt radians, about their mutual
+// perpendicular. dt is the warp-scaled sim-time elapsed this tick
+// (constant angular velocity in sim-time — at very high warp dt is
+// large enough that the slew completes in one tick, which is the
+// accepted "effectively instant at high warp" behaviour).
+//
+// Guards:
+//   - commanded ≈ 0 (undefined direction, e.g. pre-launch surface
+//     mode): no-op, hold the current nose.
+//   - CurrentAttitudeDir ≈ 0 (uninitialized: fresh spawn, legacy
+//     save, never-ticked test craft): SNAP to commanded. This is the
+//     load-bearing init guard — it prevents slewing from a garbage
+//     vector and prevents a nose teleport on a pre-v0.10.0 reload.
+//   - already within slewAngleEps, or the cap covers the whole
+//     angle: snap exactly to commanded (clean convergence, no
+//     residual jitter).
+//   - antiparallel (180°, degenerate cross product): pick an
+//     arbitrary unit perpendicular so the rotation axis is defined.
+//
+// v0.10.0+.
+func (s *Spacecraft) SlewToward(commanded orbital.Vec3, dt float64) {
+	cmd := commanded.Unit()
+	if cmd == (orbital.Vec3{}) {
+		return // undefined commanded direction — hold attitude
+	}
+	cur := s.CurrentAttitudeDir.Unit()
+	if cur == (orbital.Vec3{}) {
+		s.CurrentAttitudeDir = cmd // init snap
+		return
+	}
+
+	cosA := cur.Dot(cmd)
+	if cosA > 1 {
+		cosA = 1
+	} else if cosA < -1 {
+		cosA = -1
+	}
+	ang := math.Acos(cosA)
+	maxStep := s.SlewRateRad() * dt
+	if ang <= slewAngleEps || ang <= maxStep {
+		s.CurrentAttitudeDir = cmd // converged this tick
+		return
+	}
+
+	axis := cur.Cross(cmd)
+	if axis.Norm() == 0 {
+		// Antiparallel: any perpendicular to cur works. Try cur×Z;
+		// if cur ∥ Z, fall back to cur×X.
+		axis = cur.Cross(orbital.Vec3{Z: 1})
+		if axis.Norm() == 0 {
+			axis = cur.Cross(orbital.Vec3{X: 1})
+		}
+	}
+	s.CurrentAttitudeDir = orbital.Rotate(cur, axis.Unit(), maxStep).Unit()
+}

--- a/internal/spacecraft/slew.go
+++ b/internal/spacecraft/slew.go
@@ -4,13 +4,7 @@ import (
 	"math"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
-	"github.com/jasonfen/terminal-space-program/internal/render"
 )
-
-// RollStepDeg is the per-keypress commanded-roll adjustment (degrees)
-// for the roll-left / roll-right keys. 15° matches the default slew
-// rate's one-second budget so a tap visibly banks. v0.10.0+.
-const RollStepDeg = 15.0
 
 // slewAngleEps is the angular tolerance (radians) below which the nose
 // is considered already aligned — snap to the commanded direction
@@ -85,92 +79,4 @@ func (s *Spacecraft) SlewToward(commanded orbital.Vec3, dt float64) {
 		}
 	}
 	s.CurrentAttitudeDir = orbital.Rotate(cur, axis.Unit(), maxStep).Unit()
-}
-
-// headsUpReference returns the roll-zero "up" reference: the body's
-// dorsal axis points as close to local vertical (radial-out, away
-// from the primary) as the nose allows — i.e. heads-up / belly-down.
-// When the nose is (anti)parallel to radial (pointing straight up on
-// the pad), that projection collapses, so we fall back through the
-// primary spin axis (≈ north), then world +Z, then +X. Returns a
-// unit vector perpendicular to nose, or zero if nose is itself zero.
-func (s *Spacecraft) headsUpReference(nose orbital.Vec3) orbital.Vec3 {
-	axisR := render.BodyRotationAxisWorld(s.Primary)
-	candidates := []orbital.Vec3{
-		s.State.R,                            // radial-out (local vertical)
-		{X: axisR.X, Y: axisR.Y, Z: axisR.Z}, // spin axis ≈ north
-		{Z: 1},
-		{X: 1},
-	}
-	for _, c := range candidates {
-		perp := c.Sub(nose.Scale(nose.Dot(c)))
-		if perp.Norm() > 1e-9 {
-			return perp.Unit()
-		}
-	}
-	return orbital.Vec3{}
-}
-
-// BodyFrame returns the craft's full orientation as an orthonormal
-// triple: nose (lengthwise / thrust axis = CurrentAttitudeDir), up
-// (dorsal), and right (starboard). up is the heads-up reference
-// rotated about the nose by CurrentRollDeg, so a non-zero roll banks
-// the frame; right = nose × up completes it. ok=false when the nose
-// is uninitialised (zero) — callers fall back to the commanded
-// direction or a static navball. v0.10.0+.
-func (s *Spacecraft) BodyFrame() (nose, up, right orbital.Vec3, ok bool) {
-	return s.BodyFrameFor(s.CurrentAttitudeDir, s.CurrentRollDeg)
-}
-
-// BodyFrameFor builds the body frame from an explicit nose direction
-// and roll (degrees) rather than the stored CurrentAttitudeDir /
-// CurrentRollDeg. The navball uses this so it can substitute the
-// commanded nose/roll under InstantSAS or before the first slew tick.
-// v0.10.0+.
-func (s *Spacecraft) BodyFrameFor(noseDir orbital.Vec3, rollDeg float64) (nose, up, right orbital.Vec3, ok bool) {
-	nose = noseDir.Unit()
-	if nose == (orbital.Vec3{}) {
-		return orbital.Vec3{}, orbital.Vec3{}, orbital.Vec3{}, false
-	}
-	up0 := s.headsUpReference(nose)
-	if up0 == (orbital.Vec3{}) {
-		return orbital.Vec3{}, orbital.Vec3{}, orbital.Vec3{}, false
-	}
-	up = orbital.Rotate(up0, nose, rollDeg*math.Pi/180).Unit()
-	right = up.Cross(nose).Unit() // starboard; {nose,right,up} right-handed (nose×right=up)
-	return nose, up, right, true
-}
-
-// wrapDeg180 normalises an angle to (-180, 180].
-func wrapDeg180(d float64) float64 {
-	d = math.Mod(d, 360)
-	if d <= -180 {
-		d += 360
-	} else if d > 180 {
-		d -= 360
-	}
-	return d
-}
-
-// RollToward rotates CurrentRollDeg toward CommandedRollDeg by at most
-// SlewRate·dt degrees along the shortest signed path (wrapped to
-// ±180). dt is the warp-scaled sim seconds for the tick — same rate
-// budget as the attitude slew. v0.10.0+.
-func (s *Spacecraft) RollToward(dt float64) {
-	s.CommandedRollDeg = wrapDeg180(s.CommandedRollDeg)
-	diff := wrapDeg180(s.CommandedRollDeg - wrapDeg180(s.CurrentRollDeg))
-	if diff == 0 {
-		s.CurrentRollDeg = s.CommandedRollDeg
-		return
-	}
-	maxStep := s.SlewRateRad() * dt * 180 / math.Pi // deg this tick
-	if math.Abs(diff) <= maxStep {
-		s.CurrentRollDeg = s.CommandedRollDeg
-		return
-	}
-	step := maxStep
-	if diff < 0 {
-		step = -maxStep
-	}
-	s.CurrentRollDeg = wrapDeg180(wrapDeg180(s.CurrentRollDeg) + step)
 }

--- a/internal/spacecraft/slew.go
+++ b/internal/spacecraft/slew.go
@@ -4,7 +4,13 @@ import (
 	"math"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 )
+
+// RollStepDeg is the per-keypress commanded-roll adjustment (degrees)
+// for the roll-left / roll-right keys. 15° matches the default slew
+// rate's one-second budget so a tap visibly banks. v0.10.0+.
+const RollStepDeg = 15.0
 
 // slewAngleEps is the angular tolerance (radians) below which the nose
 // is considered already aligned — snap to the commanded direction
@@ -79,4 +85,92 @@ func (s *Spacecraft) SlewToward(commanded orbital.Vec3, dt float64) {
 		}
 	}
 	s.CurrentAttitudeDir = orbital.Rotate(cur, axis.Unit(), maxStep).Unit()
+}
+
+// headsUpReference returns the roll-zero "up" reference: the body's
+// dorsal axis points as close to local vertical (radial-out, away
+// from the primary) as the nose allows — i.e. heads-up / belly-down.
+// When the nose is (anti)parallel to radial (pointing straight up on
+// the pad), that projection collapses, so we fall back through the
+// primary spin axis (≈ north), then world +Z, then +X. Returns a
+// unit vector perpendicular to nose, or zero if nose is itself zero.
+func (s *Spacecraft) headsUpReference(nose orbital.Vec3) orbital.Vec3 {
+	axisR := render.BodyRotationAxisWorld(s.Primary)
+	candidates := []orbital.Vec3{
+		s.State.R,                            // radial-out (local vertical)
+		{X: axisR.X, Y: axisR.Y, Z: axisR.Z}, // spin axis ≈ north
+		{Z: 1},
+		{X: 1},
+	}
+	for _, c := range candidates {
+		perp := c.Sub(nose.Scale(nose.Dot(c)))
+		if perp.Norm() > 1e-9 {
+			return perp.Unit()
+		}
+	}
+	return orbital.Vec3{}
+}
+
+// BodyFrame returns the craft's full orientation as an orthonormal
+// triple: nose (lengthwise / thrust axis = CurrentAttitudeDir), up
+// (dorsal), and right (starboard). up is the heads-up reference
+// rotated about the nose by CurrentRollDeg, so a non-zero roll banks
+// the frame; right = nose × up completes it. ok=false when the nose
+// is uninitialised (zero) — callers fall back to the commanded
+// direction or a static navball. v0.10.0+.
+func (s *Spacecraft) BodyFrame() (nose, up, right orbital.Vec3, ok bool) {
+	return s.BodyFrameFor(s.CurrentAttitudeDir, s.CurrentRollDeg)
+}
+
+// BodyFrameFor builds the body frame from an explicit nose direction
+// and roll (degrees) rather than the stored CurrentAttitudeDir /
+// CurrentRollDeg. The navball uses this so it can substitute the
+// commanded nose/roll under InstantSAS or before the first slew tick.
+// v0.10.0+.
+func (s *Spacecraft) BodyFrameFor(noseDir orbital.Vec3, rollDeg float64) (nose, up, right orbital.Vec3, ok bool) {
+	nose = noseDir.Unit()
+	if nose == (orbital.Vec3{}) {
+		return orbital.Vec3{}, orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	up0 := s.headsUpReference(nose)
+	if up0 == (orbital.Vec3{}) {
+		return orbital.Vec3{}, orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	up = orbital.Rotate(up0, nose, rollDeg*math.Pi/180).Unit()
+	right = up.Cross(nose).Unit() // starboard; {nose,right,up} right-handed (nose×right=up)
+	return nose, up, right, true
+}
+
+// wrapDeg180 normalises an angle to (-180, 180].
+func wrapDeg180(d float64) float64 {
+	d = math.Mod(d, 360)
+	if d <= -180 {
+		d += 360
+	} else if d > 180 {
+		d -= 360
+	}
+	return d
+}
+
+// RollToward rotates CurrentRollDeg toward CommandedRollDeg by at most
+// SlewRate·dt degrees along the shortest signed path (wrapped to
+// ±180). dt is the warp-scaled sim seconds for the tick — same rate
+// budget as the attitude slew. v0.10.0+.
+func (s *Spacecraft) RollToward(dt float64) {
+	s.CommandedRollDeg = wrapDeg180(s.CommandedRollDeg)
+	diff := wrapDeg180(s.CommandedRollDeg - wrapDeg180(s.CurrentRollDeg))
+	if diff == 0 {
+		s.CurrentRollDeg = s.CommandedRollDeg
+		return
+	}
+	maxStep := s.SlewRateRad() * dt * 180 / math.Pi // deg this tick
+	if math.Abs(diff) <= maxStep {
+		s.CurrentRollDeg = s.CommandedRollDeg
+		return
+	}
+	step := maxStep
+	if diff < 0 {
+		step = -maxStep
+	}
+	s.CurrentRollDeg = wrapDeg180(wrapDeg180(s.CurrentRollDeg) + step)
 }

--- a/internal/spacecraft/slew_test.go
+++ b/internal/spacecraft/slew_test.go
@@ -1,0 +1,102 @@
+package spacecraft
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+func angBetween(a, b orbital.Vec3) float64 {
+	c := a.Unit().Dot(b.Unit())
+	if c > 1 {
+		c = 1
+	} else if c < -1 {
+		c = -1
+	}
+	return math.Acos(c)
+}
+
+func TestSlewTowardConvergesInAngleOverRate(t *testing.T) {
+	sc := &Spacecraft{
+		CurrentAttitudeDir: orbital.Vec3{X: 1},
+		SlewRateDegPerSec:  5,
+	}
+	cmd := orbital.Vec3{Y: 1} // 90° away
+	dt := 1.0                 // 5°/tick
+
+	prev := math.Pi / 2
+	steps := 0
+	for angBetween(sc.CurrentAttitudeDir, cmd) > 1e-6 {
+		sc.SlewToward(cmd, dt)
+		cur := angBetween(sc.CurrentAttitudeDir, cmd)
+		// Monotone non-increasing, and the per-step movement never
+		// exceeds the cap (SlewRate·dt).
+		if cur > prev+1e-12 {
+			t.Fatalf("step %d: angle increased %.9f -> %.9f", steps, prev, cur)
+		}
+		if moved := prev - cur; moved > sc.SlewRateRad()*dt+1e-9 {
+			t.Fatalf("step %d: moved more than cap (Δ=%.6f cap=%.6f)",
+				steps, moved, sc.SlewRateRad()*dt)
+		}
+		prev = cur
+		steps++
+		if steps > 100 {
+			t.Fatal("did not converge in 100 steps")
+		}
+	}
+	// 90° / 5° = 18 steps exactly.
+	if steps != 18 {
+		t.Errorf("converged in %d steps, want 18 (90°/5°)", steps)
+	}
+	if d := sc.CurrentAttitudeDir.Sub(cmd).Norm(); d > 1e-6 {
+		t.Errorf("final dir off by %.3e", d)
+	}
+}
+
+func TestSlewTowardZeroInitSnaps(t *testing.T) {
+	sc := &Spacecraft{SlewRateDegPerSec: 5} // CurrentAttitudeDir zero
+	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
+	sc.SlewToward(cmd, 0.001) // tiny dt: would barely move if it slewed
+	if d := sc.CurrentAttitudeDir.Sub(cmd).Norm(); d > 1e-12 {
+		t.Errorf("zero-init did not snap to commanded: off by %.3e", d)
+	}
+}
+
+func TestSlewTowardUndefinedCommandedHolds(t *testing.T) {
+	start := orbital.Vec3{X: 1}
+	sc := &Spacecraft{CurrentAttitudeDir: start, SlewRateDegPerSec: 5}
+	sc.SlewToward(orbital.Vec3{}, 1.0) // zero commanded => hold
+	if sc.CurrentAttitudeDir != start {
+		t.Errorf("undefined commanded changed attitude: %+v", sc.CurrentAttitudeDir)
+	}
+}
+
+func TestSlewTowardAntiparallelNoNaN(t *testing.T) {
+	sc := &Spacecraft{
+		CurrentAttitudeDir: orbital.Vec3{X: 1},
+		SlewRateDegPerSec:  10,
+	}
+	cmd := orbital.Vec3{X: -1} // exactly 180°
+	for i := 0; i < 50; i++ {
+		sc.SlewToward(cmd, 1.0)
+		d := sc.CurrentAttitudeDir
+		if math.IsNaN(d.X) || math.IsNaN(d.Y) || math.IsNaN(d.Z) {
+			t.Fatalf("NaN attitude at step %d: %+v", i, d)
+		}
+		if n := d.Norm(); math.Abs(n-1) > 1e-9 {
+			t.Fatalf("step %d: non-unit attitude |d|=%.9f", i, n)
+		}
+	}
+	if d := angBetween(sc.CurrentAttitudeDir, cmd); d > 1e-6 {
+		t.Errorf("did not converge from antiparallel: residual %.6f rad", d)
+	}
+}
+
+func TestSlewRateRadDefaultFallback(t *testing.T) {
+	sc := &Spacecraft{} // unset rate
+	want := DefaultSlewRateDegPerSec * math.Pi / 180
+	if got := sc.SlewRateRad(); math.Abs(got-want) > 1e-12 {
+		t.Errorf("SlewRateRad default = %.6f, want %.6f", got, want)
+	}
+}

--- a/internal/spacecraft/slew_test.go
+++ b/internal/spacecraft/slew_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 func angBetween(a, b orbital.Vec3) float64 {
@@ -91,6 +92,96 @@ func TestSlewTowardAntiparallelNoNaN(t *testing.T) {
 	if d := angBetween(sc.CurrentAttitudeDir, cmd); d > 1e-6 {
 		t.Errorf("did not converge from antiparallel: residual %.6f rad", d)
 	}
+}
+
+func TestBodyFrameOrthonormalAndHeadsUp(t *testing.T) {
+	sc := &Spacecraft{
+		CurrentAttitudeDir: orbital.Vec3{X: 1},                           // nose +X
+		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}}, // radial-out +Z
+	}
+	nose, up, right, ok := sc.BodyFrame()
+	if !ok {
+		t.Fatal("BodyFrame ok=false on a valid craft")
+	}
+	for name, d := range map[string]float64{
+		"nose·up": nose.Dot(up), "nose·right": nose.Dot(right), "up·right": up.Dot(right),
+	} {
+		if math.Abs(d) > 1e-9 {
+			t.Errorf("%s not orthogonal: %.3e", name, d)
+		}
+	}
+	for name, v := range map[string]orbital.Vec3{"nose": nose, "up": up, "right": right} {
+		if math.Abs(v.Norm()-1) > 1e-9 {
+			t.Errorf("%s not unit: |v|=%.9f", name, v.Norm())
+		}
+	}
+	// Roll 0 ⇒ up is the radial-out direction (heads-up / belly-down).
+	if d := up.Sub(orbital.Vec3{Z: 1}).Norm(); d > 1e-9 {
+		t.Errorf("roll-0 up should be radial-out +Z; got %+v", up)
+	}
+	if d := right.Sub(up.Cross(nose)).Norm(); d > 1e-9 {
+		t.Errorf("right should equal up×nose")
+	}
+}
+
+func TestBodyFrameRollRotatesUp(t *testing.T) {
+	sc := &Spacecraft{
+		CurrentAttitudeDir: orbital.Vec3{X: 1},
+		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}},
+		CurrentRollDeg:     90,
+	}
+	_, up, _, ok := sc.BodyFrame()
+	if !ok {
+		t.Fatal("BodyFrame ok=false")
+	}
+	// up0 = +Z rotated 90° about nose +X ⇒ −Y.
+	if d := up.Sub(orbital.Vec3{Y: -1}).Norm(); d > 1e-9 {
+		t.Errorf("roll 90° about +X should put up at −Y; got %+v", up)
+	}
+}
+
+func TestBodyFrameZeroNose(t *testing.T) {
+	sc := &Spacecraft{State: physics.StateVector{R: orbital.Vec3{Z: 7e6}}}
+	if _, _, _, ok := sc.BodyFrame(); ok {
+		t.Error("BodyFrame should be ok=false with uninitialised nose")
+	}
+}
+
+func TestBodyFrameNoseParallelRadialFallsBack(t *testing.T) {
+	// Nose pointing straight up (∥ radial) — heads-up reference must
+	// fall back to a defined perpendicular, not blow up.
+	sc := &Spacecraft{
+		CurrentAttitudeDir: orbital.Vec3{Z: 1},
+		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}},
+	}
+	nose, up, right, ok := sc.BodyFrame()
+	if !ok {
+		t.Fatal("BodyFrame ok=false at nose∥radial")
+	}
+	if math.Abs(nose.Dot(up)) > 1e-9 || math.Abs(up.Norm()-1) > 1e-9 {
+		t.Errorf("fallback up not a valid unit ⟂ nose: up=%+v", up)
+	}
+	_ = right
+}
+
+func TestRollTowardConvergesShortestPath(t *testing.T) {
+	sc := &Spacecraft{SlewRateDegPerSec: 5, CurrentRollDeg: -170, CommandedRollDeg: 170}
+	prev := 20.0 // shortest signed distance is −20°, |diff| starts at 20
+	for i := 0; i < 100; i++ {
+		sc.RollToward(1.0)
+		d := math.Abs(wrapDeg180(sc.CommandedRollDeg - sc.CurrentRollDeg))
+		if d > prev+1e-9 {
+			t.Fatalf("step %d: roll error grew %.3f → %.3f (took the long way)", i, prev, d)
+		}
+		prev = d
+		if d < 1e-9 {
+			if i > 6 { // 20°/5°·s ⇒ ~4 ticks; must not be ~68 (long way)
+				t.Fatalf("converged in %d ticks — took the 340° long way", i+1)
+			}
+			return
+		}
+	}
+	t.Fatalf("RollToward did not converge; residual %.3f", prev)
 }
 
 func TestSlewRateRadDefaultFallback(t *testing.T) {

--- a/internal/spacecraft/slew_test.go
+++ b/internal/spacecraft/slew_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
-	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 func angBetween(a, b orbital.Vec3) float64 {
@@ -92,96 +91,6 @@ func TestSlewTowardAntiparallelNoNaN(t *testing.T) {
 	if d := angBetween(sc.CurrentAttitudeDir, cmd); d > 1e-6 {
 		t.Errorf("did not converge from antiparallel: residual %.6f rad", d)
 	}
-}
-
-func TestBodyFrameOrthonormalAndHeadsUp(t *testing.T) {
-	sc := &Spacecraft{
-		CurrentAttitudeDir: orbital.Vec3{X: 1},                           // nose +X
-		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}}, // radial-out +Z
-	}
-	nose, up, right, ok := sc.BodyFrame()
-	if !ok {
-		t.Fatal("BodyFrame ok=false on a valid craft")
-	}
-	for name, d := range map[string]float64{
-		"nose·up": nose.Dot(up), "nose·right": nose.Dot(right), "up·right": up.Dot(right),
-	} {
-		if math.Abs(d) > 1e-9 {
-			t.Errorf("%s not orthogonal: %.3e", name, d)
-		}
-	}
-	for name, v := range map[string]orbital.Vec3{"nose": nose, "up": up, "right": right} {
-		if math.Abs(v.Norm()-1) > 1e-9 {
-			t.Errorf("%s not unit: |v|=%.9f", name, v.Norm())
-		}
-	}
-	// Roll 0 ⇒ up is the radial-out direction (heads-up / belly-down).
-	if d := up.Sub(orbital.Vec3{Z: 1}).Norm(); d > 1e-9 {
-		t.Errorf("roll-0 up should be radial-out +Z; got %+v", up)
-	}
-	if d := right.Sub(up.Cross(nose)).Norm(); d > 1e-9 {
-		t.Errorf("right should equal up×nose")
-	}
-}
-
-func TestBodyFrameRollRotatesUp(t *testing.T) {
-	sc := &Spacecraft{
-		CurrentAttitudeDir: orbital.Vec3{X: 1},
-		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}},
-		CurrentRollDeg:     90,
-	}
-	_, up, _, ok := sc.BodyFrame()
-	if !ok {
-		t.Fatal("BodyFrame ok=false")
-	}
-	// up0 = +Z rotated 90° about nose +X ⇒ −Y.
-	if d := up.Sub(orbital.Vec3{Y: -1}).Norm(); d > 1e-9 {
-		t.Errorf("roll 90° about +X should put up at −Y; got %+v", up)
-	}
-}
-
-func TestBodyFrameZeroNose(t *testing.T) {
-	sc := &Spacecraft{State: physics.StateVector{R: orbital.Vec3{Z: 7e6}}}
-	if _, _, _, ok := sc.BodyFrame(); ok {
-		t.Error("BodyFrame should be ok=false with uninitialised nose")
-	}
-}
-
-func TestBodyFrameNoseParallelRadialFallsBack(t *testing.T) {
-	// Nose pointing straight up (∥ radial) — heads-up reference must
-	// fall back to a defined perpendicular, not blow up.
-	sc := &Spacecraft{
-		CurrentAttitudeDir: orbital.Vec3{Z: 1},
-		State:              physics.StateVector{R: orbital.Vec3{Z: 7e6}},
-	}
-	nose, up, right, ok := sc.BodyFrame()
-	if !ok {
-		t.Fatal("BodyFrame ok=false at nose∥radial")
-	}
-	if math.Abs(nose.Dot(up)) > 1e-9 || math.Abs(up.Norm()-1) > 1e-9 {
-		t.Errorf("fallback up not a valid unit ⟂ nose: up=%+v", up)
-	}
-	_ = right
-}
-
-func TestRollTowardConvergesShortestPath(t *testing.T) {
-	sc := &Spacecraft{SlewRateDegPerSec: 5, CurrentRollDeg: -170, CommandedRollDeg: 170}
-	prev := 20.0 // shortest signed distance is −20°, |diff| starts at 20
-	for i := 0; i < 100; i++ {
-		sc.RollToward(1.0)
-		d := math.Abs(wrapDeg180(sc.CommandedRollDeg - sc.CurrentRollDeg))
-		if d > prev+1e-9 {
-			t.Fatalf("step %d: roll error grew %.3f → %.3f (took the long way)", i, prev, d)
-		}
-		prev = d
-		if d < 1e-9 {
-			if i > 6 { // 20°/5°·s ⇒ ~4 ticks; must not be ~68 (long way)
-				t.Fatalf("converged in %d ticks — took the 340° long way", i+1)
-			}
-			return
-		}
-	}
-	t.Fatalf("RollToward did not converge; residual %.3f", prev)
 }
 
 func TestSlewRateRadDefaultFallback(t *testing.T) {

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -121,6 +121,21 @@ type Spacecraft struct {
 	// mid-slew restores its real nose.
 	CurrentAttitudeDir orbital.Vec3
 
+	// CommandedRollDeg / CurrentRollDeg (v0.10.0+) are the craft's
+	// roll about its lengthwise (nose) axis, in degrees, measured
+	// from the "heads-up" reference (body-up as close to local
+	// vertical / radial-out as the nose allows — see BodyFrame).
+	// CommandedRollDeg is the player target (0 = heads-up, the
+	// default); CurrentRollDeg is the actual roll, which the slew
+	// integrator rotates toward the command at SlewRate (snapped
+	// under InstantSAS and while Landed). Together with
+	// CurrentAttitudeDir this gives the craft a full body frame
+	// {nose, up, right} so the navball has a stable left/right and
+	// the player can bank. Both persist in saves; range is wrapped
+	// to (-180, 180].
+	CommandedRollDeg float64
+	CurrentRollDeg   float64
+
 	// SlewRateDegPerSec (v0.10.0+) caps attitude angular rate in
 	// **sim-time** (deg/s, integrated against the warp-scaled tick).
 	// Zero => DefaultSlewRateDegPerSec. Set from the loadout at

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -121,21 +121,6 @@ type Spacecraft struct {
 	// mid-slew restores its real nose.
 	CurrentAttitudeDir orbital.Vec3
 
-	// CommandedRollDeg / CurrentRollDeg (v0.10.0+) are the craft's
-	// roll about its lengthwise (nose) axis, in degrees, measured
-	// from the "heads-up" reference (body-up as close to local
-	// vertical / radial-out as the nose allows — see BodyFrame).
-	// CommandedRollDeg is the player target (0 = heads-up, the
-	// default); CurrentRollDeg is the actual roll, which the slew
-	// integrator rotates toward the command at SlewRate (snapped
-	// under InstantSAS and while Landed). Together with
-	// CurrentAttitudeDir this gives the craft a full body frame
-	// {nose, up, right} so the navball has a stable left/right and
-	// the player can bank. Both persist in saves; range is wrapped
-	// to (-180, 180].
-	CommandedRollDeg float64
-	CurrentRollDeg   float64
-
 	// SlewRateDegPerSec (v0.10.0+) caps attitude angular rate in
 	// **sim-time** (deg/s, integrated against the warp-scaled tick).
 	// Zero => DefaultSlewRateDegPerSec. Set from the loadout at

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -107,6 +107,28 @@ type Spacecraft struct {
 	AttitudeMode BurnMode
 	EngineMode   EngineMode
 
+	// CurrentAttitudeDir (v0.10.0+) is the craft's *actual* nose
+	// unit vector in the same world/primary frame as State.R/V —
+	// the physical orientation, distinct from the *commanded*
+	// direction recomputed from AttitudeMode each tick. The slew
+	// integrator (sim.integrateOneCraft) rotates this toward the
+	// commanded direction at SlewRate; stepThrust + the navball
+	// sub-observer read it instead of recomputing, so burning
+	// before alignment bleeds Δv to cosine loss. A zero vector
+	// means "uninitialized" — the first slew tick snaps it to the
+	// commanded direction (no slew-from-garbage, no nose teleport
+	// on a pre-v0.10.0 save). Persists in saves so a craft caught
+	// mid-slew restores its real nose.
+	CurrentAttitudeDir orbital.Vec3
+
+	// SlewRateDegPerSec (v0.10.0+) caps attitude angular rate in
+	// **sim-time** (deg/s, integrated against the warp-scaled tick).
+	// Zero => DefaultSlewRateDegPerSec. Set from the loadout at
+	// construction (NewFromLoadout); not stage-derived, so SyncFields
+	// does not touch it, and it is re-applied via the loadout on load
+	// rather than persisted.
+	SlewRateDegPerSec float64
+
 	// DockedComponents (v0.8.3+) records the original craft that
 	// fused into this composite, so an Undock keystroke can
 	// restore them. Empty for non-composite craft. Populated by

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -491,6 +491,41 @@ func (s *Spacecraft) ThrustAccelFnAtWithTarget(mode BurnMode, mu, throttle float
 	}
 }
 
+// ThrustAccelFnFixedDir is the v0.10.0 slew-mode counterpart of
+// ThrustAccelFnAtWithTarget: instead of recomputing the thrust
+// direction from a BurnMode per RK4 sub-step, it thrusts along a
+// FIXED world-frame unit vector for the whole tick — the craft's
+// physical nose (CurrentAttitudeDir), already slewed toward the
+// commanded direction once at the tick top and already carrying mode
+// + pitch-trim resolution (it was integrated from
+// BurnDirectionWithTarget). Freezing it for the tick is correct under
+// the constant-rate, no-intra-tick-dynamics decision; the cosine loss
+// from burning while the nose still lags the commanded direction
+// emerges naturally. A zero/degenerate dir => gravity only (no thrust,
+// matches the BurnDirection "undefined direction" no-op convention).
+//
+// v0.10.0+.
+func (s *Spacecraft) ThrustAccelFnFixedDir(dir orbital.Vec3, mu, throttle float64) func(r, v orbital.Vec3, t float64) orbital.Vec3 {
+	mass := s.TotalMass()
+	if throttle < 0 {
+		throttle = 0
+	} else if throttle > 1 {
+		throttle = 1
+	}
+	thrust := s.Thrust * throttle
+	if s.ActiveStageFuel() <= 0 {
+		thrust = 0
+	}
+	d := dir.Unit()
+	return func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
+		gravity := physics.Accel(r, mu)
+		if thrust == 0 || mass == 0 || d == (orbital.Vec3{}) {
+			return gravity
+		}
+		return gravity.Add(d.Scale(thrust / mass))
+	}
+}
+
 // cross is the standard 3D cross product. Lifted here (rather than adding
 // to orbital.Vec3) to keep orbital free of spacecraft-specific helpers.
 func cross(a, b orbital.Vec3) orbital.Vec3 {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -664,21 +664,6 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				c.PitchTrim = 0
 			}
 			return a, nil
-		case key.Matches(m, a.keys.RollRight):
-			if c := a.world.ActiveCraft(); c != nil {
-				c.CommandedRollDeg += spacecraft.RollStepDeg
-			}
-			return a, nil
-		case key.Matches(m, a.keys.RollLeft):
-			if c := a.world.ActiveCraft(); c != nil {
-				c.CommandedRollDeg -= spacecraft.RollStepDeg
-			}
-			return a, nil
-		case key.Matches(m, a.keys.RollReset):
-			if c := a.world.ActiveCraft(); c != nil {
-				c.CommandedRollDeg = 0
-			}
-			return a, nil
 		case key.Matches(m, a.keys.Stage):
 			// v0.9.1+: drop the bottom stage of the active craft.
 			// Inside the maneuver form, space is the iterate-toggle

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -643,6 +643,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.statusMsg = fmt.Sprintf("nav: %s", nav)
 			a.statusExpires = time.Now().Add(2 * time.Second)
 			return a, nil
+		case key.Matches(m, a.keys.ToggleInstantSAS):
+			a.world.ToggleInstantSAS()
+			a.statusMsg = fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS))
+			a.statusExpires = time.Now().Add(2 * time.Second)
+			return a, nil
 		case key.Matches(m, a.keys.AttitudeSurfacePrograde):
 			a.handleAttitudeKey(spacecraft.BurnSurfacePrograde)
 			return a, nil
@@ -774,6 +779,19 @@ func (a *App) handleAttitudeIntent(intent sim.AttitudeIntent) {
 	a.handleAttitudeKey(a.world.ResolveAttitudeIntent(intent))
 }
 
+// sasModeLabel maps the World.InstantSAS opt-out to the player-facing
+// manual-flight attitude-model name. MANUAL = rate-limited slew (the
+// v0.10.0 default, instantSAS=false); AUTO = legacy instantaneous
+// "magic SAS" snap (instantSAS=true). The same vocabulary is used by
+// the navball [SAS] tag so the toast and the indicator never drift.
+// v0.10.0+.
+func sasModeLabel(instantSAS bool) string {
+	if instantSAS {
+		return "AUTO (instant)"
+	}
+	return "MANUAL (slew)"
+}
+
 // dispatchNavballControl routes a click on the framed navball
 // panel's controls to the same world actions as the keyboard: the
 // [MODE] button cycles NavMode (mirroring the CycleNavMode key,
@@ -806,6 +824,10 @@ func (a *App) dispatchNavballControl(ctrl screens.NavballControlID) {
 			state = "on"
 		}
 		a.statusMsg = fmt.Sprintf("RCS: %s", state)
+		a.statusExpires = time.Now().Add(2 * time.Second)
+	case screens.NavballControlSAS:
+		a.world.ToggleInstantSAS()
+		a.statusMsg = fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS))
 		a.statusExpires = time.Now().Add(2 * time.Second)
 	case screens.NavballControlTargetPlus:
 		a.handleAttitudeKey(spacecraft.BurnTarget)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -664,6 +664,21 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				c.PitchTrim = 0
 			}
 			return a, nil
+		case key.Matches(m, a.keys.RollRight):
+			if c := a.world.ActiveCraft(); c != nil {
+				c.CommandedRollDeg += spacecraft.RollStepDeg
+			}
+			return a, nil
+		case key.Matches(m, a.keys.RollLeft):
+			if c := a.world.ActiveCraft(); c != nil {
+				c.CommandedRollDeg -= spacecraft.RollStepDeg
+			}
+			return a, nil
+		case key.Matches(m, a.keys.RollReset):
+			if c := a.world.ActiveCraft(); c != nil {
+				c.CommandedRollDeg = 0
+			}
+			return a, nil
 		case key.Matches(m, a.keys.Stage):
 			// v0.9.1+: drop the bottom stage of the active craft.
 			// Inside the maneuver form, space is the iterate-toggle

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -73,6 +73,29 @@ func TestDispatchNavballControlRCS(t *testing.T) {
 	}
 }
 
+// Clicking the [SAS] tag flips World.InstantSAS both ways and toasts
+// the new model name — the locked-decision non-silent surfacing.
+func TestDispatchNavballControlSAS(t *testing.T) {
+	a, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.InstantSAS {
+		t.Fatalf("InstantSAS should default false (slew is the v0.10 default)")
+	}
+	a.dispatchNavballControl(screens.NavballControlSAS)
+	if !a.world.InstantSAS {
+		t.Errorf("InstantSAS = false, want true after first toggle")
+	}
+	if a.statusMsg == "" {
+		t.Errorf("expected a SAS-model status toast")
+	}
+	a.dispatchNavballControl(screens.NavballControlSAS)
+	if a.world.InstantSAS {
+		t.Errorf("InstantSAS = true, want false after second toggle")
+	}
+}
+
 // Clicking the target ± buttons holds BurnTarget / BurnAntiTarget.
 func TestDispatchNavballControlTarget(t *testing.T) {
 	a, err := New()

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -5,7 +5,7 @@ import "github.com/charmbracelet/bubbles/key"
 // Keymap centralises every binding the root model cares about. Screens
 // that need additional keys define them locally.
 type Keymap struct {
-	Quit       key.Binding
+	Quit key.Binding
 	// QuitAsk used to live on `q` (then `Q` after v0.7.3 freed `q`
 	// for AttitudeRadialOut). v0.7.3.1 dropped the binding entirely:
 	// quit-confirm now lives on Esc when the home (orbit) view is
@@ -29,7 +29,7 @@ type Keymap struct {
 	FocusNext  key.Binding
 	FocusPrev  key.Binding
 	FocusReset key.Binding
-	SpawnCraft    key.Binding // v0.8.1+: spawn a new craft. Replaced the v0.7.x PlanNode quick-plant default-node debug aid (m/Enter is the proper plant path).
+	SpawnCraft key.Binding // v0.8.1+: spawn a new craft. Replaced the v0.7.x PlanNode quick-plant default-node debug aid (m/Enter is the proper plant path).
 	// ClearNodes used to live on `N` (the case-collision partner of
 	// `n` SpawnCraft, which made remembering which one wiped vs
 	// spawned a constant trip-up). v0.8.6 dropped the global
@@ -37,34 +37,34 @@ type Keymap struct {
 	// alongside per-node delete (`m` then ctrl+k / ctrl+d). Field
 	// kept with no key so callers compile during transition; remove
 	// in a later cleanup.
-	ClearNodes    key.Binding
-	PlanTransfer  key.Binding
-	PlanIncl      key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
+	ClearNodes   key.Binding
+	PlanTransfer key.Binding
+	PlanIncl     key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
 	// PlanCircularize (v0.9.4+) plants a prograde burn at the active
 	// craft's next apoapsis sized to circularise the orbit there. The
 	// "single keystroke for the natural last step of an ascent"
 	// shortcut, mirroring the v0.7.4 `I` plane-match planter.
 	PlanCircularize key.Binding
-	Porkchop      key.Binding
+	Porkchop        key.Binding
 	// v0.8.6: Save / Load moved S / L → F5 / F9 to match the KSP
 	// quicksave-quickload muscle memory and to clear the case-
 	// collision with `s` (AttitudeRetrograde) and `l` (NextBody).
-	Save          key.Binding
-	Load          key.Binding
-	RefinePlan    key.Binding
-	CycleView     key.Binding
+	Save       key.Binding
+	Load       key.Binding
+	RefinePlan key.Binding
+	CycleView  key.Binding
 
 	// v0.7.3+ manual flight controls.
-	ThrottleFull       key.Binding // throttle to 100 %
-	ThrottleCut        key.Binding // throttle 0 % (also stops a manual burn)
-	ThrottleUp         key.Binding // +10 % step
-	ThrottleDown       key.Binding // -10 % step
-	AttitudePrograde   key.Binding
-	AttitudeRetrograde key.Binding
+	ThrottleFull        key.Binding // throttle to 100 %
+	ThrottleCut         key.Binding // throttle 0 % (also stops a manual burn)
+	ThrottleUp          key.Binding // +10 % step
+	ThrottleDown        key.Binding // -10 % step
+	AttitudePrograde    key.Binding
+	AttitudeRetrograde  key.Binding
 	AttitudeNormalPlus  key.Binding
 	AttitudeNormalMinus key.Binding
-	AttitudeRadialOut  key.Binding
-	AttitudeRadialIn   key.Binding
+	AttitudeRadialOut   key.Binding
+	AttitudeRadialIn    key.Binding
 	// ToggleBurn (v0.7.3.2+): explicit engage / disengage gate for
 	// manual flight. Pre-v0.7.3.2 the attitude keys auto-started the
 	// engine, which made accidental burns easy. Now attitude keys
@@ -127,47 +127,56 @@ type Keymap struct {
 	// ascent gravity-turn flight to initiate the pitch-over from
 	// vertical. Held → continuous trim ramp at the terminal's
 	// key-repeat rate. Reset via PitchTrimReset.
-	PitchTrimEast    key.Binding
-	PitchTrimWest    key.Binding
-	PitchTrimReset   key.Binding
+	PitchTrimEast  key.Binding
+	PitchTrimWest  key.Binding
+	PitchTrimReset key.Binding
+
+	// RollLeft / RollRight / RollReset (v0.10.0+): command the craft's
+	// roll about its lengthwise (nose) axis ±RollStepDeg per press;
+	// the body frame slews toward it like pitch/yaw. 0 = heads-up
+	// (belly-down). Q/E mirror KSP's roll keys (the radial q/e are
+	// the un-shifted pair). Reset via RollReset (|).
+	RollLeft  key.Binding
+	RollRight key.Binding
+	RollReset key.Binding
 }
 
 func DefaultKeymap() Keymap {
 	return Keymap{
-		Quit:       key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit (immediate)")),
+		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit (immediate)")),
 		// v0.7.3.1: QuitAsk no longer has a dedicated key — Esc on
 		// the home view opens the confirm prompt instead. Binding
 		// kept with no keys so the struct field stays stable; remove
 		// in v0.8 cleanup.
-		QuitAsk:    key.NewBinding(),
-		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-		BodyInfo:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
-		Maneuver:   key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
-		NextBody:   key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
-		PrevBody:   key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
+		QuitAsk:  key.NewBinding(),
+		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		BodyInfo: key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
+		Maneuver: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
+		NextBody: key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
+		PrevBody: key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
 		// v0.7.3: NextSystem moved s → tab to free `s` for AttitudeRetrograde.
 		NextSystem: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next system")),
 		WarpUp:     key.NewBinding(key.WithKeys("."), key.WithHelp(".", "warp up")),
 		WarpDown:   key.NewBinding(key.WithKeys(","), key.WithHelp(",", "warp down")),
 		// v0.9.1: dropped `space` from Pause; space is now Stage. `0`
 		// alone retains the pause binding (it never collided).
-		Pause:      key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "pause")),
-		ZoomIn:     key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "zoom in")),
-		ZoomOut:    key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "zoom out")),
-		Back:       key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
-		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
-		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
-		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
-		SpawnCraft:   key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "spawn craft (sister copy of active)")),
-		ClearNodes:   key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
-		PlanTransfer: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
-		PlanIncl:     key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
+		Pause:           key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "pause")),
+		ZoomIn:          key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "zoom in")),
+		ZoomOut:         key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "zoom out")),
+		Back:            key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+		FocusNext:       key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
+		FocusPrev:       key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
+		FocusReset:      key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
+		SpawnCraft:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "spawn craft (sister copy of active)")),
+		ClearNodes:      key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
+		PlanTransfer:    key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
+		PlanIncl:        key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
 		PlanCircularize: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "plant circularize burn at next apoapsis")),
-		Porkchop:     key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
-		Save:         key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
-		Load:         key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
-		RefinePlan:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
+		Porkchop:        key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
+		Save:            key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
+		Load:            key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
+		RefinePlan:      key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
+		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
 
 		ThrottleFull:        key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "throttle 100%")),
 		ThrottleCut:         key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "throttle 0% / cut burn")),
@@ -194,5 +203,8 @@ func DefaultKeymap() Keymap {
 		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +10° east")),
 		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -10° west")),
 		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
+		RollLeft:                  key.NewBinding(key.WithKeys("Q"), key.WithHelp("Q", "roll left 15°")),
+		RollRight:                 key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "roll right 15°")),
+		RollReset:                 key.NewBinding(key.WithKeys("|"), key.WithHelp("|", "reset roll (heads-up)")),
 	}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -5,7 +5,7 @@ import "github.com/charmbracelet/bubbles/key"
 // Keymap centralises every binding the root model cares about. Screens
 // that need additional keys define them locally.
 type Keymap struct {
-	Quit key.Binding
+	Quit       key.Binding
 	// QuitAsk used to live on `q` (then `Q` after v0.7.3 freed `q`
 	// for AttitudeRadialOut). v0.7.3.1 dropped the binding entirely:
 	// quit-confirm now lives on Esc when the home (orbit) view is
@@ -29,7 +29,7 @@ type Keymap struct {
 	FocusNext  key.Binding
 	FocusPrev  key.Binding
 	FocusReset key.Binding
-	SpawnCraft key.Binding // v0.8.1+: spawn a new craft. Replaced the v0.7.x PlanNode quick-plant default-node debug aid (m/Enter is the proper plant path).
+	SpawnCraft    key.Binding // v0.8.1+: spawn a new craft. Replaced the v0.7.x PlanNode quick-plant default-node debug aid (m/Enter is the proper plant path).
 	// ClearNodes used to live on `N` (the case-collision partner of
 	// `n` SpawnCraft, which made remembering which one wiped vs
 	// spawned a constant trip-up). v0.8.6 dropped the global
@@ -37,34 +37,34 @@ type Keymap struct {
 	// alongside per-node delete (`m` then ctrl+k / ctrl+d). Field
 	// kept with no key so callers compile during transition; remove
 	// in a later cleanup.
-	ClearNodes   key.Binding
-	PlanTransfer key.Binding
-	PlanIncl     key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
+	ClearNodes    key.Binding
+	PlanTransfer  key.Binding
+	PlanIncl      key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
 	// PlanCircularize (v0.9.4+) plants a prograde burn at the active
 	// craft's next apoapsis sized to circularise the orbit there. The
 	// "single keystroke for the natural last step of an ascent"
 	// shortcut, mirroring the v0.7.4 `I` plane-match planter.
 	PlanCircularize key.Binding
-	Porkchop        key.Binding
+	Porkchop      key.Binding
 	// v0.8.6: Save / Load moved S / L → F5 / F9 to match the KSP
 	// quicksave-quickload muscle memory and to clear the case-
 	// collision with `s` (AttitudeRetrograde) and `l` (NextBody).
-	Save       key.Binding
-	Load       key.Binding
-	RefinePlan key.Binding
-	CycleView  key.Binding
+	Save          key.Binding
+	Load          key.Binding
+	RefinePlan    key.Binding
+	CycleView     key.Binding
 
 	// v0.7.3+ manual flight controls.
-	ThrottleFull        key.Binding // throttle to 100 %
-	ThrottleCut         key.Binding // throttle 0 % (also stops a manual burn)
-	ThrottleUp          key.Binding // +10 % step
-	ThrottleDown        key.Binding // -10 % step
-	AttitudePrograde    key.Binding
-	AttitudeRetrograde  key.Binding
+	ThrottleFull       key.Binding // throttle to 100 %
+	ThrottleCut        key.Binding // throttle 0 % (also stops a manual burn)
+	ThrottleUp         key.Binding // +10 % step
+	ThrottleDown       key.Binding // -10 % step
+	AttitudePrograde   key.Binding
+	AttitudeRetrograde key.Binding
 	AttitudeNormalPlus  key.Binding
 	AttitudeNormalMinus key.Binding
-	AttitudeRadialOut   key.Binding
-	AttitudeRadialIn    key.Binding
+	AttitudeRadialOut  key.Binding
+	AttitudeRadialIn   key.Binding
 	// ToggleBurn (v0.7.3.2+): explicit engage / disengage gate for
 	// manual flight. Pre-v0.7.3.2 the attitude keys auto-started the
 	// engine, which made accidental burns easy. Now attitude keys
@@ -127,56 +127,47 @@ type Keymap struct {
 	// ascent gravity-turn flight to initiate the pitch-over from
 	// vertical. Held → continuous trim ramp at the terminal's
 	// key-repeat rate. Reset via PitchTrimReset.
-	PitchTrimEast  key.Binding
-	PitchTrimWest  key.Binding
-	PitchTrimReset key.Binding
-
-	// RollLeft / RollRight / RollReset (v0.10.0+): command the craft's
-	// roll about its lengthwise (nose) axis ±RollStepDeg per press;
-	// the body frame slews toward it like pitch/yaw. 0 = heads-up
-	// (belly-down). Q/E mirror KSP's roll keys (the radial q/e are
-	// the un-shifted pair). Reset via RollReset (|).
-	RollLeft  key.Binding
-	RollRight key.Binding
-	RollReset key.Binding
+	PitchTrimEast    key.Binding
+	PitchTrimWest    key.Binding
+	PitchTrimReset   key.Binding
 }
 
 func DefaultKeymap() Keymap {
 	return Keymap{
-		Quit: key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit (immediate)")),
+		Quit:       key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit (immediate)")),
 		// v0.7.3.1: QuitAsk no longer has a dedicated key — Esc on
 		// the home view opens the confirm prompt instead. Binding
 		// kept with no keys so the struct field stays stable; remove
 		// in v0.8 cleanup.
-		QuitAsk:  key.NewBinding(),
-		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-		BodyInfo: key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
-		Maneuver: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
-		NextBody: key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
-		PrevBody: key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
+		QuitAsk:    key.NewBinding(),
+		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		BodyInfo:   key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
+		Maneuver:   key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
+		NextBody:   key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
+		PrevBody:   key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
 		// v0.7.3: NextSystem moved s → tab to free `s` for AttitudeRetrograde.
 		NextSystem: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next system")),
 		WarpUp:     key.NewBinding(key.WithKeys("."), key.WithHelp(".", "warp up")),
 		WarpDown:   key.NewBinding(key.WithKeys(","), key.WithHelp(",", "warp down")),
 		// v0.9.1: dropped `space` from Pause; space is now Stage. `0`
 		// alone retains the pause binding (it never collided).
-		Pause:           key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "pause")),
-		ZoomIn:          key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "zoom in")),
-		ZoomOut:         key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "zoom out")),
-		Back:            key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
-		FocusNext:       key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
-		FocusPrev:       key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
-		FocusReset:      key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
-		SpawnCraft:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "spawn craft (sister copy of active)")),
-		ClearNodes:      key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
-		PlanTransfer:    key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
-		PlanIncl:        key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
+		Pause:      key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "pause")),
+		ZoomIn:     key.NewBinding(key.WithKeys("+", "="), key.WithHelp("+", "zoom in")),
+		ZoomOut:    key.NewBinding(key.WithKeys("-", "_"), key.WithHelp("-", "zoom out")),
+		Back:       key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+		FocusNext:  key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next focus")),
+		FocusPrev:  key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev focus")),
+		FocusReset: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "focus: system")),
+		SpawnCraft:   key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "spawn craft (sister copy of active)")),
+		ClearNodes:   key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
+		PlanTransfer: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
+		PlanIncl:     key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
 		PlanCircularize: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "plant circularize burn at next apoapsis")),
-		Porkchop:        key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
-		Save:            key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
-		Load:            key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
-		RefinePlan:      key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
+		Porkchop:     key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
+		Save:         key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
+		Load:         key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
+		RefinePlan:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
+		CycleView:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
 
 		ThrottleFull:        key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "throttle 100%")),
 		ThrottleCut:         key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "throttle 0% / cut burn")),
@@ -203,8 +194,5 @@ func DefaultKeymap() Keymap {
 		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +10° east")),
 		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -10° west")),
 		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
-		RollLeft:                  key.NewBinding(key.WithKeys("Q"), key.WithHelp("Q", "roll left 15°")),
-		RollRight:                 key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "roll right 15°")),
-		RollReset:                 key.NewBinding(key.WithKeys("|"), key.WithHelp("|", "reset roll (heads-up)")),
 	}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -130,6 +130,16 @@ type Keymap struct {
 	PitchTrimEast    key.Binding
 	PitchTrimWest    key.Binding
 	PitchTrimReset   key.Binding
+
+	// ToggleInstantSAS (v0.10.0+): flip the manual-flight attitude
+	// model between rate-limited slew (MANUAL, the v0.10 default) and
+	// the legacy instantaneous "magic SAS" snap (AUTO). This is the
+	// locked-decision surfacing for World.InstantSAS — a deliberate,
+	// non-silent behaviour switch, mirrored by the navball [SAS]
+	// MANUAL/AUTO tag. Bound to `k` (a free key adjacent to the
+	// w/s/a/d/q/e attitude cluster); the toggle is a session UI
+	// preference and is not persisted.
+	ToggleInstantSAS key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -194,5 +204,6 @@ func DefaultKeymap() Keymap {
 		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +10° east")),
 		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -10° west")),
 		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
+		ToggleInstantSAS:          key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "SAS model: slew / instant (MANUAL/AUTO)")),
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -63,6 +63,7 @@ func (h *Help) Render() string {
 			{"\\", "reset pitch trim to 0 (v0.9.2+)"},
 			{"b", "engage / cut manual burn (main engine only)"},
 			{"r", "engine: main / rcs (RCS = monoprop pulse-fire on attitude keys)"},
+			{"k", "SAS model: slew / instant (navball [MAN]/[AUT]) (v0.10.0+)"},
 		}},
 		{"MULTI-CRAFT (v0.8.1+)", [][2]string{
 			{"n", "open spawn form (loadout / position / parent body / altitude / direction)"},

--- a/internal/tui/screens/navball_panel.go
+++ b/internal/tui/screens/navball_panel.go
@@ -28,6 +28,7 @@ type NavballControlID int
 const (
 	navballControlNone NavballControlID = iota
 	NavballControlMode                  // cycle NavMode (orbit / surface / target)
+	NavballControlSAS                   // toggle InstantSAS (MANUAL slew <-> AUTO instant)
 	NavballControlPrograde
 	NavballControlRetrograde
 	NavballControlNormalPlus
@@ -108,6 +109,18 @@ func navModeLabel(m sim.NavMode) string {
 	return "ORBIT"
 }
 
+// sasTagLabel is the manual-flight attitude-model tag shown between
+// [MODE] and RCS. MAN = rate-limited slew (v0.10.0 default,
+// instantSAS=false); AUT = legacy instantaneous snap. Kept to 3
+// glyphs so the bracketed tag matches the [TGT]/[SURF] visual weight.
+// v0.10.0+.
+func sasTagLabel(instantSAS bool) string {
+	if instantSAS {
+		return "AUT"
+	}
+	return "MAN"
+}
+
 // buildNavballPanel renders the framed panel string and returns it
 // together with the control layout relative to the panel's own
 // top-left (0,0). The caller offsets these by the panel's screen
@@ -120,7 +133,7 @@ func navModeLabel(m sim.NavMode) string {
 // Every assembled line is exactly navballInnerW cells wide so the
 // caller's splitStyledCells / overlayStyledBlock splice stays
 // aligned (the historical right-border-drop invariant).
-func (v *OrbitView) buildNavballPanel(disk string, mode sim.NavMode, rcsActive bool) (string, []navballControlBox) {
+func (v *OrbitView) buildNavballPanel(disk string, mode sim.NavMode, instantSAS, rcsActive bool) (string, []navballControlBox) {
 	pad := func(s string, w int) string {
 		n := lipgloss.Width(s)
 		if n >= w {
@@ -140,34 +153,70 @@ func (v *OrbitView) buildNavballPanel(disk string, mode sim.NavMode, rcsActive b
 	var boxes []navballControlBox
 	btnStyle := lipgloss.NewStyle().Foreground(v.theme.Primary.GetForeground())
 
-	// Inner row 0 (panel row 1): [MODE] left, RCS right. No label —
-	// the disk speaks for itself.
+	// Inner row 0 (panel row 1): [MODE] left, [SAS] centred, RCS
+	// right. [MODE] cycles NavMode; [SAS] toggles the manual-flight
+	// attitude model (MAN slew / AUT instant — World.InstantSAS);
+	// RCS toggles the thruster. The disk speaks for itself, no label.
 	modeLabel := "[" + navModeLabel(mode) + "]"
+	sasLabel := "[" + sasTagLabel(instantSAS) + "]"
 	rcsLabel := "RCS"
 	rcsStyle := v.theme.Dim
 	if rcsActive {
 		rcsStyle = v.theme.Warning
 	}
-	gap := navballInnerW - lipgloss.Width(modeLabel) - lipgloss.Width(rcsLabel)
-	if gap < 1 {
-		gap = 1
+	// MAN (slew) is the v0.10 default → neutral; AUT (instant) is the
+	// legacy opt-out → Warning, so the non-default model is never
+	// silent (the locked-decision "not silent" requirement).
+	sasStyle := btnStyle
+	if instantSAS {
+		sasStyle = v.theme.Warning
+	}
+
+	mw := lipgloss.Width(modeLabel)
+	sw := lipgloss.Width(sasLabel)
+	rw := lipgloss.Width(rcsLabel)
+	// modeLabel hugs inner col 0; rcsLabel ends flush at innerW;
+	// sasLabel sits centred between, clamped off both neighbours so
+	// the three never collide on a wide [ORBIT] mode label.
+	rcsStart := navballInnerW - rw
+	sasStart := (navballInnerW - sw) / 2
+	if sasStart < mw+1 {
+		sasStart = mw + 1
+	}
+	if sasStart+sw > rcsStart-1 {
+		sasStart = rcsStart - 1 - sw
+	}
+	gap1 := sasStart - mw
+	gap2 := rcsStart - (sasStart + sw)
+	if gap1 < 1 {
+		gap1 = 1
+	}
+	if gap2 < 1 {
+		gap2 = 1
 	}
 	boxes = append(boxes,
 		navballControlBox{
 			id:       NavballControlMode,
 			colStart: 1, // +1 left border; mode starts at inner col 0
-			colEnd:   1 + lipgloss.Width(modeLabel),
+			colEnd:   1 + mw,
 			row:      1, // +1 top border; toggle is panel row 1
 		},
 		navballControlBox{
+			id:       NavballControlSAS,
+			colStart: 1 + sasStart,
+			colEnd:   1 + sasStart + sw,
+			row:      1,
+		},
+		navballControlBox{
 			id:       NavballControlRCS,
-			colStart: 1 + lipgloss.Width(modeLabel) + gap,
-			colEnd:   1 + lipgloss.Width(modeLabel) + gap + lipgloss.Width(rcsLabel),
+			colStart: 1 + rcsStart,
+			colEnd:   1 + rcsStart + rw,
 			row:      1,
 		},
 	)
 	toggleLine := pad(btnStyle.Render(modeLabel)+
-		strings.Repeat(" ", gap)+rcsStyle.Render(rcsLabel), navballInnerW)
+		strings.Repeat(" ", gap1)+sasStyle.Render(sasLabel)+
+		strings.Repeat(" ", gap2)+rcsStyle.Render(rcsLabel), navballInnerW)
 	lines := []string{toggleLine}
 
 	// Body: navballBodyRows rows. Left column = a stack of SAS

--- a/internal/tui/screens/navball_panel_test.go
+++ b/internal/tui/screens/navball_panel_test.go
@@ -127,13 +127,13 @@ func TestBuildNavballPanel(t *testing.T) {
 		Warning: lipgloss.NewStyle(),
 	})
 	disk := render.NavballString(navballDiskCols, navballDiskRows, 0, 0, nil)
-	panel, boxes := v.buildNavballPanel(disk, sim.NavOrbit, false)
+	panel, boxes := v.buildNavballPanel(disk, sim.NavOrbit, false, false)
 
 	plain := stripANSI(panel)
 	if strings.Contains(plain, "NAVBALL") {
 		t.Errorf("NAVBALL label should be gone:\n%s", plain)
 	}
-	for _, want := range []string{"[ORBIT]", "RCS", "PRO", "RET", "T+", "T-"} {
+	for _, want := range []string{"[ORBIT]", "[MAN]", "RCS", "PRO", "RET", "T+", "T-"} {
 		if !strings.Contains(plain, want) {
 			t.Errorf("panel missing %q:\n%s", want, plain)
 		}
@@ -160,17 +160,19 @@ func TestBuildNavballPanel(t *testing.T) {
 			t.Errorf("panel row %d splits to %d cells, want %d", i, c, navballPanelW)
 		}
 	}
-	// Mode + RCS + navballBtnRows hit-rows per axis button (each
-	// button is a multi-row click target).
-	wantBoxes := 2 + len(navballAxisRow)*navballBtnRows
+	// Mode + SAS + RCS + navballBtnRows hit-rows per axis button
+	// (each button is a multi-row click target).
+	wantBoxes := 3 + len(navballAxisRow)*navballBtnRows
 	if len(boxes) != wantBoxes {
 		t.Fatalf("got %d control boxes, want %d", len(boxes), wantBoxes)
 	}
-	sawMode, sawRCS := false, false
+	sawMode, sawSAS, sawRCS := false, false, false
 	for _, b := range boxes {
 		switch b.id {
 		case NavballControlMode:
 			sawMode = true
+		case NavballControlSAS:
+			sawSAS = true
 		case NavballControlRCS:
 			sawRCS = true
 		}
@@ -181,8 +183,31 @@ func TestBuildNavballPanel(t *testing.T) {
 	if !sawMode {
 		t.Errorf("no NavballControlMode box recorded")
 	}
+	if !sawSAS {
+		t.Errorf("no NavballControlSAS box recorded")
+	}
 	if !sawRCS {
 		t.Errorf("no NavballControlRCS box recorded")
+	}
+}
+
+// The [SAS] tag must flip MAN -> AUT with the instantSAS arg so the
+// non-default (legacy instant) model is never silent on the navball.
+func TestNavballPanelSASTag(t *testing.T) {
+	v := NewOrbitView(Theme{
+		Primary: lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+	})
+	disk := render.NavballString(navballDiskCols, navballDiskRows, 0, 0, nil)
+
+	man, _ := v.buildNavballPanel(disk, sim.NavOrbit, false /*slew*/, false)
+	if p := stripANSI(man); !strings.Contains(p, "[MAN]") || strings.Contains(p, "[AUT]") {
+		t.Errorf("slew model should show [MAN], not [AUT]:\n%s", p)
+	}
+	aut, _ := v.buildNavballPanel(disk, sim.NavOrbit, true /*instant*/, false)
+	if p := stripANSI(aut); !strings.Contains(p, "[AUT]") || strings.Contains(p, "[MAN]") {
+		t.Errorf("instant model should show [AUT], not [MAN]:\n%s", p)
 	}
 }
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1340,15 +1340,6 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		if math.Abs(trimDeg) > 0.05 {
 			trimLabel = v.theme.Warning.Render(trimLabel)
 		}
-		// Roll about the nose axis (heads-up = 0). Show the live roll,
-		// with the command in parens while it is still slewing there.
-		rollLabel := fmt.Sprintf("%+.0f°", c.CurrentRollDeg)
-		if math.Abs(c.CurrentRollDeg) < 0.5 {
-			rollLabel = "0° (heads-up)"
-		}
-		if math.Abs(c.CurrentRollDeg-c.CommandedRollDeg) > 0.5 {
-			rollLabel = fmt.Sprintf("%+.0f° → %+.0f°", c.CurrentRollDeg, c.CommandedRollDeg)
-		}
 		lines = append(lines, section("LAUNCH")...)
 		fpaLabel := "—"
 		if hasFPA {
@@ -1367,7 +1358,6 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  twr:        %s", twrLabel),
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),
-			fmt.Sprintf("  roll:       %s", rollLabel),
 		)
 		// v0.9.4+: live ascent prediction — apoapsis / periapsis / time-
 		// to-apoapsis / Δv-to-circularise. Mirrors v0.9.3's TARGET HUD

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1612,6 +1612,13 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 						lines = append(lines,
 							fmt.Sprintf("  apoapsis:  %.1f km", (tEl.Apoapsis()-tPrimaryR)/1000),
 							fmt.Sprintf("  periapsis: %.1f km", (tEl.Periapsis()-tPrimaryR)/1000),
+							// Target's own orbital inclination in its
+							// primary's reference frame — same quantity
+							// and frame as the active-craft / body
+							// orbit-readout "inclin." line, not a
+							// relative Δi. Always meaningful (target
+							// state is primary-relative), like apo/peri.
+							fmt.Sprintf("  inclin.:   %.2f°", tEl.I*180/math.Pi),
 						)
 					}
 					// Range / |v_rel|: use primary-frame deltas when

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1379,6 +1379,15 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			periAlt = el.Periapsis() - primaryR
 			apoFinite = true
 		}
+		// Inclination is defined whenever the craft has angular
+		// momentum (r × v ≠ 0) — including on the pad, where surface
+		// co-rotation gives the instantaneous plane. Surfaced in the
+		// LAUNCH HUD so the player can fly the launch azimuth to the
+		// target inclination before apoapsis even clears the surface.
+		inclLabel := "—"
+		if !math.IsNaN(el.I) && !math.IsInf(el.I, 0) {
+			inclLabel = fmt.Sprintf("%.2f°", el.I*180/math.Pi)
+		}
 		apLabel := "—"
 		peLabel := "—"
 		ttaLabel := "—"
@@ -1461,6 +1470,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		lines = append(lines,
 			fmt.Sprintf("  ap:         %s%s", apLabel, trendLabel),
 			fmt.Sprintf("  pe:         %s", peLabel),
+			fmt.Sprintf("  incl.:      %s", inclLabel),
 			fmt.Sprintf("  t_to_apo:   %s", ttaLabel),
 			fmt.Sprintf("  Δv→circ:    %s", dvCircLabel),
 			fmt.Sprintf("  t_burn:     %s", tBurnLabel),

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -745,7 +745,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		if rawLat, rawLon, ok := w.NavballSubObserver(); ok {
 			subLat, subLon := v.stickyNavballSubObserver(rawLat, rawLon)
 			disk := navballPanelDisk(w, subLat, subLon)
-			panel, boxes := v.buildNavballPanel(disk, w.NavMode, w.RCSActive())
+			panel, boxes := v.buildNavballPanel(disk, w.NavMode, w.InstantSAS, w.RCSActive())
 			atCol := cCols - navballPanelW
 			atRow := cRows - navballPanelH - 1
 			lines := strings.Split(canvasStr, "\n")

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1340,6 +1340,15 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		if math.Abs(trimDeg) > 0.05 {
 			trimLabel = v.theme.Warning.Render(trimLabel)
 		}
+		// Roll about the nose axis (heads-up = 0). Show the live roll,
+		// with the command in parens while it is still slewing there.
+		rollLabel := fmt.Sprintf("%+.0f°", c.CurrentRollDeg)
+		if math.Abs(c.CurrentRollDeg) < 0.5 {
+			rollLabel = "0° (heads-up)"
+		}
+		if math.Abs(c.CurrentRollDeg-c.CommandedRollDeg) > 0.5 {
+			rollLabel = fmt.Sprintf("%+.0f° → %+.0f°", c.CurrentRollDeg, c.CommandedRollDeg)
+		}
 		lines = append(lines, section("LAUNCH")...)
 		fpaLabel := "—"
 		if hasFPA {
@@ -1358,6 +1367,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			fmt.Sprintf("  twr:        %s", twrLabel),
 			fmt.Sprintf("  sas:        %s", sasLabel),
 			fmt.Sprintf("  trim:       %s", trimLabel),
+			fmt.Sprintf("  roll:       %s", rollLabel),
 		)
 		// v0.9.4+: live ascent prediction — apoapsis / periapsis / time-
 		// to-apoapsis / Δv-to-circularise. Mirrors v0.9.3's TARGET HUD


### PR DESCRIPTION
The v0.10.0 slice of the **"the fleet flies for real"** cycle:
attitude stops being an instantaneous kinematic snap and becomes a
process you fly. Built and playtest-validated on `v0.10.0-slew`.

## What's in it

**Core slew (`5c596b6`, `3ae9d26`)**
- `Spacecraft.CurrentAttitudeDir` + per-loadout `SlewRate`; per-tick
  slew integrator; consumers switched commanded → actual direction.
- Lead-compensated planted nodes (converged at ignition; node Δv
  math/tests intact). Attitude round-trips through save/load.
- `DefaultSlewRateDegPerSec = 15.0` (raised 5 → 15 after playtest).

**InstantSAS surfacing (`4a2339b`) — closes the last slice blocker**
- `k` toggles slew ↔ legacy instant with a `SAS: MANUAL / AUTO` toast.
- Clickable navball `[SAS]` tag (`[MAN]`/`[AUT]`, Warning when AUTO),
  separate from the `[MODE]` NavMode button. Non-default model is
  never silent, per the locked decision.

**Navball / launch (`4a01dc8`, `c106c10`, `174a825`, `95d5975`, `eb32136`, `7d350a0`)**
- Full roll degree of freedom + body-frame navball; zenith-centred
  North-up surface compass rose; landed-nose sync fixes so liftoff
  works after pad warp; target inclination in the TARGET HUD block.

**Docs (`98242e6` + plan/README updates)**
- `CLAUDE.md` codebase guide; `docs/v0.10-plan.md` status moved to
  in-test → no remaining slice blockers; README keybinding table.

## Verification

`go vet ./...` clean; full `go test ./... -race -count=1` green
across all packages.

## Note

Roll DOF + body-frame navball were folded in beyond the originally
"locked" v0.10.0 design — flagged in `docs/v0.10-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)