### PR TITLE
feat(sim): Apollo transposition + rebalanced lunar stack (ADR 0009)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,21 +57,20 @@ _Avoid_: Surface decouple, Ground staging, Lander separation.
 An optional per-Loadout, bottom-up list of group sizes describing how
 many contiguous bottom Stages each **Staging** press releases as a
 single craft. Default (absent) is all-ones — one Stage per press, the
-historical behaviour. The Apollo Stack declares `[1, 1, 1, 2]`: drop
-S-IC, S-II, S-IVB individually, then release the descent + ascent
-Stages **together** as a 2-stage Lunar Module craft, leaving the CSM
-as the surviving core. The plan is copied onto the Vessel at spawn and
-consumed positionally (each press pops the next entry's worth of
-Stages and advances). A released multi-Stage craft inherits **no**
-plan, so its own internal boundaries are ordinary single-Stage
+historical behaviour. The Apollo Stack declares `[1, 1, 1]` (ADR 0009):
+drop S-IC, S-II, S-IVB individually, leaving the pre-transposition
+stack `[Descent, Ascent, SM, CM]`. The plan is copied onto the Vessel
+at spawn and consumed positionally (each press pops the next entry's
+worth of Stages and advances). A released multi-Stage craft inherits
+**no** plan, so its own internal boundaries are ordinary single-Stage
 separations — the extracted 2-stage LM later **Surface Stages** its
 descent Stage alone with no special-casing.
+The Decouple Plan is **bottom-up only**. The Apollo LM is released from
+*above* the surviving core, which the plan cannot express — that is
+**Transposition**'s job: it reorders to `[SM, CM, Descent, Ascent]` and
+registers the LM as a docked **nose payload** that **Undock** releases.
+The mission survivor is the **Command Module**, not the fused CSM.
 _Avoid_: Decouple group, Staging sequence, Separation script.
-_Flagged_: the Apollo Stack's surviving core is being re-modelled — see
-**Transposition**, **Service Module**, **Command Module** below. Under
-that model the LM is no longer a bottom-up **Decouple Plan** release but
-a **nose payload** released from *above* the surviving core, and the
-survivor is the **Command Module**, not the fused CSM.
 
 **Service Module (SM)**:
 The propulsive half of the Apollo command-and-service module: carries the

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The in-game `?` overlay is the source of truth; this table mirrors it.
 | `[` / `]` | Cycle active craft (no-op when only one craft loaded) |
 | `1`–`9` | Jump directly to craft N (no-op when that slot is empty) |
 | `U` | Undock active composite |
+| `D` | Transpose (Apollo): flip the SM to the firing core, the LM becomes a releasable nose payload (then `U` to release) |
 
 ### Manual flight
 
@@ -326,19 +327,22 @@ the displayed bracket.
   (`▲`, 3-stage S-IC + S-II + S-IVB), SLS-Block1 (`▲`, 3-stage
   SRB + Core + ICPS), Falcon-9 (`▲`, 2-stage Merlin/Merlin-Vac),
   Apollo-Stack (`▲`, full mission arc S-IC → S-II → S-IVB → LM →
-  CSM), Capsule (`◓`, single-stage re-entry capsule with recovery
+  SM + CM), Capsule (`◓`, single-stage re-entry capsule with recovery
   parachute, ADR 0008). Each carries propulsion + visual
   differentiation; the orbit canvas renders every craft with its
   loadout glyph + color so they read distinctly even at small zoom.
 - **Multi-tier stack + configurator** (v0.10.1+). The **Apollo
-  Stack** loadout (S-IC → S-II → S-IVB → LM → CSM) flies the full
-  mission arc on the v0.9.1 staging chain: decoupling the mid-stage
-  LM spawns it as its own controllable craft (payload separation),
-  leaving the CSM core to fly the rendezvous / return. The spawn
-  form's **Custom…** entry opens a stack builder over a named stage
-  catalog (S-IC / S-II / S-IVB / ICPS / SRB / Core / F9 stages /
-  Lander / CSM / RCS-tug) — assemble any bottom-to-top stack and
-  spawn it. Custom craft round-trip through save with no schema
+  Stack** loadout (S-IC → S-II → S-IVB → LM → SM + CM) flies the full
+  mission arc on the v0.9.1 staging chain. After the three Saturn
+  stages drop, **transposition** (`D`, ADR 0009) flips the Service
+  Module to the firing core — so the SM's SPS does lunar-orbit
+  insertion and trans-Earth injection — with the Lunar Module riding
+  as a docked nose payload that `U` releases for the descent; the
+  Command Module is the engineless capsule that splashes down under
+  chute. The spawn form's **Custom…** entry opens a stack builder over
+  a named stage catalog (S-IC / S-II / S-IVB / ICPS / SRB / Core / F9
+  stages / Lander / CSM / RCS-tug) — assemble any bottom-to-top stack
+  and spawn it. Custom craft round-trip through save with no schema
   bump (per-stage state already persists at v6).
 - **Capture preview** (v0.8.2+). Plant a Hohmann to another body
   and the HUD's `CAPTURE PREVIEW` block shows what you'll arrive

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -313,6 +313,14 @@ type DockedComponent struct {
 	// absent → false, matching pre-Slice-3 components.
 	CanSoftLand  bool `json:"can_soft_land,omitempty"`
 	HasParachute bool `json:"has_parachute,omitempty"`
+	// Stages (v0.12 / ADR 0009, schema v6 additive — no bump): the
+	// component's full per-stage breakdown, so a multi-stage docked
+	// component (the Apollo LM = Descent + Ascent, or the SM+CM core
+	// after transposition) round-trips and Undock can rebuild it as a
+	// multi-stage craft. omitempty; absent → nil, which makes
+	// sim.Undock fall back to the legacy single-stage rebuild —
+	// matching every pre-ADR-0009 composite.
+	Stages []Stage `json:"stages,omitempty"`
 }
 
 // ActiveBurn mirrors sim.ActiveBurn. Throttle (v0.7.6+, schema v4)
@@ -525,6 +533,7 @@ func payloadFromWorld(w *sim.World) Payload {
 				RCSIsp:           dc.RCSIsp,
 				CanSoftLand:      dc.CanSoftLand,
 				HasParachute:     dc.HasParachute,
+				Stages:           simStagesToWire(dc.Stages),
 			})
 		}
 		for _, n := range c.Nodes {
@@ -717,6 +726,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				RCSIsp:           dc.RCSIsp,
 				CanSoftLand:      dc.CanSoftLand,
 				HasParachute:     dc.HasParachute,
+				Stages:           wireStagesToSim(dc.Stages),
 			})
 		}
 		// v0.8.1+: per-craft Nodes / ActiveBurn loaded directly from

--- a/internal/save/save_migrate_v5_to_v6.go
+++ b/internal/save/save_migrate_v5_to_v6.go
@@ -40,6 +40,39 @@ func wireStagesToSim(wire []Stage) []spacecraft.Stage {
 	return out
 }
 
+// simStagesToWire copies the sim's spacecraft.Stage form into this
+// package's wire Stage form — the inverse of wireStagesToSim. v0.12 /
+// ADR 0009: used for both Craft.Stages and DockedComponent.Stages so
+// the multi-stage docked-component breakdown round-trips. Returns nil
+// for an empty input (keeps the omitempty wire field absent).
+func simStagesToWire(stages []spacecraft.Stage) []Stage {
+	if len(stages) == 0 {
+		return nil
+	}
+	out := make([]Stage, len(stages))
+	for i, s := range stages {
+		out[i] = Stage{
+			LoadoutID:            s.LoadoutID,
+			Name:                 s.Name,
+			Glyph:                s.Glyph,
+			Color:                s.Color,
+			DryMass:              s.DryMass,
+			FuelMass:             s.FuelMass,
+			FuelCapacity:         s.FuelCapacity,
+			Thrust:               s.Thrust,
+			Isp:                  s.Isp,
+			MonopropMass:         s.MonopropMass,
+			MonopropCap:          s.MonopropCap,
+			RCSThrust:            s.RCSThrust,
+			RCSIsp:               s.RCSIsp,
+			BallisticCoefficient: s.BallisticCoefficient,
+			CanSoftLand:          s.CanSoftLand,
+			HasParachute:         s.HasParachute,
+		}
+	}
+	return out
+}
+
 // migrateV5CraftToStages wraps the v5 flat fields of wc into a
 // single-element Stages slice. The RCS pool numbers are passed in
 // because v5 had its own backfill for pre-v0.8.0 saves (loader

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -100,13 +100,13 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
-// TestDecouplePlanRoundtripMidStaging — v0.12 Slice 2 / ADR 0007. A
-// mission saved mid-staging must restore its remaining Decouple Plan
-// so the pending grouping (e.g. the LM extraction) still fires
-// correctly. Spawn an Apollo Stack (plan [1,1,1,2]), drop S-IC (plan
-// advances to [1,1,2]), save + reload, and assert the reloaded craft
-// carries [1,1,2]. Also confirms a craft with no plan round-trips as
-// nil (the omitempty single-pop default).
+// TestDecouplePlanRoundtripMidStaging — v0.12 / ADR 0009. A mission
+// saved mid-staging must restore its remaining Decouple Plan so the
+// pending Saturn-stage grouping still fires correctly. Spawn an Apollo
+// Stack (plan [1,1,1]), drop S-IC (plan advances to [1,1]), save +
+// reload, and assert the reloaded craft carries [1,1]. Also confirms a
+// craft with no plan round-trips as nil (the omitempty single-pop
+// default).
 func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -121,7 +121,7 @@ func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 	if _, _, err := w.StageActive(0); err != nil {
 		t.Fatalf("StageActive (drop S-IC): %v", err)
 	}
-	wantPlan := []int{1, 1, 2}
+	wantPlan := []int{1, 1}
 	if got := w.Crafts[0].DecouplePlan; len(got) != len(wantPlan) {
 		t.Fatalf("pre-save plan = %v, want %v", got, wantPlan)
 	}
@@ -135,7 +135,7 @@ func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	// Active craft (the partially-staged stack) keeps [1,1,2].
+	// Active craft (the partially-staged stack) keeps [1,1].
 	plan := got.Crafts[0].DecouplePlan
 	if len(plan) != len(wantPlan) {
 		t.Fatalf("reloaded plan = %v, want %v", plan, wantPlan)
@@ -150,6 +150,164 @@ func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 	// distinct value.
 	if got.Crafts[1].DecouplePlan != nil {
 		t.Errorf("jettisoned craft plan = %v, want nil (no plan ⇒ single-pop)", got.Crafts[1].DecouplePlan)
+	}
+}
+
+// transposedApolloWorld builds a world whose active craft is a
+// transposed Apollo composite ([SM, CM, Descent, Ascent] with the core
+// and LM as docked components carrying per-stage breakdowns). Shared by
+// the multi-stage DockedComponent save tests.
+func transposedApolloWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+	for i := 0; i < 3; i++ {
+		if _, _, err := w.StageActive(0); err != nil {
+			t.Fatalf("decouple #%d: %v", i, err)
+		}
+	}
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	return w
+}
+
+// TestSaveLoadMultiStageDockedComponent — v0.12 / ADR 0009. A transposed
+// Apollo composite carries DockedComponents with a full per-stage
+// breakdown (the LM = Descent + Ascent; the core = SM + CM). Save + Load
+// must round-trip those breakdowns so Undock post-reload still rebuilds
+// the LM as a 2-stage craft.
+func TestSaveLoadMultiStageDockedComponent(t *testing.T) {
+	w := transposedApolloWorld(t)
+
+	// Pre-save: the LM component carries 2 stages, the core 2 stages.
+	pre := w.Crafts[0].DockedComponents
+	if len(pre) != 2 {
+		t.Fatalf("pre-save: %d docked components, want 2", len(pre))
+	}
+	foundLM := false
+	for _, dc := range pre {
+		if len(dc.Stages) == 2 && dc.Stages[0].Name == "Descent" {
+			foundLM = true
+		}
+	}
+	if !foundLM {
+		t.Fatal("pre-save: no 2-stage [Descent, Ascent] docked component")
+	}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// The reloaded composite's docked components keep their breakdowns.
+	comps := got.Crafts[0].DockedComponents
+	if len(comps) != 2 {
+		t.Fatalf("reloaded: %d docked components, want 2", len(comps))
+	}
+	var lmStages int
+	for _, dc := range comps {
+		if len(dc.Stages) == 2 && dc.Stages[0].Name == "Descent" && dc.Stages[1].Name == "Ascent" {
+			lmStages = len(dc.Stages)
+		}
+	}
+	if lmStages != 2 {
+		t.Fatalf("reloaded LM component lost its 2-stage breakdown")
+	}
+
+	// Undock post-reload rebuilds the LM as a real 2-stage craft.
+	if !got.Undock(0) {
+		t.Fatal("Undock after reload returned false")
+	}
+	hasLM := false
+	for _, c := range got.Crafts {
+		if len(c.Stages) == 2 && c.Stages[0].Name == "Descent" && c.Stages[1].Name == "Ascent" {
+			hasLM = true
+		}
+	}
+	if !hasLM {
+		t.Error("post-reload undock did not rebuild a 2-stage LM craft")
+	}
+}
+
+// TestLoadOldSaveDockedComponentFallsBackSingleStage — a v6 save written
+// before ADR 0009 has DockedComponents with no "stages" array. Loading
+// it and undocking must fall back to the legacy single-stage rebuild
+// (one craft per component), not error. Simulated by stripping the
+// "stages" keys from a freshly-saved composite's JSON.
+func TestLoadOldSaveDockedComponentFallsBackSingleStage(t *testing.T) {
+	w := transposedApolloWorld(t)
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Strip every docked component's "stages" key to mimic a pre-ADR-0009
+	// save.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	payload, _ := doc["payload"].(map[string]any)
+	crafts, _ := payload["crafts"].([]any)
+	stripped := 0
+	for _, c := range crafts {
+		cm, _ := c.(map[string]any)
+		dcs, _ := cm["docked_components"].([]any)
+		for _, dc := range dcs {
+			if dcm, ok := dc.(map[string]any); ok {
+				if _, had := dcm["stages"]; had {
+					delete(dcm, "stages")
+					stripped++
+				}
+			}
+		}
+	}
+	if stripped == 0 {
+		t.Fatal("test setup: no docked-component stages found to strip")
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Load the stripped (old-shape) save and undock — must fall back to
+	// single-stage rebuild without error.
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load stripped save: %v", err)
+	}
+	for _, dc := range got.Crafts[0].DockedComponents {
+		if len(dc.Stages) != 0 {
+			t.Errorf("stripped save still carries a stage breakdown: %d stages", len(dc.Stages))
+		}
+	}
+	if !got.Undock(0) {
+		t.Fatal("Undock on stripped (old-shape) save returned false")
+	}
+	// Fallback path → each component rebuilds as a single-stage craft.
+	for _, c := range got.Crafts {
+		if len(c.DockedComponents) == 0 && len(c.Stages) != 1 {
+			t.Errorf("old-save fallback restored a %d-stage craft, want single-stage", len(c.Stages))
+		}
 	}
 }
 

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -30,7 +30,33 @@ func (w *World) Undock(idx int) bool {
 		return false
 	}
 
-	// Compute total dry + capacity sums for the share calculation.
+	// v0.12 / ADR 0009: decide whether the composite carries a full
+	// per-component stage breakdown. When every component records its
+	// Stages and the counts tile the composite's live Stages exactly
+	// (Σ len(comp.Stages) == len(c.Stages)), we partition the LIVE
+	// stages back to each component — preserving multi-stage structure
+	// (the Apollo LM = Descent + Ascent) and, crucially, CURRENT fuel.
+	// The firing Stages[0] is drained while docked (LOI burns the SM),
+	// so the dock-time snapshot fuel is stale; the live slice is not.
+	// DockCrafts/Transpose both build c.Stages as the in-order
+	// concatenation of the components' stages, so sequential slicing is
+	// exact. Falls back to the legacy single-stage prorate rebuild when
+	// any component predates the breakdown (old saves) or the counts
+	// don't tile — preserving back-compat.
+	useBreakdown := true
+	var stageSum int
+	for _, comp := range c.DockedComponents {
+		if len(comp.Stages) == 0 {
+			useBreakdown = false
+			break
+		}
+		stageSum += len(comp.Stages)
+	}
+	if stageSum != len(c.Stages) {
+		useBreakdown = false
+	}
+
+	// Compute total capacity sums for the legacy share calculation.
 	var totalCapFuel, totalCapMono float64
 	for _, comp := range c.DockedComponents {
 		totalCapFuel += comp.FuelCapacity
@@ -55,47 +81,53 @@ func (w *World) Undock(idx int) bool {
 
 	restored := make([]*spacecraft.Spacecraft, 0, len(c.DockedComponents))
 	n := len(c.DockedComponents)
+	stageOffset := 0 // running index into c.Stages for the breakdown path
 	for i, comp := range c.DockedComponents {
-		var fuelShare, monoShare float64
-		if totalCapFuel > 0 {
-			fuelShare = c.Fuel * (comp.FuelCapacity / totalCapFuel)
-		}
-		if totalCapMono > 0 {
-			monoShare = c.Monoprop * (comp.MonopropCapacity / totalCapMono)
+		var stages []spacecraft.Stage
+		if useBreakdown {
+			// Multi-stage path: peel the next len(comp.Stages) LIVE
+			// stages off the composite (own backing array so the
+			// restored craft doesn't alias the soon-discarded composite).
+			cnt := len(comp.Stages)
+			stages = append([]spacecraft.Stage(nil), c.Stages[stageOffset:stageOffset+cnt]...)
+			stageOffset += cnt
+		} else {
+			// Legacy single-stage path: rebuild a one-element Stages
+			// slice from the flat DockedComponent record, prorating the
+			// composite's pooled fuel/monoprop by pre-dock capacity.
+			var fuelShare, monoShare float64
+			if totalCapFuel > 0 {
+				fuelShare = c.Fuel * (comp.FuelCapacity / totalCapFuel)
+			}
+			if totalCapMono > 0 {
+				monoShare = c.Monoprop * (comp.MonopropCapacity / totalCapMono)
+			}
+			stages = []spacecraft.Stage{{
+				LoadoutID:    comp.LoadoutID,
+				Name:         comp.Name,
+				Glyph:        comp.Glyph,
+				Color:        comp.Color,
+				DryMass:      comp.DryMass,
+				FuelMass:     fuelShare,
+				FuelCapacity: comp.FuelCapacity,
+				Thrust:       comp.Thrust,
+				Isp:          comp.Isp,
+				MonopropMass: monoShare,
+				MonopropCap:  comp.MonopropCapacity,
+				RCSThrust:    comp.RCSThrust,
+				RCSIsp:       comp.RCSIsp,
+				// v0.12 Slice 3 (ADR 0008): restore the surface-arrival
+				// capabilities so an undocked lander / chute capsule keeps
+				// its soft-land / parachute qualification. SyncFields below
+				// re-derives the flat mirrors from this Stages[0].
+				CanSoftLand:  comp.CanSoftLand,
+				HasParachute: comp.HasParachute,
+			}}
 		}
 		// Spread components symmetrically around the composite's
 		// current position. For 2 components: -25 m and +25 m on
 		// the radial axis. For N: even spacing in [-1, +1].
 		offset := -1.0 + 2.0*float64(i)/float64(n-1)
-		// v0.9.1+: rebuild a single-stage Stages slice from the
-		// DockedComponent record. Pre-v0.9.1 components are wrapped
-		// into a one-element Stages so the restored craft has a
-		// valid source of truth for SyncFields. Multi-stage docking
-		// chains that survive a save/load + undock are not preserved
-		// in v0.9.1 — DockedComponent doesn't yet record per-stage
-		// breakdown; that's a v0.9.1.x follow-up if the playtest
-		// surfaces it.
-		stages := []spacecraft.Stage{{
-			LoadoutID:    comp.LoadoutID,
-			Name:         comp.Name,
-			Glyph:        comp.Glyph,
-			Color:        comp.Color,
-			DryMass:      comp.DryMass,
-			FuelMass:     fuelShare,
-			FuelCapacity: comp.FuelCapacity,
-			Thrust:       comp.Thrust,
-			Isp:          comp.Isp,
-			MonopropMass: monoShare,
-			MonopropCap:  comp.MonopropCapacity,
-			RCSThrust:    comp.RCSThrust,
-			RCSIsp:       comp.RCSIsp,
-			// v0.12 Slice 3 (ADR 0008): restore the surface-arrival
-			// capabilities so an undocked lander / chute capsule keeps
-			// its soft-land / parachute qualification. SyncFields below
-			// re-derives the flat mirrors from this Stages[0].
-			CanSoftLand:  comp.CanSoftLand,
-			HasParachute: comp.HasParachute,
-		}}
 		s := &spacecraft.Spacecraft{
 			Name:      comp.Name,
 			LoadoutID: comp.LoadoutID,

--- a/internal/sim/docking_test.go
+++ b/internal/sim/docking_test.go
@@ -239,6 +239,77 @@ func TestUndockRestoresComponents(t *testing.T) {
 	}
 }
 
+// TestUndockRestoresMultiStageLMWithLiveFuel — v0.12 / ADR 0009. A
+// composite whose DockedComponents carry a per-stage breakdown undocks
+// into MULTI-stage craft, and the restored stages carry the composite's
+// CURRENT (live) fuel, not the dock-time snapshot. The transposition
+// flow is the headline case: after transposing, the SM (Stages[0]) is
+// drained by the LOI burn while the LM rides docked — so on undock the
+// surviving SM/CM core must reflect the burn, and the LM (never the
+// firing stage while docked) must keep its descent/ascent propellant.
+func TestUndockRestoresMultiStageLMWithLiveFuel(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := w.StageActive(0); err != nil {
+			t.Fatalf("decouple #%d: %v", i, err)
+		}
+	}
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	comp := w.Crafts[0]
+	if comp.Stages[0].Name != "SM" {
+		t.Fatalf("post-transpose Stages[0] = %q, want SM", comp.Stages[0].Name)
+	}
+	const smStart = 16000.0
+	if comp.Stages[0].FuelMass != smStart {
+		t.Fatalf("SM start fuel = %.0f, want %.0f", comp.Stages[0].FuelMass, smStart)
+	}
+
+	// Burn SM propellant (the LOI burn analogue) — drains Stages[0].
+	const burned = 5000.0
+	if got := comp.BurnFuel(burned); got != burned {
+		t.Fatalf("BurnFuel returned %.0f, want %.0f", got, burned)
+	}
+
+	if !w.Undock(0) {
+		t.Fatal("Undock after transpose returned false")
+	}
+	var lm, csm *spacecraft.Spacecraft
+	for _, c := range w.Crafts {
+		switch {
+		case len(c.Stages) == 2 && c.Stages[0].Name == "Descent":
+			lm = c
+		case len(c.Stages) == 2 && c.Stages[0].Name == "SM":
+			csm = c
+		}
+	}
+	if csm == nil || lm == nil {
+		t.Fatalf("undock did not produce both an SM/CM core and a 2-stage LM (crafts=%d)", len(w.Crafts))
+	}
+	// The core's SM carries LIVE fuel (start − burned), not the stale
+	// 16000 snapshot — this is the live-partition correctness point.
+	if want := smStart - burned; csm.Stages[0].FuelMass != want {
+		t.Errorf("restored SM fuel = %.0f, want %.0f (live, post-burn — NOT the snapshot)",
+			csm.Stages[0].FuelMass, want)
+	}
+	// The LM never fired while docked → its tanks are intact at the
+	// loadout trim (Descent 6310, Ascent 1269).
+	if lm.Stages[0].FuelMass != 6310 || lm.Stages[1].FuelMass != 1269 {
+		t.Errorf("restored LM fuel = [%.0f, %.0f], want [6310, 1269]",
+			lm.Stages[0].FuelMass, lm.Stages[1].FuelMass)
+	}
+}
+
 // TestDockingActivePartnerKeepsName: when craft B (non-active)
 // docks with craft A (active), the composite inherits A's name.
 // When the player flies B and docks with A, B's name is kept

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -31,6 +31,10 @@ var (
 	// the only stage would leave the player with nothing to
 	// control, which is the wrong default. Status-flash + no-op.
 	ErrStageOnlyOne = errors.New("stage: cannot drop the only remaining stage")
+	// ErrTransposeNotReady — Transpose called on a craft that is not in
+	// the pre-transposition [Descent, Ascent, SM, CM] shape (ADR 0009).
+	// The player must drop the three Saturn stages first.
+	ErrTransposeNotReady = errors.New("transpose: stack not in [Descent, Ascent, SM, CM] shape — drop the launch vehicle first")
 )
 
 // StageActive jettisons the bottom stage (Stages[0]) of the craft
@@ -246,4 +250,77 @@ func retrogradeUnit(v, r orbital.Vec3) orbital.Vec3 {
 		return r.Scale(-1 / rMag)
 	}
 	return orbital.Vec3{X: -1}
+}
+
+// Transpose performs the Apollo transposition (ADR 0009) on the craft at
+// craftIdx in one shot: it reproduces the end-state of the manual
+// docking flip — the SM becomes the firing core (Stages[0]) with the LM
+// as a releasable nose payload — without flying the rendezvous.
+//
+// Precondition: the craft is exactly [Descent, Ascent, SM, CM] — the
+// state left after the three Saturn stages have decoupled (the loadout's
+// [1,1,1] DecouplePlan). Otherwise returns ErrTransposeNotReady.
+//
+// It splits the stack into the LM (Descent + Ascent) and the CSM core
+// (SM + CM), reorders the live craft to [SM, CM, Descent, Ascent] so the
+// SM's SPS is the firing engine (SyncFields mirrors Stages[0]) for LOI
+// and TEI, and registers BOTH halves as DockedComponents carrying their
+// per-stage breakdown. The LM then peels off as a 2-stage craft via the
+// existing Undock (docking.go) for the lunar descent; the SM/CM core
+// survives. This is the docking machinery already in use, not new flight
+// semantics — DockCrafts would build the identical composite from a
+// hand-flown flip.
+func (w *World) Transpose(craftIdx int) error {
+	if craftIdx < 0 || craftIdx >= len(w.Crafts) {
+		return fmt.Errorf("%w: %d (slate has %d)", ErrStageNoCraft, craftIdx, len(w.Crafts))
+	}
+	c := w.Crafts[craftIdx]
+	if c == nil {
+		return fmt.Errorf("%w: %d (nil)", ErrStageNoCraft, craftIdx)
+	}
+	// Precondition: the pre-transposition shape [Descent, Ascent, SM, CM].
+	if len(c.Stages) != 4 ||
+		c.Stages[0].Name != "Descent" || c.Stages[1].Name != "Ascent" ||
+		c.Stages[2].Name != "SM" || c.Stages[3].Name != "CM" {
+		return ErrTransposeNotReady
+	}
+
+	// Own backing arrays so the two halves don't alias the soon-rebuilt
+	// c.Stages.
+	lmStages := append([]spacecraft.Stage(nil), c.Stages[0:2]...)   // Descent, Ascent
+	coreStages := append([]spacecraft.Stage(nil), c.Stages[2:4]...) // SM, CM
+
+	// Register both halves as docked components (identity + per-stage
+	// breakdown) so Undock can restore them. Order = the reordered
+	// Stages concatenation: core first, LM appended on the nose.
+	core := dockedComponentFromStages(coreStages, "CSM", c.Role)
+	lm := dockedComponentFromStages(lmStages, "LM", "lander")
+
+	// Reorder the live craft so the SM is the firing engine.
+	c.Stages = append(append([]spacecraft.Stage(nil), coreStages...), lmStages...)
+	c.DockedComponents = []spacecraft.DockedComponent{core, lm}
+	c.Name = "CSM" // flying as the CSM core now
+	c.SyncFields()
+	c.State.M = c.TotalMass()
+	return nil
+}
+
+// dockedComponentFromStages builds a DockedComponent (identity + full
+// per-stage breakdown) from a contiguous stage group, deriving the
+// component's glyph/color/loadout from the group's bottom stage and its
+// summed mass/engine mirrors via SyncFields. Used by Transpose to wrap
+// the CSM core and the LM nose payload so the existing Undock restores
+// each as a correct multi-stage craft. v0.12 / ADR 0009.
+func dockedComponentFromStages(stages []spacecraft.Stage, name, role string) spacecraft.DockedComponent {
+	bottom := stages[0]
+	tmp := &spacecraft.Spacecraft{
+		Name:      name,
+		Role:      role,
+		Glyph:     bottom.Glyph,
+		Color:     bottom.Color,
+		LoadoutID: bottom.LoadoutID,
+		Stages:    append([]spacecraft.Stage(nil), stages...),
+	}
+	tmp.SyncFields()
+	return tmp.AsDockedComponent()
 }

--- a/internal/sim/staging_can_soft_land_test.go
+++ b/internal/sim/staging_can_soft_land_test.go
@@ -13,18 +13,19 @@ import (
 )
 
 // TestApolloStackLanderDecoupleCarriesCanSoftLand — walks through
-// the Apollo mission staging sequence (drop S-IC, S-II, S-IVB,
-// then Lander) and asserts:
+// the v0.12 / ADR 0009 Apollo mission staging sequence (drop S-IC,
+// S-II, S-IVB, then transpose + undock the LM) and asserts:
 //
 //  1. While flying the composite, the active craft's CanSoftLand
 //     reflects the *current bottom stage* — false through the
 //     ascent / coast / TLI chain (none of those stages can land).
-//  2. After the Lander stage decouples, the new jettisoned craft
-//     in the slate carries CanSoftLand=true. The surviving active
-//     (CSM alone) re-derives CanSoftLand=false via SyncFields.
+//  2. After transposition + undock, the released LM craft carries
+//     CanSoftLand=true (its Descent bottom is soft-land-capable). The
+//     surviving SM/CM core re-derives CanSoftLand=false via SyncFields
+//     (the SM has no landing gear).
 //
-// This is the "playable as designed" loop ADR 0004 promised — and
-// the v0.11.4-followup that made it actually work end-to-end.
+// This is the "playable as designed" loop ADR 0004 promised, now reached
+// via the ADR 0009 transposition path rather than a bottom-up decouple.
 func TestApolloStackLanderDecoupleCarriesCanSoftLand(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -42,10 +43,10 @@ func TestApolloStackLanderDecoupleCarriesCanSoftLand(t *testing.T) {
 		t.Errorf("Apollo Stack at spawn: CanSoftLand=true, want false (S-IC is bottom)")
 	}
 
-	// Decouple S-IC, S-II, S-IVB in sequence (DecouplePlan [1,1,1,2] —
-	// three single pops) — each should leave the active craft with
-	// CanSoftLand=false until the bottom becomes Descent (the LM's
-	// soft-land-capable bottom stage).
+	// Decouple S-IC, S-II, S-IVB in sequence (DecouplePlan [1,1,1] —
+	// three single pops). The bottom becomes Descent after the third,
+	// but Descent is the LM's soft-land-capable stage only while it is
+	// Stages[0]; transposition then buries it behind the SM.
 	for i, expectedStage := range []string{"S-II", "S-IVB", "Descent"} {
 		if _, _, err := w.StageActive(0); err != nil {
 			t.Fatalf("decouple #%d: %v", i, err)
@@ -55,9 +56,6 @@ func TestApolloStackLanderDecoupleCarriesCanSoftLand(t *testing.T) {
 			t.Fatalf("after decouple #%d: bottom stage = %q, want %q",
 				i, active.Stages[0].Name, expectedStage)
 		}
-		// Through S-II + S-IVB the bottom isn't the LM yet →
-		// CanSoftLand=false. At Descent (the third iteration), bottom
-		// IS the soft-land-capable descent stage → CanSoftLand=true.
 		wantSoftLand := expectedStage == "Descent"
 		if active.CanSoftLand != wantSoftLand {
 			t.Errorf("after decouple to %q: CanSoftLand=%v, want %v",
@@ -65,33 +63,49 @@ func TestApolloStackLanderDecoupleCarriesCanSoftLand(t *testing.T) {
 		}
 	}
 
-	// Fourth press: the plan's trailing 2 releases the LM (Descent +
-	// Ascent) as one 2-stage craft, leaving the CSM core. The
-	// jettisoned LM's bottom (Descent) carries CanSoftLand; the
-	// surviving CSM does not.
+	// Transpose: the SM becomes the firing core (no landing gear), with
+	// the LM as a docked nose payload — so the composite's CanSoftLand
+	// drops back to false.
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	if w.Crafts[0].CanSoftLand {
+		t.Errorf("post-transposition composite (SM bottom): CanSoftLand=true, want false")
+	}
+
+	// Undock: the released LM craft carries CanSoftLand (Descent bottom);
+	// the surviving SM/CM core does not.
 	beforeSlateLen := len(w.Crafts)
-	_, jettIdx, err := w.StageActive(0)
-	if err != nil {
-		t.Fatalf("decouple LM: %v", err)
+	if !w.Undock(0) {
+		t.Fatal("Undock after transpose returned false")
 	}
 	if len(w.Crafts) != beforeSlateLen+1 {
-		t.Fatalf("slate length after LM decouple: got %d, want %d",
+		t.Fatalf("slate length after undock: got %d, want %d",
 			len(w.Crafts), beforeSlateLen+1)
 	}
-	jett := w.Crafts[jettIdx]
-	if !jett.CanSoftLand {
-		t.Errorf("jettisoned LM craft: CanSoftLand=false, want true (Descent bottom carries the flag)")
+	var lm, csm *spacecraft.Spacecraft
+	for _, c := range w.Crafts {
+		switch {
+		case len(c.Stages) == 2 && c.Stages[0].Name == "Descent":
+			lm = c
+		case len(c.Stages) == 2 && c.Stages[0].Name == "SM":
+			csm = c
+		}
 	}
-	if len(jett.Stages) != 2 || jett.Stages[0].Name != "Descent" || jett.Stages[1].Name != "Ascent" {
-		t.Errorf("jettisoned LM stages = %d-stage, want [Descent, Ascent]", len(jett.Stages))
+	if lm == nil {
+		t.Fatal("no 2-stage [Descent, Ascent] LM craft after undock")
 	}
-	active := w.Crafts[0]
-	if active.Stages[0].Name != "CSM" {
-		t.Errorf("surviving active after LM decouple: bottom stage = %q, want %q",
-			active.Stages[0].Name, "CSM")
+	if !lm.CanSoftLand {
+		t.Errorf("released LM craft: CanSoftLand=false, want true (Descent bottom carries the flag)")
 	}
-	if active.CanSoftLand {
-		t.Errorf("surviving CSM: CanSoftLand=true, want false (no landing gear)")
+	if lm.Stages[1].Name != "Ascent" {
+		t.Errorf("released LM stages = [%q, %q], want [Descent, Ascent]", lm.Stages[0].Name, lm.Stages[1].Name)
+	}
+	if csm == nil {
+		t.Fatal("no surviving SM/CM core after undock")
+	}
+	if csm.CanSoftLand {
+		t.Errorf("surviving SM/CM core: CanSoftLand=true, want false (no landing gear)")
 	}
 }
 

--- a/internal/sim/staging_surface_test.go
+++ b/internal/sim/staging_surface_test.go
@@ -155,8 +155,9 @@ func TestAscentLiftoffDoesNotRefuseDescent(t *testing.T) {
 }
 
 // TestExtractedLMSurfaceStagesDescentAlone — the "inherit no plan"
-// rule (ADR 0007 decision 5). An LM extracted from the Apollo Stack
-// (via the [1,1,1,2] plan) is a 2-stage [Descent, Ascent] craft with
+// rule (ADR 0007 decision 5), now reached via the ADR 0009 transposition
+// path. An LM released from the Apollo Stack (drop the 3 Saturn stages,
+// transpose, undock) is a 2-stage [Descent, Ascent] craft with
 // DecouplePlan=nil. When it later surface-stages, the nil plan means
 // single-pop: it drops the Descent stage ALONE, leaving a single-stage
 // Ascent — it must NOT re-group descent+ascent and empty itself.
@@ -175,14 +176,27 @@ func TestExtractedLMSurfaceStagesDescentAlone(t *testing.T) {
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
 
-	// Decouple S-IC, S-II, S-IVB, then the LM pair.
-	var lmIdx int
-	for i := 0; i < 4; i++ {
-		_, jettIdx, err := w.StageActive(0)
-		if err != nil {
+	// Drop S-IC, S-II, S-IVB (the [1,1,1] plan), then transpose + undock
+	// to release the LM as its own 2-stage craft.
+	for i := 0; i < 3; i++ {
+		if _, _, err := w.StageActive(0); err != nil {
 			t.Fatalf("decouple #%d: %v", i, err)
 		}
-		lmIdx = jettIdx
+	}
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	if !w.Undock(0) {
+		t.Fatal("Undock after transpose returned false")
+	}
+	var lmIdx int = -1
+	for i, c := range w.Crafts {
+		if len(c.Stages) == 2 && c.Stages[0].Name == "Descent" {
+			lmIdx = i
+		}
+	}
+	if lmIdx < 0 {
+		t.Fatal("no released LM craft found after transpose + undock")
 	}
 	lm := w.Crafts[lmIdx]
 	if len(lm.Stages) != 2 || lm.DecouplePlan != nil {
@@ -218,10 +232,11 @@ func TestExtractedLMSurfaceStagesDescentAlone(t *testing.T) {
 }
 
 // TestDecouplePlanAdvancesOnEachPress — the plan is consumed
-// positionally: after dropping S-IC, the Apollo Stack's remaining plan
-// is [1,1,2]; after S-II it's [1,2]; etc. Pins the advance so a
-// save/reload mid-staging (which persists the remaining plan) restores
-// the correct grouping for the still-pending LM extraction.
+// positionally: after dropping S-IC, the v0.12 / ADR 0009 Apollo Stack's
+// remaining plan is [1,1]; after S-II it's [1]; after S-IVB it's empty
+// (the LM is no longer a bottom-up group — it releases via transposition
+// + undock). Pins the advance so a save/reload mid-staging (which
+// persists the remaining plan) restores the correct Saturn-drop grouping.
 func TestDecouplePlanAdvancesOnEachPress(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -234,10 +249,9 @@ func TestDecouplePlanAdvancesOnEachPress(t *testing.T) {
 	w.ActiveCraftIdx = 0
 
 	wantRemaining := [][]int{
-		{1, 1, 2}, // after S-IC
-		{1, 2},    // after S-II
-		{2},       // after S-IVB
-		nil,       // after the LM pair (plan emptied)
+		{1, 1}, // after S-IC
+		{1},    // after S-II
+		nil,    // after S-IVB (plan emptied; LM releases via transpose)
 	}
 	for i, want := range wantRemaining {
 		if _, _, err := w.StageActive(0); err != nil {

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -183,14 +183,11 @@ func TestStageActiveAdvancesEngineToNextStage(t *testing.T) {
 	}
 }
 
-// TestApolloStackDecoupleChainLeavesCSM — the v0.12 Slice 2 Apollo-
-// Stack is [S-IC, S-II, S-IVB, Descent, Ascent, CSM] with a
-// DecouplePlan [1,1,1,2] (ADR 0007). Three single decouples drop
-// S-IC → S-II → S-IVB; the fourth releases the Descent + Ascent pair
-// **together** as one 2-stage LM craft (payload separation), leaving
-// the active craft as the single-stage CSM core. The fifth decouple
-// refuses (ErrStageOnlyOne — can't drop the only/last stage).
-func TestApolloStackDecoupleChainLeavesCSM(t *testing.T) {
+// TestTransposeRejectsWrongShape — Transpose only fires on the
+// pre-transposition [Descent, Ascent, SM, CM] stack. Called on a fresh
+// full Apollo Stack (the launch vehicle still attached) it must refuse
+// with ErrTransposeNotReady rather than reorder a launch-config stack.
+func TestTransposeRejectsWrongShape(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -201,8 +198,36 @@ func TestApolloStackDecoupleChainLeavesCSM(t *testing.T) {
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
 
-	if len(stack.Stages) != 6 {
-		t.Fatalf("Apollo-Stack should start 6-stage, got %d", len(stack.Stages))
+	if err := w.Transpose(0); !errors.Is(err, ErrTransposeNotReady) {
+		t.Errorf("Transpose on full stack: err = %v, want ErrTransposeNotReady", err)
+	}
+	// Stack must be untouched (still 7 stages, S-IC at bottom).
+	if len(w.Crafts[0].Stages) != 7 || w.Crafts[0].Stages[0].Name != "S-IC" {
+		t.Errorf("rejected transpose mutated the stack: %d stages, bottom %q",
+			len(w.Crafts[0].Stages), w.Crafts[0].Stages[0].Name)
+	}
+}
+
+// TestApolloStackDecoupleChainThenTranspose — the v0.12 / ADR 0009
+// Apollo-Stack is [S-IC, S-II, S-IVB, Descent, Ascent, SM, CM] with a
+// DecouplePlan [1,1,1]. Three single decouples drop S-IC → S-II → S-IVB,
+// leaving the pre-transposition stack [Descent, Ascent, SM, CM]. The
+// transpose key (D) then reorders it to [SM, CM, Descent, Ascent] (SM =
+// firing core) with the LM registered as a docked nose payload, which
+// Undock releases as a 2-stage LM craft, leaving the SM/CM core.
+func TestApolloStackDecoupleChainThenTranspose(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+
+	if len(stack.Stages) != 7 {
+		t.Fatalf("Apollo-Stack should start 7-stage, got %d", len(stack.Stages))
 	}
 
 	// First three presses drop single launch-vehicle stages.
@@ -218,38 +243,65 @@ func TestApolloStackDecoupleChainLeavesCSM(t *testing.T) {
 		}
 	}
 
-	// Fourth press: the DecouplePlan's trailing 2 releases the LM pair
-	// (Descent + Ascent) as a SINGLE 2-stage craft.
-	_, lmIdx, err := w.StageActive(0)
-	if err != nil {
-		t.Fatalf("decouple LM: %v", err)
+	// After the three Saturn drops the active craft is the
+	// pre-transposition stack [Descent, Ascent, SM, CM].
+	pre := w.Crafts[0]
+	wantPre := []string{"Descent", "Ascent", "SM", "CM"}
+	if len(pre.Stages) != len(wantPre) {
+		t.Fatalf("pre-transposition stack: %d stages, want %d", len(pre.Stages), len(wantPre))
 	}
-	lm := w.Crafts[lmIdx]
-	if len(lm.Stages) != 2 {
-		t.Fatalf("extracted LM: %d stage(s), want 2 (Descent + Ascent grouped)", len(lm.Stages))
-	}
-	if lm.Stages[0].Name != "Descent" || lm.Stages[1].Name != "Ascent" {
-		t.Errorf("extracted LM stages = [%q, %q], want [Descent, Ascent]",
-			lm.Stages[0].Name, lm.Stages[1].Name)
-	}
-	// The LM is a real controllable craft — its bottom (Descent) fires.
-	if lm.Stages[0].Thrust <= 0 {
-		t.Errorf("extracted LM has no engine (Thrust=%v) — not controllable", lm.Stages[0].Thrust)
-	}
-	// A released multi-stage craft inherits NO plan (ADR 0007): its
-	// internal boundaries fall back to single-pop so it can later
-	// surface-stage the Descent stage alone.
-	if lm.DecouplePlan != nil {
-		t.Errorf("extracted LM DecouplePlan = %v, want nil (released sub-craft inherits no plan)", lm.DecouplePlan)
+	for i, n := range wantPre {
+		if pre.Stages[i].Name != n {
+			t.Errorf("pre-transposition stage %d = %q, want %q", i, pre.Stages[i].Name, n)
+		}
 	}
 
-	core := w.Crafts[0]
-	if len(core.Stages) != 1 || core.Stages[0].Name != "CSM" {
-		t.Fatalf("surviving core: %d stage(s) named %q, want 1× CSM",
-			len(core.Stages), core.Stages[0].Name)
+	// Transpose: reorder so the SM is the firing core, LM becomes a
+	// docked nose payload.
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
 	}
-	if _, _, err := w.StageActive(0); !errors.Is(err, ErrStageOnlyOne) {
-		t.Errorf("dropping the CSM core: err = %v, want ErrStageOnlyOne", err)
+	core := w.Crafts[0]
+	wantPost := []string{"SM", "CM", "Descent", "Ascent"}
+	for i, n := range wantPost {
+		if core.Stages[i].Name != n {
+			t.Errorf("post-transposition stage %d = %q, want %q", i, core.Stages[i].Name, n)
+		}
+	}
+	if core.Stages[0].Name != "SM" || core.Thrust != 91000 {
+		t.Errorf("firing engine after transpose: Stages[0]=%q Thrust=%.0f, want SM/91000",
+			core.Stages[0].Name, core.Thrust)
+	}
+	if len(core.DockedComponents) != 2 {
+		t.Fatalf("transposed composite: %d docked components, want 2 (core + LM)", len(core.DockedComponents))
+	}
+
+	// Undock releases the LM as a 2-stage [Descent, Ascent] craft; the
+	// SM/CM core survives and still fires the SPS.
+	if !w.Undock(0) {
+		t.Fatal("Undock after transpose returned false")
+	}
+	var lm, csm *spacecraft.Spacecraft
+	for _, c := range w.Crafts {
+		switch {
+		case len(c.Stages) == 2 && c.Stages[0].Name == "Descent":
+			lm = c
+		case len(c.Stages) == 2 && c.Stages[0].Name == "SM":
+			csm = c
+		}
+	}
+	if lm == nil {
+		t.Fatal("no 2-stage [Descent, Ascent] LM craft after undock")
+	}
+	if lm.Stages[1].Name != "Ascent" || lm.Stages[0].Thrust <= 0 {
+		t.Errorf("LM after undock: stages [%q,%q] Thrust=%.0f, want [Descent,Ascent] firing",
+			lm.Stages[0].Name, lm.Stages[1].Name, lm.Stages[0].Thrust)
+	}
+	if lm.DecouplePlan != nil {
+		t.Errorf("undocked LM DecouplePlan = %v, want nil (single-pop boundaries)", lm.DecouplePlan)
+	}
+	if csm == nil || csm.Stages[1].Name != "CM" || csm.Thrust != 91000 {
+		t.Fatalf("surviving CSM core after undock not [SM,CM] firing: %+v", csm)
 	}
 }
 

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -503,28 +503,38 @@ var Loadouts = map[string]Loadout{
 			stageWithBC(LoadoutApolloStackID, "S-IVB", "▲", "#FFD93D",
 				11000, 109000, 1023000, 421, 6.25e-5),
 			// Lunar Module — split into Descent + Ascent (v0.12 Slice 2
-			// / ADR 0007). The DecouplePlan [1,1,1,2] below releases the
-			// pair together as one 2-stage LM craft (payload separation)
-			// rather than stranding the descent stage and leaving the
-			// ascent fused to the CSM. Fuel-heavy descent (dry 2500 /
-			// fuel 9500) so the lunar landing doesn't run dry; ascent
-			// (dry 1200 / fuel 1800) returns to lunar orbit. The LM is a
-			// negligible fraction of the ~2.93 Mkg stack, so lift-off
-			// TWR stays ~1.22.
+			// / ADR 0007). Post-transposition (ADR 0009) the LM rides as
+			// a docked nose payload above the SM/CM core and is released
+			// via Undock for the lunar descent. Fuel trimmed to the ADR
+			// 0009 locked table: descent 9500→6310 (real abort reserve,
+			// ~2500 m/s cap), ascent 1800→1269 (~2200 m/s cap) — the LM
+			// no longer double-duties as the LOI engine, so it can shed
+			// the surplus. The LM is a negligible fraction of the
+			// ~2.93 Mkg stack, so lift-off TWR stays ~1.22.
 			stage(LoadoutApolloStackID, "Descent", "▼", "#5FFF87",
-				2500, 9500, 45000, 311),
+				2500, 6310, 45000, 311),
 			stage(LoadoutApolloStackID, "Ascent", "▲", "#7BFFA0",
-				1200, 1800, 16000, 311),
-			// Command/Service Module — the surviving core. SPS
-			// storable-propellant engine; enough Δv for the
-			// rendezvous / trans-Earth return.
-			stage(LoadoutApolloStackID, "CSM", "◉", "#C0C0FF",
-				11900, 18400, 91000, 314),
+				1200, 1269, 16000, 311),
+			// Command/Service Module — split into a propulsive Service
+			// Module + a passive Command Module (v0.12 / ADR 0009). The
+			// SM (SPS engine; SPS fuel trimmed 18400→16000) fires LOI and
+			// TEI once transposition makes it Stages[0]; the CM is the
+			// engineless parachute capsule that splashes down. SM dry
+			// 6000 + CM dry 5900 = the pre-split CSM dry 11900 → the
+			// split is mass-neutral and lift-off TWR is unchanged. SM
+			// below CM so the firing SPS sits beneath the passive capsule.
+			stage(LoadoutApolloStackID, "SM", "◉", "#C0C0FF",
+				6000, 16000, 91000, 314),
+			stage(LoadoutApolloStackID, "CM", "◓", "#B8C8E0",
+				5900, 0, 0, 0),
 		},
-		// v0.12 Slice 2 / ADR 0007: drop S-IC, S-II, S-IVB
-		// individually, then release Descent + Ascent together as a
-		// 2-stage LM craft, leaving the CSM core. Sum (5) < 6 stages.
-		DecouplePlan: []int{1, 1, 1, 2},
+		// v0.12 / ADR 0009: drop S-IC, S-II, S-IVB individually. After
+		// the third pop the active craft is [Descent, Ascent, SM, CM] —
+		// the pre-transposition state the transpose key (D) consumes.
+		// The LM is no longer a bottom-up decouple group; transposition
+		// reorders it to a docked nose payload released via Undock, not
+		// StageActive. Sum (3) < 7 stages.
+		DecouplePlan: []int{1, 1, 1},
 	},
 	// Re-entry capsule (v0.12 Slice 3, ADR 0008): single command-module
 	// stage carrying a parachute and no engine landing. HasParachute /

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -140,18 +140,20 @@ func TestStageCatalogShape(t *testing.T) {
 	}
 }
 
-// TestApolloStackShape — the multi-tier loadout: 6 stages bottom-first
-// [S-IC, S-II, S-IVB, Descent, Ascent, CSM] (v0.12 Slice 2 / ADR 0007
-// split the LM into Descent + Ascent), lift-off TWR > 1 at sea-level g
-// with the full payload, CSM is the surviving core. The Descent +
-// Ascent split sums to the pre-split LM mass so TWR is unchanged. The
-// DecouplePlan [1,1,1,2] groups the LM pair on the fourth press.
+// TestApolloStackShape — the multi-tier loadout: 7 stages bottom-first
+// [S-IC, S-II, S-IVB, Descent, Ascent, SM, CM] (v0.12 ADR 0009 split the
+// fused CSM into a propulsive Service Module + a passive Command Module),
+// lift-off TWR > 1 at sea-level g with the full payload. SM+CM dry mass
+// equals the pre-split CSM dry, so the split is mass-neutral and TWR is
+// unchanged. The DecouplePlan [1,1,1] drops the three Saturn stages one
+// at a time; the LM is no longer a bottom-up group — post-transposition
+// it becomes a docked nose payload released via Undock (ADR 0009).
 func TestApolloStackShape(t *testing.T) {
 	l, ok := Loadouts[LoadoutApolloStackID]
 	if !ok {
 		t.Fatal("Apollo-Stack loadout missing")
 	}
-	wantNames := []string{"S-IC", "S-II", "S-IVB", "Descent", "Ascent", "CSM"}
+	wantNames := []string{"S-IC", "S-II", "S-IVB", "Descent", "Ascent", "SM", "CM"}
 	if len(l.Stages) != len(wantNames) {
 		t.Fatalf("Apollo-Stack: %d stages, want %d", len(l.Stages), len(wantNames))
 	}
@@ -160,7 +162,7 @@ func TestApolloStackShape(t *testing.T) {
 			t.Errorf("stage %d: name %q, want %q", i, l.Stages[i].Name, n)
 		}
 	}
-	wantPlan := []int{1, 1, 1, 2}
+	wantPlan := []int{1, 1, 1}
 	if len(l.DecouplePlan) != len(wantPlan) {
 		t.Fatalf("Apollo-Stack DecouplePlan = %v, want %v", l.DecouplePlan, wantPlan)
 	}
@@ -168,6 +170,44 @@ func TestApolloStackShape(t *testing.T) {
 		if l.DecouplePlan[i] != g {
 			t.Errorf("DecouplePlan[%d] = %d, want %d", i, l.DecouplePlan[i], g)
 		}
+	}
+	// Stage-by-name lookups for the property assertions below.
+	byName := map[string]Stage{}
+	for _, s := range l.Stages {
+		byName[s.Name] = s
+	}
+	// SM: the propulsive Service Module — SPS engine, trimmed SPS fuel,
+	// no parachute (the CM carries the chute, not the SM).
+	sm := byName["SM"]
+	if sm.Thrust != 91000 || sm.Isp != 314 {
+		t.Errorf("SM engine: Thrust=%.0f Isp=%.0f, want 91000/314", sm.Thrust, sm.Isp)
+	}
+	if sm.FuelMass != 16000 {
+		t.Errorf("SM SPS fuel = %.0f, want 16000 (ADR 0009 trim)", sm.FuelMass)
+	}
+	if sm.HasParachute {
+		t.Error("SM must not carry a parachute (only the CM does)")
+	}
+	if sm.LaunchSpriteWidthPx < 2 {
+		t.Errorf("SM LaunchSpriteWidthPx = %d, want >= 2 (engine-bell render)", sm.LaunchSpriteWidthPx)
+	}
+	// CM: the passive Command Module — engineless, parachute recovery.
+	cm := byName["CM"]
+	if cm.Thrust != 0 || cm.FuelMass != 0 {
+		t.Errorf("CM should be engineless: Thrust=%.0f Fuel=%.0f", cm.Thrust, cm.FuelMass)
+	}
+	if !cm.HasParachute {
+		t.Error("CM must carry a parachute (ADR 0008 recovery model)")
+	}
+	if cm.CanSoftLand {
+		t.Error("CM has no engine landing route — CanSoftLand must be false")
+	}
+	// Locked LM trim (ADR 0009 table).
+	if d := byName["Descent"]; d.FuelMass != 6310 {
+		t.Errorf("Descent fuel = %.0f, want 6310 (ADR 0009 trim)", d.FuelMass)
+	}
+	if a := byName["Ascent"]; a.FuelMass != 1269 {
+		t.Errorf("Ascent fuel = %.0f, want 1269 (ADR 0009 trim)", a.FuelMass)
 	}
 	totalMass := SumDryMass(l.Stages) + SumFuelMass(l.Stages)
 	twr := l.Stages[0].Thrust / (totalMass * g0)

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -316,6 +316,18 @@ type DockedComponent struct {
 	// landing capabilities are cheap to carry and load-bearing.)
 	CanSoftLand  bool
 	HasParachute bool
+	// Stages (v0.12 / ADR 0009): the component's full per-stage
+	// breakdown, captured so Undock can restore a MULTI-stage craft
+	// (e.g. the Apollo LM = Descent + Ascent released as a docked nose
+	// payload after transposition). Closes the v0.9.1.x gap the flat
+	// single-stage fields above couldn't cover. Empty/nil ⇒ Undock
+	// falls back to the legacy single-stage prorate rebuild (old saves,
+	// single-stage components). The recorded FuelMass is a dock-time
+	// snapshot used only for the stage COUNT + identity; Undock reads
+	// LIVE per-stage fuel from the composite's current Stages (the
+	// firing Stages[0] is drained while docked, so the snapshot fuel
+	// goes stale — see sim.Undock).
+	Stages []Stage
 }
 
 // AsDockedComponent captures s's identity + capacity fields into a
@@ -337,6 +349,9 @@ func (s *Spacecraft) AsDockedComponent() DockedComponent {
 		RCSIsp:           s.RCSIsp,
 		CanSoftLand:      s.CanSoftLand,
 		HasParachute:     s.HasParachute,
+		// v0.12 / ADR 0009: record the full stage breakdown so a
+		// multi-stage component (the LM) round-trips through Undock.
+		Stages: append([]Stage(nil), s.Stages...),
 	}
 }
 

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -106,6 +106,18 @@ const (
 	StageModuleLanderDescentID = "lander-descent"
 	StageModuleLanderAscentID  = "lander-ascent"
 	StageModuleCSMID           = "csm" // Apollo Command/Service Module (SPS)
+	// v0.12 / ADR 0009: the fused CSM split into a propulsive Service
+	// Module (SPS engine + all propellant; does LOI/TEI) and a passive
+	// Command Module (engineless parachute capsule; the surviving core).
+	// Like lander-descent/ascent above, both live in the catalog map so
+	// the Apollo-Stack loadout's by-Name sprite/flag lookups resolve
+	// them, but are intentionally left out of StageCatalogOrder — the
+	// configurator still offers the single fused "csm" module. They do
+	// NOT alias to "csm": the csm entry carries hasParachute (it survives
+	// to re-entry as one piece), but the split SM must NOT — only the CM
+	// carries the chute.
+	StageModuleServiceModuleID = "service-module"
+	StageModuleCommandModuleID = "command-module"
 	// v0.12 Slice 3 / ADR 0008: standalone re-entry capsule — single
 	// command-module-class stage with a parachute, no engine landing.
 	StageModuleCapsuleID = "capsule"
@@ -246,6 +258,34 @@ var StageCatalog = map[string]StageModule{
 		fuelType:            FuelTypeHypergolic,
 		// v0.12 Slice 3 (ADR 0008): the CSM survives the Apollo decouple
 		// chain to re-entry and earns an Earth splashdown under chute.
+		hasParachute: true,
+	},
+	// v0.12 / ADR 0009: Service Module — the propulsive half of the split
+	// CSM. Carries the SPS engine + all the storable propellant and does
+	// LOI / mid-course corrections / TEI. Dry ~6,000 kg; SPS fuel trimmed
+	// 18,400→16,000 (ADR 0009 locked table). NO parachute — it is
+	// jettisoned before re-entry. Sprite mirrors the CSM service-module
+	// silhouette (silver, slim) so the post-transposition Stages[0]=SM
+	// renders an engine bell.
+	StageModuleServiceModuleID: {
+		ID: StageModuleServiceModuleID, Name: "SM", Glyph: "◉", Color: "#C8C8D0",
+		Tier: "payload", dry: 6000, fuel: 16000, thrust: 91000, isp: 314, bc: 0,
+		launchSpriteRowsPx:  6,
+		launchSpriteWidthPx: 2,
+		launchSpriteColor:   "#C8C8D0", // bare aluminium service module
+		fuelType:            FuelTypeHypergolic,
+	},
+	// v0.12 / ADR 0009: Command Module — the passive half of the split
+	// CSM and the true surviving core. Engineless crew capsule with a
+	// recovery parachute (ADR 0008 model); the only piece that splashes
+	// down. Dry ~5,900 kg (CSM dry 11,900 − SM 6,000). No main engine.
+	StageModuleCommandModuleID: {
+		ID: StageModuleCommandModuleID, Name: "CM", Glyph: "◓", Color: "#B8C8E0",
+		Tier: "payload", dry: 5900, fuel: 0, thrust: 0, isp: 0, bc: 0,
+		launchSpriteRowsPx:  6,
+		launchSpriteWidthPx: 3,
+		launchSpriteColor:   "#D8D8E0", // pale command-module cone (distinct from HUD #B8C8E0)
+		// fuelType intentionally unset — no main engine (RCS-only).
 		hasParachute: true,
 	},
 	// Re-entry capsule (v0.12 Slice 3, ADR 0008): a minimal command-

--- a/internal/spacecraft/stages_catalog_test.go
+++ b/internal/spacecraft/stages_catalog_test.go
@@ -45,11 +45,12 @@ func TestBuildStageCarriesFuelType(t *testing.T) {
 }
 
 // TestApolloStackSilhouetteIsUnifiedPalette (v0.11.5-followup): the
-// 5-stage Apollo Stack must paint its launch silhouette in cohesive
-// rocket-body tones (cream / white / metal), NOT a rainbow of the
-// per-stage slate-HUD colours. Pins each stage's LaunchSpriteColor
-// override against the unified catalog values so a future catalog
-// edit can't accidentally restore the rainbow read.
+// Apollo Stack must paint its launch silhouette in cohesive rocket-body
+// tones (cream / white / metal), NOT a rainbow of the per-stage
+// slate-HUD colours. Pins each stage's LaunchSpriteColor override
+// against the unified catalog values so a future catalog edit can't
+// accidentally restore the rainbow read. v0.12 / ADR 0009: the fused
+// CSM split into SM (silver service module) + CM (pale cone).
 func TestApolloStackSilhouetteIsUnifiedPalette(t *testing.T) {
 	apollo := Loadouts[LoadoutApolloStackID]
 	want := map[string]string{
@@ -58,7 +59,8 @@ func TestApolloStackSilhouetteIsUnifiedPalette(t *testing.T) {
 		"S-IVB":   "#D8D8D8",
 		"Descent": "#D4C088", // v0.12 Slice 2: LM split — descent keeps the gold foil
 		"Ascent":  "#C8C8B0", // pale metal band above the descent
-		"CSM":     "#C8C8D0",
+		"SM":      "#C8C8D0", // bare aluminium service module
+		"CM":      "#D8D8E0", // pale command-module cone
 	}
 	for _, s := range apollo.Stages {
 		w, ok := want[s.Name]
@@ -90,9 +92,10 @@ func TestLoadoutStagesCarryFuelType(t *testing.T) {
 		}
 	}
 	apollo := Loadouts[LoadoutApolloStackID]
-	// Apollo: S-IC, S-II, S-IVB, Descent, Ascent, CSM (v0.12 Slice 2:
-	// LM split into Descent + Ascent, both hypergolic).
-	wantApollo := []string{FuelTypeKerolox, FuelTypeHydrolox, FuelTypeHydrolox, FuelTypeHypergolic, FuelTypeHypergolic, FuelTypeHypergolic}
+	// Apollo: S-IC, S-II, S-IVB, Descent, Ascent, SM, CM (v0.12 / ADR
+	// 0009: the fused CSM split into a hypergolic-SPS Service Module +
+	// an engineless Command Module — the CM carries no fuelType).
+	wantApollo := []string{FuelTypeKerolox, FuelTypeHydrolox, FuelTypeHydrolox, FuelTypeHypergolic, FuelTypeHypergolic, FuelTypeHypergolic, ""}
 	for i, s := range apollo.Stages {
 		if s.FuelType != wantApollo[i] {
 			t.Errorf("Apollo-Stack Stage[%d] (%s) FuelType = %q, want %q", i, s.Name, s.FuelType, wantApollo[i])

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -743,6 +743,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.statusExpires = time.Now().Add(3 * time.Second)
 			}
 			return a, nil
+		case key.Matches(m, a.keys.Transpose):
+			// v0.12 / ADR 0009: one-shot Apollo transposition. Reorders
+			// the [Descent, Ascent, SM, CM] stack so the SM fires (LOI/
+			// TEI) with the LM as a docked nose payload released via U.
+			switch err := a.world.Transpose(a.world.ActiveCraftIdx); {
+			case err == nil:
+				a.statusMsg = "transposed: SM is firing core — press U to release the LM"
+			case errors.Is(err, sim.ErrTransposeNotReady):
+				a.statusMsg = "transpose: drop the launch vehicle first (stack must be Descent/Ascent/SM/CM)"
+			default:
+				a.statusMsg = fmt.Sprintf("transpose failed: %v", err)
+			}
+			a.statusExpires = time.Now().Add(3 * time.Second)
+			return a, nil
 		case key.Matches(m, a.keys.CycleTarget):
 			a.world.CycleTarget(true)
 			return a, nil

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -99,6 +99,11 @@ type Keymap struct {
 	// into its docked components.
 	Undock key.Binding
 
+	// Transpose (v0.12 / ADR 0009): one-shot Apollo transposition —
+	// reorder the pre-transposition [Descent, Ascent, SM, CM] stack so
+	// the SM is the firing core with the LM as a docked nose payload.
+	Transpose key.Binding
+
 	// CycleTarget / ClearTarget (v0.9.0+): unified `World.Target` slot
 	// that planted-Hohmann (`H`) and plane-match (`I`) consume in
 	// place of the pre-v0.9 implicit body cursor. Cycle order:
@@ -237,6 +242,7 @@ func DefaultKeymap() Keymap {
 		PrevCraft:           key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev craft")),
 		CraftSlot:           key.NewBinding(key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"), key.WithHelp("1-9", "jump to craft N")),
 		Undock:              key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "undock active composite")),
+		Transpose:           key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "transpose (SM → firing core, LM → nose payload)")),
 		CycleTarget:         key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "cycle target (body / craft)")),
 		ClearTarget:         key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "clear target")),
 		CycleNavMode:        key.NewBinding(key.WithKeys(";"), key.WithHelp(";", "nav: orbit / surface / target")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -73,6 +73,7 @@ func (h *Help) Render() string {
 			{"[ / ]", "cycle active craft (no-op when only one craft)"},
 			{"1-9", "jump to craft N (no-op when slot empty) (v0.12.0+)"},
 			{"U", "undock active composite (v0.8.3+)"},
+			{"D", "transpose: SM → firing core, LM → releasable nose payload (U to release) (v0.12+)"},
 			{"t / T", "cycle / clear target (v0.9.0+)"},
 			{"space", "decouple bottom stage (v0.9.1+); on a bare chute capsule, arms the parachute (v0.12+)"},
 		}},


### PR DESCRIPTION
Implements ADR 0009 so the **Apollo Stack flies a complete lunar mission**. The blocker was structural, not fuel: the firing engine is welded to `Stages[0]`, so after the S-IVB drops the LM's descent engine — not the CSM's SPS — fired LOI, which it can't complete.

## Three pieces

1. **Loadout split** — the fused `CSM` becomes a propulsive **Service Module** (SPS engine, fuel trimmed 18400→16000) + an engineless **Command Module** (parachute capsule, ADR 0008). New `SM`/`CM` catalog entries omitted from `StageCatalogOrder` (like the `lander-descent`/`ascent` precedent), so by-Name lookups resolve sprites/flags without aliasing to `csm` (which carries a parachute the SM must not inherit). LM trimmed to the locked table (Descent 9500→**6310**, Ascent 1800→**1269**). SM+CM dry = old CSM dry → **mass-neutral split, TWR unchanged**. `DecouplePlan [1,1,1,2]→[1,1,1]`.

2. **Multi-stage `DockedComponent` + `Undock`** — `DockedComponent` gains a per-stage breakdown so `Undock` rebuilds a **multi-stage** craft (the LM = Descent + Ascent). Undock partitions the composite's **live** `Stages` by per-component counts — preserving current fuel (the firing SM is drained by LOI while docked, so the dock-time snapshot is stale). Legacy single-stage prorate rebuild kept as the fallback for old saves. **Also fixes the canonical manual-docking-flip**, which silently shredded a multi-stage LM on undock.

3. **Transposition bypass key (`D`)** — `World.Transpose` reorders the pre-transposition `[Descent, Ascent, SM, CM]` stack to `[SM, CM, Descent, Ascent]` (SM = firing core) and registers the LM as a docked nose payload released via the existing `Undock`. Reproduces the manual-flip end-state in one keystroke.

## Save schema
Additive `omitempty` `Stages` on the `DockedComponent` DTO + a `simStagesToWire` helper — **no `SchemaVersion` bump** (back-compatible; old saves → single-stage fallback, covered by a test).

## Verification
- `go vet ./...` + `go test ./... -race -count=1` → **871 passed**.
- Budget probe (`TestApolloLunarBudgetProbe`) — the shipped masses ("realistic reserve + SPS shave") close every stage: **S-IVB TLI +277, SM TEI +187, DPS +500, APS +350, mission closes: true**.
- New tests: `TestUndockRestoresMultiStageLMWithLiveFuel` (live-fuel partition), `TestTransposeReordersToFiringSM` / `TestTransposeRejectsWrongShape`, `TestSaveLoadMultiStageDockedComponent` (+ old-save fallback). Updated the staging/save tests that encoded the old `[1,1,1,2]` bottom-group flow to the transposition+undock path.
- Help overlay, README key table + Apollo narrative, and `CONTEXT.md` Decouple Plan entry updated.

⚠️ **Not yet done:** the full in-app lunar-arc playtest (ascent → TLI → `D` → LOI → `U` → descent → ascent+rdv → TEI → CM re-entry). Logic is exhaustively unit/integration-tested and the budget probe confirms the margins, but a human flight is the remaining manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)