### PR TITLE
diag(sim): Apollo lunar-arc budget probe + transposition ADR 0009

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,42 @@ plan, so its own internal boundaries are ordinary single-Stage
 separations — the extracted 2-stage LM later **Surface Stages** its
 descent Stage alone with no special-casing.
 _Avoid_: Decouple group, Staging sequence, Separation script.
+_Flagged_: the Apollo Stack's surviving core is being re-modelled — see
+**Transposition**, **Service Module**, **Command Module** below. Under
+that model the LM is no longer a bottom-up **Decouple Plan** release but
+a **nose payload** released from *above* the surviving core, and the
+survivor is the **Command Module**, not the fused CSM.
+
+**Service Module (SM)**:
+The propulsive half of the Apollo command-and-service module: carries the
+SPS engine and all its storable propellant. Performs lunar-orbit
+insertion (**LOI**), mid-course corrections, and trans-Earth injection
+(**TEI**). Has no heat shield and is **never recovered** — jettisoned
+during re-entry prep. After **Transposition** it is the bottom/firing
+Stage of the surviving stack, pushing the **Command Module** plus the LM
+nose payload.
+_Avoid_: CSM (that name fuses SM+CM — keep them distinct), Service stage.
+
+**Command Module (CM)**:
+The crew capsule half of the command-and-service module: heat shield,
+parachutes, RCS only, **no main engine**. The single piece that returns
+and splashes down — the true surviving core of a lunar mission. Modelled
+on the existing parachute-recovered **Capsule** (ADR 0008): a passive,
+engineless Stage that re-enters under chute after the **Service Module**
+is jettisoned.
+_Avoid_: Capsule (that's the standalone Loadout; the CM is the Apollo
+Stack's instance of the same recovery model), Command stage, Re-entry pod.
+
+**Transposition**:
+The post-TLI restructure of the lunar stack that makes the **Service
+Module** the firing core with the **Lunar Module** as a releasable
+**nose payload** — the in-sim analogue of Apollo's transposition-and-
+docking. Happens during trans-lunar coast with **no Burn pending** (the
+S-IVB does the *full* TLI solo first, then is discarded), which is why
+it cannot be folded into TLI as a single continuous push. Resolves the
+"wrong-engine" problem: without it the linear bottom-first chain fires
+the LM Descent for LOI; after it the SM fires LOI as the real CSM did.
+_Avoid_: Flip, Restage, Dock-around.
 
 **Launch Sprite**:
 The per-Stage **braille-pixel silhouette** rendered by the ViewLaunch

--- a/docs/adr/0009-transposition-and-active-engine.md
+++ b/docs/adr/0009-transposition-and-active-engine.md
@@ -1,0 +1,176 @@
+# 0009 — Transposition: splitting the CSM and letting a non-bottom stage fire
+
+<!-- llm-parse: adr=0009 status=proposed date=2026-06-02 cycle=v0.12 slice=apollo-transposition -->
+
+**Status:** proposed (2026-06-02, `/grill-with-docs` on the Apollo
+Stack flyability problem).
+**Extends:** [`docs/adr/0007-surface-staging-and-decouple-plan.md`](0007-surface-staging-and-decouple-plan.md)
+(the bottom-up `DecouplePlan` this slice adds a *top-release* / docked
+nose-payload counterpart to) and
+[`docs/adr/0008-parachutes-atmospheric-descent-recovery.md`](0008-parachutes-atmospheric-descent-recovery.md)
+(the parachute Capsule recovery model the Command Module reuses).
+
+## Context
+
+The Apollo Stack loadout cannot complete a lunar mission as modelled,
+and a session of diagnosis (`internal/sim/apollo_ascent_probe_test.go`,
+PR #71) established that the cause is **structural, not a fuel/power
+shortfall.** Two independent findings:
+
+1. **The hardware is sized correctly.** The first three stages are
+   byte-identical to the real Saturn V. At a real Saturn-V ascent
+   efficiency (~1700 m/s gravity+drag+steering loss) the S-IVB reaches
+   a 200 km park with ~3487 m/s — clearing the ~3133 m/s TLI by ~+350.
+   The in-game shortfall (−172 m/s at the probe's ~2327 m/s loss) is
+   **excess ascent loss**, not an under-fuelled stage; the player is
+   hand-flying an ascent that the real mission flew on a closed-loop
+   guidance computer. Fuel bumps were verified near-useless (+8 t →
+   +23 m/s, the rocket-equation tax).
+
+2. **The wrong engine fires after TLI.** The firing engine is welded to
+   `Stages[0]` (the bottom stage) via `SyncFields`
+   (`internal/spacecraft/stage.go:251`, mirroring Thrust/Isp/RCS from
+   `Stages[0]`; `consumeFuel`/`BurnFuel` debit `Stages[0].FuelMass`).
+   In the linear chain `[S-IC, S-II, S-IVB, Descent, Ascent, CSM]`,
+   once the S-IVB drops the **LM Descent** is `Stages[0]` and fires.
+   Lunar-orbit insertion (LOI, ~840 m/s) therefore runs on the lander's
+   descent engine — which can't complete it (718 m/s available) and
+   eats landing propellant. The CSM/SPS (the correct LOI engine) is
+   pinned on top as the surviving core and cannot fire until the LM is
+   gone. The real mission resolves this with **transposition and
+   docking**: after a full solo TLI, the CSM separates, flips, docks to
+   the LM nose-first, and pulls it off the spent S-IVB — making the CSM
+   the active engine with the LM as a releasable nose payload.
+
+A linear, bottom-first stack with a single hardwired firing engine
+structurally **cannot represent transposition**: the return vehicle
+must survive to fire last (TEI), so it can never also be the
+mid-mission firing core under bottom-up semantics. No stage reordering
+of the *static* loadout escapes this — it is transposition or nothing.
+
+A third fidelity fact shapes the fix: the real **CSM is two vehicles**
+— a Service Module (SPS engine + all propellant; does LOI, corrections,
+TEI; never recovered) and a Command Module (engineless crew capsule;
+heat shield + parachutes; the only piece that splashes down). The game
+fuses them into one `CSM` stage.
+
+## Decision
+
+### 1. Split `CSM` into Service Module (SM) and Command Module (CM)
+
+The Apollo Stack's surviving core becomes two stages: an **SM**
+(propulsive — SPS engine, the LOI/TEI fuel) below a **CM** (passive
+capsule — no main engine, parachute recovery, reusing the ADR 0008
+Capsule model). The CM is the true surviving core; the SM is jettisoned
+before re-entry. See `CONTEXT.md` (`Service Module`, `Command Module`).
+
+### 2. Transposition makes a non-bottom stage the firing engine
+
+**Transposition** is the post-TLI restructure that makes the SM the
+firing core with the LM as a releasable **nose payload**, mirroring the
+real flip. It happens during trans-lunar coast with **no Burn pending**
+— the S-IVB does the *full* TLI solo first, then is discarded — which
+is why it cannot be folded into TLI as one continuous push (the flip
+costs coast time and would forfeit the periapsis burn position).
+
+The canonical in-game mechanic is the **manual docking flip** the
+player can already fly: drop the LM as a free craft, slew 180°, RCS-dock
+to it. `DockCrafts` (`internal/sim/docking.go:299–302`) concatenates
+`[CSM.Stages…, LM.Stages…]`, so the CSM lands at `Stages[0]` and becomes
+the firing engine, with the LM as docked upper stages that **Undock**
+later for descent. This already works end-to-end; transposition is
+**not new flight semantics, it is the docking machinery already in
+use.**
+
+### 3. A one-shot transposition bypass key
+
+Because re-flying the rendezvous every test/play iteration is tedious, a
+**bypass key performs transposition in one keystroke**: jettison the
+S-IVB (spawn passive), reorder the active craft to `[SM, CM, Descent,
+Ascent]` with the SM at `Stages[0]`, and register the LM as a docked
+component so the existing **Undock** detaches it for landing. It
+reproduces the *end-state* of the manual flip — the composite with the
+SM firing — skipping only the hand-flown approach. The manual docking
+flip remains the canonical mechanic; the key is a convenience/cheat over
+the same resulting configuration.
+
+### 4. Per-stage Δv rebalance is a separate, parallel workstream
+
+Transposition fixes *which engine fires*; it does not by itself close
+the ~172 m/s TLI gap or guarantee each stage meets its maneuver budget.
+The stack is to be **trimmed to hit each stage's maneuver capability**
+(S-IVB clears TLI solo at the in-game ascent floor; SM does
+LOI+corrections+TEI; Descent does descent; Ascent does
+ascent+rendezvous; CM recovers). That rebalance is tracked separately
+and is **out of scope for this ADR**, which records only the
+structural/architectural decision.
+
+The eval loop is `internal/sim/apollo_lunar_budget_test.go`
+(`TestApolloLunarBudgetProbe`), which flies the real ascent and computes
+each stage's post-transposition margin. Its headline finding sharpens
+the rebalance: **transposition alone leaves only the S-IVB short.** The
+SM is *not* short once the SPS burns are phased correctly (LOI at the
+heavy LM-attached mass, TEI at the light bare-CSM mass), and DPS/APS are
+*over*-fuelled because the Descent no longer double-duties as the LOI
+engine.
+
+**Locked trim target (requirements: LOI 900, descent 2000, ascent+rdv
+1850, TEI 1000; "realistic reserve + SPS shave"):**
+
+| Stage | Fuel kg | → | Capability | Margin |
+|---|---|---|---|---|
+| DPS (Descent) | 9500 | **6310** | ~2500 m/s | +500 (real abort reserve) |
+| APS (Ascent) | 1800 | **1269** | ~2200 m/s | +350 |
+| SPS (CSM/SM) | 18400 | **16000** | TEI | +187 (real reserve) |
+| S-IC / S-II / S-IVB | — | untouched | faithful Saturn V | TLI **+277** |
+
+Payload above the S-IVB drops 45300→39179 kg (−6.1 t), all from the
+genuinely over-provisioned LM and SPS surplus — **no mass cut to the
+faithful Saturn-V lower stack.** Every stage closes with a *realistic*
+margin. The over-provisioned SPS funds the S-IVB's TLI margin, so real
+LM abort reserves and a comfortable TLI do **not** conflict.
+
+## Considered options
+
+- **DPS-does-LOI trim (rejected).** Keep the single fused CSM and the
+  linear order; size the Descent stage for LOI + descent (~2840 m/s),
+  CSM = TEI only. Cheapest — pure numbers, no new machinery — but
+  diverges from Apollo (the SPS did LOI, not the DPS) and the player
+  asked for the faithful architecture. Kept on record as the fallback
+  if transposition proves too costly.
+- **Active-engine index instead of reorder (rejected for now).** Add an
+  explicit `ActiveStageIdx` so any stage can fire without moving it to
+  `Stages[0]`. Smaller change, but it does not match the *physical*
+  flip (the LM genuinely moves to the CSM's nose), and it leaks a new
+  invariant through every `Stages[0]` assumption (engine-bell/flame
+  render, staging drop, maneuver integration). The reorder approach
+  keeps `Stages[0]` meaning "firing engine" intact post-flip.
+- **S-IVB does LOI too (rejected).** Keep the S-IVB through trans-lunar
+  coast and fire it for capture. Unphysical (the real S-IVB was
+  discarded) and needs ~3973 m/s from a stage that barely makes 3133.
+- **Leave it as a skill-tight challenge (rejected).** Accept that the
+  mission is only flyable with a perfect ascent *and* the manual flip.
+  Rejected because the wrong-engine wall makes LOI impossible on the
+  Descent stage regardless of piloting — it is not merely tight, it is
+  structurally unfinishable without the flip.
+
+## Consequences
+
+- **A non-bottom stage can become the firing engine** for the first
+  time. The reorder + `SyncFields` keeps the `Stages[0]`-is-firing
+  invariant, but staging-order assumptions elsewhere (engine-bell/flame
+  render keyed to `Stages[0]`, the bottom-up `DecouplePlan`) must be
+  audited against a post-transposition stack.
+- **Top-release / nose-payload** is the conceptual inverse of ADR
+  0007's bottom-up `DecouplePlan`: the LM is released from *above* the
+  surviving core. Implemented by reusing docking's **Undock** (the LM
+  is a docked component), not by extending `DecouplePlan`.
+- **The Apollo Stack gains a stage** (CSM → SM + CM), changing its
+  stage count and `DecouplePlan`. The CONTEXT.md `Decouple Plan` entry's
+  "leaving the CSM as the surviving core" is now stale and flagged.
+- **No save-schema bump is anticipated** if the bypass key produces a
+  standard docked-composite craft (already persisted), but the docked-
+  component snapshots for the LM must round-trip through save/load.
+- **The bypass key is a cheat over a real mechanic**, so it can ship
+  ungated without inventing a flight path that doesn't otherwise exist —
+  the manual flip produces the identical configuration.

--- a/internal/sim/apollo_ascent_probe_test.go
+++ b/internal/sim/apollo_ascent_probe_test.go
@@ -1,11 +1,15 @@
 package sim
 
 // apollo_ascent_probe_test.go is a DIAGNOSTIC harness (not a CI assertion):
-// it flies a gravity-turn ascent of the Apollo Stack through the real
-// force models (physics.Accel + physics.DragAccel, RK4, real catalog
-// masses / Isp / ballistic coefficients, serial staging) to a 200 km
-// circular parking orbit and reports the S-IVB's remaining Δv at park —
-// the number that decides whether TLI (≈3133 m/s) can complete.
+// it flies a gravity-turn ascent of the Apollo Stack through the real force
+// models (physics.Accel + physics.DragAccel, RK4, real catalog masses / Isp
+// / ballistic coefficients, serial staging) to a 200 km circular parking
+// orbit and reports the S-IVB's remaining Δv at park — the number that
+// decides whether TLI (≈3133 m/s) can complete.
+//
+// The ascent simulation itself lives in apollo_probe_helpers_test.go
+// (flyApolloAscent / bestApolloAscent), shared with the lunar-arc budget
+// probe so the two can't drift.
 //
 // Run: go test ./internal/sim -run TestApolloAscentBudgetProbe -v
 // It always passes; read the t.Log output.
@@ -14,26 +18,12 @@ import (
 	"math"
 	"testing"
 
-	"github.com/jasonfen/terminal-space-program/internal/bodies"
-	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 func TestApolloAscentBudgetProbe(t *testing.T) {
-	const g0 = 9.80665
-	systems, _, err := bodies.LoadAllWithWarnings()
-	if err != nil {
-		t.Fatalf("load bodies: %v", err)
-	}
-	var earth bodies.CelestialBody
-	found := false
-	for _, sys := range systems {
-		if cb, ok := bodies.LookupByID([]bodies.System{sys}, "earth"); ok {
-			earth, found = cb, true
-			break
-		}
-	}
-	if !found {
+	earth, ok := loadEarth()
+	if !ok {
 		t.Fatal("earth not found")
 	}
 	mu := earth.GravitationalParameter()
@@ -41,233 +31,28 @@ func TestApolloAscentBudgetProbe(t *testing.T) {
 	targetAlt := 200e3
 	rTarget := Re + targetAlt
 
-	// Apollo-Stack stages bottom→top (from loadouts.go, byte-identical).
-	type stg struct{ dry, fuel, thrust, isp, bc float64 }
-	stages := []stg{
-		{130000, 2160000, 35100000, 263, 8e-6},  // S-IC
-		{40000, 440000, 5140000, 421, 2.5e-5},    // S-II
-		{11000, 109000, 1023000, 421, 6.25e-5},   // S-IVB
+	// Apollo-Stack lower stack, byte-identical to loadouts.go.
+	stages := []apolloStage{
+		{130000, 2160000, 35100000, 263, 8e-6}, // S-IC
+		{40000, 440000, 5140000, 421, 2.5e-5},  // S-II
+		{11000, 109000, 1023000, 421, 6.25e-5}, // S-IVB
 	}
 	const payload = 45300.0 // LM(Descent+Ascent) + CSM wet, dead mass above S-IVB
-	sivbDryFloor := stages[2].dry + payload
 
-	// Launch basis: equatorial point so all motion stays in the equatorial
-	// plane (spin axis is the plane normal) and the real tilted DragAccel
-	// frame stays consistent. v0 = surface co-rotation (rotation boost).
-	omega := physics.AtmosphereOmega(earth)
-	spin := omega.Unit()
-	seed := orbital.Vec3{X: 1}
-	if math.Abs(spin.Dot(seed)) > 0.9 {
-		seed = orbital.Vec3{Y: 1}
-	}
-	upHat0 := seed.Sub(spin.Scale(seed.Dot(spin))).Unit()
-	r0 := upHat0.Scale(Re)
-	v0 := omega.Cross(r0)
-
-	type result struct {
-		kickDeg, remain, apoKm, periKm, fuelLeftSIVB, maxApoKm, expended float64
-		reached                                                          bool
-	}
-
-	// vTarget paces the commanded pitch program by SURFACE SPEED (an
-	// efficient gravity turn): pitch from vertical ramps 0→90° as surface
-	// speed climbs 0→vTarget, so the vehicle tips over as it accelerates
-	// rather than as it climbs (altitude-paced lofts and wastes Δv).
-	flyAscent := func(vTarget float64) result {
-		const (
-			dt     = 0.2
-			hStart = 1000.0 // vertical rise until this altitude (m) to clear pad + build speed
-		)
-		fuel := []float64{stages[0].fuel, stages[1].fuel, stages[2].fuel}
-		active := 0
-		r, v := r0, v0
-		maxApo := 0.0
-		expendedDv := 0.0
-		nextLog := 10.0
-		// Set traceVTarget to a swept vTarget value to dump per-20s ascent
-		// telemetry for that single run (altitude / vUp / vHor / apo / peri /
-		// stage / expended Δv). -1 disables. Handy for re-debugging guidance.
-		const traceVTarget = -1.0
-		debug := traceVTarget > 0 && math.Abs(vTarget-traceVTarget) < 1
-		totalMass := func() float64 {
-			m := payload
-			for i := active; i < len(stages); i++ {
-				m += stages[i].dry + fuel[i]
-			}
-			return m
-		}
-
-		for tt := 0.0; tt < 1400; tt += dt {
-			alt := r.Norm() - Re
-			upHat := r.Unit()
-			// instantaneous "east": prograde-horizontal in the equatorial plane.
-			eastHat := spin.Cross(r).Unit()
-
-			// Projected apoapsis / perigee of the current osculating orbit.
-			sp := physics.StateVector{R: r, V: v, M: totalMass()}
-			a := physics.SemimajorAxis(sp, mu)
-			h := r.Cross(v).Norm()
-			eps := physics.SpecificEnergy(sp, mu)
-			ecc := math.Sqrt(math.Max(0, 1+2*eps*h*h/(mu*mu)))
-			apo, peri := math.NaN(), math.NaN()
-			if a > 0 {
-				apo = a * (1 + ecc)
-				peri = a * (1 - ecc)
-				if (apo-Re)/1000 > maxApo {
-					maxApo = (apo - Re) / 1000
-				}
-			}
-
-			// Guidance:
-			//  1. vertical rise to clear the pad,
-			//  2. speed-paced pitch program (gravity turn) UNTIL the projected
-			//     apoapsis reaches the target — this stops the loft early,
-			//  3. then thrust pure horizontal-prograde to raise perigee to the
-			//     target (efficient powered insertion, fuel → orbital speed).
-			vUp := v.Dot(upHat)
-			// Begin insertion once near the top of the arc: apoapsis at/above
-			// target and the climb has nearly arrested (small vUp). Before
-			// that, fly the gravity-turn pitch program.
-			horizontalNow := !math.IsNaN(apo) && apo >= rTarget*0.98 && vUp < 250
-			var thrustDir orbital.Vec3
-			switch {
-			case alt < hStart:
-				thrustDir = upHat
-			case horizontalNow:
-				// Level-flight insertion: pitch above horizontal so the
-				// vertical thrust cancels net vertical accel (gravity −
-				// centrifugal) AND damps any residual vertical speed to zero,
-				// holding altitude while the rest of thrust builds orbital
-				// velocity. As v_h → orbital the needed pitch → 0.
-				rMag := r.Norm()
-				vHorVec := v.Sub(upHat.Scale(vUp))
-				horHat := eastHat
-				if vHorVec.Norm() > 1 {
-					horHat = vHorVec.Unit()
-				}
-				aGrav := mu / (rMag * rMag)
-				aCentrifugal := vHorVec.Norm() * vHorVec.Norm() / rMag
-				aT := stages[active].thrust / totalMass()
-				aV := (aGrav - aCentrifugal) - vUp*0.1 // null vertical speed
-				sinPhi := math.Max(-1, math.Min(1, aV/aT))
-				phi := math.Asin(sinPhi)
-				thrustDir = horHat.Scale(math.Cos(phi)).Add(upHat.Scale(math.Sin(phi)))
-			default:
-				vrelSpeed := physics.AirRelativeVelocity(r, v, earth).Norm()
-				pitchDeg := 90.0 * vrelSpeed / vTarget
-				if pitchDeg > 89.0 {
-					pitchDeg = 89.0
-				}
-				p := pitchDeg * math.Pi / 180
-				thrustDir = upHat.Scale(math.Cos(p)).Add(eastHat.Scale(math.Sin(p)))
-			}
-
-			// MECO when the orbit is circular at/above target: perigee raised
-			// to within 5 km of target radius.
-			if !math.IsNaN(peri) && peri >= rTarget-5e3 && alt > 100e3 {
-				break
-			}
-
-			if debug && tt >= nextLog {
-				vUp := v.Dot(upHat)
-				vHor := v.Sub(upHat.Scale(vUp)).Norm()
-				t.Logf("    t=%4.0fs alt=%6.1fkm vUp=%5.0f vHor=%5.0f apo=%6.0f peri=%7.0f stage=%d expΔv=%5.0f horiz=%v",
-					tt, alt/1000, vUp, vHor, (apo-Re)/1000, (peri-Re)/1000, active, expendedDv, horizontalNow)
-				nextLog += 20.0
-			}
-
-			m := totalMass()
-			th := stages[active].thrust
-			isp := stages[active].isp
-			bc := stages[active].bc
-			aThrust := thrustDir.Scale(th / m)
-			accelFn := func(rr, vv orbital.Vec3, _ float64) orbital.Vec3 {
-				return physics.Accel(rr, mu).
-					Add(physics.DragAccel(rr, vv, earth, bc)).
-					Add(aThrust)
-			}
-			ns := physics.StepRK4(physics.StateVector{R: r, V: v, M: m}, dt, accelFn, tt)
-			r, v = ns.R, ns.V
-			if cl, clamped := physics.ClampToSurface(physics.StateVector{R: r, V: v, M: m}, earth); clamped {
-				r, v = cl.R, cl.V
-			}
-
-			expendedDv += (th / m) * dt // engine Δv imparted this step
-
-			// Burn fuel; stage when active tank empties.
-			mdot := th / (isp * g0)
-			fuel[active] -= mdot * dt
-			for active < len(stages)-1 && fuel[active] <= 0 {
-				fuel[active] = 0
-				active++
-			}
-			if active == len(stages)-1 && fuel[active] <= 0 {
-				return result{kickDeg: vTarget, reached: false, maxApoKm: maxApo,
-					apoKm: (apo - Re) / 1000, periKm: (peri - Re) / 1000} // ran dry before orbit
-			}
-		}
-
-		// Coast (gravity+drag, no thrust) to apoapsis: until radial velocity ≤ 0.
-		for i := 0; i < 200000; i++ {
-			vr := v.Dot(r.Unit())
-			if vr <= 0 {
-				break
-			}
-			m := totalMass()
-			bc := stages[active].bc
-			accelFn := func(rr, vv orbital.Vec3, _ float64) orbital.Vec3 {
-				return physics.Accel(rr, mu).Add(physics.DragAccel(rr, vv, earth, bc))
-			}
-			ns := physics.StepRK4(physics.StateVector{R: r, V: v, M: m}, dt, accelFn, 0)
-			r, v = ns.R, ns.V
-		}
-
-		rApo := r.Norm()
-		// Circularize at apoapsis: prograde Δv = v_circ − v_apo.
-		sp := physics.StateVector{R: r, V: v, M: totalMass()}
-		a := physics.SemimajorAxis(sp, mu)
-		vApo := math.Sqrt(mu * (2/rApo - 1/a))
-		vCirc := math.Sqrt(mu / rApo)
-		dvCirc := vCirc - vApo
-		if dvCirc < 0 {
-			dvCirc = 0
-		}
-		// Spend circularization fuel from the active (S-IVB) stage.
-		m0 := totalMass()
-		mAfter := m0 * math.Exp(-dvCirc/(stages[active].isp*g0))
-		fuel[active] -= (m0 - mAfter)
-		if fuel[active] < 0 {
-			// circularization itself ran the stage dry
-			return result{kickDeg: vTarget, reached: false, apoKm: (rApo - Re) / 1000, maxApoKm: maxApo}
-		}
-
-		// Remaining S-IVB Δv pushing the LM+CSM payload.
-		mNow := stages[2].dry + fuel[2] + payload
-		remain := stages[2].isp * g0 * math.Log(mNow/sivbDryFloor)
-
-		// Report the parked orbit (apo/peri) after circularization.
-		spc := physics.StateVector{R: r, V: v.Scale(vCirc / v.Norm()), M: mNow}
-		ac := physics.SemimajorAxis(spc, mu)
-		_ = ac
-		return result{
-			kickDeg: vTarget, remain: remain, reached: true,
-			apoKm: (rApo - Re) / 1000, periKm: (rApo - Re) / 1000,
-			fuelLeftSIVB: fuel[2], maxApoKm: maxApo, expended: expendedDv + dvCirc,
-		}
-	}
-
-	best := result{remain: -1}
 	t.Logf("Apollo Stack gravity-turn ascent to %.0f km circular (real force models):", targetAlt/1000)
-	t.Logf("  full S-IVB Δv (pushing LM+CSM) = %.0f m/s; TLI from 200 km needs ≈ 3133 m/s", stages[2].isp*g0*math.Log((stages[2].dry+stages[2].fuel+payload)/sivbDryFloor))
+	fullSIVB := rocketDv(stages[2].isp, stages[2].dry+stages[2].fuel+payload, stages[2].dry+payload)
+	t.Logf("  full S-IVB Δv (pushing LM+CSM) = %.0f m/s; TLI from 200 km needs ≈ 3133 m/s", fullSIVB)
+
+	best := apolloAscentResult{remain: -1}
 	for vt := 1400.0; vt <= 3200.0; vt += 100.0 {
-		res := flyAscent(vt)
+		res := flyApolloAscent(earth, stages, payload, vt, targetAlt)
 		if res.reached {
 			t.Logf("  vTarget %5.0f → park %6.1f km  S-IVB remaining Δv = %6.0f m/s  (TLI margin %+6.0f)", vt, res.apoKm, res.remain, res.remain-3133)
 			if res.remain > best.remain {
 				best = res
 			}
 		} else {
-			t.Logf("  vTarget %5.0f → FAILED (ran dry; orbit apo %.0f / peri %.0f km, peak apo %.0f)", vt, res.apoKm, res.periKm, res.maxApoKm)
+			t.Logf("  vTarget %5.0f → FAILED (ran dry; peak apo %.0f km)", vt, res.maxApoKm)
 		}
 	}
 	if best.remain < 0 {
@@ -275,11 +60,10 @@ func TestApolloAscentBudgetProbe(t *testing.T) {
 		return
 	}
 	vOrb := math.Sqrt(mu / rTarget)
-	rotBonus := v0.Norm()
+	rotBonus := physics.AtmosphereOmega(earth).Norm() * Re // equatorial co-rotation start speed
 	losses := best.expended - (vOrb - rotBonus)
-	t.Logf("BEST ASCENT (vTarget=%.0f): park %.0f km, S-IVB has %.0f m/s remaining.", best.kickDeg, best.apoKm, best.remain)
-	t.Logf("  ascent expended %.0f m/s to orbit; v_orbit=%.0f, rotation bonus=%.0f → gravity+drag+steering loss ≈ %.0f m/s",
-		best.expended, vOrb, rotBonus, losses)
+	t.Logf("BEST ASCENT (vTarget=%.0f): park %.0f km, S-IVB has %.0f m/s remaining.", best.vTarget, best.apoKm, best.remain)
+	t.Logf("  ascent expended %.0f m/s to orbit; v_orbit=%.0f, rotation bonus=%.0f → gravity+drag+steering loss ≈ %.0f m/s", best.expended, vOrb, rotBonus, losses)
 	t.Logf("  (textbook-optimal loss for a TWR≈1.2 vehicle is ~1600–1800 m/s; excess above that is this harness's open-loop guidance, not the stack)")
 	t.Logf("  TLI needs ≈3133 m/s → margin %+.0f m/s (%s).", best.remain-3133,
 		map[bool]string{true: "MAKES IT", false: "SHORT by this ascent"}[best.remain >= 3133])

--- a/internal/sim/apollo_lunar_budget_test.go
+++ b/internal/sim/apollo_lunar_budget_test.go
@@ -1,0 +1,160 @@
+package sim
+
+// apollo_lunar_budget_test.go is a DIAGNOSTIC harness (not a CI assertion):
+// it evaluates the FULL post-transposition lunar arc per stage and reports
+// each stage's Δv margin, so a mass rebalance can be swept against real
+// numbers (ADR 0009).
+//
+// The arc, after transposition makes the CSM/SM the firing core with the LM
+// as a releasable nose payload:
+//
+//   S-IVB : TLI solo (from the parking orbit the ascent helper delivers)
+//   SM    : mid-course corrections + LOI (pushing CSM+LM) THEN TEI (bare CSM)
+//   DPS   : lunar descent (pushing the LM down)
+//   APS   : lunar ascent + rendezvous (pushing the ascent stage to orbit)
+//   CM    : passive parachute re-entry (no Δv)
+//
+// The SM budget is PHASED: corrections+LOI burn at the heavy LM-attached
+// mass, but TEI burns at the light bare-CSM mass after the LM is gone — so
+// the SPS is far less constrained than a single "pushing the LM" figure
+// suggests.
+//
+// Run: go test ./internal/sim -run TestApolloLunarBudgetProbe -v
+// It always passes; read the t.Log output.
+
+import (
+	"math"
+	"testing"
+)
+
+// apolloReqs are the per-maneuver Δv requirements (m/s), game values.
+type apolloReqs struct {
+	tli, corrections, loi, descent, ascentRdv, tei float64
+}
+
+// apolloArcMargins are the per-stage margins (avail − need), m/s.
+type apolloArcMargins struct {
+	sivbRemain, tliMargin   float64
+	smTEIAvail, smMargin    float64
+	smLOIFuelOK             bool
+	dpsAvail, dpsMargin     float64
+	apsAvail, apsMargin     float64
+	loiFuelUsed, teiFuelRem float64
+}
+
+// computeArc computes the post-transposition lunar-arc margins analytically
+// given the ascent helper's S-IVB-at-park figure.
+func computeArc(sivb, dps, aps, csm apolloStage, reqs apolloReqs, sivbRemain float64) apolloArcMargins {
+	lm := dps.dry + dps.fuel + aps.dry + aps.fuel
+	csmWet := csm.dry + csm.fuel
+
+	m := apolloArcMargins{}
+	m.sivbRemain = sivbRemain
+	m.tliMargin = sivbRemain - reqs.tli
+
+	// SM phased budget: corrections+LOI at LM-attached mass, TEI bare CSM.
+	mLOIStart := csmWet + lm
+	dvHeavy := reqs.corrections + reqs.loi
+	// fuel burned for the heavy phase via rocket equation.
+	mAfterHeavy := mLOIStart * math.Exp(-dvHeavy/(csm.isp*apolloG0))
+	fuelHeavy := mLOIStart - mAfterHeavy
+	m.loiFuelUsed = fuelHeavy
+	m.smLOIFuelOK = fuelHeavy <= csm.fuel
+	fuelRem := csm.fuel - fuelHeavy
+	if fuelRem < 0 {
+		fuelRem = 0
+	}
+	m.teiFuelRem = fuelRem
+	mTEIStart := csm.dry + fuelRem // LM undocked, ascent stage jettisoned
+	m.smTEIAvail = rocketDv(csm.isp, mTEIStart, csm.dry)
+	m.smMargin = m.smTEIAvail - reqs.tei
+
+	// DPS: descent pushing the whole LM down (burns descent fuel).
+	m.dpsAvail = rocketDv(dps.isp, dps.dry+dps.fuel+aps.dry+aps.fuel, dps.dry+aps.dry+aps.fuel)
+	m.dpsMargin = m.dpsAvail - reqs.descent
+
+	// APS: ascent stage to orbit + rendezvous.
+	m.apsAvail = rocketDv(aps.isp, aps.dry+aps.fuel, aps.dry)
+	m.apsMargin = m.apsAvail - reqs.ascentRdv
+
+	return m
+}
+
+func TestApolloLunarBudgetProbe(t *testing.T) {
+	earth, ok := loadEarth()
+	if !ok {
+		t.Fatal("earth not found")
+	}
+	const targetAlt = 200e3
+
+	// Lower stack (fixed: byte-identical Saturn V).
+	sic := apolloStage{130000, 2160000, 35100000, 263, 8e-6}
+	sii := apolloStage{40000, 440000, 5140000, 421, 2.5e-5}
+
+	reqs := apolloReqs{tli: 3133, corrections: 50, loi: 900, descent: 2000, ascentRdv: 1850, tei: 1000}
+
+	type config struct {
+		name           string
+		sivb, dps, aps apolloStage
+		csm            apolloStage
+	}
+	// Baseline = current catalog (single fused CSM stands in for SM+CM mass;
+	// the SPS engine/fuel is what the budget cares about).
+	baseSIVB := apolloStage{11000, 109000, 1023000, 421, 6.25e-5}
+	baseDPS := apolloStage{2500, 9500, 45000, 311, 0}
+	baseAPS := apolloStage{1200, 1800, 16000, 311, 0}
+	baseCSM := apolloStage{11900, 18400, 91000, 314, 0}
+
+	configs := []config{
+		{"baseline (current catalog)", baseSIVB, baseDPS, baseAPS, baseCSM},
+		// LEAN trim: size the LM to just clear nominal + a thin buffer
+		// (DPS cap ~2200, APS cap ~2000). Maximises the S-IVB's TLI margin.
+		{"lean trim (DPS~2200, APS~2000)", baseSIVB,
+			apolloStage{2500, 5087, 45000, 311, 0},
+			apolloStage{1200, 1112, 16000, 311, 0},
+			baseCSM},
+		// REALISTIC reserve: DPS carries the real abort-to-orbit margin
+		// (cap ~2500), APS ~2200. Heavier LM → less TLI help for the S-IVB.
+		{"realistic reserve (DPS~2500, APS~2200)", baseSIVB,
+			apolloStage{2500, 6310, 45000, 311, 0},
+			apolloStage{1200, 1269, 16000, 311, 0},
+			baseCSM},
+		// REALISTIC reserve + shave the SPS surplus (TEI is well over) to
+		// claw back some S-IVB margin without touching the LM reserves.
+		{"realistic reserve + SPS shave", baseSIVB,
+			apolloStage{2500, 6310, 45000, 311, 0},
+			apolloStage{1200, 1269, 16000, 311, 0},
+			apolloStage{11900, 16000, 91000, 314, 0}},
+	}
+
+	t.Logf("Apollo lunar-arc per-stage budget (post-transposition). Requirements:")
+	t.Logf("  TLI %.0f · corrections %.0f · LOI %.0f · descent %.0f · ascent+rdv %.0f · TEI %.0f",
+		reqs.tli, reqs.corrections, reqs.loi, reqs.descent, reqs.ascentRdv, reqs.tei)
+
+	for _, c := range configs {
+		payload := (c.dps.dry + c.dps.fuel) + (c.aps.dry + c.aps.fuel) + (c.csm.dry + c.csm.fuel)
+		best := bestApolloAscent(earth, []apolloStage{sic, sii, c.sivb}, payload, targetAlt)
+		t.Logf("")
+		t.Logf("── %s ──  (payload above S-IVB = %.0f kg)", c.name, payload)
+		if !best.reached {
+			t.Logf("   ASCENT FAILED — no park reached; stack is short before TLI.")
+			continue
+		}
+		m := computeArc(c.sivb, c.dps, c.aps, c.csm, reqs, best.remain)
+		t.Logf("   S-IVB  park %.0f km, remaining %.0f → TLI margin %+.0f   %s",
+			best.apoKm, m.sivbRemain, m.tliMargin, pass(m.tliMargin >= 0))
+		t.Logf("   SM     LOI burns %.0f kg (of %.0f), %.0f kg left → TEI avail %.0f → TEI margin %+.0f   %s",
+			m.loiFuelUsed, c.csm.fuel, m.teiFuelRem, m.smTEIAvail, m.smMargin, pass(m.smMargin >= 0 && m.smLOIFuelOK))
+		t.Logf("   DPS    descent avail %.0f → margin %+.0f   %s", m.dpsAvail, m.dpsMargin, pass(m.dpsMargin >= 0))
+		t.Logf("   APS    ascent avail %.0f → margin %+.0f   %s", m.apsAvail, m.apsMargin, pass(m.apsMargin >= 0))
+		all := m.tliMargin >= 0 && m.smMargin >= 0 && m.smLOIFuelOK && m.dpsMargin >= 0 && m.apsMargin >= 0
+		t.Logf("   ⇒ mission closes: %v", all)
+	}
+}
+
+func pass(ok bool) string {
+	if ok {
+		return "OK"
+	}
+	return "SHORT"
+}

--- a/internal/sim/apollo_probe_helpers_test.go
+++ b/internal/sim/apollo_probe_helpers_test.go
@@ -1,0 +1,235 @@
+package sim
+
+// apollo_probe_helpers_test.go holds the shared ascent simulation used by
+// the Apollo diagnostic probes (apollo_ascent_probe_test.go and
+// apollo_lunar_budget_test.go). It flies a gravity-turn ascent of the
+// Saturn-V lower stack (S-IC / S-II / S-IVB) through the real force models
+// (physics.Accel + physics.DragAccel, RK4) to a circular parking orbit and
+// reports the S-IVB's remaining Δv at park — the number TLI (≈3133 m/s)
+// has to beat.
+//
+// Parameterized by `payload` (dead mass above the S-IVB) and the three
+// stage specs so the budget probe can sweep mass trims and watch the
+// at-park margin move. Lifted verbatim from the original inline closure in
+// apollo_ascent_probe_test.go; keep the two callers in sync via this one
+// helper rather than copying the integrator.
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+const apolloG0 = 9.80665
+
+// apolloStage is one stage's mass/engine spec (dry kg, fuel kg, thrust N,
+// Isp s, ballistic coefficient).
+type apolloStage struct{ dry, fuel, thrust, isp, bc float64 }
+
+// apolloAscentResult reports a single ascent run.
+type apolloAscentResult struct {
+	vTarget       float64 // commanded speed-pacing target
+	remain        float64 // S-IVB Δv remaining at park, pushing the payload
+	apoKm, periKm float64 // parked orbit
+	fuelLeftSIVB  float64 // kg of S-IVB propellant left at park
+	maxApoKm      float64 // peak osculating apoapsis during ascent
+	expended      float64 // total engine Δv imparted reaching orbit
+	reached       bool    // true if a park was achieved before running dry
+}
+
+// loadEarth returns the Earth body from the embedded systems.
+func loadEarth() (bodies.CelestialBody, bool) {
+	systems, _, err := bodies.LoadAllWithWarnings()
+	if err != nil {
+		return bodies.CelestialBody{}, false
+	}
+	for _, sys := range systems {
+		if cb, ok := bodies.LookupByID([]bodies.System{sys}, "earth"); ok {
+			return cb, true
+		}
+	}
+	return bodies.CelestialBody{}, false
+}
+
+// flyApolloAscent flies the gravity-turn ascent of `stages` (exactly three:
+// S-IC, S-II, S-IVB) carrying `payload` dead mass, pacing the pitch program
+// by surface speed against vTarget, to a `targetAltM` circular park. It
+// returns the S-IVB's remaining Δv pushing the payload.
+func flyApolloAscent(earth bodies.CelestialBody, stages []apolloStage, payload, vTarget, targetAltM float64) apolloAscentResult {
+	mu := earth.GravitationalParameter()
+	Re := earth.RadiusMeters()
+	rTarget := Re + targetAltM
+	sivbDryFloor := stages[2].dry + payload
+
+	omega := physics.AtmosphereOmega(earth)
+	spin := omega.Unit()
+	seed := orbital.Vec3{X: 1}
+	if math.Abs(spin.Dot(seed)) > 0.9 {
+		seed = orbital.Vec3{Y: 1}
+	}
+	upHat0 := seed.Sub(spin.Scale(seed.Dot(spin))).Unit()
+	r0 := upHat0.Scale(Re)
+	v0 := omega.Cross(r0)
+
+	const (
+		dt     = 0.2
+		hStart = 1000.0
+	)
+	fuel := []float64{stages[0].fuel, stages[1].fuel, stages[2].fuel}
+	active := 0
+	r, v := r0, v0
+	maxApo := 0.0
+	expendedDv := 0.0
+	totalMass := func() float64 {
+		m := payload
+		for i := active; i < len(stages); i++ {
+			m += stages[i].dry + fuel[i]
+		}
+		return m
+	}
+
+	for tt := 0.0; tt < 1400; tt += dt {
+		alt := r.Norm() - Re
+		upHat := r.Unit()
+		eastHat := spin.Cross(r).Unit()
+
+		sp := physics.StateVector{R: r, V: v, M: totalMass()}
+		a := physics.SemimajorAxis(sp, mu)
+		h := r.Cross(v).Norm()
+		eps := physics.SpecificEnergy(sp, mu)
+		ecc := math.Sqrt(math.Max(0, 1+2*eps*h*h/(mu*mu)))
+		apo, peri := math.NaN(), math.NaN()
+		if a > 0 {
+			apo = a * (1 + ecc)
+			peri = a * (1 - ecc)
+			if (apo-Re)/1000 > maxApo {
+				maxApo = (apo - Re) / 1000
+			}
+		}
+
+		vUp := v.Dot(upHat)
+		horizontalNow := !math.IsNaN(apo) && apo >= rTarget*0.98 && vUp < 250
+		var thrustDir orbital.Vec3
+		switch {
+		case alt < hStart:
+			thrustDir = upHat
+		case horizontalNow:
+			rMag := r.Norm()
+			vHorVec := v.Sub(upHat.Scale(vUp))
+			horHat := eastHat
+			if vHorVec.Norm() > 1 {
+				horHat = vHorVec.Unit()
+			}
+			aGrav := mu / (rMag * rMag)
+			aCentrifugal := vHorVec.Norm() * vHorVec.Norm() / rMag
+			aT := stages[active].thrust / totalMass()
+			aV := (aGrav - aCentrifugal) - vUp*0.1
+			sinPhi := math.Max(-1, math.Min(1, aV/aT))
+			phi := math.Asin(sinPhi)
+			thrustDir = horHat.Scale(math.Cos(phi)).Add(upHat.Scale(math.Sin(phi)))
+		default:
+			vrelSpeed := physics.AirRelativeVelocity(r, v, earth).Norm()
+			pitchDeg := 90.0 * vrelSpeed / vTarget
+			if pitchDeg > 89.0 {
+				pitchDeg = 89.0
+			}
+			p := pitchDeg * math.Pi / 180
+			thrustDir = upHat.Scale(math.Cos(p)).Add(eastHat.Scale(math.Sin(p)))
+		}
+
+		if !math.IsNaN(peri) && peri >= rTarget-5e3 && alt > 100e3 {
+			break
+		}
+
+		m := totalMass()
+		th := stages[active].thrust
+		isp := stages[active].isp
+		bc := stages[active].bc
+		aThrust := thrustDir.Scale(th / m)
+		accelFn := func(rr, vv orbital.Vec3, _ float64) orbital.Vec3 {
+			return physics.Accel(rr, mu).
+				Add(physics.DragAccel(rr, vv, earth, bc)).
+				Add(aThrust)
+		}
+		ns := physics.StepRK4(physics.StateVector{R: r, V: v, M: m}, dt, accelFn, tt)
+		r, v = ns.R, ns.V
+		if cl, clamped := physics.ClampToSurface(physics.StateVector{R: r, V: v, M: m}, earth); clamped {
+			r, v = cl.R, cl.V
+		}
+
+		expendedDv += (th / m) * dt
+
+		mdot := th / (isp * apolloG0)
+		fuel[active] -= mdot * dt
+		for active < len(stages)-1 && fuel[active] <= 0 {
+			fuel[active] = 0
+			active++
+		}
+		if active == len(stages)-1 && fuel[active] <= 0 {
+			return apolloAscentResult{vTarget: vTarget, reached: false, maxApoKm: maxApo}
+		}
+	}
+
+	// Coast to apoapsis.
+	for i := 0; i < 200000; i++ {
+		vr := v.Dot(r.Unit())
+		if vr <= 0 {
+			break
+		}
+		m := totalMass()
+		bc := stages[active].bc
+		accelFn := func(rr, vv orbital.Vec3, _ float64) orbital.Vec3 {
+			return physics.Accel(rr, mu).Add(physics.DragAccel(rr, vv, earth, bc))
+		}
+		ns := physics.StepRK4(physics.StateVector{R: r, V: v, M: m}, dt, accelFn, 0)
+		r, v = ns.R, ns.V
+	}
+
+	// Circularize at apoapsis from the S-IVB.
+	rApo := r.Norm()
+	sp := physics.StateVector{R: r, V: v, M: totalMass()}
+	a := physics.SemimajorAxis(sp, mu)
+	vApo := math.Sqrt(mu * (2/rApo - 1/a))
+	vCirc := math.Sqrt(mu / rApo)
+	dvCirc := vCirc - vApo
+	if dvCirc < 0 {
+		dvCirc = 0
+	}
+	m0 := totalMass()
+	mAfter := m0 * math.Exp(-dvCirc/(stages[active].isp*apolloG0))
+	fuel[active] -= (m0 - mAfter)
+	if fuel[active] < 0 {
+		return apolloAscentResult{vTarget: vTarget, reached: false, apoKm: (rApo - Re) / 1000, maxApoKm: maxApo}
+	}
+
+	mNow := stages[2].dry + fuel[2] + payload
+	remain := stages[2].isp * apolloG0 * math.Log(mNow/sivbDryFloor)
+	return apolloAscentResult{
+		vTarget: vTarget, remain: remain, reached: true,
+		apoKm: (rApo - Re) / 1000, periKm: (rApo - Re) / 1000,
+		fuelLeftSIVB: fuel[2], maxApoKm: maxApo, expended: expendedDv + dvCirc,
+	}
+}
+
+// bestApolloAscent sweeps vTarget and returns the run that leaves the S-IVB
+// the most Δv at park (the best clean ascent for a given mass config).
+func bestApolloAscent(earth bodies.CelestialBody, stages []apolloStage, payload, targetAltM float64) apolloAscentResult {
+	best := apolloAscentResult{remain: -1}
+	for vt := 1400.0; vt <= 3200.0; vt += 100.0 {
+		res := flyApolloAscent(earth, stages, payload, vt, targetAltM)
+		if res.reached && res.remain > best.remain {
+			best = res
+		}
+	}
+	return best
+}
+
+// rocketDv returns the rocket-equation Δv to drop from m0 to m1.
+func rocketDv(isp, m0, m1 float64) float64 {
+	if m1 <= 0 || m0 <= m1 {
+		return 0
+	}
+	return isp * apolloG0 * math.Log(m0/m1)
+}


### PR DESCRIPTION
## What & why

Closes out the long-standing **\"Apollo Stack isn't flyable as powered/fueled\"** question (handoff `/tmp/claude-501/apollo-stack-lunar-fix-handoff.md`, memory `project_apollo_stack_tli_budget`). Resolved via `/grill-with-docs`.

**The blocker is structural, not a fuel shortfall.** The linear bottom-first stack welds the firing engine to `Stages[0]`, so after the S-IVB drops the **LM Descent** fires for LOI — never the CSM. No amount of fuel fixes that. The fix is **transposition**: let a non-bottom stage fire, with the LM as a releasable nose payload (the real Apollo flip). Captured in **ADR 0009**.

## Findings (from the new budget probe)

Post-transposition, per-stage margins (real ascent sim + phased SPS burns):

| | S-IVB | SM/TEI | DPS | APS | closes |
|---|---|---|---|---|---|
| baseline | −172 | +321 | +1060 | +945 | no (only S-IVB) |
| **locked: realistic + SPS shave** | **+277** | +187 | +500 | +350 | **yes** |

- The **SM was never short** — phased burns (LOI heavy, TEI on the bare CSM) clear by +187..+483.
- Only the **S-IVB** is short, and it closes from the fat transposition exposes (DPS/APS over-fuelled once the Descent stops double-duties as LOI engine).
- **Locked trim:** DPS 9500→6310, APS 1800→1269, SPS 18400→16000. **S-IC/S-II/S-IVB untouched** (faithful Saturn V). Every stage closes with a *realistic* margin.

## Contents (diagnostic + docs only — no production/loadout changes)

- `internal/sim/apollo_lunar_budget_test.go` — new full-arc per-stage budget diagnostic
- `internal/sim/apollo_probe_helpers_test.go` — shared ascent sim (`flyApolloAscent`/`bestApolloAscent`); both probes use one integrator (no drift)
- `internal/sim/apollo_ascent_probe_test.go` — refactored onto the helper
- `docs/adr/0009-transposition-and-active-engine.md` — split CSM→SM+CM, transposition + one-shot bypass key, locked trim table
- `CONTEXT.md` — Service Module / Command Module / Transposition glossary; flagged stale Decouple Plan note

## Follow-on (separate PRs)

1. Loadout: split CSM→SM+CM, apply the locked trim
2. Transposition active-engine reorder + one-shot bypass key
3. In-app verification of the flyable arc

CI green locally: `go vet ./...` + `go test ./... -race -count=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)