### PR TITLE
fix(orbital): anchor generic ephemerides to J2000 so moon phase survives save/load

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -1,0 +1,208 @@
+# Controls & flight guide
+
+How to actually fly the thing, then the full list of keys. The in-game `?`
+overlay is the quick reference; the tables below are the same thing with a
+little more explanation.
+
+## Quick tour
+
+You start as a craft called **S-IVB-1** in a 500 km circular orbit around
+Earth, moving prograde (the direction of travel). The left panel is the map —
+the Sun (or whatever you've focused on) in the middle, planets on their real
+orbits, and your craft as a little chevron pointing the way it's moving. The
+right-hand panel is your readout: the clock, what you're looking at, fuel and
+attitude, any burns you've planned, and a preview of where they'll put you.
+
+Speed time up or slow it down with `.` and `,` to watch the planets move;
+pause with `0` or space.
+
+To go somewhere — say, the Moon:
+
+1. Press `t` to pick a **target**. Keep tapping until the target readout shows
+   the Moon. (The `←` / `→` arrow keys move a separate map cursor used by the
+   body info screen and the porkchop plot — they don't set your travel target.)
+2. Press `H` to plan the trip. Because the Moon orbits the same planet you do,
+   the planner works out two different ways to get there, plans the cheaper one,
+   and flashes both fuel costs — something like
+   `combined 4.12 / split 3.95 km/s → planted split`. Two burn markers appear:
+   one to leave your orbit and one to capture at the Moon, each showing its Δv
+   (the speed change it costs) and a countdown.
+3. Speed time up. From a fresh game the first burn is only a few hours out — a
+   new game starts you shortly before the Moon lines up with your orbital plane,
+   which is the cheapest moment to leave. (Deeper into a game, or after loading a
+   save, it can sit further out, since it always waits for that next line-up.)
+   When the countdown hits zero the burn fires on its own (time warp eases off
+   around a burn so nothing gets skipped). Your path stretches out toward the
+   Moon, still curving under Earth's gravity.
+4. The second burn fires near the Moon and drops you into a low orbit around it.
+   (The porkchop plot, `P`, is for trips to other planets — for a moon of your
+   own planet, `H` is the way.)
+
+Prefer to set up a burn by hand? Press `m` for the planner. Choose a direction
+(prograde, retrograde, normal, or radial), choose when it fires (a specific
+time, or the next high/low point of your orbit, or the next time you cross the
+target's orbital plane), set how much Δv you want, and pick a throttle. The
+burn's length is worked out for you. A live preview shows the orbit you'll end
+up with as you tweak the numbers. Press Enter to lock it in.
+
+For hands-on, stick-and-throttle flying: `z` to throttle up, the
+`w` `s` `a` `d` `q` `e` keys to point the craft, then `b` to light the engine.
+
+### Surface launches
+
+You can also spawn a Saturn V on the launchpad and fly it to orbit by hand,
+just like KSP: tip the rocket slightly east, let your speed build, switch the
+autopilot to follow your velocity, and let gravity bend you over into a
+gravity turn. The launch readout shows your projected high point, low point,
+and the Δv still needed to circularise, so you can fly by watching the numbers.
+
+A good first attempt:
+
+1. Press `n` to open the spawn form. Set position to **launchpad**, pick a
+   latitude (28.6° N is Cape Canaveral), choose **Saturn V**, and press Enter.
+   The autopilot comes up pointing straight up and is already set to follow
+   your motion relative to the ground, so `w` does the right thing from the
+   start.
+2. `z` for full throttle, `b` to light the engine. The first stage lifts off
+   at a thrust-to-weight ratio of about 1.24.
+3. Around 3 km up, tap `>` once to tip 10° east. The rocket starts building
+   sideways speed.
+4. As your ground speed passes ~100 m/s, press `w` to have the autopilot point
+   along your velocity, and `\` to clear the manual tip. From here the rocket
+   tracks its own motion and gravity rounds the climb into orbit for you.
+5. Press `space` to drop the empty first stage. You keep flying the upper
+   stage and the stage list advances. Keep burning, drop the next stage, then
+   the last one.
+6. Watch the projected high point climb. When it passes 200 km the **● ORBIT
+   READY** note appears — that's your cue to cut the throttle (`x`) and coast.
+7. Press `C` to plan a circularising burn at the top of your arc.
+8. Coast up to that point. The planned burn fires on its own and rounds out
+   your orbit. The pad-to-orbit mission completes once your low point clears
+   200 km, and the readout counts down to it along the way.
+
+The whole thing runs on numbers, not memorised pitch tables: the high point
+climbs as you burn, ORBIT READY tells you when to stop, `C` sets up the last
+burn, and the mission tracker closes the gap. If a stage flames out early, the
+readout shows you why before you watch it fall back.
+
+## Keybindings
+
+### Global
+
+| Key | Action |
+|---|---|
+| `Esc` | Back, or open the save / load / quit menu on the main view |
+| `Ctrl+C` | Quit immediately |
+| `?` | Toggle the help overlay |
+| `i` | Body info screen |
+| `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
+| `0` | Pause / resume |
+| `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn) |
+
+### Map view
+
+| Key | Action |
+|---|---|
+| `→` / `l` | Move the map cursor to the next body. This cursor feeds the body info screen (`i`) and the porkchop plot (`P`) — it does **not** set your travel target. For that, use `t` / `T` |
+| `←` / `h` | Move the map cursor to the previous body |
+| `+` / `-` | Zoom in / out |
+| `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your craft) |
+| `g` | Reset the camera to the whole system |
+| `v` | Cycle the view (tilted → top → right → bottom → left → flat). Tilted is the default — a 3D-style perspective that shows orbits leaning in space |
+| `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
+| `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build your own rocket stack: on the stack field, `←` / `→` browse parts, `a` adds one on top, `x` removes the top one |
+| `H` | Plan a transfer to your target. To a moon of the planet you're at, it works out two ways to get there and plans the cheaper one, showing you both fuel costs. To another planet, it plans a standard Hohmann transfer. To a moon's parent planet, it plans an escape |
+| `I` | Plan a burn to match your target's orbital tilt (or to level out to the equator when nothing is targeted) |
+| `C` | Plan a circularising burn at the top of your orbit — pairs with the ORBIT READY cue on launch. Won't work if the top of your orbit is still inside the atmosphere or you're on an escape trajectory |
+| `K` | Plan a small nudge to close in on a target craft. Reads the closest-approach numbers in the target readout. Needs a craft target sharing your planet, and only works when there's an improvement to be had |
+| `t` / `T` | Pick / clear your target (other craft nearby → bodies in the system → none) |
+| `space` | Drop the bottom stage of your craft (only if it has more than one). On a bare capsule with a parachute, this arms the chute instead — it opens on its own once you hit the atmosphere |
+| `P` | Porkchop plot for the body under the map cursor (not your `t` target). `Enter` on a cell plans that transfer. For another planet only — moon targets point you back to `H`. Press `o` inside for transfer options |
+| `R` | Refine the plan — recompute the transfer from where you are right now and update the arrival |
+| `m` | Open the maneuver planner |
+| `F5` / `F9` | Quicksave / quickload |
+| `[` / `]` | Switch which craft you're flying (when you have more than one) |
+| `1`–`9` | Jump straight to craft N (does nothing if that slot is empty) |
+| `U` | Undock a docked craft back into its parts |
+| `D` | Apollo transposition — flip the Service Module to the front to do the flying, leaving the Lunar Module as a nose payload (then `U` to release it) |
+| `V` | Jump to the launch chase-cam, following your active craft |
+| `E` | End the flight — remove a crashed craft after a `y` / `n` confirm |
+
+### Manual flight
+
+| Key | Action |
+|---|---|
+| `z` / `x` | Throttle to full / cut to zero |
+| `Z` / `X` | Throttle up / down 10% |
+| `w` / `s` | Point prograde / retrograde (with / against your motion) |
+| `a` / `d` | Point normal+ / normal- (perpendicular to your orbit) |
+| `q` / `e` | Point radial+ / radial- (away from / toward the body) |
+| `b` | Light / cut the main engine (needs throttle above zero) |
+| `r` | Switch between the main engine and RCS thrusters |
+| `k` | Steering style: smooth turning (the default) or instant snap |
+| `;` | Switch the autopilot's reference: Orbit → Surface → Target (skips Target when none is set) |
+| `W` / `S` | Point along / against your ground speed — matches your velocity relative to the spinning atmosphere. Use this for the launch gravity turn |
+| `>` / `<` | Tip the nose 10° east / west on top of whatever the autopilot is doing |
+| `\` | Clear the manual tip |
+
+The pointing keys only aim the craft — `b` is what actually fires the engine.
+In RCS mode those same keys also fire one small thruster pulse per press (hold
+a key for a steady stream). The readouts show which engine is armed, how much
+RCS fuel you have, and how much Δv it's worth.
+
+### Mouse
+
+Click only — no dragging, no scroll-to-zoom.
+
+| Click | Action |
+|---|---|
+| `[Menu]` (top-right) | Save / load / quit menu |
+| `[Missions]` (top-right) | Mission list with pass / fail marks |
+| A body | Follow it with the camera (same as cursoring onto it) |
+| A craft | Follow it with the camera |
+| A planned burn | Open the planner for that burn (its fire time is kept) |
+| Empty space | Open the planner with a new burn at the nearest point on your orbit |
+| A readout panel | Open body info |
+| A porkchop cell | Move the cursor there (then `Enter` to plan it) |
+
+### Maneuver planner (`m`)
+
+| Key | Action |
+|---|---|
+| `Tab` / `Shift+Tab` | Move between fields (direction → when → Δv → throttle → refine) |
+| `←` / `→` | Change the field you're on (direction / when / refine) |
+| `Space` | Toggle the refine option when you're on that field |
+| digits / backspace | Type a Δv or throttle value |
+| `Enter` | Lock in the burn |
+| `Esc` | Cancel and go back |
+| `Ctrl+D` | Delete the burn you're editing (does nothing when creating a new one) |
+| `c` / `C` | Clear every planned burn for this craft |
+
+The panel lists all the burns you've planned for the current craft —
+direction, Δv, and a countdown — with the one you're editing marked, so you
+can see your whole schedule, not just the burn in front of you.
+
+The Δv you enter sets the burn's length automatically; craft with no engine
+fall back to an instant nudge. The "when" field lets you fire at a set time or
+at the next high point, low point, or orbital-plane crossing. Throttle is saved
+per burn, so changing your live throttle while coasting won't slow down a burn
+you've already planned. The preview updates the resulting orbit as you edit.
+
+The **refine** toggle spends a little extra Δv to make up for the fuel lost
+steering and fighting gravity during a long burn, so you end up where an
+instant burn of the same size would have put you. Leave it off for short burns;
+turn it on for low-thrust craft or big burns where the loss is noticeable.
+
+### Porkchop plot (`P`)
+
+| Key | Action |
+|---|---|
+| `←` / `→` | Move the departure-day cursor |
+| `↑` / `↓` | Move the travel-time cursor |
+| `Enter` | Plan the transfer for the selected cell |
+| `o` | Open transfer options — number of laps, prograde/retrograde, and the short/long path; closing re-draws the grid |
+| Click a cell | Move the cursor there (then `Enter` to plan) |
+| `Esc` | Back to the map |
+
+The cursor opens on the cheapest cell. A `·` marks cells where no transfer was
+found — `Enter` does nothing there.

--- a/internal/orbital/calculator.go
+++ b/internal/orbital/calculator.go
@@ -37,21 +37,24 @@ type Calculator interface {
 }
 
 // SolarSystemCalculator uses J2000.0 mean anomalies for Sol's 8+1 bodies.
-type SolarSystemCalculator struct{ epochTime time.Time }
+type SolarSystemCalculator struct{}
 
 // GenericCalculator seeds a deterministic mean anomaly from the body's
 // physical parameters — suitable for exoplanet systems without published
-// J2000-equivalent ephemerides.
-type GenericCalculator struct{ epochTime time.Time }
+// J2000-equivalent ephemerides. Phase is anchored to bodies.J2000 (a fixed
+// reference, like the table-driven planets), so a body's position is a pure
+// function of sim-time — independent of when the calculator was constructed.
+// This is what lets save/load and system-switch (Tab) preserve moon phase.
+type GenericCalculator struct{}
 
 // ExactCalculator uses per-body OrbitalElements.Epoch/MeanAnomaly.
 type ExactCalculator struct{}
 
-func NewSolarSystemCalculator(epoch time.Time) *SolarSystemCalculator {
-	return &SolarSystemCalculator{epochTime: epoch}
+func NewSolarSystemCalculator() *SolarSystemCalculator {
+	return &SolarSystemCalculator{}
 }
-func NewGenericCalculator(epoch time.Time) *GenericCalculator {
-	return &GenericCalculator{epochTime: epoch}
+func NewGenericCalculator() *GenericCalculator {
+	return &GenericCalculator{}
 }
 func NewExactCalculator() *ExactCalculator { return &ExactCalculator{} }
 
@@ -72,7 +75,7 @@ var j2000MeanAnomalies = map[string]float64{
 func (sc *SolarSystemCalculator) CalculateMeanAnomaly(body bodies.CelestialBody, t time.Time) float64 {
 	m0, ok := j2000MeanAnomalies[body.EnglishName]
 	if !ok {
-		return NewGenericCalculator(sc.epochTime).CalculateMeanAnomaly(body, t)
+		return NewGenericCalculator().CalculateMeanAnomaly(body, t)
 	}
 	days := t.Sub(bodies.J2000).Hours() / 24.0
 	if body.SideralOrbit <= 0 {
@@ -87,7 +90,7 @@ func (sc *SolarSystemCalculator) GetSystemType() SystemType { return SystemTypeS
 func (gc *GenericCalculator) CalculateMeanAnomaly(body bodies.CelestialBody, t time.Time) float64 {
 	seed := body.SemimajorAxis + body.SideralOrbit + body.MeanRadius
 	m0 := math.Mod(seed*(math.Pi/180.0), 2*math.Pi)
-	days := t.Sub(gc.epochTime).Hours() / 24.0
+	days := t.Sub(bodies.J2000).Hours() / 24.0
 	if body.SideralOrbit <= 0 {
 		return m0
 	}
@@ -115,14 +118,14 @@ func (ec *ExactCalculator) GetSystemType() SystemType { return SystemTypeExact }
 // ForSystem picks the right Calculator for a System name. Sol uses the
 // J2000-keyed table; everything else falls back to Generic unless any body
 // has explicit OrbitalElements, in which case Exact is used.
-func ForSystem(system bodies.System, epoch time.Time) Calculator {
+func ForSystem(system bodies.System) Calculator {
 	if system.Name == "Sol" {
-		return NewSolarSystemCalculator(epoch)
+		return NewSolarSystemCalculator()
 	}
 	for _, b := range system.Bodies {
 		if b.OrbitalElements != nil {
 			return NewExactCalculator()
 		}
 	}
-	return NewGenericCalculator(epoch)
+	return NewGenericCalculator()
 }

--- a/internal/orbital/calculator_test.go
+++ b/internal/orbital/calculator_test.go
@@ -20,7 +20,7 @@ func TestSolarSystemCalculatorAtJ2000(t *testing.T) {
 			break
 		}
 	}
-	calc := ForSystem(sol, bodies.J2000)
+	calc := ForSystem(sol)
 	if calc.GetSystemType() != SystemTypeSolar {
 		t.Fatalf("wrong calculator type: %s", calc.GetSystemType())
 	}
@@ -36,7 +36,7 @@ func TestSolarSystemCalculatorProgresses(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	sol := systems[0]
 	earth := sol.FindBody("Earth")
-	calc := ForSystem(sol, bodies.J2000)
+	calc := ForSystem(sol)
 	// After one sidereal year Earth's mean anomaly should return to starting value (mod 2π).
 	then := bodies.J2000.Add(time.Duration(earth.SideralOrbit*24) * time.Hour)
 	m0 := calc.CalculateMeanAnomaly(*earth, bodies.J2000)
@@ -56,7 +56,7 @@ func TestGenericCalculatorForExoplanet(t *testing.T) {
 			break
 		}
 	}
-	calc := ForSystem(trappist, bodies.J2000)
+	calc := ForSystem(trappist)
 	if calc.GetSystemType() != SystemTypeGeneric {
 		t.Errorf("TRAPPIST-1 expected Generic, got %s", calc.GetSystemType())
 	}

--- a/internal/orbital/frame_test.go
+++ b/internal/orbital/frame_test.go
@@ -36,7 +36,7 @@ func TestEarthPositionAtJ2000(t *testing.T) {
 	systems, _ := bodies.LoadAll()
 	sol := systems[0]
 	earth := sol.FindBody("Earth")
-	calc := ForSystem(sol, bodies.J2000)
+	calc := ForSystem(sol)
 	M := calc.CalculateMeanAnomaly(*earth, bodies.J2000)
 	E := SolveKepler(M, earth.Eccentricity)
 	nu := TrueAnomaly(E, earth.Eccentricity)

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -618,7 +618,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	// v0.9.3+: restore NavMode. Absent field → zero → NavOrbit (the
 	// pre-v0.9.3 default frame).
 	w.NavMode = sim.NavMode(p.NavMode)
-	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+	w.Calculator = orbital.ForSystem(w.System())
 
 	// v0.8.1+: load path translates the pre-v5 singular Craft field
 	// into the Crafts slice, and distributes pre-v5 payload-level

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -1230,3 +1230,41 @@ func TestRoundtripParachute(t *testing.T) {
 		t.Errorf("Spacecraft.HasParachute mirror not re-derived on load")
 	}
 }
+
+// TestRoundtripPreservesMoonPhase is a regression for the moon-phase bug:
+// the Moon's mean anomaly used to be anchored to the calculator's mutable
+// seed epoch (re-seeded from SimTime on Load), so a reloaded game snapped the
+// Moon back to its m0 base position instead of where it sat at save time.
+// Anchoring generic ephemerides to bodies.J2000 makes the position a pure
+// function of SimTime, so a save/load round-trip must preserve it.
+func TestRoundtripPreservesMoonPhase(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		t.Skip("Moon missing from Sol")
+	}
+	// Advance well past J2000 so the Moon is nowhere near its m0 base phase.
+	w.Clock.SimTime = w.Clock.SimTime.Add(7 * 24 * time.Hour)
+	before := w.BodyPositionAt(*moon, w.Clock.SimTime)
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	gsys := got.System()
+	gm := gsys.FindBody("Moon")
+	after := got.BodyPositionAt(*gm, got.Clock.SimTime)
+	if d := before.Sub(after).Norm(); d > 1.0 { // metres
+		t.Errorf("Moon moved across save/load: |Δ| = %.3g m (before %v, after %v)",
+			d, before, after)
+	}
+}

--- a/internal/sim/lunar_start.go
+++ b/internal/sim/lunar_start.go
@@ -1,0 +1,111 @@
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// DefaultLunarTransferLead is how far before the next ideal Moon-transfer
+// departure a fresh game should start. Short enough to reach by warping a
+// little, long enough to look at the system and set up the burn first.
+const DefaultLunarTransferLead = 4 * time.Hour
+
+// lunarStartTolerance bounds how far the chosen start may sit from the
+// requested lead. The achievable departure wait is quantized to the craft's
+// parking period (~94 min for a 500 km LEO), so we accept anything within one
+// such period of the target.
+const lunarStartTolerance = 95 * time.Minute
+
+// AdjustStartForLunarTransferWindow shifts the world clock so the next ideal
+// Moon-transfer departure (the split-strategy line-of-nodes crossing the
+// planner would plant on `H`) sits ~lead away, instead of the ~10 days out
+// that the J2000 epoch yields. It mutates only the clock — the craft and the
+// calculator are untouched — so the Moon's phase (a pure function of SimTime
+// since the J2000-anchored ephemeris fix) moves with the chosen start.
+//
+// Returns false and leaves the clock at its original value if there's no
+// Moon, no craft in orbit around it, or no start within tolerance can be
+// found. A false return is harmless: the game simply opens at J2000.
+func (w *World) AdjustStartForLunarTransferWindow(lead time.Duration) bool {
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		return false
+	}
+	c := w.ActiveCraft()
+	if c == nil || c.Primary.ID != moon.ParentID {
+		return false
+	}
+
+	base := w.Clock.SimTime
+	leadSec := lead.Seconds()
+
+	// Fixed-point search. The departure wait τ decreases ~1:1 as the start
+	// advances (the node crossing is a fixed Moon-ephemeris event), so moving
+	// the start later by (τ − lead) lands it `lead` before that same crossing.
+	// One step from J2000 essentially converges; a few more refine. We never
+	// step past the crossing, so there's no overshoot.
+	epoch := base
+	for i := 0; i < 5; i++ {
+		w.Clock.SimTime = epoch
+		tau, ok := w.lunarDepartureWait(*moon)
+		if !ok {
+			w.Clock.SimTime = base
+			return false
+		}
+		delta := tau - leadSec
+		if math.Abs(delta) < 300 { // within 5 min — let the local scan finish
+			break
+		}
+		epoch = epoch.Add(time.Duration(delta * float64(time.Second)))
+	}
+
+	// Local pick. τ is a step function of the start quantized to the parking
+	// period (the craft's spawn geometry fixes the in-plane departure point),
+	// so scan a small window and keep the start whose τ is closest to lead.
+	bestEpoch := epoch
+	bestErr := math.Inf(1)
+	for off := -3 * time.Hour; off <= 3*time.Hour; off += 5 * time.Minute {
+		cand := epoch.Add(off)
+		w.Clock.SimTime = cand
+		tau, ok := w.lunarDepartureWait(*moon)
+		if !ok {
+			continue
+		}
+		if e := math.Abs(tau - leadSec); e < bestErr {
+			bestErr = e
+			bestEpoch = cand
+		}
+	}
+
+	if bestErr > lunarStartTolerance.Seconds() {
+		w.Clock.SimTime = base
+		return false
+	}
+
+	w.Clock.SimTime = bestEpoch
+	w.Clock.RotationTime = bestEpoch
+	return true
+}
+
+// lunarDepartureWait returns the wait (seconds) until the split-strategy
+// departure burn would fire for a transfer to `target`, reading the current
+// w.Clock.SimTime. It is read-only and mirrors the split-timing setup in
+// PlanTransfer's intra-primary branch, calling the same pure helpers so the
+// number tracks what the game actually plants on `H`.
+func (w *World) lunarDepartureWait(target bodies.CelestialBody) (float64, bool) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return 0, false
+	}
+	muShared := c.Primary.GravitationalParameter()
+	rPark := c.State.R.Norm()
+	rArrival := target.SemimajorAxisMeters()
+	dvDep := estimateIntraPrimaryDepDv(muShared, rPark, rArrival) +
+		intraPlaneChangeAllowance(w, c, target, muShared, rPark)
+	minLead := c.BurnTimeForDV(dvDep).Seconds() / 2
+	tau, _, ok := w.splitNodePhasing(c, target, muShared, rPark, rArrival, minLead)
+	return tau, ok
+}

--- a/internal/sim/lunar_start_test.go
+++ b/internal/sim/lunar_start_test.go
@@ -1,0 +1,64 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// TestAdjustStartForLunarTransferWindow: the computed start lands the split
+// departure burn ~lead away (not the ~10 days out J2000 yields), and the
+// number the search models matches what PlanTransfer actually plants.
+func TestAdjustStartForLunarTransferWindow(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx := moonIndex(w)
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+
+	const lead = 4 * time.Hour
+	if !w.AdjustStartForLunarTransferWindow(lead) {
+		t.Fatalf("AdjustStartForLunarTransferWindow returned false")
+	}
+	if w.Clock.SimTime.Equal(bodies.J2000) {
+		t.Fatalf("clock still at J2000 after adjustment")
+	}
+	if !w.Clock.RotationTime.Equal(w.Clock.SimTime) {
+		t.Errorf("RotationTime %v not synced to SimTime %v",
+			w.Clock.RotationTime, w.Clock.SimTime)
+	}
+
+	plan, err := w.PlanTransfer(moonIdx)
+	if err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	if w.LastTransfer.Strategy != "split" {
+		t.Fatalf("strategy = %q, want split", w.LastTransfer.Strategy)
+	}
+	// The achievable departure is quantized to the parking period, so allow
+	// one such period of slack around the 4 h target.
+	got := plan.Departure.OffsetTime
+	if got < lead-95*time.Minute || got > lead+95*time.Minute {
+		t.Errorf("departure offset = %v, want within 95m of %v", got, lead)
+	}
+}
+
+// TestAdjustStartForLunarTransferWindowDeterministic: the search is a pure
+// function of the spawn state, so repeated calls land the same start.
+func TestAdjustStartForLunarTransferWindowDeterministic(t *testing.T) {
+	w1 := mustWorld(t)
+	if moonIndex(w1) < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	w2 := mustWorld(t)
+
+	if !w1.AdjustStartForLunarTransferWindow(4*time.Hour) ||
+		!w2.AdjustStartForLunarTransferWindow(4*time.Hour) {
+		t.Fatalf("adjustment returned false")
+	}
+	if !w1.Clock.SimTime.Equal(w2.Clock.SimTime) {
+		t.Errorf("non-deterministic start: %v vs %v",
+			w1.Clock.SimTime, w2.Clock.SimTime)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -240,7 +240,7 @@ func NewWorld() (*World, error) {
 		Clock:     NewClock(bodies.J2000, 50*time.Millisecond),
 		ViewTilt:  DefaultViewTilt(),
 	}
-	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+	w.Calculator = orbital.ForSystem(w.System())
 
 	// v0.6.5: seed missions from the embedded starter catalog. A failure
 	// to load the catalog is non-fatal — missions are an additive
@@ -357,7 +357,7 @@ func (w *World) System() bodies.System { return w.Systems[w.SystemIdx] }
 // systems and the craft is only visible in Sol.
 func (w *World) CycleSystem() {
 	w.SystemIdx = (w.SystemIdx + 1) % len(w.Systems)
-	w.Calculator = orbital.ForSystem(w.System(), w.Clock.SimTime)
+	w.Calculator = orbital.ForSystem(w.System())
 	w.ResetFocus()
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -72,6 +72,10 @@ func New() (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Open a fresh game a few hours before the next ideal Moon-transfer
+	// window instead of the ~10 days out the J2000 epoch yields. A false
+	// return just keeps the J2000 start — never fatal.
+	w.AdjustStartForLunarTransferWindow(sim.DefaultLunarTransferLead)
 	th := DefaultTheme()
 	sth := screens.Theme{
 		Primary: th.Primary,


### PR DESCRIPTION
The Moon isn't in the j2000MeanAnomalies table, so it fell through to
GenericCalculator, which computed its mean anomaly off the calculator's
*mutable* seed epoch. That epoch was re-derived from SimTime on Load
(save.go) and on system switch (CycleSystem), so days=0 and the Moon
snapped back to its m0 base position — a saved game lost where the moon(s)
were at save time, and Tab perturbed them mid-session.

Anchor GenericCalculator to bodies.J2000 (mirroring the table-driven
planets), making a body's phase a pure function of SimTime. SimTime is
already persisted, so save/load and Tab now preserve moon positions.

With the seed epoch dead, drop it entirely: remove the epochTime fields
and the epoch params from the calculator constructors and ForSystem, so
the footgun can't return. Existing tests are unaffected (they all seeded
and evaluated at J2000). Adds a save/load round-trip regression that pins
the Moon's position.

https://claude.ai/code/session_01HD3hQgfLdn3UCv8eLZ7fTy