### PR TITLE
fix(tui): gate the LAUNCH HUD hyperbolic branch on altitude (no panel on departures/approaches)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2335,10 +2335,16 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 	}
 	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
 	if el.E >= 1 || el.A <= 0 {
-		// Hyperbolic or degenerate: still on an ascent-class
-		// trajectory (or thrown off it). Show the HUD with `—`
-		// placeholders rather than silently hiding.
-		return true
+		// Hyperbolic or degenerate. This counts as an ascent only while
+		// the craft is still LOW — a straight-up pad climb reads as a
+		// radial/degenerate orbit, and an over-burned ascent can flicker
+		// hyperbolic. But a hyperbolic trajectory HIGH above the body is
+		// a departure (an over-energetic TLI escaping Earth) or a
+		// flyby/approach to another atmosphered body (a hyperbolic Mars
+		// arrival) — not a launch. Gate on altitude so the ascent HUD
+		// doesn't pop back far from any launch; show the `—` placeholders
+		// only while genuinely near the surface.
+		return c.Altitude() < c.Primary.Atmosphere.CutoffAltitude
 	}
 	primaryR := c.Primary.RadiusMeters()
 	periAlt := el.Periapsis() - primaryR

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
@@ -200,6 +201,53 @@ func TestLaunchHUDHidesOnStableSubMissionFloorOrbit(t *testing.T) {
 	c.State.M = c.TotalMass()
 	if !shouldShowLaunchHUD(c) {
 		t.Error("sub-orbital ascent arc: launch HUD hidden, want shown")
+	}
+}
+
+// TestLaunchHUDHidesOnHighHyperbolicTrajectory — the hyperbolic /
+// degenerate branch must be gated on altitude. A hyperbolic trajectory
+// HIGH above the body is a departure (an over-energetic TLI escaping
+// Earth) or a flyby/approach to another atmosphered body — NOT a launch,
+// so the ascent panel must stay hidden. Only a hyperbolic state near the
+// surface (a straight-up / over-burned pad climb) counts as a launch.
+func TestLaunchHUDHidesOnHighHyperbolicTrajectory(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	atmTop := c.Primary.Atmosphere.CutoffAltitude
+
+	hyperbolicAt := func(altM float64) {
+		r := primaryR + altM
+		vEsc := math.Sqrt(2 * mu / r)
+		c.State.R.X, c.State.R.Y, c.State.R.Z = r, 0, 0
+		c.State.V.X, c.State.V.Y, c.State.V.Z = 0, 1.4*vEsc, 0 // e > 1
+		c.State.M = c.TotalMass()
+		el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+		if el.E < 1 {
+			t.Fatalf("setup: orbit not hyperbolic at %.0f km (e=%.3f)", altM/1e3, el.E)
+		}
+	}
+
+	// High + hyperbolic (escaping Earth, well above the atmosphere) →
+	// hidden: this is a departure, not a launch.
+	hyperbolicAt(100_000e3) // 100,000 km, far above the 150 km cutoff
+	if shouldShowLaunchHUD(c) {
+		t.Error("high hyperbolic departure: launch HUD shown, want hidden (not a launch)")
+	}
+
+	// Low + hyperbolic (an over-burned pad ascent still near the surface)
+	// → shown.
+	hyperbolicAt(5e3) // 5 km, below the cutoff
+	if 5e3 >= atmTop {
+		t.Fatalf("test premise broken: 5 km must be below the atmosphere cutoff %.0f", atmTop)
+	}
+	if !shouldShowLaunchHUD(c) {
+		t.Error("low hyperbolic ascent (near surface): launch HUD hidden, want shown")
 	}
 }
 


### PR DESCRIPTION
Follow-on to PR #77, from the *"LAUNCH panel came back inside the SOI of the Moon"* playtest report.

## Diagnosis
The reported symptom is the boxed **LAUNCH panel** (`shouldShowLaunchHUD`) on the **trans-lunar coast**, which is still inside **Earth's** SOI at periapsis ~186 km — under the old 200 km gate, so it stayed pinned the whole way out. **PR #77 already fixes that** (gate lowered to the 150 km atmosphere cutoff; a 186 km trans-lunar periapsis now hides it). The Moon itself is airless, so the panel can't show there on either build.

## What this PR adds
While confirming, I found a **related latent bug**: the function short-circuits to "show" for *any* hyperbolic/degenerate orbit (`el.E >= 1 || el.A <= 0`) **regardless of altitude**. That's right for a straight-up / over-burned pad climb (low, genuinely a launch), but wrong for a hyperbolic trajectory far from the surface — an over-energetic TLI that **escapes Earth**, or a hyperbolic **Mars** arrival — where the ascent panel pops back far from any launch.

Fix: gate the hyperbolic branch on altitude — only count it as a launch when the craft is **below the atmosphere cutoff**. The elliptical-coast branch (`periapsis < cutoff`) is unchanged, so the panel still shows through a high circularization coast.

## Test
`TestLaunchHUDHidesOnHighHyperbolicTrajectory` — high hyperbolic departure (100,000 km, escaping) → hidden; low hyperbolic ascent (5 km) → shown. Full suite green: **878** (`-race`), `go vet` clean.

> Note for the reporter: your immediate symptom is the periapsis case fixed in **v0.12.7** — check `./terminal-space-program --version`; you're likely running an older binary. This PR is additional hardening for departures / atmosphered-body approaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)