### PR TITLE
v0.12 Slice 5 follow-on: Projected Orbit Kepler fidelity (#66) + Line-of-Nodes split rendezvous (#67)

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -399,7 +399,7 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 
 		// Split: refine the finite coplanar departure (v0.6.2 iterator) so
 		// the burn delivers the target apoapsis under integration, then
-		// plant raise → plane change at apoapsis → capture.
+		// plant raise → plane change → capture.
 		w.LastTransfer.Strategy = "split"
 		plan := seed
 		refineFiniteDeparture(&plan, muShared, rPark, mass, thrust, c.Isp, rArrival)
@@ -411,17 +411,48 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 			plan.TransferDt = time.Duration(nodeTransfer * float64(time.Second))
 			plan.Arrival.OffsetTime = plan.Departure.OffsetTime + plan.TransferDt
 		}
+
+		// v0.12.x (GH #67 follow-up): the plane change can only align the
+		// planes at a node, and the only cheap node (apoapsis) sits inside
+		// the target's SOI — firing it there would run in the target's
+		// frame and collide with the capture (both at apoapsis). Instead
+		// fire the plane change just before SOI entry (still in the
+		// primary's frame, near-apoapsis so still cheap, off-node so it
+		// only *reduces* the relative inclination) and the capture at
+		// perilune. Distinct times; partial — not perfect — coplanarity
+		// (see ADR 0006 A: a truly coplanar capture needs frame alignment
+		// at capture, deferred).
+		planeChangeOffset := plan.Arrival.OffsetTime
+		captureOffset := plan.Arrival.OffsetTime
+		pcDv, pcTheta := planeChangeDv, planeChangeTheta
+		if nodeOK && depOK {
+			raiseDir := spacecraft.DirectionUnit(spacecraft.BurnPrograde, depState.R, depState.V)
+			post := depState
+			post.V = depState.V.Add(raiseDir.Scale(seed.Departure.DV))
+			depClock := now.Add(time.Duration(nodeTau * float64(time.Second)))
+			if tEntry, tCA, found := w.transferEncounterTimes(post, c.Primary, target, depClock, nodeTransfer*1.2); found {
+				if entry, ok := physics.KeplerStep(post, muShared, tEntry); ok {
+					if _, nTgt, ok2 := w.craftTargetPlaneNormals(c, target); ok2 {
+						pcDv, pcTheta = planeChangeAtState(entry, nTgt)
+					}
+				}
+				planeChangeOffset = time.Duration((nodeTau + tEntry) * float64(time.Second))
+				captureOffset = time.Duration((nodeTau + tCA) * float64(time.Second))
+			}
+		}
+
 		w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
-		if planeChangeDv > 0 {
+		if pcDv > 0 {
 			w.PlanNode(ManeuverNode{
-				TriggerTime:    now.Add(plan.Arrival.OffsetTime),
+				TriggerTime:    now.Add(planeChangeOffset),
 				Mode:           spacecraft.BurnPlaneChange,
-				DV:             planeChangeDv,
-				Duration:       c.BurnTimeForDV(planeChangeDv),
+				DV:             pcDv,
+				Duration:       c.BurnTimeForDV(pcDv),
 				PrimaryID:      c.Primary.ID,
-				PlaneChangeRad: planeChangeTheta,
+				PlaneChangeRad: pcTheta,
 			})
 		}
+		plan.Arrival.OffsetTime = captureOffset
 		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, c))
 		return &plan, nil
 	}
@@ -1434,6 +1465,61 @@ func (w *World) splitNodePhasing(c *spacecraft.Spacecraft, target bodies.Celesti
 		return 0, 0, false
 	}
 	return best, tTransfer, true
+}
+
+// planeChangeAtState sizes a plane-change burn fired at an arbitrary
+// point on the transfer (not necessarily the line of nodes): the Δv
+// magnitude (2·v_h·sin(|θ|/2)) and the signed rotation θ the
+// BurnPlaneChange node carries. θ is the rotation about the radial that
+// brings the orbit normal as close to the target's as a single radial-
+// axis rotation allows — exact when the fire point is on the node line,
+// a best-effort tilt reduction otherwise (v0.12.x, GH #67 follow-up: the
+// split fires this just before SOI entry, off-apoapsis, so the burn can
+// run in the primary's frame instead of the target's — see PlanTransfer).
+func planeChangeAtState(st physics.StateVector, nTargetHat orbital.Vec3) (dv, theta float64) {
+	rHat := st.R.Unit()
+	vHor := st.V.Sub(rHat.Scale(st.V.Dot(rHat)))
+	hHat := st.R.Cross(st.V).Unit()
+	theta = math.Atan2(hHat.Cross(nTargetHat).Dot(rHat), hHat.Dot(nTargetHat))
+	dv = 2 * vHor.Norm() * math.Sin(math.Abs(theta)/2)
+	return dv, theta
+}
+
+// transferEncounterTimes propagates the post-departure transfer state
+// analytically (Earth/primary frame, exact two-body) and returns the
+// time (s, measured from departure) at which the craft first crosses into
+// the target's SOI and the time of closest approach to the target.
+// ok=false if the craft never enters the SOI within the horizon. Used by
+// the split to fire the plane change just before SOI entry (in the
+// primary's frame) and the capture at perilune — distinct burns rather
+// than two stacked at the apoapsis instant (GH #67 follow-up).
+func (w *World) transferEncounterTimes(post physics.StateVector, primary, target bodies.CelestialBody, startClock time.Time, horizon float64) (tEntry, tCA float64, ok bool) {
+	mu := primary.GravitationalParameter()
+	soi := physics.SOIRadius(target, primary)
+	const n = 4000
+	minD := math.Inf(1)
+	tEntry = -1
+	for i := 0; i <= n; i++ {
+		dt := horizon * float64(i) / float64(n)
+		st, k := physics.KeplerStep(post, mu, dt)
+		if !k {
+			continue
+		}
+		tt := startClock.Add(time.Duration(dt * float64(time.Second)))
+		rel := st.R.Sub(w.BodyPositionAt(target, tt).Sub(w.BodyPositionAt(primary, tt)))
+		d := rel.Norm()
+		if d < minD {
+			minD = d
+			tCA = dt
+		}
+		if tEntry < 0 && d < soi {
+			tEntry = dt
+		}
+	}
+	if tEntry < 0 {
+		return 0, 0, false
+	}
+	return tEntry, tCA, true
 }
 
 // intraPlaneChangeAllowance estimates the extra departure Δv a fused

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -365,10 +365,23 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 			combinedDv = combined.Departure.DV + combined.Arrival.DV
 		}
 
+		// v0.12.x (ADR 0006 A): for an inclined target the split must
+		// place its apoapsis on the line of nodes (craft-plane ∩ target-
+		// plane) where the target will be, so the transfer rendezvous and
+		// the plane change there arrives coplanar. Node-aligned timing
+		// drives the departure point; near-coplanar targets (nodeOK=false)
+		// keep the opposition phasing from the analytic seed.
+		nodeTau, nodeTransfer, nodeOK := w.splitNodePhasing(c, target, muShared, rPark, rArrival, minLead)
+		splitWait := seed.Departure.OffsetTime.Seconds()
+		if nodeOK {
+			splitWait = nodeTau
+		}
+
 		// Split sizing: coplanar raise + capture come from the analytic
-		// seed; the plane change is added at the apoapsis.
+		// seed; the plane change is added at the apoapsis (now on the node
+		// line, so its rotation maps the craft's plane onto the target's).
 		var planeChangeDv, planeChangeTheta float64
-		depState, depOK := physics.KeplerStep(c.State, muShared, seed.Departure.OffsetTime.Seconds())
+		depState, depOK := physics.KeplerStep(c.State, muShared, splitWait)
 		if nCraftHat, nTargetHat, ok := w.craftTargetPlaneNormals(c, target); ok && depOK {
 			planeChangeDv, planeChangeTheta = splitPlaneChangeAtApoapsis(
 				depState, nCraftHat, nTargetHat, muShared, rPark, rArrival)
@@ -390,6 +403,14 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		w.LastTransfer.Strategy = "split"
 		plan := seed
 		refineFiniteDeparture(&plan, muShared, rPark, mass, thrust, c.Isp, rArrival)
+		// Override the seed's opposition phasing with the node-aligned
+		// departure/arrival so apoapsis lands on the node where the target
+		// is (the Δv magnitudes above are phasing-independent).
+		if nodeOK {
+			plan.Departure.OffsetTime = time.Duration(nodeTau * float64(time.Second))
+			plan.TransferDt = time.Duration(nodeTransfer * float64(time.Second))
+			plan.Arrival.OffsetTime = plan.Departure.OffsetTime + plan.TransferDt
+		}
 		w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
 		if planeChangeDv > 0 {
 			w.PlanNode(ManeuverNode{
@@ -1263,6 +1284,156 @@ func splitPlaneChangeAtApoapsis(depState physics.StateVector, nCraftHat, nTarget
 	hHat := nCraftHat
 	theta = math.Atan2(hHat.Cross(nTargetHat).Dot(rApoHat), hHat.Dot(nTargetHat))
 	return dv, theta
+}
+
+// splitNodeMinIncl is the relative-inclination floor (rad, ≈0.5°) below
+// which the craft and target planes have no distinct line of nodes worth
+// constraining — splitNodePhasing bails and the caller keeps the coplanar
+// opposition phasing.
+const splitNodeMinIncl = 0.5 * math.Pi / 180
+
+// wrapTau normalises an angle to [0, 2π).
+func wrapTau(a float64) float64 {
+	const tau = 2 * math.Pi
+	a = math.Mod(a, tau)
+	if a < 0 {
+		a += tau
+	}
+	return a
+}
+
+// signedAngleAbout returns the signed angle (rad, in (−π, π]) from `from`
+// to `to` measured about `axis` (right-handed): positive when `to` leads
+// `from` in the +axis rotation sense. Used to time when a body sweeps
+// onto a given inertial ray.
+func signedAngleAbout(from, to, axis orbital.Vec3) float64 {
+	f, t := from.Unit(), to.Unit()
+	return math.Atan2(f.Cross(t).Dot(axis), f.Dot(t))
+}
+
+// timeToBodyDirection returns the soonest dt ≥ 0 (s) at which body b's
+// position in primary's frame points along dHat — i.e. b crosses the
+// inertial ray dHat (which must lie in b's orbit plane, normal nHat).
+// A mean-motion estimate seeds a few Newton refinements against the true
+// ephemeris, so the target's orbital eccentricity is accounted for rather
+// than assuming uniform angular rate. period is b's orbital period (s).
+func (w *World) timeToBodyDirection(b, primary bodies.CelestialBody, dHat, nHat orbital.Vec3, period float64) (float64, bool) {
+	if period <= 0 || math.IsNaN(period) || math.IsInf(period, 0) {
+		return 0, false
+	}
+	n := 2 * math.Pi / period
+	psi := func(dt float64) float64 {
+		t := w.Clock.SimTime.Add(time.Duration(dt * float64(time.Second)))
+		p := w.BodyPositionAt(b, t).Sub(w.BodyPositionAt(primary, t))
+		if p.Norm() == 0 {
+			return 0
+		}
+		// Angle from dHat to the body about nHat; zero when aligned.
+		return signedAngleAbout(dHat, p, nHat)
+	}
+	// Seed: the body must travel prograde (about nHat) by however far it
+	// currently sits behind dHat.
+	dt := wrapTau(-psi(0)) / n
+	const h = 1.0 // 1 s finite-difference step for the angular rate
+	for i := 0; i < 8; i++ {
+		f := psi(dt)
+		fp := (psi(dt+h) - f) / h
+		if fp == 0 {
+			break
+		}
+		step := f / fp
+		dt -= step
+		if math.Abs(step) < 1 {
+			break
+		}
+	}
+	for dt < 0 {
+		dt += period
+	}
+	return dt, true
+}
+
+// splitNodePhasing computes the Line-of-Nodes departure timing for the
+// split strategy (ADR 0006 decision A). It returns the wait time τ (s)
+// until the prograde raise fires and the coast time (s) to apoapsis, so
+// that:
+//
+//   - the raise's apoapsis lands on the craft-plane ∩ target-plane node
+//     line (the craft departs from the antipodal node point, 180° away in
+//     its own plane, so a pure in-plane raise puts apoapsis on the node);
+//     and
+//   - the target sits at that node when the craft arrives at apoapsis.
+//
+// A plane change at that apoapsis rotates about the node line (= the
+// radial there), which maps the craft's plane exactly onto the target's —
+// so the arrival is coplanar AND co-located with the target. This is what
+// makes the inclined split actually rendezvous; pre-fix the plane change
+// sat at an arbitrary apoapsis and the craft stayed ~sin(Δi)·r_apo (~100k
+// km for LEO→Luna) out of the target's plane.
+//
+// Returns ok=false for near-coplanar geometry (no distinct node line) or
+// a non-elliptic craft orbit; the caller keeps the opposition phasing.
+func (w *World) splitNodePhasing(c *spacecraft.Spacecraft, target bodies.CelestialBody, muShared, rPark, rArrival, minLead float64) (tau, tTransfer float64, ok bool) {
+	nCraftHat, nTargetHat, ok := w.craftTargetPlaneNormals(c, target)
+	if !ok || relInclination(nCraftHat, nTargetHat) < splitNodeMinIncl {
+		return 0, 0, false
+	}
+	nodeLine := nCraftHat.Cross(nTargetHat)
+	if nodeLine.Norm() == 0 {
+		return 0, 0, false
+	}
+	lineHat := nodeLine.Unit()
+
+	aT := (rPark + rArrival) / 2
+	tTransfer = math.Pi * math.Sqrt(aT*aT*aT/muShared)
+
+	nCraft := math.Sqrt(muShared / (rPark * rPark * rPark))
+	if nCraft <= 0 || math.IsNaN(nCraft) || math.IsInf(nCraft, 0) {
+		return 0, 0, false
+	}
+	tPark := 2 * math.Pi / nCraft
+	tTarget := 2 * math.Pi * math.Sqrt(rArrival*rArrival*rArrival/muShared)
+
+	best := math.Inf(1)
+	// Either node of the line can host the apoapsis; try both and take the
+	// soonest feasible departure.
+	for _, s := range []float64{1, -1} {
+		nodeHat := lineHat.Scale(s) // apoapsis lands here; target must be here at arrival
+		depHat := nodeHat.Scale(-1) // craft departs from the antipodal point
+
+		// Craft's next pass through the departure point (circular parking
+		// orbit, prograde about nCraftHat).
+		tDepFirst := wrapTau(signedAngleAbout(c.State.R, depHat, nCraftHat)) / nCraft
+
+		// Target's next arrival at the node, then the soonest later pass
+		// whose implied departure (arrival − coast) clears minLead.
+		tNode, okN := w.timeToBodyDirection(target, c.Primary, nodeHat, nTargetHat, tTarget)
+		if !okN {
+			continue
+		}
+		depTarget := tNode - tTransfer
+		for depTarget < minLead {
+			depTarget += tTarget
+		}
+		// Snap the departure to the nearest craft node-crossing (parking
+		// period ≪ target period, so the residual is sub-orbit and the
+		// target is still within its SOI at apoapsis).
+		k := math.Round((depTarget - tDepFirst) / tPark)
+		if k < 0 {
+			k = 0
+		}
+		cand := tDepFirst + k*tPark
+		for cand < minLead {
+			cand += tPark
+		}
+		if cand < best {
+			best = cand
+		}
+	}
+	if math.IsInf(best, 0) {
+		return 0, 0, false
+	}
+	return best, tTransfer, true
 }
 
 // intraPlaneChangeAllowance estimates the extra departure Δv a fused
@@ -2172,9 +2343,14 @@ func (w *World) propagateStateWithPrimary(startState physics.StateVector, startP
 	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
 	bc := w.ActiveCraft().EffectiveBallisticCoefficient()
 	for i := 0; i < nSteps; i++ {
-		state = physics.StepVerletWithAccel(state, muNow, step, func(r, v orbital.Vec3) orbital.Vec3 {
-			return physics.DragAccel(r, v, current, bc)
-		})
+		// v0.12.x (GH #66): propagate ballistic coast legs with analytic
+		// Kepler (predictStep), Verlet only for drag/hyperbolic/sub-
+		// surface. A long phasing wait (an inclined transfer can sit ~50
+		// parking orbits out) would otherwise drift tens of degrees of
+		// phase under the 1024-step Verlet cap — misplacing the departure
+		// point and, for the node-aligned split, the apoapsis off the
+		// line of nodes. Mirrors the predictor in predict.go.
+		state = predictStep(state, muNow, step, current, bc)
 		// v0.8.5: terminate propagation at surface contact. Mirrors the
 		// live integrator (sim/world.go) and the trajectory predictor
 		// (sim/predict.go) so node-planning sees the same landed state

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -939,10 +939,14 @@ func TestPlanTransferIntraPrimaryPhasingMatchesArrival(t *testing.T) {
 	if math.Abs(dTheta) > 0.017 {
 		t.Errorf("phasing residual = %.4f rad (%.2f°); want < 1°", dTheta, dTheta*180/math.Pi)
 	}
-	// Also: waitSecs must be non-negative and bounded by the synodic
-	// period (LEO + Luna ≈ 89 min). 7200s = 2h is generous.
-	if waitSecs < 0 || waitSecs > 7200 {
-		t.Errorf("waitSecs = %.1f s, want in [0, 7200]", waitSecs)
+	// Also: waitSecs must be non-negative and bounded. v0.12.x (ADR 0006
+	// A): the inclined split waits for the line-of-nodes alignment, not
+	// the synodic window — so the bound is the target's orbital period
+	// (the node recurs ~twice per target orbit), not the old ~89 min
+	// synodic period.
+	moonPeriod := 2 * math.Pi * math.Sqrt(math.Pow(moon.SemimajorAxisMeters(), 3)/mu)
+	if waitSecs < 0 || waitSecs > moonPeriod {
+		t.Errorf("waitSecs = %.1f s, want in [0, %.0f] (≤ one Luna period)", waitSecs, moonPeriod)
 	}
 	_ = transferSecs
 }

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -71,6 +71,29 @@ func predictMaxSubStep(period float64) float64 {
 	return predictMaxSubStepCap
 }
 
+// predictStep advances one predictor sub-step. Ballistic coast legs use
+// analytic Kepler propagation (physics.KeplerStep) — exact for bound
+// two-body arcs, with none of the dt² truncation that the fixed-step
+// Verlet path drifts on an eccentric ellipse (GH #66: ~46 000 km by
+// apogee on the e≈0.96 LEO→Luna transfer, so the dashed line sailed past
+// Luna's SOI). It falls back to drag-aware Verlet exactly where Kepler
+// can't apply — inside an atmosphere, on hyperbolic/degenerate arcs, or
+// on an impactor whose periapsis dips below the surface — gated by the
+// same canKeplerStepState guard the live integrator uses, so the
+// predicted line agrees with the craft's actual flight. SOI transitions
+// stay the caller's job: the sub-step loop's FindPrimary/Rebase runs
+// against each step's output regardless of which propagator produced it.
+func predictStep(state physics.StateVector, mu, dt float64, primary bodies.CelestialBody, bc float64) physics.StateVector {
+	if canKeplerStepState(state, mu, primary) {
+		if next, ok := physics.KeplerStep(state, mu, dt); ok {
+			return next
+		}
+	}
+	return physics.StepVerletWithAccel(state, mu, dt, func(r, v orbital.Vec3) orbital.Vec3 {
+		return physics.DragAccel(r, v, primary, bc)
+	})
+}
+
 // SOISegment is a contiguous run of predicted-trajectory samples that
 // share the same owning SOI primary. PrimaryID == craft's home primary
 // means "still in the home SOI"; a different ID means the segment has
@@ -140,9 +163,7 @@ predict:
 		dt := stepSecs / float64(nSub)
 		stepDur := time.Duration(stepSecs * float64(time.Second))
 		for j := 0; j < nSub; j++ {
-			state = physics.StepVerletWithAccel(state, muNow, dt, func(r, v orbital.Vec3) orbital.Vec3 {
-				return physics.DragAccel(r, v, current, bc)
-			})
+			state = predictStep(state, muNow, dt, current, bc)
 
 			// v0.8.5: stop the predicted line at surface contact so
 			// the dashed trajectory terminates on the body instead of

--- a/internal/sim/predict_test.go
+++ b/internal/sim/predict_test.go
@@ -149,6 +149,152 @@ func TestPredictedSegmentsTransferEncounterStable(t *testing.T) {
 	}
 }
 
+// TestPredictedSegmentsCoastMatchesKeplerArc: a ballistic coast leg must
+// be propagated with analytic Kepler propagation, not fixed-step Verlet,
+// so the dashed Projected Orbit follows the true two-body arc with no
+// truncation drift. On a highly-eccentric ellipse (e≈0.91) the old 120 s
+// Verlet sub-step drifted ~46 000 km by apogee (GH #66, clean dt²
+// convergence); analytic Kepler is exact. This is the load-bearing #66
+// regression guard — it goes red on the Verlet path and green on Kepler.
+func TestPredictedSegmentsCoastMatchesKeplerArc(t *testing.T) {
+	w := mustWorld(t)
+	craft := w.ActiveCraft()
+	primary := craft.Primary
+	mu := primary.GravitationalParameter()
+	R := primary.RadiusMeters()
+
+	// High-eccentricity bound orbit about the home primary: perigee
+	// ~1000 km altitude (well above the atmosphere, so the Kepler path is
+	// eligible), apogee ~150 000 km — comfortably inside Earth's SOI and
+	// never within ~168 000 km of the Moon, so the leg stays a single
+	// segment. Start at perigee in the X–Y plane.
+	rp := R + 1000e3
+	ra := R + 150000e3
+	a := (rp + ra) / 2
+	vp := math.Sqrt(mu * (2/rp - 1/a)) // vis-viva at perigee
+	post := physics.StateVector{
+		R: orbital.Vec3{X: rp},
+		V: orbital.Vec3{Y: vp},
+		M: craft.State.M,
+	}
+
+	// Propagate perigee→apogee (half the period) — the stretch where
+	// Verlet truncation peaks.
+	period := 2 * math.Pi * math.Sqrt(a*a*a/mu)
+	horizon := period / 2
+	const samples = 128
+	startClock := w.Clock.SimTime
+	segs := w.PredictedSegmentsFrom(post, primary, startClock, horizon, samples)
+
+	if len(segs) != 1 {
+		ids := make([]string, len(segs))
+		for i, s := range segs {
+			ids[i] = s.PrimaryID
+		}
+		t.Fatalf("coast leg split into %d segments %v; want 1 (no SOI crossing)", len(segs), ids)
+	}
+	pts := segs[0].Points
+	if len(pts) != samples {
+		t.Fatalf("got %d points, want %d", len(pts), samples)
+	}
+
+	// Each predicted point i sits at the body position at startClock+i·dt
+	// plus the craft's primary-relative state. The exact reference is a
+	// single analytic Kepler step of i·dt from the start state. They must
+	// agree to within solver noise; a Verlet path would diverge by tens
+	// of thousands of km near apogee.
+	stepSecs := horizon / float64(samples-1)
+	stepDur := time.Duration(stepSecs * float64(time.Second))
+	var maxErr float64
+	for i := 0; i < samples; i++ {
+		exact, ok := physics.KeplerStep(post, mu, float64(i)*stepSecs)
+		if !ok {
+			t.Fatalf("KeplerStep reference failed at sample %d", i)
+		}
+		bodyPos := w.BodyPositionAt(primary, startClock.Add(time.Duration(i)*stepDur))
+		rel := pts[i].Sub(bodyPos)
+		if e := rel.Sub(exact.R).Norm(); e > maxErr {
+			maxErr = e
+		}
+	}
+	if maxErr > 1000 {
+		t.Errorf("predicted coast leg drifts %.0f m from the exact Kepler arc (want <1 km) — fixed-step Verlet truncation, not analytic propagation", maxErr)
+	}
+}
+
+// coplanarLEOTowardMoon places the active craft in a circular LEO
+// coplanar with the Moon so an intra-primary [H] transfer's coast leg
+// actually reaches the Moon, then plants the transfer. Returns the
+// first predicted leg. (Pulled out so the integrator-fidelity and
+// SOI-entry guards share one setup; the default inclined Luna split
+// doesn't rendezvous yet — that's GH #67.)
+func coplanarLEOTowardMoon(t *testing.T, w *World) PredictedLeg {
+	t.Helper()
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon not in loaded Sol system")
+	}
+	moon := sys.Bodies[moonIdx]
+
+	mel := orbital.ElementsFromBody(moon)
+	sI, cI := math.Sin(mel.I), math.Cos(mel.I)
+	sO, cO := math.Sin(mel.Omega), math.Cos(mel.Omega)
+	moonN := orbital.Vec3{X: sO * sI, Y: -cO * sI, Z: cI}.Unit()
+	ref := orbital.Vec3{X: 1}
+	if math.Abs(moonN.Dot(ref)) > 0.9 {
+		ref = orbital.Vec3{Y: 1}
+	}
+	e1 := ref.Sub(moonN.Scale(moonN.Dot(ref))).Unit()
+	e2 := moonN.Cross(e1)
+
+	mu := w.ActiveCraft().Primary.GravitationalParameter()
+	r := w.ActiveCraft().State.R.Norm()
+	v := math.Sqrt(mu / r)
+	w.ActiveCraft().State.R = e1.Scale(r)
+	w.ActiveCraft().State.V = e2.Scale(v)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs after PlanTransfer")
+	}
+	return legs[0]
+}
+
+// TestPredictedSegmentsEntersMoonSOI: the now-analytic coast leg of an
+// LEO→Luna transfer must actually cross into the Moon's sphere of
+// influence — a foreign "moon" segment present — proving the Kepler
+// propagation path still drives the per-sub-step FindPrimary/Rebase
+// (GH #66 acceptance test 2: the predicted path draws the encounter).
+func TestPredictedSegmentsEntersMoonSOI(t *testing.T) {
+	w := mustWorld(t)
+	leg := coplanarLEOTowardMoon(t, w)
+
+	segs := w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples)
+	ids := make([]string, len(segs))
+	foundMoon := false
+	for i, s := range segs {
+		ids[i] = s.PrimaryID
+		if s.PrimaryID == "moon" {
+			foundMoon = true
+		}
+		if s.PrimaryID == "sun" {
+			t.Fatalf("predicted leg escaped to the Sun (%v) — coast leg flung off its conic", ids)
+		}
+	}
+	if !foundMoon {
+		t.Errorf("predicted coast leg never entered the Moon's SOI (segments %v); the dashed line misses the encounter", ids)
+	}
+}
+
 // TestPredictedSegmentsContinuousAtSOIBoundary: plant a hyperbolic
 // trajectory escaping Earth SOI; PredictedSegments should split into
 // (≥) two segments at the boundary, AND the last point of the inner

--- a/internal/sim/split_node_test.go
+++ b/internal/sim/split_node_test.go
@@ -91,18 +91,20 @@ func TestPlanTransferSplitArrivesCoplanar(t *testing.T) {
 		t.Fatal("craftTargetPlaneNormals degenerate")
 	}
 
-	// Coplanarity is a property of the Earth-relative transfer orbit at
-	// arrival: propagate the raise leg to apoapsis (Earth frame) and apply
-	// the plane-change impulse there, then compare the orbit's plane normal
-	// to Luna's. (We can't read the predicted leg's stored state directly —
-	// the predictor rebases into the Moon's frame on SOI entry, which
-	// happens ~21 000 km out, before apoapsis; that state is Moon-relative
-	// and not comparable to the Earth-frame Luna plane.)
+	// Coplanarity is a property of the Earth-relative transfer orbit after
+	// the plane change. The plane change fires just before SOI entry, in
+	// the Earth frame (the raise leg's horizon ends at that node); apply it
+	// to the propagated raise-leg state there and compare the orbit's plane
+	// normal to Luna's. (We can't read the predicted leg's stored state
+	// directly — the predictor rebases into the Moon's frame on SOI entry,
+	// so that state is Moon-relative and not comparable to the Earth-frame
+	// Luna plane.) Firing off-node only *reduces* the tilt — but near
+	// apoapsis the residual is small.
 	legs := w.PredictedLegs()
 	raise := legs[0]
-	apo, okk := physics.KeplerStep(raise.State, mu, raise.HorizonSecs)
+	atPC, okk := physics.KeplerStep(raise.State, mu, raise.HorizonSecs)
 	if !okk {
-		t.Fatal("KeplerStep to apoapsis failed")
+		t.Fatal("KeplerStep to plane-change point failed")
 	}
 	var pc spacecraft.ManeuverNode
 	for _, n := range c.Nodes {
@@ -110,20 +112,60 @@ func TestPlanTransferSplitArrivesCoplanar(t *testing.T) {
 			pc = n
 		}
 	}
-	dir := spacecraft.NodeBurnDirection(pc, apo.R, apo.V)
-	vNew := apo.V.Add(dir.Scale(pc.DV))
-	normal := apo.R.Cross(vNew).Unit()
+	dir := spacecraft.NodeBurnDirection(pc, atPC.R, atPC.V)
+	vNew := atPC.V.Add(dir.Scale(pc.DV))
+	normal := atPC.R.Cross(vNew).Unit()
 	relIncl := relInclination(normal, nTargetHat) * 180 / math.Pi
 	if relIncl > 2.0 {
-		t.Errorf("arrival orbit is %.2f° off Luna's plane (want ≈0°) — plane change not on the line of nodes", relIncl)
+		t.Errorf("arrival orbit is %.2f° off Luna's plane after the plane change (want <2°)", relIncl)
+	}
+}
+
+// TestPlanTransferSplitBurnsAreDistinct: the plane change and capture
+// must be planted at distinct times — the plane change in the Earth frame
+// before SOI entry, the capture at perilune. Pre-fix both were stacked at
+// the apoapsis instant, which the executor can't fly as two burns (the
+// later ActiveBurn clobbers the earlier). GH #67 follow-up.
+func TestPlanTransferSplitBurnsAreDistinct(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, _ := findMoon(t, w)
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if w.LastTransfer.Strategy != "split" {
+		t.Fatalf("strategy = %q, want split", w.LastTransfer.Strategy)
+	}
+	nodes := w.ActiveCraft().Nodes
+	if len(nodes) < 3 {
+		t.Fatalf("split should plant 3 nodes; got %d", len(nodes))
+	}
+	var planeChange, capture spacecraft.ManeuverNode
+	for _, n := range nodes {
+		switch n.Mode {
+		case spacecraft.BurnPlaneChange:
+			planeChange = n
+		case spacecraft.BurnRetrograde:
+			capture = n
+		}
+	}
+	gap := capture.TriggerTime.Sub(planeChange.TriggerTime)
+	if gap <= 0 {
+		t.Errorf("plane change (T=%v) and capture (T=%v) are not ordered distinctly — burns collide",
+			planeChange.TriggerTime, capture.TriggerTime)
+	}
+	// The plane change must fire before the capture by more than their
+	// burn windows so the integrator doesn't run them concurrently.
+	if gap < planeChange.Duration/2+capture.Duration/2 {
+		t.Errorf("plane change and capture burn windows overlap (gap %v < %v)",
+			gap, planeChange.Duration/2+capture.Duration/2)
 	}
 }
 
 // TestPlanTransferSplitPredictedPathEntersMoonSOI: end-to-end — with the
-// node-aligned split, the predicted coast into apoapsis must cross Luna's
-// SOI (a foreign "moon" segment present). This exercises the #66 Kepler
-// predictor on the #67-corrected geometry: the dashed Projected Orbit
-// actually draws the encounter for the default inclined Luna.
+// node-aligned split, the predicted transfer must cross Luna's SOI (a
+// foreign "moon" segment present on some leg). This exercises the #66
+// Kepler predictor on the #67-corrected geometry: the dashed Projected
+// Orbit actually draws the encounter for the default inclined Luna.
 func TestPlanTransferSplitPredictedPathEntersMoonSOI(t *testing.T) {
 	w := mustWorld(t)
 	moonIdx, _ := findMoon(t, w)
@@ -135,19 +177,23 @@ func TestPlanTransferSplitPredictedPathEntersMoonSOI(t *testing.T) {
 	if len(legs) == 0 {
 		t.Fatal("no predicted legs")
 	}
-	// The raise leg (node 0) coasts from departure to apoapsis, where Luna
-	// is — so the encounter shows up there.
-	leg := legs[0]
-	segs := w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples)
+	// The encounter shows up on whichever leg coasts through apoapsis (the
+	// plane change splits the coast at SOI entry), so scan all of them —
+	// either a leg already rebased into the Moon's frame or a "moon"
+	// segment in a leg's predicted trajectory counts.
 	foundMoon := false
-	ids := make([]string, len(segs))
-	for i, s := range segs {
-		ids[i] = s.PrimaryID
-		if s.PrimaryID == "moon" {
+	for _, leg := range legs {
+		if leg.Primary.ID == "moon" {
 			foundMoon = true
+			break
+		}
+		for _, s := range w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples) {
+			if s.PrimaryID == "moon" {
+				foundMoon = true
+			}
 		}
 	}
 	if !foundMoon {
-		t.Errorf("predicted raise leg never enters Luna's SOI (segments %v) — split misses the encounter", ids)
+		t.Error("predicted transfer never enters Luna's SOI — split misses the encounter")
 	}
 }

--- a/internal/sim/split_node_test.go
+++ b/internal/sim/split_node_test.go
@@ -1,0 +1,153 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// findMoon locates the Moon in the loaded Sol system (skips if absent).
+func findMoon(t *testing.T, w *World) (int, bodies.CelestialBody) {
+	t.Helper()
+	for i, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			return i, b
+		}
+	}
+	t.Skip("Moon missing from Sol")
+	return -1, bodies.CelestialBody{}
+}
+
+// TestPlanTransferSplitArrivesAtMoon: the default LEO is ~19° off Luna's
+// plane, so [H] auto-picks the split. Per ADR 0006 decision A the split
+// must place its apoapsis on the line of nodes where Luna will be, so the
+// transfer actually rendezvous. Asserted geometrically: the transfer
+// apoapsis (reached at the capture node's time) lands within Luna's SOI.
+// Pre-fix the plane change sat at an arbitrary apoapsis and missed by
+// ~100 000 km (GH #67).
+func TestPlanTransferSplitArrivesAtMoon(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, moon := findMoon(t, w)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if w.LastTransfer.Strategy != "split" {
+		t.Fatalf("strategy = %q, want split (default LEO is inclined to Luna)", w.LastTransfer.Strategy)
+	}
+
+	c := w.ActiveCraft()
+	muShared := c.Primary.GravitationalParameter()
+	nodes := c.Nodes
+	if len(nodes) < 3 {
+		t.Fatalf("split should plant 3 nodes; got %d", len(nodes))
+	}
+	depTime := nodes[0].TriggerTime
+	arrTime := nodes[len(nodes)-1].TriggerTime
+	waitSecs := depTime.Sub(w.Clock.SimTime).Seconds()
+
+	// Transfer apoapsis lies 180° from the departure point in the craft's
+	// plane, at the target's orbital radius. A plane change there doesn't
+	// move it, so this is where the craft arrives regardless of strategy.
+	depState, ok := physics.KeplerStep(c.State, muShared, waitSecs)
+	if !ok {
+		t.Fatalf("KeplerStep to departure failed")
+	}
+	rArrival := moon.SemimajorAxisMeters()
+	apo := depState.R.Unit().Scale(-rArrival)
+
+	lunaPos := w.BodyPositionAt(moon, arrTime).Sub(w.BodyPositionAt(c.Primary, arrTime))
+	miss := apo.Sub(lunaPos).Norm()
+	soi := physics.SOIRadius(moon, c.Primary)
+	if miss > soi {
+		t.Errorf("transfer apoapsis misses Luna by %.0f km (Luna SOI %.0f km) — split does not rendezvous",
+			miss/1e3, soi/1e3)
+	}
+}
+
+// TestPlanTransferSplitArrivesCoplanar: after the line-of-nodes plane
+// change, the arrival orbit must be coplanar with Luna (≈0° relative
+// inclination), so the capture inserts into a sane orbit rather than a
+// badly tilted one (ADR 0006 decision A acceptance bar). The post-plane-
+// change leg's orbital plane normal must align with Luna's.
+func TestPlanTransferSplitArrivesCoplanar(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, moon := findMoon(t, w)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if w.LastTransfer.Strategy != "split" {
+		t.Fatalf("strategy = %q, want split", w.LastTransfer.Strategy)
+	}
+
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	_, nTargetHat, ok := w.craftTargetPlaneNormals(c, moon)
+	if !ok {
+		t.Fatal("craftTargetPlaneNormals degenerate")
+	}
+
+	// Coplanarity is a property of the Earth-relative transfer orbit at
+	// arrival: propagate the raise leg to apoapsis (Earth frame) and apply
+	// the plane-change impulse there, then compare the orbit's plane normal
+	// to Luna's. (We can't read the predicted leg's stored state directly —
+	// the predictor rebases into the Moon's frame on SOI entry, which
+	// happens ~21 000 km out, before apoapsis; that state is Moon-relative
+	// and not comparable to the Earth-frame Luna plane.)
+	legs := w.PredictedLegs()
+	raise := legs[0]
+	apo, okk := physics.KeplerStep(raise.State, mu, raise.HorizonSecs)
+	if !okk {
+		t.Fatal("KeplerStep to apoapsis failed")
+	}
+	var pc spacecraft.ManeuverNode
+	for _, n := range c.Nodes {
+		if n.Mode == spacecraft.BurnPlaneChange {
+			pc = n
+		}
+	}
+	dir := spacecraft.NodeBurnDirection(pc, apo.R, apo.V)
+	vNew := apo.V.Add(dir.Scale(pc.DV))
+	normal := apo.R.Cross(vNew).Unit()
+	relIncl := relInclination(normal, nTargetHat) * 180 / math.Pi
+	if relIncl > 2.0 {
+		t.Errorf("arrival orbit is %.2f° off Luna's plane (want ≈0°) — plane change not on the line of nodes", relIncl)
+	}
+}
+
+// TestPlanTransferSplitPredictedPathEntersMoonSOI: end-to-end — with the
+// node-aligned split, the predicted coast into apoapsis must cross Luna's
+// SOI (a foreign "moon" segment present). This exercises the #66 Kepler
+// predictor on the #67-corrected geometry: the dashed Projected Orbit
+// actually draws the encounter for the default inclined Luna.
+func TestPlanTransferSplitPredictedPathEntersMoonSOI(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, _ := findMoon(t, w)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	// The raise leg (node 0) coasts from departure to apoapsis, where Luna
+	// is — so the encounter shows up there.
+	leg := legs[0]
+	segs := w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples)
+	foundMoon := false
+	ids := make([]string, len(segs))
+	for i, s := range segs {
+		ids[i] = s.PrimaryID
+		if s.PrimaryID == "moon" {
+			foundMoon = true
+		}
+	}
+	if !foundMoon {
+		t.Errorf("predicted raise leg never enters Luna's SOI (segments %v) — split misses the encounter", ids)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1143,34 +1143,33 @@ func (w *World) canKeplerStep(c *spacecraft.Spacecraft, simDelta time.Duration) 
 	if w.Clock.Warp() <= 1 {
 		return false
 	}
-	mu := c.Primary.GravitationalParameter()
-	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	return canKeplerStepState(c.State, c.Primary.GravitationalParameter(), c.Primary)
+}
+
+// canKeplerStepState is the orbital-geometry half of canKeplerStep,
+// shared so the Predictor's Kepler-vs-Verlet switch (predict.go) agrees
+// with the live integrator on which coast legs the analytic propagator
+// can handle. Analytic Kepler propagation is valid only when:
+//   - the orbit is bound (e < 1, a > 0) — KeplerStep rejects hyperbolic
+//     and parabolic arcs (returns ok=false) anyway, but bail here too;
+//   - v0.8.4: periapsis sits above the primary's atmospheric cutoff —
+//     drag breaks the conic, so a peri that grazes atmosphere needs the
+//     per-sub-step drag accel the Verlet path integrates;
+//   - v0.11.4-followup: periapsis sits above the surface — an impactor
+//     would Kepler-step straight through an airless body, since only the
+//     sub-step loop's ClampToSurface knows about surface contact.
+func canKeplerStepState(s physics.StateVector, mu float64, primary bodies.CelestialBody) bool {
+	if mu <= 0 {
+		return false
+	}
+	el := orbital.ElementsFromState(s.R, s.V, mu)
 	if el.E >= 1 || el.A <= 0 {
 		return false
 	}
-	// v0.8.4: drag breaks the analytic propagation. If the orbit's
-	// periapsis dips below the primary's atmospheric cutoff (or the
-	// craft is already inside the atmosphere), fall back to Verlet so
-	// the per-sub-step drag accel is integrated. Compared at the
-	// orbit periapsis altitude — if peri grazes atmosphere the orbit
-	// will decay over time, so analytic Kepler propagation is wrong.
-	if atm := c.Primary.Atmosphere; atm != nil {
-		periAlt := el.A*(1-el.E) - c.Primary.RadiusMeters()
-		if periAlt < atm.CutoffAltitude {
-			return false
-		}
+	periAlt := el.A*(1-el.E) - primary.RadiusMeters()
+	if atm := primary.Atmosphere; atm != nil && periAlt < atm.CutoffAltitude {
+		return false
 	}
-	// v0.11.4-followup: an impactor trajectory (periapsis below the
-	// primary's mean radius) on an airless body would Kepler-step
-	// straight through the surface — the analytic propagator has no
-	// concept of surface contact, only ClampToSurface does, and the
-	// sub-step loop is what dispatches that. Without this guard, a
-	// player descending toward the Moon (or Mercury / a Mars moon /
-	// Galilean moons) at warp >1× with peri < 0 gets "sucked" through
-	// the surface mid-tick and the lifecycle predicate is never
-	// consulted. Pull back to Verlet whenever the orbit's periapsis
-	// dips below the surface, regardless of atmosphere.
-	periAlt := el.A*(1-el.E) - c.Primary.RadiusMeters()
 	if periAlt < 0 {
 		return false
 	}


### PR DESCRIPTION
Fixes the two latent bugs from v0.12 Slice 5, both designed in ADR 0006 and confirmed in playtests. `fix/67` is built on top of `fix/66`, so this single PR carries both.

## #66 — Projected Orbit propagates with Kepler Step (`0c3ac6b`)
The predictor integrated ballistic coast legs with fixed-step Verlet (120 s cap), which on an eccentric transfer drifts ~46,000 km by apogee — the dashed line sailed past Luna's SOI. Now coast legs use analytic `physics.KeplerStep` (exact for bound two-body arcs), with Verlet retained only for drag / hyperbolic / sub-surface legs, gated by a shared `canKeplerStepState`. Found and fixed a **second instance** of the same drift in `propagateStateWithPrimary` (the leg-start propagator behind `PredictedLegs`).

## #67 — Inclined split arrives via the Line of Nodes (`5bc3009`, `906ce54`)
The dual-strategy `[H]` split placed its plane change at an arbitrary apoapsis, so an inclined target (default LEO is ~19° off Luna) missed by ~103,700 km. Now `splitNodePhasing` puts the transfer apoapsis on the craft∩target line of nodes and phases so the target is there at arrival → rendezvous (21,152 km, inside Luna's SOI). The Δv math was already correct; only the apoapsis placement was wrong.

The plane change and capture were also planted at the same apoapsis instant (the executor can't fly two finite burns at once, and apoapsis is inside the SOI). Now the plane change fires just before SOI entry (Earth frame, near-apoapsis → still cheap, 19.44° → 0.65° transfer tilt) and the capture at perilune — distinct burns ~19 h apart.

## Known limitation (tracked as #68)
The *lunar capture* orbit still comes out ~12–17° inclined / retrograde — the Moon-relative approach geometry can't be controlled from the transfer side. A truly coplanar capture needs a Moon-frame maneuver (post-capture inclination trim or a combined brake+plane-change at perilune); filed as #68 for a later grill. This is a large improvement over the prior 70°+ tilts, so accepted as-is.

## Tests
`go vet ./...` + `go test ./... -race -count=1` green (828 tests). New: `split_node_test.go` (rendezvous, coplanar transfer, distinct burns, SOI-entry draw) and the Kepler-arc / Moon-SOI predictor guards in `predict_test.go`.

Closes #66
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
