### PR TITLE
v0.10.2 — rendezvous actionability + HUD chrome polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ coverage.*
 # OS
 .DS_Store
 Thumbs.db
+
+# sidechat
+.sidechat/

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `H` | Auto-plant Hohmann transfer to `World.Target` body (intra-primary for moons of the craft's parent; moon → parent escape via bound transfer ellipse). TargetCraft flashes "needs v0.9.3" |
 | `I` | Plant inclination match — rotates the orbital plane to `World.Target` body's inclination (or 0° equatorial when target is None). TargetCraft flashes "needs v0.9.3" |
 | `C` | Plant circularize burn at next apoapsis (v0.9.4+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
+| `K` | Plant rendezvous nudge to target craft (v0.10.2+) — single-burn Lambert intercept projected onto the closest velocity-frame axis. Reads the TARGET HUD's ACH CA / Δv readouts. Errors when there's no craft target, target shares a different primary, already DOCK READY, or no improvement available |
 | `t` / `T` | Cycle / clear `World.Target` (non-active sibling craft → bodies in active system → none) |
 | `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+) |
 | `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H` |

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -666,8 +666,16 @@ tag plus the major slice / cycle it would naturally pair with.
 Items here are **not under active development** unless noted.
 
 ### Rendezvous tooling
-<!-- llm-parse: id=rendezvous status=backlog target=v0.9 -->
-🧊 **backlog · target v0.9**. Real rendezvous flow that v0.8.3 docking left as a "spawn alongside / thumb-fly" cheat. Five sequenced steps: target-craft selection → target-relative prograde / retrograde burn modes → prograde-to-target nudge from a phasing orbit → null v_rel at predicted closest approach → iterate until in DOCK READY range. Foundations needed: `World.TargetCraftIdx`, `BurnTargetPrograde` / `BurnTargetRetrograde` modes (h-direction-from-relative-velocity), `planner.NextClosestApproach`, `World.PlanRendezvous` auto-plant, TARGET HUD block. Pair with staging slices that grow the craft fleet.
+<!-- llm-parse: id=rendezvous status=partially-shipped target=v0.9-foundations+v0.10.2-actionability -->
+🟡 **partially shipped — foundations v0.9.3, actionability v0.10.2; manual loop unchanged.** Five sequenced steps from the original spec:
+
+1. **Target-craft selection** — ✅ v0.9.0 (`World.Target` unified slot) + v0.9.3 (per-craft target binding survives active-craft switches).
+2. **Target-relative prograde / retrograde burn modes** — ✅ v0.9.3 (`BurnTargetPrograde` / `BurnTargetRetrograde` / `BurnTarget` / `BurnAntiTarget`).
+3. **Prograde-to-target nudge from a phasing orbit** — ✅ v0.10.2 (`World.PlanRendezvousNudge` / `K` keystroke; Lambert intercept ⇒ project onto eight velocity-frame axes ⇒ verify via `NextClosestApproach`; TARGET HUD shows achievable CA + Δv readouts).
+4. **Null v_rel at predicted closest approach** — ✅ v0.9.3 (`m`-form `next closest approach` trigger event + `BurnTargetRetrograde` planted node). Manual step — no auto-plant variant.
+5. **Iterate until in DOCK READY range** — ✅ player loop using the above; the v0.10.2 advisory recomputes per frame so the recommendation updates after each burn.
+
+**Remaining open** (deferred, not gating): a single `World.PlanRendezvous` auto-plant that chains steps 3 + 4 in one keystroke. v0.10.2's `K` covers step 3 only; the player handles step 4 manually through the `m` form. The remaining auto-plant is a candidate v0.11+ slice rider once the slice-3 actionability has playtest signal.
 
 ### Mission scripting / editor
 <!-- llm-parse: id=mission-scripting status=rolled-back target=v0.9 attempted=v0.8.7 -->

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -36,7 +36,7 @@ is picked up. Mission scripting stays design-pass-first and is
 |---------|----------|----------|-------|
 | v0.10.0 | **shipped** | `v0.10.0` | Released 2026-05-19 (PR #54 → `main` `0f57406`, tag `v0.10.0`, GoReleaser 5-platform binaries). Slew + attitude save-persistence + lead-compensated nodes; `InstantSAS` surfacing wired (`k` key + navball `[MAN]`/`[AUT]` tag). Unplanned scope folded in: full roll DOF + body-frame navball. No remaining slice blockers (see slice note). |
 | v0.10.1 | **in progress** | — | Staging chain (L) — multi-tier fleet. **Scope committed 2026-05-19** (branch `v0.10.1-staging`): named stage catalog + multi-tier loadouts (Apollo-Stack w/ payload separation) + spawn-form stack configurator. See slice below. |
-| v0.10.2 | candidate| —        | Rendezvous tooling (M) — consumes staging fleet; gains depth from v0.10.0. |
+| v0.10.2 | **in progress** | — | Rendezvous tooling (M) — actionability layer on top of v0.9.3 (achievable-vs-current CA, Δv-to-improve, recommended-burn auto-plant via `K`). Scope-committed 2026-05-19; built on branch `v0.10.2-rendezvous`. See slice below. |
 | v0.10.3 | candidate| —        | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. |
 | v0.10.4 | candidate| —        | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. |
 
@@ -268,7 +268,92 @@ screens. Help overlay + README mirror the new keys. **Deferred
 as specced:** stack reorder/insert, per-stage param editing.
 Slice ready for tag/merge once playtested.
 
-### v0.10.2+ — carry-over candidates
+### v0.10.2 — rendezvous: actionability layer on top of v0.9.3
+
+<!-- llm-parse: slice=v0.10.2 weight=M scope=planner+sim+tui status=in-progress branch=v0.10.2-rendezvous -->
+
+**Scope committed 2026-05-19.** v0.9.3 shipped the *foundations*
+(target-relative SAS modes, `;` NavMode cycle, `NextClosestApproach`
+predictor with parabolic sub-grid refinement, TARGET HUD TCA/CA/DOCK
+READY readouts). What that left missing — and what this slice
+delivers — is the **actionability layer**: surfacing whether the
+approach *can* and *should* be adjusted, with a single keystroke
+that plants the recommendation.
+
+**Algorithm — single-burn nudge.** For active chaser A and target
+craft B sharing a primary:
+
+1. **Lambert lookahead scan** at `T_k = {0.15, 0.3, 0.5, 0.8, 1.2} ·
+   P_B`. For each `T_k`, propagate B forward by `T_k` and solve
+   `LambertSolve(rA, rB(T_k), T_k, mu, false)` for departure
+   velocity. Pick the lookahead minimising `|ΔV|`.
+2. **Axis projection** onto the eight velocity-frame axes
+   (prograde / retrograde / normal± / radial± / target-prograde /
+   target-retrograde). Pick the axis with the largest positive
+   projection of the Lambert ΔV. Position-relative axes
+   (`BurnTarget` / `BurnAntiTarget`) are *excluded* — Lambert's ΔV
+   is a velocity correction; a position-axis pick is physically
+   unjustified. Projection is intentionally lossy (~30 % typical);
+   the slice's loop is "iterate until DOCK READY".
+3. **Verify** by re-running `NextClosestApproach` with the axis-
+   aligned perturbation applied. This is the *honest* post-burn CA,
+   not the Lambert intercept ideal.
+4. **Two-prong improvement floor.** Recommend only when
+   `(rel improvement ≥ 10 %) OR (Δv ≥ 0.5 m/s AND absolute
+   improvement ≥ 100 m)`. Lets sub-m/s proximity nudges through;
+   filters jitter on already-close approaches.
+5. **Tick-throttled cache** — `RecommendedRendezvousBurn` reuses
+   the prior advisory for up to 500 ms of sim-time, recomputing on
+   key change `(activeIdx, targetIdx)` or sim-time expiry. Keeps
+   the per-frame HUD path cheap.
+
+**Built (2026-05-19, branch `v0.10.2-rendezvous`).** Implemented as
+specced:
+
+- `internal/planner/rendezvous_recommend.go` (new) — `AxisLabel`
+  planner-local enum (sibling package — planner cannot import
+  spacecraft), `RendezvousAdvisory` struct, `RecommendRendezvousNudge`
+  function. Five planner-level tests (co-orbital lagging, plane-
+  dominated inclined target, no-improvement on identical states,
+  horizon-too-short Lambert gate, projection-quality regression
+  guard).
+- `internal/sim/rendezvous.go` (new) — `World.RecommendedRendezvousBurn`
+  with `rendezvousAdvisoryCache` (sim-time-throttled, key-invalidated),
+  `World.PlanRendezvousNudge` with *dynamic lead buffer*
+  (`max(30 s, nodeLeadSlack·angle/SlewRate + 5 s)`; reuses v0.10.0's
+  `nodeLeadSlack` constant so the slew estimator stays consistent
+  across plant paths), and four sentinel errors
+  (`ErrRendezvousNoTarget` / `…DifferentPrimaries` /
+  `…AlreadyDocked` / `…NoImprovement` / `…NoCraft`). Seven sim tests
+  (two-craft LEO recommend, plant single node, no-target gate, lead-
+  buffer correctness under 180° attitude offset, different-primaries
+  Earth-vs-Moon gate, cache identity within interval, ClearTarget
+  invalidation, axis-label-to-burn-mode round-trip).
+- `internal/tui/input.go` + `app.go` + `screens/help.go` — `K`
+  bound to `PlanRendezvous`, dispatch mirrors the
+  `PlanCircularize` shape (status flash with Δv / mode /
+  achievable CA / TArrival), help overlay row.
+- `internal/tui/screens/orbit.go` — TARGET HUD ACH CA + Δv lines
+  spliced between v0.9.3's TCA/CA block and the DOCK READY check.
+  Faint single-line "K: no useful nudge in range" when the advisory
+  reports `no improvement available`; suppressed for other gate
+  reasons (cross-primary, no-target — the existing TCA/CA / hidden-
+  block paths already convey state).
+- `README.md` mirrors the new `K` row.
+
+**Scope explicitly NOT in this slice** (deferred to the player's
+manual step 4 with the v0.9.3 `m`-form `next closest approach`
+trigger): the null-v_rel arrival burn at TCA. The slice's loop is
+**plant nudge with K → coast/warp to ignition → re-evaluate → plant
+arrival burn manually via `m` form**. The "auto-plant the full
+nudge-then-null sequence" expansion is the still-open
+[rendezvous backlog item](../docs/state-of-game.md#rendezvous-tooling)
+of the v0.9-cycle plan.
+
+**Regression surface.** New planner tests + new sim tests; full
+`go vet ./...` + `go test ./... -race -count=1` green.
+
+### v0.10.3+ — carry-over candidates
 
 Detailed specs live in `docs/state-of-game.md` §Backlog; not
 duplicated here until committed. Ordered rationale:

--- a/internal/planner/rendezvous_recommend.go
+++ b/internal/planner/rendezvous_recommend.go
@@ -79,7 +79,7 @@ type RendezvousAdvisory struct {
 
 	LambertIdealDV float64 // m/s — |full Lambert ΔV| (always ≥ DV; gap shows projection loss)
 
-	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short"
+	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short" | "burn too large — use H/I/m"
 }
 
 // RecommendRendezvousNudge picks a single-burn nudge that brings the
@@ -102,6 +102,13 @@ type RendezvousAdvisory struct {
 //  4. Two-prong improvement floor:
 //     (CA_improvement ≥ 10 %) OR (Δv ≥ 0.5 m/s AND
 //     CA_improvement ≥ 100 m absolute). Fails the gate ⇒ Ok=false.
+//  5. Nudge-scale ceiling (v0.10.3+): bestProj ≤ maxNudgeDV — single-
+//     burn recommendations above this aren't "nudges", they're major
+//     orbit-shape changes that belong in the manual planner (H / I /
+//     m). Without this ceiling the gate would happily plant a 1.7
+//     km/s K-burn whenever it improved CA by ≥10 %, because the
+//     Lambert lookahead fan converges on whatever transfer fits T_k
+//     even when the orbits are wildly mismatched.
 //
 // Caller-side gates (no target, target == active, different
 // primaries, already DOCK READY) live in the sim layer; the planner
@@ -222,6 +229,19 @@ func RecommendRendezvousNudge(
 		return out
 	}
 
+	// Step 5: nudge-scale ceiling. Above maxNudgeDV the recommendation
+	// isn't a "nudge", it's an orbit-shape change the player should
+	// plan deliberately (H / I / m). Hide rather than plant.
+	if bestProj > maxNudgeDV {
+		out.AchievableCA = caStar
+		out.TArrival = tStar
+		out.DV = bestProj
+		out.Axis = bestAxis
+		out.AxisUnit = bestAxisUnit
+		out.Reason = "burn too large — use H/I/m"
+		return out
+	}
+
 	out.Ok = true
 	out.DV = bestProj
 	out.Axis = bestAxis
@@ -230,6 +250,17 @@ func RecommendRendezvousNudge(
 	out.TArrival = tStar
 	return out
 }
+
+// maxNudgeDV is the ceiling for a single-burn rendezvous nudge
+// recommendation. Calibrated v0.10.3+ after a 1.7-km/s K-plant was
+// observed for chaser/target in mismatched orbits (the 10 %
+// CA-improvement gate alone wasn't enough — Lambert happily returned
+// a fast-transfer solution that "improved" CA but was effectively a
+// full orbit-change burn). Tuned to cover small phasing burns and
+// modest plane corrections; major orbit-shape changes belong in the
+// H / I / m planners. Const, not a knob — the player intent is
+// "small nudge to refine an already-close intercept."
+const maxNudgeDV = 300.0 // m/s
 
 var allAxisLabels = []AxisLabel{
 	AxisPrograde,

--- a/internal/planner/rendezvous_recommend.go
+++ b/internal/planner/rendezvous_recommend.go
@@ -79,7 +79,7 @@ type RendezvousAdvisory struct {
 
 	LambertIdealDV float64 // m/s — |full Lambert ΔV| (always ≥ DV; gap shows projection loss)
 
-	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short" | "burn too large — use H/I/m"
+	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short" | "burn too large — use H/I/m" | "burn drops periapsis unsafely"
 }
 
 // RecommendRendezvousNudge picks a single-burn nudge that brings the
@@ -109,6 +109,13 @@ type RendezvousAdvisory struct {
 //     km/s K-burn whenever it improved CA by ≥10 %, because the
 //     Lambert lookahead fan converges on whatever transfer fits T_k
 //     even when the orbits are wildly mismatched.
+//  6. Orbit-safety gate (v0.10.3+): the projection in Step 2 is
+//     lossy — the perturbed orbit is NOT the Lambert transfer, just
+//     the chaser's orbit + a scalar push in one axis. A large
+//     retrograde or radial-in nudge can drop the chaser's periapsis
+//     into the atmosphere while still nominally "improving CA."
+//     Reject burns that put post-periapsis below primary+50 km or
+//     drop it by more than 100 km from pre-burn.
 //
 // Caller-side gates (no target, target == active, different
 // primaries, already DOCK READY) live in the sim layer; the planner
@@ -239,6 +246,33 @@ func RecommendRendezvousNudge(
 		out.Axis = bestAxis
 		out.AxisUnit = bestAxisUnit
 		out.Reason = "burn too large — use H/I/m"
+		return out
+	}
+
+	// Step 6 (v0.10.3+): orbit-safety gate. The projection step in
+	// Step 2 applies the Lambert Δv along a single axis, so the
+	// perturbed orbit is NOT the Lambert transfer orbit — it's the
+	// chaser's existing orbit pushed once in one direction. A large
+	// retrograde nudge can drop periapsis far below atmosphere while
+	// still "improving" CA (the chaser sweeps past the target on a
+	// re-entry arc). Reject the burn if the post-burn periapsis
+	// either falls below a hard floor (primary surface + 50 km) or
+	// drops more than 100 km from the pre-burn periapsis. Hard floor
+	// uses primary.RadiusMeters() when available; with a zero-radius
+	// primary (tests) only the relative-drop check fires. Without
+	// this gate, a K-plant has been observed deorbiting the chaser
+	// to a 25 km periapsis while ostensibly improving CA.
+	prePeri := orbital.ElementsFromState(stateA.R, stateA.V, mu).Periapsis()
+	postPeri := orbital.ElementsFromState(perturbed.R, perturbed.V, mu).Periapsis()
+	periSurfaceFloor := primary.RadiusMeters() + 50_000.0
+	periDropLimit := prePeri - 100_000.0
+	if (primary.RadiusMeters() > 0 && postPeri < periSurfaceFloor) || postPeri < periDropLimit {
+		out.AchievableCA = caStar
+		out.TArrival = tStar
+		out.DV = bestProj
+		out.Axis = bestAxis
+		out.AxisUnit = bestAxisUnit
+		out.Reason = "burn drops periapsis unsafely"
 		return out
 	}
 

--- a/internal/planner/rendezvous_recommend.go
+++ b/internal/planner/rendezvous_recommend.go
@@ -1,0 +1,309 @@
+package planner
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// AxisLabel identifies which of the eight velocity-frame burn axes
+// RecommendRendezvousNudge picked. The sim layer (which does have
+// the spacecraft package in scope) maps this to a spacecraft.BurnMode
+// before plant. Kept here as a planner-local enum so this file stays
+// dependency-clean (planner is a sibling of spacecraft — neither
+// imports the other; see CLAUDE.md "Architecture").
+//
+// Order matches spacecraft.AllBurnModes for the eight non-position
+// modes. The two position-relative modes (BurnTarget / BurnAntiTarget)
+// are intentionally excluded — Lambert's Δv is a velocity correction;
+// a position-axis pick would be physically unjustified. v0.10.2+.
+type AxisLabel int
+
+const (
+	AxisPrograde AxisLabel = iota
+	AxisRetrograde
+	AxisNormalPlus
+	AxisNormalMinus
+	AxisRadialOut
+	AxisRadialIn
+	AxisTargetPrograde
+	AxisTargetRetrograde
+)
+
+// String labels match the spacecraft.BurnMode.String() canonical names
+// so HUD callers don't need a parallel naming table.
+func (a AxisLabel) String() string {
+	switch a {
+	case AxisPrograde:
+		return "Prograde"
+	case AxisRetrograde:
+		return "Retrograde"
+	case AxisNormalPlus:
+		return "Normal+"
+	case AxisNormalMinus:
+		return "Normal-"
+	case AxisRadialOut:
+		return "Radial+"
+	case AxisRadialIn:
+		return "Radial-"
+	case AxisTargetPrograde:
+		return "Target Prograde"
+	case AxisTargetRetrograde:
+		return "Target Retrograde"
+	}
+	return "?"
+}
+
+// RendezvousAdvisory is the result of a single-burn nudge
+// recommendation. v0.10.2+.
+//
+// Ok=true: DV / Axis / AxisUnit / AchievableCA / TArrival populated; a
+// plant-side caller can build the maneuver node directly from these
+// fields.
+//
+// Ok=false: Reason carries a short tag for the gate that fired. The
+// HUD surfaces the "no improvement available" tag specifically; other
+// reasons mean the advisory block is hidden (the existing TARGET HUD
+// readouts already convey state).
+type RendezvousAdvisory struct {
+	Ok       bool
+	DV       float64      // scalar Δv along AxisUnit, m/s
+	Axis     AxisLabel    // discrete pick from the eight velocity-frame axes
+	AxisUnit orbital.Vec3 // unit vector for the recommended axis (in same frame as stateA)
+
+	CurrentCA    float64 // m — what the player would get with no burn
+	AchievableCA float64 // m — what the recommended burn delivers
+	TArrival     float64 // s — time-to-CA from now after the burn
+
+	LambertIdealDV float64 // m/s — |full Lambert ΔV| (always ≥ DV; gap shows projection loss)
+
+	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short"
+}
+
+// RecommendRendezvousNudge picks a single-burn nudge that brings the
+// chaser (stateA) closer to the target (stateB) at a future closest
+// approach, given they share a primary with gravitational parameter
+// mu. currentCA is the no-burn closest-approach distance the caller
+// already has on the HUD (typically from NextClosestApproach); the
+// function uses it for the two-prong improvement floor.
+//
+// Algorithm (see docs/v0.10-plan.md §v0.10.2 / plan file):
+//
+//  1. Scan Lambert intercept solutions at T_k = {0.15, 0.3, 0.5, 0.8,
+//     1.2}·P_B; pick the lookahead that minimises |Δv_full|.
+//  2. Project Δv_full onto the eight velocity-frame axes; pick the
+//     axis with the largest positive projection (scalar Δv ≥ 0).
+//  3. Re-run NextClosestApproach with the axis-aligned perturbation
+//     applied — this is the *honest* post-burn CA, not the Lambert
+//     ideal (the projection is lossy by design; the slice's loop is
+//     "iterate until DOCK READY").
+//  4. Two-prong improvement floor:
+//     (CA_improvement ≥ 10 %) OR (Δv ≥ 0.5 m/s AND
+//     CA_improvement ≥ 100 m absolute). Fails the gate ⇒ Ok=false.
+//
+// Caller-side gates (no target, target == active, different
+// primaries, already DOCK READY) live in the sim layer; the planner
+// is not exercised on those paths.
+func RecommendRendezvousNudge(
+	stateA, stateB orbital.Vec3State,
+	primary bodies.CelestialBody,
+	mu, horizon, currentCA float64,
+) RendezvousAdvisory {
+	_ = primary // captured for symmetry with NextClosestApproach; future cross-frame work
+
+	out := RendezvousAdvisory{CurrentCA: currentCA}
+
+	if mu <= 0 || horizon <= 0 {
+		out.Reason = "horizon too short"
+		return out
+	}
+
+	axes := buildVelocityFrameAxes(stateA, stateB)
+	if len(axes) == 0 {
+		out.Reason = "degenerate axes"
+		return out
+	}
+
+	// Step 1: Lambert lookahead scan.
+	pB := orbitalPeriod(physics.StateVector{R: stateB.R, V: stateB.V}, mu)
+	if math.IsInf(pB, 0) || pB <= 0 {
+		out.Reason = "horizon too short"
+		return out
+	}
+	lookaheads := []float64{0.15, 0.3, 0.5, 0.8, 1.2}
+	var bestDV orbital.Vec3
+	var bestT float64
+	bestMag := math.Inf(1)
+	for _, k := range lookaheads {
+		T := k * pB
+		if T <= 0 || T > horizon {
+			continue
+		}
+		stateBatT := propagateStateVerlet(stateB, mu, T)
+		v1, _, err := LambertSolve(stateA.R, stateBatT.R, T, mu, false)
+		if err != nil {
+			continue
+		}
+		dv := v1.Sub(stateA.V)
+		m := dv.Norm()
+		if math.IsNaN(m) || math.IsInf(m, 0) {
+			continue
+		}
+		if m < bestMag {
+			bestMag = m
+			bestDV = dv
+			bestT = T
+		}
+	}
+	if math.IsInf(bestMag, 0) {
+		out.Reason = "no lambert convergence"
+		return out
+	}
+	_ = bestT
+	out.LambertIdealDV = bestMag
+
+	// Step 2: axis projection. Pick axis with the largest positive
+	// projection onto bestDV. Equivalent to maximising the
+	// along-axis component magnitude when both signs of each axis
+	// pair are in the map (which they are).
+	var bestAxis AxisLabel
+	var bestAxisUnit orbital.Vec3
+	bestProj := 0.0
+	found := false
+	for _, label := range allAxisLabels {
+		axisUnit, ok := axes[label]
+		if !ok {
+			continue
+		}
+		proj := bestDV.Dot(axisUnit)
+		if proj > bestProj {
+			bestProj = proj
+			bestAxis = label
+			bestAxisUnit = axisUnit
+			found = true
+		}
+	}
+	if !found {
+		// All projections ≤ 0 — bestDV is a zero vector or the
+		// degenerate axis set didn't include the right direction.
+		out.Reason = "degenerate axes"
+		return out
+	}
+
+	// Step 3: achievable-CA verification. Apply the axis-aligned
+	// scalar Δv to stateA and re-run NextClosestApproach for the
+	// honest post-burn number.
+	perturbed := orbital.Vec3State{
+		R: stateA.R,
+		V: stateA.V.Add(bestAxisUnit.Scale(bestProj)),
+	}
+	tStar, caStar, _, err := NextClosestApproach(perturbed, stateB, primary, mu, horizon)
+	if err != nil {
+		out.Reason = "ca-verify failed"
+		return out
+	}
+
+	// Step 4: two-prong improvement floor.
+	improvement := currentCA - caStar
+	relImprovement := 0.0
+	if currentCA > 0 {
+		relImprovement = improvement / currentCA
+	}
+	twoProng := (relImprovement >= 0.10) || (bestProj >= 0.5 && improvement >= 100.0)
+	if caStar >= currentCA || !twoProng {
+		out.AchievableCA = caStar
+		out.TArrival = tStar
+		out.DV = bestProj
+		out.Axis = bestAxis
+		out.AxisUnit = bestAxisUnit
+		out.Reason = "no improvement available"
+		return out
+	}
+
+	out.Ok = true
+	out.DV = bestProj
+	out.Axis = bestAxis
+	out.AxisUnit = bestAxisUnit
+	out.AchievableCA = caStar
+	out.TArrival = tStar
+	return out
+}
+
+var allAxisLabels = []AxisLabel{
+	AxisPrograde,
+	AxisRetrograde,
+	AxisNormalPlus,
+	AxisNormalMinus,
+	AxisRadialOut,
+	AxisRadialIn,
+	AxisTargetPrograde,
+	AxisTargetRetrograde,
+}
+
+// buildVelocityFrameAxes constructs unit vectors for the eight
+// velocity-frame burn axes from chaser + target states in a common
+// frame. Skips degenerate axes (e.g. target-prograde when v_rel is
+// zero) — the projection loop simply doesn't consider them.
+func buildVelocityFrameAxes(stateA, stateB orbital.Vec3State) map[AxisLabel]orbital.Vec3 {
+	axes := make(map[AxisLabel]orbital.Vec3, 8)
+
+	rMag := stateA.R.Norm()
+	vMag := stateA.V.Norm()
+	if rMag > 0 && vMag > 0 {
+		prograde := stateA.V.Scale(1 / vMag)
+		radialOut := stateA.R.Scale(1 / rMag)
+		axes[AxisPrograde] = prograde
+		axes[AxisRetrograde] = prograde.Scale(-1)
+		axes[AxisRadialOut] = radialOut
+		axes[AxisRadialIn] = radialOut.Scale(-1)
+
+		h := stateA.R.Cross(stateA.V)
+		if hMag := h.Norm(); hMag > 0 {
+			normal := h.Scale(1 / hMag)
+			axes[AxisNormalPlus] = normal
+			axes[AxisNormalMinus] = normal.Scale(-1)
+		}
+	}
+
+	vRel := stateB.V.Sub(stateA.V)
+	if m := vRel.Norm(); m > 0 {
+		tp := vRel.Scale(1 / m)
+		axes[AxisTargetPrograde] = tp
+		axes[AxisTargetRetrograde] = tp.Scale(-1)
+	}
+
+	return axes
+}
+
+// propagateStateVerlet steps a state forward by T seconds using
+// Verlet integration with a period/200 substep (matches
+// NextClosestApproach's stability budget). For Lambert lookahead
+// fans, T is fractional-period so this is bounded: 0.15·P at
+// period/200 substep = ~30 sub-steps.
+func propagateStateVerlet(s orbital.Vec3State, mu, T float64) orbital.Vec3State {
+	sv := physics.StateVector{R: s.R, V: s.V}
+	period := orbitalPeriod(sv, mu)
+	var subStep float64
+	if math.IsInf(period, 0) || period <= 0 {
+		subStep = T / 100
+	} else {
+		subStep = period / 200
+	}
+	if subStep <= 0 || subStep > T/4 {
+		subStep = T / 4
+	}
+	if subStep <= 0 {
+		return s
+	}
+	n := int(math.Ceil(T / subStep))
+	if n < 4 {
+		n = 4
+	}
+	dt := T / float64(n)
+	for i := 0; i < n; i++ {
+		sv = physics.StepVerlet(sv, mu, dt)
+	}
+	return orbital.Vec3State{R: sv.R, V: sv.V}
+}

--- a/internal/planner/rendezvous_recommend.go
+++ b/internal/planner/rendezvous_recommend.go
@@ -267,7 +267,10 @@ func buildVelocityFrameAxes(stateA, stateB orbital.Vec3State) map[AxisLabel]orbi
 		}
 	}
 
-	vRel := stateB.V.Sub(stateA.V)
+	// KSP convention: target-prograde = unit(v_active − v_target)
+	// (chaser's motion relative to target); target-retrograde =
+	// unit(v_target − v_active) (the closing / null-v_rel axis).
+	vRel := stateA.V.Sub(stateB.V)
 	if m := vRel.Norm(); m > 0 {
 		tp := vRel.Scale(1 / m)
 		axes[AxisTargetPrograde] = tp

--- a/internal/planner/rendezvous_recommend_test.go
+++ b/internal/planner/rendezvous_recommend_test.go
@@ -199,3 +199,34 @@ func TestRecommendRendezvousNudge_BurnTooLarge(t *testing.T) {
 		t.Errorf("setup: expected DV > %.0f m/s to exercise the ceiling; got %.1f", maxNudgeDV, adv.DV)
 	}
 }
+
+// TestRecommendRendezvousNudge_PeriapsisGate — chaser leading target
+// by a large phase angle in the same circular LEO. Lambert finds a
+// fast "drop and swoop" intercept; projection onto a single axis
+// (Retrograde or RadialIn) applies that Δv to the chaser's existing
+// orbit, dropping periapsis dramatically — observed in the wild as a
+// K-plant that put the chaser into a 25 km altitude periapsis arc.
+// v0.10.3+: the Step 6 orbit-safety gate rejects burns that drop
+// post-burn periapsis below primary+50 km OR by more than 100 km
+// vs pre-burn. Caller (HUD) reads Reason="burn drops periapsis
+// unsafely" and surfaces a faint diagnostic instead of planting.
+func TestRecommendRendezvousNudge_PeriapsisGate(t *testing.T) {
+	// Earth-radius primary so the surface floor check fires.
+	earth := bodies.CelestialBody{MeanRadius: 6378} // km
+	r := 6.771e6                                    // ~400 km circular LEO
+	chaser := circularStateAtRadius(r, 30*math.Pi/180, muEarth)
+	target := circularStateAtRadius(r, 0, muEarth)
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, earth, muEarth, 10000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, earth, muEarth, 10000, currentCA)
+	if adv.Ok {
+		t.Errorf("expected Ok=false for chaser-far-ahead-of-target geometry (the Lambert projection drops periapsis); got Ok=true, DV=%.1f, axis=%s, achCA=%.0f", adv.DV, adv.Axis, adv.AchievableCA)
+	}
+	if adv.Reason != "burn drops periapsis unsafely" && adv.Reason != "burn too large — use H/I/m" {
+		t.Errorf("expected Reason=\"burn drops periapsis unsafely\" (or ceiling reason if DV exceeds it), got %q (DV=%.0f, axis=%s)", adv.Reason, adv.DV, adv.Axis)
+	}
+}

--- a/internal/planner/rendezvous_recommend_test.go
+++ b/internal/planner/rendezvous_recommend_test.go
@@ -66,21 +66,20 @@ func TestRecommendRendezvousNudge_CoOrbitalLagging(t *testing.T) {
 	}
 }
 
-// TestRecommendRendezvousNudge_InclinedTarget — 10° plane offset
-// with no phase offset along the inclined orbit; the only meaningful
-// component of the Lambert ΔV is plane-changing, so the projection
-// should pick AxisNormalPlus or AxisNormalMinus. Verifies the normal-
-// axis branch of the projection loop is exercised in tests (not just
-// the buildVelocityFrameAxes builder).
+// TestRecommendRendezvousNudge_InclinedTarget — small plane offset
+// dominates a tiny phase offset; the only meaningful component of
+// the Lambert ΔV is plane-changing, so the projection should pick
+// AxisNormalPlus or AxisNormalMinus. Verifies the normal-axis branch
+// of the projection loop is exercised in tests (not just the
+// buildVelocityFrameAxes builder). v0.10.3+: dropped from (30°, 10°)
+// to (2°, 2°) so the recommendation stays under the nudge-scale
+// ceiling AND the plane component still dominates the phasing
+// component in the projection — a 10° plane change at LEO is
+// ~1.3 km/s, which belongs in the manual planner, not a K-plant.
 func TestRecommendRendezvousNudge_InclinedTarget(t *testing.T) {
 	r := 6.771e6
 	chaser := circularStateAtRadius(r, 0, muEarth)
-	// Phase slightly offset from the line of nodes so positions
-	// differ at t=0 (currentCA > 0) but plane offset dominates the
-	// intercept geometry. 30° phase on a 10° inclined orbit gives
-	// currentCA in the few-hundred-km range with the cross-plane
-	// distance growing with phase.
-	target := inclinedCircularState(r, 30*math.Pi/180, 10*math.Pi/180, muEarth)
+	target := inclinedCircularState(r, 2*math.Pi/180, 2*math.Pi/180, muEarth)
 
 	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
 	if err != nil {
@@ -167,5 +166,36 @@ func TestRecommendRendezvousNudge_ProjectionQuality(t *testing.T) {
 	// must be ≤ that (projecting onto a unit axis can only shorten).
 	if adv.DV > adv.LambertIdealDV+1e-6 {
 		t.Errorf("projected DV %.3f exceeds Lambert ideal %.3f", adv.DV, adv.LambertIdealDV)
+	}
+}
+
+// TestRecommendRendezvousNudge_BurnTooLarge — chaser in LEO, target
+// in a much higher orbit (~3× LEO radius). The single-burn Lambert
+// transfer is a major orbit-change worth thousands of m/s, not a
+// rendezvous "nudge". v0.10.3+: the nudge-scale ceiling rejects the
+// recommendation rather than planting a 1.7-km/s K-burn that improves
+// CA by ≥10 %. Caller (the HUD / K-plant flow) should see
+// Ok=false with Reason="burn too large — use H/I/m" and direct the
+// player to the manual planner.
+func TestRecommendRendezvousNudge_BurnTooLarge(t *testing.T) {
+	rChaser := 6.771e6   // LEO ~400 km
+	rTarget := 20.000e6  // mid-MEO — ~13600 km altitude
+	chaser := circularStateAtRadius(rChaser, 0, muEarth)
+	target := circularStateAtRadius(rTarget, math.Pi/4, muEarth)
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 50000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 50000, currentCA)
+	if adv.Ok {
+		t.Errorf("expected Ok=false for orbit-mismatch case (DV=%.0f m/s should exceed nudge ceiling); got Ok=true, axis=%s", adv.DV, adv.Axis)
+	}
+	if adv.Reason != "burn too large — use H/I/m" {
+		t.Errorf("expected Reason=\"burn too large — use H/I/m\", got %q (DV=%.0f, achCA=%.0f, currentCA=%.0f)", adv.Reason, adv.DV, adv.AchievableCA, currentCA)
+	}
+	if adv.DV <= maxNudgeDV {
+		t.Errorf("setup: expected DV > %.0f m/s to exercise the ceiling; got %.1f", maxNudgeDV, adv.DV)
 	}
 }

--- a/internal/planner/rendezvous_recommend_test.go
+++ b/internal/planner/rendezvous_recommend_test.go
@@ -1,0 +1,171 @@
+package planner
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// circularStateAtRadius is like circularState but lets the test pick
+// the circular-orbit radius independently of the phase. Reused by the
+// rendezvous-recommend cases below.
+func circularStateAtRadius(r, phaseRad, mu float64) orbital.Vec3State {
+	return circularState(r, phaseRad, mu)
+}
+
+// inclinedCircularState builds a circular orbit at radius r whose
+// plane is tilted by inclinationRad about the +X axis (i.e. the
+// ascending node sits on +X). Used to construct a target offset only
+// by plane angle so the rendezvous recommendation picks a Normal±
+// axis.
+func inclinedCircularState(r, phaseRad, inclinationRad, mu float64) orbital.Vec3State {
+	flat := circularState(r, phaseRad, mu)
+	cosI, sinI := math.Cos(inclinationRad), math.Sin(inclinationRad)
+	// Rotate (Y, Z) by inclination about +X.
+	rot := func(v orbital.Vec3) orbital.Vec3 {
+		return orbital.Vec3{
+			X: v.X,
+			Y: v.Y*cosI - v.Z*sinI,
+			Z: v.Y*sinI + v.Z*cosI,
+		}
+	}
+	return orbital.Vec3State{R: rot(flat.R), V: rot(flat.V)}
+}
+
+// TestRecommendRendezvousNudge_CoOrbitalLagging — chaser 0.5° behind
+// target in the same 400 km circular orbit. Current CA is essentially
+// the constant separation. The recommendation should reduce it.
+func TestRecommendRendezvousNudge_CoOrbitalLagging(t *testing.T) {
+	r := 6.771e6
+	target := circularStateAtRadius(r, 0, muEarth)
+	chaser := circularStateAtRadius(r, -0.5*math.Pi/180, muEarth)
+
+	// Current CA from the no-burn predictor.
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+	if currentCA < 100 {
+		t.Fatalf("setup: currentCA=%.1f m too small to test improvement", currentCA)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, currentCA)
+	if !adv.Ok {
+		t.Fatalf("expected Ok=true (currentCA=%.0f m), got Reason=%q", currentCA, adv.Reason)
+	}
+	if adv.DV <= 0 || adv.DV > 200 {
+		t.Errorf("DV %.2f m/s outside (0, 200] m/s", adv.DV)
+	}
+	if adv.AchievableCA >= currentCA {
+		t.Errorf("AchievableCA=%.0f did not improve on currentCA=%.0f", adv.AchievableCA, currentCA)
+	}
+	if adv.TArrival <= 0 || adv.TArrival > 6000 {
+		t.Errorf("TArrival %.0f outside (0, horizon]", adv.TArrival)
+	}
+}
+
+// TestRecommendRendezvousNudge_InclinedTarget — 10° plane offset
+// with no phase offset along the inclined orbit; the only meaningful
+// component of the Lambert ΔV is plane-changing, so the projection
+// should pick AxisNormalPlus or AxisNormalMinus. Verifies the normal-
+// axis branch of the projection loop is exercised in tests (not just
+// the buildVelocityFrameAxes builder).
+func TestRecommendRendezvousNudge_InclinedTarget(t *testing.T) {
+	r := 6.771e6
+	chaser := circularStateAtRadius(r, 0, muEarth)
+	// Phase slightly offset from the line of nodes so positions
+	// differ at t=0 (currentCA > 0) but plane offset dominates the
+	// intercept geometry. 30° phase on a 10° inclined orbit gives
+	// currentCA in the few-hundred-km range with the cross-plane
+	// distance growing with phase.
+	target := inclinedCircularState(r, 30*math.Pi/180, 10*math.Pi/180, muEarth)
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, currentCA)
+	if !adv.Ok {
+		t.Fatalf("expected Ok=true (currentCA=%.0f m, inclination=10°), got Reason=%q", currentCA, adv.Reason)
+	}
+	switch adv.Axis {
+	case AxisNormalPlus, AxisNormalMinus:
+		// expected — confirms the plane-change branch fires.
+	default:
+		t.Errorf("expected Normal± axis for plane-dominated target, got %s (DV=%.1f, currentCA=%.0f, achCA=%.0f, LambertDV=%.1f)",
+			adv.Axis, adv.DV, currentCA, adv.AchievableCA, adv.LambertIdealDV)
+	}
+}
+
+// TestRecommendRendezvousNudge_NoImprovement — identical states ⇒
+// currentCA == 0, no possible improvement, advisory returns Reason
+// "no improvement available" (the two-prong floor cannot pass with
+// currentCA=0 since rel improvement is undefined and absolute is ≤ 0).
+func TestRecommendRendezvousNudge_NoImprovement(t *testing.T) {
+	r := 6.771e6
+	s := circularStateAtRadius(r, 0, muEarth)
+	adv := RecommendRendezvousNudge(s, s, bodies.CelestialBody{}, muEarth, 6000, 0)
+	if adv.Ok {
+		t.Fatalf("expected Ok=false for identical states, got DV=%.2f axis=%s",
+			adv.DV, adv.Axis)
+	}
+	if adv.Reason == "" {
+		t.Errorf("expected non-empty Reason")
+	}
+}
+
+// TestRecommendRendezvousNudge_HorizonTooShort — horizon below the
+// shortest lookahead-fraction of target period ⇒ no Lambert solve
+// completes ⇒ Ok=false with reason "no lambert convergence".
+func TestRecommendRendezvousNudge_HorizonTooShort(t *testing.T) {
+	r := 6.771e6
+	a := circularStateAtRadius(r, 0, muEarth)
+	b := circularStateAtRadius(r, -0.5*math.Pi/180, muEarth)
+	adv := RecommendRendezvousNudge(a, b, bodies.CelestialBody{}, muEarth, 10, 1000) // 10 s horizon ≪ 0.15 P
+	if adv.Ok {
+		t.Errorf("expected Ok=false for too-short horizon, got DV=%.2f", adv.DV)
+	}
+	if adv.Reason == "" {
+		t.Errorf("expected non-empty Reason")
+	}
+}
+
+// TestRecommendRendezvousNudge_ProjectionQuality — guards against
+// future axis-selection refactors silently degrading. On the
+// co-orbital lagging case, AchievableCA should be much better than
+// currentCA — assert at least a 30 % improvement (the projection is
+// lossy but should beat this floor handily in this geometry).
+func TestRecommendRendezvousNudge_ProjectionQuality(t *testing.T) {
+	r := 6.771e6
+	target := circularStateAtRadius(r, 0, muEarth)
+	chaser := circularStateAtRadius(r, -0.5*math.Pi/180, muEarth)
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, currentCA)
+	if !adv.Ok {
+		t.Fatalf("expected Ok=true, got Reason=%q", adv.Reason)
+	}
+	improvement := (currentCA - adv.AchievableCA) / currentCA
+	// The single-axis projection is intentionally lossy vs the full
+	// Lambert ΔV (the slice's loop is "iterate until DOCK READY"),
+	// so we set the floor low enough to catch silent regressions
+	// without being aspirational about projection quality. 20 % on a
+	// 0.5° co-orbital phase offset is healthy headroom; if axis
+	// selection degrades, this number drops first.
+	if improvement < 0.20 {
+		t.Errorf("co-orbital improvement %.1f%% < 20%% (currentCA=%.0f, achCA=%.0f, DV=%.1f, axis=%s, LambertDV=%.1f)",
+			improvement*100, currentCA, adv.AchievableCA, adv.DV, adv.Axis, adv.LambertIdealDV)
+	}
+	// LambertIdealDV is the unprojected magnitude; the projected DV
+	// must be ≤ that (projecting onto a unit axis can only shorten).
+	if adv.DV > adv.LambertIdealDV+1e-6 {
+		t.Errorf("projected DV %.3f exceeds Lambert ideal %.3f", adv.DV, adv.LambertIdealDV)
+	}
+}

--- a/internal/render/navball.go
+++ b/internal/render/navball.go
@@ -53,9 +53,9 @@ const (
 // NavballMarker is a glyph drawn at a fixed (lat, lon) on the navball
 // sphere in the active basis. The painter projects (LatDeg, LonDeg)
 // through the sub-observer point to a cell offset; if the marker lies
-// in the front hemisphere it draws Glyph in Color, otherwise the
-// marker is skipped (back-hemisphere dimming + limb bracketing are
-// future polish).
+// in the front hemisphere (or in the narrow limb dead zone) it draws
+// Glyph in Color, otherwise the marker is skipped — the ball reads
+// like a solid sphere with no antipodal bleed-through.
 //
 // v0.9.5+.
 type NavballMarker struct {
@@ -374,34 +374,33 @@ func NavballString(cols, rows int, subLatDeg, subLonDeg float64, markers []Navba
 		placed = append(placed, placedMarker{m, col, row, front})
 	}
 
-	// Two passes so front markers overwrite back markers at coincident
-	// cells (e.g. prograde at the disk centre hides retrograde when
-	// sub-observer points at prograde — KSP behavior). Markers render
-	// Bold so the glyph reads cleanly against the hemisphere texture
-	// even when marker and hemisphere colors are close in hue (yellow
-	// prograde on orange ground, cyan radial on blue sky).
-	paint := func(p placedMarker, dimmed bool) {
+	// Front-only: back-hemisphere markers are skipped entirely (not
+	// dimmed) so the ball reads like a solid sphere — the player only
+	// ever sees the glyphs on the side of the ball facing them, never
+	// the antipodal pair bleeding through. Faint styling on terminals
+	// varied too much to reliably read as "behind" (some terminals
+	// render Faint nearly as strong as Bold), so the antipode of an
+	// axis looked like it was sharing the disk with its partner —
+	// especially confusing for prograde/retrograde, which sit at
+	// opposite poles of the orbit-frame basis. Markers that genuinely
+	// lie on the silhouette (|z| ≤ limbFrontEpsZ) are still classed
+	// front by projectLatLonToPixel so they render at the rim instead
+	// of strobing on float noise.
+	//
+	// Markers render Bold so the glyph reads cleanly against the
+	// hemisphere texture even when marker and hemisphere colors are
+	// close in hue (yellow prograde on orange ground, cyan radial on
+	// blue sky).
+	for _, p := range placed {
+		if !p.front {
+			continue
+		}
 		glyph := string(p.m.Glyph)
 		if p.m.Glyph == 0 {
 			glyph = "•"
 		}
 		style := lipgloss.NewStyle().Foreground(p.m.Color).Bold(true)
-		if dimmed {
-			style = style.Faint(true).Bold(false)
-		}
 		cells[p.row][p.col] = style.Render(glyph)
-	}
-	for _, p := range placed {
-		if p.front {
-			continue
-		}
-		paint(p, true)
-	}
-	for _, p := range placed {
-		if !p.front {
-			continue
-		}
-		paint(p, false)
 	}
 
 	lines := make([]string, rows)

--- a/internal/render/navball_test.go
+++ b/internal/render/navball_test.go
@@ -139,21 +139,23 @@ func TestNavballMarkerOverlay(t *testing.T) {
 	}
 }
 
-// TestNavballMarkerBackHemisphereDimmed confirms a marker on the far
-// side of the ball is still painted (so the player can see where to
-// rotate toward when an axis is behind the nose), but with Faint
-// styling so it reads as "behind."
-func TestNavballMarkerBackHemisphereDimmed(t *testing.T) {
+// TestNavballMarkerBackHemisphereHidden confirms a marker on the far
+// side of the ball is NOT painted. The ball should read like a solid
+// sphere — the antipode of the sub-observer is hidden, not dimmed.
+// Faint dimming was tried in v0.9.5 but read too strongly on many
+// terminals, so the prograde/retrograde pair looked like both were
+// on the visible side at once.
+func TestNavballMarkerBackHemisphereHidden(t *testing.T) {
 	withoutMarker := NavballString(13, 13, 0, 0, nil)
 	markers := []NavballMarker{
 		{LatDeg: 0, LonDeg: 180, Glyph: '⊕', Color: ColorNavballMarkerPrograde},
 	}
 	withMarker := NavballString(13, 13, 0, 0, markers)
-	if withMarker == withoutMarker {
-		t.Errorf("back-hemisphere marker should still appear (dimmed)")
+	if withMarker != withoutMarker {
+		t.Errorf("back-hemisphere marker should be skipped, but output changed")
 	}
-	if !strings.ContainsRune(withMarker, '⊕') {
-		t.Errorf("back-hemisphere marker glyph should be in output")
+	if strings.ContainsRune(withMarker, '⊕') {
+		t.Errorf("back-hemisphere marker glyph leaked into output")
 	}
 }
 

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -38,7 +38,7 @@ type NavballBasis struct {
 // NavOrbit / NavTarget are velocity-framed (the sphere's pole is the
 // orbital normal):
 //
-//   - EX (lat 0, lon 0): +v̂ (orbit) or +(v_target − v_active)̂ (target)
+//   - EX (lat 0, lon 0): +v̂ (orbit) or +(v_active − v_target)̂ (target)
 //   - EZ (lat +90):      orbital normal (r × v)̂, re-orthogonalised
 //     against EX (target-prograde isn't generally ⟂ the orbit plane)
 //   - EY = EZ × EX
@@ -117,7 +117,11 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 		if !ok {
 			return NavballBasis{}, false
 		}
-		dv := vT.Sub(v)
+		// KSP convention: target-prograde = unit(v_active − v_target),
+		// the direction of motion relative to the target. The navball
+		// re-centres on that axis so when SAS holds target-prograde
+		// the marker sits at the disk centre.
+		dv := v.Sub(vT)
 		n := dv.Norm()
 		if n == 0 {
 			return NavballBasis{}, false

--- a/internal/sim/rcs.go
+++ b/internal/sim/rcs.go
@@ -40,9 +40,10 @@ func (w *World) RCSActive() bool {
 // is in flight (the planted burn owns the engine — RCS pulses while
 // a main burn fires would muddy the integrator's force model).
 //
-// Updates AttitudeMode so the HUD reflects the last fired direction
-// — the player's mental model is "this key just nudged me prograde,"
-// so showing prograde as the held attitude is the least surprising.
+// Does NOT touch AttitudeMode: RCS is a 6-axis translation tool, so
+// pulses apply Δv along the requested orbital-frame direction without
+// re-pointing the nose. SAS hold is controlled separately via the
+// main-engine attitude keys / SetAttitudeMode.
 //
 // v0.8.0+.
 func (w *World) FireRCSPulse(mode spacecraft.BurnMode) bool {
@@ -63,7 +64,6 @@ func (w *World) FireRCSPulse(mode spacecraft.BurnMode) bool {
 	if !w.ActiveCraft().ApplyRCSPulseWithTarget(mode, rT, vT) {
 		return false
 	}
-	w.ActiveCraft().AttitudeMode = mode
 	w.recordRCSPuff(dir)
 	return true
 }

--- a/internal/sim/rcs_test.go
+++ b/internal/sim/rcs_test.go
@@ -55,14 +55,18 @@ func TestFireRCSPulseGatesOnEngineMode(t *testing.T) {
 	}
 }
 
-// TestFireRCSPulseUpdatesAttitudeMode: the HUD's "hold" line should
-// reflect the last fired direction.
-func TestFireRCSPulseUpdatesAttitudeMode(t *testing.T) {
+// TestFireRCSPulsePreservesAttitudeMode: RCS is a 6-axis translation
+// tool — firing a pulse should apply Δv without re-pointing the nose.
+// The SAS hold (AttitudeMode) must survive an RCS pulse in a different
+// direction so the slew system doesn't slew the craft mid-translation.
+func TestFireRCSPulsePreservesAttitudeMode(t *testing.T) {
 	w, _ := NewWorld()
+	before := w.ActiveCraft().AttitudeMode
 	w.CycleEngineMode()
 	w.FireRCSPulse(spacecraft.BurnRetrograde)
-	if w.ActiveCraft().AttitudeMode != spacecraft.BurnRetrograde {
-		t.Errorf("AttitudeMode = %v, want Retrograde", w.ActiveCraft().AttitudeMode)
+	if w.ActiveCraft().AttitudeMode != before {
+		t.Errorf("AttitudeMode changed by RCS pulse: %v → %v, want unchanged",
+			before, w.ActiveCraft().AttitudeMode)
 	}
 }
 

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -1,0 +1,304 @@
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Rendezvous advisory errors. Exported so app.go's status flash can
+// switch on them via errors.Is, mirroring the PlanCircularize* family
+// (see maneuver.go:1132). v0.10.2+.
+var (
+	ErrRendezvousNoTarget           = transferError("rendezvous: no craft target")
+	ErrRendezvousDifferentPrimaries = transferError("rendezvous: target around a different primary")
+	ErrRendezvousAlreadyDocked      = transferError("rendezvous: already in DOCK READY range")
+	ErrRendezvousNoImprovement      = transferError("rendezvous: no useful nudge in range")
+	ErrRendezvousNoCraft            = transferError("rendezvous: no active craft")
+)
+
+// rendezvousAdvisoryCache stores the most recent recommendation so
+// the per-frame TARGET HUD readout does not have to re-run the
+// Lambert + NextClosestApproach pipeline every tick (~5 ms LEO).
+// Sim-time-throttled: recompute when the active/target indices
+// change OR when sim-time has advanced past
+// rendezvousRecomputeInterval since the last computation.
+//
+// Sim-time (not real-time) is the throttle clock because at warp the
+// trajectories change with sim-time — a 50× warp player wants a
+// recompute every ~10 ms real-time, which sim-time naturally
+// produces. At 1× normal play the cache hits ~10 frames in a row,
+// which is the per-frame budget win we're after.
+type rendezvousAdvisoryCache struct {
+	lastSimTime time.Time
+	activeIdx   int
+	targetIdx   int
+	advisory    planner.RendezvousAdvisory
+	ok          bool
+	populated   bool
+}
+
+// rendezvousRecomputeInterval is the sim-time gap that forces a
+// recompute. 500 ms balances stale-by-a-tick acceptability against
+// per-frame CPU cost. State changes smoothly at this granularity.
+const rendezvousRecomputeInterval = 500 * time.Millisecond
+
+// rendezvousBurnLeadMin is the floor on the dynamic lead buffer
+// PlanRendezvousNudge applies to TriggerTime. Keeps a minimum margin
+// for v0.10.0 slew alignment even when CurrentAttitudeDir already
+// happens to line up with the recommended axis (slewTime ≈ 0).
+const rendezvousBurnLeadMin = 30 * time.Second
+
+// rendezvousBurnLeadPad is added on top of the dynamic slew estimate
+// so a NavMode toggle mid-coast or a small attitude drift before
+// ignition does not steal the lead-comp slew window.
+const rendezvousBurnLeadPad = 5 * time.Second
+
+// RecommendedRendezvousBurn returns the cached rendezvous advisory
+// for the current active+target craft pair, recomputing on cache
+// miss. Returns (_, false) when the advisory cannot be computed
+// (no craft target, different primaries, or no active craft) so the
+// TARGET HUD just hides the block.
+//
+// The returned advisory is the same struct callers see from the
+// underlying planner.RecommendRendezvousNudge; ok=false-with-advisory
+// is the "no improvement available" path (advisory.Reason populated)
+// the HUD surfaces as a faint single-line tag.
+func (w *World) RecommendedRendezvousBurn() (planner.RendezvousAdvisory, bool) {
+	active := w.ActiveCraft()
+	if active == nil || w.Target.Kind != TargetCraft {
+		w.rendezvousCache = rendezvousAdvisoryCache{}
+		return planner.RendezvousAdvisory{}, false
+	}
+	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
+		return planner.RendezvousAdvisory{}, false
+	}
+	t := w.Crafts[w.Target.CraftIdx]
+	if t == nil || t.Primary.EnglishName != active.Primary.EnglishName {
+		// Different-primary case is a gate, not an advisory — the
+		// HUD just hides the block (cross-SOI rendezvous is out of
+		// the v0.10.2 scope, matches v0.9.3 NextClosestApproach).
+		return planner.RendezvousAdvisory{}, false
+	}
+
+	// Cache key: (active, target, sim-time within interval).
+	if w.rendezvousCache.populated &&
+		w.rendezvousCache.activeIdx == w.ActiveCraftIdx &&
+		w.rendezvousCache.targetIdx == w.Target.CraftIdx &&
+		w.Clock.SimTime.Sub(w.rendezvousCache.lastSimTime) < rendezvousRecomputeInterval {
+		return w.rendezvousCache.advisory, w.rendezvousCache.ok
+	}
+
+	advisory, ok := w.computeRendezvousAdvisory(active, t)
+	w.rendezvousCache = rendezvousAdvisoryCache{
+		lastSimTime: w.Clock.SimTime,
+		activeIdx:   w.ActiveCraftIdx,
+		targetIdx:   w.Target.CraftIdx,
+		advisory:    advisory,
+		ok:          ok,
+		populated:   true,
+	}
+	return advisory, ok
+}
+
+// computeRendezvousAdvisory does the uncached work: gather primary-
+// relative states, compute currentCA via NextClosestApproach, check
+// the docked gate, then hand off to the planner.
+func (w *World) computeRendezvousAdvisory(active, target *spacecraft.Spacecraft) (planner.RendezvousAdvisory, bool) {
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return planner.RendezvousAdvisory{}, false
+	}
+	stateA := orbital.Vec3State{R: active.State.R, V: active.State.V}
+	stateB := orbital.Vec3State{R: rT, V: vT}
+
+	mu := active.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return planner.RendezvousAdvisory{}, false
+	}
+
+	// Docked gate: < 50 m + |v_rel| < 0.1 m/s ⇒ no recommendation.
+	separation := stateB.R.Sub(stateA.R).Norm()
+	vRel := stateB.V.Sub(stateA.V).Norm()
+	if separation < 50 && vRel < 0.1 {
+		return planner.RendezvousAdvisory{
+			Ok:     false,
+			Reason: "docked",
+		}, false
+	}
+
+	// Horizon mirrors v0.9.3 NextClosestApproach defaults: ~2× the
+	// longer orbital period, capped so the predictor's grid stays
+	// dense.
+	horizon := rendezvousHorizonSeconds(stateA, stateB, mu)
+	_, currentCA, _, err := planner.NextClosestApproach(stateA, stateB, target.Primary, mu, horizon)
+	if err != nil {
+		return planner.RendezvousAdvisory{}, false
+	}
+
+	advisory := planner.RecommendRendezvousNudge(stateA, stateB, target.Primary, mu, horizon, currentCA)
+	if !advisory.Ok {
+		// no-improvement / Lambert-divergence / degenerate-axes:
+		// caller surfaces advisory.Reason in the HUD; bool=true here
+		// so the HUD can distinguish "we computed and the answer is
+		// 'no useful nudge'" from "we couldn't compute" (false from
+		// the outer gate).
+		return advisory, true
+	}
+	return advisory, true
+}
+
+// rendezvousHorizonSeconds picks a horizon for the closest-approach
+// search. ~2× the larger of the two craft's orbital periods is
+// enough to find the first encounter for any practical co-orbital
+// scenario; capped at 2 hours so the predictor's grid stays sparse
+// at deep-space distances.
+func rendezvousHorizonSeconds(stateA, stateB orbital.Vec3State, mu float64) float64 {
+	period := func(s orbital.Vec3State) float64 {
+		r := s.R.Norm()
+		v := s.V.Norm()
+		// Vis-viva: a = 1 / (2/r - v²/μ).
+		denom := 2/r - v*v/mu
+		if denom <= 0 {
+			return math.Inf(1)
+		}
+		a := 1 / denom
+		return 2 * math.Pi * math.Sqrt(a*a*a/mu)
+	}
+	pA := period(stateA)
+	pB := period(stateB)
+	p := math.Max(pA, pB)
+	if math.IsInf(p, 0) || p <= 0 {
+		return 7200 // 2-hour fallback
+	}
+	horizon := 2 * p
+	if horizon > 7200 {
+		horizon = 7200
+	}
+	if horizon < 600 {
+		horizon = 600
+	}
+	return horizon
+}
+
+// PlanRendezvousNudge plants the recommended single-burn nudge as a
+// new ManeuverNode on the active craft. Returns the advisory used so
+// the caller can build a status flash; returns (nil, err) when the
+// gate fails (no target, different primaries, no improvement, etc.).
+//
+// TriggerTime = SimTime + leadBuffer, where leadBuffer is dynamic:
+// max(rendezvousBurnLeadMin, nodeLeadSlack·angle/SlewRateRad + pad).
+// This ensures v0.10.0 lead-compensated slew has room to converge
+// even when the recommended axis is far from the current attitude.
+// Event=TriggerAbsolute (immediate-style — fires at the computed
+// time, no future event-relative resolution). TargetCraftIdx is
+// captured one-based per the spacecraft.ManeuverNode convention so
+// a later target switch does not retarget the planted burn.
+//
+// v0.10.2+.
+func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return nil, ErrRendezvousNoCraft
+	}
+	if w.Target.Kind != TargetCraft {
+		return nil, ErrRendezvousNoTarget
+	}
+	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
+		return nil, ErrRendezvousNoTarget
+	}
+	t := w.Crafts[w.Target.CraftIdx]
+	if t == nil {
+		return nil, ErrRendezvousNoTarget
+	}
+	if t.Primary.EnglishName != c.Primary.EnglishName {
+		return nil, ErrRendezvousDifferentPrimaries
+	}
+
+	advisory, ok := w.RecommendedRendezvousBurn()
+	if !ok {
+		return nil, ErrRendezvousNoImprovement
+	}
+	if !advisory.Ok {
+		// Computed, but the answer is "no useful nudge".
+		if advisory.Reason == "docked" {
+			return nil, ErrRendezvousAlreadyDocked
+		}
+		return nil, ErrRendezvousNoImprovement
+	}
+
+	leadBuffer := w.rendezvousLeadBuffer(c, advisory.AxisUnit)
+
+	mode := axisLabelToBurnMode(advisory.Axis)
+	node := ManeuverNode{
+		Mode:           mode,
+		DV:             advisory.DV,
+		Duration:       c.BurnTimeForDV(advisory.DV),
+		Event:          spacecraft.TriggerAbsolute,
+		TriggerTime:    w.Clock.SimTime.Add(leadBuffer),
+		PrimaryID:      c.Primary.ID,
+		Throttle:       1.0,
+		TargetCraftIdx: w.Target.CraftIdx + 1, // one-based per ManeuverNode.TargetCraftIdx convention
+	}
+	w.PlanNode(node)
+	out := advisory
+	return &out, nil
+}
+
+// rendezvousLeadBuffer computes the lead time PlanRendezvousNudge
+// applies to TriggerTime. Mirrors the v0.10.0 nodeLeadActive formula
+// (nodeLeadSlack·angle/SlewRate) and adds a 5 s pad + a 30 s floor.
+func (w *World) rendezvousLeadBuffer(c *spacecraft.Spacecraft, axisUnit orbital.Vec3) time.Duration {
+	floor := rendezvousBurnLeadMin
+	slew := c.SlewRateRad()
+	if slew <= 0 {
+		return floor
+	}
+	cur := c.CurrentAttitudeDir.Unit()
+	axisU := axisUnit.Unit()
+	if cur.Norm() == 0 || axisU.Norm() == 0 {
+		return floor
+	}
+	cosA := cur.Dot(axisU)
+	if cosA > 1 {
+		cosA = 1
+	} else if cosA < -1 {
+		cosA = -1
+	}
+	ang := math.Acos(cosA)
+	slewSecs := nodeLeadSlack * ang / slew
+	dynamic := time.Duration(slewSecs*float64(time.Second)) + rendezvousBurnLeadPad
+	if dynamic < floor {
+		return floor
+	}
+	return dynamic
+}
+
+// axisLabelToBurnMode maps the planner's local axis enum to the
+// spacecraft package's BurnMode. The planner cannot import
+// spacecraft (sibling packages), so the mapping lives here on the
+// sim side which already imports both.
+func axisLabelToBurnMode(a planner.AxisLabel) spacecraft.BurnMode {
+	switch a {
+	case planner.AxisPrograde:
+		return spacecraft.BurnPrograde
+	case planner.AxisRetrograde:
+		return spacecraft.BurnRetrograde
+	case planner.AxisNormalPlus:
+		return spacecraft.BurnNormalPlus
+	case planner.AxisNormalMinus:
+		return spacecraft.BurnNormalMinus
+	case planner.AxisRadialOut:
+		return spacecraft.BurnRadialOut
+	case planner.AxisRadialIn:
+		return spacecraft.BurnRadialIn
+	case planner.AxisTargetPrograde:
+		return spacecraft.BurnTargetPrograde
+	case planner.AxisTargetRetrograde:
+		return spacecraft.BurnTargetRetrograde
+	}
+	return spacecraft.BurnPrograde
+}

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -1,0 +1,248 @@
+package sim
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// rendezvousTwoCraftWorld sets up a world with two LEO craft on
+// different altitudes so RecommendedRendezvousBurn has a non-trivial
+// scenario to solve. Active is idx 0 (the original LEO craft); the
+// sister at idx 1 sits in a 600 km orbit. Target is bound to idx 1.
+func rendezvousTwoCraftWorld(t *testing.T) *World {
+	t.Helper()
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestRecommendedRendezvousBurn_TwoCraftLEO — the basic positive case.
+// Two craft on different LEO altitudes around Earth, primaries match,
+// CA > 50 m → the advisory should populate and pick one of the eight
+// velocity-frame axes with a finite Δv.
+func TestRecommendedRendezvousBurn_TwoCraftLEO(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	adv, ok := w.RecommendedRendezvousBurn()
+	if !ok {
+		t.Fatalf("expected ok=true, got Reason=%q", adv.Reason)
+	}
+	if !adv.Ok {
+		t.Skipf("two-craft LEO geometry yielded no-improvement advisory (Reason=%q); not a regression but the case isn't useful here", adv.Reason)
+	}
+	// The default SpawnCraft places the sister 90° around the
+	// primary, so Lambert intercept Δv here is Hohmann-class
+	// (~1.5 km/s), not the tens-of-m/s range a real "phasing nudge"
+	// would see — the test only checks the API + axis selection are
+	// sane, not that the geometry is operationally useful.
+	if adv.DV <= 0 || adv.DV > 5000 {
+		t.Errorf("DV %.2f m/s outside (0, 5000] m/s — finite/sane range", adv.DV)
+	}
+	switch adv.Axis {
+	case planner.AxisPrograde, planner.AxisRetrograde,
+		planner.AxisNormalPlus, planner.AxisNormalMinus,
+		planner.AxisRadialOut, planner.AxisRadialIn,
+		planner.AxisTargetPrograde, planner.AxisTargetRetrograde:
+		// any of the eight velocity-frame axes is valid
+	default:
+		t.Errorf("Axis %v not in the eight velocity-frame axes", adv.Axis)
+	}
+}
+
+// TestPlanRendezvousNudge_PlantsOneNode — the happy path for the K
+// keybinding's plant action. Verifies node fields match the advisory
+// + the lead buffer + TargetCraftIdx one-based encoding.
+func TestPlanRendezvousNudge_PlantsOneNode(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	c := w.ActiveCraft()
+	if len(c.Nodes) != 0 {
+		t.Fatalf("precondition: active craft has %d nodes, expected 0", len(c.Nodes))
+	}
+
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if errors.Is(err, ErrRendezvousNoImprovement) {
+			t.Skipf("two-craft LEO geometry yielded no useful nudge in this case; not a regression")
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if adv == nil {
+		t.Fatal("expected advisory pointer on success")
+	}
+	if !adv.Ok {
+		t.Errorf("expected advisory.Ok=true on success path, got Reason=%q", adv.Reason)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected exactly 1 node after plant, got %d", len(c.Nodes))
+	}
+	n := c.Nodes[0]
+	if n.Event != spacecraft.TriggerAbsolute {
+		t.Errorf("Event = %v, want TriggerAbsolute", n.Event)
+	}
+	wantMode := axisLabelToBurnMode(adv.Axis)
+	if n.Mode != wantMode {
+		t.Errorf("Mode = %v, want %v (from axis %v)", n.Mode, wantMode, adv.Axis)
+	}
+	if math.Abs(n.DV-adv.DV) > 1e-9 {
+		t.Errorf("DV = %.3f, want %.3f", n.DV, adv.DV)
+	}
+	if n.TargetCraftIdx != w.Target.CraftIdx+1 {
+		t.Errorf("TargetCraftIdx = %d, want %d (one-based encoding of slate idx %d)",
+			n.TargetCraftIdx, w.Target.CraftIdx+1, w.Target.CraftIdx)
+	}
+	if n.PrimaryID != c.Primary.ID {
+		t.Errorf("PrimaryID = %q, want %q", n.PrimaryID, c.Primary.ID)
+	}
+	if n.TriggerTime.Sub(w.Clock.SimTime) < rendezvousBurnLeadMin {
+		t.Errorf("TriggerTime lead %v < min %v", n.TriggerTime.Sub(w.Clock.SimTime), rendezvousBurnLeadMin)
+	}
+}
+
+// TestPlanRendezvousNudge_NoTarget — without a craft target the
+// planter must reject with ErrRendezvousNoTarget and plant nothing.
+func TestPlanRendezvousNudge_NoTarget(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if _, err := w.PlanRendezvousNudge(); !errors.Is(err, ErrRendezvousNoTarget) {
+		t.Errorf("err = %v, want ErrRendezvousNoTarget", err)
+	}
+	if got := len(c.Nodes); got != 0 {
+		t.Errorf("rejected plant should not append node; got %d", got)
+	}
+}
+
+// TestPlanRendezvousNudge_LeadBufferAccountsForSlew — when the
+// craft's attitude is 180° from the recommended axis the lead buffer
+// must exceed nodeLeadSlack·π/SlewRate so the v0.10.0 lead-comp slew
+// converges before T0.
+func TestPlanRendezvousNudge_LeadBufferAccountsForSlew(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	c := w.ActiveCraft()
+	// Probe the recommended axis without planting first.
+	adv, ok := w.RecommendedRendezvousBurn()
+	if !ok || !adv.Ok {
+		t.Skipf("rendezvous advisory unavailable in this case (Reason=%q)", adv.Reason)
+	}
+	// Force the craft attitude to point 180° from the recommended axis.
+	c.CurrentAttitudeDir = adv.AxisUnit.Scale(-1)
+
+	planted, err := w.PlanRendezvousNudge()
+	if err != nil {
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	n := c.Nodes[0]
+	lead := n.TriggerTime.Sub(w.Clock.SimTime)
+
+	// Expected lower bound: nodeLeadSlack · π / SlewRate + pad
+	wantSlewLead := nodeLeadSlack * math.Pi / c.SlewRateRad()
+	wantTotal := time.Duration(wantSlewLead*float64(time.Second)) + rendezvousBurnLeadPad
+	// Allow the rendezvousBurnLeadMin floor to win if it happens to
+	// exceed the dynamic value (it does on the small default slew).
+	if wantTotal < rendezvousBurnLeadMin {
+		wantTotal = rendezvousBurnLeadMin
+	}
+	if lead < wantTotal {
+		t.Errorf("lead buffer %v < expected ≥ %v (slew %.3f rad/s, axis %v)",
+			lead, wantTotal, c.SlewRateRad(), planted.Axis)
+	}
+}
+
+// TestPlanRendezvousNudge_DifferentPrimaries — moving the target
+// craft to a different primary returns ErrRendezvousDifferentPrimaries
+// and plants nothing.
+func TestPlanRendezvousNudge_DifferentPrimaries(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	moon := w.Systems[0].FindBody("Moon")
+	if moon == nil {
+		t.Skip("Moon not in catalog — skipping different-primaries gate")
+	}
+	t1 := w.Crafts[1]
+	t1.Primary = *moon
+
+	c := w.ActiveCraft()
+	_, err := w.PlanRendezvousNudge()
+	if !errors.Is(err, ErrRendezvousDifferentPrimaries) {
+		t.Errorf("err = %v, want ErrRendezvousDifferentPrimaries", err)
+	}
+	if got := len(c.Nodes); got != 0 {
+		t.Errorf("rejected plant should not append node; got %d", got)
+	}
+}
+
+// TestRecommendedRendezvousBurn_CacheReusesWithinInterval — two
+// back-to-back calls without advancing the sim clock return
+// identical advisories (cache hit; not a recompute). Indirect: we
+// can't see "did we recompute" externally, so this is a functional
+// guard that the cache returns a consistent value rather than NaN-ing
+// across calls.
+func TestRecommendedRendezvousBurn_CacheReusesWithinInterval(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	a, ok1 := w.RecommendedRendezvousBurn()
+	b, ok2 := w.RecommendedRendezvousBurn()
+	if ok1 != ok2 {
+		t.Fatalf("ok mismatch across calls: %v vs %v", ok1, ok2)
+	}
+	if a != b {
+		t.Errorf("cached advisory not identical:\n  first = %+v\n  second = %+v", a, b)
+	}
+}
+
+// TestRecommendedRendezvousBurn_ClearTargetInvalidates — dropping the
+// target between calls flushes the advisory to ok=false. Verifies the
+// cache-key check on (activeIdx, targetIdx).
+func TestRecommendedRendezvousBurn_ClearTargetInvalidates(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	if _, ok := w.RecommendedRendezvousBurn(); !ok {
+		t.Skipf("baseline advisory not available; cannot test invalidation")
+	}
+	w.ClearTarget()
+	if _, ok := w.RecommendedRendezvousBurn(); ok {
+		t.Errorf("expected ok=false after ClearTarget, got cached ok=true")
+	}
+}
+
+// TestAxisLabelToBurnMode_RoundTripsAllEight — every axis label maps
+// to a distinct, non-zero BurnMode in the velocity-frame subset.
+// Regression guard against a future planner.AxisLabel addition that
+// the mapping table forgets.
+func TestAxisLabelToBurnMode_RoundTripsAllEight(t *testing.T) {
+	labels := []planner.AxisLabel{
+		planner.AxisPrograde, planner.AxisRetrograde,
+		planner.AxisNormalPlus, planner.AxisNormalMinus,
+		planner.AxisRadialOut, planner.AxisRadialIn,
+		planner.AxisTargetPrograde, planner.AxisTargetRetrograde,
+	}
+	wantModes := []spacecraft.BurnMode{
+		spacecraft.BurnPrograde, spacecraft.BurnRetrograde,
+		spacecraft.BurnNormalPlus, spacecraft.BurnNormalMinus,
+		spacecraft.BurnRadialOut, spacecraft.BurnRadialIn,
+		spacecraft.BurnTargetPrograde, spacecraft.BurnTargetRetrograde,
+	}
+	seen := make(map[spacecraft.BurnMode]bool, len(labels))
+	for i, l := range labels {
+		got := axisLabelToBurnMode(l)
+		if got != wantModes[i] {
+			t.Errorf("axis %v → %v, want %v", l, got, wantModes[i])
+		}
+		if seen[got] {
+			t.Errorf("duplicate mapping target: %v", got)
+		}
+		seen[got] = true
+	}
+}
+
+// (compile guard) the test file references orbital so the import is
+// not optimised out when the assertions above don't directly use it.
+var _ = orbital.Vec3{}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -90,6 +90,13 @@ type World struct {
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
 
+	// rendezvousCache stores the most recent v0.10.2 rendezvous
+	// advisory keyed by (activeIdx, targetIdx, sim-time). Per-frame
+	// HUD callers (TARGET HUD ACH-CA block) hit this; the Lambert
+	// scan + NextClosestApproach verification only runs on cache
+	// miss. See internal/sim/rendezvous.go for the policy.
+	rendezvousCache rendezvousAdvisoryCache
+
 	// trail is a ring buffer of recent craft samples for the vessel-
 	// position-trail render. Each sample stores the primary's body ID
 	// and the craft's position *in that primary's frame* (v0.5.4) — at

--- a/internal/spacecraft/burn_direction_test.go
+++ b/internal/spacecraft/burn_direction_test.go
@@ -122,27 +122,29 @@ func TestBurnDirectionAppliesPitchTrim(t *testing.T) {
 }
 
 // TestDirectionUnitTargetPrograde — target ahead in +Y, faster:
-// v_target − v_active = +Y, so BurnTargetPrograde = +Y.
+// KSP convention has target-prograde = unit(v_active − v_target),
+// which here is −Y (active is the slower one).
 func TestDirectionUnitTargetPrograde(t *testing.T) {
 	rA := orbital.Vec3{X: 7e6}
 	vA := orbital.Vec3{Y: 7500}
 	rT := orbital.Vec3{X: 7e6, Y: 1000}
 	vT := orbital.Vec3{Y: 7600}
 	got := DirectionUnitTarget(BurnTargetPrograde, rA, vA, rT, vT)
-	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-1) > 1e-9 || math.Abs(got.Z) > 1e-9 {
-		t.Errorf("target prograde: got %+v, want (0, 1, 0)", got)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-(-1)) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("target prograde: got %+v, want (0, -1, 0)", got)
 	}
 }
 
-// TestDirectionUnitTargetRetrograde — flip of TargetPrograde.
+// TestDirectionUnitTargetRetrograde — flip of TargetPrograde: the
+// closing / null-v_rel axis, unit(v_target − v_active) = +Y here.
 func TestDirectionUnitTargetRetrograde(t *testing.T) {
 	rA := orbital.Vec3{X: 7e6}
 	vA := orbital.Vec3{Y: 7500}
 	rT := orbital.Vec3{X: 7e6, Y: 1000}
 	vT := orbital.Vec3{Y: 7600}
 	got := DirectionUnitTarget(BurnTargetRetrograde, rA, vA, rT, vT)
-	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-(-1)) > 1e-9 || math.Abs(got.Z) > 1e-9 {
-		t.Errorf("target retrograde: got %+v, want (0, -1, 0)", got)
+	if math.Abs(got.X) > 1e-9 || math.Abs(got.Y-1) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Errorf("target retrograde: got %+v, want (0, 1, 0)", got)
 	}
 }
 

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -122,18 +122,19 @@ const (
 	BurnSurfaceRetrograde
 
 	// Target-relative modes (v0.9.3+). Direction depends on the
-	// active *and* target craft states in the same frame:
+	// active *and* target craft states in the same frame. KSP
+	// convention (v0.10.3+, was swapped pre-v0.10.3):
 	//
-	//   BurnTargetPrograde   = unit(v_target − v_active)
-	//   BurnTargetRetrograde = unit(v_active − v_target)
+	//   BurnTargetPrograde   = unit(v_active − v_target)
+	//   BurnTargetRetrograde = unit(v_target − v_active)
 	//   BurnTarget           = unit(r_target − r_active)
 	//   BurnAntiTarget       = unit(r_active − r_target)
 	//
 	// The velocity-relative pair is the primary tool for the manual
-	// rendezvous loop — hold target-prograde to close v_rel during
-	// approach, flip target-retrograde at closest approach to null
-	// v_rel. The position-relative pair is for sub-m/s proximity-ops
-	// nudges after v_rel is nulled.
+	// rendezvous loop — hold target-RETROGRADE to null v_rel during
+	// approach (the closing axis), hold target-PROGRADE to widen the
+	// relative-velocity gap on the way out. The position-relative pair
+	// is for sub-m/s proximity-ops nudges after v_rel is nulled.
 	//
 	// All four require World.Target.Kind == TargetCraft. Without a
 	// craft target, DirectionUnitTarget returns the zero vector and
@@ -254,13 +255,24 @@ func DirectionUnit(mode BurnMode, r, v orbital.Vec3) orbital.Vec3 {
 // velocities for BurnTargetPrograde / Retrograde) or when called
 // with zero rT, vT (no target resolved — caller passes zeros so the
 // closure still constructs but the burn no-ops).
+//
+// KSP convention (v0.10.3+): target-prograde = unit(v_active − v_target),
+// target-retrograde = unit(v_target − v_active). Burn target-RETROGRADE
+// to null v_rel during a rendezvous approach.
 func DirectionUnitTarget(mode BurnMode, rA, vA, rT, vT orbital.Vec3) orbital.Vec3 {
 	var d orbital.Vec3
 	switch mode {
 	case BurnTargetPrograde:
-		d = vT.Sub(vA)
-	case BurnTargetRetrograde:
+		// KSP convention: target-prograde = direction of v_active
+		// relative to target = unit(v_active − v_target). Burning
+		// this INCREASES |v_rel| (moves you away from matching).
 		d = vA.Sub(vT)
+	case BurnTargetRetrograde:
+		// KSP convention: target-retrograde points along
+		// unit(v_target − v_active). Burning this nulls v_rel — the
+		// closing axis the manual rendezvous loop holds during
+		// approach.
+		d = vT.Sub(vA)
 	case BurnTarget:
 		d = rT.Sub(rA)
 	case BurnAntiTarget:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -570,6 +570,25 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.statusExpires = time.Now().Add(3 * time.Second)
 			}
 			return a, nil
+		case key.Matches(m, a.keys.PlanRendezvous):
+			// v0.10.2+: `K` plants the recommended single-burn nudge
+			// toward the current craft target. Reads from
+			// world.RecommendedRendezvousBurn (Lambert intercept →
+			// project onto velocity-frame axes → verify via
+			// NextClosestApproach). Mirrors PlanCircularize shape; the
+			// HUD's TARGET block already shows the advisory's
+			// achievable-CA / Δv readouts when the gate passes.
+			if a.world.CraftVisibleHere() {
+				adv, err := a.world.PlanRendezvousNudge()
+				if err != nil {
+					a.statusMsg = fmt.Sprintf("rendezvous: %v", err)
+				} else {
+					a.statusMsg = fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs",
+						adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival)
+				}
+				a.statusExpires = time.Now().Add(3 * time.Second)
+			}
+			return a, nil
 		case key.Matches(m, a.keys.Porkchop):
 			if a.active == screenOrbit && a.world.CraftVisibleHere() && a.selectedBody > 0 {
 				a.porkchop.Load(a.world, a.selectedBody)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -793,11 +793,12 @@ func (a *App) hudNodeHit(x, y int) bool {
 }
 
 // handleAttitudeKey dispatches a w/s/a/d/q/e tap. In EngineMain mode
-// it just sets the held attitude (the v0.7.3.2 explicit-engage UX
-// stays — `b` actually fires the engine). In EngineRCS mode the same
-// keypress fires one RCS pulse in addition to setting the attitude,
-// so each tap nudges the craft by the RCS Δv quantum and a held key
-// produces a sustained pulse train at the terminal's key-repeat rate.
+// it sets the held attitude (the v0.7.3.2 explicit-engage UX stays —
+// `b` actually fires the engine). In EngineRCS mode the same keypress
+// fires one RCS pulse in the requested orbital-frame direction without
+// touching the SAS hold — RCS is a 6-axis translation tool, so the
+// nose stays put while the pulse nudges Δv. A held key produces a
+// sustained pulse train at the terminal's key-repeat rate.
 // v0.8.0+.
 func (a *App) handleAttitudeKey(mode spacecraft.BurnMode) {
 	if a.world.ActiveCraft().EngineMode == spacecraft.EngineRCS {

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -45,6 +45,13 @@ type Keymap struct {
 	// "single keystroke for the natural last step of an ascent"
 	// shortcut, mirroring the v0.7.4 `I` plane-match planter.
 	PlanCircularize key.Binding
+	// PlanRendezvous (v0.10.2+) plants the recommended single-burn
+	// nudge that improves closest approach to the current craft
+	// target. Mirrors the H/I/C capital-letter plant-burn family;
+	// reads from World.RecommendedRendezvousBurn (Lambert-and-project
+	// over the 8 velocity-frame axes). No-op without a craft target
+	// or when the advisory reports no useful nudge.
+	PlanRendezvous key.Binding
 	Porkchop      key.Binding
 	// v0.8.6: Save / Load moved S / L → F5 / F9 to match the KSP
 	// quicksave-quickload muscle memory and to clear the case-
@@ -173,6 +180,7 @@ func DefaultKeymap() Keymap {
 		PlanTransfer: key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant Hohmann transfer to selected body")),
 		PlanIncl:     key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
 		PlanCircularize: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "plant circularize burn at next apoapsis")),
+		PlanRendezvous:  key.NewBinding(key.WithKeys("K"), key.WithHelp("K", "plant rendezvous nudge to target craft")),
 		Porkchop:     key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),
 		Save:         key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
 		Load:         key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -49,6 +49,7 @@ func (h *Help) Render() string {
 			{"H", "plant Hohmann transfer to selected body"},
 			{"I", "plant inclination match (selected body / equatorial)"},
 			{"C", "plant circularize burn at next apoapsis"},
+			{"K", "plant rendezvous nudge to target craft (recommended single-burn)"},
 			{"P", "porkchop plot for selected body"},
 			{"R", "refine plan (re-Lambert arrival)"},
 		}},

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -795,7 +795,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// `m` planner in v0.8.6) and added the flight / target / stage /
 	// save row players actually reach for.
 	footer := v.theme.Footer.Render(
-		"[?]help [esc]menu [+/-]zoom [f/F/g]focus [.,]warp [0]pause [m]burn [b]fire [wasdqe]attitude [space]stage [t/T]target [H/I/C]plan [n]spawn [[/]]craft [F5/F9]save/load",
+		"[?]help [esc]menu [+/-]zoom [f/F/g]focus [.,]warp [0]pause [m]maneuver [b]fire [wasdqe]attitude [space]stage [t/T]target [H/I/C]plan [n]spawn [[/]]craft [F5/F9]save/load",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)
@@ -1811,6 +1811,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 							} else if adv.Reason == "no improvement available" {
 								faint := lipgloss.NewStyle().Faint(true)
 								lines = append(lines, "  "+faint.Render("K: no useful nudge in range"))
+							} else if adv.Reason == "burn too large — use H/I/m" {
+								faint := lipgloss.NewStyle().Faint(true)
+								lines = append(lines, "  "+faint.Render(fmt.Sprintf("K: %.0f m/s exceeds nudge scale — plan with H/I/m", adv.DV)))
 							}
 						}
 						// DOCK READY: current range < 50 m && |v_rel| <

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1713,6 +1713,37 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 								)
 							}
 						}
+						// v0.10.2+: rendezvous advisory — achievable CA +
+						// recommended Δv from the single-burn Lambert-and-
+						// project planner. Surfaced only when the gate
+						// passes (returns Ok=true); the "no improvement
+						// available" path renders as one faint line so the
+						// player knows `K` would be a no-op without
+						// cluttering the HUD with all gate reasons.
+						if adv, hudOk := w.RecommendedRendezvousBurn(); hudOk {
+							if adv.Ok {
+								achLabel := fmt.Sprintf("%.0f m", adv.AchievableCA)
+								switch {
+								case adv.AchievableCA > 1e6:
+									achLabel = fmt.Sprintf("%.0f km", adv.AchievableCA/1000)
+								case adv.AchievableCA > 1000:
+									achLabel = fmt.Sprintf("%.2f km", adv.AchievableCA/1000)
+								}
+								achTLabel := fmt.Sprintf("%.0fs", adv.TArrival)
+								if adv.TArrival >= 3600 {
+									achTLabel = fmt.Sprintf("%.2fh", adv.TArrival/3600)
+								} else if adv.TArrival >= 60 {
+									achTLabel = fmt.Sprintf("%.1fmin", adv.TArrival/60)
+								}
+								lines = append(lines,
+									fmt.Sprintf("  ACH CA: %s @ T+%s", achLabel, achTLabel),
+									fmt.Sprintf("  Δv:     %.1f m/s %s  (K plant)", adv.DV, adv.Axis),
+								)
+							} else if adv.Reason == "no improvement available" {
+								faint := lipgloss.NewStyle().Faint(true)
+								lines = append(lines, "  "+faint.Render("K: no useful nudge in range"))
+							}
+						}
 						// DOCK READY: current range < 50 m && |v_rel| <
 						// 0.1 m/s. Gates on v0.8.3 DockCrafts which the
 						// player invokes once the indicator lights.

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -728,6 +728,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// bottom-right navball panel.
 	viewLabel := "view: " + w.ViewMode.String()
 	v.canvas.SetCellLabel(0, v.canvas.Rows()-1, viewLabel)
+	// v0.10.3+: focus indicator overlaid into the canvas's top-left
+	// corner (was a HUD block alongside CLOCK). Pairs visually with
+	// the bottom-left "view:" label — both describe what the
+	// projection is centered on.
+	v.canvas.SetCellLabel(0, 0, "focus: "+w.FocusName())
 
 	canvasStr := v.canvas.String()
 
@@ -781,7 +786,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	if n := len(w.Crafts); n > 1 {
 		craftChip = fmt.Sprintf(" — CRAFT %d/%d", w.ActiveCraftIdx+1, n)
 	}
-	title := v.renderTitleBar(sys.Name+craftChip, totalCols)
+	title := v.renderTitleBar(sys.Name+craftChip, w, totalCols)
 	// Footer is a cheat-sheet of the most-used keys; `?` opens the
 	// full help overlay (source of truth). Streamlined v0.10.1+ —
 	// dropped stale labels (`q` is attitude:radial+ since v0.7.3,
@@ -814,12 +819,33 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 // right-aligned `[Menu]` and `[Missions]` clickable buttons. Stores
 // the cell ranges of each button so HitMenuButton / HitMissionsButton
 // can map subsequent clicks back to a screen action. v0.7.4+.
-func (v *OrbitView) renderTitleBar(systemName string, totalCols int) string {
+func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols int) string {
 	left := fmt.Sprintf("terminal-space-program — %s — %s", version.Version, systemName)
 	const menuLabel = "[Menu]"
 	const missionsLabel = "[Missions]"
 	const gap = "  "
-	rightPlain := menuLabel + gap + missionsLabel
+	const clockGap = "    " // 4-space gap between clock chip and the buttons
+
+	// v0.10.3+: clock + warp + pause chip, placed between the left
+	// title and the right-aligned buttons (was a HUD CLOCK block).
+	// Warp shows the effective rate when the integrator clamps it
+	// (e.g. ≤10x during burns) so the player sees the actual
+	// propagation speed, not the requested one.
+	clockChip := "T+" + w.Clock.SimTime.Format("2006-01-02") + "  "
+	reqWarp := w.Clock.Warp()
+	if eff := w.EffectiveWarp(); eff < reqWarp {
+		clockChip += fmt.Sprintf("warp %.0fx→%.0fx", reqWarp, eff)
+	} else {
+		clockChip += fmt.Sprintf("warp %.0fx", reqWarp)
+	}
+	pauseChipPlain := ""
+	pauseChipRendered := ""
+	if w.Clock.Paused {
+		pauseChipPlain = "  PAUSED"
+		pauseChipRendered = "  " + v.theme.Warning.Render("PAUSED")
+	}
+
+	rightPlain := clockChip + pauseChipPlain + clockGap + menuLabel + gap + missionsLabel
 
 	// Compute the absolute column where the right group starts so the
 	// hit-test ranges match what the player sees on screen.
@@ -830,14 +856,18 @@ func (v *OrbitView) renderTitleBar(systemName string, totalCols int) string {
 		pad = 1
 	}
 	rightStart := leftRunes + pad
+	buttonsStart := rightStart + len([]rune(clockChip+pauseChipPlain+clockGap))
 
-	v.menuColStart = rightStart
-	v.menuColEnd = rightStart + len([]rune(menuLabel))
+	v.menuColStart = buttonsStart
+	v.menuColEnd = v.menuColStart + len([]rune(menuLabel))
 	v.missionsColStart = v.menuColEnd + len([]rune(gap))
 	v.missionsColEnd = v.missionsColStart + len([]rune(missionsLabel))
 
 	rendered := v.theme.Title.Render(left) +
 		strings.Repeat(" ", pad) +
+		v.theme.Dim.Render(clockChip) +
+		pauseChipRendered +
+		clockGap +
 		v.theme.Primary.Render(menuLabel) +
 		gap +
 		v.theme.Primary.Render(missionsLabel)
@@ -1092,20 +1122,12 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		}
 	}
 
-	warpLine := fmt.Sprintf("  warp: %.0fx", w.Clock.Warp())
-	if eff := w.EffectiveWarp(); eff < w.Clock.Warp() {
-		warpLine += v.theme.Warning.Render(fmt.Sprintf(" (clamped to %.0fx)", eff))
-	}
-	lines := []string{
-		v.theme.Primary.Render("CLOCK"),
-		"  T+" + w.Clock.SimTime.Format("2006-01-02"),
-		warpLine,
-	}
-	if w.Clock.Paused {
-		lines = append(lines, "  "+v.theme.Warning.Render("[PAUSED]"))
-	}
-	lines = append(lines, section("FOCUS")...)
-	lines = append(lines, "  "+w.FocusName())
+	// v0.10.3+: CLOCK + FOCUS moved out of the HUD — clock/warp/pause
+	// now live in the title bar; focus is overlaid into the canvas's
+	// top-left corner alongside the bottom-left "view:" label. HUD
+	// starts directly at the VESSEL/PROPELLANT block.
+	lines := []string{}
+
 
 	// Spacecraft block — only in Sol per plan §MVP.
 	if w.CraftVisibleHere() {
@@ -1128,25 +1150,48 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		// column so each block reads as its own pane. Falls back to
 		// stacked rendering when the HUD is too narrow to split (< 36
 		// cols of content) — labels would clip otherwise.
-		const minSplitWidth = 36
+		// v0.10.3+: phase-aware row gating — during ascent the LAUNCH
+		// block re-renders altitude / apo / pe / inclin. with richer
+		// context (trend tag, progress row), and during close
+		// rendezvous the TARGET block dominates the right-side scan.
+		// Both phases collapse VESSEL to name + primary so the
+		// duplicate orbit-shape rows don't compete with the
+		// authoritative block. The peri-below-surface alert is gated
+		// to flight phase only: it's expected during ascent and the
+		// craft is in stable orbit during proximity.
+		phase := currentHudPhase(w)
+		// minSplitWidth gates the two-column VESSEL/PROPELLANT layout.
+		// half-width = (width-4)/2 — must be wide enough for the
+		// longest content line in either column. PROPELLANT's "fuel"
+		// and "mass" rows reach ~23 chars with Saturn-V-class masses;
+		// VESSEL's "velocity" reaches ~22 chars. Pre-v0.10.3 this was
+		// 36, which gave half = 16 and silently wrapped both columns
+		// on every terminal under ~250 cols. v0.10.3+ raises the
+		// threshold so split fires only when half >= 24 (≈ width 52).
+		const minSplitWidth = 52
 		if width-2 >= minSplitWidth {
 			half := (width - 4) / 2 // gutter of 2 chars between columns
+			// v0.10.3+: no leading divider — VESSEL is now the first
+			// HUD block (CLOCK + FOCUS moved to title bar / canvas).
 			vesselLines := []string{
-				v.theme.Dim.Render(strings.Repeat("─", half)),
 				v.theme.Primary.Render("VESSEL"),
 				"  " + c.Name,
 				"  primary:   " + c.Primary.EnglishName,
-				fmt.Sprintf("  altitude:  %.1f km", c.Altitude()/1000),
-				fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
-				fmt.Sprintf("  apoapsis:  %.1f km", apoAlt/1000),
-				fmt.Sprintf("  periapsis: %.1f km", periAlt/1000),
-				fmt.Sprintf("  inclin.:   %.2f°", incDeg),
 			}
-			if periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
-				vesselLines = append(vesselLines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+			if phase == hudPhaseFlight {
+				vesselLines = append(vesselLines,
+					fmt.Sprintf("  altitude:  %.1f km", c.Altitude()/1000),
+					fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
+					fmt.Sprintf("  apoapsis:  %.1f km", apoAlt/1000),
+					fmt.Sprintf("  periapsis: %.1f km", periAlt/1000),
+					fmt.Sprintf("  inclin.:   %.2f°", incDeg),
+				)
 			}
+			// ⚠ PERIAPSIS BELOW SURFACE is 27 chars; would wrap inside
+			// any half-column. Appended after the JoinHorizontal below
+			// so it spans the full HUD width as a single alert row.
+			belowSurface := phase == hudPhaseFlight && periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0)
 			propLines := []string{
-				v.theme.Dim.Render(strings.Repeat("─", half)),
 				v.theme.Primary.Render("PROPELLANT"),
 				fmt.Sprintf("  fuel:      %.0f kg", c.Fuel),
 				fmt.Sprintf("  mass:      %.0f kg", c.TotalMass()),
@@ -1154,8 +1199,13 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 				fmt.Sprintf("  throttle:  %.0f%%", c.EffectiveThrottle()*100),
 			}
 			if c.MonopropCapacity > 0 {
+				// v0.10.3+: split kg + Δv onto two narrower lines so
+				// the row fits the half-column without wrap. Previous
+				// single-line "%.2f kg (%.1f m/s)" form reached 33
+				// chars — the worst offender in PROPELLANT.
 				propLines = append(propLines,
-					fmt.Sprintf("  monoprop:  %.2f kg (%.1f m/s)", c.Monoprop, c.RCSDeltaV()),
+					fmt.Sprintf("  monoprop:  %.0f kg", c.Monoprop),
+					fmt.Sprintf("  rcs Δv:    %.0f m/s", c.RCSDeltaV()),
 				)
 			}
 			colStyle := lipgloss.NewStyle().Width(half)
@@ -1163,19 +1213,29 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			propCol := colStyle.Render(strings.Join(propLines, "\n"))
 			combined := lipgloss.JoinHorizontal(lipgloss.Top, vesselCol, "  ", propCol)
 			lines = append(lines, strings.Split(combined, "\n")...)
+			if belowSurface {
+				lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+			}
 		} else {
-			lines = append(lines, section("VESSEL")...)
+			// v0.10.3+: VESSEL is now the first HUD block (no leading
+			// divider) — CLOCK + FOCUS migrated to the title bar /
+			// canvas overlay.
+			lines = append(lines, v.theme.Primary.Render("VESSEL"))
 			lines = append(lines,
 				"  "+c.Name,
 				"  primary:   "+c.Primary.EnglishName,
-				fmt.Sprintf("  altitude:  %.1f km", c.Altitude()/1000),
-				fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
-				fmt.Sprintf("  apoapsis:  %.1f km", apoAlt/1000),
-				fmt.Sprintf("  periapsis: %.1f km", periAlt/1000),
-				fmt.Sprintf("  inclin.:   %.2f°", incDeg),
 			)
-			if periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
-				lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+			if phase == hudPhaseFlight {
+				lines = append(lines,
+					fmt.Sprintf("  altitude:  %.1f km", c.Altitude()/1000),
+					fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
+					fmt.Sprintf("  apoapsis:  %.1f km", apoAlt/1000),
+					fmt.Sprintf("  periapsis: %.1f km", periAlt/1000),
+					fmt.Sprintf("  inclin.:   %.2f°", incDeg),
+				)
+				if periAlt < 0 && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
+					lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+				}
 			}
 			lines = append(lines, section("PROPELLANT")...)
 			lines = append(lines,
@@ -1186,7 +1246,8 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			)
 			if c.MonopropCapacity > 0 {
 				lines = append(lines,
-					fmt.Sprintf("  monoprop:  %.2f kg (%.1f m/s)", c.Monoprop, c.RCSDeltaV()),
+					fmt.Sprintf("  monoprop:  %.0f kg", c.Monoprop),
+					fmt.Sprintf("  rcs Δv:    %.0f m/s", c.RCSDeltaV()),
 				)
 			}
 		}
@@ -1200,7 +1261,15 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		}
 		lines = append(lines,
 			fmt.Sprintf("  nav:       %s", w.NavMode),
-			fmt.Sprintf("  hold:      %s", w.ActiveCraft().AttitudeMode.String()),
+		)
+		// v0.10.3+: during ascent the LAUNCH `sas` row renders the
+		// exact same AttitudeMode string; skip the dup here.
+		if phase != hudPhaseAscent {
+			lines = append(lines,
+				fmt.Sprintf("  hold:      %s", w.ActiveCraft().AttitudeMode.String()),
+			)
+		}
+		lines = append(lines,
 			fmt.Sprintf("  engine:    %s", w.ActiveCraft().EngineMode.String()),
 			fmt.Sprintf("  manual:    %s", manualState),
 		)
@@ -1902,6 +1971,46 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 	// first row is row 1.
 	v.scanHudNodeRows(rendered, 1)
 	return rendered
+}
+
+// hudPhase tags the active craft's flight phase so the always-on
+// VESSEL / ATTITUDE blocks can skip rows that a phase-specific block
+// (LAUNCH, TARGET) already covers. v0.10.3+.
+type hudPhase int
+
+const (
+	hudPhaseFlight    hudPhase = iota // free flight — default, all rows render
+	hudPhaseAscent                    // LAUNCH HUD is up — drop dup orbit-shape + SAS rows from VESSEL/ATTITUDE
+	hudPhaseProximity                 // close rendezvous (TARGET craft, < 5 km, shared primary) — drop dup orbit-shape rows from VESSEL
+)
+
+// proximityRangeM is the range (m) below which the TARGET block's
+// rendezvous readouts (TCA / CA / closing / |v_rel|) are dense enough
+// that the player no longer scans VESSEL's own apo/peri/inclin. v0.10.3+.
+const proximityRangeM = 5000.0
+
+// currentHudPhase resolves the HUD's render phase. Ascent takes
+// precedence (LAUNCH is the richer block); proximity fires only when
+// a TARGET craft sharing the active primary is within proximityRangeM.
+// Computed once per renderHUD frame so VESSEL/ATTITUDE conditionals
+// stay in lockstep.
+func currentHudPhase(w *sim.World) hudPhase {
+	c := w.ActiveCraft()
+	if c == nil {
+		return hudPhaseFlight
+	}
+	if shouldShowLaunchHUD(c) {
+		return hudPhaseAscent
+	}
+	if w.Target.Kind == sim.TargetCraft &&
+		w.Target.CraftIdx >= 0 && w.Target.CraftIdx < len(w.Crafts) {
+		if tc := w.Crafts[w.Target.CraftIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+			if tc.State.R.Sub(c.State.R).Norm() < proximityRangeM {
+				return hudPhaseProximity
+			}
+		}
+	}
+	return hudPhaseFlight
 }
 
 // shouldShowLaunchHUD returns true when the active craft is in

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1814,6 +1814,9 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 							} else if adv.Reason == "burn too large — use H/I/m" {
 								faint := lipgloss.NewStyle().Faint(true)
 								lines = append(lines, "  "+faint.Render(fmt.Sprintf("K: %.0f m/s exceeds nudge scale — plan with H/I/m", adv.DV)))
+							} else if adv.Reason == "burn drops periapsis unsafely" {
+								faint := lipgloss.NewStyle().Faint(true)
+								lines = append(lines, "  "+faint.Render("K: would drop periapsis unsafely — plan with H/I/m"))
 							}
 						}
 						// DOCK READY: current range < 50 m && |v_rel| <

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -42,11 +43,12 @@ func TestOrbitViewRendersAllSystems(t *testing.T) {
 	}
 }
 
-// TestOrbitHUDRendersVesselAndPropellantSideBySide: when the HUD has
-// at least 36 cols of content room, the VESSEL and PROPELLANT block
-// headers share a row so the right-hand HUD doesn't get tall enough
-// to push the layout off-screen. Below that threshold the blocks
-// fall back to stacked rendering. v0.7.5+ height-saving change.
+// TestOrbitHUDRendersVesselAndPropellantSideBySide: at sufficiently
+// wide terminals the VESSEL and PROPELLANT block headers share a row
+// so the right-hand HUD doesn't get tall enough to push the layout
+// off-screen. Below the threshold (v0.10.3+: half-column < 24 cols)
+// the blocks fall back to stacked rendering. v0.7.5+ height-saving
+// change; threshold bumped in v0.10.3+ to avoid content wrap.
 func TestOrbitHUDRendersVesselAndPropellantSideBySide(t *testing.T) {
 	th := Theme{
 		Primary: lipgloss.NewStyle(),
@@ -58,18 +60,155 @@ func TestOrbitHUDRendersVesselAndPropellantSideBySide(t *testing.T) {
 		Title:   lipgloss.NewStyle(),
 	}
 	v := NewOrbitView(th)
-	v.Resize(180, 40)
+	v.Resize(240, 40)
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	out := v.Render(w, 0, 180, 40)
+	out := v.Render(w, 0, 240, 40)
 	for _, line := range strings.Split(out, "\n") {
 		if strings.Contains(line, "VESSEL") && strings.Contains(line, "PROPELLANT") {
 			return
 		}
 	}
-	t.Errorf("expected VESSEL and PROPELLANT on the same row at width 180; got render:\n%s", out)
+	t.Errorf("expected VESSEL and PROPELLANT on the same row at width 240; got render:\n%s", out)
+}
+
+// TestHudPhaseCollapsesVesselDuringAscent: in ascent phase
+// (shouldShowLaunchHUD is true) the VESSEL block drops its
+// altitude/apoapsis/periapsis/inclin. rows because the LAUNCH block
+// already renders them with trend tags and a progress row, and the
+// ATTITUDE block drops `hold` because LAUNCH's `sas` is the same
+// value. The orbit-shape rows return once the craft circularises
+// above the mission floor. v0.10.3+.
+func TestHudPhaseCollapsesVesselDuringAscent(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// NewWorld spawns in LEO; force a sub-orbital ascent arc
+	// (periapsis below the 200 km mission floor) so
+	// shouldShowLaunchHUD fires.
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	rApo := primaryR + 250e3
+	rPeri := primaryR - 100e3
+	a := (rPeri + rApo) / 2
+	vAtPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	c.State.R.X, c.State.R.Y, c.State.R.Z = rPeri, 0, 0
+	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vAtPeri, 0
+
+	out := v.Render(w, 0, 200, 60)
+	// VESSEL header still renders, but its rows are gated.
+	if !strings.Contains(out, "VESSEL") {
+		t.Fatal("expected VESSEL header to render during ascent")
+	}
+	// "altitude:" still appears (LAUNCH block uses the same prefix),
+	// so check VESSEL's distinctive rows are gone instead.
+	if strings.Contains(out, "  apoapsis:") || strings.Contains(out, "  periapsis:") {
+		t.Errorf("expected VESSEL apoapsis/periapsis rows to be hidden during ascent; LAUNCH already shows ap/pe.\nrender:\n%s", out)
+	}
+	if strings.Contains(out, "  hold:") {
+		t.Errorf("expected ATTITUDE `hold` row to be hidden during ascent; LAUNCH `sas` is the same value.\nrender:\n%s", out)
+	}
+	// LAUNCH's own rows must still be present.
+	if !strings.Contains(out, "  ap:") || !strings.Contains(out, "  sas:") {
+		t.Errorf("expected LAUNCH ap and sas rows during ascent.\nrender:\n%s", out)
+	}
+
+	// Circularise: drop the craft into a 300 km circular orbit, well
+	// above the 200 km mission floor → flight phase.
+	rCirc := primaryR + 300e3
+	vCirc := math.Sqrt(mu / rCirc)
+	c.State.R.X, c.State.R.Y, c.State.R.Z = rCirc, 0, 0
+	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vCirc, 0
+
+	out = v.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "  apoapsis:") || !strings.Contains(out, "  periapsis:") {
+		t.Errorf("expected VESSEL apoapsis/periapsis rows to return once in stable orbit.\nrender:\n%s", out)
+	}
+	if !strings.Contains(out, "  hold:") {
+		t.Errorf("expected ATTITUDE `hold` row to return in flight phase.\nrender:\n%s", out)
+	}
+	if strings.Contains(out, "LAUNCH") {
+		t.Errorf("expected LAUNCH block to vanish once periapsis clears the mission floor.\nrender:\n%s", out)
+	}
+}
+
+// TestTitleBarShowsClockAndWarp: v0.10.3+ moved the CLOCK block from
+// the HUD into the title bar. The title row must show T+date and the
+// current warp rate; the HUD must no longer carry a `CLOCK` header.
+func TestTitleBarShowsClockAndWarp(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	v.Resize(200, 40)
+	out := v.Render(w, 0, 200, 40)
+	titleRow := strings.Split(out, "\n")[0]
+	if !strings.Contains(titleRow, "T+") {
+		t.Errorf("expected T+date on title row; got %q", titleRow)
+	}
+	if !strings.Contains(titleRow, "warp ") {
+		t.Errorf("expected `warp Nx` on title row; got %q", titleRow)
+	}
+	if strings.Contains(out, "CLOCK") {
+		t.Errorf("expected no CLOCK header in HUD after move to title bar; render:\n%s", out)
+	}
+}
+
+// TestFocusLabelOverlaidOnCanvas: v0.10.3+ moved the FOCUS block from
+// the HUD into the canvas's top-left corner via SetCellLabel. The
+// rendered output must contain `focus: <name>` and no longer a FOCUS
+// section header in the HUD.
+func TestFocusLabelOverlaidOnCanvas(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	v.Resize(160, 40)
+	out := v.Render(w, 0, 160, 40)
+	if !strings.Contains(out, "focus: ") {
+		t.Errorf("expected `focus:` overlay on canvas; render:\n%s", out)
+	}
+	// Ensure FOCUS HUD header is gone (the old "FOCUS" was an exact
+	// section header line; check the trailing newline pattern that
+	// distinguishes it from any other use of the word).
+	if strings.Contains(out, "\nFOCUS\n") {
+		t.Errorf("expected FOCUS HUD section to be gone after move to canvas; render:\n%s", out)
+	}
 }
 
 // TestOrbitTitleBarButtonHits: after rendering, the title-bar


### PR DESCRIPTION
## Summary

- **v0.10.2 rendezvous actionability layer** (47f3164): `RecommendRendezvousNudge` (Lambert lookahead → 8-axis projection → NextClosestApproach verify), `K` plants the single-burn nudge, TARGET HUD shows achievable CA + Δv-to-improve.
- **KSP-axis convention** (14be808): target-prograde = unit(v_active − v_target) across the navball, planner axes, and `DirectionUnitTarget`. Hold target-RETROGRADE to null v_rel during approach. Navball drops back-hemisphere markers. RCS pulses no longer mutate `AttitudeMode`.
- **Phase-aware HUD chrome** (14be808): VESSEL collapses during ascent (LAUNCH owns altitude/apo/pe/inclin/sas) and proximity ops (TARGET owns relative state); CLOCK + FOCUS moved out of the HUD (clock chip in title row, focus overlay on canvas top-left). `minSplitWidth` raised so split-column VESSEL/PROPELLANT doesn't silently wrap; ⚠ PERIAPSIS BELOW SURFACE spans full width; monoprop split to `monoprop` + `rcs Δv`.
- **K-nudge guardrails** (8ef94e7, 8562122): 300 m/s ceiling so a mismatched-orbit pair doesn't plant a 1.7-km/s "nudge"; orbit-safety gate so the axis-projection step can't drop the chaser's periapsis into the atmosphere (observed: a 25 km periapsis re-entry arc that nominally "improved CA"). HUD surfaces both rejection reasons faintly.
- **Polish**: `[m]` footer label corrected from "burn" to "maneuver".

## Test plan
- [x] `go vet ./...` green
- [x] `go test ./... -race -count=1` green (full suite)
- [x] New tests: `TestHudPhaseCollapsesVesselDuringAscent`, `TestTitleBarShowsClockAndWarp`, `TestFocusLabelOverlaidOnCanvas`, `TestRecommendRendezvousNudge_BurnTooLarge`, `TestRecommendRendezvousNudge_PeriapsisGate`
- [ ] Playtest: pad-to-LEO ascent, dual-craft rendezvous from co-orbital lag (K plants a small useful burn, not a re-entry arc), mismatched orbits (K stays silent with diagnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)