### PR TITLE
Parachutes for atmospheric descent + recovery (Slice 3, ADR 0008)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,16 @@ Program that lives in your terminal, distributed as a single static Go binary.
 
 ## Install
 
-Latest release: **v0.9.1** — staging chain. KSP-style player-managed sequential decouples; `space` drops the bottom stage and spawns it as a passive cycle-able craft, with the active vehicle continuing on the upper-stage chain. Saturn-V loadout (S-IC + S-II + S-IVB, TWR > 1 at sea level) ships alongside the four single-stage loadouts, which wrap into a one-element `Stages: [{...}]` shim with no behavior change. New STAGES HUD block, `Spacecraft.Stages` source-of-truth for dry mass / propellant / engine numbers, save schema v5 → v6 with typed migration. Followed v0.9.0 (unified `World.Target` slot, `t` / `T` cycle / clear, TARGET HUD).
+Latest release: **v0.12.4** — parachutes for atmospheric descent + recovery (ADR 0008). `space` on a chute-bearing capsule arms the parachute; it auto-deploys when dynamic pressure builds in the atmosphere, dropping terminal velocity below V\_CRIT so the capsule lands safely without `CanSoftLand`. New Capsule loadout (standalone re-entry test vehicle). Preceded by v0.12.3 (2-stage Lander + surface staging, ADR 0007), v0.12.2 (analytic-Kepler predictor fidelity + Line-of-Nodes split rendezvous, ADR 0006), v0.12.1 (plane-aware dual-strategy transfer, ADR 0005), and v0.12.0 (numbered craft slots 1–9).
 
-**v0.9.4 ascent ergonomics in flight.** Ground launch primitives
-landed in v0.9.2 (`n` → POSITION → launchpad spawns a Saturn V at
-altitude 0 on a rotating Earth, with surface-frame SAS, pitch trim,
-and a LAUNCH HUD), and v0.9.4 layers KSP-style live guidance on top:
-predictive **ap / pe / t-to-apo / Δv→circ** readouts in the LAUNCH
-HUD, an **ORBIT READY** callout when apoapsis crosses 200 km,
-auto-snap to NavSurface on launchpad spawn (so `w` already means
-surface-prograde), and a single-key **`C`** that plants the
-circularisation node at next apoapsis. Pad-to-LEO is now a
-playable loop — see [Surface launches](#surface-launches) below.
+**Full v0.12 cycle.** v0.12 is a grab-bag coverage cycle spanning
+descent/recovery (parachutes, 2-stage Lander), transfer math (dual-strategy
+Hohmann + analytic predictor), and cleanup (numbered craft slots). The
+v0.10 cycle added rate-limited slew, true plane-match/inclination burns,
+multi-rev porkchop, and a perspective-tilt orbit view. v0.11 added the
+launch chase-cam (`ViewLaunch`), the crashed/landed lifecycle (ADR 0004),
+and Lander silhouette + soft-landing polish. Pad-to-LEO is a playable
+loop — see [Surface launches](#surface-launches) below.
 
 ```bash
 # Linux x86_64
@@ -173,7 +171,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `C` | Plant circularize burn at next apoapsis (v0.9.4+) — pairs with the LAUNCH HUD's ORBIT READY callout. Errors when apoapsis is below the primary's atmosphere cutoff or the orbit is hyperbolic |
 | `K` | Plant rendezvous nudge to target craft (v0.10.2+) — single-burn Lambert intercept projected onto the closest velocity-frame axis. Reads the TARGET HUD's ACH CA / Δv readouts. Errors when there's no craft target, target shares a different primary, already DOCK READY, or no improvement available |
 | `t` / `T` | Cycle / clear `World.Target` (non-active sibling craft → bodies in active system → none) |
-| `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+) |
+| `space` | Decouple bottom stage of active craft (multi-stage only; single-stage status-flashes "cannot drop the only remaining stage") (v0.9.1+). On a bare chute-bearing capsule the same press **arms the parachute** instead — it auto-deploys once dynamic pressure builds in the atmosphere (v0.12+, ADR 0008) |
 | `P` | Porkchop plot for selected body; `Enter` on a cell plants that Lambert transfer. Inter-primary only — moon targets show a banner redirecting to `H`. Press `o` inside to open the transfer-options sub-menu (`n` cycles nRev 0–3, `r` toggles prograde/retrograde, `b` toggles short/long branch); `enter`/`o`/`esc` closes and re-solves (v0.10.5+) |
 | `R` | Refine plan — re-Lambert from live state, plant mid-course correction + update arrival |
 | `m` | Open maneuver planner |
@@ -194,6 +192,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `b` | Engage / cut manual burn (main engine, throttle > 0) |
 | `r` | Engine: main / RCS (v0.8.0+) |
 | `k` | SAS model: slew / instant — MANUAL (rate-limited, default) vs AUTO (legacy instant snap); navball `[MAN]`/`[AUT]` tag mirrors it (v0.10.0+) |
+| `;` | NavMode cycle: Orbit → Surface → Target (skips Target when no craft target is set) (v0.9.3+) |
 | `W` / `S` | Attitude surface-prograde / surface-retrograde — track velocity in the rotating-atmosphere frame (v - ω × r). For ascent gravity turn (v0.9.2+) |
 | `>` / `<` | Pitch trim ±10° east / west — rotate thrust vector about local-north axis on top of current SAS mode (v0.9.2+) |
 | `\` | Reset pitch trim to 0 (v0.9.2+) |
@@ -318,13 +317,19 @@ the displayed bracket.
   a node row opens the maneuver planner for edit-replace. Title
   bar shows `CRAFT N/M` chip when more than one craft is loaded.
   Save schema bumped v4 → v5 to nest per-craft state.
-- **Craft types** (v0.8.2+). Four loadouts in the launch catalog:
+- **Craft types** (v0.8.2+). Nine loadouts in the launch catalog:
   S-IVB-1 (yellow `▲`, J-2 third stage), ICPS (blue `◆`, RL-10
   low-TWR), RCS-tug (pink `●`, pure monoprop, no main engine),
-  Lander (mint `▼`, throttleable descent stage). Each carries
-  propulsion + visual differentiation; the orbit canvas renders
-  every craft with its loadout glyph + color so they read
-  distinctly even at small zoom.
+  Lander (mint `▼`, 2-stage Apollo-LM-style — Descent + Ascent;
+  surface-staging the descent leaves it as a landed wreck and
+  flies the ascent stage back to orbit, ADR 0007), Saturn-V
+  (`▲`, 3-stage S-IC + S-II + S-IVB), SLS-Block1 (`▲`, 3-stage
+  SRB + Core + ICPS), Falcon-9 (`▲`, 2-stage Merlin/Merlin-Vac),
+  Apollo-Stack (`▲`, full mission arc S-IC → S-II → S-IVB → LM →
+  CSM), Capsule (`◓`, single-stage re-entry capsule with recovery
+  parachute, ADR 0008). Each carries propulsion + visual
+  differentiation; the orbit canvas renders every craft with its
+  loadout glyph + color so they read distinctly even at small zoom.
 - **Multi-tier stack + configurator** (v0.10.1+). The **Apollo
   Stack** loadout (S-IC → S-II → S-IVB → LM → CSM) flies the full
   mission arc on the v0.9.1 staging chain: decoupling the mid-stage
@@ -494,7 +499,12 @@ prints a warning to stderr and falls back to defaults.
 | v0.6 | Planner UX + missions | Burn-at-next scheduler, projected-orbit HUD, finite-burn-aware iteration, moon → parent escape, click-only mouse + 5-way views, mission scaffold, multiplayer design spike. |
 | v0.7 | Modding + manual flight + textures | External system / theme overlays, manual-flight stick (throttle + attitude), inclination-change planner, retrograde Lambert flag, textured Earth/Moon/Mars/Jupiter, per-node throttle, SOI / frame-transition HUD. |
 | v0.8 | Multi-craft polish | RCS / monopropellant precision thruster (v0.8.0). Multi-craft slate with per-craft burns + spawn keystroke + selector + save schema v4→v5 (v0.8.1). Craft types (4 loadouts with glyph/color visuals), full spawn form, clickable HUD nodes, Hohmann capture-preview, equatorial inclination match (v0.8.2). Docking + undocking, RENDEZVOUS HUD, alongside-spawn, engine-firing flame + per-thruster RCS puff visuals (v0.8.3). Atmospheric drag (Earth + Mars exponential atmospheres, drag-aware Verlet wired into live integrator + predictor, surface-clamp on impact, haze halo) (v0.8.4). Sim-time planet rotation, view-aware texture projection with per-body axial tilts, polygon-rasterised Earth grid, far-side / polar Moon detail, tilted Saturn rings with C / B / Cassini Division / A / F bands, textured Sun + Galileans + Uranus + Neptune, tidally-locked moons keeping their iconic face on the parent (v0.8.5). KSP-style F5/F9 quicksave/load + per-node delete/clear, body-equatorial Keplerian frame for body-bound orbits, adaptive warp clamps (throttle-change + upcoming-node predictive ramp-down), finite-burn iterate-for-target toggle in `m` form (v0.8.6). |
-| v0.9 | The craft fleet grows up (in progress) | Unified `World.Target` slot (kind ∈ {None, Body, Craft}) replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD block; `H` / `I` planters consume the slot (v0.9.0). KSP-style player-managed staging chain: `space` decouples bottom stage; `Spacecraft.Stages` source-of-truth; Saturn-V 3-stage loadout; STAGES HUD; save schema v5 → v6 (v0.9.1). Ground-launch primitives: launchpad spawn at altitude 0, surface-frame SAS (`W` / `S`), pitch trim (`<` / `>` / `\`), LAUNCH HUD, `saturn-v-pad-to-leo` mission (v0.9.2). Rendezvous tooling: target-relative SAS modes, TCA / CA / DOCK READY, KSP-style NavMode cycle (`;`), `m`-form integration with `next closest approach` trigger event (v0.9.3). Ascent ergonomics: predictive `ap` / `pe` / `Δv→circ` in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, `C` plants circularize-at-apoapsis (v0.9.4). |
+| v0.9 | The craft fleet grows up | Unified `World.Target` slot (kind ∈ {None, Body, Craft}) replaces the implicit body cursor; `t` / `T` cycle / clear; TARGET HUD block; `H` / `I` planters consume the slot (v0.9.0). KSP-style player-managed staging chain: `space` decouples bottom stage; `Spacecraft.Stages` source-of-truth; Saturn-V 3-stage loadout; STAGES HUD; save schema v5 → v6 (v0.9.1). Ground-launch primitives: launchpad spawn at altitude 0, surface-frame SAS (`W` / `S`), pitch trim (`<` / `>` / `\`), LAUNCH HUD, `saturn-v-pad-to-leo` mission (v0.9.2). Rendezvous tooling: target-relative SAS modes, TCA / CA / DOCK READY, KSP-style NavMode cycle (`;`), `m`-form integration with `next closest approach` trigger event (v0.9.3). Ascent ergonomics: predictive `ap` / `pe` / `Δv→circ` in LAUNCH HUD, ORBIT READY callout, NavSurface auto-snap on launchpad spawn, `C` plants circularize-at-apoapsis (v0.9.4). |
+| v0.9.5 | Navball | KSP-style attitude indicator clamped into the bottom-right HUD: braille-rendered sphere with classic-ADI horizon split, per-mode SAS/target/maneuver-node markers, NavSurface compass ticks. |
+| v0.9.6 | Solar lighting + navball overhaul | Solar lighting + day/night terminator + eclipses (exponential-density shading, sub-solar geometry). Navball redesigned: opaque KSP-style panel composited bottom-right over the canvas, relocated + doubled ball, clickable SAS buttons, HUD trim. |
+| v0.10 | Planner + maneuver tooling | Rate-limited slew (attitude, `k` toggles MANUAL/AUTO), true plane-match + inclination burns, predictor adaptive sampling, multi-rev porkchop + Lambert short/long picker, rendezvous tooling (`K` plant, TCA / CA / DOCK READY HUD), perspective-tilt orbit view (`shift+↑/↓`), launch-anchor (v0.10.6+). |
+| v0.11 | Chase-cam + lifecycle | Launch chase-cam (`ViewLaunch`, `V` to jump); crashed/landed lifecycle (ADR 0004): `CanSoftLand` capability gates soft Touchdown vs. Crashed; `[E]` end-flight removes wreckage. Lander silhouette + soft-landing polish (landing legs, hypergolic flame, v0.11.2–.5). |
+| v0.12 | Grab-bag coverage cycle | Numbered craft slots 1–9 + cleanup (v0.12.0). Plane-aware dual-strategy Hohmann: combined fused-Lambert vs. split coplanar raise + cheap plane change, plants the cheaper (v0.12.1, ADR 0005). Analytic-Kepler predictor fidelity + Line-of-Nodes split rendezvous for inclined targets (v0.12.2, ADR 0006, GH #66/#67). 2-stage Lander + surface staging: Descent jettisoned on the surface as a Landed wreck, Ascent returns to orbit (v0.12.3, ADR 0007). Parachutes: arm via `space`, auto-deploy on dynamic pressure; Capsule loadout for standalone re-entry (v0.12.4, ADR 0008). |
 
 Per-version detail: [`docs/state-of-game.md`](docs/state-of-game.md).
 v0.5 release notes: [`docs/v0.5-release-notes.md`](docs/v0.5-release-notes.md).
@@ -502,20 +512,33 @@ v0.6 / v0.7 / v0.8 / v0.9 plans: [`docs/v0.6-plan.md`](docs/v0.6-plan.md), [`doc
 
 ## Future plans
 
-v0.9 — **the craft fleet grows up**. Slice breakdown in
-[`docs/v0.9-plan.md`](docs/v0.9-plan.md):
+**v0.12 cycle** — the current cycle ([`docs/v0.12-plan.md`](docs/v0.12-plan.md))
+shipped its five slices; the two remaining polish items from the grab-bag are
+the natural next targets:
 
-- ~~v0.9.0 — unified `World.Target` slot (kind ∈ {None, Body, Craft}); `t` / `T` cycle / clear; TARGET HUD; `H` / `I` planters read it~~ **shipped.**
-- ~~v0.9.1 — staging chain (KSP-style player-managed sequential decouples; `Spacecraft.Stages []Stage`; `space` keystroke; Saturn-V 3-stage loadout; save schema v5 → v6)~~ **shipped.**
-- v0.9.2 — ground launch primitives (`SpawnSpec.Launchpad`, surface-co-rotating spawn at altitude 0, LAUNCH HUD, surface-frame SAS, pitch trim). **In flight on branch — work-in-progress.** Orbital insertion routinely undershoots without a gravity-turn assist; treat as an experimental loop pending an ergonomic pass.
-- v0.9.3 — rendezvous tooling (target-relative SAS modes, live closest-approach countdown; manual loop is the success metric).
-- v0.9.5 navball — KSP-style attitude indicator clamped into the bottom-right HUD; consumes v0.9.3 target-relative burn modes + v0.9.4 NavSurface frame routing.
-- v0.9.6+ bandwidth-permitting — multi-rev porkchop UI + Lambert short/long picker, capture-direction toggle, predictor adaptive sampling, solar lighting + terminator + eclipses (research-first), polish bag.
+- Two-colour flame with hot-white core (`ComposeFlame` in
+  `internal/tui/screens/launch_sprite.go`) — Mach-diamond white-hot core +
+  fuel-coloured outer plume.
+- Multi-row engine-bell taper — reopen once the v0.11.5 single-row bell
+  has had playtest signal.
 
-Deferred to v0.10+: multiplayer implementation, interstellar transfer,
-N-body perturbations, mission scripting / editor (eight-decision-point
-design pass intact), atmospheric heating / structural overstress,
-drag-to-edit nodes, theme-file hot-reload, race-detector CI.
+**Accepted backlog** (not yet cycled):
+
+- Moon-frame lunar-capture inclination trim (GH #68, deferred from v0.12.2) —
+  plane-change + capture burn inside Luna's SOI for inclined orbits.
+- Dedicated `ViewLanding` ViewMode — gates on landing-HUD instruments
+  diverging enough from launch-HUD to warrant a split.
+- F9-S1 landing-leg deploy-state flag — `Stage.LegsDeployed` runtime flag
+  for Falcon-9 recovery (always-legged Lander doesn't need it).
+- General vessel-removal action — removing live orbital craft beyond `[E]`
+  end-flight for crashed vessels.
+- Polar-launch fallback hardening — no playtest signal yet.
+- Stippled ground-fill — reopen on a "looks flat" playtest signal.
+
+**Deferred (future cycles):** multiplayer implementation, interstellar
+transfer, N-body perturbations, mission scripting / editor
+(eight-decision-point design pass intact), atmospheric heating / structural
+overstress, drag-to-edit nodes, theme-file hot-reload.
 
 Full backlog in [`docs/state-of-game.md`](docs/state-of-game.md).
 

--- a/docs/adr/0008-parachutes-atmospheric-descent-recovery.md
+++ b/docs/adr/0008-parachutes-atmospheric-descent-recovery.md
@@ -126,8 +126,8 @@ Retunable from playtest, like `V_CRIT` / `NOSE_TOL`.
 each with its own gates:
 
 ```
-engine route (unchanged):  CanSoftLand   && v < V_CRIT && cosNose > NOSE_TOL
-chute route (new):         ChuteDeployed && v < V_CRIT          // nose waived
+engine route (unchanged):  CanSoftLand   && |V_inertial| < V_CRIT && cosNose > NOSE_TOL
+chute route (new):         ChuteDeployed && |v_rel|      < V_CRIT          // nose waived
 ```
 
 The chute route **waives the `NOSE_TOL` nose-alignment gate.** Under a
@@ -135,6 +135,24 @@ canopy the chute is the stabiliser, the player is not actively flying
 attitude, and demanding a specific nose angle for a *passive* descent
 is the artificial part. The engine route keeps its nose check
 untouched (a Falcon 9 thrusting in 60° off-vertical is still a crash).
+
+**Velocity frame — amended after Slice 3 verification.** The chute
+route measures **air-relative** speed `v_rel = |V − ω×r|`, *not*
+inertial `|V|` like the engine route. This deviates from this ADR's
+original frozen spec (which reused the engine route's inertial `v`) and
+was caught by flying the actual descent: a parachute nulls the vessel's
+velocity *relative to the co-rotating atmosphere*, so on a fast-rotating
+body a perfectly-descending capsule still carries the surface
+co-rotation velocity in the inertial frame (~465 m/s at Earth's
+equator). The inertial `V_CRIT` test crashed every Earth splashdown
+despite an ideal canopy descent (`|v_rel|` converged to ~7.6 m/s while
+`|V_inertial|` held ~426 m/s all the way down). The engine route keeps
+inertial `|V|` — its shipped tests pin that, a powered lander on the
+slow-rotating Moon sees a negligible `ω×r`, and the parachute is the
+*first* Earth-landing feature to exercise the fast-rotation regime
+ADR 0004's inertial predicate never hit. `ω` is `physics.AtmosphereOmega`
+— the same spin vector the drag model uses, so the chute route's frame
+agrees with the air the canopy is actually braking against.
 
 ### 5. Thresholds — global consts
 
@@ -275,6 +293,17 @@ body-agnostic — no body-specific deploy-altitude constant.
   `HasParachute`/`ChuteDeployed` now both gate Landed, via two
   branches. A future maintainer must keep the engine route's
   nose-alignment check and the chute route's waiver distinct.
+- **Two velocity frames on the surface predicate** (Slice 3 verification
+  amendment, see Decision §4). The engine route tests inertial `|V|`;
+  the chute route tests air-relative `|v_rel| = |V − ω×r|`. The split is
+  load-bearing — collapsing it back to one frame re-breaks Earth
+  splashdown (inertial) or shipped Falcon-9/Moon soft-lands (air-
+  relative). The latent inertial-vs-air-relative tension lives in the
+  engine route too (a powered Earth-equator landing arrives at ~465 m/s
+  inertial), but it is invisible today: powered landers fly the
+  slow-rotating Moon, where `ω×r` is ~4.6 m/s. If a powered atmospheric
+  Earth landing ever becomes a real arc, the engine route needs the same
+  air-relative treatment — banked, not done here.
 - A `Spacecraft.HasParachute` mirror joins the `CanSoftLand` /
   `Landed` / `Crashed` flag cluster; the SyncFields re-derive list
   grows by one.

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -2,13 +2,12 @@
 
 <!--
   meta:
-    snapshot_version: v0.12.2 (Slice 5 follow-on — Projected Orbit
-      Kepler-step fidelity (#66) + Line-of-Nodes split rendezvous
-      (#67); v0.12 cycle in progress, Slices 2/3 + flame polish remain)
-    snapshot_date: 2026-05-29
-    revised_date: 2026-05-29 (header refreshed from the stale v0.9.6
-      snapshot: v0.10–v0.12 cycle summaries folded in, released-
-      versions table extended through v0.12.2; origin/main sole branch)
+    snapshot_version: v0.12.3 (2-stage Lander + surface staging, ADR 0007;
+      parachutes Slice 3 in flight on branch slice3-parachutes, ADR 0008)
+    snapshot_date: 2026-05-30
+    revised_date: 2026-05-30 (parachutes moved from backlog → in-progress
+      v0.12.4; releases index and snapshot block updated; v0.12 row reflects
+      v0.12.3 shipped)
     archive: docs/state-of-game-archive.md
   Read the archive for the full v0.7.6-baseline-plus-v0.8-additions
   detail this rewrite condensed. This file is the canonical
@@ -17,7 +16,7 @@
   ADRs (docs/adr/); this file keeps the entries + the snapshot.
 -->
 
-> Snapshot at **v0.12.2** (May 2026). Three cycles have shipped to
+> Snapshot at **v0.12.3** (May 2026). Three cycles have shipped to
 > `main` since v0.9.6:
 >
 > - **v0.10** (May 19–23) — planner + maneuver tooling: rate-limited
@@ -27,21 +26,20 @@
 > - **v0.11** (May 24–27) — the launch chase-cam (`ViewLaunch`), the
 >   crashed/landed lifecycle ([ADR 0004](adr/0004-crashed-landed-lifecycle.md)),
 >   and Lander silhouette + soft-landing polish.
-> - **v0.12** (May 29, *in progress*) — numbered craft slots + a
+> - **v0.12** (May 29–30, *in progress*) — numbered craft slots + a
 >   cleanup bundle (v0.12.0); the combined plane-shift + Hohmann
 >   dual-strategy intra-primary transfer (v0.12.1,
 >   [ADR 0005](adr/0005-combined-plane-shift-hohmann-via-lambert.md));
->   and the **Slice 5 follow-on** (v0.12.2,
+>   the **Slice 5 follow-on** (v0.12.2,
 >   [ADR 0006](adr/0006-intra-primary-transfer-arrival-and-predictor-fidelity.md)):
 >   analytic-Kepler Projected-Orbit fidelity (GH #66) and a
->   Line-of-Nodes split that actually rendezvous with an inclined
->   Luna (GH #67).
+>   Line-of-Nodes split rendezvous (GH #67); and the 2-stage Lander
+>   + surface staging (v0.12.3, [ADR 0007](adr/0007-surface-staging-and-decouple-plan.md)).
 >
-> **Remaining in v0.12:** parachutes (Slice 3, ADR 0008), two-colour
-> flame polish (Slice 4 leftover), and the Moon-frame lunar-capture
-> inclination trim (GH #68, deferred from v0.12.2). The 2-stage Lander
-> + surface staging (Slice 2, ADR 0007) shipped in **v0.12.3**. Pre-v0.8
-> per-feature detail preserved at
+> **In flight:** parachutes (Slice 3, ADR 0008, branch `slice3-parachutes`,
+> targeting **v0.12.4**). **Remaining after that:** two-colour flame polish
+> (Slice 4 leftover) and Moon-frame lunar-capture inclination trim
+> (GH #68, deferred from v0.12.2). Pre-v0.8 per-feature detail preserved at
 > [`docs/state-of-game-archive.md`](state-of-game-archive.md).
 
 ---
@@ -96,8 +94,9 @@ inclination burns, multi-rev porkchop) and the orbit view
 crashed/landed lifecycle (ADR 0004) with Lander / soft-landing
 polish. v0.12 (in progress) brought numbered craft slots, the
 combined plane-shift + Hohmann dual-strategy transfer (ADR 0005),
-and the Line-of-Nodes split + analytic-Kepler predictor fidelity
-(ADR 0006).
+the Line-of-Nodes split + analytic-Kepler predictor fidelity
+(ADR 0006), and the 2-stage Lander + surface staging (ADR 0007, v0.12.3);
+parachutes (ADR 0008) are in flight at v0.12.4.
 
 The codebase still tracks Apollo-era reality more than KSP-style
 fantasy — atmospheric scale heights, axial tilts, sidereal periods,
@@ -126,7 +125,7 @@ flyby) match real spacecraft work.
 
 | Version | Date | Status | Theme |
 |---|---|---|---|
-| [v0.12](v0.12-plan.md) | 2026-05-29 | ✓ | **Cycle in progress.** Numbered craft slots + cleanup (v0.12.0); combined plane-shift + Hohmann dual-strategy transfer (v0.12.1, ADR 0005); Slice 5 follow-on — Line-of-Nodes split rendezvous + analytic-Kepler Projected-Orbit fidelity (v0.12.2, ADR 0006, GH #66/#67). Remaining: lander 2-stage (ADR 0007), parachutes (ADR 0008), flame polish, GH #68. |
+| [v0.12](v0.12-plan.md) | 2026-05-29 | 🚧 | **Cycle in progress.** Numbered craft slots + cleanup (v0.12.0); combined plane-shift + Hohmann dual-strategy transfer (v0.12.1, ADR 0005); Slice 5 follow-on — Line-of-Nodes split rendezvous + analytic-Kepler Projected-Orbit fidelity (v0.12.2, ADR 0006, GH #66/#67); 2-stage Lander + surface staging (v0.12.3, ADR 0007). **In flight:** parachutes (v0.12.4, ADR 0008, branch `slice3-parachutes`). Remaining after that: flame polish, GH #68. |
 | [v0.11](v0.11-plan.md) | 2026-05-24 → 27 | ✓ | Launch chase-cam (`ViewLaunch`, v0.11.0); crashed/landed lifecycle (ADR 0004); Lander silhouette + soft-landing polish (v0.11.2–.5). |
 | [v0.10](v0.10-plan.md) | 2026-05-19 → 23 | ✓ | Planner + maneuver tooling — rate-limited slew, staging chain, rendezvous tooling, true plane-match/inclination burns, predictor adaptive sampling, multi-rev porkchop, perspective-tilt orbit view, launch-anchor. |
 | [v0.9.6](#v096) | 2026-05-17 | ✓ | Solar lighting + day/night terminator + eclipses, plus a navball overhaul (flicker root-cause fix + KSP-style framed panel). Closes the v0.9 cycle. |
@@ -851,8 +850,8 @@ the [capture-direction toggle](#capture-direction-toggle) and
 🧊 **backlog**. `EvalContext` doesn't carry fuel / monoprop / dv_budget today, so the rolled-back v0.8.7 expression env had those zeroed. Trivial threading from `sim.World.Tick`; pairs with the mission-scripting design pass.
 
 ### Parachutes for atmospheric descent + recovery
-<!-- llm-parse: id=parachutes status=backlog target=v0.12 origin=adr-0004 -->
-🧊 **backlog · target v0.12 · ADR-worthy when it lands**. A non-engine path to soft Touchdown — a deployed parachute on a Vessel without `CanSoftLand` qualifies for the surface-arrival predicate via aerodynamic deceleration. Touches drag (deploy-time `BallisticCoefficient` bump), spacecraft state (parachute deploy flag, deployed-vs-torn states), control modes (deploy keystroke gated on dynamic pressure + altitude). The v0.11.4 Crashed / Soft-Landed lifecycle (ADR 0004) explicitly preserved this hook so capsule-class vessels — historically the natural parachute users — get a non-`CanSoftLand` route to surviving entry. Sources: `docs/adr/0004-crashed-landed-lifecycle.md` §214; `docs/v0.11-plan.md` §Deferred line 950.
+<!-- llm-parse: id=parachutes status=in-progress target=v0.12.4 adr=0008 branch=slice3-parachutes -->
+🚧 **in progress · v0.12.4 · branch `slice3-parachutes` · ADR 0008 authored (2026-05-30)**. A non-engine path to soft Touchdown — a deployed parachute on a Vessel without `CanSoftLand` qualifies for the surface-arrival predicate via aerodynamic deceleration. `space` on a chute-bearing capsule arms the chute; it auto-deploys when dynamic pressure ≥ `ChuteDeployQMin`, dropping terminal velocity to ~7.4 m/s (mass-independent via `ChuteDeployedBC ≈ 0.3 m²/kg` absolute replace). New Capsule loadout is the directly-spawnable test vehicle. See [`docs/adr/0008-parachutes-atmospheric-descent-recovery.md`](adr/0008-parachutes-atmospheric-descent-recovery.md).
 
 ### Stippled ground-fill variant
 <!-- llm-parse: id=stippled-ground-fill status=backlog target=v0.12 origin=v0.11.4 -->

--- a/internal/physics/drag.go
+++ b/internal/physics/drag.go
@@ -74,6 +74,18 @@ func atmospherePeriodSeconds(primary bodies.CelestialBody) float64 {
 	return primary.SideralRotationSeconds()
 }
 
+// AirRelativeVelocity returns the craft's velocity relative to the
+// co-rotating atmosphere: v_rel = v − ω×r, where ω is the body's spin
+// vector (AtmosphereOmega). Single source of truth for "air-relative
+// velocity" — the quantity the drag model opposes, the parachute
+// auto-deploy gate measures, the surface-arrival chute route tests, and
+// the descent HUD reads. Sharing it keeps those consumers in agreement
+// by construction instead of re-deriving v_rel from independent ω
+// sources that could drift apart. v0.12 Slice 3 (ADR 0008).
+func AirRelativeVelocity(r, v orbital.Vec3, primary bodies.CelestialBody) orbital.Vec3 {
+	return v.Sub(AtmosphereOmega(primary).Cross(r))
+}
+
 // DynamicPressure returns q = 0.5 · ρ · |v_rel|² (Pa) for a craft at
 // state (r, v) relative to primary, using the same air-relative
 // velocity (v_rel = v − ω × r) and exponential-density model as
@@ -94,7 +106,7 @@ func DynamicPressure(r, v orbital.Vec3, primary bodies.CelestialBody) float64 {
 	if rho == 0 {
 		return 0
 	}
-	vRel := v.Sub(AtmosphereOmega(primary).Cross(r))
+	vRel := AirRelativeVelocity(r, v, primary)
 	return 0.5 * rho * vRel.Dot(vRel)
 }
 
@@ -125,7 +137,7 @@ func DragAccel(r, v orbital.Vec3, primary bodies.CelestialBody, bc float64) orbi
 	if rho == 0 {
 		return orbital.Vec3{}
 	}
-	vRel := v.Sub(AtmosphereOmega(primary).Cross(r))
+	vRel := AirRelativeVelocity(r, v, primary)
 	vRelMag := vRel.Norm()
 	if vRelMag == 0 {
 		return orbital.Vec3{}

--- a/internal/physics/drag.go
+++ b/internal/physics/drag.go
@@ -74,6 +74,30 @@ func atmospherePeriodSeconds(primary bodies.CelestialBody) float64 {
 	return primary.SideralRotationSeconds()
 }
 
+// DynamicPressure returns q = 0.5 · ρ · |v_rel|² (Pa) for a craft at
+// state (r, v) relative to primary, using the same air-relative
+// velocity (v_rel = v − ω × r) and exponential-density model as
+// DragAccel. Returns 0 outside the body's atmosphere (no Atmosphere,
+// altitude above cutoff, below the surface). v0.12 Slice 3 (ADR 0008):
+// the parachute auto-deploy gate is expressed in q, which is
+// body-agnostic — no body-specific deploy-altitude constant.
+func DynamicPressure(r, v orbital.Vec3, primary bodies.CelestialBody) float64 {
+	if primary.Atmosphere == nil {
+		return 0
+	}
+	rMag := r.Norm()
+	if rMag == 0 {
+		return 0
+	}
+	altitude := rMag - primary.RadiusMeters()
+	rho := AtmosphericDensity(primary, altitude)
+	if rho == 0 {
+		return 0
+	}
+	vRel := v.Sub(AtmosphereOmega(primary).Cross(r))
+	return 0.5 * rho * vRel.Dot(vRel)
+}
+
 // DragAccel returns the atmospheric-drag acceleration vector on a craft
 // with state (r, v) relative to primary, given a ballistic coefficient
 // BC = C_D · A / m (m²/kg). Returns zero outside the body's atmosphere

--- a/internal/physics/drag_test.go
+++ b/internal/physics/drag_test.go
@@ -134,6 +134,39 @@ func TestDragAccelMagnitudeAtKnownConditions(t *testing.T) {
 	}
 }
 
+// TestDynamicPressureAtKnownConditions — q = 0.5·ρ·|v_rel|² (Pa),
+// using the same air-relative velocity and exponential-density model
+// as DragAccel. At the surface (ρ = 1.225) with a 100 m/s air-relative
+// velocity, q = 0.5·1.225·100² = 6125 Pa.
+func TestDynamicPressureAtKnownConditions(t *testing.T) {
+	earth := earthWithAtm()
+	r := orbital.Vec3{X: earth.RadiusMeters()}
+	vRelTest := orbital.Vec3{Z: 100}
+	v := AtmosphereOmega(earth).Cross(r).Add(vRelTest)
+	q := DynamicPressure(r, v, earth)
+	want := 0.5 * 1.225 * 100 * 100
+	if math.Abs(q-want) > 1e-6 {
+		t.Errorf("q = %g, want %g (0.5·ρ·v²)", q, want)
+	}
+}
+
+// TestDynamicPressureZeroOutsideAtmosphere — zero above the cutoff and
+// for airless bodies (the chute can never deploy there).
+func TestDynamicPressureZeroOutsideAtmosphere(t *testing.T) {
+	earth := earthWithAtm()
+	// Above cutoff.
+	rHigh := orbital.Vec3{X: earth.RadiusMeters() + earth.Atmosphere.CutoffAltitude + 1000}
+	if q := DynamicPressure(rHigh, orbital.Vec3{Z: 5000}, earth); q != 0 {
+		t.Errorf("above cutoff: q = %g, want 0", q)
+	}
+	// Airless body.
+	moon := luna()
+	rMoon := orbital.Vec3{X: moon.RadiusMeters()}
+	if q := DynamicPressure(rMoon, orbital.Vec3{Z: 100}, moon); q != 0 {
+		t.Errorf("airless body: q = %g, want 0", q)
+	}
+}
+
 // TestDragAccelZeroBC: zero ballistic coefficient ⇒ zero drag. (Useful
 // shortcut for craft that want to bypass the drag path, though we
 // always pass effective-BC ≥ 0.01 today.)

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -201,6 +201,14 @@ type Craft struct {
 	LandedLatDeg float64 `json:"landed_lat_deg,omitempty"`
 	LandedLonDeg float64 `json:"landed_lon_deg,omitempty"`
 
+	// ChuteState (v0.12 Slice 3 / ADR 0008, schema v6 additive — no
+	// bump): the runtime parachute deploy state (0=Stowed, 1=Armed,
+	// 2=Deployed). omitempty so pre-Slice-3 saves round-trip without
+	// the field: absent ⇒ 0 ⇒ Stowed, correct for any vessel saved
+	// before this slice. The per-Stage HasParachute capability rides
+	// the Stage DTO; SyncFields re-derives the flat Spacecraft mirror.
+	ChuteState int `json:"chute_state,omitempty"`
+
 	// DecouplePlan (v0.12 Slice 2 / ADR 0007, schema v6 additive — no
 	// bump): the remaining bottom-up staging group sizes. omitempty so
 	// pre-v0.12 saves and craft with no plan (the common single-pop
@@ -239,6 +247,14 @@ type Stage struct {
 	// Pre-v0.11.4 saves load with the field absent → default-false,
 	// which matches every pre-v0.11.4 catalog stage.
 	CanSoftLand bool `json:"can_soft_land,omitempty"`
+
+	// HasParachute (v0.12 Slice 3 / ADR 0008, schema v6 additive — no
+	// bump): per-Stage parachute capability, round-tripped on the wire
+	// so a saved capsule (or the Apollo CSM stage) loads with the right
+	// chute-route gate after SyncFields re-derives the flat
+	// Spacecraft.HasParachute mirror. Pre-Slice-3 saves load with the
+	// field absent → default-false, matching every pre-Slice-3 stage.
+	HasParachute bool `json:"has_parachute,omitempty"`
 }
 
 // Node mirrors sim.ManeuverNode. Event (v0.6.0+, schema v2) is
@@ -460,6 +476,7 @@ func payloadFromWorld(w *sim.World) Payload {
 			LandedLatDeg:       c.LandedLatDeg,
 			LandedLonDeg:       c.LandedLonDeg,
 			DecouplePlan:       c.DecouplePlan,
+			ChuteState:         int(c.ChuteState),
 		}
 		// v0.9.1+: serialize Stages so v6 saves carry per-stage
 		// detail. Single-stage craft still wire out a one-element
@@ -482,6 +499,7 @@ func payloadFromWorld(w *sim.World) Payload {
 				RCSIsp:               s.RCSIsp,
 				BallisticCoefficient: s.BallisticCoefficient,
 				CanSoftLand:          s.CanSoftLand,
+				HasParachute:         s.HasParachute,
 			})
 		}
 		for _, dc := range c.DockedComponents {
@@ -652,6 +670,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			LandedLatDeg:       wc.LandedLatDeg,
 			LandedLonDeg:       wc.LandedLonDeg,
 			DecouplePlan:       wc.DecouplePlan,
+			ChuteState:         spacecraft.ChuteState(wc.ChuteState),
 		}
 		c.SyncFields()
 		// v0.8.2+: pre-v0.8.2 saves carry no Glyph/Color; backfill

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -306,6 +306,13 @@ type DockedComponent struct {
 	Thrust           float64 `json:"thrust,omitempty"`
 	RCSThrust        float64 `json:"rcs_thrust,omitempty"`
 	RCSIsp           float64 `json:"rcs_isp,omitempty"`
+	// CanSoftLand / HasParachute (v0.12 Slice 3 / ADR 0008, schema v6
+	// additive — no bump): the surface-arrival capability flags, so a
+	// composite saved with a chute-bearing or soft-land component
+	// restores those capabilities on undock after reload. omitempty;
+	// absent → false, matching pre-Slice-3 components.
+	CanSoftLand  bool `json:"can_soft_land,omitempty"`
+	HasParachute bool `json:"has_parachute,omitempty"`
 }
 
 // ActiveBurn mirrors sim.ActiveBurn. Throttle (v0.7.6+, schema v4)
@@ -516,6 +523,8 @@ func payloadFromWorld(w *sim.World) Payload {
 				Thrust:           dc.Thrust,
 				RCSThrust:        dc.RCSThrust,
 				RCSIsp:           dc.RCSIsp,
+				CanSoftLand:      dc.CanSoftLand,
+				HasParachute:     dc.HasParachute,
 			})
 		}
 		for _, n := range c.Nodes {
@@ -706,6 +715,8 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				Thrust:           dc.Thrust,
 				RCSThrust:        dc.RCSThrust,
 				RCSIsp:           dc.RCSIsp,
+				CanSoftLand:      dc.CanSoftLand,
+				HasParachute:     dc.HasParachute,
 			})
 		}
 		// v0.8.1+: per-craft Nodes / ActiveBurn loaded directly from

--- a/internal/save/save_migrate_v5_to_v6.go
+++ b/internal/save/save_migrate_v5_to_v6.go
@@ -34,6 +34,7 @@ func wireStagesToSim(wire []Stage) []spacecraft.Stage {
 			RCSIsp:               s.RCSIsp,
 			BallisticCoefficient: s.BallisticCoefficient,
 			CanSoftLand:          s.CanSoftLand,
+			HasParachute:         s.HasParachute,
 		}
 	}
 	return out

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -1033,3 +1033,42 @@ func TestLegacySaveNoAttitudeDirSnapsNoTeleport(t *testing.T) {
 		t.Errorf("first-tick snap did not seed a unit nose: |dir|=%.6f", n)
 	}
 }
+
+// TestRoundtripParachute — v0.12 Slice 3 (ADR 0008): the runtime
+// ChuteState (craft-level) and the per-Stage HasParachute capability
+// both round-trip, and SyncFields re-derives the Spacecraft.HasParachute
+// mirror from Stages[0] on load. No SchemaVersion bump (omitempty-additive).
+func TestRoundtripParachute(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// Stamp the active craft as a chute-bearing capsule mid-descent
+	// (armed, waiting to inflate).
+	c.Stages[0].HasParachute = true
+	c.ChuteState = spacecraft.ChuteArmed
+	c.SyncFields()
+	if !c.HasParachute {
+		t.Fatalf("setup: mirror should be true after SyncFields")
+	}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	gc := got.ActiveCraft()
+	if gc.ChuteState != spacecraft.ChuteArmed {
+		t.Errorf("ChuteState: got %v, want Armed", gc.ChuteState)
+	}
+	if !gc.Stages[0].HasParachute {
+		t.Errorf("per-stage HasParachute did not round-trip")
+	}
+	if !gc.HasParachute {
+		t.Errorf("Spacecraft.HasParachute mirror not re-derived on load")
+	}
+}

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -89,6 +89,12 @@ func (w *World) Undock(idx int) bool {
 			MonopropCap:  comp.MonopropCapacity,
 			RCSThrust:    comp.RCSThrust,
 			RCSIsp:       comp.RCSIsp,
+			// v0.12 Slice 3 (ADR 0008): restore the surface-arrival
+			// capabilities so an undocked lander / chute capsule keeps
+			// its soft-land / parachute qualification. SyncFields below
+			// re-derives the flat mirrors from this Stages[0].
+			CanSoftLand:  comp.CanSoftLand,
+			HasParachute: comp.HasParachute,
 		}}
 		s := &spacecraft.Spacecraft{
 			Name:      comp.Name,

--- a/internal/sim/lifecycle.go
+++ b/internal/sim/lifecycle.go
@@ -152,7 +152,7 @@ func classifySurfaceArrival(
 	switch {
 	case c.ChuteState == spacecraft.ChuteDeployed:
 		// chute route — air-relative velocity ceiling; nose waived.
-		vRel := preClampV.Sub(physics.AtmosphereOmega(c.Primary).Cross(preClampR))
+		vRel := physics.AirRelativeVelocity(preClampR, preClampV, c.Primary)
 		if vRel.Norm() >= CrashVCritMps {
 			return outcomeCrashed, 0, 0
 		}

--- a/internal/sim/lifecycle.go
+++ b/internal/sim/lifecycle.go
@@ -47,7 +47,36 @@ const (
 	// off local vertical — a Falcon 9 with the nose past 45° from
 	// up isn't going to land softly; flag as crash.
 	CrashNoseTol = 0.7
+
+	// ChuteDeployQMin is the dynamic-pressure floor (Pa) at which an
+	// ARMED parachute auto-deploys (v0.12 Slice 3, ADR 0008). The deploy
+	// gate is expressed in q = 0.5·ρ·|v_rel|², which is body-agnostic —
+	// no body-specific deploy-altitude constant. 1000 Pa is the starting
+	// value: low enough that a capsule re-entering through thickening air
+	// reaches it well before the surface (giving the canopy time to bleed
+	// off velocity), high enough that a chute armed in near-vacuum at the
+	// atmosphere's edge doesn't pop the instant q lifts off zero.
+	// Retunable from playtest like V_CRIT / NOSE_TOL.
+	ChuteDeployQMin = 1000.0
 )
+
+// maybeDeployParachute auto-deploys an armed parachute the first tick
+// its dynamic pressure reaches ChuteDeployQMin. Returns true if it
+// transitioned this call. No-op for a stowed chute (the player must arm
+// it first via the Stage action) or an already-deployed one (DEPLOYED
+// is terminal). Called once per tick from integrateOneCraft before the
+// effective-BC read, so the deployed BC bump engages for the whole tick
+// the deploy fires on (ADR 0008 §2).
+func maybeDeployParachute(c *spacecraft.Spacecraft) bool {
+	if c.ChuteState != spacecraft.ChuteArmed {
+		return false
+	}
+	if physics.DynamicPressure(c.State.R, c.State.V, c.Primary) >= ChuteDeployQMin {
+		c.ChuteState = spacecraft.ChuteDeployed
+		return true
+	}
+	return false
+}
 
 // surfaceArrivalOutcome encodes what the predicate decided. Local
 // to the lifecycle dispatch site; not exported. Every Surface
@@ -65,17 +94,20 @@ const (
 	outcomeCrashed
 )
 
-// classifySurfaceArrival runs the v0.11.4 predicate at the
-// ClampToSurface site. preClampV is the velocity vector before the
-// clamp zeroed it; preClampR is the position at which contact was
-// detected. Returns:
+// classifySurfaceArrival runs the surface-arrival predicate at the
+// ClampToSurface site (v0.11.4; chute route added v0.12 Slice 3 / ADR
+// 0008). preClampV is the velocity vector before the clamp zeroed it;
+// preClampR is the position at which contact was detected. Returns:
 //
 //   - outcomeLanded with the sub-craft (lat, lon) when the vessel
-//     qualifies for a soft touchdown (CanSoftLand + |V| < V_CRIT +
-//     nose alignment > NOSE_TOL).
+//     qualifies for a soft touchdown via either the engine route
+//     (CanSoftLand + |V_inertial| < V_CRIT + nose alignment > NOSE_TOL)
+//     or the chute route (ChuteDeployed + |v_rel| < V_CRIT, nose
+//     waived — air-relative speed, since a chute nulls velocity
+//     relative to the co-rotating atmosphere, not the inertial frame).
 //   - outcomeCrashed with zero (lat, lon) when it doesn't —
-//     including the historical case of a non-CanSoftLand vessel
-//     hitting the surface at any speed.
+//     including the historical case of a vessel with neither
+//     CanSoftLand nor a deployed chute hitting the surface at any speed.
 //
 // Pure (no World state mutation) so unit tests can exercise the
 // branching with hand-built inputs. The integrateOneCraft caller
@@ -86,22 +118,60 @@ func classifySurfaceArrival(
 	preClampR, preClampV orbital.Vec3,
 	simTime time.Time,
 ) (surfaceArrivalOutcome, float64, float64) {
-	vImpact := preClampV.Norm()
-	if !c.CanSoftLand || vImpact >= CrashVCritMps {
-		return outcomeCrashed, 0, 0
-	}
 	rMag := preClampR.Norm()
 	if rMag == 0 {
 		return outcomeCrashed, 0, 0
 	}
 	localUp := preClampR.Scale(1 / rMag)
-	nose := c.CurrentAttitudeDir
-	if nose.Norm() == 0 {
-		return outcomeCrashed, 0, 0
-	}
-	nose = nose.Scale(1 / nose.Norm())
-	cosNose := nose.Dot(localUp)
-	if cosNose <= CrashNoseTol {
+
+	// Two routes qualify a contact as a soft Touchdown, each with its
+	// own gates (ADR 0004 engine route + ADR 0008 chute route). They
+	// differ on the capability gate, the nose-alignment requirement, AND
+	// the reference frame of the velocity ceiling:
+	//
+	//   engine route:  CanSoftLand   && |V_inertial| < V_CRIT && cosNose > NOSE_TOL
+	//   chute route:   ChuteDeployed && |v_rel| < V_CRIT                  (nose waived)
+	//
+	// The chute route measures *air-relative* speed v_rel = V − ω×r, not
+	// inertial |V|. A parachute nulls the vessel's velocity relative to
+	// the co-rotating atmosphere, not the inertial frame — so on a fast-
+	// rotating body a perfectly-descending capsule still carries the
+	// surface co-rotation velocity (~465 m/s at Earth's equator) in the
+	// inertial frame. Testing inertial |V| would crash every Earth
+	// splashdown despite an ideal canopy descent; v_rel is what the chute
+	// actually controls (ADR 0008 — amended after Slice 3 verification).
+	// The engine route keeps inertial |V| (its tests + shipped behaviour
+	// pin that, and a powered lander on the slow-rotating Moon sees a
+	// negligible ω×r anyway).
+	//
+	// The chute route also waives NOSE_TOL: under a canopy the chute is
+	// the stabiliser, the player isn't flying attitude, and demanding a
+	// nose angle for a passive descent is the artificial part. The engine
+	// route keeps its nose check (a Falcon 9 thrusting 60° off-vertical
+	// is still a crash).
+	switch {
+	case c.ChuteState == spacecraft.ChuteDeployed:
+		// chute route — air-relative velocity ceiling; nose waived.
+		vRel := preClampV.Sub(physics.AtmosphereOmega(c.Primary).Cross(preClampR))
+		if vRel.Norm() >= CrashVCritMps {
+			return outcomeCrashed, 0, 0
+		}
+	case c.CanSoftLand:
+		// engine route — inertial velocity ceiling + nose alignment.
+		if preClampV.Norm() >= CrashVCritMps {
+			return outcomeCrashed, 0, 0
+		}
+		nose := c.CurrentAttitudeDir
+		if nose.Norm() == 0 {
+			return outcomeCrashed, 0, 0
+		}
+		nose = nose.Scale(1 / nose.Norm())
+		if nose.Dot(localUp) <= CrashNoseTol {
+			return outcomeCrashed, 0, 0
+		}
+	default:
+		// neither capability — Crash regardless of how gentle (a non-
+		// CanSoftLand vessel with no deployed chute).
 		return outcomeCrashed, 0, 0
 	}
 	dir := render.Vec3{X: localUp.X, Y: localUp.Y, Z: localUp.Z}

--- a/internal/sim/parachute_test.go
+++ b/internal/sim/parachute_test.go
@@ -7,6 +7,7 @@
 package sim
 
 import (
+	"math"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -186,5 +187,97 @@ func TestParachuteFullDescentEarthSplashdown(t *testing.T) {
 	}
 	if !c.Landed {
 		t.Fatalf("capsule neither Landed nor Crashed after %d ticks (did it reach the surface?)", i)
+	}
+}
+
+// TestParachuteCapabilitySurvivesUndock — the per-stage parachute
+// capability must ride through a dock/undock cycle. A CSM/Capsule that
+// docks with another craft and later undocks (the Apollo arc) would
+// otherwise lose HasParachute (DockedComponent didn't record it) and
+// crash on its Earth splashdown. v0.12 Slice 3 (ADR 0008).
+func TestParachuteCapabilitySurvivesUndock(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+
+	a := w.Crafts[0]
+	a.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	a.State.V = orbital.Vec3{Y: 7600}
+
+	b := spacecraft.NewFromLoadout(spacecraft.LoadoutCapsuleID)
+	b.Name = "Capsule"
+	b.Primary = *earth
+	b.State = physics.StateVector{
+		R: a.State.R.Add(orbital.Vec3{X: 10}),
+		V: a.State.V,
+		M: b.TotalMass(),
+	}
+	if !b.HasParachute {
+		t.Fatal("setup: capsule should have HasParachute before docking")
+	}
+	w.Crafts = append(w.Crafts, b)
+
+	if _, _, ok := w.checkDocking(); !ok {
+		t.Fatalf("expected dock to fire")
+	}
+	if !w.Undock(0) {
+		t.Fatal("Undock returned false on a composite")
+	}
+	// Find the restored Capsule and confirm it kept its chute capability.
+	var capsule *spacecraft.Spacecraft
+	for _, c := range w.Crafts {
+		if c.Name == "Capsule" {
+			capsule = c
+		}
+	}
+	if capsule == nil {
+		t.Fatal("Capsule not restored after undock")
+	}
+	if !capsule.HasParachute {
+		t.Errorf("restored Capsule lost HasParachute across dock/undock")
+	}
+	if len(capsule.Stages) == 0 || !capsule.Stages[0].HasParachute {
+		t.Errorf("restored Capsule's Stages[0] lost HasParachute (SyncFields mirror would re-clear it)")
+	}
+}
+
+// TestWarpClampedDuringChuteDescent — a live (armed or deployed) chute
+// inside the atmosphere caps warp to 10×, like an active burn. Without
+// it a single high-warp tick (one giant sub-step) could leap past the q
+// deploy window (auto-deploy missed → crash undeployed) or inflate the
+// canopy in one integration step (the instant-inflation overshoot ADR
+// 0008 banked). The clamp guarantees fine sub-steps so the per-tick /
+// per-sub-step deploy check resolves the crossing. v0.12 Slice 3.
+func TestWarpClampedDuringChuteDescent(t *testing.T) {
+	w, _ := NewWorld()
+	w.Clock.WarpIdx = len(WarpFactors) - 1 // max warp selected
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	// Circular orbit at 100 km — inside Earth's 150 km atmosphere cutoff,
+	// but a sane orbit so the period clamp stays generous and the chute
+	// cap is what's actually being measured.
+	r := c.Primary.RadiusMeters() + 100_000
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	c.HasParachute = true
+
+	c.ChuteState = spacecraft.ChuteArmed
+	if eff := w.EffectiveWarp(); eff != 10 {
+		t.Errorf("armed chute in atmosphere should cap warp to 10×, got %.0f", eff)
+	}
+	c.ChuteState = spacecraft.ChuteDeployed
+	if eff := w.EffectiveWarp(); eff != 10 {
+		t.Errorf("deployed chute in atmosphere should cap warp to 10×, got %.0f", eff)
+	}
+	// Stowed → no chute clamp; warp returns to the (generous) period cap.
+	c.ChuteState = spacecraft.ChuteStowed
+	if eff := w.EffectiveWarp(); eff <= 10 {
+		t.Errorf("stowed chute should not force the 10× cap, got %.0f", eff)
+	}
+	// Live chute but above the atmosphere cutoff → no chute clamp.
+	c.ChuteState = spacecraft.ChuteArmed
+	c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + c.Primary.Atmosphere.CutoffAltitude + 1000}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / c.State.R.Norm())}
+	if eff := w.EffectiveWarp(); eff <= 10 {
+		t.Errorf("armed chute above the atmosphere cutoff should not clamp, got %.0f", eff)
 	}
 }

--- a/internal/sim/parachute_test.go
+++ b/internal/sim/parachute_test.go
@@ -1,0 +1,190 @@
+// Package sim — v0.12 Slice 3 parachute lifecycle tests (ADR 0008).
+// Exercises the q-threshold auto-deploy state machine and the second
+// (non-engine) route into the Touchdown predicate that a deployed
+// chute opens — a vessel without CanSoftLand can still soft-land under
+// a canopy, with the nose-alignment gate waived.
+
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestParachuteAutoDeploysAboveQMin — an armed chute auto-deploys the
+// first tick dynamic pressure reaches ChuteDeployQMin; below the floor
+// it stays armed.
+func TestParachuteAutoDeploysAboveQMin(t *testing.T) {
+	_, c := crashTestPrimaryFor(t)
+	radius := c.Primary.RadiusMeters()
+
+	// Below the floor: high above the atmosphere cutoff → q ≈ 0.
+	c.ChuteState = spacecraft.ChuteArmed
+	c.State.R = orbital.Vec3{X: radius + c.Primary.Atmosphere.CutoffAltitude + 1000}
+	c.State.V = orbital.Vec3{Z: 50}
+	if maybeDeployParachute(c) {
+		t.Errorf("chute deployed above the atmosphere cutoff (q≈0), want stay armed")
+	}
+	if c.ChuteState != spacecraft.ChuteArmed {
+		t.Errorf("state changed off the armed floor: %v", c.ChuteState)
+	}
+
+	// Above the floor: at the surface with a fast descent → q ≫ QMin.
+	c.State.R = orbital.Vec3{X: radius}
+	c.State.V = orbital.Vec3{X: -300}
+	if !maybeDeployParachute(c) {
+		t.Fatalf("chute did not deploy at the surface with a 300 m/s descent (q ≫ QMin)")
+	}
+	if c.ChuteState != spacecraft.ChuteDeployed {
+		t.Errorf("state = %v, want Deployed", c.ChuteState)
+	}
+}
+
+// TestParachuteDeployOnlyFromArmed — a stowed chute never auto-deploys
+// (the player must arm it first), and a deployed chute is terminal
+// (maybeDeployParachute is a no-op once up).
+func TestParachuteDeployOnlyFromArmed(t *testing.T) {
+	_, c := crashTestPrimaryFor(t)
+	radius := c.Primary.RadiusMeters()
+	// High-q state so the only thing gating deploy is the ChuteState.
+	c.State.R = orbital.Vec3{X: radius}
+	c.State.V = orbital.Vec3{X: -300}
+
+	c.ChuteState = spacecraft.ChuteStowed
+	if maybeDeployParachute(c) || c.ChuteState != spacecraft.ChuteStowed {
+		t.Errorf("stowed chute auto-deployed without arming, state=%v", c.ChuteState)
+	}
+	c.ChuteState = spacecraft.ChuteDeployed
+	if maybeDeployParachute(c) {
+		t.Errorf("deployed chute reported a fresh transition (should be terminal no-op)")
+	}
+}
+
+// coRotate adds the surface co-rotation velocity (ω×r, the same axis
+// the chute's air-relative frame uses) to the craft's inertial velocity,
+// so its air-relative velocity v_rel = V − ω×r equals whatever
+// setImpactState set. Models a vessel descending *with* the air (the
+// realistic chute case) rather than at rest in the inertial frame.
+func coRotate(c *spacecraft.Spacecraft) {
+	c.State.V = c.State.V.Add(physics.AtmosphereOmega(c.Primary).Cross(c.State.R))
+}
+
+// TestChuteRouteSoftLandsDespiteCoRotation — the marquee case + the
+// Slice 3 verification regression guard: a capsule with NO CanSoftLand
+// but a DEPLOYED chute, co-rotating with the ground (so its INERTIAL
+// |V| is hundreds of m/s — the Earth-equator co-rotation) yet descending
+// at only 3 m/s air-relative with the nose NOT aligned to local-up,
+// still Touches Down (Landed). The chute route measures air-relative
+// v_rel (3 m/s < V_CRIT) and waives NOSE_TOL — testing inertial |V|
+// here would crash the splashdown (ADR 0008 §4, amended).
+func TestChuteRouteSoftLandsDespiteCoRotation(t *testing.T) {
+	w, c := crashTestPrimaryFor(t)
+	c.CanSoftLand = false
+	noseSideways := orbital.Vec3{Y: 1}
+	setImpactState(c, 3, noseSideways) // 3 m/s air-relative descent
+	coRotate(c)                        // huge inertial |V| from surface co-rotation
+	c.ChuteState = spacecraft.ChuteDeployed
+	// Guard the test's premise: inertial |V| must be well above V_CRIT,
+	// else the v_rel-vs-inertial distinction isn't actually exercised.
+	if c.State.V.Norm() <= CrashVCritMps {
+		t.Fatalf("setup: inertial |V|=%.1f should exceed V_CRIT to exercise the co-rotation case", c.State.V.Norm())
+	}
+	w.integrateOneCraft(c, w.Clock.BaseStep)
+	if !c.Landed {
+		t.Errorf("deployed chute + v_rel=3 m/s + !CanSoftLand: Landed=false, want true (inertial |V| must not crash it)")
+	}
+	if c.Crashed {
+		t.Errorf("chute-route touchdown: Crashed=true, want false")
+	}
+}
+
+// TestChuteRouteCrashesAboveVCrit — the chute route still enforces the
+// velocity ceiling, in the air-relative frame. A deployed chute whose
+// air-relative descent exceeds V_CRIT (never had time to slow) Crashes
+// even while co-rotating.
+func TestChuteRouteCrashesAboveVCrit(t *testing.T) {
+	w, c := crashTestPrimaryFor(t)
+	c.CanSoftLand = false
+	localUp := orbital.Vec3{X: 1}
+	setImpactState(c, 40, localUp) // 40 m/s air-relative > V_CRIT
+	coRotate(c)
+	c.ChuteState = spacecraft.ChuteDeployed
+	w.integrateOneCraft(c, w.Clock.BaseStep)
+	if !c.Crashed {
+		t.Errorf("deployed chute + v_rel=40 m/s: Crashed=false, want true")
+	}
+	if c.Landed {
+		t.Errorf("deployed chute above V_CRIT: Landed=true, want Crashed-only")
+	}
+}
+
+// TestArmedChuteStillCrashes — an ARMED (not yet deployed) chute gives
+// no soft-land qualification. A capsule that hits with the chute armed
+// but never inflated (e.g. airless body, or contact before the q floor)
+// Crashes like any non-CanSoftLand vessel.
+func TestArmedChuteStillCrashes(t *testing.T) {
+	w, c := crashTestPrimaryFor(t)
+	c.CanSoftLand = false
+	localUp := orbital.Vec3{X: 1}
+	setImpactState(c, 3, localUp)
+	c.ChuteState = spacecraft.ChuteArmed
+	w.integrateOneCraft(c, w.Clock.BaseStep)
+	if !c.Crashed {
+		t.Errorf("armed (undeployed) chute + !CanSoftLand: Crashed=false, want true")
+	}
+	if c.Landed {
+		t.Errorf("armed (undeployed) chute: Landed=true, want Crashed")
+	}
+}
+
+// TestParachuteFullDescentEarthSplashdown — the end-to-end Slice 3
+// verification: a re-entry capsule armed and dropped into Earth's
+// atmosphere co-rotating with the ground deploys its chute, decelerates
+// to terminal velocity, and soft-lands (Landed, not Crashed) despite a
+// large inertial velocity from surface co-rotation. This is the arc the
+// Slice 3 verification exercised by hand; pinned here so a regression in
+// the auto-deploy gate, the BC bump, or the predicate frame is caught.
+func TestParachuteFullDescentEarthSplashdown(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.ActiveCraft().Primary
+	if earth.Atmosphere == nil {
+		t.Fatal("default Earth primary should have an atmosphere")
+	}
+	R := earth.RadiusMeters()
+	c := spacecraft.NewFromLoadout(spacecraft.LoadoutCapsuleID)
+	c.Primary = earth
+	r0 := orbital.Vec3{X: R + 5000} // 5 km up, equator
+	// Co-rotating horizontally + 200 m/s straight down (a fast entry that
+	// crosses the q deploy floor immediately).
+	c.State = physics.StateVector{
+		R: r0,
+		V: physics.AtmosphereOmega(earth).Cross(r0).Add(orbital.Vec3{X: -200}),
+		M: c.TotalMass(),
+	}
+	c.ChuteState = spacecraft.ChuteArmed
+	w.Crafts = []*spacecraft.Spacecraft{c}
+	w.ActiveCraftIdx = 0
+
+	var i int
+	for i = 0; i < 300000; i++ {
+		w.integrateOneCraft(c, w.Clock.BaseStep)
+		if c.Landed || c.Crashed {
+			break
+		}
+	}
+	if c.ChuteState != spacecraft.ChuteDeployed {
+		t.Errorf("chute should have auto-deployed during the descent, got %v", c.ChuteState)
+	}
+	if c.Crashed {
+		t.Fatalf("capsule Crashed on Earth splashdown after %d ticks; want Landed (chute descent should soft-land)", i)
+	}
+	if !c.Landed {
+		t.Fatalf("capsule neither Landed nor Crashed after %d ticks (did it reach the surface?)", i)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -890,6 +890,13 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	sys := w.System()
 	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
 	clock := tickStart
+	// v0.12 Slice 3 (ADR 0008): auto-deploy an armed parachute the first
+	// tick dynamic pressure reaches ChuteDeployQMin. Done before the
+	// effective-BC read so the deployed BC bump engages for the whole
+	// tick the deploy fires on. A descending chute craft always takes
+	// this Verlet path — canKeplerStepState rejects the analytic fast
+	// path once periapsis dips below the atmosphere cutoff.
+	maybeDeployParachute(c)
 	bc := c.EffectiveBallisticCoefficient()
 	for i := 0; i < nSteps; i++ {
 		if w.thrustingAt(c, tickStart, dt, i) {

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -683,6 +683,15 @@ func (w *World) clampedWarp() float64 {
 	if selected > 10 && w.recentlyChangedThrottle(throttleClampWindow) {
 		selected = 10
 	}
+	// v0.12 Slice 3 (ADR 0008): chute-descent clamp. An armed or deployed
+	// parachute inside the atmosphere caps warp to 10×, like an active
+	// burn — otherwise a single high-warp tick can leap across the q
+	// deploy window (auto-deploy missed) or inflate the canopy in one
+	// giant integration step (instant-inflation overshoot). Keeps the
+	// per-tick sub-steps fine enough for the deploy check to resolve.
+	if selected > 10 && w.anyCraftChuteLive() {
+		selected = 10
+	}
 	// v0.8.6.x+: upcoming-node approach clamp. At 100000× warp one
 	// tick advances 5000 s of sim time, so a planted node 30 s out
 	// would be skipped entirely before the burn-active cap could
@@ -797,6 +806,31 @@ func (w *World) anyCraftThrusting() bool {
 	return false
 }
 
+// anyCraftChuteLive reports whether any craft has an armed or deployed
+// parachute while inside its primary's atmosphere. v0.12 Slice 3 (ADR
+// 0008): drives the chute-descent warp clamp in clampedWarp. High warp
+// lets a single tick span a large sim-time leap; for a chute craft that
+// means the integrator can step clean across the q deploy window
+// (auto-deploy missed → crash undeployed) or inflate the canopy in one
+// giant step (the instant-inflation overshoot ADR 0008 banked). Walking
+// all crafts mirrors the burn cap (a passive chute craft descending while
+// the player flies another still needs fine sub-steps).
+func (w *World) anyCraftChuteLive() bool {
+	for _, c := range w.Crafts {
+		if c == nil || c.ChuteState == spacecraft.ChuteStowed {
+			continue
+		}
+		atm := c.Primary.Atmosphere
+		if atm == nil {
+			continue
+		}
+		if c.Altitude() < atm.CutoffAltitude {
+			return true
+		}
+	}
+	return false
+}
+
 // EffectiveWarp exposes the clamped warp for HUD display. Returns the same
 // as Clock.Warp() when the user isn't hitting the step-size guard.
 func (w *World) EffectiveWarp() float64 { return w.clampedWarp() }
@@ -890,15 +924,22 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	sys := w.System()
 	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
 	clock := tickStart
-	// v0.12 Slice 3 (ADR 0008): auto-deploy an armed parachute the first
-	// tick dynamic pressure reaches ChuteDeployQMin. Done before the
-	// effective-BC read so the deployed BC bump engages for the whole
-	// tick the deploy fires on. A descending chute craft always takes
+	// v0.12 Slice 3 (ADR 0008): a descending chute craft always takes
 	// this Verlet path — canKeplerStepState rejects the analytic fast
-	// path once periapsis dips below the atmosphere cutoff.
-	maybeDeployParachute(c)
+	// path once periapsis dips below the atmosphere cutoff — so the
+	// auto-deploy check lives here. It runs once per SUB-step (below),
+	// not once per tick: at high warp a single tick spans a large
+	// simDelta, and a capsule can cross the q deploy floor AND reach the
+	// surface within one tick. A tick-granularity check would miss the
+	// crossing and crash the capsule undeployed. The per-sub-step call
+	// short-circuits cheaply once stowed/deployed/no-chute, and re-reads
+	// the effective BC the moment the chute fires so the canopy drag
+	// engages for the remaining sub-steps of the tick the deploy fires on.
 	bc := c.EffectiveBallisticCoefficient()
 	for i := 0; i < nSteps; i++ {
+		if maybeDeployParachute(c) {
+			bc = c.EffectiveBallisticCoefficient()
+		}
 		if w.thrustingAt(c, tickStart, dt, i) {
 			w.stepThrust(c, mu, dt)
 		} else {

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -148,6 +148,15 @@ const LoadoutFalcon9ID = "Falcon-9"
 // canonical Saturn-V tuning so ascent flies identically.
 const LoadoutApolloStackID = "Apollo-Stack"
 
+// LoadoutCapsule is the v0.12 Slice 3 (ADR 0008) standalone re-entry
+// capsule: a single command-module-class stage with a recovery
+// parachute and no engine landing capability. The clean, directly-
+// spawnable test vehicle for the chute subsystem — spawn it, de-orbit,
+// `space` to arm, watch it auto-deploy and splash down under V_CRIT
+// without crashing. The CSM is only reachable via the full Apollo
+// Stack → orbit → four decouples, too slow to iterate on.
+const LoadoutCapsuleID = "Capsule"
+
 // stageRCS builds the per-stage RCS pool for a stage of the given
 // dry mass via DefaultRCSLoadout — same scaling that single-stage
 // craft used pre-v0.9.1, so existing loadouts inherit identical
@@ -195,7 +204,26 @@ func stageWithBC(loadoutID, name, glyph, color string, dry, fuel, thrust, isp, b
 		FuelType:             catalogFuelTypeByName(name),
 		LaunchSpriteHasLegs:  catalogLaunchSpriteHasLegsByName(name),
 		CanSoftLand:          catalogCanSoftLandByName(name),
+		HasParachute:         catalogHasParachuteByName(name),
 	}
+}
+
+// catalogHasParachuteByName looks up the StageCatalog's hasParachute
+// flag for a loadout stage by its Name field. Mirrors
+// catalogCanSoftLandByName (same LM→Lander alias for the Apollo-Stack
+// literal). v0.12 Slice 3 (ADR 0008): the Apollo-Stack's "CSM" literal
+// resolves against the catalog's "CSM" entry and so inherits its
+// parachute capability.
+func catalogHasParachuteByName(name string) bool {
+	if name == "LM" {
+		name = "Lander"
+	}
+	for _, m := range StageCatalog {
+		if m.Name == name {
+			return m.hasParachute
+		}
+	}
+	return false
 }
 
 // catalogLaunchSpriteRowsPxByName returns the StageCatalog
@@ -498,6 +526,21 @@ var Loadouts = map[string]Loadout{
 		// 2-stage LM craft, leaving the CSM core. Sum (5) < 6 stages.
 		DecouplePlan: []int{1, 1, 1, 2},
 	},
+	// Re-entry capsule (v0.12 Slice 3, ADR 0008): single command-module
+	// stage carrying a parachute and no engine landing. HasParachute /
+	// !CanSoftLand ride per-Stage via the StageCatalog by-Name lookup
+	// (the "Capsule" entry). No main engine — the player de-orbits with
+	// RCS (or spawns sub-orbital) and recovers under chute.
+	LoadoutCapsuleID: {
+		ID:    LoadoutCapsuleID,
+		Name:  "Capsule",
+		Role:  "capsule",
+		Glyph: "◓",
+		Color: "#B8C8E0", // pale bare-metal command module
+		Stages: []Stage{
+			stage(LoadoutCapsuleID, "Capsule", "◓", "#B8C8E0", 5800, 0, 0, 0),
+		},
+	},
 }
 
 // LoadoutOrder lists loadouts in canonical UI cycle order — the
@@ -513,6 +556,7 @@ var LoadoutOrder = []string{
 	LoadoutSLSBlock1ID,
 	LoadoutFalcon9ID,
 	LoadoutApolloStackID,
+	LoadoutCapsuleID,
 }
 
 // LookupLoadout returns the catalog entry for the given ID, or the

--- a/internal/spacecraft/parachute.go
+++ b/internal/spacecraft/parachute.go
@@ -1,0 +1,74 @@
+package spacecraft
+
+// Parachute subsystem (v0.12 Slice 3, ADR 0008). A Parachute is a
+// per-Stage *capability* (HasParachute, catalog data, mirrored onto
+// the Spacecraft from Stages[0] by SyncFields like CanSoftLand) plus a
+// per-Vessel runtime *deploy state* (ChuteState). A deployed chute
+// raises the vessel's effective Ballistic Coefficient enough that
+// terminal velocity falls below V_CRIT, and qualifies the vessel for a
+// Touchdown even without CanSoftLand — the second non-engine route
+// into Landed that ADR 0004 banked.
+//
+// The whole subsystem is additive and omitempty: ChuteState's zero
+// value is ChuteStowed and HasParachute defaults false, so a save
+// written before this slice loads as a stowed, capability-less chute —
+// no SchemaVersion bump (same posture as ADR 0004 / 0007).
+
+// ChuteState is the runtime deploy state of a Parachute. One-way:
+// STOWED → ARMED → DEPLOYED, with DEPLOYED terminal (no re-stow /
+// cut-away). There is deliberately no torn / failure state — the
+// over-speed tear model was considered and cut during the grill (ADR
+// 0008 Alternatives → tear model).
+type ChuteState int
+
+const (
+	// ChuteStowed is the zero value: the capability may be present but
+	// the chute has not been staged/armed.
+	ChuteStowed ChuteState = iota
+	// ChuteArmed: staged, waiting for enough air to inflate. Arming is
+	// folded into the Stage (`space`) action — see ArmParachute.
+	ChuteArmed
+	// ChuteDeployed: inflated; the ChuteDeployedBC bump is active. Terminal.
+	ChuteDeployed
+)
+
+// String renders a ChuteState for the HUD readout (STOWED / ARMED /
+// DEPLOYED).
+func (s ChuteState) String() string {
+	switch s {
+	case ChuteArmed:
+		return "ARMED"
+	case ChuteDeployed:
+		return "DEPLOYED"
+	default:
+		return "STOWED"
+	}
+}
+
+// ChuteDeployedBC is the fixed effective Ballistic Coefficient (C_D ·
+// A / m, m²/kg) a vessel reports while its parachute is deployed — an
+// *absolute replace* of the normal BC chain, not a multiplier. The
+// canopy area physically dominates the capsule's own drag, so the base
+// BC is irrelevant; fixing BC makes terminal velocity predictable and
+// mass-independent (the mass term lives inside BC = C_D·A/m). At Earth
+// sea level (ρ₀ ≈ 1.2, g ≈ 9.81) the drag-model terminal-velocity
+// relation v_term = √(2g / (ρ · BC)) gives ≈ 7.4 m/s — comfortably
+// under CrashVCritMps (10 m/s). Retunable from playtest like V_CRIT.
+const ChuteDeployedBC = 0.3
+
+// ArmParachute moves a stowed parachute to the armed state. Returns
+// true if it transitioned. It is a no-op (returns false) when the
+// craft lacks the capability (HasParachute false), when the chute is
+// already armed, or when it is already deployed (terminal). Arming is
+// allowed in any conditions, including vacuum — "arm on the way down
+// and forget it"; auto-deploy fires later when dynamic pressure
+// reaches the floor (ADR 0008 §2). Callers gate the player-facing
+// trigger on the chute being the bare top stage (the Stage action's
+// single-stage no-op branch).
+func (s *Spacecraft) ArmParachute() bool {
+	if !s.HasParachute || s.ChuteState != ChuteStowed {
+		return false
+	}
+	s.ChuteState = ChuteArmed
+	return true
+}

--- a/internal/spacecraft/parachute_test.go
+++ b/internal/spacecraft/parachute_test.go
@@ -1,0 +1,144 @@
+package spacecraft
+
+import "testing"
+
+// TestEffectiveBCDeployedShortCircuits — a deployed parachute swamps
+// the capsule's own drag: EffectiveBallisticCoefficient returns the
+// fixed ChuteDeployedBC regardless of the bottom stage's BC or the
+// legacy / default fallback chain (ADR 0008 §3).
+func TestEffectiveBCDeployedShortCircuits(t *testing.T) {
+	// Bottom stage carries a small BC; deployed chute should override it.
+	c := &Spacecraft{
+		Stages: []Stage{{BallisticCoefficient: 8e-6}},
+	}
+	if got := c.EffectiveBallisticCoefficient(); got != 8e-6 {
+		t.Fatalf("stowed: got %g, want stage BC 8e-6", got)
+	}
+	c.ChuteState = ChuteArmed
+	if got := c.EffectiveBallisticCoefficient(); got != 8e-6 {
+		t.Errorf("armed: got %g, want stage BC 8e-6 (armed != deployed)", got)
+	}
+	c.ChuteState = ChuteDeployed
+	if got := c.EffectiveBallisticCoefficient(); got != ChuteDeployedBC {
+		t.Errorf("deployed: got %g, want ChuteDeployedBC %g", got, ChuteDeployedBC)
+	}
+}
+
+// TestEffectiveBCDeployedOverridesDefaultFallback — deployed BC wins
+// even when the craft has no stage BC at all (would otherwise hit the
+// DefaultBallisticCoefficient fallback).
+func TestEffectiveBCDeployedOverridesDefaultFallback(t *testing.T) {
+	c := &Spacecraft{ChuteState: ChuteDeployed}
+	if got := c.EffectiveBallisticCoefficient(); got != ChuteDeployedBC {
+		t.Errorf("deployed w/ no stages: got %g, want ChuteDeployedBC %g", got, ChuteDeployedBC)
+	}
+}
+
+// TestSyncFieldsDerivesHasParachute — the Spacecraft.HasParachute
+// mirror is re-derived from Stages[0] on every SyncFields, exactly
+// like CanSoftLand (ADR 0008 §1).
+func TestSyncFieldsDerivesHasParachute(t *testing.T) {
+	c := &Spacecraft{
+		Stages: []Stage{
+			{Name: "booster", HasParachute: false, Thrust: 1000, Isp: 300},
+			{Name: "capsule", HasParachute: true},
+		},
+	}
+	c.SyncFields()
+	// Bottom stage (booster) has no chute, so the mirror is false even
+	// though an upper stage carries one — the chute rides the surviving
+	// top stage and only becomes "active" once it is the bottom.
+	if c.HasParachute {
+		t.Errorf("HasParachute mirror should be false while a non-chute booster is the bottom stage")
+	}
+	// Drop the booster so the capsule is the bottom stage.
+	c.Stages = c.Stages[1:]
+	c.SyncFields()
+	if !c.HasParachute {
+		t.Errorf("HasParachute mirror should be true once the chute-bearing capsule is the bottom stage")
+	}
+}
+
+// TestCSMStageHasParachute — the Apollo CSM stage (catalog + the
+// Apollo-Stack loadout literal that resolves by Name) carries the
+// parachute capability so the marquee Apollo arc earns an Earth
+// splashdown (ADR 0008 §6).
+func TestCSMStageHasParachute(t *testing.T) {
+	csm, ok := BuildStage(StageModuleCSMID)
+	if !ok {
+		t.Fatalf("BuildStage(csm) not found in catalog")
+	}
+	if !csm.HasParachute {
+		t.Errorf("catalog csm stage should have HasParachute=true")
+	}
+	if csm.CanSoftLand {
+		t.Errorf("csm has no engine landing capability — CanSoftLand should be false")
+	}
+	// The Apollo-Stack loadout's CSM literal resolves its flags by Name.
+	if !catalogHasParachuteByName("CSM") {
+		t.Errorf("catalogHasParachuteByName(CSM) should be true")
+	}
+}
+
+// TestReentryCapsuleLoadout — the standalone re-entry capsule is a
+// single command-module-class stage carrying HasParachute and *not*
+// CanSoftLand: the clean, directly-spawnable test vehicle (ADR 0008
+// §6). It must be in LoadoutOrder so the spawn form lists it.
+func TestReentryCapsuleLoadout(t *testing.T) {
+	c := NewFromLoadout(LoadoutCapsuleID)
+	if len(c.Stages) != 1 {
+		t.Fatalf("re-entry capsule should be single-stage, got %d", len(c.Stages))
+	}
+	if !c.HasParachute {
+		t.Errorf("re-entry capsule should have HasParachute=true (mirror), got false")
+	}
+	if c.CanSoftLand {
+		t.Errorf("re-entry capsule should NOT have CanSoftLand (chute is its only route down)")
+	}
+	if c.ChuteState != ChuteStowed {
+		t.Errorf("fresh capsule chute should be Stowed, got %v", c.ChuteState)
+	}
+	var inOrder bool
+	for _, id := range LoadoutOrder {
+		if id == LoadoutCapsuleID {
+			inOrder = true
+		}
+	}
+	if !inOrder {
+		t.Errorf("LoadoutCapsuleID missing from LoadoutOrder (spawn form won't list it)")
+	}
+}
+
+// TestArmParachuteStateMachine — ArmParachute moves a stowed chute to
+// armed exactly once and only when the craft has the capability; it is
+// a no-op (returns false) without the capability, when already armed,
+// and when already deployed (one-way, no re-stow — ADR 0008 §2).
+func TestArmParachuteStateMachine(t *testing.T) {
+	// No capability → cannot arm.
+	noCap := &Spacecraft{HasParachute: false}
+	if noCap.ArmParachute() {
+		t.Errorf("ArmParachute on a craft without HasParachute should return false")
+	}
+	if noCap.ChuteState != ChuteStowed {
+		t.Errorf("state should stay Stowed when arming fails, got %v", noCap.ChuteState)
+	}
+
+	c := &Spacecraft{HasParachute: true}
+	if !c.ArmParachute() {
+		t.Fatalf("first ArmParachute on a capable stowed craft should return true")
+	}
+	if c.ChuteState != ChuteArmed {
+		t.Fatalf("state should be Armed after arming, got %v", c.ChuteState)
+	}
+	if c.ArmParachute() {
+		t.Errorf("re-arming an already-armed chute should return false (no-op)")
+	}
+	// Deployed is terminal: arming must not re-stow / re-arm it.
+	c.ChuteState = ChuteDeployed
+	if c.ArmParachute() {
+		t.Errorf("arming a deployed chute should return false (terminal)")
+	}
+	if c.ChuteState != ChuteDeployed {
+		t.Errorf("deployed state must be preserved, got %v", c.ChuteState)
+	}
+}

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -304,6 +304,18 @@ type DockedComponent struct {
 	Thrust           float64
 	RCSThrust        float64
 	RCSIsp           float64
+	// CanSoftLand / HasParachute (v0.12 Slice 3, ADR 0008): the two
+	// surface-arrival capability flags, captured so Undock can restore
+	// them onto the rebuilt single-stage craft. Without this a chute-
+	// bearing capsule (or a CanSoftLand lander) that docks then undocks
+	// loses its capability — the restored Stages[0] would default false
+	// and SyncFields would re-derive a false mirror, crashing the Earth
+	// splashdown the chute exists for. (DockedComponent still doesn't
+	// record the full per-stage breakdown — that broader gap is the
+	// banked v0.9.1.x follow-up the Undock comment notes — but the
+	// landing capabilities are cheap to carry and load-bearing.)
+	CanSoftLand  bool
+	HasParachute bool
 }
 
 // AsDockedComponent captures s's identity + capacity fields into a
@@ -323,6 +335,8 @@ func (s *Spacecraft) AsDockedComponent() DockedComponent {
 		Thrust:           s.Thrust,
 		RCSThrust:        s.RCSThrust,
 		RCSIsp:           s.RCSIsp,
+		CanSoftLand:      s.CanSoftLand,
+		HasParachute:     s.HasParachute,
 	}
 }
 

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -185,6 +185,25 @@ type Spacecraft struct {
 	// `omitempty`-default-false (existing vessels are crash-only).
 	CanSoftLand bool
 
+	// HasParachute (v0.12 Slice 3, ADR 0008): the Vessel-level mirror
+	// of the bottom stage's per-Stage parachute capability. Re-derived
+	// from Stages[0] on every SyncFields exactly like CanSoftLand, so
+	// it rides the hardware across a decouple (the chute capability
+	// becomes "active" once the chute-bearing stage is the bottom /
+	// surviving core). Gates the Stage-action arm path and the
+	// auto-deploy check. `omitempty`-default-false.
+	HasParachute bool
+
+	// ChuteState (v0.12 Slice 3, ADR 0008): the runtime parachute
+	// deploy state — STOWED → ARMED → DEPLOYED, one-way, DEPLOYED
+	// terminal. Lives alongside Landed / Crashed (the other surface-
+	// lifecycle runtime flags). Zero value = ChuteStowed, so pre-Slice-3
+	// saves load stowed; `omitempty`, no SchemaVersion bump. While
+	// ChuteDeployed, EffectiveBallisticCoefficient returns the fixed
+	// ChuteDeployedBC and the surface-arrival predicate gains a second
+	// (nose-waived) route into Landed.
+	ChuteState ChuteState
+
 	// OnPad (v0.11.4+): true between Launchpad spawn and first
 	// liftoff. Set by surfaceSpawnPosVel; cleared on the first
 	// Landed=false transition. Distinguishes "fresh launchpad
@@ -344,6 +363,12 @@ const DefaultBallisticCoefficient = 0.01
 // back to s.BallisticCoefficient (legacy field), then
 // DefaultBallisticCoefficient.
 func (s *Spacecraft) EffectiveBallisticCoefficient() float64 {
+	// v0.12 Slice 3 (ADR 0008): a deployed parachute swamps the
+	// capsule's own drag. Absolute replace at the top of the chain so
+	// terminal velocity is predictable and mass-independent.
+	if s.ChuteState == ChuteDeployed {
+		return ChuteDeployedBC
+	}
 	if len(s.Stages) > 0 && s.Stages[0].BallisticCoefficient > 0 {
 		return s.Stages[0].BallisticCoefficient
 	}

--- a/internal/spacecraft/stage.go
+++ b/internal/spacecraft/stage.go
@@ -176,6 +176,14 @@ type Stage struct {
 	// dock / save-load. Set true on stages designed to land —
 	// today: `lander` and `f9-s1` in StageCatalog.
 	CanSoftLand bool `json:",omitempty"`
+
+	// HasParachute (v0.12 Slice 3, ADR 0008): per-stage parachute
+	// capability, the exact mirror of CanSoftLand. Set in StageCatalog
+	// (today: the `csm` stage and the standalone re-entry capsule);
+	// SyncFields re-derives Spacecraft.HasParachute from Stages[0] on
+	// every staging / dock / load so the capability rides the hardware
+	// across a decouple. `omitempty`.
+	HasParachute bool `json:",omitempty"`
 }
 
 // SumDryMass returns the total dry mass across every stage in kg.
@@ -258,6 +266,10 @@ func (s *Spacecraft) SyncFields() {
 	// doesn't) and the Apollo Stack model (Lander stage decouples
 	// into its own slate craft carrying CanSoftLand=true).
 	s.CanSoftLand = bottom.CanSoftLand
+	// v0.12 Slice 3 (ADR 0008): parachute capability mirrors the
+	// bottom stage too — the chute becomes "active" only once the
+	// chute-bearing stage is the surviving core (Stages[0]).
+	s.HasParachute = bottom.HasParachute
 }
 
 // ActiveStageFuel returns the bottom (currently-firing) stage's

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -72,6 +72,15 @@ type StageModule struct {
 	// stays false — Saturn V stages crash on contact, CSM crashes
 	// on contact, F9-S2 crashes on contact.
 	canSoftLand bool
+	// hasParachute (v0.12 Slice 3, ADR 0008) marks stages that carry a
+	// recovery parachute — populates Stage.HasParachute (directly in
+	// BuildStage, by-Name via catalogHasParachuteByName for the loadout
+	// literals) so the surface-arrival predicate's chute route and the
+	// Stage-action arm path gate correctly across staging. Today's true
+	// entries: csm (Apollo Command/Service Module) and capsule (the
+	// standalone re-entry test vehicle). Disjoint from canSoftLand —
+	// a capsule has no engine landing route, only the chute.
+	hasParachute bool
 }
 
 // Catalog stage IDs.
@@ -97,7 +106,10 @@ const (
 	StageModuleLanderDescentID = "lander-descent"
 	StageModuleLanderAscentID  = "lander-ascent"
 	StageModuleCSMID           = "csm" // Apollo Command/Service Module (SPS)
-	StageModuleRCSTugID   = "rcs-tug"   // pure-monoprop proximity-ops module
+	// v0.12 Slice 3 / ADR 0008: standalone re-entry capsule — single
+	// command-module-class stage with a parachute, no engine landing.
+	StageModuleCapsuleID = "capsule"
+	StageModuleRCSTugID  = "rcs-tug" // pure-monoprop proximity-ops module
 )
 
 // StageCatalog indexes the parts library by ID. The numbers mirror
@@ -232,6 +244,27 @@ var StageCatalog = map[string]StageModule{
 		// CSM Service Module was bare aluminium — silver-white.
 		launchSpriteColor:   "#C8C8D0",
 		fuelType:            FuelTypeHypergolic,
+		// v0.12 Slice 3 (ADR 0008): the CSM survives the Apollo decouple
+		// chain to re-entry and earns an Earth splashdown under chute.
+		hasParachute: true,
+	},
+	// Re-entry capsule (v0.12 Slice 3, ADR 0008): a minimal command-
+	// module-class stage carrying a parachute and NO engine landing
+	// capability — the clean, directly-spawnable test vehicle for the
+	// chute subsystem (one spawn, a de-orbit, a `space` press). Sized
+	// roughly like an Apollo Command Module alone (the CSM minus the
+	// Service Module): ~5,800 kg dry, a small RCS-only attitude budget,
+	// no main engine. bc 0 → the stowed/armed BC falls back to the
+	// default; only the deployed chute's ChuteDeployedBC matters for its
+	// descent.
+	StageModuleCapsuleID: {
+		ID: StageModuleCapsuleID, Name: "Capsule", Glyph: "◓", Color: "#B8C8E0",
+		Tier: "payload", dry: 5800, fuel: 0, thrust: 0, isp: 0, bc: 0,
+		launchSpriteRowsPx:  6,
+		launchSpriteWidthPx: 3,
+		launchSpriteColor:   "#C8C8D0", // bare-metal command module
+		// fuelType intentionally unset — no main engine (RCS-only).
+		hasParachute: true,
 	},
 	StageModuleRCSTugID: {
 		ID: StageModuleRCSTugID, Name: "RCS Tug", Glyph: "●", Color: "#FF87D7",
@@ -294,5 +327,6 @@ func BuildStage(id string) (Stage, bool) {
 		FuelType:             m.fuelType,
 		LaunchSpriteHasLegs:  m.launchSpriteHasLegs,
 		CanSoftLand:          m.canSoftLand,
+		HasParachute:         m.hasParachute,
 	}, true
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -791,7 +791,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				name := a.world.Crafts[jettIdx].Name
 				a.statusMsg = fmt.Sprintf("staged: %s jettisoned", name)
 			case errors.Is(err, sim.ErrStageOnlyOne):
-				a.statusMsg = "stage: cannot drop the only remaining stage"
+				// v0.12 Slice 3 (ADR 0008): once the vessel is reduced to
+				// its bare chute-bearing stage, the staging-no-op press
+				// arms the parachute instead — "just another staging
+				// action," no new keybinding. Falls through to the normal
+				// no-op flash when there's no stowed chute to arm.
+				if c := a.world.ActiveCraft(); c != nil && c.ArmParachute() {
+					a.statusMsg = "parachute ARMED — auto-deploys in atmosphere"
+				} else {
+					a.statusMsg = "stage: cannot drop the only remaining stage"
+				}
 			default:
 				a.statusMsg = fmt.Sprintf("stage failed: %v", err)
 			}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -61,11 +61,12 @@ func (h *Help) Render() string {
 			{"a / d", "attitude normal+ / normal- (orient only in main; pulse-fire in rcs)"},
 			{"q / e", "attitude radial+ / radial- (orient only in main; pulse-fire in rcs)"},
 			{"W / S", "attitude surface prograde / retrograde — locks to v - ω×r (v0.9.2+)"},
-			{"< / >", "pitch trim ±5° east — held thrust direction tilts off the active mode (v0.9.2+)"},
+			{"< / >", "pitch trim ±10° east — held thrust direction tilts off the active mode (v0.9.2+)"},
 			{"\\", "reset pitch trim to 0 (v0.9.2+)"},
 			{"b", "engage / cut manual burn (main engine only)"},
 			{"r", "engine: main / rcs (RCS = monoprop pulse-fire on attitude keys)"},
 			{"k", "SAS model: slew / instant (navball [MAN]/[AUT]) (v0.10.0+)"},
+			{";", "NavMode cycle: Orbit → Surface → Target (skips Target when none set) (v0.9.3+)"},
 		}},
 		{"MULTI-CRAFT (v0.8.1+)", [][2]string{
 			{"n", "open spawn form (loadout / position / parent / altitude / dir; Custom = stack builder, v0.10.1+)"},
@@ -73,7 +74,7 @@ func (h *Help) Render() string {
 			{"1-9", "jump to craft N (no-op when slot empty) (v0.12.0+)"},
 			{"U", "undock active composite (v0.8.3+)"},
 			{"t / T", "cycle / clear target (v0.9.0+)"},
-			{"space", "decouple bottom stage (v0.9.1+, multi-stage craft only)"},
+			{"space", "decouple bottom stage (v0.9.1+); on a bare chute capsule, arms the parachute (v0.12+)"},
 		}},
 		{"PERSISTENCE", [][2]string{
 			{"F5", "quicksave (XDG_STATE_HOME)"},

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -464,6 +464,13 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 	bell := ComposeEngineBell(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM)
 	legs := ComposeLegs(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM)
 	flame := ComposeFlame(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM, flameThrottle, frameIdx, bellWidth)
+	// v0.12 Slice 3 (ADR 0008): a deployed parachute paints a canopy
+	// above the top stage, giving the chute a visual identity for the
+	// Shift+V manual jump and the test-lob cases.
+	var canopy []SpritePixel
+	if craft.ChuteState == spacecraft.ChuteDeployed {
+		canopy = ComposeCanopy(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM)
+	}
 	// Plot each pixel as a braille sub-cell dot via PlotColored.
 	// No SetCellOverlay glyph: braille dots are direction-agnostic,
 	// so a tilted rocket renders smoothly at any pitch — the
@@ -488,6 +495,11 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 		v.canvas.ClearCellOverlay(world)
 	}
 	for _, p := range flame {
+		world := anchorWorld.Add(p.OffsetWorld)
+		v.canvas.PlotColored(world, p.Color)
+		v.canvas.ClearCellOverlay(world)
+	}
+	for _, p := range canopy {
 		world := anchorWorld.Add(p.OffsetWorld)
 		v.canvas.PlotColored(world, p.Color)
 		v.canvas.ClearCellOverlay(world)

--- a/internal/tui/screens/launch_sprite.go
+++ b/internal/tui/screens/launch_sprite.go
@@ -259,14 +259,11 @@ func ComposeLaunchSprite(stages []spacecraft.Stage, cmdWorld orbital.Vec3, basis
 		// top of the stack (no upper neighbour). The taper rows do
 		// NOT alter Stage.LaunchSpriteRowsPx — they extend the
 		// composed stack height by 1 row per boundary.
-		if i+1 < len(stages) {
-			up := stages[i+1]
-			if up.LaunchSpriteRowsPx >= taperThreshold && s.LaunchSpriteRowsPx >= taperThreshold {
-				upWidth := stageSpriteWidthPx(up)
-				taperWidth := (width + upWidth + 1) / 2 // round half-up
-				emitRect(rowOffset, 1, taperWidth, color)
-				rowOffset++
-			}
+		if i+1 < len(stages) && taperRowBetween(s, stages[i+1]) > 0 {
+			upWidth := stageSpriteWidthPx(stages[i+1])
+			taperWidth := (width + upWidth + 1) / 2 // round half-up
+			emitRect(rowOffset, 1, taperWidth, color)
+			rowOffset++
 		}
 	}
 	if len(pixels) == 0 {
@@ -292,6 +289,20 @@ const (
 // fabric against the metal stage bodies and the coloured flame.
 const canopyColor = lipgloss.Color("#F5F0E0")
 
+// taperRowBetween returns the number of synthetic inter-stage taper
+// rows painted between two vertically-adjacent stages: 1 when both
+// clear taperThreshold, else 0. The single source of truth for the
+// taper rule, shared by ComposeLaunchSprite (which emits the taper
+// band) and composedStackRows (which only needs the height) so the two
+// can't drift — if they disagreed, ComposeCanopy would anchor at the
+// wrong height. v0.12 Slice 3 (ADR 0008).
+func taperRowBetween(lower, upper spacecraft.Stage) int {
+	if lower.LaunchSpriteRowsPx >= taperThreshold && upper.LaunchSpriteRowsPx >= taperThreshold {
+		return 1
+	}
+	return 0
+}
+
 // composedStackRows returns the total sub-pixel height of the composed
 // launch sprite, including inter-stage taper rows — mirrors the
 // rowOffset accumulation in ComposeLaunchSprite so ComposeCanopy can
@@ -304,10 +315,7 @@ func composedStackRows(stages []spacecraft.Stage) int {
 		}
 		rows += s.LaunchSpriteRowsPx
 		if i+1 < len(stages) {
-			up := stages[i+1]
-			if up.LaunchSpriteRowsPx >= taperThreshold && s.LaunchSpriteRowsPx >= taperThreshold {
-				rows++
-			}
+			rows += taperRowBetween(s, stages[i+1])
 		}
 	}
 	return rows

--- a/internal/tui/screens/launch_sprite.go
+++ b/internal/tui/screens/launch_sprite.go
@@ -275,6 +275,107 @@ func ComposeLaunchSprite(stages []spacecraft.Stage, cmdWorld orbital.Vec3, basis
 	return pixels
 }
 
+// Canopy geometry constants (v0.12 Slice 3, ADR 0008). A deployed
+// parachute paints a synthetic braille dome above the top stage,
+// connected by a short shroud-line gap — reusing the (stack-dir,
+// width-dir) basis seam the bell / legs / flame already use so the
+// canopy leans with the vessel through any attitude.
+const (
+	canopyGapRows    = 2  // shroud-line rows between the capsule top and canopy skirt
+	canopyRows       = 3  // dome height in sub-pixels
+	canopyMinWidth   = 5  // skirt width floor (sub-pixels)
+	canopyMaxWidth   = 11 // skirt width cap so a wide stack doesn't get an absurd canopy
+	canopyShroudDots = 3  // interpolated dots per shroud line
+)
+
+// canopyColor is the canopy tint — a pale off-white that reads as
+// fabric against the metal stage bodies and the coloured flame.
+const canopyColor = lipgloss.Color("#F5F0E0")
+
+// composedStackRows returns the total sub-pixel height of the composed
+// launch sprite, including inter-stage taper rows — mirrors the
+// rowOffset accumulation in ComposeLaunchSprite so ComposeCanopy can
+// anchor itself just above the top stage.
+func composedStackRows(stages []spacecraft.Stage) int {
+	rows := 0
+	for i, s := range stages {
+		if s.LaunchSpriteRowsPx <= 0 {
+			continue
+		}
+		rows += s.LaunchSpriteRowsPx
+		if i+1 < len(stages) {
+			up := stages[i+1]
+			if up.LaunchSpriteRowsPx >= taperThreshold && s.LaunchSpriteRowsPx >= taperThreshold {
+				rows++
+			}
+		}
+	}
+	return rows
+}
+
+// ComposeCanopy paints a deployed-parachute canopy above the top stage:
+// a 3-row braille dome at canopyWidth, plus two converging shroud lines
+// bridging the canopyGapRows gap down to the top stage's shoulders.
+// Geometry is defined in the (stack-dir, width-dir) basis so the canopy
+// leans with the vessel through gravity turns, like the bell / legs.
+// The caller gates this on craft.ChuteState == ChuteDeployed. Returns
+// nil when there is no composed stack to sit above. v0.12 Slice 3
+// (ADR 0008).
+func ComposeCanopy(stages []spacecraft.Stage, cmdWorld orbital.Vec3, basis widgets.Basis, scaleMPerPx float64) []SpritePixel {
+	totalRows := composedStackRows(stages)
+	if totalRows == 0 {
+		return nil
+	}
+	topWidth := stageSpriteWidthPx(stages[len(stages)-1])
+
+	canopyW := topWidth*2 + 3
+	if canopyW < canopyMinWidth {
+		canopyW = canopyMinWidth
+	}
+	if canopyW > canopyMaxWidth {
+		canopyW = canopyMaxWidth
+	}
+
+	pxSize := scaleMPerPx
+	stackX, stackY := stackDirScreen(cmdWorld, basis)
+	widthX, widthY := stackY, -stackX
+	emit := func(rowAbove, xPx float64) SpritePixel {
+		screenSX := rowAbove*pxSize*stackX + xPx*pxSize*widthX
+		screenSY := rowAbove*pxSize*stackY + xPx*pxSize*widthY
+		offset := basis.X.Scale(screenSX).Add(basis.Y.Scale(screenSY))
+		return SpritePixel{OffsetWorld: offset, Color: canopyColor}
+	}
+
+	baseRow := float64(totalRows + canopyGapRows) // canopy skirt sits here
+	var pixels []SpritePixel
+	// Dome: narrows toward the top (a rounded canopy) — widest at the
+	// skirt (r=0), losing 2 sub-pixels of width per row up.
+	for r := 0; r < canopyRows; r++ {
+		w := canopyW - 2*r
+		if w < 1 {
+			w = 1
+		}
+		rowAbove := baseRow + float64(r)
+		for col := 0; col < w; col++ {
+			xPx := float64(col) - float64(w-1)/2.0
+			pixels = append(pixels, emit(rowAbove, xPx))
+		}
+	}
+	// Shroud lines: two lines from the canopy skirt corners down to the
+	// top stage's shoulder corners across the gap.
+	skirtX := float64(canopyW-1) / 2.0
+	shoulderX := float64(topWidth-1) / 2.0
+	for _, sign := range [...]float64{-1, +1} {
+		for d := 1; d <= canopyShroudDots; d++ {
+			frac := float64(d) / float64(canopyShroudDots+1) // 0<frac<1 along the gap
+			rowAbove := baseRow - frac*float64(canopyGapRows)
+			xPx := sign * (skirtX + frac*(shoulderX-skirtX))
+			pixels = append(pixels, emit(rowAbove, xPx))
+		}
+	}
+	return pixels
+}
+
 // flameMaxRows is the cap on flame height in sub-pixel rows
 // (v0.11.5-followup). Replaces the pre-followup 12-row max — a tall
 // rectangle read as a clunky bar of exhaust; capping at 4 and tapering

--- a/internal/tui/screens/launch_sprite_test.go
+++ b/internal/tui/screens/launch_sprite_test.go
@@ -825,3 +825,62 @@ func TestComposeLaunchSpriteDefaultsToTwoWhenWidthZero(t *testing.T) {
 		t.Errorf("got %d pixels, want %d (3 rows × default %d wide)", got, want, defaultSpriteWidthPx)
 	}
 }
+
+// TestComposeCanopy_SitsAboveStack — the deployed-chute canopy paints
+// above the top stage (higher screen.Y than every stage pixel at
+// vertical climb) and spreads wider than the top stage's body
+// (v0.12 Slice 3, ADR 0008).
+func TestComposeCanopy_SitsAboveStack(t *testing.T) {
+	stages := []spacecraft.Stage{
+		{LaunchSpriteRowsPx: 6, LaunchSpriteWidthPx: 3, Color: "#B8C8E0"},
+	}
+	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
+	basis := widgets.Basis{
+		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
+		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
+	}
+	body := ComposeLaunchSprite(stages, cmd, basis, 1.0)
+	canopy := ComposeCanopy(stages, cmd, basis, 1.0)
+	if len(canopy) == 0 {
+		t.Fatal("ComposeCanopy returned no pixels")
+	}
+	// Highest body pixel.
+	maxBodyY := -1e18
+	for _, p := range body {
+		if y := p.OffsetWorld.Dot(basis.Y); y > maxBodyY {
+			maxBodyY = y
+		}
+	}
+	minCanopyY, maxCanopyX, minCanopyX := 1e18, -1e18, 1e18
+	for _, p := range canopy {
+		y := p.OffsetWorld.Dot(basis.Y)
+		x := p.OffsetWorld.Dot(basis.X)
+		if y < minCanopyY {
+			minCanopyY = y
+		}
+		if x > maxCanopyX {
+			maxCanopyX = x
+		}
+		if x < minCanopyX {
+			minCanopyX = x
+		}
+	}
+	if minCanopyY <= maxBodyY {
+		t.Errorf("canopy bottom (%.2f) should sit above the body top (%.2f)", minCanopyY, maxBodyY)
+	}
+	// Canopy spans wider than the 3-wide top stage body (±1 sub-pixel).
+	if span := maxCanopyX - minCanopyX; span <= 2.0 {
+		t.Errorf("canopy width span %.2f should exceed the 3-wide stage body (2 sub-pixels)", span)
+	}
+}
+
+// TestComposeCanopy_EmptyStages — defensive: no stages ⇒ no canopy.
+func TestComposeCanopy_EmptyStages(t *testing.T) {
+	basis := widgets.Basis{
+		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
+		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
+	}
+	if got := ComposeCanopy(nil, orbital.Vec3{Z: 1}, basis, 1.0); got != nil {
+		t.Errorf("ComposeCanopy(nil) = %v, want nil", got)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -837,7 +837,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// `m` planner in v0.8.6) and added the flight / target / stage /
 	// save row players actually reach for.
 	footer := v.theme.Footer.Render(
-		"[?]help [esc]menu [+/-]zoom [f/F/g]focus [.,]warp [0]pause [m]maneuver [b]fire [wasdqe]attitude [space]stage [t/T]target [H/I/C]plan [n]spawn [[/]]craft [F5/F9]save/load",
+		"[?]help [esc]menu [+/-]zoom [f/F/g]focus [.,]warp [0]pause [m]maneuver [b]fire [wasdqe]attitude [space]stage/chute [t/T]target [H/I/C]plan [n]spawn [[/]]craft [F5/F9]save/load",
 	)
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, canvasPanel, hud)
@@ -1732,6 +1732,51 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		)
 	}
 
+	// v0.12 Slice 3 (ADR 0008): CHUTE block. Descent under a canopy
+	// happens in OrbitView (ViewLanding is still deferred), so the HUD
+	// is the player's only window onto the chute — surface the deploy
+	// state (STOWED / ARMED / DEPLOYED) and the descent rate so they
+	// can watch terminal velocity settle under V_CRIT. Shown for any
+	// chute-bearing vessel still in flight, independent of the LAUNCH /
+	// DESCENT gates above (a re-entry capsule on Earth routes through
+	// LAUNCH; this block rides alongside it).
+	if c := w.ActiveCraft(); c != nil && shouldShowChuteHUD(c) {
+		stateLabel := c.ChuteState.String()
+		switch c.ChuteState {
+		case spacecraft.ChuteDeployed:
+			stateLabel = v.theme.Primary.Render(stateLabel)
+		case spacecraft.ChuteArmed:
+			stateLabel = v.theme.Warning.Render(stateLabel)
+		default:
+			stateLabel = v.theme.Dim.Render(stateLabel)
+		}
+		// Descent rate = surface-relative downward speed (the vertical
+		// component of v_rel along −r̂). The surface-arrival predicate
+		// crashes on total |V| ≥ V_CRIT, so flag when the craft is still
+		// arriving too fast for the canopy to have saved it.
+		omegaRender := render.BodySpinOmegaWorld(c.Primary)
+		omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
+		vRel := c.State.V.Sub(omega.Cross(c.State.R))
+		var descentRate float64
+		if rNorm := c.State.R.Norm(); rNorm > 0 {
+			rHat := c.State.R.Scale(1 / rNorm)
+			descentRate = -(vRel.X*rHat.X + vRel.Y*rHat.Y + vRel.Z*rHat.Z)
+		}
+		rateLabel := fmt.Sprintf("%.1f m/s", descentRate)
+		if vRel.Norm() >= sim.CrashVCritMps {
+			rateLabel = v.theme.Alert.Render(
+				fmt.Sprintf("%.1f m/s (|V| > %.0f = CRASH on contact)", descentRate, sim.CrashVCritMps))
+		}
+		lines = append(lines, section("CHUTE")...)
+		lines = append(lines,
+			fmt.Sprintf("  state:        %s", stateLabel),
+			fmt.Sprintf("  descent rate: %s", rateLabel),
+		)
+		if c.ChuteState == spacecraft.ChuteStowed {
+			lines = append(lines, v.theme.Dim.Render("  [space] arms the chute on a bare capsule"))
+		}
+	}
+
 	// v0.8.2.x: arrival inclination preview. Surfaces the post-
 	// capture orbit at the last frame-changing planted node so the
 	// player catches retrograde-around-target gotchas (a prograde
@@ -2328,6 +2373,19 @@ const descentHUDAltitudeM = 50_000.0
 //
 // Crashed / Landed crafts never reach the surrounding HUD path so the
 // predicate doesn't need to gate on them.
+// shouldShowChuteHUD gates the v0.12 Slice 3 CHUTE block: shown for any
+// chute-bearing vessel (HasParachute mirror true) that is still in
+// flight — not Landed (the descent is over) and not Crashed (no chute
+// could save it). Independent of the LAUNCH / DESCENT atmosphere gates;
+// the chute readout is relevant for the whole descent, and STOWED state
+// reminds the player they can still arm it.
+func shouldShowChuteHUD(c *spacecraft.Spacecraft) bool {
+	if c == nil {
+		return false
+	}
+	return c.HasParachute && !c.Landed && !c.Crashed
+}
+
 func shouldShowDescentHUD(c *spacecraft.Spacecraft) bool {
 	if c == nil {
 		return false

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -1751,12 +1752,13 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 			stateLabel = v.theme.Dim.Render(stateLabel)
 		}
 		// Descent rate = surface-relative downward speed (the vertical
-		// component of v_rel along −r̂). The surface-arrival predicate
-		// crashes on total |V| ≥ V_CRIT, so flag when the craft is still
-		// arriving too fast for the canopy to have saved it.
-		omegaRender := render.BodySpinOmegaWorld(c.Primary)
-		omega := orbital.Vec3{X: omegaRender.X, Y: omegaRender.Y, Z: omegaRender.Z}
-		vRel := c.State.V.Sub(omega.Cross(c.State.R))
+		// component of v_rel along −r̂). The chute route of the surface-
+		// arrival predicate crashes on AIR-relative |v_rel| ≥ V_CRIT (not
+		// inertial |V| — a chute nulls velocity relative to the air, see
+		// classifySurfaceArrival), so use the same physics.AirRelative-
+		// Velocity source the predicate uses and flag when |v_rel| is
+		// still too fast for the canopy to have saved it.
+		vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
 		var descentRate float64
 		if rNorm := c.State.R.Norm(); rNorm > 0 {
 			rHat := c.State.R.Scale(1 / rNorm)
@@ -1765,7 +1767,7 @@ func (v *OrbitView) renderHUD(w *sim.World, selectedIdx int, width int) string {
 		rateLabel := fmt.Sprintf("%.1f m/s", descentRate)
 		if vRel.Norm() >= sim.CrashVCritMps {
 			rateLabel = v.theme.Alert.Render(
-				fmt.Sprintf("%.1f m/s (|V| > %.0f = CRASH on contact)", descentRate, sim.CrashVCritMps))
+				fmt.Sprintf("%.1f m/s (|v_rel| > %.0f = CRASH on contact)", descentRate, sim.CrashVCritMps))
 		}
 		lines = append(lines, section("CHUTE")...)
 		lines = append(lines,

--- a/internal/tui/screens/orbit_chute_hud_test.go
+++ b/internal/tui/screens/orbit_chute_hud_test.go
@@ -1,0 +1,107 @@
+// Package screens — v0.12 Slice 3 CHUTE HUD tests (ADR 0008).
+//
+// Descent under a parachute happens in OrbitView (ADR 0004 deferred a
+// dedicated ViewLanding), so the HUD is the player's only window onto
+// the chute: the CHUTE block surfaces the deploy state (STOWED / ARMED
+// / DEPLOYED) and the descent rate so the player can watch terminal
+// velocity settle under V_CRIT before contact.
+
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// placeCapsuleOnEarth parks a re-entry capsule descending toward Earth
+// at the given altitude with a downward (radially-inward) velocity.
+func placeCapsuleOnEarth(t *testing.T, w *sim.World, altM, vDown float64) *spacecraft.Spacecraft {
+	t.Helper()
+	c := spacecraft.NewFromLoadout(spacecraft.LoadoutCapsuleID)
+	// Reuse the default active craft's Earth primary.
+	c.Primary = w.ActiveCraft().Primary
+	c.State = physics.StateVector{
+		R: orbital.Vec3{X: c.Primary.RadiusMeters() + altM},
+		V: orbital.Vec3{X: -vDown},
+		M: c.TotalMass(),
+	}
+	w.Crafts = []*spacecraft.Spacecraft{c}
+	w.ActiveCraftIdx = 0
+	return c
+}
+
+// TestShouldShowChuteHUDForCapsule — a chute-bearing capsule in flight
+// shows the block; a Landed or Crashed one, or a non-chute craft, does
+// not.
+func TestShouldShowChuteHUDForCapsule(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := placeCapsuleOnEarth(t, w, 8_000, 50)
+	if !shouldShowChuteHUD(c) {
+		t.Errorf("capsule in flight: shouldShowChuteHUD=false, want true")
+	}
+	c.Landed = true
+	if shouldShowChuteHUD(c) {
+		t.Errorf("Landed capsule: shouldShowChuteHUD=true, want false")
+	}
+	c.Landed = false
+	c.Crashed = true
+	if shouldShowChuteHUD(c) {
+		t.Errorf("Crashed capsule: shouldShowChuteHUD=true, want false")
+	}
+	// A craft without the capability never shows the block.
+	c.Crashed = false
+	c.HasParachute = false
+	if shouldShowChuteHUD(c) {
+		t.Errorf("non-chute craft: shouldShowChuteHUD=true, want false")
+	}
+}
+
+// TestChuteHUDRendersStateAndDescentRate — the rendered block carries
+// the CHUTE header, the deploy-state word, and a descent-rate readout.
+func TestChuteHUDRendersStateAndDescentRate(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := placeCapsuleOnEarth(t, w, 6_000, 7) // 7 m/s descent, under V_CRIT
+	c.ChuteState = spacecraft.ChuteDeployed
+	view := NewOrbitView(descentHUDTheme())
+	out := view.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "CHUTE") {
+		t.Errorf("expected CHUTE section header; got:\n%s", out)
+	}
+	if !strings.Contains(out, "DEPLOYED") {
+		t.Errorf("expected DEPLOYED state word in CHUTE block; got:\n%s", out)
+	}
+	if !strings.Contains(out, "descent rate:") {
+		t.Errorf("expected descent-rate readout; got:\n%s", out)
+	}
+}
+
+// TestChuteHUDAlertsAboveVCrit — a chute craft still descending faster
+// than V_CRIT gets a crash-on-contact alert so the player knows the
+// canopy hasn't bled off enough speed yet.
+func TestChuteHUDAlertsAboveVCrit(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := placeCapsuleOnEarth(t, w, 6_000, 60) // 60 m/s > V_CRIT
+	c.ChuteState = spacecraft.ChuteArmed
+	view := NewOrbitView(descentHUDTheme())
+	out := view.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "ARMED") {
+		t.Errorf("expected ARMED state word; got:\n%s", out)
+	}
+	if !strings.Contains(out, "CRASH on contact") {
+		t.Errorf("expected crash-on-contact alert above V_CRIT; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Implements v0.12 Slice 3 — parachutes — per [ADR 0008](docs/adr/0008-parachutes-atmospheric-descent-recovery.md). Gives capsule-class vessels (no `CanSoftLand`) a non-engine route to a soft **Touchdown** via aerodynamic deceleration, closing the loop the LM landing opened: the Apollo CSM now earns a real Earth splashdown.

## What it adds

- **Capability + state split**, mirroring `CanSoftLand`: a per-`Stage` `HasParachute` (catalog data, synced to a `Spacecraft.HasParachute` mirror from `Stages[0]`) plus a runtime `ChuteState` enum (`Stowed → Armed → Deployed`, one-way, no torn state).
- **Arm via the Stage action** — once a vessel is reduced to its bare chute-bearing stage, the next `space` arms the chute instead of the single-stage no-op. No new keybinding.
- **Auto-deploy** the first tick dynamic pressure `q = ½ρ·|v_rel|²` reaches `ChuteDeployQMin` (1000 Pa).
- **BC bump**: while deployed, `EffectiveBallisticCoefficient()` returns a fixed `ChuteDeployedBC` (0.3 m²/kg) — absolute replace, so terminal velocity is ~7.4 m/s, mass-independent, comfortably under `V_CRIT`.
- **Second Touchdown route** in `classifySurfaceArrival`: `ChuteDeployed && |v_rel| < V_CRIT`, nose-alignment waived.
- **Loadouts**: `csm` stage flagged; new standalone **Capsule** re-entry test vehicle.
- **Render**: HUD CHUTE block (state + descent rate) and a synthetic braille canopy above the top stage in ViewLaunch.
- Additive/`omitempty` save fields — **no `SchemaVersion` bump**.

## Verification finding (ADR §4 amended)

Flying the actual descent caught that the predicate tested *inertial* `|V|`, but a parachute nulls *air-relative* velocity. On Earth a flawless canopy descent (`|v_rel|`≈7.6 m/s) still carries ~465 m/s inertial co-rotation, so the inertial check crashed every splashdown. **Fix: the chute route tests air-relative `|v_rel| = |V − ω×r|`** (engine route keeps inertial `|V|` — Moon's ω×r is negligible, shipped behaviour preserved). Pinned by an end-to-end Earth-splashdown integration test.

## Code-review fixes (second commit)

- Undock now preserves `CanSoftLand` + `HasParachute` (was dropped — would crash a CSM that docked then undocked before re-entry).
- Warp clamps to 10× during a chute descent, like the burn cap — prevents a high-warp tick from aliasing past the deploy window or inflating the canopy in one giant step.
- HUD label corrected to `|v_rel|`; `physics.AirRelativeVelocity` is now the single source of truth for `v − ω×r`; taper rule deduplicated.

## Testing

`go vet ./...` clean; `go test ./... -race -count=1` → **858 passed**. New coverage: BC short-circuit, SyncFields mirror, arm state machine, dynamic pressure, q-threshold deploy, both predicate routes (incl. the co-rotation case), save round-trip, dock/undock capability survival, warp clamp, HUD + canopy sprite, and the full Earth-splashdown arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)