### PR TITLE
v0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `f` / `F` | Cycle camera focus forward / backward (system → bodies → craft) |
 | `g` | Reset camera focus to system |
 | `v` | Cycle view (top → right → bottom → left → orbit-flat) |
-| `n` | Open spawn form (loadout / position / parent body / altitude / direction) |
+| `n` | Open spawn form (loadout / position / parent body / altitude / direction). Pick **Custom…** for the v0.10.1+ stack builder: on the STACK field, `←/→` picks a catalog part, `a` adds it on top, `x` removes the top stage |
 | `H` | Auto-plant Hohmann transfer to `World.Target` body (intra-primary for moons of the craft's parent; moon → parent escape via bound transfer ellipse). TargetCraft flashes "needs v0.9.3" |
 | `I` | Plant inclination match — rotates the orbital plane to `World.Target` body's inclination (or 0° equatorial when target is None). TargetCraft flashes "needs v0.9.3" |
 | `C` | Plant circularize burn at next apoapsis (v0.9.4+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
@@ -310,6 +310,16 @@ where Lambert didn't converge — `Enter` on those is a no-op.
   propulsion + visual differentiation; the orbit canvas renders
   every craft with its loadout glyph + color so they read
   distinctly even at small zoom.
+- **Multi-tier stack + configurator** (v0.10.1+). The **Apollo
+  Stack** loadout (S-IC → S-II → S-IVB → LM → CSM) flies the full
+  mission arc on the v0.9.1 staging chain: decoupling the mid-stage
+  LM spawns it as its own controllable craft (payload separation),
+  leaving the CSM core to fly the rendezvous / return. The spawn
+  form's **Custom…** entry opens a stack builder over a named stage
+  catalog (S-IC / S-II / S-IVB / ICPS / SRB / Core / F9 stages /
+  Lander / CSM / RCS-tug) — assemble any bottom-to-top stack and
+  spawn it. Custom craft round-trip through save with no schema
+  bump (per-stage state already persists at v6).
 - **Capture preview** (v0.8.2+). Plant a Hohmann to another body
   and the HUD's `CAPTURE PREVIEW` block shows what you'll arrive
   with — relative approach speed and predicted prograde /

--- a/README.md
+++ b/README.md
@@ -228,7 +228,12 @@ Click-only. No drag, no wheel-zoom.
 | `Enter` | Commit burn |
 | `Esc` | Cancel and back to orbit view |
 | `Ctrl+D` | Delete the planted node being edited (no-op when creating new) |
-| `Ctrl+K` | Clear ALL planted nodes for the active craft |
+| `c` / `C` | Clear ALL planted nodes for the active craft (`Ctrl+K` still works) |
+
+The form panel lists every planted node for the active craft
+(mode / Δv / fire-time countdown), with the node under edit
+flagged — so the planner shows the whole schedule, not just the
+burn being created.
 
 Δv drives both delivered Δv **and** burn duration via the rocket
 equation `t = (m₀/ṁ)·(1 − exp(−Δv/(Isp·g₀)))`. Zero-thrust craft

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -708,8 +708,8 @@ The reverted artifacts are git history, not a starting point. **Do not re-implem
 ✅ **shipped v0.9.6** (`internal/render/lighting.go` + `eclipse.go` + tests; merged from `v0.9.6-lighting` 78639ea → `main` 32e8d03). Sub-solar-point per body per tick → `cos(angle to sun)` shading + day/night terminator; eclipses fall out of the same geometry. Was the research-first v0.9.6 pick that closed the v0.9 cycle.
 
 ### Staging chain
-<!-- llm-parse: id=staging-chain status=backlog target=v0.9 -->
-🧊 **backlog · target v0.9**. Ground launch → orbit → ICPS / S-IVB / lander staging chain so the craft fleet has more than one tier of capability. Unblocks (c) multi-rev porkchop and the rendezvous tooling slice (more craft → more practical scenarios).
+<!-- llm-parse: id=staging-chain status=in-progress target=v0.10.1 -->
+🛠 **in progress · v0.10.1** (branch `v0.10.1-staging`). Basic manual chain shipped v0.9.1 (`space` decouples `Stages[0]`, Saturn-V loadout, STAGES HUD). The L expansion — multi-tier loadouts (Apollo-Stack with mid-stage Lander payload separation) + a named stage catalog + a spawn-form stack configurator — is scope-committed in `docs/v0.10-plan.md` §v0.10.1. Unblocks (c) multi-rev porkchop and the rendezvous tooling slice (more craft → more practical scenarios).
 
 ### Multiplayer implementation
 <!-- llm-parse: id=multiplayer status=planning target=v0.9-stretch -->

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -688,8 +688,50 @@ The reverted artifacts are git history, not a starting point. **Do not re-implem
 🧊 **backlog · target v0.9**. v0.5.7's `PlanIntraPrimaryHohmann` covers same-parent (LEO → Luna); v0.6.3 covers moon → parent. The remaining direction — heliocentric → moon-of-other-planet (Phobos from a Mars approach, a Galilean from a Jupiter cruise) — needs a real patched-conic capture pass through both SOIs.
 
 ### Combined plane-shift + Hohmann
-<!-- llm-parse: id=plane-shift-hohmann status=backlog target=v0.9 weight=L -->
-🧊 **backlog · target v0.9 · substantial**. Lambert solver constrained on post-capture inclination so departure geometry lands prograde at the destination instead of the current "match ecliptic, hope arrival inclination is OK" pattern. The v0.8-plan.md retrospective explicitly flags this as **substantial** — the binding technical work is the constrained Lambert variant (root-find on inclination as well as time-of-flight), not the UI plumbing. Pairs naturally with the [capture-direction toggle](#capture-direction-toggle) since both touch arrival-side geometry.
+<!-- llm-parse: id=plane-shift-hohmann status=spec-committed target=v0.11 weight=L -->
+🧊 **backlog · spec-committed · target v0.11 · substantial**. Lambert solver constrained on post-capture inclination so departure geometry lands prograde at the destination instead of the current "match ecliptic, hope arrival inclination is OK" pattern. The v0.8-plan.md retrospective explicitly flags this as **substantial** — the binding technical work is the constrained Lambert variant (root-find on inclination as well as time-of-flight), not the UI plumbing. Pairs naturally with the [capture-direction toggle](#capture-direction-toggle) since both touch arrival-side geometry.
+
+**Why now committed (2026-05-19, from v0.10.1 playtest):** the
+playtest confirmed the user-visible symptom this fixes — the `H`
+auto-plant "only calculates properly from a 0° inclination,
+circular orbit." Root cause is two coupled assumptions in
+`planner.PlanIntraPrimaryHohmann` / `HohmannTransfer` +
+`sim.PlanTransfer`: (1) `rPark := craft.State.R.Norm()` is fed in
+as a *circular* radius (`vDepCirc = √(µ/rPark)`), so an eccentric
+departure orbit gets the wrong Δv and the burn isn't placed at
+periapsis; (2) phasing is a flat `atan2(R.Y, R.X)` with **no
+plane-change term at all**, so an inclined parking orbit can't
+reach the target's plane. A non-blocking advisory guard shipped
+in v0.10.1 (`sim.HohmannDepartureWarning` / `hohmannGuardDetail`,
+surfaced on `H` and in `HohmannPreview.Warn`) so the symptom is
+no longer silent, but it does **not** change the math.
+
+**Committed scope for the real fix (the L slice):**
+- **Eccentric-aware departure** — derive the parking orbit's
+  Keplerian elements, place the departure impulse at periapsis (or
+  the optimal true anomaly), and size Δv off the *actual* speed
+  there, not `√(µ/r)`. Removes assumption (1); independently
+  useful even coplanar.
+- **Plane change folded into the transfer** — the constrained
+  Lambert variant: root-find on the inclination/RAAN match as well
+  as time-of-flight so the transfer arc leaves the craft's plane
+  and arrives in the target's, replacing the separate `I`-then-`H`
+  dance. Removes assumption (2).
+- **Δv split policy** — combined plane+raise at departure vs. a
+  cheaper plane change at the higher-altitude node; expose enough
+  in the preview/HUD that the player sees the trade.
+- **Guard retirement** — once the planner is plane/eccentricity
+  aware the v0.10.1 advisory becomes a (much rarer) true-error
+  case; downgrade or remove it.
+- **Test surface** — eccentric coplanar departure matches an
+  independent two-body propagation; inclined departure arrives in
+  the target plane within tolerance; `I`-then-`H` and the combined
+  path converge to the same orbit.
+
+Sized **L / substantial** (real transfer math, not UI plumbing);
+**not** in v0.10 — targeted at v0.11 (its own slice), pairs with
+the [capture-direction toggle](#capture-direction-toggle) and
+[wider cross-SOI PlanTransfer](#wider-cross-soi-plantransfer).
 
 ### Capture-direction toggle
 <!-- llm-parse: id=capture-direction-toggle status=backlog target=v0.9 -->
@@ -892,7 +934,7 @@ doc.
 | 1 | [Staging chain](#staging-chain) | L | 🧊 backlog | Ground launch → LEO → ICPS → lander chain. Composes multi-stage staging + atmosphere + launch mechanics. Unblocks practical use of (2)–(4). Open Qs: [staging continuity](#staging-continuity), [composite-craft mass distribution](#composite-craft-mass-distribution-post-docking) gate this. |
 | 2 | [Mission scripting](#mission-scripting--editor) | L | ⚠ rolled back | **Design-pass first** (eight decision points), then re-implement. Reference v0.8.7-attempt artifacts only for implementation shape. Block 1: write the modder-UX target end-to-end. |
 | 3 | [Wider cross-SOI PlanTransfer](#wider-cross-soi-plantransfer) | L | 🧊 backlog | Heliocentric → moon-of-other-planet patched-conic capture. Substantial new transfer math. |
-| 4 | [Combined plane-shift + Hohmann](#combined-plane-shift--hohmann) | L | 🧊 backlog | Lambert constrained on post-capture inclination. Substantial — root-find on inclination + time-of-flight. |
+| 4 | [Combined plane-shift + Hohmann](#combined-plane-shift--hohmann) | L | 🧊 spec-committed (v0.11) | Eccentric-aware departure + plane change folded into the transfer (constrained Lambert). v0.10.1 shipped a non-blocking advisory guard only; full spec committed. |
 | 5 | [Rendezvous tooling](#rendezvous-tooling) | M | 🧊 backlog | Target-craft selection + target-relative burn modes + null-v_rel at closest approach + iteration. Pairs with multi-craft fleet from (1). |
 | 6 | [Solar lighting + terminator + eclipses](#solar-lighting--daynight-terminator--eclipses) | M | ✅ shipped v0.9.6 | Landed `internal/render/lighting.go`+`eclipse.go`; closed the v0.9 cycle (merge 32e8d03). |
 | 7 | [Predictor adaptive sampling](#predictor-adaptive-sampling) | M | 🧊 backlog | Three-cycle carry-over; foundation shipped v0.8.4. ~150–200 LOC. |

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -35,7 +35,7 @@ is picked up. Mission scripting stays design-pass-first and is
 | slice   | status   | tag      | notes |
 |---------|----------|----------|-------|
 | v0.10.0 | **shipped** | `v0.10.0` | Released 2026-05-19 (PR #54 → `main` `0f57406`, tag `v0.10.0`, GoReleaser 5-platform binaries). Slew + attitude save-persistence + lead-compensated nodes; `InstantSAS` surfacing wired (`k` key + navball `[MAN]`/`[AUT]` tag). Unplanned scope folded in: full roll DOF + body-frame navball. No remaining slice blockers (see slice note). |
-| v0.10.1 | candidate| —        | Staging chain (L) — the standing #1; multi-tier fleet. |
+| v0.10.1 | **in progress** | — | Staging chain (L) — multi-tier fleet. **Scope committed 2026-05-19** (branch `v0.10.1-staging`): named stage catalog + multi-tier loadouts (Apollo-Stack w/ payload separation) + spawn-form stack configurator. See slice below. |
 | v0.10.2 | candidate| —        | Rendezvous tooling (M) — consumes staging fleet; gains depth from v0.10.0. |
 | v0.10.3 | candidate| —        | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. |
 | v0.10.4 | candidate| —        | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. |
@@ -167,14 +167,115 @@ to align" HUD readout is the only carried-forward item, now a
 polish-bag rider for a later v0.10.x slice (not a v0.10.0 debt).
 Cycle continues with v0.10.1 (staging chain) as the next slice.
 
-### v0.10.1+ — carry-over candidates
+### v0.10.1 — multi-tier fleet: stage catalog + stack configurator
+
+<!-- llm-parse: slice=v0.10.1 weight=L scope=spacecraft+sim+tui status=in-progress branch=v0.10.1-staging -->
+
+**Scope committed 2026-05-19.** v0.9.1 shipped the *basic* manual
+staging chain (`space` decouples `Stages[0]`, Saturn-V loadout,
+STAGES HUD). The L expansion grows the fleet into a *multi-tier*
+one and lets the player build their own stack — the prerequisite
+the v0.10.2 rendezvous slice "consumes a richer post-staging
+fleet" framing depends on. Headline (locked via AskUserQuestion):
+**multi-tier loadouts + stack configurator**.
+
+**Key enabling observation.** The existing linear pop-bottom
+staging chain (`sim/staging.go`) *already* supports payload
+separation: a `Lander` placed as a **mid-stage** in a chain
+spawns as its own controllable slate craft on decouple, while the
+top stage (`Stages[len-1]`) is the surviving core. So Part A
+needs **no sim changes** — it is purely an additive catalog +
+loadouts. Part B needs a constructor + a spec field + form UI,
+and — because per-stage `Stage` already round-trips at save
+schema v6 (v0.9.1) — **no save-schema bump / migration**. This is
+what keeps an L-tier slice bounded.
+
+**Part A — named stage catalog + multi-tier loadouts.**
+
+- New `internal/spacecraft/stages_catalog.go`: an ID-addressable
+  `StageModule` library (`s-ic`, `s-ii`, `s-ivb`, `icps`, `srb`,
+  `core-rs25`, `f9-s1`, `f9-s2`, `lander`, `csm`, `rcs-tug`) with
+  `StageCatalogOrder` + `BuildStage(id)` (fresh full-tank `Stage`).
+  **Additive only** — existing `Loadouts` literals are *not*
+  refactored onto the catalog, so every existing loadout/golden
+  test stays byte-identical. The catalog feeds the configurator
+  (Part B) and the new loadout (this part).
+- New **CSM** module (Apollo Command/Service Module, storable-
+  propellant SPS) — a payload-tier part that can do real orbital
+  maneuvers (rendezvous-relevant).
+- New **Apollo-Stack** loadout: `[S-IC, S-II, S-IVB, Lander, CSM]`
+  bottom-first. Decouple sequence drops S-IC → S-II → S-IVB
+  (post-TLI) → **Lander** (spawns as a separate controllable
+  craft) leaving the **CSM** as the player's surviving core — a
+  real launch→TLI→separation→rendezvous arc on top of the v0.9.1
+  machinery. Appended to `LoadoutOrder` (existing default
+  unchanged).
+
+**Part B — stack configurator (spawn form).**
+
+- `spacecraft.NewFromStages([]Stage)` — sibling of
+  `NewFromLoadout`; empty `LoadoutID`, `SyncFields` derives the
+  flat mirror. Custom craft persist via the existing v6 `Stages`
+  wire format (LoadoutID empty resolves to default for shadow
+  fields only — no migration).
+- `SpawnSpec.CustomStages []spacecraft.Stage`; `World.SpawnCraft`
+  builds from custom stages when non-empty (orbit/launchpad/
+  alongside placement all still apply). Empty stack rejected.
+- `tui/screens/spawn.go`: a `Custom…` pseudo-entry at the end of
+  the CRAFT TYPE list. When selected + focused, a **STACK** editor
+  block renders the working stack bottom→top with a catalog part
+  picker. Keys (form-local, no global collisions): `←/→` move the
+  part picker, `a` add picked part on top, `x` remove top stage.
+  Reorder/insert-at-cursor is **deferred polish** (build-up-only
+  covers the core; keeps the slice shippable).
+
+**Weight.** L — spans `spacecraft` + `sim` + `tui`. The v0.8
+sizing caveat applies (plan generously); the no-sim-change /
+no-migration observations above are the deliberate scope
+reductions that keep it from sprawling.
+
+**Regression surface.** `internal/spacecraft/loadouts_test.go`
+(catalog parity, Apollo-Stack TWR/stage-count), `internal/sim/
+staging_test.go` (Apollo-Stack decouple chain leaves CSM),
+`internal/sim/spawn_test.go` (CustomStages spawn), new
+`spawn_test.go` form tests (Custom entry, STACK add/remove,
+render). Existing loadout/golden tests must stay green
+(additive-only invariant).
+
+**Deferred within the slice.** Stack reorder / insert-at-cursor;
+per-stage parameter editing in the form (catalog parts are fixed
+presets this slice); a save field marking a craft "custom"
+(cosmetic — Stages already persist).
+
+**Built (2026-05-19, branch `v0.10.1-staging`).** Shipped on
+branch; full `go vet ./...` + `go test ./... -race -count=1`
+green. Implemented exactly as specced — both scope-reduction
+observations held: **no sim change** (Apollo-Stack rides the
+v0.9.1 staging chain unmodified — the LM mid-stage decouples to a
+controllable slate craft, CSM is the surviving core) and **no
+save migration** (custom craft round-trip via the v6 per-stage
+wire form; the empty-LoadoutID rewrite at load is skipped because
+`NewFromStages` populates Glyph/Color from the core stage). New:
+`internal/spacecraft/stages_catalog.go` (11-part catalog incl.
+net-new CSM module; additive — existing loadout literals
+untouched, all golden tests byte-identical), `Apollo-Stack`
+loadout (lift-off TWR ≈ 1.22), `spacecraft.NewFromStages`,
+`SpawnSpec.CustomStages` + the `SpawnCraft` custom branch, and
+the spawn-form `Custom…` entry + STACK editor (`←/→` pick part,
+`a` add on top, `x` remove top; empty-stack confirm rejected with
+a flash, form stays open). Tests added across spacecraft / sim /
+screens. Help overlay + README mirror the new keys. **Deferred
+as specced:** stack reorder/insert, per-stage param editing.
+Slice ready for tag/merge once playtested.
+
+### v0.10.2+ — carry-over candidates
 
 Detailed specs live in `docs/state-of-game.md` §Backlog; not
 duplicated here until committed. Ordered rationale:
 
-- **Staging chain (L)** — standing #1; multi-tier fleet. Unblocks
-  practical rendezvous and multi-rev porkchop. Largest item;
-  apply the v0.8 sizing caveat (plan generously).
+- **Staging chain (L)** — *committed as v0.10.1 (in progress)*;
+  see the slice section above. Unblocks practical rendezvous and
+  multi-rev porkchop.
 - **Rendezvous tooling (M)** — consumes a richer post-staging
   fleet *and* gains its core difficulty from v0.10.0 (target-
   relative burns under real slew). Thematic partner of v0.10.0,

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -316,7 +316,15 @@ design-pass-first, its own future cycle.
 - Mission scripting / editor (design pass first — eight decision
   points; reverted v0.8.7 attempt is reference only).
 - Wider cross-SOI `PlanTransfer`; combined plane-shift + Hohmann
-  (L-tier backlog, real transfer math, not this cycle's path).
+  (L-tier, real transfer math, not this cycle's path). v0.10.1
+  playtest confirmed the user-visible symptom (the `H` auto-plant
+  is accurate only from a ~circular, coplanar orbit) and shipped a
+  **non-blocking advisory guard** (`sim.HohmannDepartureWarning`,
+  surfaced on `H` + in `HohmannPreview.Warn`) — the math is
+  unchanged. The real fix (eccentric-aware departure + plane
+  change folded into the transfer / constrained Lambert) is now
+  **spec-committed** in `docs/state-of-game.md` §"Combined
+  plane-shift + Hohmann", targeted at v0.11.
 - Multiplayer (design current, foundations in, not slated).
 
 ## Open questions for v0.10

--- a/internal/sim/hohmann.go
+++ b/internal/sim/hohmann.go
@@ -20,6 +20,12 @@ type HohmannPreview struct {
 	TTransfer  float64 // seconds
 	Valid      bool    // false when inputs are degenerate
 	Note       string  // human-readable reason when !Valid
+	// Warn (v0.10.1+) is a non-fatal advisory shown alongside a
+	// VALID preview: the intra-primary numbers assume a circular
+	// coplanar departure orbit, so an eccentric / inclined parking
+	// orbit makes them optimistic. Empty when the orbit is within
+	// tolerance. See HohmannDepartureWarning.
+	Warn string
 }
 
 // HohmannPreviewFor computes a preview to the indicated body index in
@@ -48,6 +54,7 @@ func (w *World) HohmannPreviewFor(bodyIdx int) HohmannPreview {
 	}
 
 	var mu, r1, r2 float64
+	var warn string
 	switch {
 	case target.ParentID == w.ActiveCraft().Primary.ID:
 		// Intra-primary: craft and target both orbit the craft's
@@ -57,6 +64,7 @@ func (w *World) HohmannPreviewFor(bodyIdx int) HohmannPreview {
 		mu = w.ActiveCraft().Primary.GravitationalParameter()
 		r1 = w.ActiveCraft().State.R.Norm()
 		r2 = target.SemimajorAxisMeters()
+		warn = w.HohmannDepartureWarning(bodyIdx)
 	case w.ActiveCraft().Primary.ParentID != "" && target.ID == w.ActiveCraft().Primary.ParentID:
 		// Moon → parent (e.g. Luna craft + Earth target). The actual
 		// transfer is a moon-escape ellipse, not a two-impulse
@@ -90,6 +98,7 @@ func (w *World) HohmannPreviewFor(bodyIdx int) HohmannPreview {
 		DV2:        dv2,
 		TTransfer:  t,
 		Valid:      true,
+		Warn:       warn,
 	}
 }
 
@@ -101,9 +110,13 @@ func (p HohmannPreview) Format() []string {
 		}
 		return []string{fmt.Sprintf("  Hohmann: %s", p.Note)}
 	}
-	return []string{
+	lines := []string{
 		fmt.Sprintf("  Δv1: %.2f km/s", p.DV1/1000),
 		fmt.Sprintf("  Δv2: %.2f km/s", p.DV2/1000),
 		fmt.Sprintf("  t:   %.1f d", p.TTransfer/bodies.SecondsPerDay),
 	}
+	if p.Warn != "" {
+		lines = append(lines, "  ⚠ "+p.Warn)
+	}
+	return lines
 }

--- a/internal/sim/hohmann_guard.go
+++ b/internal/sim/hohmann_guard.go
@@ -1,0 +1,114 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// Hohmann coplanar/circular guard (v0.10.1+).
+//
+// The Hohmann auto-plant (`H` → PlanTransfer → PlanIntraPrimaryHohmann)
+// is a textbook *circular-to-circular coplanar* two-impulse solver: it
+// feeds the craft's instantaneous |R| in as a circular parking radius
+// (sim/maneuver.go) and has no plane-change term anywhere. When the
+// departure orbit is eccentric the assumed circular speed √(µ/r) is
+// wrong; when it is inclined relative to the target's orbital plane a
+// prograde burn never reaches the target. Either way the planted
+// transfer is silently off.
+//
+// This guard does NOT change the planner — the real fix (eccentric-
+// aware departure at periapsis + a plane change folded into the burns,
+// a constrained-Lambert variant) is the deferred L-tier "Combined
+// plane-shift + Hohmann" backlog item. It only surfaces a clear,
+// non-blocking warning so the player understands why the result looks
+// off and what to do instead (match the plane with `I`, circularize,
+// then `H`). The transfer is still planted — this is advisory, not a
+// refusal.
+
+const (
+	// hohmannEccTol — departure eccentricity above which the circular
+	// assumption introduces a meaningful Δv / timing error.
+	hohmannEccTol = 0.02
+	// hohmannInclTolDeg — relative-plane tilt (deg) above which the
+	// coplanar assumption breaks the rendezvous geometry. ~1° at
+	// Luna's distance is already thousands of km of miss.
+	hohmannInclTolDeg = 1.0
+)
+
+// hohmannGuardDetail returns a human-readable warning when the
+// departure orbit (rC, vC about a primary with GM mu) is too
+// eccentric or too far out of the target orbit's plane (normal
+// nTarget, in the same frame as rC/vC) for the coplanar circular
+// Hohmann solver to be accurate. Returns "" when the orbit is within
+// tolerance — or when the inputs are too degenerate to assess (no
+// false positives).
+//
+// Pure (no World) so the geometry is unit-testable in isolation; the
+// World wrapper below only supplies nTarget.
+func hohmannGuardDetail(rC, vC orbital.Vec3, mu float64, nTarget orbital.Vec3, eTol, inclTolDeg float64) string {
+	nCraft := rC.Cross(vC)
+	if nCraft.Norm() == 0 || nTarget.Norm() == 0 || mu <= 0 {
+		return "" // can't assess — stay silent rather than cry wolf
+	}
+	var problems []string
+
+	if el := orbital.ElementsFromState(rC, vC, mu); el.E > eTol {
+		problems = append(problems, fmt.Sprintf("e=%.2f", el.E))
+	}
+
+	cos := nCraft.Dot(nTarget) / (nCraft.Norm() * nTarget.Norm())
+	if cos > 1 {
+		cos = 1
+	} else if cos < -1 {
+		cos = -1
+	}
+	ang := math.Acos(cos) * 180 / math.Pi
+	relIncl := math.Min(ang, 180-ang) // plane tilt, direction-agnostic
+	if relIncl > inclTolDeg {
+		problems = append(problems, fmt.Sprintf("rel.incl %.1f°", relIncl))
+	}
+
+	if len(problems) == 0 {
+		return ""
+	}
+	return "Hohmann assumes a ~circular, coplanar orbit (" +
+		strings.Join(problems, ", ") +
+		") — match plane [I] + circularize, then [H]"
+}
+
+// HohmannDepartureWarning returns a non-empty advisory when the
+// active craft's departure orbit is poorly conditioned for the
+// coplanar circular Hohmann auto-plant to the body at targetIdx.
+// Scoped to the intra-primary case (craft + target share a primary,
+// e.g. LEO → Luna) — the path where the |R|-as-circular-radius and
+// zero-inclination assumptions bite hardest. Returns "" for the
+// heliocentric / moon-escape paths (out of scope for this guard) and
+// whenever the geometry is within tolerance. v0.10.1+.
+func (w *World) HohmannDepartureWarning(targetIdx int) string {
+	sys := w.System()
+	if targetIdx <= 0 || targetIdx >= len(sys.Bodies) {
+		return ""
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		return ""
+	}
+	target := sys.Bodies[targetIdx]
+	if target.ParentID != c.Primary.ID {
+		return "" // not the intra-primary path
+	}
+	mu := c.Primary.GravitationalParameter()
+	// Target orbit-plane normal: two parent-relative samples a short
+	// time apart, crossed. Frame-agnostic and needs no body-velocity
+	// API — works for any moon/parent pair.
+	now := w.Clock.SimTime
+	const dt = time.Hour
+	p0 := w.BodyPositionAt(target, now).Sub(w.BodyPositionAt(c.Primary, now))
+	p1 := w.BodyPositionAt(target, now.Add(dt)).Sub(w.BodyPositionAt(c.Primary, now.Add(dt)))
+	nTarget := p0.Cross(p1)
+	return hohmannGuardDetail(c.State.R, c.State.V, mu, nTarget, hohmannEccTol, hohmannInclTolDeg)
+}

--- a/internal/sim/hohmann_guard_test.go
+++ b/internal/sim/hohmann_guard_test.go
@@ -1,0 +1,130 @@
+package sim
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+const earthMuTest = 3.986004418e14
+
+// circularState returns a circular orbit at radius r in the XY plane
+// (plane normal = +Z) about a primary with GM mu.
+func circularState(r, mu float64) (orbital.Vec3, orbital.Vec3) {
+	return orbital.Vec3{X: r}, orbital.Vec3{Y: math.Sqrt(mu / r)}
+}
+
+// TestHohmannGuardDetailCircularCoplanar — a circular orbit coplanar
+// with the target plane is within tolerance: no warning.
+func TestHohmannGuardDetailCircularCoplanar(t *testing.T) {
+	r, v := circularState(7.0e6, earthMuTest)
+	nTarget := orbital.Vec3{Z: 1} // same plane as the XY orbit
+	if got := hohmannGuardDetail(r, v, earthMuTest, nTarget, hohmannEccTol, hohmannInclTolDeg); got != "" {
+		t.Errorf("circular coplanar should not warn, got %q", got)
+	}
+}
+
+// TestHohmannGuardDetailEccentric — an eccentric (but coplanar)
+// departure orbit trips the eccentricity clause.
+func TestHohmannGuardDetailEccentric(t *testing.T) {
+	r, v := circularState(7.0e6, earthMuTest)
+	v = v.Scale(1.25) // raise apoapsis → e well above 0.02
+	nTarget := orbital.Vec3{Z: 1}
+	got := hohmannGuardDetail(r, v, earthMuTest, nTarget, hohmannEccTol, hohmannInclTolDeg)
+	if !strings.Contains(got, "e=") {
+		t.Errorf("eccentric orbit should flag e=, got %q", got)
+	}
+	if strings.Contains(got, "rel.incl") {
+		t.Errorf("coplanar orbit should not flag inclination, got %q", got)
+	}
+}
+
+// TestHohmannGuardDetailInclined — a circular orbit tilted out of
+// the target plane trips the inclination clause (and not e).
+func TestHohmannGuardDetailInclined(t *testing.T) {
+	r, v := circularState(7.0e6, earthMuTest)
+	// Target plane normal tilted 30° off the craft's +Z normal.
+	nTarget := orbital.Vec3{Y: math.Sin(30 * math.Pi / 180), Z: math.Cos(30 * math.Pi / 180)}
+	got := hohmannGuardDetail(r, v, earthMuTest, nTarget, hohmannEccTol, hohmannInclTolDeg)
+	if !strings.Contains(got, "rel.incl 30.0") {
+		t.Errorf("30° tilt should flag rel.incl 30.0, got %q", got)
+	}
+	if strings.Contains(got, "e=") {
+		t.Errorf("circular orbit should not flag eccentricity, got %q", got)
+	}
+}
+
+// TestHohmannGuardDetailDegenerateSilent — degenerate inputs (zero
+// target normal, zero velocity) must stay silent, never cry wolf.
+func TestHohmannGuardDetailDegenerateSilent(t *testing.T) {
+	r, v := circularState(7.0e6, earthMuTest)
+	if got := hohmannGuardDetail(r, v, earthMuTest, orbital.Vec3{}, hohmannEccTol, hohmannInclTolDeg); got != "" {
+		t.Errorf("zero target normal should be silent, got %q", got)
+	}
+	if got := hohmannGuardDetail(r, orbital.Vec3{}, earthMuTest, orbital.Vec3{Z: 1}, hohmannEccTol, hohmannInclTolDeg); got != "" {
+		t.Errorf("zero craft velocity should be silent, got %q", got)
+	}
+}
+
+// moonIndex finds the Moon's body index in the active system, or -1.
+func moonIndex(w *World) int {
+	for i, b := range w.System().Bodies {
+		if b.ID == "moon" || b.EnglishName == "Moon" {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestHohmannDepartureWarningLEOtoLuna — the default equatorial LEO
+// is ~circular but Luna's orbit is inclined ~5.1° to it, so the
+// intra-primary auto-plant is off-plane: the advisory must fire and
+// name the inclination (this is exactly the reported "only works
+// from a 0° circular orbit" symptom, now surfaced not silent).
+func TestHohmannDepartureWarningLEOtoLuna(t *testing.T) {
+	w := mustWorld(t)
+	mi := moonIndex(w)
+	if mi < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	warn := w.HohmannDepartureWarning(mi)
+	if warn == "" {
+		t.Fatal("expected an advisory for equatorial-LEO → inclined-Luna")
+	}
+	if !strings.Contains(warn, "rel.incl") {
+		t.Errorf("advisory should name the plane mismatch, got %q", warn)
+	}
+
+	// The preview surfaces the same advisory as a 4th HUD line.
+	p := w.HohmannPreviewFor(mi)
+	if !p.Valid || p.Warn == "" {
+		t.Fatalf("intra-primary preview should be Valid with a Warn, got valid=%v warn=%q", p.Valid, p.Warn)
+	}
+	if lines := p.Format(); len(lines) != 4 || !strings.Contains(lines[3], "⚠") {
+		t.Errorf("Format should append a ⚠ advisory line, got %v", lines)
+	}
+}
+
+// TestHohmannDepartureWarningOutOfScopeSilent — the guard is scoped
+// to the intra-primary path; heliocentric targets and the system
+// primary must return no advisory.
+func TestHohmannDepartureWarningOutOfScopeSilent(t *testing.T) {
+	w := mustWorld(t)
+	if got := w.HohmannDepartureWarning(0); got != "" {
+		t.Errorf("system primary should be silent, got %q", got)
+	}
+	marsIdx := -1
+	for i, b := range w.System().Bodies {
+		if b.ID == "mars" || b.EnglishName == "Mars" {
+			marsIdx = i
+			break
+		}
+	}
+	if marsIdx >= 0 {
+		if got := w.HohmannDepartureWarning(marsIdx); got != "" {
+			t.Errorf("heliocentric Mars is out of guard scope, want silent, got %q", got)
+		}
+	}
+}

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -81,6 +81,15 @@ type SpawnSpec struct {
 	Retrograde   bool
 	Alongside    bool
 
+	// CustomStages (v0.10.1+) is a player-assembled stage list from
+	// the spawn-form stack configurator, bottom-first (same
+	// convention as Loadout.Stages). When non-empty it builds the
+	// craft via spacecraft.NewFromStages and LoadoutID is ignored —
+	// a custom stack has no catalog archetype. Empty (the common
+	// case) → the LoadoutID path. Placement (orbit / launchpad /
+	// alongside) is orthogonal and still applies.
+	CustomStages []spacecraft.Stage
+
 	// Launchpad (v0.9.2+): when true, spawn at altitude 0 on the
 	// parent body's surface co-moving with the rotating ground at
 	// `Latitude` / `LongitudeOffset` (degrees, north / east positive).
@@ -133,11 +142,20 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		return nil, errNoActiveCraftToCopy
 	}
 
-	id := spec.LoadoutID
-	if id == "" {
-		id = w.nextLoadoutID()
+	var c *spacecraft.Spacecraft
+	if len(spec.CustomStages) > 0 {
+		// v0.10.1+: player-assembled stack from the configurator.
+		// Ignores LoadoutID — a custom craft is not a catalog
+		// archetype. NewFromStages returns nil only on an empty
+		// slice, already excluded by the len() guard.
+		c = spacecraft.NewFromStages(spec.CustomStages)
+	} else {
+		id := spec.LoadoutID
+		if id == "" {
+			id = w.nextLoadoutID()
+		}
+		c = spacecraft.NewFromLoadout(id)
 	}
-	c := spacecraft.NewFromLoadout(id)
 	c.Name = w.nextCraftName(c.Name)
 
 	if spec.Alongside {

--- a/internal/sim/spawn_custom_test.go
+++ b/internal/sim/spawn_custom_test.go
@@ -1,0 +1,77 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestSpawnCustomStagesBuildsFromStack — v0.10.1 stack-configurator
+// path: a SpawnSpec carrying CustomStages builds the craft via
+// NewFromStages (ignoring LoadoutID), places it in orbit like any
+// other spawn, and adds it as the active slate craft.
+func TestSpawnCustomStagesBuildsFromStack(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sic, _ := spacecraft.BuildStage(spacecraft.StageModuleSICID)
+	sivb, _ := spacecraft.BuildStage(spacecraft.StageModuleSIVBID)
+	csm, _ := spacecraft.BuildStage(spacecraft.StageModuleCSMID)
+
+	before := len(w.Crafts)
+	c, err := w.SpawnCraft(SpawnSpec{
+		// LoadoutID set but must be ignored when CustomStages present.
+		LoadoutID:    spacecraft.LoadoutSaturnVID,
+		CustomStages: []spacecraft.Stage{sic, sivb, csm},
+		ParentBodyID: "earth",
+		AltitudeM:    400e3,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(custom): %v", err)
+	}
+	if len(w.Crafts) != before+1 || w.ActiveCraft() != c {
+		t.Fatalf("custom craft not added as active (slate %d→%d)", before, len(w.Crafts))
+	}
+	if len(c.Stages) != 3 {
+		t.Errorf("custom craft stage count = %d, want 3", len(c.Stages))
+	}
+	if c.LoadoutID != "" {
+		t.Errorf("custom craft LoadoutID = %q, want empty (Saturn-V must be ignored)", c.LoadoutID)
+	}
+	if c.Stages[0].Name != "S-IC" || c.Stages[2].Name != "CSM" {
+		t.Errorf("stack order wrong: bottom=%q top=%q", c.Stages[0].Name, c.Stages[2].Name)
+	}
+	if c.Primary.ID != "earth" {
+		t.Errorf("primary = %q, want earth", c.Primary.ID)
+	}
+	// The custom stack must still decouple through the v0.9.1 chain.
+	if _, _, err := w.StageActive(w.ActiveCraftIdx); err != nil {
+		t.Errorf("custom craft StageActive: %v", err)
+	}
+	if len(w.ActiveCraft().Stages) != 2 {
+		t.Errorf("after one decouple: %d stages, want 2", len(w.ActiveCraft().Stages))
+	}
+}
+
+// TestSpawnEmptyCustomStagesFallsThroughToLoadout — defence in
+// depth: an empty CustomStages slice must NOT be treated as a
+// custom craft (the form layer rejects empty stacks before here,
+// but SpawnCraft must not panic / mis-build if one slips through).
+func TestSpawnEmptyCustomStagesFallsThroughToLoadout(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID:    spacecraft.LoadoutICPSID,
+		CustomStages: nil,
+		ParentBodyID: "earth",
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if c.LoadoutID != spacecraft.LoadoutICPSID {
+		t.Errorf("empty CustomStages should fall through to LoadoutID, got %q", c.LoadoutID)
+	}
+}

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -181,3 +181,52 @@ func TestStageActiveAdvancesEngineToNextStage(t *testing.T) {
 		t.Errorf("post-stage Isp (S-II): got %.0f, want 421", active.Isp)
 	}
 }
+
+// TestApolloStackDecoupleChainLeavesCSM — the v0.10.1 Apollo-Stack
+// is [S-IC, S-II, S-IVB, LM, CSM]. Four decouples drop S-IC → S-II
+// → S-IVB → LM; the LM jettison spawns a separate controllable
+// slate craft (payload separation), and the active craft is left
+// as the single-stage CSM core. The fifth decouple refuses
+// (ErrStageOnlyOne — can't drop the only/last stage).
+func TestApolloStackDecoupleChainLeavesCSM(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+
+	if len(stack.Stages) != 5 {
+		t.Fatalf("Apollo-Stack should start 5-stage, got %d", len(stack.Stages))
+	}
+
+	wantDropped := []string{"S-IC", "S-II", "S-IVB", "LM"}
+	for i, name := range wantDropped {
+		_, jettIdx, err := w.StageActive(0)
+		if err != nil {
+			t.Fatalf("decouple %d (%s): %v", i, name, err)
+		}
+		jett := w.Crafts[jettIdx]
+		if jett.Stages[0].Name != name {
+			t.Errorf("decouple %d dropped %q, want %q", i, jett.Stages[0].Name, name)
+		}
+		// LM separation must yield a real, distinct slate craft the
+		// player can switch to and fly (payload separation).
+		if name == "LM" && jett.Stages[0].Thrust <= 0 {
+			t.Errorf("separated LM has no engine (Thrust=%v) — not controllable",
+				jett.Stages[0].Thrust)
+		}
+	}
+
+	core := w.Crafts[0]
+	if len(core.Stages) != 1 || core.Stages[0].Name != "CSM" {
+		t.Fatalf("surviving core: %d stage(s) named %q, want 1× CSM",
+			len(core.Stages), core.Stages[0].Name)
+	}
+	if _, _, err := w.StageActive(0); !errors.Is(err, ErrStageOnlyOne) {
+		t.Errorf("dropping the CSM core: err = %v, want ErrStageOnlyOne", err)
+	}
+}

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -19,6 +19,10 @@ package spacecraft
 //                 approximate as sequential.
 //   - Falcon-9:   2-stage SpaceX LV (Merlin 1D × 9 / Merlin Vacuum).
 //                 v0.9.4+. Smaller stack, higher lift-off TWR.
+//   - Apollo-Stack: Saturn-V launch chain + LM + CSM payload, 5
+//                 stages. v0.10.1+. Mid-stage Lander decouples to a
+//                 controllable craft (payload separation); CSM is
+//                 the surviving core.
 //
 // Future loadouts land alongside this catalog and are referenced
 // from Spacecraft.LoadoutID — a string lookup keeps the on-disk
@@ -121,6 +125,18 @@ const LoadoutSLSBlock1ID = "SLS-Block1"
 // stack — handles like a sport rocket compared to the Saturn V /
 // SLS heavies.
 const LoadoutFalcon9ID = "Falcon-9"
+
+// LoadoutApolloStack is the v0.10.1+ full Apollo mission stack:
+// Saturn-V launch chain with a Lunar Module + Command/Service
+// Module payload on top. Stages bottom-first =
+// [S-IC, S-II, S-IVB, Lander, CSM]. The decouple sequence is the
+// real mission arc on top of the v0.9.1 staging machinery:
+// drop S-IC → S-II → S-IVB (after the TLI burn) → Lander; the
+// Lander spawns as its own controllable slate craft (payload
+// separation) and the CSM is left as the player's surviving core
+// to fly the rendezvous / return. The first three stages reuse the
+// canonical Saturn-V tuning so ascent flies identically.
+const LoadoutApolloStackID = "Apollo-Stack"
 
 // stageRCS builds the per-stage RCS pool for a stage of the given
 // dry mass via DefaultRCSLoadout — same scaling that single-stage
@@ -306,6 +322,37 @@ var Loadouts = map[string]Loadout{
 				3900, 107500, 934000, 348, 5e-5),
 		},
 	},
+	// Apollo-Stack (v0.10.1+): the full mission stack. The first
+	// three stages are the canonical Saturn-V tuning (byte-identical
+	// numbers — ascent flies the same). On top: a Lunar Module
+	// (Lander tier) then the Command/Service Module as the surviving
+	// core. Lift-off TWR with the LM+CSM payload: 35,100 kN against
+	// ~2.93 Mkg total ≈ 1.22 at sea-level g — still > 1.
+	LoadoutApolloStackID: {
+		ID:    LoadoutApolloStackID,
+		Name:  "Apollo Stack",
+		Role:  "mission-stack",
+		Glyph: "▲",
+		Color: "#FFD93D",
+		Stages: []Stage{
+			stageWithBC(LoadoutApolloStackID, "S-IC", "▲", "#FF8C42",
+				130000, 2160000, 35100000, 263, 8e-6),
+			stageWithBC(LoadoutApolloStackID, "S-II", "▲", "#FFC042",
+				40000, 440000, 5140000, 421, 2.5e-5),
+			stageWithBC(LoadoutApolloStackID, "S-IVB", "▲", "#FFD93D",
+				11000, 109000, 1023000, 421, 6.25e-5),
+			// Lunar Module — descent/ascent payload. Mid-stage:
+			// decoupling it spawns a controllable LM craft (payload
+			// separation) and leaves the CSM core.
+			stage(LoadoutApolloStackID, "LM", "▼", "#5FFF87",
+				4000, 8000, 45000, 311),
+			// Command/Service Module — the surviving core. SPS
+			// storable-propellant engine; enough Δv for the
+			// rendezvous / trans-Earth return.
+			stage(LoadoutApolloStackID, "CSM", "◉", "#C0C0FF",
+				11900, 18400, 91000, 314),
+		},
+	},
 }
 
 // LoadoutOrder lists loadouts in canonical UI cycle order — the
@@ -320,6 +367,7 @@ var LoadoutOrder = []string{
 	LoadoutSaturnVID,
 	LoadoutSLSBlock1ID,
 	LoadoutFalcon9ID,
+	LoadoutApolloStackID,
 }
 
 // LookupLoadout returns the catalog entry for the given ID, or the
@@ -357,6 +405,56 @@ func NewFromLoadout(loadoutID string) *Spacecraft {
 		BallisticCoefficient: DefaultBallisticCoefficient,
 		Stages:               stages,
 		SlewRateDegPerSec:    l.SlewRateDegPerSec,
+	}
+	c.SyncFields()
+	return c
+}
+
+// NewFromStages constructs a Spacecraft from a player-assembled
+// stage list (bottom-first, same convention as Loadout.Stages) —
+// the v0.10.1+ stack-configurator path. Sibling of NewFromLoadout
+// with no catalog entry behind it: LoadoutID is left empty (a
+// custom craft is not a catalog archetype), and identity/visuals
+// come from the top (core) stage so the slate HUD has a sensible
+// name + marker for the vessel the player keeps flying.
+//
+// The caller still sets Primary + State. Returns nil when stages
+// is empty — an empty stack is not a spawnable craft (callers
+// reject before reaching the spawn path).
+//
+// Custom craft persist through save/load via the existing v6
+// per-stage wire format (save schema v6, v0.9.1) — no migration:
+// the flat shadow fields are re-derived by SyncFields on load and
+// the empty LoadoutID resolves to the default only for those
+// derived mirrors, never overriding the round-tripped Stages.
+func NewFromStages(stages []Stage) *Spacecraft {
+	if len(stages) == 0 {
+		return nil
+	}
+	cp := make([]Stage, len(stages))
+	copy(cp, stages)
+	core := cp[len(cp)-1] // top stage = the surviving "core"
+	name := core.Name
+	if name == "" {
+		name = "Custom"
+	}
+	glyph := core.Glyph
+	if glyph == "" {
+		glyph = "▲"
+	}
+	color := core.Color
+	if color == "" {
+		color = "#FFD93D"
+	}
+	c := &Spacecraft{
+		Name:                 name,
+		LoadoutID:            "", // custom — no catalog archetype
+		Role:                 "custom",
+		Glyph:                glyph,
+		Color:                color,
+		Throttle:             1.0,
+		BallisticCoefficient: DefaultBallisticCoefficient,
+		Stages:               cp,
 	}
 	c.SyncFields()
 	return c

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -66,3 +66,108 @@ func TestPureRCSTugHasNoMainEngine(t *testing.T) {
 		t.Errorf("RCS-tug shipped with main fuel: %v kg", c.Fuel)
 	}
 }
+
+// --- v0.10.1: stage catalog + multi-tier loadout + NewFromStages ---
+
+// TestStageCatalogShape — every StageCatalogOrder id resolves in
+// StageCatalog, BuildStage succeeds with full tanks + visual fields,
+// and the net-new CSM payload module is present and engine-capable.
+func TestStageCatalogShape(t *testing.T) {
+	for _, id := range StageCatalogOrder {
+		m, ok := StageCatalog[id]
+		if !ok {
+			t.Errorf("StageCatalogOrder references %q but StageCatalog has none", id)
+			continue
+		}
+		if m.ID != id || m.Name == "" || m.Glyph == "" || m.Color == "" || m.Tier == "" {
+			t.Errorf("catalog %q: incomplete meta %+v", id, m)
+		}
+		st, built := BuildStage(id)
+		if !built {
+			t.Errorf("BuildStage(%q) failed", id)
+			continue
+		}
+		if st.LoadoutID != "" {
+			t.Errorf("catalog stage %q: LoadoutID = %q, want empty (not a loadout)", id, st.LoadoutID)
+		}
+		if st.FuelMass != st.FuelCapacity {
+			t.Errorf("catalog stage %q: built with non-full tank (%.0f/%.0f)",
+				id, st.FuelMass, st.FuelCapacity)
+		}
+		if st.Name == "" || st.Glyph == "" || st.Color == "" {
+			t.Errorf("catalog stage %q: empty visual field on built Stage", id)
+		}
+	}
+	if _, ok := StageCatalog[StageModuleCSMID]; !ok {
+		t.Fatal("CSM module missing from catalog")
+	}
+	csm, _ := BuildStage(StageModuleCSMID)
+	if csm.Thrust <= 0 || csm.Isp <= 0 {
+		t.Errorf("CSM should have a maneuvering engine: Thrust=%v Isp=%v", csm.Thrust, csm.Isp)
+	}
+	if _, ok := BuildStage("not-a-real-part"); ok {
+		t.Error("BuildStage accepted an unknown id")
+	}
+}
+
+// TestApolloStackShape — the v0.10.1 multi-tier loadout: 5 stages
+// bottom-first [S-IC, S-II, S-IVB, LM, CSM], lift-off TWR > 1 at
+// sea-level g with the full payload, CSM is the surviving core.
+func TestApolloStackShape(t *testing.T) {
+	l, ok := Loadouts[LoadoutApolloStackID]
+	if !ok {
+		t.Fatal("Apollo-Stack loadout missing")
+	}
+	wantNames := []string{"S-IC", "S-II", "S-IVB", "LM", "CSM"}
+	if len(l.Stages) != len(wantNames) {
+		t.Fatalf("Apollo-Stack: %d stages, want %d", len(l.Stages), len(wantNames))
+	}
+	for i, n := range wantNames {
+		if l.Stages[i].Name != n {
+			t.Errorf("stage %d: name %q, want %q", i, l.Stages[i].Name, n)
+		}
+	}
+	totalMass := SumDryMass(l.Stages) + SumFuelMass(l.Stages)
+	twr := l.Stages[0].Thrust / (totalMass * g0)
+	if twr <= 1.0 {
+		t.Errorf("Apollo-Stack lift-off TWR = %.3f, want > 1", twr)
+	}
+	// Catalog parity: shared parts must match the loadout's tuning so
+	// a configurator-built S-IVB flies like the Apollo-Stack S-IVB.
+	sivb, _ := BuildStage(StageModuleSIVBID)
+	if sivb.Thrust != l.Stages[2].Thrust || sivb.Isp != l.Stages[2].Isp ||
+		sivb.DryMass != l.Stages[2].DryMass || sivb.FuelCapacity != l.Stages[2].FuelMass {
+		t.Errorf("catalog S-IVB diverges from Apollo-Stack S-IVB tuning")
+	}
+}
+
+// TestNewFromStages — empty slice → nil; a real stack derives the
+// craft identity from the top (core) stage, sums mass via
+// SyncFields, and carries an empty LoadoutID (custom, not a
+// catalog archetype).
+func TestNewFromStages(t *testing.T) {
+	if NewFromStages(nil) != nil {
+		t.Error("NewFromStages(nil) should be nil (empty stack not spawnable)")
+	}
+	sic, _ := BuildStage(StageModuleSICID)
+	csm, _ := BuildStage(StageModuleCSMID)
+	c := NewFromStages([]Stage{sic, csm})
+	if c == nil {
+		t.Fatal("NewFromStages returned nil for a non-empty stack")
+	}
+	if c.LoadoutID != "" {
+		t.Errorf("custom craft LoadoutID = %q, want empty", c.LoadoutID)
+	}
+	if c.Name != "CSM" || c.Glyph != csm.Glyph {
+		t.Errorf("identity should come from core stage: Name=%q Glyph=%q", c.Name, c.Glyph)
+	}
+	want := SumDryMass(c.Stages) + SumFuelMass(c.Stages) + SumMonopropMass(c.Stages)
+	if c.TotalMass() != want {
+		t.Errorf("TotalMass = %.0f, want %.0f (summed via SyncFields)", c.TotalMass(), want)
+	}
+	// Defensive: NewFromStages must copy, not alias, the input slice.
+	c.Stages[0].FuelMass = 0
+	if sic.FuelMass == 0 {
+		t.Error("NewFromStages aliased the caller's stage slice")
+	}
+}

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -1,0 +1,157 @@
+package spacecraft
+
+// Stage catalog (v0.10.1+). An ID-addressable library of reusable
+// stage "modules" — the parts menu the spawn-form stack configurator
+// builds a custom craft from, and the source the multi-tier
+// Apollo-Stack loadout's payload tiers are sized against.
+//
+// Design note — additive only. The pre-v0.10.1 Loadouts literals
+// (Saturn-V / SLS / Falcon-9 / single-stage) are deliberately NOT
+// refactored to reference this catalog: every existing loadout and
+// golden test must stay byte-identical. The numbers below mirror the
+// inline loadout stages so a catalog-built module flies identically
+// to the same stage inside its canonical launch vehicle, but the two
+// definitions are independent on purpose (the catalog can gain parts
+// or be retuned without touching shipped loadout regression tests).
+//
+// Catalog modules carry an empty Stage.LoadoutID — they did not come
+// from a Loadout. Their Glyph / Color / Name are populated so the
+// jettison-as-passive path (sim/staging.go buildJettisonedCraft) and
+// the STAGES HUD still render them; save round-trips the per-stage
+// fields directly (save schema v6, no migration needed).
+
+// StageModule is one catalog part: a stage preset plus the metadata
+// the configurator UI needs to list and describe it.
+type StageModule struct {
+	// ID is the stable catalog key (kebab-case). Referenced by the
+	// configurator and BuildStage.
+	ID string
+	// Name / Glyph / Color are copied onto the built Stage so the
+	// HUD + jettison rendering have a label and marker.
+	Name  string
+	Glyph string
+	Color string
+	// Tier is a one-word configurator hint: "booster", "sustainer",
+	// "transfer", "payload", "tug". Purely descriptive.
+	Tier string
+	// dry / fuel / thrust / isp / bc are the stage's physical
+	// numbers (kg, kg, N, s, m²/kg) — same units as stageWithBC.
+	dry, fuel, thrust, isp, bc float64
+}
+
+// Catalog stage IDs.
+const (
+	StageModuleSICID      = "s-ic"      // Saturn V first stage (F-1 cluster)
+	StageModuleSIIID      = "s-ii"      // Saturn V second stage (J-2 cluster)
+	StageModuleSIVBID     = "s-ivb"     // S-IVB / J-2 insertion + transfer
+	StageModuleICPSID     = "icps"      // RL-10 low-TWR transfer stage
+	StageModuleSRBID      = "srb"       // SLS twin 5-segment solids
+	StageModuleCoreRS25ID = "core-rs25" // SLS core (4× RS-25)
+	StageModuleF9S1ID     = "f9-s1"     // Falcon 9 first stage (9× Merlin 1D)
+	StageModuleF9S2ID     = "f9-s2"     // Falcon 9 second stage (Merlin Vac)
+	StageModuleLanderID   = "lander"    // LM-derived throttleable descent
+	StageModuleCSMID      = "csm"       // Apollo Command/Service Module (SPS)
+	StageModuleRCSTugID   = "rcs-tug"   // pure-monoprop proximity-ops module
+)
+
+// StageCatalog indexes the parts library by ID. The numbers mirror
+// the inline loadout literals in loadouts.go (see file-level note).
+// The CSM is net-new in v0.10.1 — Apollo Command/Service Module:
+// CM + SM dry ≈ 11,900 kg, SPS storable propellant ≈ 18,400 kg,
+// SPS thrust 91.2 kN @ Isp 314 s. It can do real orbital maneuvers,
+// which is what makes it a rendezvous-relevant payload tier.
+var StageCatalog = map[string]StageModule{
+	StageModuleSICID: {
+		ID: StageModuleSICID, Name: "S-IC", Glyph: "▲", Color: "#FF8C42",
+		Tier: "booster", dry: 130000, fuel: 2160000, thrust: 35100000, isp: 263, bc: 8e-6,
+	},
+	StageModuleSIIID: {
+		ID: StageModuleSIIID, Name: "S-II", Glyph: "▲", Color: "#FFC042",
+		Tier: "sustainer", dry: 40000, fuel: 440000, thrust: 5140000, isp: 421, bc: 2.5e-5,
+	},
+	StageModuleSIVBID: {
+		ID: StageModuleSIVBID, Name: "S-IVB", Glyph: "▲", Color: "#FFD93D",
+		Tier: "transfer", dry: 11000, fuel: 109000, thrust: 1023000, isp: 421, bc: 6.25e-5,
+	},
+	StageModuleICPSID: {
+		ID: StageModuleICPSID, Name: "ICPS", Glyph: "◆", Color: "#5BB3FF",
+		Tier: "transfer", dry: 3500, fuel: 25000, thrust: 110000, isp: 462, bc: 6.25e-5,
+	},
+	StageModuleSRBID: {
+		ID: StageModuleSRBID, Name: "SRBs", Glyph: "▲", Color: "#E0E0E0",
+		Tier: "booster", dry: 198000, fuel: 1270000, thrust: 32000000, isp: 268, bc: 8e-6,
+	},
+	StageModuleCoreRS25ID: {
+		ID: StageModuleCoreRS25ID, Name: "Core", Glyph: "▲", Color: "#FF6B35",
+		Tier: "sustainer", dry: 85275, fuel: 979452, thrust: 9290000, isp: 452, bc: 2.5e-5,
+	},
+	StageModuleF9S1ID: {
+		ID: StageModuleF9S1ID, Name: "F9-S1", Glyph: "▲", Color: "#E8E8E8",
+		Tier: "booster", dry: 25600, fuel: 411000, thrust: 7607000, isp: 282, bc: 7.4e-6,
+	},
+	StageModuleF9S2ID: {
+		ID: StageModuleF9S2ID, Name: "F9-S2", Glyph: "▲", Color: "#B0D8FF",
+		Tier: "transfer", dry: 3900, fuel: 107500, thrust: 934000, isp: 348, bc: 5e-5,
+	},
+	StageModuleLanderID: {
+		ID: StageModuleLanderID, Name: "Lander", Glyph: "▼", Color: "#5FFF87",
+		Tier: "payload", dry: 4000, fuel: 8000, thrust: 45000, isp: 311, bc: 0,
+	},
+	StageModuleCSMID: {
+		ID: StageModuleCSMID, Name: "CSM", Glyph: "◉", Color: "#C0C0FF",
+		Tier: "payload", dry: 11900, fuel: 18400, thrust: 91000, isp: 314, bc: 0,
+	},
+	StageModuleRCSTugID: {
+		ID: StageModuleRCSTugID, Name: "RCS Tug", Glyph: "●", Color: "#FF87D7",
+		Tier: "tug", dry: 200, fuel: 0, thrust: 0, isp: 0, bc: 0,
+	},
+}
+
+// StageCatalogOrder is the configurator's canonical cycle order —
+// roughly bottom-of-stack (heavy boosters) to top (payload), so a
+// player building a stack from scratch naturally walks the list
+// adding a booster first and a payload last.
+var StageCatalogOrder = []string{
+	StageModuleSICID,
+	StageModuleSRBID,
+	StageModuleF9S1ID,
+	StageModuleCoreRS25ID,
+	StageModuleSIIID,
+	StageModuleSIVBID,
+	StageModuleF9S2ID,
+	StageModuleICPSID,
+	StageModuleLanderID,
+	StageModuleCSMID,
+	StageModuleRCSTugID,
+}
+
+// BuildStage returns a fresh, full-tank Stage for the given catalog
+// ID, with the catalog's default RCS pool (same DefaultRCSLoadout
+// scaling stageWithBC uses). Unknown IDs return the zero Stage and
+// ok=false so callers can reject rather than silently spawn junk.
+func BuildStage(id string) (Stage, bool) {
+	m, present := StageCatalog[id]
+	if !present {
+		return Stage{}, false
+	}
+	mp, monoCap, rcsThrust, rcsIsp := stageRCS(m.dry)
+	return Stage{
+		// LoadoutID intentionally empty — a catalog part is not from
+		// a Loadout. Glyph/Color/Name below keep jettison + HUD
+		// rendering working without a loadout lookup.
+		LoadoutID:            "",
+		Name:                 m.Name,
+		Glyph:                m.Glyph,
+		Color:                m.Color,
+		DryMass:              m.dry,
+		FuelMass:             m.fuel,
+		FuelCapacity:         m.fuel,
+		Thrust:               m.thrust,
+		Isp:                  m.isp,
+		MonopropMass:         mp,
+		MonopropCap:          monoCap,
+		RCSThrust:            rcsThrust,
+		RCSIsp:               rcsIsp,
+		BallisticCoefficient: m.bc,
+	}, true
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -339,8 +339,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			action := a.spawn.HandleKey(m.String())
 			switch action {
 			case screens.SpawnActionConfirm:
+				// v0.10.1+: Custom selected but no stages assembled is
+				// not a spawnable craft — flash and keep the form open
+				// so the player can add parts instead of silently
+				// getting a round-robin default.
+				if a.spawn.CustomStackEmpty() {
+					a.statusMsg = "custom stack is empty — add a part with [a]"
+					a.statusExpires = time.Now().Add(3 * time.Second)
+					return a, nil
+				}
 				spec := sim.SpawnSpec{
 					LoadoutID:       a.spawn.SelectedLoadoutID(),
+					CustomStages:    a.spawn.SelectedCustomStages(),
 					ParentBodyID:    a.spawn.SelectedParentID(),
 					AltitudeM:       a.spawn.SelectedAltitudeM(),
 					Retrograde:      a.spawn.SelectedRetrograde(),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -496,6 +496,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				switch a.world.Target.Kind {
 				case sim.TargetBody:
 					_, _ = a.world.PlanTransfer(a.world.Target.BodyIdx)
+					// v0.10.1: the auto-plant is a coplanar circular
+					// solver; if the departure orbit is eccentric or
+					// out of the target's plane it plants a silently-
+					// off transfer. Surface a non-blocking advisory so
+					// the result isn't a mystery (the node is still
+					// planted — advisory, not a refusal).
+					if warn := a.world.HohmannDepartureWarning(a.world.Target.BodyIdx); warn != "" {
+						a.statusMsg = warn
+						a.statusExpires = time.Now().Add(6 * time.Second)
+					}
 				case sim.TargetCraft:
 					a.statusMsg = "H targets bodies — for craft, plan via [m]"
 					a.statusExpires = time.Now().Add(3 * time.Second)

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -45,7 +45,7 @@ func (h *Help) Render() string {
 			{"enter", "commit burn"},
 			{"esc (in planner)", "cancel burn"},
 			{"ctrl+d (in planner)", "delete the node being edited"},
-			{"ctrl+k (in planner)", "clear ALL planned nodes for active craft"},
+			{"c / C (in planner)", "clear ALL planned nodes for active craft (ctrl+k still works)"},
 			{"H", "plant Hohmann transfer to selected body"},
 			{"I", "plant inclination match (selected body / equatorial)"},
 			{"C", "plant circularize burn at next apoapsis"},

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -66,7 +66,7 @@ func (h *Help) Render() string {
 			{"k", "SAS model: slew / instant (navball [MAN]/[AUT]) (v0.10.0+)"},
 		}},
 		{"MULTI-CRAFT (v0.8.1+)", [][2]string{
-			{"n", "open spawn form (loadout / position / parent body / altitude / direction)"},
+			{"n", "open spawn form (loadout / position / parent / altitude / dir; Custom = stack builder, v0.10.1+)"},
 			{"[ / ]", "cycle active craft (no-op when only one craft)"},
 			{"U", "undock active composite (v0.8.3+)"},
 			{"t / T", "cycle / clear target (v0.9.0+)"},

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -147,10 +147,11 @@ type NodeDeleteMsg struct {
 	EditingIdx int
 }
 
-// NodeClearAllMsg is emitted when the player presses ctrl+k in the
-// maneuver form. The app handles it by calling World.ClearNodes()
-// and closing the screen. Replaces the v0.8.5-and-earlier `N`
-// global keybinding for the wipe-all case. v0.8.6+.
+// NodeClearAllMsg is emitted when the player presses c / C (or the
+// ctrl+k back-compat alias) in the maneuver form. The app handles
+// it by calling World.ClearNodes() and closing the screen. Replaces
+// the v0.8.5-and-earlier `N` global keybinding for the wipe-all
+// case. v0.8.6+; primary binding simplified to `c` in v0.10.1.
 type NodeClearAllMsg struct{}
 
 func NewManeuver(th Theme) *Maneuver {
@@ -298,7 +299,7 @@ func (m *Maneuver) Resize(cols, rows int) {
 //   enter                  — commit burn → emits BurnExecutedMsg with rocket-equation duration
 //   esc                    — cancel → plain exit (app handles)
 //   ctrl+d                 — delete the planted node being edited (no-op when creating new)
-//   ctrl+k                 — clear ALL planted nodes for the active craft
+//   c / C (or ctrl+k)      — clear ALL planted nodes for the active craft
 //   digits/backspace       — forwarded to focused text input
 func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	const focusFields = 5 // mode / fireAt / dv / throttle / iterate
@@ -313,10 +314,14 @@ func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		idx := m.editingIdx
 		return func() tea.Msg { return NodeDeleteMsg{EditingIdx: idx} }, true
-	case "ctrl+k":
-		// v0.8.6+: clear all nodes for the active craft. Replaces
-		// the v0.8.5-and-earlier `N` global keybinding. Closes the
-		// form on dispatch.
+	case "c", "C", "ctrl+k":
+		// Clear ALL nodes for the active craft, then close the form.
+		// v0.10.1+: `c` / `C` is the memorable primary binding (the
+		// dv/throttle inputs are numeric, so a letter never collides
+		// with field editing); `ctrl+k` stays as a back-compat alias
+		// for existing muscle memory. Replaces the v0.8.5-and-earlier
+		// `N` global keybinding (retired in v0.8.6 for the case-
+		// collision reason noted on input.go ClearNodes).
 		return func() tea.Msg { return NodeClearAllMsg{} }, true
 	case "tab":
 		m.focus = (m.focus + 1) % focusFields
@@ -596,7 +601,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, "  ", form)
 
 	footer := m.theme.Footer.Render(
-		"[tab] cycle field  [←/→] cycle mode  [enter] commit  [esc] cancel  [digits] edit",
+		"[tab] field  [←/→] cycle  [enter] commit  [esc] cancel  [ctrl+d] del node  [c] clear all",
 	)
 	title := "maneuver planner"
 	if m.editingIdx >= 0 {
@@ -700,6 +705,40 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		"",
 		"  Δv budget remaining: " + fmt.Sprintf("%.0f m/s", budget),
 		fmt.Sprintf("  thrust: %.0f N  Isp: %.0f s", c.Thrust, c.Isp),
+	}
+
+	// PLANNED NODES (v0.10.1+): list every node currently planted on
+	// the active craft so the planner shows the full schedule, not
+	// just the one being created/edited. The node under edit
+	// (editingIdx) is called out so Enter-replaces-this is obvious.
+	// Resolved nodes show a T± countdown; event-relative nodes that
+	// haven't frozen a trigger yet show the event name instead.
+	lines = append(lines, "")
+	if len(c.Nodes) == 0 {
+		lines = append(lines, m.theme.Dim.Render("PLANNED NODES (none) — [enter] plants one"))
+	} else {
+		lines = append(lines, m.theme.Primary.Render(
+			fmt.Sprintf("PLANNED NODES (%d)  —  [c] clears all", len(c.Nodes))))
+		const maxList = 8
+		for i, n := range c.Nodes {
+			if i >= maxList {
+				lines = append(lines, m.theme.Dim.Render(
+					fmt.Sprintf("  … +%d more", len(c.Nodes)-maxList)))
+				break
+			}
+			when := n.Event.String()
+			if !n.TriggerTime.IsZero() {
+				when = formatCountdown(n.TriggerTime.Sub(w.Clock.SimTime))
+			}
+			row := fmt.Sprintf("  %d. %-10s %6.0f m/s  %s",
+				i+1, n.Mode.String(), n.DV, when)
+			if i == m.editingIdx {
+				row = m.theme.Warning.Render(row + "  ← editing")
+			} else {
+				row = m.theme.Dim.Render(row)
+			}
+			lines = append(lines, row)
+		}
 	}
 
 	// v0.6.1: PROJECTED ORBIT readout — apo / peri / AN / DN of the

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -1,0 +1,68 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "ctrl+k":
+		return tea.KeyMsg{Type: tea.KeyCtrlK}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+// TestManeuverClearAllBindings — the simplified `c` / `C` binding
+// (and the ctrl+k back-compat alias) all emit NodeClearAllMsg and
+// close the form.
+func TestManeuverClearAllBindings(t *testing.T) {
+	for _, key := range []string{"c", "C", "ctrl+k"} {
+		m := NewManeuver(Theme{})
+		cmd, done := m.HandleKey(keyMsg(key))
+		if !done {
+			t.Errorf("%q: done = false, want true (form should close)", key)
+		}
+		if cmd == nil {
+			t.Fatalf("%q: nil cmd, want a NodeClearAllMsg command", key)
+		}
+		if _, ok := cmd().(NodeClearAllMsg); !ok {
+			t.Errorf("%q: emitted %T, want NodeClearAllMsg", key, cmd())
+		}
+	}
+}
+
+// TestManeuverRendersPlannedNodes — the form panel lists every
+// planted node for the active craft, and shows the empty-state
+// hint when there are none.
+func TestManeuverRendersPlannedNodes(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	m := NewManeuver(Theme{})
+
+	if out := m.Render(w, 120, 40); !strings.Contains(out, "PLANNED NODES (none)") {
+		t.Error("empty-state PLANNED NODES hint missing when no nodes planted")
+	}
+
+	c := w.ActiveCraft()
+	c.Nodes = append(c.Nodes,
+		spacecraft.ManeuverNode{DV: 120, TriggerTime: w.Clock.SimTime.Add(time.Hour)},
+		spacecraft.ManeuverNode{DV: 45, TriggerTime: w.Clock.SimTime.Add(2 * time.Hour)},
+	)
+	out := m.Render(w, 120, 40)
+	if !strings.Contains(out, "PLANNED NODES (2)") {
+		t.Error("node-count header missing / wrong with 2 nodes planted")
+	}
+	if !strings.Contains(out, "120 m/s") || !strings.Contains(out, "45 m/s") {
+		t.Errorf("planned-node Δv values not listed:\n%s", out)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -993,7 +993,21 @@ func (v *OrbitView) plotClusterTagged(center orbital.Vec3, n int, tag widgets.Ce
 // another body's SOI use stride-1 (solid) so the crossing is visually
 // distinct at a glance.
 func (v *OrbitView) drawNodes(w *sim.World) {
-	if len(w.ActiveCraft().Nodes) == 0 || w.ActiveCraft() == nil {
+	if w.ActiveCraft() == nil || len(w.ActiveCraft().Nodes) == 0 {
+		return
+	}
+	// v0.10.1: suppress the ENTIRE node overlay (markers + dashed
+	// post-burn legs) while a finite burn is firing. The live craft
+	// state is mutated every integrator step, so NodeInertialPosition
+	// — which forward-propagates the *current* orbit to each node's
+	// trigger time — whirls the marker crosses around the orbit and
+	// outward every frame (the reported "crosshair circling the orbit
+	// and beyond"). v0.6.1 already skipped the dashed preview for this
+	// exact reason but did it AFTER the marker loop, so the markers
+	// kept spinning. Guard hoisted above the loop so both freeze
+	// together; the live ellipse + active-burn HUD carry the visual
+	// load until the burn completes (KSP freezes the node here too).
+	if w.ActiveCraft().ActiveBurn != nil {
 		return
 	}
 	homeID := w.ActiveCraft().Primary.ID
@@ -1013,15 +1027,6 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 			Color:   render.ManeuverSegmentColor(i),
 			NodeIdx: i + 1, // 0 = none; planted node i is 1+i in the tag.
 		})
-	}
-
-	// v0.6.1: while a finite burn is firing the live craft state is
-	// mutated every integrator step; the dashed trajectory preview
-	// would otherwise rotate wildly each frame. Skip the preview and
-	// let the live ellipse + active-burn HUD block carry the visual
-	// load until the burn completes.
-	if w.ActiveCraft().ActiveBurn != nil {
-		return
 	}
 
 	// v0.6.1: render each post-maneuver leg in its own color so the

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -782,8 +782,15 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		craftChip = fmt.Sprintf(" — CRAFT %d/%d", w.ActiveCraftIdx+1, n)
 	}
 	title := v.renderTitleBar(sys.Name+craftChip, totalCols)
+	// Footer is a cheat-sheet of the most-used keys; `?` opens the
+	// full help overlay (source of truth). Streamlined v0.10.1+ —
+	// dropped stale labels (`q` is attitude:radial+ since v0.7.3,
+	// `s` is attitude:retrograde, ←/→ body-cycle was superseded by
+	// the v0.9.0 `t`/`T` target slot, `N` clear-all moved into the
+	// `m` planner in v0.8.6) and added the flight / target / stage /
+	// save row players actually reach for.
 	footer := v.theme.Footer.Render(
-		"[q]quit [s]system [←/→]body [+/-]zoom [f/F]focus [g]sys [n]spawn [N]clr [[/]]craft [H]hohmann [P]porkchop [R]refine [m]burn [i]info [?]help [.,]warp [0]pause",
+		"[?]help [esc]menu [+/-]zoom [f/F/g]focus [.,]warp [0]pause [m]burn [b]fire [wasdqe]attitude [space]stage [t/T]target [H/I/C]plan [n]spawn [[/]]craft [F5/F9]save/load",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)

--- a/internal/tui/screens/orbit_nodes_burn_test.go
+++ b/internal/tui/screens/orbit_nodes_burn_test.go
@@ -1,0 +1,70 @@
+package screens
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// countNodeTaggedCells scans the orbit canvas for cells tagged as a
+// planted-node marker (CellTag.NodeIdx > 0 — the same tag HitHudNode
+// uses to route node clicks).
+func countNodeTaggedCells(v *OrbitView) int {
+	n := 0
+	for row := 0; row < v.canvas.Rows(); row++ {
+		for col := 0; col < v.canvas.Cols(); col++ {
+			if v.canvas.HitAt(col, row).NodeIdx > 0 {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestNodeMarkersSuppressedDuringActiveBurn — regression for the
+// "crosshair circles the orbit and beyond mid-burn" bug. The node
+// marker position is recomputed every frame from the live (burning)
+// orbit; drawNodes must suppress the whole node overlay while a
+// finite burn is firing (mirrors the v0.6.1 dashed-preview skip,
+// now hoisted above the marker loop).
+func TestNodeMarkersSuppressedDuringActiveBurn(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft from NewWorld")
+	}
+	// Two nodes at different points on the orbit so at least one is
+	// clear of the primary disk regardless of phase.
+	c.Nodes = append(c.Nodes,
+		spacecraft.ManeuverNode{DV: 100, TriggerTime: w.Clock.SimTime.Add(15 * time.Minute)},
+		spacecraft.ManeuverNode{DV: 100, TriggerTime: w.Clock.SimTime.Add(45 * time.Minute)},
+	)
+
+	v.Render(w, 0, 180, 48)
+	idle := countNodeTaggedCells(v)
+	if idle == 0 {
+		t.Fatal("no node markers drawn while idle — test can't observe suppression")
+	}
+
+	// Now simulate an in-progress finite burn.
+	c.ActiveBurn = &spacecraft.ActiveBurn{}
+	v.Render(w, 0, 180, 48)
+	if burning := countNodeTaggedCells(v); burning != 0 {
+		t.Errorf("node markers still drawn during active burn: %d tagged cells (want 0)", burning)
+	}
+
+	// And they come back once the burn ends.
+	c.ActiveBurn = nil
+	v.Render(w, 0, 180, 48)
+	if after := countNodeTaggedCells(v); after == 0 {
+		t.Error("node markers did not return after the burn completed")
+	}
+}

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -17,7 +17,7 @@ import (
 // focus; ←/→ edit the focused field; Enter spawns; Esc cancels.
 type SpawnCraft struct {
 	theme    Theme
-	fieldIdx int // 0=loadout, 1=position, 2=parent, 3=altitude/latitude, 4=direction
+	fieldIdx int // 0=loadout, 1=position, 2=parent, 3=alt/lat, 4=direction, 5=stack(custom only)
 
 	loadoutIdx   int
 	posMode      spawnPosMode // v0.9.2+: tri-state — orbit / alongside / launchpad
@@ -26,7 +26,19 @@ type SpawnCraft struct {
 	altIdx       int
 	latIdx       int // v0.9.2+: latitude preset cursor when posMode=launchpad
 	retrograde   bool
+
+	// v0.10.1+ stack configurator. loadoutIdx == len(LoadoutOrder)
+	// is the synthetic "Custom…" entry; when it's selected a STACK
+	// field (idx 5) becomes reachable. customStages is the working
+	// stack bottom-first (Loadout.Stages convention); partIdx is the
+	// catalog part-picker cursor over StageCatalogOrder.
+	customStages []spacecraft.Stage
+	partIdx      int
 }
+
+// stackFieldIdx is the form-field index of the STACK editor — only
+// reachable (Tab includes it) when the Custom loadout is selected.
+const stackFieldIdx = 5
 
 // spawnPosMode enumerates the v0.8.3 / v0.9.2 spawn-position modes.
 type spawnPosMode int
@@ -81,6 +93,8 @@ func NewSpawnCraft(th Theme) *SpawnCraft { return &SpawnCraft{theme: th} }
 func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string) {
 	s.fieldIdx = 0
 	s.loadoutIdx = 0
+	s.customStages = nil
+	s.partIdx = 0
 	s.posMode = posOrbit
 	s.altIdx = 1 // 500 km — matches the v0.8.1 sister-spawn default
 	s.latIdx = 1 // 28.6° KSC — matches the v0.9.2 launchpad default
@@ -104,12 +118,46 @@ const (
 	SpawnActionConfirm             // enter — caller reads accessors
 )
 
-// SelectedLoadoutID returns the loadout ID for the current cursor.
+// loadoutChoiceCount is the number of CRAFT TYPE rows — every
+// catalog loadout plus the synthetic "Custom…" entry at the end.
+func loadoutChoiceCount() int { return len(spacecraft.LoadoutOrder) + 1 }
+
+// IsCustomSelected reports whether the cursor is on the synthetic
+// "Custom…" CRAFT TYPE entry (the last row). v0.10.1+.
+func (s *SpawnCraft) IsCustomSelected() bool {
+	return s.loadoutIdx == len(spacecraft.LoadoutOrder)
+}
+
+// SelectedLoadoutID returns the loadout ID for the current cursor,
+// or "" when the synthetic Custom entry is selected (the caller
+// then reads SelectedCustomStages instead). v0.10.1+.
 func (s *SpawnCraft) SelectedLoadoutID() string {
+	if s.IsCustomSelected() {
+		return ""
+	}
 	if s.loadoutIdx < 0 || s.loadoutIdx >= len(spacecraft.LoadoutOrder) {
 		return spacecraft.LoadoutOrder[0]
 	}
 	return spacecraft.LoadoutOrder[s.loadoutIdx]
+}
+
+// SelectedCustomStages returns a copy of the player-assembled stack
+// (bottom-first), or nil when Custom is not selected. The spawn
+// path treats a nil/empty result as "no custom craft". v0.10.1+.
+func (s *SpawnCraft) SelectedCustomStages() []spacecraft.Stage {
+	if !s.IsCustomSelected() || len(s.customStages) == 0 {
+		return nil
+	}
+	out := make([]spacecraft.Stage, len(s.customStages))
+	copy(out, s.customStages)
+	return out
+}
+
+// CustomStackEmpty reports Custom-selected-but-no-stages — the one
+// confirm state the caller must reject (an empty stack is not a
+// spawnable craft). v0.10.1+.
+func (s *SpawnCraft) CustomStackEmpty() bool {
+	return s.IsCustomSelected() && len(s.customStages) == 0
 }
 
 // SelectedParentID returns the body ID the cursor is on, or empty
@@ -165,7 +213,17 @@ func (s *SpawnCraft) SelectedLongitudeEastDeg() float64 {
 // HandleKey maps a raw key string to a SpawnAction. Tab cycles
 // fields; ←/→ edit the focused field; Enter commits; Esc cancels.
 func (s *SpawnCraft) HandleKey(key string) SpawnAction {
-	const numFields = 5
+	// v0.10.1+: the STACK field (idx 5) exists only while Custom is
+	// selected. numFields flexes 5↔6 so Tab skips it otherwise; if
+	// the player cycled off Custom while parked on STACK, snap focus
+	// back to CRAFT TYPE so a stale idx can't strand the cursor.
+	numFields := 5
+	if s.IsCustomSelected() {
+		numFields = 6
+	}
+	if s.fieldIdx >= numFields {
+		s.fieldIdx = 0
+	}
 	switch key {
 	case "esc":
 		return SpawnActionCancel
@@ -179,8 +237,31 @@ func (s *SpawnCraft) HandleKey(key string) SpawnAction {
 		s.cycleField(-1)
 	case "right", "l":
 		s.cycleField(+1)
+	case "a":
+		// Add the picked catalog part on top of the working stack.
+		// Form-local: only meaningful on the STACK field.
+		if s.fieldIdx == stackFieldIdx && s.IsCustomSelected() {
+			if id := s.pickedPartID(); id != "" {
+				if st, ok := spacecraft.BuildStage(id); ok {
+					s.customStages = append(s.customStages, st)
+				}
+			}
+		}
+	case "x":
+		// Remove the top (last-added) stage.
+		if s.fieldIdx == stackFieldIdx && s.IsCustomSelected() && len(s.customStages) > 0 {
+			s.customStages = s.customStages[:len(s.customStages)-1]
+		}
 	}
 	return SpawnActionNone
+}
+
+// pickedPartID returns the catalog ID under the part-picker cursor.
+func (s *SpawnCraft) pickedPartID() string {
+	if s.partIdx < 0 || s.partIdx >= len(spacecraft.StageCatalogOrder) {
+		return ""
+	}
+	return spacecraft.StageCatalogOrder[s.partIdx]
 }
 
 // cycleField nudges the focused field's value by step (typically
@@ -191,7 +272,11 @@ func (s *SpawnCraft) HandleKey(key string) SpawnAction {
 func (s *SpawnCraft) cycleField(step int) {
 	switch s.fieldIdx {
 	case 0:
-		s.loadoutIdx = wrapIdx(s.loadoutIdx+step, len(spacecraft.LoadoutOrder))
+		// +1 row for the synthetic "Custom…" entry. v0.10.1+.
+		s.loadoutIdx = wrapIdx(s.loadoutIdx+step, loadoutChoiceCount())
+	case stackFieldIdx:
+		// STACK field: ←/→ moves the catalog part-picker cursor.
+		s.partIdx = wrapIdx(s.partIdx+step, len(spacecraft.StageCatalogOrder))
 	case 1:
 		s.posMode = spawnPosMode(wrapIdx(int(s.posMode)+step, 3))
 	case 2:
@@ -246,6 +331,65 @@ func (s *SpawnCraft) Render(width int) string {
 			row = s.theme.Dim.Render(row)
 		}
 		lines = append(lines, "  "+marker+row)
+	}
+	// v0.10.1+: synthetic "Custom…" row — opens the STACK editor.
+	{
+		customRow := "✎ Custom…  build-your-own  — assemble a stage stack"
+		marker := "  "
+		if s.IsCustomSelected() {
+			marker = s.theme.Warning.Render("→ ")
+			if s.fieldIdx == 0 {
+				customRow = s.theme.Warning.Render(customRow)
+			} else {
+				customRow = s.theme.Primary.Render(customRow)
+			}
+		} else {
+			customRow = s.theme.Dim.Render(customRow)
+		}
+		lines = append(lines, "  "+marker+customRow)
+	}
+
+	// v0.10.1+ STACK editor — only when Custom is selected. Shows the
+	// working stack bottom→top, the catalog part-picker, and the
+	// add/remove key hints. Field idx 5 (stackFieldIdx).
+	if s.IsCustomSelected() {
+		lines = append(lines, "")
+		lines = append(lines, s.fieldHeader(stackFieldIdx, "STACK (bottom → top)"))
+		if len(s.customStages) == 0 {
+			lines = append(lines, "  "+s.theme.Dim.Render("(empty — pick a part below and press [a] to add)"))
+		} else {
+			for i := len(s.customStages) - 1; i >= 0; i-- {
+				st := s.customStages[i]
+				tag := "top/core"
+				if i == 0 {
+					tag = "bottom/fires first"
+				} else if i != len(s.customStages)-1 {
+					tag = "mid"
+				}
+				eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
+				if st.Thrust == 0 {
+					eng = "RCS-only"
+				}
+				lines = append(lines, "  "+s.theme.Primary.Render(
+					fmt.Sprintf("%s %-7s  dry %.0fkg fuel %.0fkg  %s  (%s)",
+						st.Glyph, st.Name, st.DryMass, st.FuelMass, eng, tag)))
+			}
+		}
+		// Catalog part-picker line.
+		lines = append(lines, "")
+		pid := s.pickedPartID()
+		if m, ok := spacecraft.StageCatalog[pid]; ok {
+			st, _ := spacecraft.BuildStage(pid)
+			eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
+			if st.Thrust == 0 {
+				eng = "RCS-only"
+			}
+			pickLabel := fmt.Sprintf("%s %s  [%s]  dry %.0fkg fuel %.0fkg  %s",
+				m.Glyph, m.Name, m.Tier, st.DryMass, st.FuelMass, eng)
+			lines = append(lines, "  "+s.fieldValue(stackFieldIdx, "part: "+pickLabel))
+		}
+		lines = append(lines, "  "+s.theme.Footer.Render(
+			"[←/→] pick part  [a] add on top  [x] remove top"))
 	}
 
 	// Field 1: position mode — tri-state cycle. orbit (uses PARENT

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -1,0 +1,154 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// selectCustom cycles the CRAFT TYPE field to the synthetic
+// "Custom…" row (one past the last catalog loadout).
+func selectCustom(s *SpawnCraft) {
+	s.fieldIdx = 0
+	for !s.IsCustomSelected() {
+		s.HandleKey("right")
+	}
+}
+
+// TestSpawnCustomEntryReachableAndEmpty — cycling past every catalog
+// loadout lands on the Custom entry; before any part is added the
+// stack is empty (the one confirm state the caller must reject) and
+// SelectedLoadoutID is blank so the spawn path takes the custom
+// branch.
+func TestSpawnCustomEntryReachableAndEmpty(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+	selectCustom(s)
+
+	if !s.IsCustomSelected() {
+		t.Fatal("could not reach the Custom entry by cycling CRAFT TYPE")
+	}
+	if s.SelectedLoadoutID() != "" {
+		t.Errorf("Custom SelectedLoadoutID = %q, want empty", s.SelectedLoadoutID())
+	}
+	if !s.CustomStackEmpty() {
+		t.Error("fresh Custom selection should report an empty stack")
+	}
+	if s.SelectedCustomStages() != nil {
+		t.Error("empty custom stack should yield nil stages")
+	}
+	// Cycling forward once more wraps back to the first real loadout.
+	s.HandleKey("right")
+	if s.IsCustomSelected() {
+		t.Error("Custom should wrap back to a real loadout")
+	}
+	if s.SelectedLoadoutID() != spacecraft.LoadoutOrder[0] {
+		t.Errorf("after wrap, loadout = %q, want %q",
+			s.SelectedLoadoutID(), spacecraft.LoadoutOrder[0])
+	}
+}
+
+// TestSpawnStackFieldReachableOnlyInCustom — the STACK field (Tab
+// stop 5) must be unreachable for catalog loadouts and reachable
+// only once Custom is selected.
+func TestSpawnStackFieldReachableOnlyInCustom(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+
+	// Non-custom: Tab through a full cycle never lands on stackFieldIdx.
+	for i := 0; i < 12; i++ {
+		s.HandleKey("tab")
+		if s.fieldIdx == stackFieldIdx {
+			t.Fatalf("STACK field reached on a non-custom loadout (fieldIdx=%d)", s.fieldIdx)
+		}
+	}
+
+	selectCustom(s)
+	seen := false
+	for i := 0; i < 12; i++ {
+		s.HandleKey("tab")
+		if s.fieldIdx == stackFieldIdx {
+			seen = true
+			break
+		}
+	}
+	if !seen {
+		t.Error("STACK field never reached while Custom selected")
+	}
+
+	// Leaving Custom while parked on STACK must not strand the cursor.
+	s.fieldIdx = stackFieldIdx
+	s.loadoutIdx = 0 // off Custom
+	s.HandleKey("tab")
+	if s.fieldIdx == stackFieldIdx {
+		t.Error("cursor stranded on STACK after leaving Custom")
+	}
+}
+
+// TestSpawnStackAddRemove — on the STACK field, ←/→ moves the part
+// picker, [a] appends the picked part on top, [x] removes the top.
+func TestSpawnStackAddRemove(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+	selectCustom(s)
+	s.fieldIdx = stackFieldIdx
+
+	first := s.pickedPartID()
+	s.HandleKey("a") // add first catalog part
+	s.HandleKey("right")
+	second := s.pickedPartID()
+	if second == first {
+		t.Fatal("part picker did not advance on right")
+	}
+	s.HandleKey("a") // add second part on top
+
+	stack := s.SelectedCustomStages()
+	if len(stack) != 2 {
+		t.Fatalf("stack size = %d, want 2", len(stack))
+	}
+	wantBottom, _ := spacecraft.BuildStage(first)
+	wantTop, _ := spacecraft.BuildStage(second)
+	if stack[0].Name != wantBottom.Name {
+		t.Errorf("bottom = %q, want %q (first added)", stack[0].Name, wantBottom.Name)
+	}
+	if stack[1].Name != wantTop.Name {
+		t.Errorf("top = %q, want %q (added on top)", stack[1].Name, wantTop.Name)
+	}
+
+	s.HandleKey("x") // remove top
+	if got := s.SelectedCustomStages(); len(got) != 1 || got[0].Name != wantBottom.Name {
+		t.Errorf("after remove-top: %v, want single %q", got, wantBottom.Name)
+	}
+	// Add/remove are inert off the STACK field (no global collision).
+	s.fieldIdx = 0
+	s.HandleKey("x")
+	if len(s.SelectedCustomStages()) != 1 {
+		t.Error("[x] mutated the stack while off the STACK field")
+	}
+}
+
+// TestSpawnRenderShowsStackEditor — the STACK block appears only
+// for Custom and reflects added parts.
+func TestSpawnRenderShowsStackEditor(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+
+	if strings.Contains(s.Render(80), "STACK (bottom → top)") {
+		t.Error("STACK editor rendered for a non-custom loadout")
+	}
+	selectCustom(s)
+	out := s.Render(80)
+	if !strings.Contains(out, "Custom…") {
+		t.Error("Custom row missing from CRAFT TYPE list")
+	}
+	if !strings.Contains(out, "STACK (bottom → top)") {
+		t.Error("STACK editor not rendered when Custom selected")
+	}
+	s.fieldIdx = stackFieldIdx
+	s.HandleKey("a")
+	picked := s.SelectedCustomStages()[0].Name
+	if !strings.Contains(s.Render(80), picked) {
+		t.Errorf("rendered stack does not list the added part %q", picked)
+	}
+}


### PR DESCRIPTION
## v0.10.1

Polish + advisory cycle on top of v0.10.0.

### What changed
- **Multi-tier loadouts + stack configurator** (`661df78`) — picker now spans the launch catalog with a configurable stack.
- **Simpler clear-all key + planned-nodes list in `m` planner** (`ff3180e`) — easier maneuver management.
- **Freeze node markers during a finite burn** (`ed6ea3e`) — orbit view no longer jitters while a node is firing.
- **Non-blocking coplanar/circular Hohmann advisory** (`f9d0159`) — surfaces the edge case without blocking the plan; real fix is spec'd.
- **Streamline orbit-view footer cheat-sheet** (`e970e82`) — drops stale labels.

### CI
`go vet ./...` + `go test ./... -race -count=1` — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
