### PR TITLE
fix(tui): hide the LAUNCH HUD once the orbit is stable, not at the 200 km floor

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2342,7 +2342,16 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 	}
 	primaryR := c.Primary.RadiusMeters()
 	periAlt := el.Periapsis() - primaryR
-	return periAlt < launchMissionFloorM
+	// Hide once the orbit is stable — the periapsis has climbed clear of
+	// the atmosphere, so the ascent is finished and drag can no longer
+	// decay the orbit. The ascent instruments (TWR, FPA, downrange) are
+	// done; the orbit-relative HUD takes over. The old gate compared
+	// against the 200 km mission floor, which kept the launch HUD pinned
+	// over a perfectly good sub-200 km parking orbit (e.g. a 186 × 186 km
+	// circular orbit reads periAlt 186 km < 200 km and never cleared).
+	// The mission floor stays the threshold for the ORBIT READY callout
+	// + progress row above; this is only the show/hide gate.
+	return periAlt < c.Primary.Atmosphere.CutoffAltitude
 }
 
 // launchMissionFloorM is the package-local alias for the canonical

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -149,6 +149,60 @@ func TestHudPhaseCollapsesVesselDuringAscent(t *testing.T) {
 	}
 }
 
+// TestLaunchHUDHidesOnStableSubMissionFloorOrbit — regression for the
+// "186×186 km orbit but the launch display is still active" playtest
+// report. The launch HUD must hide once the orbit is stable (periapsis
+// clear of the atmosphere), not require periapsis above the 200 km
+// mission floor — a 186 km circular parking orbit is finished ascending
+// even though it's under 200 km.
+func TestLaunchHUDHidesOnStableSubMissionFloorOrbit(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	atmTop := c.Primary.Atmosphere.CutoffAltitude // 150 km on Earth
+
+	circularAt := func(altM float64) {
+		r := primaryR + altM
+		v := math.Sqrt(mu / r)
+		c.State.R.X, c.State.R.Y, c.State.R.Z = r, 0, 0
+		c.State.V.X, c.State.V.Y, c.State.V.Z = 0, v, 0
+		c.State.M = c.TotalMass()
+	}
+
+	// 186 km circular: periapsis 186 km > 150 km atmosphere but < 200 km
+	// mission floor. Ascent is done → HUD must hide.
+	circularAt(186e3)
+	if 186e3 <= atmTop || 186e3 >= 200e3 {
+		t.Fatalf("test premise broken: 186 km must sit between atmosphere %.0f and floor 200km", atmTop)
+	}
+	if shouldShowLaunchHUD(c) {
+		t.Error("186 km circular orbit: launch HUD still shown, want hidden (orbit is stable, above the atmosphere)")
+	}
+
+	// 140 km circular: periapsis still inside the 150 km atmosphere →
+	// HUD stays up (orbit would decay; not a real parking orbit yet).
+	circularAt(140e3)
+	if !shouldShowLaunchHUD(c) {
+		t.Error("140 km circular orbit (periapsis inside atmosphere): launch HUD hidden, want shown")
+	}
+
+	// Ascent arc: periapsis below the surface (deep sub-orbital) → shown.
+	rApo := primaryR + 250e3
+	rPeri := primaryR - 100e3
+	a := (rPeri + rApo) / 2
+	c.State.R.X, c.State.R.Y, c.State.R.Z = rPeri, 0, 0
+	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, math.Sqrt(mu*(2/rPeri-1/a)), 0
+	c.State.M = c.TotalMass()
+	if !shouldShowLaunchHUD(c) {
+		t.Error("sub-orbital ascent arc: launch HUD hidden, want shown")
+	}
+}
+
 // TestTitleBarShowsClockAndWarp: v0.10.3+ moved the CLOCK block from
 // the HUD into the title bar. The title row must show T+date and the
 // current warp rate; the HUD must no longer carry a `CLOCK` header.


### PR DESCRIPTION
**Playtest report:** *"I'm in a 186×186 km orbit and the launch display is still active."*

## Cause
There are two "launch displays". The **ViewLaunch chase-cam** (PR #75) already hands off at apoapsis-clears-atmosphere + Δv→circ ≤ 750. But the boxed **LAUNCH HUD overlay** (the ascent instruments in the orbit view — TWR, FPA, downrange, Δv→circ, ORBIT READY) is gated by `shouldShowLaunchHUD`, which returned `periAlt < launchMissionFloorM` (**200 km**). A 186 km circular parking orbit has periapsis 186 km < 200 km, so the ascent HUD **never cleared** even though the ascent was done.

## Fix
Gate on the periapsis clearing the **atmosphere** instead — `periAlt < Primary.Atmosphere.CutoffAltitude` (150 km on Earth). Once the periapsis is above the atmosphere the orbit is stable (drag can't decay it) and the ascent instruments have served their purpose; the orbit-relative HUD takes over.

The 200 km mission floor stays the threshold for the **ORBIT READY** callout and the `pe X / 200 km` progress row — this only changes the show/hide gate.

## Test
`TestLaunchHUDHidesOnStableSubMissionFloorOrbit`:
- 186 km circular (periapsis above atmosphere, below 200 km floor) → **hidden**.
- 140 km circular (periapsis still inside the atmosphere) → shown.
- Sub-orbital ascent arc → shown.

Full suite green: **875** (`-race`), `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)