### PR TITLE
docs(v0.10): reconcile plan — v0.10.0 shipped

### DIFF
--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -34,7 +34,7 @@ is picked up. Mission scripting stays design-pass-first and is
 
 | slice   | status   | tag      | notes |
 |---------|----------|----------|-------|
-| v0.10.0 | in-test  | branch `v0.10.0-slew` | Slew + attitude save-persistence **built and playtest-validated** on branch (not yet tagged / merged to `main`). Lead-compensated nodes in. Unplanned scope folded in: full roll DOF + body-frame navball. `InstantSAS` surfacing **now wired** (`k` key + navball `[MAN]`/`[AUT]` tag); no remaining slice blockers (see slice note). |
+| v0.10.0 | **shipped** | `v0.10.0` | Released 2026-05-19 (PR #54 → `main` `0f57406`, tag `v0.10.0`, GoReleaser 5-platform binaries). Slew + attitude save-persistence + lead-compensated nodes; `InstantSAS` surfacing wired (`k` key + navball `[MAN]`/`[AUT]` tag). Unplanned scope folded in: full roll DOF + body-frame navball. No remaining slice blockers (see slice note). |
 | v0.10.1 | candidate| —        | Staging chain (L) — the standing #1; multi-tier fleet. |
 | v0.10.2 | candidate| —        | Rendezvous tooling (M) — consumes staging fleet; gains depth from v0.10.0. |
 | v0.10.3 | candidate| —        | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. |
@@ -71,7 +71,7 @@ is picked up. Mission scripting stays design-pass-first and is
 
 ### v0.10.0 — manual flight: rate-limited attitude (+ persistence rider)
 
-<!-- llm-parse: slice=v0.10.0 weight=M scope=sim status=in-test pair=attitude-save -->
+<!-- llm-parse: slice=v0.10.0 weight=M scope=sim status=shipped tag=v0.10.0 pair=attitude-save -->
 
 **Problem.** The nose is recomputed from `AttitudeMode` every tick
 (`NavballSubObserver` / `stepThrust` both call
@@ -159,6 +159,13 @@ updated; tests added (panel tag flip, click dispatch, box count);
 full `-race` suite green. **Slice has no remaining blockers** —
 only the non-blocking "slewing — N s to align" HUD readout stays
 deferred to a later app/render polish pass.
+
+**Shipped (2026-05-19).** Merged via PR #54 to `main` (`0f57406`)
+and released as tag `v0.10.0` — GoReleaser published 5-platform
+binaries (release run `26106292564`, success). The "slewing — N s
+to align" HUD readout is the only carried-forward item, now a
+polish-bag rider for a later v0.10.x slice (not a v0.10.0 debt).
+Cycle continues with v0.10.1 (staging chain) as the next slice.
 
 ### v0.10.1+ — carry-over candidates
 


### PR DESCRIPTION
Post-release doc reconciliation (repo convention: update the plan
when a slice ships).

- Status table: v0.10.0 `in-test` → **shipped**, tag `v0.10.0`.
- Slice `llm-parse` marker: `status=in-test` → `status=shipped tag=v0.10.0`.
- Added a "Shipped (2026-05-19)" note (PR #54 → `main` `0f57406`,
  GoReleaser run `26106292564` success, 5-platform binaries).
- Cycle header stays `status=in-progress` — v0.10.1–.4 remain
  candidates; next slice is v0.10.1 (staging chain).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)