### PR TITLE
fix(sim): restore the Apollo LM as a 2-stage decouple group (don't split the lander)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,19 +57,25 @@ _Avoid_: Surface decouple, Ground staging, Lander separation.
 An optional per-Loadout, bottom-up list of group sizes describing how
 many contiguous bottom Stages each **Staging** press releases as a
 single craft. Default (absent) is all-ones — one Stage per press, the
-historical behaviour. The Apollo Stack declares `[1, 1, 1]` (ADR 0009):
-drop S-IC, S-II, S-IVB individually, leaving the pre-transposition
-stack `[Descent, Ascent, SM, CM]`. The plan is copied onto the Vessel
-at spawn and consumed positionally (each press pops the next entry's
-worth of Stages and advances). A released multi-Stage craft inherits
-**no** plan, so its own internal boundaries are ordinary single-Stage
-separations — the extracted 2-stage LM later **Surface Stages** its
-descent Stage alone with no special-casing.
-The Decouple Plan is **bottom-up only**. The Apollo LM is released from
-*above* the surviving core, which the plan cannot express — that is
-**Transposition**'s job: it reorders to `[SM, CM, Descent, Ascent]` and
-registers the LM as a docked **nose payload** that **Undock** releases.
-The mission survivor is the **Command Module**, not the fused CSM.
+historical behaviour. The Apollo Stack declares `[1, 1, 1, 2]` (ADR
+0009): drop S-IC, S-II, S-IVB individually to reach the
+pre-transposition stack `[Descent, Ascent, SM, CM]`, then the trailing
+`2` releases the LM (Descent + Ascent) as a single 2-stage craft. The
+plan is copied onto the Vessel at spawn and consumed positionally (each
+press pops the next entry's worth of Stages and advances). A released
+multi-Stage craft inherits **no** plan, so its own internal boundaries
+are ordinary single-Stage separations — the extracted 2-stage LM later
+**Surface Stages** its descent Stage alone with no special-casing.
+The trailing `2` is what makes the **canonical manual flip** work: it
+drops the whole LM as one craft, leaving the `[SM, CM]` core firing the
+SPS, ready to slew and re-dock. Staging the LM one Stage at a time
+(the bug from the `[1,1,1]` interim) would strand the Descent and split
+the lander. The one-shot **Transposition** key (`D`) is the alternative
+at the same `[Descent, Ascent, SM, CM]` state: it reorders to `[SM, CM,
+Descent, Ascent]` and registers the LM as a docked **nose payload** that
+**Undock** releases (clearing the unconsumed trailing `2` so the core
+doesn't later pop as a group). The mission survivor is the **Command
+Module**, not the fused CSM.
 _Avoid_: Decouple group, Staging sequence, Separation script.
 
 **Service Module (SM)**:

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -102,11 +102,11 @@ func TestRoundtrip(t *testing.T) {
 
 // TestDecouplePlanRoundtripMidStaging — v0.12 / ADR 0009. A mission
 // saved mid-staging must restore its remaining Decouple Plan so the
-// pending Saturn-stage grouping still fires correctly. Spawn an Apollo
-// Stack (plan [1,1,1]), drop S-IC (plan advances to [1,1]), save +
-// reload, and assert the reloaded craft carries [1,1]. Also confirms a
-// craft with no plan round-trips as nil (the omitempty single-pop
-// default).
+// pending grouping (the trailing LM 2-group) still fires correctly.
+// Spawn an Apollo Stack (plan [1,1,1,2]), drop S-IC (plan advances to
+// [1,1,2]), save + reload, and assert the reloaded craft carries
+// [1,1,2]. Also confirms a craft with no plan round-trips as nil (the
+// omitempty single-pop default).
 func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -121,7 +121,7 @@ func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 	if _, _, err := w.StageActive(0); err != nil {
 		t.Fatalf("StageActive (drop S-IC): %v", err)
 	}
-	wantPlan := []int{1, 1}
+	wantPlan := []int{1, 1, 2}
 	if got := w.Crafts[0].DecouplePlan; len(got) != len(wantPlan) {
 		t.Fatalf("pre-save plan = %v, want %v", got, wantPlan)
 	}
@@ -135,7 +135,7 @@ func TestDecouplePlanRoundtripMidStaging(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	// Active craft (the partially-staged stack) keeps [1,1].
+	// Active craft (the partially-staged stack) keeps [1,1,2].
 	plan := got.Crafts[0].DecouplePlan
 	if len(plan) != len(wantPlan) {
 		t.Fatalf("reloaded plan = %v, want %v", plan, wantPlan)

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -252,14 +252,27 @@ func retrogradeUnit(v, r orbital.Vec3) orbital.Vec3 {
 	return orbital.Vec3{X: -1}
 }
 
+// TransposeReady reports whether a craft is in the pre-transposition
+// shape [Descent, Ascent, SM, CM] — the state left after the three
+// Saturn stages decouple, where the transpose key (D) is actionable.
+// The HUD uses it to surface the "TRANSPOSE READY — press D" hint, and
+// Transpose uses it as its precondition.
+func TransposeReady(c *spacecraft.Spacecraft) bool {
+	return c != nil && len(c.Stages) == 4 &&
+		c.Stages[0].Name == "Descent" && c.Stages[1].Name == "Ascent" &&
+		c.Stages[2].Name == "SM" && c.Stages[3].Name == "CM"
+}
+
 // Transpose performs the Apollo transposition (ADR 0009) on the craft at
 // craftIdx in one shot: it reproduces the end-state of the manual
 // docking flip — the SM becomes the firing core (Stages[0]) with the LM
 // as a releasable nose payload — without flying the rendezvous.
 //
 // Precondition: the craft is exactly [Descent, Ascent, SM, CM] — the
-// state left after the three Saturn stages have decoupled (the loadout's
-// [1,1,1] DecouplePlan). Otherwise returns ErrTransposeNotReady.
+// state left after the three Saturn stages have decoupled (the first
+// three entries of the loadout's [1,1,1,2] DecouplePlan; the trailing 2
+// drops the LM for the manual flip instead). Otherwise returns
+// ErrTransposeNotReady.
 //
 // It splits the stack into the LM (Descent + Ascent) and the CSM core
 // (SM + CM), reorders the live craft to [SM, CM, Descent, Ascent] so the
@@ -278,10 +291,7 @@ func (w *World) Transpose(craftIdx int) error {
 	if c == nil {
 		return fmt.Errorf("%w: %d (nil)", ErrStageNoCraft, craftIdx)
 	}
-	// Precondition: the pre-transposition shape [Descent, Ascent, SM, CM].
-	if len(c.Stages) != 4 ||
-		c.Stages[0].Name != "Descent" || c.Stages[1].Name != "Ascent" ||
-		c.Stages[2].Name != "SM" || c.Stages[3].Name != "CM" {
+	if !TransposeReady(c) {
 		return ErrTransposeNotReady
 	}
 
@@ -300,6 +310,13 @@ func (w *World) Transpose(craftIdx int) error {
 	c.Stages = append(append([]spacecraft.Stage(nil), coreStages...), lmStages...)
 	c.DockedComponents = []spacecraft.DockedComponent{core, lm}
 	c.Name = "CSM" // flying as the CSM core now
+	// Clear any leftover DecouplePlan (the loadout's trailing LM-group
+	// "2" if the player transposed instead of staging the LM off). Post-
+	// transposition the LM leaves via Undock and the SM/CM core stages
+	// one-at-a-time (SM jettison after TEI, then the CM re-enters); a
+	// stale "2" here would pop the [SM, CM] core as a group on the next
+	// space press.
+	c.DecouplePlan = nil
 	c.SyncFields()
 	c.State.M = c.TotalMass()
 	return nil

--- a/internal/sim/staging_surface_test.go
+++ b/internal/sim/staging_surface_test.go
@@ -232,11 +232,11 @@ func TestExtractedLMSurfaceStagesDescentAlone(t *testing.T) {
 }
 
 // TestDecouplePlanAdvancesOnEachPress — the plan is consumed
-// positionally: after dropping S-IC, the v0.12 / ADR 0009 Apollo Stack's
-// remaining plan is [1,1]; after S-II it's [1]; after S-IVB it's empty
-// (the LM is no longer a bottom-up group — it releases via transposition
-// + undock). Pins the advance so a save/reload mid-staging (which
-// persists the remaining plan) restores the correct Saturn-drop grouping.
+// positionally: after dropping S-IC the v0.12 / ADR 0009 Apollo Stack's
+// remaining plan is [1,1,2]; after S-II it's [1,2]; after S-IVB it's [2]
+// (the trailing LM group, released as a 2-stage craft on the next press).
+// Pins the advance so a save/reload mid-staging (which persists the
+// remaining plan) restores the correct grouping for the pending LM drop.
 func TestDecouplePlanAdvancesOnEachPress(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -249,9 +249,9 @@ func TestDecouplePlanAdvancesOnEachPress(t *testing.T) {
 	w.ActiveCraftIdx = 0
 
 	wantRemaining := [][]int{
-		{1, 1}, // after S-IC
-		{1},    // after S-II
-		nil,    // after S-IVB (plan emptied; LM releases via transpose)
+		{1, 1, 2}, // after S-IC
+		{1, 2},    // after S-II
+		{2},       // after S-IVB (the trailing LM group)
 	}
 	for i, want := range wantRemaining {
 		if _, _, err := w.StageActive(0); err != nil {

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
+// stageNames returns the Name of each stage, for readable failure output.
+func stageNames(stages []spacecraft.Stage) []string {
+	out := make([]string, len(stages))
+	for i, s := range stages {
+		out[i] = s.Name
+	}
+	return out
+}
+
 // TestStageActiveOnSaturnVPopsBottomStage — Saturn-V starts as a
 // 3-stage craft. Pressing space jettisons S-IC; the active craft
 // becomes 2-stage (S-II + S-IVB). A new passive craft appears at
@@ -180,6 +189,95 @@ func TestStageActiveAdvancesEngineToNextStage(t *testing.T) {
 	}
 	if active.Isp != 421 {
 		t.Errorf("post-stage Isp (S-II): got %.0f, want 421", active.Isp)
+	}
+}
+
+// TestApolloStackManualFlipDropsLMAsOneCraft — regression for the
+// LM-splits-when-staging playtest bug. At the pre-transposition stack
+// [Descent, Ascent, SM, CM], pressing space (the canonical manual-flip
+// first step) must drop the LM as a SINGLE 2-stage [Descent, Ascent]
+// craft and leave the [SM, CM] core firing the SPS — NOT peel the
+// descent and ascent off one stage at a time (which would split the
+// lander). The DecouplePlan's trailing "2" group is what keeps it whole.
+func TestApolloStackManualFlipDropsLMAsOneCraft(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+
+	// Drop the three Saturn stages → pre-transposition [Descent, Ascent, SM, CM].
+	for i := 0; i < 3; i++ {
+		if _, _, err := w.StageActive(0); err != nil {
+			t.Fatalf("Saturn drop #%d: %v", i, err)
+		}
+	}
+	pre := w.Crafts[0]
+	if len(pre.Stages) != 4 || pre.Stages[0].Name != "Descent" {
+		t.Fatalf("pre-transposition stack = %d stages, bottom %q; want [Descent,Ascent,SM,CM]",
+			len(pre.Stages), pre.Stages[0].Name)
+	}
+
+	// One more press: the trailing "2" releases the LM as a 2-stage craft.
+	_, lmIdx, err := w.StageActive(0)
+	if err != nil {
+		t.Fatalf("LM drop: %v", err)
+	}
+	lm := w.Crafts[lmIdx]
+	if len(lm.Stages) != 2 || lm.Stages[0].Name != "Descent" || lm.Stages[1].Name != "Ascent" {
+		t.Errorf("dropped LM = %d-stage %v, want 2-stage [Descent, Ascent] (lander must not split)",
+			len(lm.Stages), stageNames(lm.Stages))
+	}
+	// The surviving core is [SM, CM] with the SPS firing.
+	core := w.Crafts[0]
+	if len(core.Stages) != 2 || core.Stages[0].Name != "SM" || core.Thrust != 91000 {
+		t.Errorf("surviving core = %v Thrust=%.0f, want [SM, CM] firing SPS (91000)",
+			stageNames(core.Stages), core.Thrust)
+	}
+}
+
+// TestTransposeClearsDecouplePlan — after a one-shot transpose (D), the
+// leftover loadout plan (the trailing LM "2" group, unconsumed because
+// the player transposed instead of staging the LM off) must be cleared.
+// Otherwise the next space press would pop the [SM, CM] core as a group
+// instead of jettisoning the SM alone after TEI.
+func TestTransposeClearsDecouplePlan(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+
+	for i := 0; i < 3; i++ {
+		if _, _, err := w.StageActive(0); err != nil {
+			t.Fatalf("Saturn drop #%d: %v", i, err)
+		}
+	}
+	// After 3 drops the unconsumed plan is the trailing [2].
+	if got := w.Crafts[0].DecouplePlan; len(got) != 1 || got[0] != 2 {
+		t.Fatalf("pre-transpose leftover plan = %v, want [2]", got)
+	}
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	if got := w.Crafts[0].DecouplePlan; got != nil {
+		t.Errorf("post-transpose DecouplePlan = %v, want nil (cleared)", got)
+	}
+	// A space press now jettisons the SM alone (single-pop), not [SM, CM].
+	_, _, err = w.StageActive(0)
+	if err != nil {
+		t.Fatalf("post-transpose stage: %v", err)
+	}
+	if dropped := w.Crafts[len(w.Crafts)-1]; len(dropped.Stages) != 1 || dropped.Stages[0].Name != "SM" {
+		t.Errorf("post-transpose stage dropped %v, want single SM", stageNames(dropped.Stages))
 	}
 }
 

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -528,13 +528,18 @@ var Loadouts = map[string]Loadout{
 			stage(LoadoutApolloStackID, "CM", "◓", "#B8C8E0",
 				5900, 0, 0, 0),
 		},
-		// v0.12 / ADR 0009: drop S-IC, S-II, S-IVB individually. After
-		// the third pop the active craft is [Descent, Ascent, SM, CM] —
-		// the pre-transposition state the transpose key (D) consumes.
-		// The LM is no longer a bottom-up decouple group; transposition
-		// reorders it to a docked nose payload released via Undock, not
-		// StageActive. Sum (3) < 7 stages.
-		DecouplePlan: []int{1, 1, 1},
+		// v0.12 / ADR 0009: drop S-IC, S-II, S-IVB individually, then the
+		// trailing 2 releases the LM (Descent + Ascent) as a single
+		// 2-stage craft. After the three Saturn pops the active craft is
+		// [Descent, Ascent, SM, CM] — the pre-transposition state. From
+		// there the player either presses D (one-shot transpose: reorder
+		// so the SM fires, LM rides as a docked nose payload) OR stages
+		// once more to drop the LM as a free craft for the canonical
+		// manual flip (slew the [SM, CM] core 180°, RCS-dock to the LM).
+		// The 2-group keeps the LM intact either way — staging it one
+		// stage at a time would strand the Descent and split the lander.
+		// Sum (5) < 7 stages.
+		DecouplePlan: []int{1, 1, 1, 2},
 	},
 	// Re-entry capsule (v0.12 Slice 3, ADR 0008): single command-module
 	// stage carrying a parachute and no engine landing. HasParachute /

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -145,9 +145,11 @@ func TestStageCatalogShape(t *testing.T) {
 // fused CSM into a propulsive Service Module + a passive Command Module),
 // lift-off TWR > 1 at sea-level g with the full payload. SM+CM dry mass
 // equals the pre-split CSM dry, so the split is mass-neutral and TWR is
-// unchanged. The DecouplePlan [1,1,1] drops the three Saturn stages one
-// at a time; the LM is no longer a bottom-up group — post-transposition
-// it becomes a docked nose payload released via Undock (ADR 0009).
+// unchanged. The DecouplePlan [1,1,1,2] drops the three Saturn stages one
+// at a time, then releases the LM (Descent + Ascent) as a single 2-stage
+// craft — so the canonical manual flip (drop LM, slew, dock) keeps the
+// lander intact; the one-shot transpose key (D) is the alternative that
+// reorders the LM to a docked nose payload (ADR 0009).
 func TestApolloStackShape(t *testing.T) {
 	l, ok := Loadouts[LoadoutApolloStackID]
 	if !ok {
@@ -162,7 +164,7 @@ func TestApolloStackShape(t *testing.T) {
 			t.Errorf("stage %d: name %q, want %q", i, l.Stages[i].Name, n)
 		}
 	}
-	wantPlan := []int{1, 1, 1}
+	wantPlan := []int{1, 1, 1, 2}
 	if len(l.DecouplePlan) != len(wantPlan) {
 		t.Fatalf("Apollo-Stack DecouplePlan = %v, want %v", l.DecouplePlan, wantPlan)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -804,6 +804,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case err == nil:
 				name := a.world.Crafts[jettIdx].Name
 				a.statusMsg = fmt.Sprintf("staged: %s jettisoned", name)
+				// v0.12 / ADR 0009: surface the transposition hint the
+				// moment a stage drop leaves the Apollo stack in the
+				// pre-transposition shape [Descent, Ascent, SM, CM] — the
+				// player needs to know `D` flips the SM to the firing core
+				// (or stage once more to drop the LM for a manual flip).
+				// Without this the wrong-engine state is silent.
+				if sim.TransposeReady(a.world.ActiveCraft()) {
+					a.statusMsg = "TRANSPOSE READY — press D to flip (SM → firing core; LM becomes nose payload)"
+				}
 			case errors.Is(err, sim.ErrStageOnlyOne):
 				// v0.12 Slice 3 (ADR 0008): once the vessel is reduced to
 				// its bare chute-bearing stage, the staging-no-op press


### PR DESCRIPTION
**Playtest report:** *"the descent and ascent stages separate in orbit as I am trying to do the orbital flip with CSM and LM stages."*

## Cause
PR #74 (ADR 0009) over-zealously changed the Apollo `DecouplePlan` `[1,1,1,2]` → `[1,1,1]`, dropping the trailing LM group. At the pre-transposition stack `[Descent, Ascent, SM, CM]`, pressing **space** then popped `Descent` alone, then `Ascent` alone — **splitting the lander** — instead of releasing the LM as one craft. That silently broke the canonical manual flip (drop the LM → `[SM, CM]` core fires the SPS → slew 180° → re-dock).

## Fix
- **Restore `DecouplePlan [1,1,1,2]`** — the trailing `2` drops the LM (Descent + Ascent) as a single 2-stage craft, leaving the `[SM, CM]` core firing. The manual flip works again; the one-shot `D` transpose is the alternative at the same state.
- **`Transpose` clears the leftover plan** — after a `D`-transpose the unconsumed trailing `2` is dropped, so a later `space` jettisons the SM alone (post-TEI) instead of popping `[SM, CM]` as a group.
- **Discoverability:** a stage drop that lands the stack in `[Descent, Ascent, SM, CM]` now flashes **"TRANSPOSE READY — press D …"** (new `sim.TransposeReady` predicate, shared with `Transpose`'s precondition) so the player isn't stuck in a silent wrong-engine state.

## Tests
- `TestApolloStackManualFlipDropsLMAsOneCraft` — the regression: the LM drops whole, the `[SM, CM]` core fires.
- `TestTransposeClearsDecouplePlan` — post-`D`, a space press drops the SM alone, not the core group.
- Restored `[1,1,1,2]` expectations in `TestApolloStackShape`, `TestDecouplePlanAdvancesOnEachPress`, `TestDecouplePlanRoundtripMidStaging`.
- Full suite green: **876** (`-race`), `go vet` clean. `CONTEXT.md` Decouple Plan entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)