### PR TITLE
feat(sim): release ViewLaunch on a near-orbital predicate, not a fixed apo floor

### DIFF
--- a/internal/sim/launch_route_test.go
+++ b/internal/sim/launch_route_test.go
@@ -125,16 +125,18 @@ func TestLaunchRouteSeedsSessionState(t *testing.T) {
 }
 
 // TestLaunchAutoReleaseAtApoFloor — when the active craft is in
-// an orbit whose apoapsis exceeds LaunchMissionFloorM (200 km), the
-// per-tick handler's auto-release predicate fires: PrevViewMode is
-// restored to ViewMode, LaunchSessionActive flips false, and the
-// session-scoped state (T0, MaxQ, trail, zoom) clears so the next
-// route doesn't see stale data.
+// a circular orbit whose apoapsis is clear of the atmosphere and whose
+// circularisation Δv is within the cap, the per-tick handler's
+// auto-release predicate fires: PrevViewMode is restored to ViewMode,
+// LaunchSessionActive flips false, and the session-scoped state (T0,
+// MaxQ, trail, zoom) clears so the next route doesn't see stale data.
 //
-// Predicate parity with v0.10.7's LaunchAnchorPhi (`apoAlt >
-// LaunchMissionFloorM`) is the architectural commitment from ADR
-// 0002 — the ORBIT READY callout and the ViewLaunch release fire
-// off the same gate.
+// The release predicate (launchAscentNearlyOrbital) is deliberately
+// stricter than the ORBIT READY / LaunchAnchor LaunchMissionFloorM gate:
+// it also requires the ascent to be near circularisation (see
+// TestLaunchNoReleaseWhenEccentric / TestLaunchReleaseWithinCircDvCap).
+// A 201 km circular orbit satisfies both halves (apo 201 km > Earth's
+// 150 km atmosphere cutoff; Δv→circ = 0).
 func TestLaunchAutoReleaseAtApoFloor(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -192,6 +194,99 @@ func TestLaunchAutoReleaseAtApoFloor(t *testing.T) {
 	}
 	if !w.LaunchT0.IsZero() {
 		t.Errorf("LaunchT0 = %v, want zero (release must clear)", w.LaunchT0)
+	}
+}
+
+// launchSessionCraftAtApo plants the world mid-ViewLaunch-session with a
+// single active craft sitting AT apoapsis: position (R+apoAltM, 0, 0)
+// with a purely tangential velocity equal to the local circular speed
+// minus dvToCircMS. That makes the point the orbit's apoapsis and the
+// impulsive Δv→circ there exactly dvToCircMS. Throttle is zeroed so a
+// single Tick's free-flight integration doesn't perturb the orbit.
+// Returns the world plus the orbit's resolved elements for pre-checks.
+func launchSessionCraftAtApo(t *testing.T, apoAltM, dvToCircMS float64) (*World, orbital.Elements) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.Systems[0].FindBody("earth")
+	if earth == nil {
+		t.Fatal("setup: earth not found in default system")
+	}
+	mu := earth.GravitationalParameter()
+	rApo := earth.RadiusMeters() + apoAltM
+	vApo := math.Sqrt(mu/rApo) - dvToCircMS
+
+	c := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
+	c.Primary = *earth
+	c.Throttle = 0
+	c.State = physics.StateVector{
+		R: orbital.Vec3{X: rApo},
+		V: orbital.Vec3{Y: vApo},
+		M: c.TotalMass(),
+	}
+	w.Crafts = []*spacecraft.Spacecraft{c}
+	w.ActiveCraftIdx = 0
+	w.LaunchSessionActive = true
+	w.PrevViewMode = ViewTop
+	w.ViewMode = ViewLaunch
+	w.LaunchT0 = w.Clock.SimTime
+	return w, orbital.ElementsFromState(c.State.R, c.State.V, mu)
+}
+
+// TestLaunchNoReleaseWhenEccentric — an orbit whose apoapsis is well
+// clear of the atmosphere but whose circularisation Δv exceeds the cap
+// (an ascent that has raised apoapsis but not yet built orbital speed)
+// must NOT auto-release: the chase-cam stays until the upper stage is
+// near circularisation.
+func TestLaunchNoReleaseWhenEccentric(t *testing.T) {
+	// 300 km apoapsis (> 150 km atmosphere), Δv→circ 1000 m/s (> 750 cap).
+	w, el := launchSessionCraftAtApo(t, 300_000, 1000)
+	if el.E >= 1 || el.A <= 0 {
+		t.Fatalf("setup: orbit not bound (e=%.3f, a=%.0f)", el.E, el.A)
+	}
+
+	w.Tick()
+
+	if !w.LaunchSessionActive {
+		t.Error("eccentric ascent (Δv→circ 1000 > 750): session auto-released, want it to stay active")
+	}
+	if w.ViewMode != ViewLaunch {
+		t.Errorf("ViewMode = %v, want ViewLaunch (no release until near circularisation)", w.ViewMode)
+	}
+}
+
+// TestLaunchReleaseWithinCircDvCap — once the apoapsis is clear of the
+// atmosphere AND the circularisation Δv falls within the cap, the
+// session auto-releases even though the orbit is not perfectly circular.
+func TestLaunchReleaseWithinCircDvCap(t *testing.T) {
+	// 300 km apoapsis, Δv→circ 500 m/s (< 750 cap).
+	w, _ := launchSessionCraftAtApo(t, 300_000, 500)
+	w.Tick()
+
+	if w.LaunchSessionActive {
+		t.Error("ascent within Δv→circ cap (500 < 750): session still active, want auto-release")
+	}
+	if w.ViewMode != ViewTop {
+		t.Errorf("ViewMode = %v, want ViewTop (restored from PrevViewMode)", w.ViewMode)
+	}
+}
+
+// TestLaunchNoReleaseApoInsideAtmosphere — even a circular orbit whose
+// apoapsis is still inside the atmosphere must NOT auto-release: drag
+// would decay it, so it isn't a real orbit yet. Guards the atmosphere
+// half of the predicate independently of the Δv half.
+func TestLaunchNoReleaseApoInsideAtmosphere(t *testing.T) {
+	// 120 km apoapsis (< 150 km cutoff), circular (Δv→circ 0).
+	w, _ := launchSessionCraftAtApo(t, 120_000, 0)
+	w.Tick()
+
+	if !w.LaunchSessionActive {
+		t.Error("apoapsis inside the atmosphere: session auto-released, want it to stay active")
+	}
+	if w.ViewMode != ViewLaunch {
+		t.Errorf("ViewMode = %v, want ViewLaunch (apoapsis still in atmosphere)", w.ViewMode)
 	}
 }
 

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -56,7 +56,8 @@ const (
 	// curving below in Body.SurfaceColor, and a body-fixed pad
 	// marker + breadcrumb trail. Routed into automatically on
 	// active-slot Landed-false→true transitions; auto-released when
-	// the orbit's apoapsis crosses LaunchMissionFloorM. Appended to
+	// the ascent goes nearly orbital (apoapsis clear of the atmosphere
+	// and within the circularisation-Δv cap). Appended to
 	// the cycle (NOT prepended) so ViewTilted stays the zero-value
 	// default. ADR-0002 captures the rationale for shipping this as
 	// a distinct ViewMode instead of extending ViewTilted.

--- a/internal/sim/view_launch.go
+++ b/internal/sim/view_launch.go
@@ -3,10 +3,14 @@
 // ViewLaunch is the chase-cam launch scene routed into automatically
 // when an active vessel transitions Landed false→true (Launchpad
 // spawn today; future Touchdown semantics will extend the trigger).
-// Auto-release fires when the orbit's apoapsis crosses
-// LaunchMissionFloorM — the same predicate that gates v0.10.7's
-// ORBIT READY callout, sharing single-source-of-truth with the
-// LaunchAnchor on ViewTilted.
+// Auto-release fires when the ascent is essentially orbital: the orbit's
+// apoapsis has climbed clear of the primary's atmosphere AND the
+// impulsive circularisation Δv at that apoapsis is within
+// LaunchCircularizeDvCapMS — so the player stays in the chase-cam until
+// the upper stage has built most of its orbital velocity, then hands off
+// to the orbit view. (The ORBIT READY callout and the ViewTilted
+// LaunchAnchor keep their own LaunchMissionFloorM gate; this release is
+// deliberately stricter.)
 //
 // This file owns the per-tick handler called from World.Tick and the
 // session-open/close helpers. Render-side (the chase-cam scene
@@ -68,10 +72,11 @@ func (w *World) tickLaunchView() {
 		w.routeToLaunchView()
 	}
 
-	// 3. Apo-floor auto-release. Gated on LaunchSessionActive so a
-	// manually-entered ViewLaunch (no session) stays put even when
-	// apo > floor.
-	if w.LaunchSessionActive && active != nil && apoAltAboveFloor(active) {
+	// 3. Auto-release once the ascent is essentially orbital (apoapsis
+	// clear of the atmosphere AND within the circularisation Δv cap).
+	// Gated on LaunchSessionActive so a manually-entered ViewLaunch (no
+	// session) stays put even when the predicate is satisfied.
+	if w.LaunchSessionActive && active != nil && launchAscentNearlyOrbital(active) {
 		w.releaseLaunchSession()
 	}
 
@@ -143,17 +148,47 @@ func (w *World) handleActiveCraftSwitch(newActive *spacecraft.Spacecraft) {
 	// is moving between flying vessels with no launch state on either.
 }
 
-// apoAltAboveFloor reports whether the craft's current orbit has an
-// apoapsis altitude (AGL relative to the primary's mean radius) above
-// LaunchMissionFloorM. Hyperbolic / degenerate orbits (a ≤ 0,
-// e ≥ 1) return false — apoapsis is undefined there, and the plan
-// explicitly leaves the session running until the orbit becomes
-// bound. Mirrors the predicate in v0.10.7's LaunchAnchorPhi.
-func apoAltAboveFloor(c *spacecraft.Spacecraft) bool {
+// LaunchCircularizeDvCapMS is the impulsive circularisation-Δv budget
+// (m/s) at or below which an ascent counts as "essentially orbital" —
+// the second half of the ViewLaunch auto-release predicate (the first
+// being an apoapsis clear of the atmosphere). At ~750 m/s the upper
+// stage has built nearly all of its orbital velocity, so the chase-cam
+// has served its purpose and the orbit view takes over. Chosen to be
+// comfortably above a clean low-orbit circularisation burn yet well
+// below the multi-km/s gap of an ascent still mid-gravity-turn.
+const LaunchCircularizeDvCapMS = 750.0
+
+// launchAscentNearlyOrbital reports whether the craft's current orbit is
+// far enough along to release the ViewLaunch session: its apoapsis sits
+// above the primary's atmosphere (above the surface for an airless body)
+// AND the impulsive circularisation Δv at that apoapsis is within
+// LaunchCircularizeDvCapMS. Hyperbolic / degenerate orbits (a ≤ 0,
+// e ≥ 1) return false — apoapsis is undefined there, and the session
+// stays open until the trajectory becomes bound.
+func launchAscentNearlyOrbital(c *spacecraft.Spacecraft) bool {
 	mu := c.Primary.GravitationalParameter()
 	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-	apoAlt := el.Apoapsis() - c.Primary.RadiusMeters()
-	return apoAlt > LaunchMissionFloorM
+	// Apoapsis undefined on unbound / degenerate orbits.
+	if el.A <= 0 || el.E >= 1 {
+		return false
+	}
+	rApo := el.Apoapsis()
+	apoAlt := rApo - c.Primary.RadiusMeters()
+	// 1. Apoapsis must clear the atmosphere so drag can't decay it
+	// (above the surface for an airless body, where atmTop = 0).
+	atmTop := 0.0
+	if c.Primary.Atmosphere != nil {
+		atmTop = c.Primary.Atmosphere.CutoffAltitude
+	}
+	if apoAlt <= atmTop {
+		return false
+	}
+	// 2. Impulsive circularisation Δv at apoapsis: vis-viva speed there
+	// vs. the local circular speed (mirrors the LAUNCH HUD's Δv→circ
+	// readout in tui/screens/orbit.go). A circular orbit reads 0.
+	vApo := math.Sqrt(mu * (2/rApo - 1/el.A))
+	vCirc := math.Sqrt(mu / rApo)
+	return vCirc-vApo <= LaunchCircularizeDvCapMS
 }
 
 // LaunchReleaseEvent records a ViewLaunch session ending so the App's

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -80,8 +80,9 @@ type World struct {
 
 	// LaunchSessionActive is the v0.11.0+ ViewLaunch session sentinel.
 	// True between the per-tick route handler firing on an active-slot
-	// Landed-false→true transition and the auto-release (apo crosses
-	// LaunchMissionFloorM) or manual `v` cycle out. Distinguished from
+	// Landed-false→true transition and the auto-release (ascent goes
+	// nearly orbital — apoapsis clear of the atmosphere and within the
+	// circularisation-Δv cap) or manual `v` cycle out. Distinguished from
 	// PrevViewMode because PrevViewMode's zero value (ViewTilted)
 	// collides with "no session" — the boolean is the unambiguous
 	// signal that session-scoped state (PrevViewMode, LaunchT0,


### PR DESCRIPTION
The launch chase-cam (`ViewLaunch`) previously auto-released purely on **apoapsis > 200 km** (`LaunchMissionFloorM`) — so it could drop the player out mid-ascent before they'd built orbital velocity, and it ignored the planet's actual atmosphere height.

## Change
Replace the release predicate (`launchAscentNearlyOrbital`, `internal/sim/view_launch.go`) with an orbit-aware condition:

- **Apoapsis clear of the atmosphere** — `apoAlt > Primary.Atmosphere.CutoffAltitude` (150 km for Earth; the surface, i.e. `0`, for airless bodies).
- **Within the circularisation Δv cap** — impulsive `vCirc(r_apo) − v(r_apo) ≤ LaunchCircularizeDvCapMS` (**750 m/s**), mirroring the LAUNCH HUD's existing `Δv→circ` vis-viva math.

So the chase-cam stays up through the coast + upper-stage burn until the ascent is essentially orbital, then hands off to the orbit view.

**Scope:** only the `ViewLaunch` session release changes. The **ORBIT READY** callout and the **ViewTilted LaunchAnchor** keep their `LaunchMissionFloorM` gate (left intentionally untouched).

## Tests
- `TestLaunchNoReleaseWhenEccentric` — apo clear of atmosphere but Δv→circ 1000 > cap → session stays.
- `TestLaunchReleaseWithinCircDvCap` — Δv→circ 500 < cap → releases.
- `TestLaunchNoReleaseApoInsideAtmosphere` — circular but apoapsis at 120 km < 150 km cutoff → stays.
- Updated the stale "predicate parity" comment on `TestLaunchAutoReleaseAtApoFloor` (201 km circular still releases: apo > 150 km, Δv→circ = 0).
- Full suite green: **870 passed** (`-race`), `go vet` clean.

Note: 750 m/s is generous (a clean LEO circularization is a few hundred m/s), so the hand-off happens slightly before a tidy circularization — easy to tighten via the `LaunchCircularizeDvCapMS` constant if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)