### PR TITLE
v0.10.6 — perspective tilt for orbit view + far-side dashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `+` / `-` | Zoom in / out |
 | `f` / `F` | Cycle camera focus forward / backward (system → bodies → craft) |
 | `g` | Reset camera focus to system |
-| `v` | Cycle view (top → right → bottom → left → orbit-flat) |
+| `v` | Cycle view (tilted → top → right → bottom → left → orbit-flat). `tilted` (v0.10.6+) is the new default — perspective tilt over the active craft's perifocal basis, with far-side orbit arcs rendered as same-hue stipple for depth read |
+| `shift+↑` / `shift+↓` | While in `ViewTilted`, nudge the polar tilt θ ±5° (clamped 0–60°). HUD shows `view: tilted Nº` when off the 25° default. No-op in cardinal / orbit-flat modes (v0.10.6+) |
 | `n` | Open spawn form (loadout / position / parent body / altitude / direction). Pick **Custom…** for the v0.10.1+ stack builder: on the STACK field, `←/→` picks a catalog part, `a` adds it on top, `x` removes the top stage |
 | `H` | Auto-plant Hohmann transfer to `World.Target` body (intra-primary for moons of the craft's parent; moon → parent escape via bound transfer ellipse). TargetCraft flashes "needs v0.9.3" |
 | `I` | Plant inclination match — rotates the orbital plane to `World.Target` body's inclination (or 0° equatorial when target is None). TargetCraft flashes "needs v0.9.3" |

--- a/docs/v0.10-plan.md
+++ b/docs/v0.10-plan.md
@@ -52,7 +52,7 @@ per macbotm5's review notes. No further fold-ins this cycle.
 | v0.10.3 | **in progress** | — | Predictor adaptive sampling (M) — three-cycle carry-over; foundation shipped v0.8.4. **Scope committed 2026-05-22** (branch `v0.10.3-predictor-sampling`). See slice below. |
 | v0.10.4 | **in progress** | — | Inclination-burn true plane change (M) — `I` was a pure orbit-normal burn that over-sped the craft and left the orbit eccentric. **Scope committed 2026-05-22** (branch `v0.10.4-inclination-burn`), playtest-triggered. See slice below. |
 | v0.10.5 | **in progress** | — | Multi-rev porkchop UI + Lambert short/long picker (S) — library-ready; useful post-staging. **Scope committed 2026-05-22** (branch `v0.10.5-porkchop`). See slice below. |
-| v0.10.6 | **designed** | — | Perspective tilt for orbit view (M, render+sim) — `ViewTilted` + far-side dashing + HUD readout. **Scope committed 2026-05-23** (lock-break approved in-channel via lighting-amortization framing; no branch yet). See slice below. |
+| v0.10.6 | **shipped** | `v0.10.6` | Perspective tilt for orbit view (M, render+sim) — `ViewTilted` + far-side dashing + tilted-world-basis fallback + ColorBodyOrbit + shift+↑/↓ θ controls. Shipped 2026-05-23 (branch `v0.10.6-perspective` → `main`, tag `v0.10.6`); grilled spec in this doc captures the deltas vs the original design pass. See slice below. |
 | v0.10.7 | **designed** | — | Launch-anchor for `ViewTilted` (S, sim+render) — yaw-lock to local-vertical when in-atmosphere or `alt < 100 km`, guarded behind `ViewMode == ViewTilted`. Depends on v0.10.6 shipping. **Scope committed 2026-05-23**. See slice below. |
 
 ## Locked decisions
@@ -604,7 +604,7 @@ ready for tag/merge once playtested.
 
 ### v0.10.6 — perspective tilt for orbit view
 
-<!-- llm-parse: slice=v0.10.6 weight=M scope=render+sim status=designed fold-in=2026-05-23 design=tsp-v0.10.6-perspective-v2.md -->
+<!-- llm-parse: slice=v0.10.6 weight=M scope=render+sim status=shipped tag=v0.10.6 fold-in=2026-05-23 design=tsp-v0.10.6-perspective-v2.md -->
 
 **Scope committed 2026-05-23 — lock-break fold-in.** All five
 existing view modes are axis-aligned orthographic (`Top` / `Right` /
@@ -707,7 +707,27 @@ grill), φ controls deferred (vessel-icon observation made the
 yaw keymap underspecified), HUD format simplified to `tilted Nº`
 without the `/φ` segment.
 
-### v0.10.7 — launch-anchor for `ViewTilted`
+**Built / Shipped (2026-05-23, branch `v0.10.6-perspective`).**
+Implemented exactly as the grilled spec above; `go vet ./...` +
+`go test ./... -race -count=1` green. 591-line diff across 12
+files. New helpers: `widgets.TiltedWorldBasis(θ, φ)` +
+`widgets.TiltedPerifocalBasis(el, θ, φ)` (canvas.go); identity
+rotations collapse to `DefaultBasis()` / `PerifocalBasis(el)`
+verbatim so existing tests stay byte-identical. New
+`widgets.DrawEllipseOffsetFarSideDashed` replaces
+`DrawEllipseOffsetOccluded` at lines 582 / 704 of orbit.go and
+`DrawEllipseDotted` at line 345 (body orbits). New
+`render.ColorBodyOrbit = "#6E6E6E"` with palette doc-comment
+capturing the same-hue stipple convention. New
+`sim.ViewTilt{Theta, Phi}` + `sim.DefaultViewTilt()` (25°/0°) +
+`sim.NudgeViewTiltTheta(±5°)` clamped to [0°, 60°]. New
+`screens.activeCraftElements` shared by ViewTilted's perifocal-
+vs-world fallback and ViewOrbitFlat's perifocal-vs-DefaultBasis
+fallback. Tests added in sim (defaults, clamp, cycle order),
+widgets (basis identity / tilt / orthonormality, far-side
+stipple ratio), and screens (default render label, off-default
+HUD degrees, Landed fallback). Help + README mirror shift+↑/↓.
+Slice ready for tag/merge.
 
 <!-- llm-parse: slice=v0.10.7 weight=S scope=sim+render status=designed depends-on=v0.10.6 fold-in=2026-05-23 -->
 

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -17,12 +17,24 @@ import (
 // UI tier colors — used for non-body UI elements that need consistent
 // semantic colors across screens. Independent of the body palette so
 // editing one doesn't shift the other.
+//
+// Far-side rendering convention (v0.10.6+): the orbit-trace draw path
+// renders the far-side arc (depth < 0 relative to the orbit's
+// primary, under the canvas's active basis) at stride*2 stipple in
+// the **same hue** as the near-side arc. Terminals can't do alpha,
+// so per-sample stride flips are the lossless equivalent of KSP's
+// dim-the-back-arc rendering. Callers don't pick a separate "back"
+// colour; the canvas helper (DrawEllipseOffsetFarSideDashed) handles
+// it automatically. ColorBodyOrbit is the one new entry the
+// convention surfaced — body orbits had no dedicated colour before
+// v0.10.6, defaulting to whatever Plot wrote (terminal default).
 var (
 	ColorAlert        = lipgloss.Color("#FF5F5F") // hard errors, peri-below-surface
 	ColorWarning      = lipgloss.Color("#FFAF00") // warp clamps, near-collision
 	ColorPlannedNode  = lipgloss.Color("#5FD7FF") // maneuver-node markers
 	ColorTrajectory   = lipgloss.Color("#FFFFFF") // fallback trajectory preview
 	ColorCurrentOrbit = lipgloss.Color("#A8B8C8") // craft's live Keplerian ellipse — pale slate, distinct from any body palette and from maneuver-leg colors
+	ColorBodyOrbit    = lipgloss.Color("#6E6E6E") // heliocentric body orbits — dim grey backdrop (KSP-aligned: body orbits are quiet so craft / maneuver layers pop). v0.10.6+
 	ColorCraftMarker  = lipgloss.Color("#FFD93D") // craft icon when zoomed out (orbit too small to render) — saturated yellow distinct from Sun gold-white, amber leg, and every body color
 	ColorForeignSOI   = lipgloss.Color("#D75FFF") // post-SOI-crossing trajectory segments
 	ColorDim          = lipgloss.Color("#5F5F5F") // background / inactive

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -5,18 +5,29 @@ package sim
 // and the maneuver-planner mini-canvas share the same camera angle
 // without per-screen coordination.
 //
-// Five modes: four hard-coded cardinal views (Top, Right, Bottom,
-// Left) plus the orbit-flat view that projects onto the active
-// craft's orbit plane regardless of inclination. Cycle order rolls
-// from Top through the cardinals and ends on orbit-flat before
-// wrapping.
+// Six modes: the v0.10.6 perspective-tilt view (the new zero-value
+// default), four hard-coded cardinal views (Top, Right, Bottom,
+// Left), plus the orbit-flat view that projects onto the active
+// craft's orbit plane regardless of inclination. Cycle order opens
+// on the tilted projection, walks through the cardinals, and ends
+// on orbit-flat as punctuation before wrapping.
 type ViewMode int
 
 const (
+	// ViewTilted (v0.10.6+) renders the active craft's perifocal basis
+	// with a polar tilt θ + yaw φ (sourced from World.ViewTilt). When
+	// the active craft has no valid orbit (Landed / hyperbolic /
+	// degenerate / no craft) the basis falls back to a tilted world-
+	// axis basis so the depth cue stays alive on the pad. Prepended
+	// to the cycle so it is the iota zero-value — a freshly spawned
+	// World opens here, replacing pre-v0.10.6's ViewTop default. No
+	// save migration: ViewMode is a per-session UI preference, not
+	// persisted (world.go:60-70).
+	ViewTilted ViewMode = iota
 	// ViewTop is the pre-v0.6.4 default: drop world Z, project onto
 	// world (X, Y). Equatorial orbits read as ellipses; inclined
-	// orbits foreshorten. Zero-value preserves backwards behaviour.
-	ViewTop ViewMode = iota
+	// orbits foreshorten.
+	ViewTop
 	// ViewRight looks at the system from world +X toward origin:
 	// canvas X+ = world Y+, canvas Y+ = world Z+. An equatorial
 	// orbit appears edge-on as a horizontal line passing through
@@ -45,6 +56,8 @@ const (
 // String returns a short human label for the view mode.
 func (m ViewMode) String() string {
 	switch m {
+	case ViewTilted:
+		return "tilted"
 	case ViewTop:
 		return "top"
 	case ViewRight:
@@ -60,10 +73,12 @@ func (m ViewMode) String() string {
 }
 
 // AllViewModes enumerates the modes in canonical cycle order.
-// Top → Right → Bottom → Left → OrbitFlat → Top — cardinal cameras
-// first (each rotates 90° around the system), then the orbit-plane
-// projection as a punctuation mark.
+// Tilted → Top → Right → Bottom → Left → OrbitFlat → Tilted —
+// the v0.10.6+ tilt opens the cycle as the new zero-value default,
+// the four cardinal cameras follow (each rotates 90° around the
+// system), and orbit-flat lands last as punctuation before wrapping.
 var AllViewModes = [...]ViewMode{
+	ViewTilted,
 	ViewTop,
 	ViewRight,
 	ViewBottom,
@@ -75,4 +90,49 @@ var AllViewModes = [...]ViewMode{
 // Wraps around — modes are a small finite set.
 func (w *World) CycleViewMode() {
 	w.ViewMode = (w.ViewMode + 1) % ViewMode(len(AllViewModes))
+}
+
+// ViewTilt holds the polar tilt θ and yaw φ (degrees) that
+// ViewTilted applies to the projection basis. v0.10.6+. Per-session
+// UI state — not persisted to save (same convention as ViewMode and
+// InstantSAS). Theta is player-tunable via shift+up / shift+down at
+// the orbit screen; Phi is reserved for v0.10.7's launch-anchor
+// (player controls deferred to a post-ship playtest signal).
+type ViewTilt struct {
+	Theta float64
+	Phi   float64
+}
+
+// DefaultViewTilt returns the starting (Theta, Phi) for a freshly
+// constructed World. 25° polar tilt, 0° yaw — KSP defaults to ~30°
+// but the terminal canvas's 2:4 braille aspect makes foreshortening
+// read stronger than a graphical UI, so a touch less keeps inclined
+// orbits from looking squashed. Tune in flight (shift+up / shift+down).
+func DefaultViewTilt() ViewTilt {
+	return ViewTilt{Theta: 25, Phi: 0}
+}
+
+// ViewTiltThetaMinDeg / ViewTiltThetaMaxDeg clamp the player's
+// shift+up / shift+down nudges. 0° collapses the tilt back to the
+// world-axis ViewTop projection (identity rotation); 60° pushes
+// foreshortening to where the orbit ellipse starts to read as a
+// horizontal cigar. Step is 5° per press.
+const (
+	ViewTiltThetaMinDeg = 0.0
+	ViewTiltThetaMaxDeg = 60.0
+	ViewTiltThetaStep   = 5.0
+)
+
+// NudgeViewTiltTheta adds delta degrees to ViewTilt.Theta and clamps
+// to [ViewTiltThetaMinDeg, ViewTiltThetaMaxDeg]. v0.10.6+. Returns
+// the resulting Theta so the caller can stamp it into a status flash.
+func (w *World) NudgeViewTiltTheta(deltaDeg float64) float64 {
+	w.ViewTilt.Theta += deltaDeg
+	if w.ViewTilt.Theta < ViewTiltThetaMinDeg {
+		w.ViewTilt.Theta = ViewTiltThetaMinDeg
+	}
+	if w.ViewTilt.Theta > ViewTiltThetaMaxDeg {
+		w.ViewTilt.Theta = ViewTiltThetaMaxDeg
+	}
+	return w.ViewTilt.Theta
 }

--- a/internal/sim/view_test.go
+++ b/internal/sim/view_test.go
@@ -2,15 +2,17 @@ package sim
 
 import "testing"
 
-// TestCycleViewModeWraps: starts at the zero-value (ViewTop),
-// cycles forward through Top → Right → Bottom → Left → OrbitFlat →
-// Top in canonical order. v0.6.4+.
+// TestCycleViewModeWraps: starts at the zero-value (ViewTilted,
+// v0.10.6+) and cycles forward through Tilted → Top → Right →
+// Bottom → Left → OrbitFlat → Tilted in canonical order. The
+// pre-v0.10.6 zero-value was ViewTop; the new prepend makes
+// freshly-spawned worlds open on the perspective-tilt view.
 func TestCycleViewModeWraps(t *testing.T) {
 	w := mustWorld(t)
-	if w.ViewMode != ViewTop {
-		t.Fatalf("default ViewMode = %v, want ViewTop", w.ViewMode)
+	if w.ViewMode != ViewTilted {
+		t.Fatalf("default ViewMode = %v, want ViewTilted", w.ViewMode)
 	}
-	want := []ViewMode{ViewRight, ViewBottom, ViewLeft, ViewOrbitFlat, ViewTop}
+	want := []ViewMode{ViewTop, ViewRight, ViewBottom, ViewLeft, ViewOrbitFlat, ViewTilted}
 	for i, expect := range want {
 		w.CycleViewMode()
 		if w.ViewMode != expect {
@@ -33,5 +35,48 @@ func TestViewModeStringDistinct(t *testing.T) {
 			t.Errorf("duplicate label %q", s)
 		}
 		seen[s] = true
+	}
+}
+
+// TestDefaultViewTiltMatchesGrilledSpec (v0.10.6+): the freshly
+// constructed World opens at θ=25°, φ=0 — the values the
+// design pass and the grilled spec committed to. Bumping these
+// defaults is a player-visible behaviour change and should require
+// updating this test deliberately.
+func TestDefaultViewTiltMatchesGrilledSpec(t *testing.T) {
+	w := mustWorld(t)
+	if w.ViewTilt.Theta != 25 {
+		t.Errorf("Theta = %v, want 25", w.ViewTilt.Theta)
+	}
+	if w.ViewTilt.Phi != 0 {
+		t.Errorf("Phi = %v, want 0", w.ViewTilt.Phi)
+	}
+	if w.ViewMode != ViewTilted {
+		t.Errorf("ViewMode = %v, want ViewTilted (the new zero-value default)", w.ViewMode)
+	}
+}
+
+// TestNudgeViewTiltThetaClamps (v0.10.6+): shift+↑/↓ keys come in
+// as ±5° nudges through NudgeViewTiltTheta; the clamp must keep
+// Theta inside [ViewTiltThetaMinDeg, ViewTiltThetaMaxDeg] so a
+// stuck-key spam can't drive the basis into a degenerate state.
+func TestNudgeViewTiltThetaClamps(t *testing.T) {
+	w := mustWorld(t)
+	for i := 0; i < 30; i++ {
+		w.NudgeViewTiltTheta(ViewTiltThetaStep)
+	}
+	if w.ViewTilt.Theta != ViewTiltThetaMaxDeg {
+		t.Errorf("after spam up: Theta = %v, want %v", w.ViewTilt.Theta, ViewTiltThetaMaxDeg)
+	}
+	for i := 0; i < 30; i++ {
+		w.NudgeViewTiltTheta(-ViewTiltThetaStep)
+	}
+	if w.ViewTilt.Theta != ViewTiltThetaMinDeg {
+		t.Errorf("after spam down: Theta = %v, want %v", w.ViewTilt.Theta, ViewTiltThetaMinDeg)
+	}
+	// Round-trip in the middle of the range — no clamp should fire.
+	w.NudgeViewTiltTheta(ViewTiltThetaStep * 4) // 0 → 20
+	if got := w.NudgeViewTiltTheta(ViewTiltThetaStep); got != 25 {
+		t.Errorf("Theta = %v, want 25 (in-range nudge)", got)
 	}
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -57,11 +57,19 @@ type World struct {
 	// dropped. v0.9.3+.
 	NavMode NavMode
 
-	// ViewMode selects the canvas projection basis. v0.6.4+. Zero
-	// value (ViewEquatorial) matches the pre-v0.6.4 (X, Y)-drop
-	// projection. Set per-session via the `v` hot-key; not persisted
-	// to save (UI preference, not game state).
+	// ViewMode selects the canvas projection basis. v0.6.4+; v0.10.6+
+	// prepended ViewTilted as the new zero-value default. Set per-
+	// session via the `v` hot-key; not persisted to save (UI
+	// preference, not game state).
 	ViewMode ViewMode
+
+	// ViewTilt carries the polar tilt θ and yaw φ (degrees) that
+	// ViewTilted applies to the projection basis. v0.10.6+. Per-
+	// session UI state — not persisted. NewWorld seeds defaults via
+	// DefaultViewTilt(); struct-literal Worlds (test fixtures) get
+	// the {0, 0} zero value, which evaluates to an identity rotation
+	// and therefore behaves the same as ViewTop.
+	ViewTilt ViewTilt
 
 	// InstantSAS opts back into the legacy instantaneous-attitude
 	// path. v0.10.0+ makes rate-limited slew the DEFAULT (zero value
@@ -163,6 +171,7 @@ func NewWorld() (*World, error) {
 		Systems:   systems,
 		SystemIdx: 0,
 		Clock:     NewClock(bodies.J2000, 50*time.Millisecond),
+		ViewTilt:  DefaultViewTilt(),
 	}
 	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -722,6 +722,22 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
+		case key.Matches(m, a.keys.TiltUp), key.Matches(m, a.keys.TiltDown):
+			// v0.10.6+: nudge ViewTilted's polar tilt θ ±5°. No-op when
+			// the active projection isn't ViewTilted — keep the binding
+			// silent on cardinals / orbit-flat so a stray shift+arrow
+			// while in ViewTop doesn't blast a misleading flash.
+			if a.world.ViewMode != sim.ViewTilted {
+				return a, nil
+			}
+			delta := sim.ViewTiltThetaStep
+			if key.Matches(m, a.keys.TiltDown) {
+				delta = -sim.ViewTiltThetaStep
+			}
+			theta := a.world.NudgeViewTiltTheta(delta)
+			a.statusMsg = fmt.Sprintf("view: tilted %g°", theta)
+			a.statusExpires = time.Now().Add(1500 * time.Millisecond)
+			return a, nil
 		}
 	}
 	return a, nil

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -147,6 +147,17 @@ type Keymap struct {
 	// w/s/a/d/q/e attitude cluster); the toggle is a session UI
 	// preference and is not persisted.
 	ToggleInstantSAS key.Binding
+
+	// TiltUp / TiltDown (v0.10.6+): nudge World.ViewTilt.Theta ±5°
+	// while ViewMode == ViewTilted. Per-press step + clamp lives in
+	// sim.World.NudgeViewTiltTheta. Bound to shift+↑ / shift+↓ —
+	// arrow keys don't have an uppercase form, so the explicit
+	// modifier syntax is required (W/S used capitals for letter-key
+	// shifts). Yaw φ controls are deliberately deferred to a post-
+	// ship playtest signal; the vessel is a single icon, so yaw
+	// isn't visually load-bearing the way tilt is.
+	TiltUp   key.Binding
+	TiltDown key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -213,5 +224,7 @@ func DefaultKeymap() Keymap {
 		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -10° west")),
 		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
 		ToggleInstantSAS:          key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "SAS model: slew / instant (MANUAL/AUTO)")),
+		TiltUp:                    key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+↑", "tilt +5° (ViewTilted)")),
+		TiltDown:                  key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+↓", "tilt -5° (ViewTilted)")),
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -33,7 +33,8 @@ func (h *Help) Render() string {
 			{"f", "next focus target"},
 			{"F", "previous focus target"},
 			{"g", "reset to system-wide view"},
-			{"v", "cycle view (top / right / bottom / left / orbit-flat)"},
+			{"v", "cycle view (tilted / top / right / bottom / left / orbit-flat)"},
+			{"shift+↑ / shift+↓", "tilt +5° / -5° (ViewTilted only, v0.10.6+)"},
 		}},
 		{"TIME", [][2]string{
 			{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -336,13 +336,19 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	v.canvas.Center(center)
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
+	// v0.10.6+: far-side arc renders at stride*2 (visually dashed) in
+	// the dedicated dim-grey ColorBodyOrbit — KSP-aligned quiet
+	// backdrop. bodyPxR=0 skips disk occlusion; the system primary at
+	// origin doesn't meaningfully occlude body orbits at heliocentric
+	// zoom. Pre-v0.10.6 this was a flat DrawEllipseDotted with no
+	// depth read.
 	for i := range sys.Bodies {
 		b := sys.Bodies[i]
 		if b.SemimajorAxis == 0 {
 			continue
 		}
 		el := orbital.ElementsFromBody(b)
-		v.canvas.DrawEllipseDotted(el, 360, 6)
+		v.canvas.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 6, orbital.Vec3{}, 0, render.ColorBodyOrbit)
 	}
 
 	// Plot each body at its perceived-size disk. System primary (index 0)
@@ -579,7 +585,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// same check.
 		primaryPxR := BodyPixelRadius(c.Primary, false, scale, canvasReach)
 		if orbitVisible {
-			v.canvas.DrawEllipseOffsetOccluded(el, primaryPos, 360, 3, primaryPos, primaryPxR, render.ColorCurrentOrbit)
+			v.canvas.DrawEllipseOffsetFarSideDashed(el, primaryPos, 360, 3, primaryPos, primaryPxR, render.ColorCurrentOrbit)
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 			if !v.canvas.IsBehindBody(peri, primaryPos, primaryPxR) {
@@ -701,7 +707,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				if isTarget {
 					stride = 3
 				}
-				v.canvas.DrawEllipseOffsetOccluded(otherEl, otherPrimaryPos, 180, stride, otherPrimaryPos, otherPxR, otherColor)
+				v.canvas.DrawEllipseOffsetFarSideDashed(otherEl, otherPrimaryPos, 180, stride, otherPrimaryPos, otherPxR, otherColor)
 			}
 			if !v.canvas.IsBehindBody(otherInertial, otherPrimaryPos, otherPxR) {
 				v.canvas.PlotColored(otherInertial, otherColor)
@@ -727,6 +733,15 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// v0.9.6-polish moved it left so it no longer sits under the
 	// bottom-right navball panel.
 	viewLabel := "view: " + w.ViewMode.String()
+	if w.ViewMode == sim.ViewTilted && w.ViewTilt.Theta != sim.DefaultViewTilt().Theta {
+		// v0.10.6+: surface θ in degrees when the player has nudged it
+		// off the default via shift+↑/↓. Plain "view: tilted" stays
+		// the at-default form; "view: tilted 30°" cues that the value
+		// is non-default (useful when triaging player reports of
+		// "the angle is wrong"). The /anchor suffix is reserved for
+		// v0.10.7's launch-anchor.
+		viewLabel = fmt.Sprintf("view: tilted %g°", w.ViewTilt.Theta)
+	}
 	v.canvas.SetCellLabel(0, v.canvas.Rows()-1, viewLabel)
 	// v0.10.3+: focus indicator overlaid into the canvas's top-left
 	// corner (was a HUD block alongside CLOCK). Pairs visually with
@@ -982,11 +997,15 @@ func (v *OrbitView) cameraDirForView(view sim.ViewMode) render.Vec3 {
 		return render.CameraDirRight
 	case sim.ViewLeft:
 		return render.CameraDirLeft
-	case sim.ViewOrbitFlat:
+	case sim.ViewTilted, sim.ViewOrbitFlat:
 		// Depth axis points out of screen toward the camera, which
 		// is exactly the body-to-camera direction the sub-observer
-		// math wants. For a craft on a near-equatorial orbit this is
-		// approximately +Z; for inclined orbits it tips accordingly.
+		// math wants. For ViewOrbitFlat on a near-equatorial orbit
+		// this is approximately +Z; for inclined orbits it tips
+		// accordingly. ViewTilted (v0.10.6+) feeds through the same
+		// path because viewBasis has already encoded the θ/φ tilt
+		// into the canvas basis — the texture pipeline just reads
+		// whatever depth axis came out.
 		d := v.canvas.Basis().DepthAxis()
 		return render.Vec3{X: d.X, Y: d.Y, Z: d.Z}
 	}
@@ -2155,17 +2174,27 @@ func normalizeDeg(d float64) float64 {
 }
 
 // viewBasis returns the canvas projection basis for the world's
-// current ViewMode. Four cardinal cases — Top (XY drop), Right (YZ),
-// Bottom (XY mirrored), Left (YZ mirrored) — plus orbit-flat, which
-// projects onto the active craft's orbit plane via the perifocal
-// (x̂, ŷ) basis so the orbit reads as a clean ellipse regardless of
-// inclination. Falls back to Top's basis when the orbit is degenerate
-// (no craft, e ≥ 1, a ≤ 0).
+// current ViewMode. Six cases — ViewTilted (v0.10.6+ default;
+// perifocal tilt with TiltedWorldBasis fallback), four cardinals
+// (Top XY-drop, Right YZ, Bottom XY mirrored, Left YZ mirrored),
+// and orbit-flat (perifocal x̂/ŷ for a clean ellipse regardless
+// of inclination). Orbit-flat falls back to Top's basis when the
+// orbit is degenerate (no craft, Landed, e ≥ 1, a ≤ 0); ViewTilted
+// falls back to TiltedWorldBasis in the same cases so the depth
+// cue stays alive on the pad.
 //
 // Single-craft today; multi-craft will need an active-craft selector
 // to disambiguate "the active orbit" (state-of-game.md §2 backlog).
 func viewBasis(w *sim.World) widgets.Basis {
 	switch w.ViewMode {
+	case sim.ViewTilted:
+		thetaRad := w.ViewTilt.Theta * math.Pi / 180
+		phiRad := w.ViewTilt.Phi * math.Pi / 180
+		el, ok := activeCraftElements(w)
+		if !ok {
+			return widgets.TiltedWorldBasis(thetaRad, phiRad)
+		}
+		return widgets.TiltedPerifocalBasis(el, thetaRad, phiRad)
 	case sim.ViewRight:
 		return widgets.Basis{
 			X: orbital.Vec3{Y: 1},
@@ -2182,30 +2211,40 @@ func viewBasis(w *sim.World) widgets.Basis {
 			Y: orbital.Vec3{Z: 1},
 		}
 	case sim.ViewOrbitFlat:
-		if w.ActiveCraft() == nil {
-			return widgets.DefaultBasis()
-		}
-		// v0.9.2+: a Landed craft co-rotates with the body, so its
-		// (r, v) gives an orbit plane that also co-rotates. Using
-		// that as the canvas's orbit-flat basis would lock the
-		// camera to the body and hide its rotation entirely (the
-		// body's surface texture appears frozen). Fall back to the
-		// top-view basis for parked crafts so the player can see
-		// Earth turning under them. Once they engage the engine
-		// (Landed → false) the live orbit picks up.
-		if w.ActiveCraft().Landed {
-			return widgets.DefaultBasis()
-		}
-		mu := w.ActiveCraft().Primary.GravitationalParameter()
-		if mu <= 0 {
-			return widgets.DefaultBasis()
-		}
-		el := orbital.ElementsFromState(w.ActiveCraft().State.R, w.ActiveCraft().State.V, mu)
-		if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		el, ok := activeCraftElements(w)
+		if !ok {
 			return widgets.DefaultBasis()
 		}
 		xHat, yHat := orbital.PerifocalBasis(el)
 		return widgets.Basis{X: xHat, Y: yHat}
 	}
 	return widgets.DefaultBasis() // ViewTop or any future mode
+}
+
+// activeCraftElements returns the active craft's heliocentric-or-
+// primary-centric Keplerian elements when they're meaningful for
+// basis selection, and ok=false when the perifocal basis is
+// undefined: no active craft, Landed (co-rotating "orbit" would
+// lock the camera to the body and freeze the surface texture),
+// hyperbolic (e ≥ 1), or degenerate (a ≤ 0 / NaN / Inf). Shared by
+// ViewTilted's perifocal-vs-world fallback and ViewOrbitFlat's
+// perifocal-vs-DefaultBasis fallback so both modes apply the same
+// "is the orbit basis usable?" rule. v0.10.6+.
+func activeCraftElements(w *sim.World) (orbital.Elements, bool) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return orbital.Elements{}, false
+	}
+	if c.Landed {
+		return orbital.Elements{}, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return orbital.Elements{}, false
+	}
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	if el.A <= 0 || el.E >= 1 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return orbital.Elements{}, false
+	}
+	return el, true
 }

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -211,6 +211,101 @@ func TestFocusLabelOverlaidOnCanvas(t *testing.T) {
 	}
 }
 
+// TestViewTiltedLandedFallback (v0.10.6+): when the active craft
+// is Landed (Launchpad spawn, pre-ignition) the perifocal basis is
+// undefined — co-rotating "(r, v)" describes a body-fixed point,
+// not a meaningful orbit. ViewTilted must route through the
+// TiltedWorldBasis fallback rather than crashing or defaulting to
+// flat ViewTop; otherwise the headline feature dies on the pad,
+// which is the very view where the planet looms largest and the
+// depth cue matters most. activeCraftElements is the shared gate.
+func TestViewTiltedLandedFallback(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected starter craft")
+	}
+	c.Landed = true
+	if _, ok := activeCraftElements(w); ok {
+		t.Errorf("activeCraftElements should report ok=false for a Landed craft (forces TiltedWorldBasis fallback)")
+	}
+	// And confirm the render path doesn't panic in this state.
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	v.Resize(120, 40)
+	out := v.Render(w, 0, 120, 40)
+	if !strings.Contains(out, "view: tilted") {
+		t.Errorf("Landed + ViewTilted should still render the tilted label; render:\n%s", out)
+	}
+}
+
+// TestViewTiltedIsDefaultRenderedLabel (v0.10.6+): a freshly
+// constructed World opens in ViewTilted, so the bottom-left view
+// label reads "view: tilted" at the spec'd 25° default (no
+// degrees segment until θ is nudged off-default).
+func TestViewTiltedIsDefaultRenderedLabel(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	v.Resize(160, 40)
+	out := v.Render(w, 0, 160, 40)
+	if !strings.Contains(out, "view: tilted") {
+		t.Errorf("expected `view: tilted` overlay (default ViewTilted, 25°); render:\n%s", out)
+	}
+	if strings.Contains(out, "view: tilted 25°") {
+		t.Errorf("at-default tilt should drop the degrees segment, got literal 25°; render:\n%s", out)
+	}
+}
+
+// TestViewTiltedHUDDegreesAfterNudge (v0.10.6+): nudging θ off the
+// 25° default surfaces the degrees segment in the HUD label —
+// "view: tilted 30°". Catches a regression where the off-default
+// branch fails to fire (sloppy float comparison).
+func TestViewTiltedHUDDegreesAfterNudge(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NudgeViewTiltTheta(sim.ViewTiltThetaStep) // 25 → 30
+	v.Resize(160, 40)
+	out := v.Render(w, 0, 160, 40)
+	if !strings.Contains(out, "view: tilted 30°") {
+		t.Errorf("expected `view: tilted 30°` after one shift+↑ nudge; render:\n%s", out)
+	}
+}
+
 // TestOrbitTitleBarButtonHits: after rendering, the title-bar
 // hit-test ranges line up with the right-aligned [Menu] /
 // [Missions] buttons. Pre-render hits return false (col ranges are

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -55,6 +55,42 @@ func DefaultBasis() Basis {
 	}
 }
 
+// TiltedWorldBasis is the v0.10.6 ViewTilted projection when no
+// valid orbit is available (Landed / hyperbolic / degenerate / no
+// craft) — start from DefaultBasis (world X, world Y), yaw φ around
+// world Z, then tilt θ around the yawed X axis. The (θ, φ) inputs
+// are in radians. θ = 0 ∧ φ = 0 returns DefaultBasis verbatim.
+// Keeps the depth cue alive on the pad — a flat DefaultBasis
+// fallback would defeat the headline feature on the very view
+// that needs depth most (planet looming under the rocket).
+func TiltedWorldBasis(thetaRad, phiRad float64) Basis {
+	xHat := orbital.Vec3{X: 1}
+	yHat := orbital.Vec3{Y: 1}
+	zHat := orbital.Vec3{Z: 1}
+	xYaw := orbital.Rotate(xHat, zHat, phiRad)
+	yYaw := orbital.Rotate(yHat, zHat, phiRad)
+	yTilt := orbital.Rotate(yYaw, xYaw, thetaRad)
+	return Basis{X: xYaw, Y: yTilt}
+}
+
+// TiltedPerifocalBasis is the v0.10.6 ViewTilted projection when
+// the active craft has a valid Keplerian orbit — start from
+// PerifocalBasis(el), yaw φ around the orbit normal (x̂ × ŷ), then
+// tilt θ around the yawed x̂ axis. Inputs in radians. θ = 0 ∧
+// φ = 0 collapses to PerifocalBasis verbatim (same as ViewOrbitFlat).
+// θ rotates the camera away from straight-down-on-the-orbit-plane
+// toward looking at it from an angle; the perifocal frame still
+// anchors the basis so an inclined orbit still reads as a clean
+// ellipse, just tilted.
+func TiltedPerifocalBasis(el orbital.Elements, thetaRad, phiRad float64) Basis {
+	xHat, yHat := orbital.PerifocalBasis(el)
+	n := xHat.Cross(yHat)
+	xYaw := orbital.Rotate(xHat, n, phiRad)
+	yYaw := orbital.Rotate(yHat, n, phiRad)
+	yTilt := orbital.Rotate(yYaw, xYaw, thetaRad)
+	return Basis{X: xYaw, Y: yTilt}
+}
+
 // DepthAxis returns the unit vector pointing toward the camera, i.e.
 // "out of screen." Points with positive (world − center)·DepthAxis()
 // are in front of the basis plane through center; negative is
@@ -592,12 +628,84 @@ func (c *Canvas) IsBehindBody(samplePos, bodyPos orbital.Vec3, bodyPxR int) bool
 	return dx*dx+dy*dy <= bodyPxR*bodyPxR
 }
 
+// DrawEllipseOffsetFarSideDashed plots an ellipse with near-side
+// pixels rendered at nearStride (solid stride) and far-side pixels
+// rendered at nearStride*2 (visually dashed) in the same colour.
+// Pixels truly occluded by the body disk — far side AND inside the
+// body's projected pixel radius — are skipped entirely. v0.10.6+.
+//
+// "Far side" is decided by the sign of (p − bodyPos) · DepthAxis()
+// against the canvas's active basis: negative depth is behind the
+// basis plane through bodyPos, positive is in front.
+//
+// Same-hue stippling is the lossless equivalent of KSP's
+// dim-the-back-arc rendering — a terminal canvas can't do alpha,
+// so per-sample stride flips do the depth read instead. The
+// convention is documented in internal/render/palette.go; see
+// ColorBodyOrbit's doc comment for the standard.
+//
+// Pass bodyPxR = 0 to skip the disk-occlusion check (suitable for
+// heliocentric body orbits, where the system primary's disk doesn't
+// meaningfully occlude at default zoom).
+func (c *Canvas) DrawEllipseOffsetFarSideDashed(
+	el orbital.Elements,
+	offset orbital.Vec3,
+	samples int,
+	nearStride int,
+	bodyPos orbital.Vec3,
+	bodyPxR int,
+	color lipgloss.Color,
+) {
+	if samples < 16 {
+		samples = 16
+	}
+	if nearStride < 1 {
+		nearStride = 1
+	}
+	farStride := nearStride * 2
+	depthAxis := c.basis.DepthAxis()
+	for i := 0; i < samples; i++ {
+		nu := 2 * math.Pi * float64(i) / float64(samples)
+		p := offset.Add(orbital.PositionAtTrueAnomaly(el, nu))
+		rel := p.Sub(bodyPos)
+		depth := rel.X*depthAxis.X + rel.Y*depthAxis.Y + rel.Z*depthAxis.Z
+		if depth < 0 {
+			if bodyPxR > 0 {
+				spx, spy, ok := c.Project(p)
+				if ok {
+					bpx, bpy, _ := c.Project(bodyPos)
+					dx := spx - bpx
+					dy := spy - bpy
+					if dx*dx+dy*dy <= bodyPxR*bodyPxR {
+						continue
+					}
+				}
+			}
+			if i%farStride != 0 {
+				continue
+			}
+		} else {
+			if i%nearStride != 0 {
+				continue
+			}
+		}
+		if color == "" {
+			c.Plot(p)
+		} else {
+			c.PlotColored(p, color)
+		}
+	}
+}
+
 // DrawEllipseOffsetOccluded plots a dotted ellipse but skips any
 // sample IsBehindBody-occluded by the supplied (bodyPos, bodyPxR).
 // Same shape as DrawEllipseOffsetDotted; v0.6.4+ side-view variant.
 // Pass an untagged stride to keep the existing colour helpers; this
 // helper writes through PlotColored when `color` is non-empty,
-// otherwise plain Plot.
+// otherwise plain Plot. v0.10.6 supersedes this on the orbit-trace
+// draw path with DrawEllipseOffsetFarSideDashed (renders the back
+// arc dashed instead of skipping); this helper is retained for
+// callers that want strict occlusion without far-side dashing.
 func (c *Canvas) DrawEllipseOffsetOccluded(
 	el orbital.Elements,
 	offset orbital.Vec3,

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -1,6 +1,7 @@
 package widgets
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -446,6 +447,142 @@ func TestDepthAxisCardinalBases(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestTiltedWorldBasisIdentity (v0.10.6+): TiltedWorldBasis(0, 0)
+// must return DefaultBasis verbatim. The struct-literal World zero
+// value gives ViewTilt{0, 0}, and the ViewTilted code path then
+// has to reduce to the pre-v0.10.6 ViewTop projection so existing
+// golden tests stay byte-identical.
+func TestTiltedWorldBasisIdentity(t *testing.T) {
+	got := TiltedWorldBasis(0, 0)
+	want := DefaultBasis()
+	if abs(got.X.X-want.X.X) > 1e-12 || abs(got.X.Y-want.X.Y) > 1e-12 || abs(got.X.Z-want.X.Z) > 1e-12 {
+		t.Errorf("X: got %v, want %v", got.X, want.X)
+	}
+	if abs(got.Y.X-want.Y.X) > 1e-12 || abs(got.Y.Y-want.Y.Y) > 1e-12 || abs(got.Y.Z-want.Y.Z) > 1e-12 {
+		t.Errorf("Y: got %v, want %v", got.Y, want.Y)
+	}
+}
+
+// TestTiltedWorldBasisTilts (v0.10.6+): with θ = 25° and φ = 0,
+// the basis stays anchored on world X but the Y axis pitches into
+// +Z (orbital.Rotate is right-hand-rule about the axis). DepthAxis
+// = X × Y therefore tips from +Z toward -Y. Catches sign / axis-
+// order errors in the rotation composition; the tilt direction
+// itself is a free convention — what matters is that the basis
+// stays orthonormal and the tilt is non-zero. Players (or v0.10.7's
+// launch-anchor) can yaw via φ to retarget which world axis ends
+// up at screen-Y+.
+func TestTiltedWorldBasisTilts(t *testing.T) {
+	theta := 25 * math.Pi / 180
+	b := TiltedWorldBasis(theta, 0)
+	// X axis untouched (yaw φ = 0 leaves world X alone; θ rotates
+	// around it).
+	if abs(b.X.X-1) > 1e-12 || abs(b.X.Y) > 1e-12 || abs(b.X.Z) > 1e-12 {
+		t.Errorf("X = %v, want (1, 0, 0)", b.X)
+	}
+	// Y rotated around X by θ (right-hand): (0, 1, 0) → (0, cosθ, sinθ).
+	wantY := orbital.Vec3{Y: math.Cos(theta), Z: math.Sin(theta)}
+	if abs(b.Y.X-wantY.X) > 1e-9 || abs(b.Y.Y-wantY.Y) > 1e-9 || abs(b.Y.Z-wantY.Z) > 1e-9 {
+		t.Errorf("Y = %v, want %v", b.Y, wantY)
+	}
+	// Depth axis: X × Y = (1,0,0) × (0, cosθ, sinθ) = (0, -sinθ, cosθ).
+	d := b.DepthAxis()
+	wantD := orbital.Vec3{Y: -math.Sin(theta), Z: math.Cos(theta)}
+	if abs(d.X-wantD.X) > 1e-9 || abs(d.Y-wantD.Y) > 1e-9 || abs(d.Z-wantD.Z) > 1e-9 {
+		t.Errorf("DepthAxis = %v, want %v", d, wantD)
+	}
+}
+
+// TestTiltedPerifocalBasisIdentity (v0.10.6+): TiltedPerifocalBasis
+// with θ = 0 and φ = 0 must return PerifocalBasis(el) verbatim —
+// the ViewOrbitFlat projection. Documents the
+// ViewTilted-with-zero-tilt ≡ ViewOrbitFlat equivalence so a
+// player at θ=0 sees the same basis the cycle's last mode gives.
+func TestTiltedPerifocalBasisIdentity(t *testing.T) {
+	el := orbital.Elements{A: 7_000_000, E: 0.1, I: 0.3, Omega: 0.4, Arg: 0.5}
+	got := TiltedPerifocalBasis(el, 0, 0)
+	wantX, wantY := orbital.PerifocalBasis(el)
+	if abs(got.X.X-wantX.X) > 1e-12 || abs(got.X.Y-wantX.Y) > 1e-12 || abs(got.X.Z-wantX.Z) > 1e-12 {
+		t.Errorf("X: got %v, want %v", got.X, wantX)
+	}
+	if abs(got.Y.X-wantY.X) > 1e-12 || abs(got.Y.Y-wantY.Y) > 1e-12 || abs(got.Y.Z-wantY.Z) > 1e-12 {
+		t.Errorf("Y: got %v, want %v", got.Y, wantY)
+	}
+}
+
+// TestTiltedPerifocalBasisPreservesOrthonormality (v0.10.6+): for
+// any (el, θ, φ) the resulting Basis is orthonormal — |X|=|Y|=1
+// and X·Y=0. Two rotations of unit vectors around unit axes
+// preserve magnitudes and angles; if this test breaks, the
+// rotation composition order is wrong.
+func TestTiltedPerifocalBasisPreservesOrthonormality(t *testing.T) {
+	el := orbital.Elements{A: 1.5e7, E: 0.4, I: 1.1, Omega: 0.9, Arg: 0.7}
+	for _, theta := range []float64{0, 0.2, 0.6, math.Pi / 3} {
+		for _, phi := range []float64{0, 0.3, 1.5} {
+			b := TiltedPerifocalBasis(el, theta, phi)
+			if abs(b.X.Norm()-1) > 1e-9 {
+				t.Errorf("θ=%v φ=%v: |X| = %v", theta, phi, b.X.Norm())
+			}
+			if abs(b.Y.Norm()-1) > 1e-9 {
+				t.Errorf("θ=%v φ=%v: |Y| = %v", theta, phi, b.Y.Norm())
+			}
+			if abs(b.X.Dot(b.Y)) > 1e-9 {
+				t.Errorf("θ=%v φ=%v: X·Y = %v", theta, phi, b.X.Dot(b.Y))
+			}
+		}
+	}
+}
+
+// TestDrawEllipseOffsetFarSideDashed_FarSideStippled (v0.10.6+):
+// with a circular orbit straddling the basis plane, near-side
+// samples render at the requested nearStride and far-side samples
+// render at 2*nearStride. The test counts plotted pixels in each
+// half and asserts the near-side count is meaningfully higher
+// than the far-side count — the depth-stride invariant the
+// player relies on for the depth read.
+func TestDrawEllipseOffsetFarSideDashed_FarSideStippled(t *testing.T) {
+	c := NewCanvas(80, 40)
+	c.Center(orbital.Vec3{})
+	c.FitTo(1e7)
+	// Top-down basis means the depth axis is +Z; a circular
+	// equatorial orbit lies entirely on the basis plane (depth = 0),
+	// which is the boundary case. Tilt the basis by 30° so half
+	// the orbit lands on each side cleanly.
+	c.SetBasis(TiltedWorldBasis(30*math.Pi/180, 0))
+	el := orbital.Elements{A: 5e6, E: 0, I: 0, Omega: 0, Arg: 0}
+	c.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 3, orbital.Vec3{}, 0, "")
+	// Count tagged-or-set pixels by depth sign.
+	near, far := 0, 0
+	for i := 0; i < 360; i++ {
+		nu := 2 * math.Pi * float64(i) / 360
+		p := orbital.PositionAtTrueAnomaly(el, nu)
+		d := p.Dot(c.Basis().DepthAxis())
+		px, py, ok := c.Project(p)
+		if !ok {
+			continue
+		}
+		if c.dc.Get(px, py) {
+			if d >= 0 {
+				near++
+			} else {
+				far++
+			}
+		}
+	}
+	if near == 0 {
+		t.Fatalf("no near-side pixels drawn — basis or projection broken")
+	}
+	if far == 0 {
+		t.Fatalf("no far-side pixels drawn — far-side stipple should still produce some pixels")
+	}
+	// Near side renders ~1/3 (stride=3); far side renders ~1/6
+	// (stride=6). Expect roughly 2:1 ratio. Allow slack for
+	// drawille pixel quantisation.
+	if near < far*3/2 {
+		t.Errorf("near=%d, far=%d — near should be ~2x far (stride 3 vs 6)", near, far)
 	}
 }
 


### PR DESCRIPTION
## Summary

- New `ViewTilted` mode prepended as the zero-value default — perifocal-tilted basis with a tilted-world-axis fallback for Landed / hyperbolic / no-craft (the headline feature stays alive on the pad). `shift+↑/↓` nudges θ ±5°.
- Far-side dashing on every current-orbit ellipse (active craft, other crafts, body orbits) via same-hue stipple — KSP-style depth read without alpha. New `ColorBodyOrbit` plugs the body-orbit colour gap; same-hue stipple = far-side captured as a palette convention.
- Plan + design pass `/grill-with-docs`-sharpened (b1ed5d3): tilted-world fallback, palette token, ORBIT-READY-inverse predicate (for v0.10.7), φ controls deferred to playtest. Built/Shipped notes in plan.md.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` green (existing tests stay green; identity-rotation reduction makes `ViewTilted+θ=0` byte-identical to ViewTop)
- [x] New tests in widgets (basis identity / tilt / orthonormality, far-side stipple ratio), sim (defaults, clamp, cycle order), screens (default render label, off-default HUD degrees, Landed fallback)
- [ ] Playtest pad → ascent → ORBIT READY transition (the predicate v0.10.7 will mirror) and confirm depth-cue feel at 25° default

🤖 Generated with [Claude Code](https://claude.com/claude-code)