### PR TITLE
feat(v0.10.5): multi-rev porkchop UI + Lambert short/long picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `K` | Plant rendezvous nudge to target craft (v0.10.2+) — single-burn Lambert intercept projected onto the closest velocity-frame axis. Reads the TARGET HUD's ACH CA / Δv readouts. Errors when there's no craft target, target shares a different primary, already DOCK READY, or no improvement available |
 | `t` / `T` | Cycle / clear `World.Target` (non-active sibling craft → bodies in active system → none) |
 | `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+) |
-| `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H` |
+| `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H`. Press `o` inside to open the transfer-options sub-menu (`n` cycles nRev 0–3, `r` toggles prograde/retrograde, `b` toggles short/long branch); `enter`/`o`/`esc` closes and re-solves (v0.10.5+) |
 | `R` | Refine plan — re-Lambert from live state, plant mid-course correction + update arrival |
 | `m` | Open maneuver planner |
 | `F5` / `F9` | Quicksave / quickload (`$XDG_STATE_HOME/terminal-space-program/save.json`) — KSP-style |
@@ -263,11 +263,14 @@ Normal± burns (no apse target — use `I` for plane-rotation Δv).
 | `←` / `→` | Departure-day cursor |
 | `↑` / `↓` | Time-of-flight cursor |
 | `Enter` | Plant Lambert transfer for selected cell |
+| `o` | Open transfer-options sub-menu — `n` cycles nRev (0–3), `r` toggles prograde/retrograde, `b` toggles short/long branch (only meaningful for nRev ≥ 1); `Enter`/`o`/`Esc` closes and re-solves the grid (v0.10.5+) |
 | Click cell | Move cursor to that cell (then `Enter` to plant) |
 | `Esc` | Back to orbit view |
 
 Cursor opens snapped to the minimum-Δv cell. `·` glyphs mark cells
-where Lambert didn't converge — `Enter` on those is a no-op.
+where Lambert didn't converge — `Enter` on those is a no-op. The TOF
+axis range auto-scales by `(nRev + 1)` so multi-rev cells stay inside
+the displayed bracket.
 
 ## Features
 

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -684,12 +684,12 @@ Items here are **not under active development** unless noted.
 The reverted artifacts are git history, not a starting point. **Do not re-implement without the design pass.** Full retrospective + decision-point list in [`state-of-game-archive.md` §6 *Mission scripting / editor*](state-of-game-archive.md). Suggested sequencing: (1) write the modder-UX target end-to-end, (2) pick the engine in service of that UX, (3) reference v0.8.7-attempt artifacts only for implementation shape, (4) implement.
 
 ### Multi-rev porkchop UI
-<!-- llm-parse: id=multi-rev-porkchop status=deferred target=v0.9 -->
-⏸ **deferred from v0.8.6 (c) → v0.9**. `LambertSolveRev` + retrograde flag have been library-ready since v0.7.5; UI not sliced. Defer until staging slices grow craft fleet — current chemical S-IVB-1-class fleet always picks nRev=0 prograde, so UI gives no leverage until that changes. Pairs with the Lambert short/long branch picker [(below)](#lambert-shortlong-branch-picker).
+<!-- llm-parse: id=multi-rev-porkchop status=in-progress target=v0.10.5 -->
+🛠 **in progress · v0.10.5** (branch `v0.10.5-porkchop`). The three-cycle-deferred carry-over has shipped on branch — the porkchop screen gains an `o` transfer-options sub-menu that exposes nRev (0–3), prograde/retrograde, and the new short/long branch picker. The TOF axis auto-scales by `(nRev+1)` so multi-rev cells live in a sensible TOF window. The options bundle (`sim.TransferOptions{NRev, Retrograde, LongBranch}`) plumbs through `World.PorkchopGrid` → `World.PlanTransferAt` so a planted Δv matches the cell's scored Δv for any options combo. Specced in `docs/v0.10-plan.md` §v0.10.5. Pairs with the [Lambert short/long branch picker (below)](#lambert-shortlong-branch-picker) — both shipped in the same slice.
 
 ### Lambert short/long branch picker
-<!-- llm-parse: id=lambert-short-long status=backlog target=v0.9-with-multi-rev -->
-🧊 **backlog · pairs with multi-rev porkchop**. Today `LambertSolveRev` returns the first root the bracket finds (lower-z side); a per-N "short" / "long" flag would expose both branches per rev count. Library-only LOC (~30) — the surface is plumbing through `PlanLambertTransfer` + `PorkchopGrid` + a UI control. Travels with multi-rev porkchop because both expose nRev≥1 branches that don't exist on the nRev=0 path.
+<!-- llm-parse: id=lambert-short-long status=in-progress target=v0.10.5 -->
+🛠 **in progress · v0.10.5 · pairs with multi-rev porkchop**. `LambertSolveRev` now takes a trailing `longBranch bool` (after `retrograde bool`). For nRev≥1 the two roots flanking the minimum-energy critical z map to short (lower z, more eccentric, lower-TOF) and long (higher z, higher-TOF) branches; the flag seeds Newton from the appropriate side and confines steps to the rev band so it can't leap across the critical z. For nRev=0 the flag is ignored (single branch). Plumbed through `PlanLambertTransfer` + `PorkchopGrid` + the new porkchop sub-menu (`b` toggle). Shipped on branch `v0.10.5-porkchop`.
 
 ### Wider cross-SOI PlanTransfer
 <!-- llm-parse: id=cross-soi-transfer status=backlog target=v0.9 -->
@@ -950,7 +950,7 @@ doc.
 | 5 | [Rendezvous tooling](#rendezvous-tooling) | M | 🧊 backlog | Target-craft selection + target-relative burn modes + null-v_rel at closest approach + iteration. Pairs with multi-craft fleet from (1). |
 | 6 | [Solar lighting + terminator + eclipses](#solar-lighting--daynight-terminator--eclipses) | M | ✅ shipped v0.9.6 | Landed `internal/render/lighting.go`+`eclipse.go`; closed the v0.9 cycle (merge 32e8d03). |
 | 7 | [Predictor adaptive sampling](#predictor-adaptive-sampling) | M | 🛠 in progress v0.10.3 | Three-cycle carry-over; foundation shipped v0.8.4. Adaptive per-leg sample budget (`adaptiveSampleCount`, `[96,720]`). |
-| 8 | [Multi-rev porkchop UI](#multi-rev-porkchop-ui) + [Lambert short/long picker](#lambert-shortlong-branch-picker) | S | ⏸ deferred | UI for `LambertSolveRev` (nRev + retrograde + short/long). Library-ready since v0.7.5. Useful once (1) staging grows the fleet. |
+| 8 | [Multi-rev porkchop UI](#multi-rev-porkchop-ui) + [Lambert short/long picker](#lambert-shortlong-branch-picker) | S | 🛠 in progress v0.10.5 | UI for `LambertSolveRev` (nRev + retrograde + short/long) via the porkchop `o` sub-menu + `TransferOptions` plumbing. Branch `v0.10.5-porkchop`. |
 | 9 | [Capture-direction toggle](#capture-direction-toggle) | S | 🧊 backlog | "Capture prograde-around-target" mode for auto-Hohmann arrival. Trades ~50–100 m/s for the right-direction capture. |
 | 10 | [Theme-file hot-reload](#theme-file-hot-reload) | S | ⏸ deferred | ~200 LOC fsnotify watcher. Reopen if a modder hits theme-iteration friction. |
 | 11 | Polish open questions ([spawn-form persistence](#spawn-form-persistence), [docking visual feedback](#docking-visual-feedback), [numbered craft slots](#numbered-craft-slots-19)) | S | 📐 / 🧊 | Bundle-of-small-stuff candidates if cycle bandwidth allows. |

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -39,7 +39,7 @@ is picked up. Mission scripting stays design-pass-first and is
 | v0.10.2 | **in progress** | — | Rendezvous tooling (M) — actionability layer on top of v0.9.3 (achievable-vs-current CA, Δv-to-improve, recommended-burn auto-plant via `K`). Scope-committed 2026-05-19; built on branch `v0.10.2-rendezvous`. See slice below. |
 | v0.10.3 | **in progress** | — | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. **Scope committed 2026-05-22** (branch `v0.10.3-predictor-sampling`). See slice below. |
 | v0.10.4 | **in progress** | — | Inclination-burn true plane change (M) — `I` was a pure orbit-normal burn that over-sped the craft and left the orbit eccentric. **Scope committed 2026-05-22** (branch `v0.10.4-inclination-burn`), playtest-triggered. See slice below. |
-| v0.10.5 | candidate| —        | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. |
+| v0.10.5 | **in progress** | — | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. **Scope committed 2026-05-22** (branch `v0.10.5-porkchop`). See slice below. |
 
 ## Locked decisions
 
@@ -517,7 +517,78 @@ the dashed line flies off to a bogus heliocentric escape instead of
 showing the Moon encounter, even though the maneuver itself is
 correct. A predictor-fidelity fix (v0.10.3 area).
 
-### v0.10.4+ — carry-over candidates
+### v0.10.5 — multi-rev porkchop UI + Lambert short/long branch picker
+
+<!-- llm-parse: slice=v0.10.5 weight=S scope=planner+sim+tui status=in-progress branch=v0.10.5-porkchop -->
+
+**Scope committed 2026-05-22.** The three-cycle-deferred carry-over.
+`LambertSolveRev` has shipped the multi-rev (`nRev≥1`) and retrograde
+flags since v0.7.5, but the porkchop UI only ever called
+`LambertSolve(retrograde=false)` — locked to nRev=0 prograde. v0.10.5
+exposes the rest of the solver to the player and adds the missing
+short/long branch selector for nRev≥1.
+
+**Design.**
+
+- **Planner — short/long branch selection.** `LambertSolveRev` gains a
+  `longBranch bool` (trailing arg). For nRev ≥ 1 the F(z)=0 equation
+  has two roots flanking the minimum-energy critical z; `longBranch=
+  false` (default) seeds Newton from just above the lower bound
+  (`zLower + 0.01`) → converges to the short-TOF / lower-z root
+  (legacy behavior, byte-identical). `longBranch=true` seeds from just
+  below the upper bound (`zUpper − 0.01`) → converges to the long-TOF
+  / higher-z root. Newton steps are confined to `[zLower+ε, zUpper−ε]`
+  via the same step-halving mechanism that handled `y < 0` before, so
+  it can't leap across the critical z onto the wrong branch. For
+  nRev = 0 the flag is ignored (single branch).
+- **Planner — porkchop + plan plumbing.** `PorkchopGrid` and
+  `PlanLambertTransfer` gain `nRev int, longBranch bool` (after the
+  existing `retrograde bool`). Both pass through to `LambertSolveRev`.
+- **Sim — TransferOptions bundle.** New
+  `sim.TransferOptions{NRev, Retrograde, LongBranch}` value type
+  carries the trio. `World.PorkchopGrid` and `World.PlanTransferAt`
+  take an `opts TransferOptions` arg; existing call sites supply
+  `TransferOptions{}` (zero value = legacy path).
+- **TUI — transfer-options sub-menu.** The porkchop screen gains a
+  small in-screen options panel toggled with `o`. While open, `n`
+  cycles `NRev` 0 → 1 → 2 → 3 → 0, `r` toggles retrograde, `b` toggles
+  short/long. `enter` / `esc` / `o` close the menu and re-solve the
+  grid. Current options always echo in the title (`(rev=N direction
+  branch)`), so the player can see what's being scored without opening
+  the panel. The footer flips to the sub-menu key set while open.
+- **TUI — TOF axis auto-scale.** `recompute()` derives the displayed
+  TOF range as `[100, 400]·(nRev+1)` days. An nRev=1 transfer's
+  minimum TOF is ≈ one transfer-ellipse period (Earth→Mars ≈ 510 d);
+  the flat 100–400 d window would have shown mostly NaN cells.
+- **Plant carries options.** `Porkchop.PendingPlant()` returns the
+  active `TransferOptions` alongside the cell; the app passes them
+  straight to `World.PlanTransferAt`, guaranteeing the planted Δv
+  matches the cell's scored Δv (the existing
+  `TestPlanTransferAtMatchesPorkchopGridCell` invariant, now for any
+  options combination).
+
+**Weight.** S — planner library work is ~30 LOC (the longBranch
+seed + Newton-bracket clamp), plus mechanical plumbing through
+`PorkchopGrid` / `PlanLambertTransfer` / `World.PorkchopGrid` /
+`World.PlanTransferAt`; sim TransferOptions type + sub-menu UI
+account for the rest. No save migration (the options are a UI
+preference, not persisted craft state).
+
+**Regression surface.** New planner tests:
+`TestLambertMultiRevShortLongBranches` (short/long return distinct,
+both physically valid via Verlet round-trip), `TestLambertSolve-
+LongBranchIgnoredForN0` (flag is a no-op at single-rev). New porkchop-
+screen tests: `TestPorkchopOptionsSubmenu` (sub-menu open/close +
+n/r/b toggles + nRev wrap), `TestPorkchopPendingPlantCarriesOptions`
+(plant surfaces the active options). Existing porkchop +
+PlanTransferAt tests stay green (zero-value `TransferOptions` is the
+legacy code path).
+
+**Built (2026-05-22, branch `v0.10.5-porkchop`).** Implemented as
+specced; `go vet ./...` + `go test ./... -race -count=1` green. Slice
+ready for tag/merge once playtested.
+
+### v0.10.5+ — carry-over candidates
 
 Detailed specs live in `docs/state-of-game.md` §Backlog; not
 duplicated here until committed. Ordered rationale:
@@ -547,8 +618,9 @@ duplicated here until committed. Ordered rationale:
   the `I` auto-plant was a pure orbit-normal burn that over-sped the
   craft and left the orbit eccentric.
 - **Multi-rev porkchop UI + Lambert short/long picker (S)** —
-  *candidate v0.10.5*; library-ready since v0.7.5; only leverages
-  once staging grows the fleet off the nRev=0 path.
+  *committed as v0.10.5 (in progress)*; see the slice section
+  above. Library-ready since v0.7.5; only leverages once staging
+  grows the fleet off the nRev=0 path.
 
 ## Sequencing
 

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -30,6 +30,18 @@ committed in the ordering shown, with only slice-time details
 is picked up. Mission scripting stays design-pass-first and is
 **not** raw-sliced this cycle.
 
+**Lock-break (2026-05-23) — perspective tilt folded in as v0.10.6 +
+v0.10.7.** Approved in-channel after the lighting-amortization
+framing: v0.9.6's terminator/shadow pipeline is currently
+load-bearing only at close zoom, so a tilted orbit view isn't *new*
+render scope so much as it *unlocks value already shipped* — and it
+makes every preceding v0.10 slice (slew navball, staging silhouettes,
+rendezvous depth read) land harder. Renders the perspective work a
+finish-what-we-started fold-in rather than a v0.11-grade new feature.
+Design pass `tsp-v0.10.6-perspective-v2.md` (fenbot, sidechat file
+`a485f755`) is the approved spec; reviewed and split into M+S slices
+per macbotm5's review notes. No further fold-ins this cycle.
+
 ## Status
 
 | slice   | status   | tag      | notes |
@@ -40,6 +52,8 @@ is picked up. Mission scripting stays design-pass-first and is
 | v0.10.3 | **in progress** | — | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. **Scope committed 2026-05-22** (branch `v0.10.3-predictor-sampling`). See slice below. |
 | v0.10.4 | **in progress** | — | Inclination-burn true plane change (M) — `I` was a pure orbit-normal burn that over-sped the craft and left the orbit eccentric. **Scope committed 2026-05-22** (branch `v0.10.4-inclination-burn`), playtest-triggered. See slice below. |
 | v0.10.5 | **in progress** | — | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. **Scope committed 2026-05-22** (branch `v0.10.5-porkchop`). See slice below. |
+| v0.10.6 | **designed** | — | Perspective tilt for orbit view (M, render+sim) — `ViewTilted` + far-side dashing + HUD readout. **Scope committed 2026-05-23** (lock-break approved in-channel via lighting-amortization framing; no branch yet). See slice below. |
+| v0.10.7 | **designed** | — | Launch-anchor for `ViewTilted` (S, sim+render) — yaw-lock to local-vertical when in-atmosphere or `alt < 100 km`, guarded behind `ViewMode == ViewTilted`. Depends on v0.10.6 shipping. **Scope committed 2026-05-23**. See slice below. |
 
 ## Locked decisions
 
@@ -588,6 +602,112 @@ legacy code path).
 specced; `go vet ./...` + `go test ./... -race -count=1` green. Slice
 ready for tag/merge once playtested.
 
+### v0.10.6 — perspective tilt for orbit view
+
+<!-- llm-parse: slice=v0.10.6 weight=M scope=render+sim status=designed fold-in=2026-05-23 design=tsp-v0.10.6-perspective-v2.md -->
+
+**Scope committed 2026-05-23 — lock-break fold-in.** All five
+existing view modes are axis-aligned orthographic (`Top` / `Right` /
+`Bottom` / `Left` cardinals + `OrbitFlat` perifocal), so the player
+must choose between *seeing the orbit shape* OR *seeing depth* —
+never both. Top-down gives clean ellipses but flat-disk planets;
+edge-on gives a horizon but compresses orbits to lines; `OrbitFlat`
+is the cleanest orbit but the body still reads as a 2D coin. The
+v0.9.6 lighting + terminator pipeline is currently load-bearing
+only at close zoom (the terminator collapses to a few pixels at
+default orbit distance), so it does most of its work on the
+surface-launch zoom band and is decorative everywhere else. A
+tilted projection makes the planet disk render as an ellipse with
+the terminator as a visible hyperbola at *any* zoom — the
+foreshortening dominates the lighting gradient as the depth cue.
+That's the lock-break case: tilt isn't *new* render scope so much
+as it *unlocks value already shipped*.
+
+**Design — `ViewTilted` mode.**
+
+- New `ViewTilted` enum entry; **prepend** to `AllViewModes` so it
+  becomes the zero value. No save-schema migration — `ViewMode` is
+  per-session UI preference (`internal/sim/world.go:60-70`).
+- Polar tilt θ (default 25°) + yaw φ (default 0) applied to the
+  active craft's perifocal basis. KSP defaults to ~30°; the
+  terminal canvas's 2:4 braille aspect makes foreshortening read
+  stronger than a graphical UI, so a touch less tilt keeps the
+  ellipse from looking squashed. Tune in flight.
+- `cameraDirForView` (`internal/tui/screens/orbit.go:966`) extended
+  to compute the tilted basis from the active craft's elements +
+  θ/φ. `widgets.Basis{X, Y}` + `DepthAxis()`
+  (`internal/tui/widgets/canvas.go:31, :48`) accept arbitrary unit
+  vectors — no rendering pipeline changes needed downstream.
+- **Far-side dashing** in the orbit-trace draw path: tag each
+  sampled orbit point by sign of `(p − body) · DepthAxis()`; render
+  dashed when negative, solid when positive. KSP-style depth read
+  on the orbit itself. Conservative draw style — clutter drops when
+  the back arc is dotted instead of solid.
+- **HUD readout:** when tilt or yaw is not at defaults, the
+  bottom-left "view:" indicator includes degrees
+  (`view: tilted 25°/0°`). Cheap; saves an hour debugging player
+  reports of "the angle is wrong."
+- Cardinals + `OrbitFlat` unchanged; inertial basis throughout. No
+  launch-frame interaction in this slice (that's v0.10.7). Safe to
+  ship alone.
+
+**Weight.** M, render + sim. Comparable to v0.10.3 / v0.10.4.
+
+**Regression surface.** New: `TestViewTiltedBasis` (orbit with known
+inclination + tilt θ, assert `Basis.X × Basis.Y` matches expected
+world-frame camera direction — natural sibling to existing
+`TestDepthAxisCardinalBases` at
+`internal/tui/widgets/canvas_test.go:431`); `TestFarSideDashing`
+(synthesized orbit point list, tag by depth sign, assert near-side
+count matches geometry expectation). Existing orbit-screen tests
+pass unchanged; tilt applies after the world-to-canvas projection.
+
+**Design pass.** `tsp-v0.10.6-perspective-v2.md` (fenbot, sidechat
+file `a485f755-cbdd-4a50-bbf2-ac05992a50ba`), status
+`approved-for-implementation`; reviewed by macbotm5 (sidechat
+mention 2907) and ratified in-channel by Jason 2026-05-23 14:56
+("agree, make it so").
+
+### v0.10.7 — launch-anchor for `ViewTilted`
+
+<!-- llm-parse: slice=v0.10.7 weight=S scope=sim+render status=designed depends-on=v0.10.6 fold-in=2026-05-23 -->
+
+**Scope committed 2026-05-23 — depends on v0.10.6 shipping.** With
+v0.10.6's tilt, the orbit view's basis is still inertial — so as
+Earth rotates under the launchpad, the rocket slides sideways
+across the screen and the craft's local-up stops being screen-up.
+Players want chase-plane orientation on launch: horizon curve at
+the bottom, rocket ascending vertically in screen-space, planet
+rotating behind the rocket. Surface-frame SAS already operates in
+that frame post-v0.10.0; v0.10.7 makes the view agree with the
+navball.
+
+**Design — yaw re-anchor under tilt.**
+
+- Re-anchor basis yaw to local-vertical (craft position − body
+  centre) when craft is `inAtmosphere` or `alt < 100 km`. Tilt
+  stays; only yaw reference changes — same `Basis` machinery as
+  v0.10.6.
+- **Guarded behind `ViewMode == ViewTilted`** so cardinal modes
+  stay inertial — a player who explicitly picks Top/Right/etc gets
+  inertial geometry, no auto-anchor surprise. This guard is
+  load-bearing.
+- Hard switch at the threshold, no cross-fade — matches the LAUNCH
+  HUD's appear/disappear behavior.
+- Trigger: prefer the `inAtmosphere` flag if the atmosphere package
+  exports a sentinel; otherwise `alt < 100 km`. Sim-side state —
+  render-side reads it.
+
+**Weight.** S, sim + render. Consumes v0.10.6's basis machinery; no
+new render-pipeline surface.
+
+**Regression surface.** New: `TestLaunchAnchor` (craft at 50 km
+altitude, body rotating; successive ticks should keep
+local-vertical → canvas Y+ invariant within the tilt-frame
+precision); `TestLaunchAnchorGuard` (same scenario but `ViewMode ==
+ViewTop`; anchor must NOT fire, basis stays inertial). The guard
+test is what keeps the cardinal-mode user from getting surprised.
+
 ### v0.10.5+ — carry-over candidates
 
 Detailed specs live in `docs/state-of-game.md` §Backlog; not
@@ -621,6 +741,11 @@ duplicated here until committed. Ordered rationale:
   *committed as v0.10.5 (in progress)*; see the slice section
   above. Library-ready since v0.7.5; only leverages once staging
   grows the fleet off the nRev=0 path.
+- **Perspective tilt for orbit view (M)** — *committed as v0.10.6
+  (designed) + v0.10.7 (designed)*; see slice sections above.
+  Lock-break fold-in 2026-05-23; the lighting-amortization framing
+  re-classifies this from a v0.11 candidate to an in-cycle slice
+  that finishes what v0.9.6's terminator/shadow pipeline started.
 
 ## Sequencing
 
@@ -629,8 +754,10 @@ land **early** — it de-risks rendezvous and is a self-contained
 sim slice. Staging is the long pole; start its design in parallel.
 Rendezvous follows staging (fleet) and benefits from v0.10.0
 (fidelity). Adaptive sampling / porkchop UI are interleaved as
-bandwidth allows. Mission scripting is **not** in this cycle —
-design-pass-first, its own future cycle.
+bandwidth allows. Perspective tilt (v0.10.6) lands as a
+render-tier slice after v0.10.5 — independent of the sim spine;
+v0.10.7 launch-anchor stacks on it. Mission scripting is **not**
+in this cycle — design-pass-first, its own future cycle.
 
 ## Deferred / out of scope for v0.10
 

--- a/internal/planner/lambert.go
+++ b/internal/planner/lambert.go
@@ -14,7 +14,7 @@ import (
 // direction when the system happens to spin retrograde, or for
 // exploring multi-rev porkchop alternatives. v0.7.5+.
 func LambertSolve(r1, r2 orbital.Vec3, dt, mu float64, retrograde bool) (v1, v2 orbital.Vec3, err error) {
-	return LambertSolveRev(r1, r2, dt, mu, 0, retrograde)
+	return LambertSolveRev(r1, r2, dt, mu, 0, retrograde, false)
 }
 
 // LambertSolveRev solves Lambert's problem for an N-revolution transfer:
@@ -28,17 +28,18 @@ func LambertSolve(r1, r2 orbital.Vec3, dt, mu float64, retrograde bool) (v1, v2 
 // (each rev contributes (2π)² to the universal-variable domain);
 // the bracket sweep starts just past that lower bound.
 //
-// Single branch only — at N ≥ 1 there are typically two time-of-flight
-// solutions per N (a "long" and "short" transfer separated by the
-// minimum-energy critical z). This solver returns whichever branch the
-// bracket sweep lands in first, which is adequate for the porkchop
-// grid's coarse sampling. Multi-branch selection is a v0.4 polish item
-// if it comes up.
+// At N ≥ 1 there are typically two time-of-flight solutions per N — a
+// "short" branch (lower z, more eccentric ellipse) and a "long" branch
+// (higher z) flanking the minimum-energy critical z. longBranch=false
+// returns the short branch (the default; v0.10.5 and earlier behavior);
+// longBranch=true seeds Newton from just below the upper bound so it
+// converges onto the long-branch root instead. For N = 0 the flag is
+// ignored (single branch).
 //
 // retrograde flips the transfer-angle convention: prograde takes the
 // short way when (r1 × r2)·ẑ ≥ 0 and the long way otherwise; retrograde
 // reverses the rule. v0.7.5+.
-func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde bool) (v1, v2 orbital.Vec3, err error) {
+func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde, longBranch bool) (v1, v2 orbital.Vec3, err error) {
 	if dt <= 0 {
 		return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: dt must be > 0")
 	}
@@ -114,17 +115,26 @@ func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde b
 	if nRev == 0 {
 		zUpper = 4 * math.Pi * math.Pi
 	}
-	z := zLower
-	if nRev > 0 {
-		z += 0.01 // nudge past the lower critical value
-	}
-	if nRev == 0 && !math.IsNaN(F(z)) && F(z) > 0 {
-		// N=0 only: F(0) already positive → walk negative into the
-		// hyperbolic region to find the bracket.
-		for F(z) > 0 && z > -4*math.Pi*math.Pi {
+	var z float64
+	switch {
+	case nRev > 0 && longBranch:
+		// Long branch: F(z) → +∞ at both rev-band boundaries with a
+		// single minimum between, so seeding Newton near the upper
+		// boundary converges to the upper (long-TOF) root. Walk
+		// inward until F is non-singular.
+		z = zUpper - 0.01
+		for {
+			fv := F(z)
+			if !math.IsNaN(fv) && fv >= 0 {
+				break
+			}
 			z -= 0.1
+			if z <= zLower {
+				return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: bracket search failed — no long-branch solution in this rev band")
+			}
 		}
-	} else {
+	case nRev > 0:
+		z = zLower + 0.01
 		for {
 			fv := F(z)
 			if !math.IsNaN(fv) && fv >= 0 {
@@ -135,6 +145,26 @@ func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde b
 				return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: bracket search failed — no solution in this rev band")
 			}
 		}
+	default:
+		z = zLower
+		if !math.IsNaN(F(z)) && F(z) > 0 {
+			// N=0 only: F(0) already positive → walk negative into the
+			// hyperbolic region to find the bracket.
+			for F(z) > 0 && z > -4*math.Pi*math.Pi {
+				z -= 0.1
+			}
+		} else {
+			for {
+				fv := F(z)
+				if !math.IsNaN(fv) && fv >= 0 {
+					break
+				}
+				z += 0.1
+				if z >= zUpper {
+					return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: bracket search failed — no solution in this rev band")
+				}
+			}
+		}
 	}
 
 	// Newton-Raphson. Convergence: stop when the step in z is below
@@ -142,6 +172,14 @@ func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde b
 	// |F|, which sits at ~ε·sqrt(mu)·dt scale and bounces on noise).
 	const tolStep = 1e-12
 	const maxIter = 100
+	// For N-rev branches, confine Newton inside [zLower+ε, zUpper−ε] so
+	// it can't step out of the rev band (or, for the long branch, leap
+	// across the minimum onto the short-branch root).
+	zMin, zMax := math.Inf(-1), math.Inf(1)
+	if nRev > 0 {
+		zMin = zLower + 1e-6
+		zMax = zUpper - 1e-6
+	}
 	converged := false
 	for i := 0; i < maxIter; i++ {
 		fv := F(z)
@@ -154,7 +192,7 @@ func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde b
 		}
 		step := fv / fp
 		zNext := z - step
-		for yFn(zNext) < 0 {
+		for yFn(zNext) < 0 || zNext <= zMin || zNext >= zMax {
 			zNext = (z + zNext) / 2
 			if math.Abs(zNext-z) < 1e-15 {
 				return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: failed to recover from y<0 step")

--- a/internal/planner/lambert_test.go
+++ b/internal/planner/lambert_test.go
@@ -90,7 +90,7 @@ func TestLambertMultiRevN1(t *testing.T) {
 	// N=1 domain while staying inside N=1's bracket.
 	dt := 20000.0
 
-	v1, _, err := LambertSolveRev(r1, r2, dt, mu, 1, false)
+	v1, _, err := LambertSolveRev(r1, r2, dt, mu, 1, false, false)
 	if err != nil {
 		t.Fatalf("LambertSolveRev N=1: %v", err)
 	}
@@ -112,12 +112,79 @@ func TestLambertMultiRevN1(t *testing.T) {
 	}
 }
 
+// TestLambertMultiRevShortLongBranches: for nRev≥1 the same (r1, r2, dt)
+// admits two solutions (short = lower z / more eccentric, long = higher
+// z) flanking the minimum-energy critical z. Verify both branches:
+//   - converge,
+//   - round-trip to r2 within Verlet drift,
+//   - return distinct v1 vectors (the long-branch sanity check — if
+//     branch selection broke, both would alias to the short root).
+// v0.10.5+.
+func TestLambertMultiRevShortLongBranches(t *testing.T) {
+	r1 := orbital.Vec3{X: 7e6}
+	r2 := orbital.Vec3{X: -1e7 * math.Cos(math.Pi*10/180), Y: 1e7 * math.Sin(math.Pi*10/180)}
+	mu := 398600e9
+	dt := 20000.0
+
+	v1Short, _, err := LambertSolveRev(r1, r2, dt, mu, 1, false, false)
+	if err != nil {
+		t.Fatalf("LambertSolveRev N=1 short: %v", err)
+	}
+	v1Long, _, err := LambertSolveRev(r1, r2, dt, mu, 1, false, true)
+	if err != nil {
+		t.Fatalf("LambertSolveRev N=1 long: %v", err)
+	}
+
+	delta := v1Long.Sub(v1Short).Norm()
+	if delta/v1Short.Norm() < 1e-3 {
+		t.Errorf("short/long branches alias: |Δv1| = %.2e (rel %.2e) — expected distinct branches",
+			delta, delta/v1Short.Norm())
+	}
+
+	// Round-trip the long branch — it must also be physically valid.
+	state := physics.StateVector{R: r1, V: v1Long}
+	period := 2 * math.Pi * math.Sqrt(math.Pow(r1.Norm(), 3)/mu)
+	maxStep := period / 100.0
+	nSteps := int(math.Ceil(dt / maxStep))
+	if nSteps < 1000 {
+		nSteps = 1000
+	}
+	step := dt / float64(nSteps)
+	for i := 0; i < nSteps; i++ {
+		state = physics.StepVerlet(state, mu, step)
+	}
+	if d := state.R.Sub(r2).Norm() / r2.Norm(); d > 0.05 {
+		t.Errorf("N=1 long-branch round-trip: r mismatch %.2e (rel) — v1=%+v", d, v1Long)
+	}
+}
+
+// TestLambertSolveLongBranchIgnoredForN0: at nRev=0 there is only one
+// branch — the longBranch flag must not change behavior. v0.10.5+.
+func TestLambertSolveLongBranchIgnoredForN0(t *testing.T) {
+	r1 := orbital.Vec3{X: 5000e3, Y: 10000e3, Z: 2100e3}
+	r2 := orbital.Vec3{X: -14600e3, Y: 2500e3, Z: 7000e3}
+	dt := 3600.0
+	mu := 398600e9
+
+	v1Short, _, err := LambertSolveRev(r1, r2, dt, mu, 0, false, false)
+	if err != nil {
+		t.Fatalf("LambertSolveRev N=0 short: %v", err)
+	}
+	v1Long, _, err := LambertSolveRev(r1, r2, dt, mu, 0, false, true)
+	if err != nil {
+		t.Fatalf("LambertSolveRev N=0 long: %v", err)
+	}
+	if d := v1Long.Sub(v1Short).Norm() / v1Short.Norm(); d > 1e-9 {
+		t.Errorf("N=0 long flag changed v1: rel %.2e — flag must be ignored at single-rev", d)
+	}
+}
+
 // TestLambertMultiRevRejectsNegative: N < 0 should error rather than
 // panic or silently degrade to single-rev.
 func TestLambertMultiRevRejectsNegative(t *testing.T) {
 	r1 := orbital.Vec3{X: 7e6}
 	r2 := orbital.Vec3{X: -1e7}
-	if _, _, err := LambertSolveRev(r1, r2, 3600, 398600e9, -1, false); err == nil {
+	if _, _, err := LambertSolveRev(r1, r2, 3600, 398600e9, -1, false, false); err == nil {
 		t.Error("expected error for nRev=-1")
 	}
 }

--- a/internal/planner/porkchop.go
+++ b/internal/planner/porkchop.go
@@ -33,6 +33,11 @@ type EphemerisFn func(epoch float64) (r, v orbital.Vec3)
 // - retrograde: forwarded to LambertSolve to select the prograde or
 //   retrograde transfer branch. The TUI surfaces prograde today;
 //   retrograde unblocks multi-rev porkchop work in v0.8+. v0.7.5+.
+// - nRev / longBranch: forwarded to LambertSolveRev. nRev=0 +
+//   longBranch=false is the legacy single-rev short-only path
+//   (byte-identical to pre-v0.10.5). nRev≥1 scores N-revolution
+//   transfers; longBranch picks the higher-z (long) root of the
+//   two-branch N-rev solution. v0.10.5+.
 func PorkchopGrid(
 	muSun float64,
 	depState, arrState EphemerisFn,
@@ -41,6 +46,8 @@ func PorkchopGrid(
 	muDep, rPark float64,
 	muArr, rCapture float64,
 	retrograde bool,
+	nRev int,
+	longBranch bool,
 ) [][]float64 {
 	grid := make([][]float64, len(tofDays))
 	for j := range grid {
@@ -62,7 +69,7 @@ func PorkchopGrid(
 			tArr := tDep + tof*secondsPerDay
 			r2, vArr := arrState(tArr)
 
-			v1, v2, err := LambertSolve(r1, r2, tof*secondsPerDay, muSun, retrograde)
+			v1, v2, err := LambertSolveRev(r1, r2, tof*secondsPerDay, muSun, nRev, retrograde, longBranch)
 			if err != nil {
 				continue // leave NaN
 			}

--- a/internal/planner/porkchop_test.go
+++ b/internal/planner/porkchop_test.go
@@ -55,7 +55,7 @@ func TestPorkchopGridCenterMatchesHohmann(t *testing.T) {
 		depDays, tofDays,
 		3.986e14, 6.578e6, // Earth μ, LEO
 		4.282837e13, 3.59e6, // Mars μ, low capture
-		false,
+		false, 0, false,
 	)
 
 	depIdx, tofIdx, total, ok := PorkchopMinCell(grid)
@@ -86,7 +86,7 @@ func TestPorkchopGridMarksInvalidCellsNaN(t *testing.T) {
 		[]float64{0}, []float64{0, 100}, // first TOF zero → must be NaN
 		3.986e14, 6.578e6,
 		4.282837e13, 3.59e6,
-		false,
+		false, 0, false,
 	)
 	if !math.IsNaN(grid[0][0]) {
 		t.Errorf("zero-TOF cell should be NaN, got %v", grid[0][0])

--- a/internal/planner/transfer.go
+++ b/internal/planner/transfer.go
@@ -290,11 +290,13 @@ func PlanLambertTransfer(
 	muDestination, rCapture float64, destinationID string,
 	depOffset time.Duration,
 	retrograde bool,
+	nRev int,
+	longBranch bool,
 ) (TransferPlan, error) {
 	if muSun <= 0 || tof <= 0 {
 		return TransferPlan{}, errors.New("planlambert: muSun and tof must be > 0")
 	}
-	v1, v2, err := LambertSolve(rDep, rArr, tof, muSun, retrograde)
+	v1, v2, err := LambertSolveRev(rDep, rArr, tof, muSun, nRev, retrograde, longBranch)
 	if err != nil {
 		return TransferPlan{}, err
 	}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -553,7 +553,7 @@ func (w *World) RefinePlan() (correctionDv, arrivalDv float64, err error) {
 //
 // depDay / tofDay are in days; depDay is an offset from w.Clock.SimTime.
 // Used by the porkchop screen's Enter-to-plant path (v0.4.1).
-func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.TransferPlan, error) {
+func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64, opts TransferOptions) (*planner.TransferPlan, error) {
 	sys := w.System()
 	if targetIdx <= 0 || targetIdx >= len(sys.Bodies) {
 		return nil, errInvalidTransferTarget
@@ -593,9 +593,6 @@ func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.
 	rArr, vArr := arrEph(tArr)
 
 	depOffset := time.Duration(depDay * secondsPerDay * float64(time.Second))
-	// Prograde transfer — the porkchop UI scores prograde transfers
-	// today; v0.8+ multi-rev work will surface retrograde as a UI
-	// toggle and start passing true.
 	plan, err := planner.PlanLambertTransfer(
 		muSun,
 		rDep, vDep,
@@ -604,7 +601,9 @@ func (w *World) PlanTransferAt(targetIdx int, depDay, tofDay float64) (*planner.
 		muDep, rPark, w.ActiveCraft().Primary.ID,
 		muArr, rCapture, target.ID,
 		depOffset,
-		false,
+		opts.Retrograde,
+		opts.NRev,
+		opts.LongBranch,
 	)
 	if err != nil {
 		return nil, err
@@ -980,7 +979,18 @@ func (w *World) PlanCircularizeAtApoapsis() (*CircularizePlan, error) {
 // errSamePrimaryUseHohmann — the heliocentric Lambert math doesn't
 // model in-SOI transfers. The porkchop screen surfaces the error as a
 // "use [P] for Hohmann" banner.
-func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]float64, error) {
+// TransferOptions bundles the per-cell Lambert solve parameters that
+// porkchop / PlanTransferAt forward to the planner: prograde-vs-
+// retrograde, revolution count, and short-vs-long branch selection.
+// Zero value (NRev=0, Retrograde=false, LongBranch=false) is the
+// legacy single-rev prograde short-branch path. v0.10.5+.
+type TransferOptions struct {
+	NRev       int
+	Retrograde bool
+	LongBranch bool
+}
+
+func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64, opts TransferOptions) ([][]float64, error) {
 	sys := w.System()
 	if targetIdx <= 0 || targetIdx >= len(sys.Bodies) {
 		return nil, errInvalidTransferTarget
@@ -1014,7 +1024,9 @@ func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64) ([][]flo
 		depDays, tofDays,
 		muDep, rPark,
 		muArr, rCapture,
-		false, // prograde — v0.8+ multi-rev porkchop will toggle this.
+		opts.Retrograde,
+		opts.NRev,
+		opts.LongBranch,
 	)
 	return grid, nil
 }

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -871,7 +871,7 @@ func TestPorkchopGridRejectsSamePrimaryTarget(t *testing.T) {
 	if moonIdx < 0 {
 		t.Skip("Moon missing from Sol")
 	}
-	if _, err := w.PorkchopGrid(moonIdx, []float64{0}, []float64{5}); err == nil {
+	if _, err := w.PorkchopGrid(moonIdx, []float64{0}, []float64{5}, TransferOptions{}); err == nil {
 		t.Errorf("PorkchopGrid for Moon (same-primary) returned nil error — should be errSamePrimaryUseHohmann")
 	}
 }
@@ -1561,7 +1561,7 @@ func TestPlanTransferAtPlantsTwoNodes(t *testing.T) {
 	}
 
 	const depDay, tofDay = 30.0, 260.0
-	plan, err := w.PlanTransferAt(marsIdx, depDay, tofDay)
+	plan, err := w.PlanTransferAt(marsIdx, depDay, tofDay, TransferOptions{})
 	if err != nil {
 		t.Fatalf("PlanTransferAt: %v", err)
 	}
@@ -1613,7 +1613,7 @@ func TestPlanTransferAtMatchesPorkchopGridCell(t *testing.T) {
 	}
 	depDays := []float64{30}
 	tofDays := []float64{260}
-	grid, err := w.PorkchopGrid(marsIdx, depDays, tofDays)
+	grid, err := w.PorkchopGrid(marsIdx, depDays, tofDays, TransferOptions{})
 	if err != nil {
 		t.Fatalf("PorkchopGrid: %v", err)
 	}
@@ -1621,7 +1621,7 @@ func TestPlanTransferAtMatchesPorkchopGridCell(t *testing.T) {
 	if math.IsNaN(want) {
 		t.Skip("porkchop cell did not converge — pick different depDay/tofDay")
 	}
-	plan, err := w.PlanTransferAt(marsIdx, depDays[0], tofDays[0])
+	plan, err := w.PlanTransferAt(marsIdx, depDays[0], tofDays[0], TransferOptions{})
 	if err != nil {
 		t.Fatalf("PlanTransferAt: %v", err)
 	}
@@ -1650,7 +1650,7 @@ func TestPlanTransferAtRejectsBadInputs(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			before := len(w.ActiveCraft().Nodes)
-			if _, err := w.PlanTransferAt(c.idx, c.depDay, c.tofDay); err == nil {
+			if _, err := w.PlanTransferAt(c.idx, c.depDay, c.tofDay, TransferOptions{}); err == nil {
 				t.Errorf("expected error for %s", c.name)
 			}
 			if len(w.ActiveCraft().Nodes) != before {
@@ -1702,7 +1702,7 @@ func TestRefinePlanUpdatesArrivalAfterPlanTransferAt(t *testing.T) {
 	// r1 (craft_helio_now ≈ Earth_now) would not match — the two
 	// Lambert solutions would land on different trajectories and
 	// arrival Δv would diverge legitimately.
-	plan, err := w.PlanTransferAt(marsIdx, 0, 260)
+	plan, err := w.PlanTransferAt(marsIdx, 0, 260, TransferOptions{})
 	if err != nil {
 		t.Fatalf("PlanTransferAt: %v", err)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -389,8 +389,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.active == screenPorkchop {
 			_, done := a.porkchop.HandleKey(m)
 			if done {
-				if tgt, depD, tofD, ok := a.porkchop.PendingPlant(); ok {
-					_, _ = a.world.PlanTransferAt(tgt, depD, tofD)
+				if tgt, depD, tofD, opts, ok := a.porkchop.PendingPlant(); ok {
+					_, _ = a.world.PlanTransferAt(tgt, depD, tofD, opts)
 				}
 				a.active = screenOrbit
 			}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -85,6 +85,11 @@ func (h *Help) Render() string {
 			{"click empty", "open planner staged at projected orbit point"},
 			{"click HUD", "open body info"},
 		}},
+		{"PORKCHOP", [][2]string{
+			{"o", "open transfer-options sub-menu (nRev / direction / branch)"},
+			{"n / r / b", "(sub-menu) cycle nRev / toggle retrograde / toggle short-vs-long branch"},
+			{"enter / esc / o", "(sub-menu) close — re-solves grid with the new options"},
+		}},
 		{"MOUSE (porkchop)", [][2]string{
 			{"click cell", "select that (dep, tof) — press [enter] to plant"},
 		}},

--- a/internal/tui/screens/porkchop.go
+++ b/internal/tui/screens/porkchop.go
@@ -17,6 +17,11 @@ import (
 // Simplistic ASCII render (no color) to stay portable across terminals
 // without touching lipgloss color config. Darker/heavier glyph = lower
 // total Δv ("cheaper" transfer). "·" marks infeasible / non-converged.
+//
+// v0.10.5: a transfer-options sub-menu (toggled with `o`) holds the
+// per-cell Lambert solve params (nRev, retrograde, short/long branch).
+// Toggling re-runs the grid and rescales the TOF axis so multi-rev
+// cells live in a sensible TOF range.
 type Porkchop struct {
 	theme        Theme
 	targetIdx    int
@@ -28,7 +33,13 @@ type Porkchop struct {
 	selTof       int
 	errMsg       string
 	plantPending bool
+
+	world    *sim.World
+	opts     sim.TransferOptions
+	optsOpen bool
 }
+
+const porkchopMaxNRev = 3
 
 // NewPorkchop constructs an empty screen. Call Load(world, targetIdx)
 // before the first render to populate the grid.
@@ -42,20 +53,34 @@ func NewPorkchop(th Theme) *Porkchop {
 // it on the screen. Cheap to call once on open; not recomputed per
 // frame since the grid doesn't change unless the craft's state or
 // target shifts, and the player pauses on this screen to select a
-// cell anyway.
+// cell anyway. v0.10.5: resets transfer options to single-rev prograde
+// short on each fresh Load (the sub-menu drives subsequent re-solves).
 func (p *Porkchop) Load(w *sim.World, targetIdx int) {
 	p.targetIdx = targetIdx
-	p.selDep, p.selTof = 0, 0
+	p.world = w
+	p.opts = sim.TransferOptions{}
+	p.optsOpen = false
 	sys := w.System()
 	if targetIdx > 0 && targetIdx < len(sys.Bodies) {
 		p.targetName = sys.Bodies[targetIdx].EnglishName
 	}
+	p.recompute()
+}
 
-	// Default grid: 0–365 dep days step 10, 100–400 tof days step 15.
-	// Gives a 37 × 21 grid — readable in a typical 120-col terminal.
+// recompute regenerates the dep/tof axes for the current options +
+// re-solves the grid. The TOF range scales with (nRev+1) so an N-rev
+// transfer's natural minimum-TOF (≈ N × transfer-ellipse periods)
+// stays inside the displayed window; otherwise multi-rev cells would
+// mostly fall below the bracket and read as NaN.
+func (p *Porkchop) recompute() {
+	p.selDep, p.selTof = 0, 0
+	if p.world == nil {
+		return
+	}
 	p.depDays = linspace(0, 365, 37)
-	p.tofDays = linspace(100, 400, 21)
-	grid, err := w.PorkchopGrid(targetIdx, p.depDays, p.tofDays)
+	scale := float64(p.opts.NRev + 1)
+	p.tofDays = linspace(100*scale, 400*scale, 21)
+	grid, err := p.world.PorkchopGrid(p.targetIdx, p.depDays, p.tofDays, p.opts)
 	if err != nil {
 		p.errMsg = err.Error()
 		p.grid = nil
@@ -63,7 +88,6 @@ func (p *Porkchop) Load(w *sim.World, targetIdx int) {
 	}
 	p.grid = grid
 	p.errMsg = ""
-	// Center cursor on the min-Δv cell if one exists.
 	if d, t, _, ok := porkchopMin(grid); ok {
 		p.selDep = d
 		p.selTof = t
@@ -74,7 +98,25 @@ func (p *Porkchop) Load(w *sim.World, targetIdx int) {
 // Esc (cancel) or Enter (plant → app reads PendingPlant()) to signal
 // the app should return to orbit view. Enter also sets the plant
 // flag, checked by the app immediately after done=true.
+//
+// With the transfer-options sub-menu open (`o`), keys instead drive
+// the option toggles (n nRev / r retrograde / b branch) and esc/enter/o
+// closes the menu — re-solving the grid on close.
 func (p *Porkchop) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if p.optsOpen {
+		switch msg.String() {
+		case "n":
+			p.opts.NRev = (p.opts.NRev + 1) % (porkchopMaxNRev + 1)
+		case "r":
+			p.opts.Retrograde = !p.opts.Retrograde
+		case "b":
+			p.opts.LongBranch = !p.opts.LongBranch
+		case "o", "enter", "esc":
+			p.optsOpen = false
+			p.recompute()
+		}
+		return nil, false
+	}
 	switch msg.String() {
 	case "left":
 		if p.selDep > 0 {
@@ -92,6 +134,8 @@ func (p *Porkchop) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		if p.selTof < len(p.tofDays)-1 {
 			p.selTof++
 		}
+	case "o":
+		p.optsOpen = true
 	case "enter":
 		if p.grid != nil && p.selTof < len(p.grid) && p.selDep < len(p.grid[p.selTof]) &&
 			!math.IsNaN(p.grid[p.selTof][p.selDep]) {
@@ -104,16 +148,18 @@ func (p *Porkchop) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	return nil, false
 }
 
-// PendingPlant returns the selected (targetIdx, depDay, tofDay) if the
-// user pressed Enter on a feasible cell; ok=false if no plant is
-// pending (Esc-close or infeasible cell). Consumes the pending flag —
-// next call returns ok=false until the user plants again.
-func (p *Porkchop) PendingPlant() (targetIdx int, depDay, tofDay float64, ok bool) {
+// PendingPlant returns the selected (targetIdx, depDay, tofDay, opts)
+// if the user pressed Enter on a feasible cell; ok=false if no plant
+// is pending (Esc-close or infeasible cell). Consumes the pending flag
+// — next call returns ok=false until the user plants again. v0.10.5
+// also returns the active TransferOptions so PlanTransferAt uses the
+// same nRev/retrograde/branch the cell was scored against.
+func (p *Porkchop) PendingPlant() (targetIdx int, depDay, tofDay float64, opts sim.TransferOptions, ok bool) {
 	if !p.plantPending {
-		return 0, 0, 0, false
+		return 0, 0, 0, sim.TransferOptions{}, false
 	}
 	p.plantPending = false
-	return p.targetIdx, p.depDays[p.selDep], p.tofDays[p.selTof], true
+	return p.targetIdx, p.depDays[p.selDep], p.tofDays[p.selTof], p.opts, true
 }
 
 // HitCell maps a screen-space (col, row) onto the porkchop grid's
@@ -180,7 +226,7 @@ func (p *Porkchop) Render(w *sim.World, cols, rows int) string {
 	}
 
 	var b strings.Builder
-	title := fmt.Sprintf("porkchop plot — Earth → %s", p.targetName)
+	title := fmt.Sprintf("porkchop plot — Earth → %s  %s", p.targetName, p.optsSummary())
 	b.WriteString(p.theme.Title.Render(title))
 	b.WriteString("\n\n")
 
@@ -247,8 +293,60 @@ func (p *Porkchop) Render(w *sim.World, cols, rows int) string {
 	}
 	b.WriteString("  (darker = cheaper; · = no solution)\n\n")
 
-	b.WriteString(p.theme.Footer.Render("[←/→] dep [↑/↓] tof [enter] plant [esc] back"))
+	if p.optsOpen {
+		b.WriteString(p.renderOptionsPanel())
+		b.WriteString("\n")
+	}
+
+	footer := "[←/→] dep [↑/↓] tof [o] options [enter] plant [esc] back"
+	if p.optsOpen {
+		footer = "[n] nRev [r] retrograde [b] short/long [enter/o/esc] close"
+	}
+	b.WriteString(p.theme.Footer.Render(footer))
 	return b.String()
+}
+
+// optsSummary renders the active TransferOptions as a compact "rev=N
+// prograde short" tag — shown in the title so the player can always
+// see what the grid is scoring.
+func (p *Porkchop) optsSummary() string {
+	dir := "prograde"
+	if p.opts.Retrograde {
+		dir = "retrograde"
+	}
+	branch := "short"
+	if p.opts.LongBranch {
+		branch = "long"
+	}
+	if p.opts.NRev == 0 {
+		// Branch is irrelevant at nRev=0 — hide it to avoid implying it matters.
+		return p.theme.Dim.Render(fmt.Sprintf("(rev=0 %s)", dir))
+	}
+	return p.theme.Dim.Render(fmt.Sprintf("(rev=%d %s %s)", p.opts.NRev, dir, branch))
+}
+
+// renderOptionsPanel draws the open transfer-options sub-menu. Keys
+// are listed inline; the active values are highlighted.
+func (p *Porkchop) renderOptionsPanel() string {
+	dir := "prograde"
+	if p.opts.Retrograde {
+		dir = "retrograde"
+	}
+	branch := "short"
+	if p.opts.LongBranch {
+		branch = "long"
+	}
+	var sb strings.Builder
+	sb.WriteString(p.theme.Warning.Render("transfer options"))
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("  [n] revs:      %d (0–%d)\n", p.opts.NRev, porkchopMaxNRev))
+	sb.WriteString(fmt.Sprintf("  [r] direction: %s\n", dir))
+	if p.opts.NRev == 0 {
+		sb.WriteString(p.theme.Dim.Render("  [b] branch:    n/a (only one branch at rev=0)") + "\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("  [b] branch:    %s\n", branch))
+	}
+	return sb.String()
 }
 
 // porkchopLegendRamp is the intensity ramp from cheapest (left) to

--- a/internal/tui/screens/porkchop_test.go
+++ b/internal/tui/screens/porkchop_test.go
@@ -20,6 +20,7 @@ func TestPorkchopLoadAndRender(t *testing.T) {
 		Footer:  lipgloss.NewStyle(),
 		Warning: lipgloss.NewStyle(),
 		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
 	}
 	p := NewPorkchop(th)
 	w, err := sim.NewWorld()
@@ -74,5 +75,74 @@ func TestPorkchopHandleKeyCursorBounds(t *testing.T) {
 	p.HandleKey(rightKey)
 	if p.selDep != 1 {
 		t.Errorf("right at right edge should clamp: selDep=%d, want 1", p.selDep)
+	}
+}
+
+// TestPorkchopOptionsSubmenu: `o` opens the transfer-options sub-menu;
+// n/r/b inside flip nRev / retrograde / longBranch; enter/o/esc closes
+// the menu. Verifies key dispatch + visible state changes; does not
+// re-solve the grid (no world).
+func TestPorkchopOptionsSubmenu(t *testing.T) {
+	p := NewPorkchop(Theme{Dim: lipgloss.NewStyle(), Warning: lipgloss.NewStyle()})
+	p.depDays = []float64{0}
+	p.tofDays = []float64{100}
+	p.grid = [][]float64{{1000}}
+
+	key := func(s string) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+	p.HandleKey(key("o"))
+	if !p.optsOpen {
+		t.Fatal("`o` should open the options sub-menu")
+	}
+	p.HandleKey(key("n"))
+	if p.opts.NRev != 1 {
+		t.Errorf("`n` did not advance NRev: got %d, want 1", p.opts.NRev)
+	}
+	p.HandleKey(key("r"))
+	if !p.opts.Retrograde {
+		t.Error("`r` did not toggle Retrograde on")
+	}
+	p.HandleKey(key("b"))
+	if !p.opts.LongBranch {
+		t.Error("`b` did not toggle LongBranch on")
+	}
+	// nRev wraps: 1 → 2 → 3 → 0.
+	for i := 0; i < porkchopMaxNRev; i++ {
+		p.HandleKey(key("n"))
+	}
+	if p.opts.NRev != 0 {
+		t.Errorf("nRev did not wrap back to 0 at %d cycles past 0: got %d", porkchopMaxNRev, p.opts.NRev)
+	}
+	// `o` closes the menu (and would re-solve the grid if world were set).
+	p.HandleKey(key("o"))
+	if p.optsOpen {
+		t.Error("`o` should close the options sub-menu")
+	}
+}
+
+// TestPorkchopPendingPlantCarriesOptions: a plant from within the
+// options-driven state surfaces those options to the caller so
+// PlanTransferAt uses the same Lambert params the cell was scored at.
+func TestPorkchopPendingPlantCarriesOptions(t *testing.T) {
+	p := NewPorkchop(Theme{Warning: lipgloss.NewStyle()})
+	p.depDays = []float64{0}
+	p.tofDays = []float64{200}
+	p.grid = [][]float64{{1500}}
+	p.opts = sim.TransferOptions{NRev: 2, Retrograde: true, LongBranch: true}
+	p.targetIdx = 4
+
+	enterKey := tea.KeyMsg{Type: tea.KeyEnter}
+	if _, done := p.HandleKey(enterKey); !done {
+		t.Fatal("Enter on a feasible cell should signal done=true")
+	}
+	tgt, depD, tofD, opts, ok := p.PendingPlant()
+	if !ok {
+		t.Fatal("PendingPlant ok=false after Enter on feasible cell")
+	}
+	if tgt != 4 || depD != 0 || tofD != 200 {
+		t.Errorf("plant target/cell mismatch: tgt=%d dep=%v tof=%v", tgt, depD, tofD)
+	}
+	if opts.NRev != 2 || !opts.Retrograde || !opts.LongBranch {
+		t.Errorf("plant did not carry opts forward: got %+v", opts)
 	}
 }


### PR DESCRIPTION
## Summary

- **Lambert solver — short/long branch.** `LambertSolveRev` gains `longBranch bool` (trailing arg). For nRev ≥ 1 the F(z)=0 equation has two roots flanking the minimum-energy critical z; the seed + Newton-bracket clamp selects the short-TOF (legacy, byte-identical) or long-TOF root. nRev=0 ignores the flag.
- **Porkchop UI — transfer-options sub-menu.** New `o` key opens an in-screen options panel; `n` cycles nRev (0→3 wrap), `r` toggles retrograde, `b` toggles short/long branch. TOF axis auto-scales to `[100, 400]·(nRev+1)` days so multi-rev cells live in a sensible window. Title shows the active options (`rev=N direction branch`) so the grid's scoring is always visible.
- **Plumbing.** New `sim.TransferOptions{NRev, Retrograde, LongBranch}` carries the trio through `World.PorkchopGrid` / `World.PlanTransferAt`; `PendingPlant()` surfaces the active options so the planted Δv matches the cell's scored Δv.
- **Plan fold-in (60ddbb8).** Mirrors the channel-approved v0.10.6 perspective tilt + v0.10.7 launch-anchor design into `docs/v0.10-plan.md` with the lock-break paragraph and full slice sections. Plan-of-record only; no code change.

## Test plan

- [x] `go vet ./...` green
- [x] `go test ./... -race -count=1` green
- [x] New planner tests: `TestLambertMultiRevShortLongBranches` (short/long return distinct, both physically valid via Verlet round-trip), `TestLambertSolveLongBranchIgnoredForN0` (flag is a no-op at single-rev)
- [x] New porkchop-screen tests: `TestPorkchopOptionsSubmenu` (sub-menu open/close + n/r/b toggles + nRev wrap), `TestPorkchopPendingPlantCarriesOptions` (plant surfaces the active options)
- [x] Existing porkchop + `PlanTransferAt` tests stay green (zero-value `TransferOptions` is the legacy code path)
- [ ] Playtest: pick an Earth→Mars window, open options, cycle through nRev=1/2/3 short and long branches, plant from a non-default cell — confirm the planted node's Δv matches the cell readout

🤖 Generated with [Claude Code](https://claude.com/claude-code)