### PR TITLE
feat(spawn): docked composites via Nose Payload Plan + Dock Seam (ADR 0011)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,29 @@ doesn't later pop as a group). The mission survivor is the **Command
 Module**, not the fused CSM.
 _Avoid_: Decouple group, Staging sequence, Separation script.
 
+**Nose Payload Plan**:
+The spawn-time, top-release counterpart to the **Decouple Plan**: a
+bottom-up list (one entry today) naming how many contiguous *top* Stages
+of a custom build or **Loadout** form a docked **nose payload** rather
+than linear firing-core Stages. At spawn the builder splits the stack at
+the **Dock Seam**, builds the core and the payload as separate Vessels,
+and **Docks** them into a ready **Composite** — so a player-assembled
+CSM+LM spawns *already* in the post-**Transposition** shape (SM firing
+core, LM an **Undock**-able nose payload), with no flip to fly. Where the
+Decouple Plan releases bottom Stages via **Staging**, the Nose Payload
+Plan pre-assembles the top group and hands release to **Undock**. Default
+(absent) ⇒ a plain linear Vessel, the historical custom-build behaviour.
+_Avoid_: Payload plan, Top decouple plan, Reverse staging.
+
+**Dock Seam**:
+The marker in the spawn configurator's stack list that designates the
+contiguous top group as a docked **nose payload** (the editor-side
+expression of the **Nose Payload Plan**). A pre-seamed **CSM+LM** module
+pick drops the four Apollo Stages `[SM, CM, Descent, Ascent]` with the
+seam set between `CM` and `Descent`, so the spawned Composite fires the
+SM and carries the LM as an Undockable payload.
+_Avoid_: Payload boundary, Split point, Stack divider.
+
 **Service Module (SM)**:
 The propulsive half of the Apollo command-and-service module: carries the
 SPS engine and all its storable propellant. Performs lunar-orbit

--- a/docs/adr/0009-transposition-and-active-engine.md
+++ b/docs/adr/0009-transposition-and-active-engine.md
@@ -1,9 +1,9 @@
 # 0009 — Transposition: splitting the CSM and letting a non-bottom stage fire
 
-<!-- llm-parse: adr=0009 status=proposed date=2026-06-02 cycle=v0.12 slice=apollo-transposition -->
+<!-- llm-parse: adr=0009 status=accepted date=2026-06-02 cycle=v0.12 slice=apollo-transposition -->
 
-**Status:** proposed (2026-06-02, `/grill-with-docs` on the Apollo
-Stack flyability problem).
+**Status:** accepted (2026-06-02, `/grill-with-docs` on the Apollo
+Stack flyability problem; decisions 1–3 shipped + tested as of 2026-06-04).
 **Extends:** [`docs/adr/0007-surface-staging-and-decouple-plan.md`](0007-surface-staging-and-decouple-plan.md)
 (the bottom-up `DecouplePlan` this slice adds a *top-release* / docked
 nose-payload counterpart to) and

--- a/docs/adr/0011-spawn-time-docked-composites-nose-payload-seam.md
+++ b/docs/adr/0011-spawn-time-docked-composites-nose-payload-seam.md
@@ -1,0 +1,200 @@
+# 0011 — Spawn-time docked composites: the Nose Payload Plan + Dock Seam
+
+<!-- llm-parse: adr=0011 status=accepted date=2026-06-04 cycle=v0.14 slice=spawn-docked-composite -->
+
+**Status:** accepted (2026-06-04, `/grill-with-docs` on the
+"custom CSM+LM splits in orbit" playtest report).
+**Extends:** [`docs/adr/0007-surface-staging-and-decouple-plan.md`](0007-surface-staging-and-decouple-plan.md)
+(the bottom-up `DecouplePlan` this slice mirrors as a *top-release*
+counterpart) and
+[`docs/adr/0009-transposition-and-active-engine.md`](0009-transposition-and-active-engine.md)
+(this realizes 0009's "top-release / nose-payload" forward hook — the
+post-transposition composite, now reachable at spawn instead of only by
+flying the flip).
+
+## Context
+
+A player wanting to repeat-test the lunar-operations arc — CSM in Moon
+orbit → LM descent → ascent → dock → trans-Earth return → re-entry —
+built a **custom** vessel in the spawn configurator by picking the CSM
+and the Lander, spawned into Moon orbit, and **Staged**. The descent and
+ascent stages separated *in orbit*, not on the surface as intended.
+
+The cause is structural, not a numeric bug. A custom build becomes a
+single **linear** Vessel via `NewFromStages`, which sets
+`DecouplePlan: nil` — so every **Staging** press single-pops one Stage
+(`staging.go`, `groupSize = 1`). For a `[CSM, Descent, Ascent]` stack
+that means: drop CSM, then drop Descent *alone in orbit*, stranding it
+from the Ascent. There is no key sequence on a linear custom build that
+produces the intended arc.
+
+The intended arc is not a linear stage chain at all. Per ADR 0009 the
+real Apollo lunar configuration is a **docking composite**: the
+**Service Module** is the firing core (LOI/TEI engine), the **Lunar
+Module** rides as a docked **nose payload** released by **Undock** (not
+Staging), and the LM only splits its descent stage from its ascent stage
+*later, on the surface*, via **Surface Staging** (ADR 0007). A linear
+bottom-first stack with a single hardwired firing engine **cannot
+represent this** — exactly the wrong-engine / can't-detach-as-a-unit wall
+ADR 0009 documented for the Apollo Stack.
+
+Crucially, every piece needed to *fly* that arc already shipped in v0.12:
+
+- `DockCrafts` concatenates `[core.Stages…, payload.Stages…]` so the
+  core's bottom is `Stages[0]` (the firing engine) and records each half
+  as a `DockedComponent` carrying its full per-Stage breakdown.
+- `Undock` reconstitutes a multi-stage component — the LM comes back as a
+  coherent `[Descent, Ascent]` craft with live fuel — from
+  `DockedComponent.Stages`.
+- `DockedComponent.Stages` **persists** through save/load
+  (`save.go`), so a docked composite round-trips.
+- The Apollo Stack already carries the SM/CM split and a one-key
+  **Transposition** (`D`) producing the `[SM, CM, Descent, Ascent]`
+  composite.
+
+The **only** missing capability is the one the player hit: `SpawnSpec`
+can place a single *linear* craft only — there is no way to spawn a
+**pre-docked composite**. The full Apollo arc is otherwise reachable only
+by flying the Saturn V ascent + TLI + transposition flip every iteration,
+which defeats repeat play-testing of the lunar-operations portion alone.
+
+## Decision
+
+### 1. The Nose Payload Plan — a top-release counterpart to the Decouple Plan
+
+A custom build or `Loadout` may declare a **Nose Payload Plan**: a list
+of group sizes naming how many contiguous **top** Stages form a docked
+**nose payload** rather than linear firing-core Stages. Where the
+bottom-up `DecouplePlan` releases bottom Stages via **Staging**, the
+Nose Payload Plan pre-assembles the top group at spawn and hands its
+release to **Undock**. The two are duals: `DecouplePlan` is consumed
+upward by Staging during flight; the Nose Payload Plan is consumed once,
+at spawn, to build the composite.
+
+The plan is **list-shaped** (`[]int`) though v0.14 supports exactly one
+entry — a single nose payload (the LM, itself possibly multi-stage). This
+covers the Apollo arc today while leaving multiple distinct payloads
+(core + LM + a separate probe) an **additive** extension with no save
+migration. Absent ⇒ a plain linear Vessel, the historical custom-build
+behaviour, unchanged.
+
+### 2. Spawn assembles the composite by reusing DockCrafts
+
+At spawn, when a Nose Payload Plan is present, the builder splits the
+flat stack at the seam, constructs the core and the payload as separate
+co-located Vessels, and **`DockCrafts`** them into a ready composite. The
+two are spawned at the same inertial state, so `DockCrafts`'s centroid /
+momentum merge is an identity — the value is its existing, tested
+production of the concatenated `Stages` plus the `DockedComponent`
+snapshots. The result is an ordinary docked-composite Vessel: SM at
+`Stages[0]` firing, LM an `Undock`-able nose payload, **already in the
+post-Transposition shape with no flip to fly.**
+
+Because the spawned composite is an ordinary `DockedComponents` craft
+that already persists (ADR 0009), there is **no `SchemaVersion` bump**.
+The Nose Payload Plan is a spawn-time / Loadout concept, not new
+persisted Vessel state — once assembled, the composite is indistinguish-
+able from one a player built by docking in flight.
+
+### 3. The Dock Seam marks the boundary in the configurator
+
+In the spawn configurator's stack list, the player marks the contiguous
+top group as the nose payload with a **Dock Seam** — the editor-side
+expression of the Nose Payload Plan. The single bottom-first stack editor
+is kept (no two-pane redesign); the seam is one extra marker on the
+existing list. Below the seam fires; above it Undocks.
+
+### 4. A pre-seamed CSM+LM configurator module
+
+A `BuildModule`-style **CSM+LM** catalog pick drops the four Apollo
+Stages `[SM, CM, Descent, Ascent]` with the Dock Seam pre-set between
+`CM` and `Descent`, reusing the exact SM/CM/LM hardware the Apollo Stack
+already defines. Picking it, choosing Moon orbit, and spawning lands the
+player in the assembled composite ready to `U`-release the LM — the
+one-pick repeat-test loop, without leaving the configurator surface.
+
+## Alternatives considered
+
+### Scope of the fix
+- **"Just tell me the key sequence" (no code).** Route the player to
+  spawn CSM + Lander as two craft and manually dock to transpose.
+  Rejected: the player asked for custom builds to support this generally,
+  and two-spawns-plus-a-manual-rendezvous is exactly the friction
+  repeat-testing wants gone.
+- **Apollo-only spawn affordance** ("spawn the Apollo Stack already in
+  Moon orbit, post-transposition"). Narrower, but bespoke to one mission
+  and doesn't generalize the configurator. Rejected for the general seam.
+- **General nose-payload seam in the configurator. Chosen.** Any
+  player-built core + nose payload works; the Apollo case is then just a
+  pre-seamed module on top of the primitive.
+
+### Configurator UX for the boundary
+- **Two-pane "Core" + "Payload" editor.** Clearest mental model but a
+  larger screen/UI change and more spawn-time state. Rejected as
+  heavier than the arc needs.
+- **Composite-only catalog modules** (no general seam). Smallest change,
+  nails Apollo, but only as-curated. Rejected: the player asked for
+  generality.
+- **Dock Seam marker on the single stack list. Chosen.** Smallest UI
+  delta that is still fully general, and the literal inverse of
+  `DecouplePlan`.
+
+### Seam multiplicity / storage
+- **Single split-index int.** Simplest, but multiple distinct payloads
+  later would force a data-model/wire change. Rejected.
+- **Full multi-payload now.** Most flexible, more configurator + spawn
+  complexity than the arc needs. Rejected for v0.14.
+- **One payload, `[]int` list-shaped storage. Chosen.** Covers Apollo,
+  no dead-end, no future migration.
+
+### Spawn-assembly mechanism
+- **Bespoke composite builder** that constructs `Stages` +
+  `DockedComponents` directly, skipping `DockCrafts`. Avoids the no-op
+  centroid merge but duplicates the snapshot/concatenation logic that is
+  the single source of truth for docked composites. Rejected.
+- **Reuse `DockCrafts` on two co-located craft. Chosen.** One code path
+  for composites whether assembled at spawn or by flying a dock; the
+  identity merge is cheap.
+
+### Release semantics of the payload
+- **Extend `DecouplePlan` with negative/top-release entries.** Rejected
+  by ADR 0009 already: the LM-as-docked-component is what lets it Undock
+  as a coherent unit *and* retain its own internal grouping for Surface
+  Staging. Top-release belongs to **docking**, not the Staging plan.
+
+## Consequences
+
+**Positive.**
+- The full lunar-operations arc becomes repeat-testable from a single
+  spawn — no Saturn V ascent, TLI, or flip per iteration.
+- The Nose Payload Plan is a reusable primitive: any future stack that
+  carries an Undockable top payload (sample-return probe, tug + cargo)
+  can declare one, and the list shape already admits several.
+- Realizes ADR 0009's top-release forward hook with **no new flight
+  semantics and no `SchemaVersion` bump** — it rides `DockCrafts`,
+  `Undock`, and the existing `DockedComponents` persistence.
+
+**Negative / trade-offs to live with.**
+- `SpawnSpec` and `Loadout` each gain a `NosePayloadPlan` field, and the
+  spawn path branches on it — a new shape for `SpawnCraft` to carry.
+- The Dock Seam adds configurator state and a render/edit affordance to
+  the stack list — modest UI surface on a screen that ADR 0010 just
+  worked to keep slim.
+- A custom core with no firing engine below the seam (e.g. seam placed so
+  the core is the engineless CM alone) spawns a composite that cannot
+  thrust. Treated as a sandbox footgun, not a hard validation error;
+  a soft check may warn.
+- "One payload now" means a build wanting two distinct nose payloads
+  must wait for the additive extension; the list shape keeps that cheap
+  but it is not in v0.14.
+
+**Forward hooks.**
+- **Multiple nose payloads.** The `[]int` plan already admits more than
+  one entry; the configurator seam UX and the spawn split loop generalize
+  to N payloads when a stack needs it (e.g. dual-probe deploy).
+- **Spawn-list composite Loadouts.** The Nose Payload Plan living on
+  `Loadout` means a top-level "Apollo CSM+LM (lunar ops)" spawn entry —
+  skipping the custom editor entirely — is a later additive option if the
+  configurator module proves too many keystrokes for repeat testing.
+- **Core-without-engine validation.** A soft "this core can't fire"
+  warning in the configurator is deferred to the seam UX polish.

--- a/docs/state-of-game.md
+++ b/docs/state-of-game.md
@@ -2,17 +2,18 @@
 
 <!--
   meta:
-    snapshot_version: v0.13.0 (HUD overlay refactor — ADR 0010: the orbit
-      HUD's tall conditional-block stack becomes a slim/pinned core chip +
-      compact canvas-corner chips on a full-width orbit map, killing the
-      overflow that scrolled the title/view off-screen. Adds a Settings
-      screen (chip visibility, persisted to settings.json) + F2 declutter;
-      Orbit metrics & the active-burn readout are always-on. Bundled
-      playtest fixes + the configurator 2-stage Lander as one vessel.)
+    snapshot_version: v0.14.0 (spawn-time docked composites — ADR 0011:
+      SpawnSpec.NosePayloadPlan, the top-release counterpart to the bottom-up
+      DecouplePlan, splits a custom stack at the Dock Seam and reuses
+      dockedComponentFromStages so a custom CSM+LM spawns as a ready docked
+      composite — SM firing core, LM Undock-able nose payload — instead of a
+      linear single-pop craft. Configurator [d] Dock-Seam cycle + csm-lm
+      composite module pick. No save schema bump.)
     snapshot_date: 2026-06-04
-    revised_date: 2026-06-04 (v0.13.0 shipped: HUD overlay refactor cycle —
-      chips-on-canvas + Settings screen + F2 declutter (ADR 0010, merge
-      f8e74d0). Prior: v0.12.8 LAUNCH HUD hyperbolic-altitude gate (PR #78);
+    revised_date: 2026-06-04 (v0.14.0 shipped: spawn-time docked composites
+      (ADR 0011, PR #81) + ADR 0009 status flip. Prior: v0.13.0 HUD overlay
+      refactor cycle — chips-on-canvas + Settings screen + F2 declutter (ADR
+      0010, merge f8e74d0); v0.12.8 LAUNCH HUD hyperbolic-altitude gate (PR #78);
       v0.12.7 Apollo LM decouple-group + LAUNCH HUD stable-orbit (PR #76/#77);
       v0.12.6 burn-pause + Apollo transposition (ADR 0009) + near-orbital
       launch-view release. Remaining pre-v0.13 item is GH #68, deferred)
@@ -24,7 +25,7 @@
   ADRs (docs/adr/); this file keeps the entries + the snapshot.
 -->
 
-> Snapshot at **v0.13.0** (June 2026). Four cycles have shipped to
+> Snapshot at **v0.14.0** (June 2026). Five cycles have shipped to
 > `main` since v0.9.6:
 >
 > - **v0.10** (May 19–23) — planner + maneuver tooling: rate-limited
@@ -60,6 +61,14 @@
 >   readout are always-on. Bundled playtest fixes + the configurator's
 >   2-stage Lander as one vessel. Playtest verdict: "really makes the game
 >   look thought-out"; remaining refinement is chip timing + content.
+> - **v0.14** (Jun 4) — **spawn-time docked composites**
+>   ([ADR 0011](adr/0011-spawn-time-docked-composites-nose-payload-seam.md)):
+>   `SpawnSpec.NosePayloadPlan` (the top-release counterpart to the bottom-up
+>   `DecouplePlan`) splits a custom stack at the **Dock Seam** and reuses
+>   `dockedComponentFromStages`, so a custom CSM+LM spawns as a ready docked
+>   composite — SM firing core, LM Undock-able nose payload — instead of a
+>   linear single-pop craft that split the LM in orbit. Configurator `[d]`
+>   Dock-Seam cycle + a `csm-lm` composite module pick. No save schema bump.
 >
 > **Remaining:** Moon-frame lunar-capture inclination trim
 > (GH #68, deferred from v0.12.2) — the only open carry-over thread.
@@ -149,6 +158,7 @@ flyby) match real spacecraft work.
 
 | Version | Date | Status | Theme |
 |---|---|---|---|
+| v0.14.0 | 2026-06-04 | ✓ | **Spawn-time docked composites** (PR #81, [ADR 0011](adr/0011-spawn-time-docked-composites-nose-payload-seam.md)). A custom CSM+LM build used to spawn as a linear single-pop craft, so staging split the LM's Descent/Ascent in orbit instead of letting it descend as a unit and surface-stage — the Apollo arc is a *docking composite* (CSM fires, LM is an Undock-able nose payload), which a linear stack can't represent. Adds `SpawnSpec.NosePayloadPlan` — the top-release counterpart to the bottom-up `DecouplePlan`: `newCustomCraft` splits the stack at the **Dock Seam** and reuses `dockedComponentFromStages` (the helper `Transpose` uses) to assemble a ready composite in post-transposition shape. No save schema bump. Configurator: `[d]` cycles the Dock Seam in the STACK editor + a `csm-lm` composite module pick drops the LM pre-seamed for one-pick lunar-ops testing. Also flips [ADR 0009](adr/0009-transposition-and-active-engine.md) `proposed`→`accepted` (its decisions shipped in v0.12.6). |
 | v0.12.8 | 2026-06-02 | ✓ | LAUNCH HUD hyperbolic-altitude gate (PR #78). Follow-on to v0.12.7's stable-orbit fix: the boxed ascent panel no longer pops back on a hyperbolic trajectory **far from any launch** — an over-energetic TLI that escapes Earth, or a hyperbolic arrival at another atmosphered body (Mars). The `e ≥ 1 → show` short-circuit is now gated on altitude, so it only counts as a launch when the craft is genuinely low (below the atmosphere cutoff). No change to airless-body behaviour (the Moon already shows no panel). |
 | v0.12.7 | 2026-06-02 | ✓ | Apollo / launch playtest fixes. **LM no longer splits when staging** (PR #76): restores the Apollo `DecouplePlan` trailing `2` so the post-Saturn stack drops the Lunar Module (Descent + Ascent) as a single 2-stage craft for the canonical manual flip — pressing `space` at `[Descent, Ascent, SM, CM]` no longer peels the descent and ascent off one at a time. `Transpose` (`D`) clears the leftover plan; a "TRANSPOSE READY — press D" hint now flashes when the stack reaches the pre-transposition shape. **LAUNCH HUD hides on a stable orbit** (PR #77): the boxed ascent-instrument overlay now clears once the periapsis is above the atmosphere (not the 200 km mission floor), so a sub-200 km parking orbit (e.g. 186 × 186 km) reads as flight, not ascent. |
 | v0.12.6 | 2026-06-02 | ✓ | Three slices bundled. **Burn pause-and-resume across staging** (PR #72): a planted finite burn whose firing stage runs dry with Δv still owed now **stalls** (keeping its remaining Δv) and **auto-resumes** when the player decouples to a fuelled stage, instead of silently cancelling — HUD shows "⚠ STALLED — stage to resume", throttle-cut (`x`) aborts. **Apollo transposition + rebalanced lunar stack** (PR #74, [ADR 0009](adr/0009-transposition-and-active-engine.md)): the fused CSM splits into a propulsive Service Module + an engineless parachute Command Module; a one-shot transpose key (`D`) reorders the post-S-IVB stack so the SM fires LOI/TEI with the LM as a docked nose payload released via Undock (multi-stage DockedComponent breakdown, which also fixes the manual docking-flip). The Apollo Stack now flies a complete lunar mission. **ViewLaunch near-orbital release** (PR #75): the launch chase-cam now hands off when the apoapsis clears the atmosphere AND the circularisation Δv is within 750 m/s, instead of a fixed 200 km apoapsis floor. |

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -87,6 +87,18 @@ type SpawnSpec struct {
 	// alongside) is orthogonal and still applies.
 	CustomStages []spacecraft.Stage
 
+	// NosePayloadPlan (v0.14 / ADR 0011) is the top-release counterpart
+	// to a Loadout's bottom-up DecouplePlan: a list of how many
+	// contiguous TOP stages of CustomStages form a docked nose payload
+	// (released by Undock, not Staging) rather than linear firing-core
+	// stages. v0.14 honours a single entry — one nose payload, itself
+	// possibly multi-stage (the Apollo LM = [Descent, Ascent]). When set
+	// (and CustomStages is non-empty), SpawnCraft splits the stack at the
+	// seam, builds the core and payload, and assembles them into a ready
+	// docked composite — so a CSM+LM spawns already in the
+	// post-transposition shape. Nil/empty ⇒ a plain linear custom craft.
+	NosePayloadPlan []int
+
 	// Launchpad (v0.9.2+): when true, spawn at altitude 0 on the
 	// parent body's surface co-moving with the rotating ground at
 	// `Latitude` / `LongitudeOffset` (degrees, north / east positive).
@@ -145,7 +157,12 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		// Ignores LoadoutID — a custom craft is not a catalog
 		// archetype. NewFromStages returns nil only on an empty
 		// slice, already excluded by the len() guard.
-		c = spacecraft.NewFromStages(spec.CustomStages)
+		//
+		// v0.14 / ADR 0011: a NosePayloadPlan marks a contiguous TOP
+		// group as a docked nose payload, so the stack spawns as an
+		// assembled composite (core firing, payload Undock-able) rather
+		// than a linear chain. A malformed plan falls back to linear.
+		c = newCustomCraft(spec.CustomStages, spec.NosePayloadPlan)
 	} else {
 		id := spec.LoadoutID
 		if id == "" {
@@ -285,6 +302,89 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 	w.StopManualBurn()
 	w.initCraftAttitude(c)
 	return c, nil
+}
+
+// newCustomCraft builds the Spacecraft for a player-assembled stack.
+// With no nose-payload plan it is a plain linear craft (NewFromStages,
+// the v0.10.1 behaviour). With a single-entry plan `k` (v0.14 / ADR
+// 0011) it splits the top k stages off as a docked nose payload: the
+// result is a composite whose Stages are the full stack (core at the
+// bottom, firing) with DockedComponents recording the core and the
+// payload so the existing Undock (docking.go) releases the payload as a
+// coherent — possibly multi-stage — craft. The composite flies as the
+// core, the surviving firing vehicle. A malformed seam (k ≤ 0 or k ≥
+// len) degrades to a linear craft rather than erroring, so a stray plan
+// can never strand the spawn.
+//
+// This reuses dockedComponentFromStages — the same helper Transpose
+// (staging.go) uses to wrap the CSM core and LM nose payload — so a
+// spawned composite is byte-for-byte the configuration a hand-flown
+// dock or the `D` transpose key produces, and rides the identical
+// Undock / save-load machinery (no schema bump).
+func newCustomCraft(stages []spacecraft.Stage, nosePayloadPlan []int) *spacecraft.Spacecraft {
+	c := spacecraft.NewFromStages(stages)
+	if c == nil || len(nosePayloadPlan) == 0 {
+		return c
+	}
+	k := nosePayloadPlan[0]
+	n := len(stages)
+	if k <= 0 || k >= n {
+		return c // malformed seam — leave it a linear craft
+	}
+	coreStages := append([]spacecraft.Stage(nil), stages[:n-k]...)
+	payloadStages := append([]spacecraft.Stage(nil), stages[n-k:]...)
+
+	coreName := vehicleNameForStages(coreStages)
+	core := dockedComponentFromStages(coreStages, coreName, "custom")
+	payload := dockedComponentFromStages(
+		payloadStages, vehicleNameForStages(payloadStages), payloadRoleForStages(payloadStages))
+	c.DockedComponents = []spacecraft.DockedComponent{core, payload}
+
+	// Identity: fly as the core (the surviving firing vehicle), not the
+	// top-of-stack payload that NewFromStages defaulted the name/marker to.
+	c.Name = coreName
+	c.Glyph = coreStages[0].Glyph
+	c.Color = coreStages[0].Color
+	c.SyncFields()
+	return c
+}
+
+// vehicleNameForStages picks a friendly name for a contiguous stage
+// group used as a docked composite component (ADR 0011). It recognises
+// the Apollo halves so the CSM+LM composite reads as "CSM" / "LM"; any
+// other group falls back to its surviving-core (top) stage name — the
+// same identity rule NewFromStages uses.
+func vehicleNameForStages(stages []spacecraft.Stage) string {
+	has := func(name string) bool {
+		for _, s := range stages {
+			if s.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	switch {
+	case has("SM") && has("CM"):
+		return "CSM"
+	case has("Descent") && has("Ascent"):
+		return "LM"
+	}
+	if top := stages[len(stages)-1].Name; top != "" {
+		return top
+	}
+	return "Custom"
+}
+
+// payloadRoleForStages assigns a role to a nose-payload component so the
+// undocked craft surfaces sensibly — a soft-land-capable payload (the LM)
+// becomes a "lander", matching what Transpose records. v0.14.
+func payloadRoleForStages(stages []spacecraft.Stage) string {
+	for _, s := range stages {
+		if s.CanSoftLand {
+			return "lander"
+		}
+	}
+	return "payload"
 }
 
 // nextCraftName returns a name for the next spawned craft of the

--- a/internal/sim/spawn_custom_test.go
+++ b/internal/sim/spawn_custom_test.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -93,6 +94,123 @@ func TestSpawnCustomLanderSplitStages(t *testing.T) {
 	}
 	if rem := w.ActiveCraft().Stages; len(rem) != 1 || rem[0].Name != "Ascent" {
 		t.Errorf("remaining active = %d stages (bottom %q), want [Ascent]", len(rem), rem[0].Name)
+	}
+}
+
+// TestSpawnNosePayloadCompositeAssembles — v0.14 / ADR 0011. A custom
+// stack carrying a NosePayloadPlan spawns as an assembled docked
+// composite, not a linear chain: the core fires at Stages[0], the nose
+// payload is recorded as a DockedComponent, and Undock releases it as a
+// coherent multi-stage craft. This is the fix for the playtest report —
+// the CSM+LM spawns in the post-transposition shape so the LM leaves via
+// Undock (and only splits Descent/Ascent on the surface), instead of the
+// linear single-pop that stranded the Descent in orbit.
+func TestSpawnNosePayloadCompositeAssembles(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stages, ok := spacecraft.BuildModule(spacecraft.StageModuleApolloCSMLMID)
+	if !ok || len(stages) != 4 {
+		t.Fatalf("BuildModule(csm-lm) = %d stages (ok=%v), want 4", len(stages), ok)
+	}
+
+	c, err := w.SpawnCraft(SpawnSpec{
+		CustomStages:    stages,
+		NosePayloadPlan: []int{2}, // top 2 (the LM) ride as a docked nose payload
+		ParentBodyID:    "moon",
+		AltitudeM:       100e3,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(composite): %v", err)
+	}
+
+	// Full stack, core at the bottom and firing.
+	wantNames := []string{"SM", "CM", "Descent", "Ascent"}
+	for i, want := range wantNames {
+		if c.Stages[i].Name != want {
+			t.Errorf("Stages[%d] = %q, want %q", i, c.Stages[i].Name, want)
+		}
+	}
+	if c.Thrust <= 0 || c.Stages[0].Name != "SM" {
+		t.Errorf("composite firing core = %q @ %.0fN, want SM with thrust", c.Stages[0].Name, c.Thrust)
+	}
+	// Flies as the core, not the top payload stage. nextCraftName adds the
+	// usual "-N" slate suffix, so check the prefix.
+	if !strings.HasPrefix(c.Name, "CSM") {
+		t.Errorf("composite name = %q, want a CSM* name (flies as the core, not the top payload stage)", c.Name)
+	}
+
+	// Two docked components: the [SM, CM] core and the [Descent, Ascent] LM.
+	if len(c.DockedComponents) != 2 {
+		t.Fatalf("DockedComponents = %d, want 2 (core + LM)", len(c.DockedComponents))
+	}
+	core, lm := c.DockedComponents[0], c.DockedComponents[1]
+	if len(core.Stages) != 2 || core.Stages[0].Name != "SM" {
+		t.Errorf("core component = %d stages (bottom %q), want [SM, CM]", len(core.Stages), core.Stages[0].Name)
+	}
+	if len(lm.Stages) != 2 || lm.Stages[0].Name != "Descent" {
+		t.Errorf("LM component = %d stages (bottom %q), want [Descent, Ascent]", len(lm.Stages), lm.Stages[0].Name)
+	}
+
+	// Undock releases the LM as a coherent 2-stage craft (NOT a single
+	// Descent stranded in orbit) and leaves the SM/CM core flying.
+	if !w.Undock(w.ActiveCraftIdx) {
+		t.Fatal("Undock of the spawned composite returned false")
+	}
+	var freedLM, freedCore *spacecraft.Spacecraft
+	for _, cc := range w.Crafts {
+		switch {
+		case len(cc.Stages) == 2 && cc.Stages[0].Name == "Descent":
+			freedLM = cc
+		case len(cc.Stages) == 2 && cc.Stages[0].Name == "SM":
+			freedCore = cc
+		}
+	}
+	if freedLM == nil {
+		t.Error("Undock did not release a 2-stage [Descent, Ascent] LM")
+	}
+	if freedCore == nil {
+		t.Error("Undock did not leave a 2-stage [SM, CM] core")
+	}
+}
+
+// TestSpawnNosePayloadAbsentIsLinear — control for ADR 0011: the SAME
+// stack with no NosePayloadPlan spawns as a plain linear craft (no
+// DockedComponents), staging single-pops, and a malformed seam degrades
+// to linear rather than erroring.
+func TestSpawnNosePayloadAbsentIsLinear(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stages, _ := spacecraft.BuildModule(spacecraft.StageModuleApolloCSMLMID)
+
+	linear, err := w.SpawnCraft(SpawnSpec{
+		CustomStages: stages,
+		ParentBodyID: "moon",
+		AltitudeM:    100e3,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(linear): %v", err)
+	}
+	if len(linear.DockedComponents) != 0 {
+		t.Errorf("no-plan custom craft has %d DockedComponents, want 0 (linear)", len(linear.DockedComponents))
+	}
+
+	// A malformed seam (≥ stack length) must fall back to linear, not panic
+	// or strand the spawn.
+	bad, err := w.SpawnCraft(SpawnSpec{
+		CustomStages:    stages,
+		NosePayloadPlan: []int{len(stages)}, // whole stack = payload → no core
+		ParentBodyID:    "moon",
+		AltitudeM:       100e3,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(malformed seam): %v", err)
+	}
+	if len(bad.DockedComponents) != 0 {
+		t.Errorf("malformed seam produced %d DockedComponents, want 0 (linear fallback)", len(bad.DockedComponents))
 	}
 }
 

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -175,6 +175,49 @@ func TestLanderModuleIsTwoStages(t *testing.T) {
 	}
 }
 
+// TestApolloCSMLMCompositeModule — v0.14 / ADR 0011. The "csm-lm" pick
+// expands to the post-transposition stack [SM, CM, Descent, Ascent]
+// bottom-first (SM the firing core), and ModuleNosePayloadTop reports 2
+// so the spawn path docks the LM (top 2) as a nose payload. The module
+// is offered in the configurator; its split sub-stages are not.
+func TestApolloCSMLMCompositeModule(t *testing.T) {
+	stages, ok := BuildModule(StageModuleApolloCSMLMID)
+	if !ok || len(stages) != 4 {
+		t.Fatalf("BuildModule(csm-lm) = (%d stages, ok=%v), want 4", len(stages), ok)
+	}
+	wantNames := []string{"SM", "CM", "Descent", "Ascent"}
+	for i, want := range wantNames {
+		if stages[i].Name != want {
+			t.Errorf("stage[%d] = %q, want %q (bottom-first SM core + LM on top)", i, stages[i].Name, want)
+		}
+	}
+	if stages[0].Thrust <= 0 {
+		t.Errorf("SM (Stages[0]) thrust = %.0f, want > 0 (it is the firing core)", stages[0].Thrust)
+	}
+	if top := ModuleNosePayloadTop(StageModuleApolloCSMLMID); top != 2 {
+		t.Errorf("ModuleNosePayloadTop(csm-lm) = %d, want 2 (the LM rides on the nose)", top)
+	}
+	// Non-composite modules carry no nose payload.
+	if top := ModuleNosePayloadTop(StageModuleLanderID); top != 0 {
+		t.Errorf("ModuleNosePayloadTop(lander) = %d, want 0 (linear pick)", top)
+	}
+
+	// The composite is offered as a single pick; its split halves are not
+	// separate configurator entries.
+	offered := false
+	for _, id := range StageCatalogOrder {
+		switch id {
+		case StageModuleApolloCSMLMID:
+			offered = true
+		case StageModuleServiceModuleID, StageModuleCommandModuleID:
+			t.Errorf("StageCatalogOrder exposes %q separately; the csm-lm module should bundle it", id)
+		}
+	}
+	if !offered {
+		t.Error("StageCatalogOrder does not offer the csm-lm composite pick")
+	}
+}
+
 // TestApolloStackShape — the multi-tier loadout: 7 stages bottom-first
 // [S-IC, S-II, S-IVB, Descent, Ascent, SM, CM] (v0.12 ADR 0009 split the
 // fused CSM into a propulsive Service Module + a passive Command Module),

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -115,6 +115,13 @@ const (
 	// carries the chute.
 	StageModuleServiceModuleID = "service-module"
 	StageModuleCommandModuleID = "command-module"
+	// StageModuleApolloCSMLMID (v0.14 / ADR 0011) is a COMPOSITE module
+	// pick: BuildModule expands it to [SM, CM, Descent, Ascent] and
+	// ModuleNosePayloadTop reports that the top 2 (the LM) form a docked
+	// nose payload. Picking it in the configurator and spawning lands the
+	// post-transposition Apollo composite — SM firing core, LM an
+	// Undock-able nose payload — already assembled, no flip to fly.
+	StageModuleApolloCSMLMID = "csm-lm"
 	// v0.12 Slice 3 / ADR 0008: standalone re-entry capsule — single
 	// command-module-class stage with a parachute, no engine landing.
 	StageModuleCapsuleID = "capsule"
@@ -285,6 +292,24 @@ var StageCatalog = map[string]StageModule{
 		// fuelType intentionally unset — no main engine (RCS-only).
 		hasParachute: true,
 	},
+	// v0.14 / ADR 0011: the Apollo CSM+LM composite configurator pick.
+	// This catalog row exists only so the part-picker has a Name/Glyph/Tier
+	// to preview; BuildModule expands the id to the real [SM, CM, Descent,
+	// Ascent] stages (the numbers here are the SM's, for any sum-less
+	// reader). Glyph is the SM/CSM marker since the SM is the firing core.
+	StageModuleApolloCSMLMID: {
+		ID: StageModuleApolloCSMLMID, Name: "CSM+LM", Glyph: "◉", Color: "#C0C0FF",
+		Tier: "payload", dry: 6000, fuel: 16000, thrust: 91000, isp: 314, bc: 0,
+		// Sprite fields mirror the SM (the firing core). BuildModule
+		// intercepts this id and expands it to real [SM, CM, Descent,
+		// Ascent] stages, so the single-stage form is never rendered — but
+		// the catalog-shape invariant wants every pick buildable with a
+		// sprite, matching the "lander" meta-module precedent.
+		launchSpriteRowsPx:  6,
+		launchSpriteWidthPx: 2,
+		launchSpriteColor:   "#C8C8D0",
+		fuelType:            FuelTypeHypergolic,
+	},
 	// Re-entry capsule (v0.12 Slice 3, ADR 0008): a minimal command-
 	// module-class stage carrying a parachute and NO engine landing
 	// capability — the clean, directly-spawnable test vehicle for the
@@ -332,6 +357,11 @@ var StageCatalogOrder = []string{
 	// "Lander" loadout. The descent/ascent are NOT separate picker entries.
 	StageModuleLanderID,
 	StageModuleCSMID,
+	// The "csm-lm" pick is a composite: BuildModule expands it to
+	// [SM, CM, Descent, Ascent] and ModuleNosePayloadTop marks the top 2
+	// (the LM) as a docked nose payload, so spawning it lands the
+	// post-transposition Apollo composite already assembled (ADR 0011).
+	StageModuleApolloCSMLMID,
 	StageModuleRCSTugID,
 }
 
@@ -390,9 +420,38 @@ func BuildModule(id string) ([]Stage, bool) {
 		}
 		return []Stage{d, a}, true
 	}
+	if id == StageModuleApolloCSMLMID {
+		// v0.14 / ADR 0011: the post-transposition Apollo composite as one
+		// pick — the [SM, CM] core (SM firing the SPS) with the [Descent,
+		// Ascent] LM stacked on top. ModuleNosePayloadTop reports the top 2
+		// so the spawn path docks the LM as a nose payload rather than
+		// stacking it linearly.
+		sm, okSM := BuildStage(StageModuleServiceModuleID)
+		cm, okCM := BuildStage(StageModuleCommandModuleID)
+		d, okD := BuildStage(StageModuleLanderDescentID)
+		a, okA := BuildStage(StageModuleLanderAscentID)
+		if !okSM || !okCM || !okD || !okA {
+			return nil, false
+		}
+		return []Stage{sm, cm, d, a}, true
+	}
 	st, ok := BuildStage(id)
 	if !ok {
 		return nil, false
 	}
 	return []Stage{st}, true
+}
+
+// ModuleNosePayloadTop reports how many of the TOP stages that
+// BuildModule(id) produces form a docked nose payload — released by
+// Undock, not Staging (the top-release counterpart to a Loadout's
+// bottom-up DecouplePlan; ADR 0011). Non-composite modules return 0, so
+// the configurator stacks them linearly. The "csm-lm" composite returns
+// 2 (the LM = Descent + Ascent rides on the [SM, CM] core's nose).
+// v0.14.
+func ModuleNosePayloadTop(id string) int {
+	if id == StageModuleApolloCSMLMID {
+		return 2
+	}
+	return 0
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -426,6 +426,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				spec := sim.SpawnSpec{
 					LoadoutID:       a.spawn.SelectedLoadoutID(),
 					CustomStages:    a.spawn.SelectedCustomStages(),
+					NosePayloadPlan: a.spawn.SelectedNosePayloadPlan(),
 					ParentBodyID:    a.spawn.SelectedParentID(),
 					AltitudeM:       a.spawn.SelectedAltitudeM(),
 					Retrograde:      a.spawn.SelectedRetrograde(),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -70,7 +70,7 @@ func (h *Help) Render() string {
 			{";", "NavMode cycle: Orbit → Surface → Target (skips Target when none set) (v0.9.3+)"},
 		}},
 		{"MULTI-CRAFT (v0.8.1+)", [][2]string{
-			{"n", "open spawn form (loadout / position / parent / altitude / dir; Custom = stack builder, v0.10.1+)"},
+			{"n", "open spawn form (loadout / position / parent / altitude / dir; Custom = stack builder, [d] dock-seam composites — spawn a CSM+LM ready to U-release, v0.14+)"},
 			{"[ / ]", "cycle active craft (no-op when only one craft)"},
 			{"1-9", "jump to craft N (no-op when slot empty) (v0.12.0+)"},
 			{"U", "undock active composite (v0.8.3+)"},

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -34,6 +34,14 @@ type SpawnCraft struct {
 	// catalog part-picker cursor over StageCatalogOrder.
 	customStages []spacecraft.Stage
 	partIdx      int
+
+	// nosePayloadCount (v0.14 / ADR 0011) is the Dock Seam: how many
+	// contiguous TOP stages of customStages form a docked nose payload
+	// (released by Undock, not Staging) rather than linear firing-core
+	// stages. 0 ⇒ a plain linear craft (the historical default). [d]
+	// cycles it; adding the composite "CSM+LM" pick pre-sets it to the
+	// LM's stage count. Clamped to [0, len-1] so the core keeps ≥1 stage.
+	nosePayloadCount int
 }
 
 // stackFieldIdx is the form-field index of the STACK editor — only
@@ -95,6 +103,7 @@ func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID 
 	s.loadoutIdx = 0
 	s.customStages = nil
 	s.partIdx = 0
+	s.nosePayloadCount = 0
 	s.posMode = posOrbit
 	s.altIdx = 1 // 500 km — matches the v0.8.1 sister-spawn default
 	s.latIdx = 1 // 28.6° KSC — matches the v0.9.2 launchpad default
@@ -265,6 +274,14 @@ func (s *SpawnCraft) HandleKey(key string) SpawnAction {
 			if id := s.pickedPartID(); id != "" {
 				if stages, ok := spacecraft.BuildModule(id); ok {
 					s.customStages = append(s.customStages, stages...)
+					// v0.14 / ADR 0011: a composite pick (CSM+LM) marks its
+					// own top stages as the docked nose payload, so the
+					// player gets the assembled composite without setting
+					// the seam by hand. Clamped below.
+					if top := spacecraft.ModuleNosePayloadTop(id); top > 0 {
+						s.nosePayloadCount = top
+					}
+					s.clampNosePayload()
 				}
 			}
 		}
@@ -272,9 +289,47 @@ func (s *SpawnCraft) HandleKey(key string) SpawnAction {
 		// Remove the top (last-added) stage.
 		if s.fieldIdx == stackFieldIdx && s.IsCustomSelected() && len(s.customStages) > 0 {
 			s.customStages = s.customStages[:len(s.customStages)-1]
+			s.clampNosePayload()
+		}
+	case "d":
+		// v0.14 / ADR 0011: cycle the Dock Seam — how many TOP stages form
+		// the docked nose payload. Walks 0 (linear) → 1 → … → len-1 → 0,
+		// keeping the core at ≥1 stage.
+		if s.fieldIdx == stackFieldIdx && s.IsCustomSelected() && len(s.customStages) > 1 {
+			s.nosePayloadCount = (s.nosePayloadCount + 1) % len(s.customStages)
 		}
 	}
 	return SpawnActionNone
+}
+
+// clampNosePayload keeps the Dock Seam in range after the stack changes:
+// the nose payload may take at most len-1 stages (the core keeps ≥1), and
+// an empty/1-stage stack can't have a seam. v0.14 / ADR 0011.
+func (s *SpawnCraft) clampNosePayload() {
+	if len(s.customStages) < 2 {
+		s.nosePayloadCount = 0
+		return
+	}
+	if s.nosePayloadCount > len(s.customStages)-1 {
+		s.nosePayloadCount = len(s.customStages) - 1
+	}
+	if s.nosePayloadCount < 0 {
+		s.nosePayloadCount = 0
+	}
+}
+
+// SelectedNosePayloadPlan returns the Dock Seam as a top-release group
+// list for SpawnSpec.NosePayloadPlan (ADR 0011), or nil when no seam is
+// set / Custom isn't selected — i.e. a plain linear custom craft. The
+// single-entry list mirrors a Loadout's bottom-up DecouplePlan. v0.14.
+func (s *SpawnCraft) SelectedNosePayloadPlan() []int {
+	if !s.IsCustomSelected() || s.nosePayloadCount <= 0 {
+		return nil
+	}
+	if s.nosePayloadCount >= len(s.customStages) {
+		return nil // would leave the core empty — treat as linear
+	}
+	return []int{s.nosePayloadCount}
 }
 
 // pickedPartID returns the catalog ID under the part-picker cursor.
@@ -379,12 +434,27 @@ func (s *SpawnCraft) Render(width int) string {
 		if len(s.customStages) == 0 {
 			lines = append(lines, "  "+s.theme.Dim.Render("(empty — pick a part below and press [a] to add)"))
 		} else {
+			// v0.14 / ADR 0011: the Dock Seam splits the stack into the
+			// linear firing core (bottom) and the docked nose payload (top
+			// nosePayloadCount stages). seam == len means no seam (linear).
+			seam := len(s.customStages) - s.nosePayloadCount
 			for i := len(s.customStages) - 1; i >= 0; i-- {
+				if s.nosePayloadCount > 0 && i == seam-1 {
+					lines = append(lines, "  "+s.theme.Warning.Render(
+						"── dock seam ──  (above = nose payload, [U]ndock to release)"))
+				}
 				st := s.customStages[i]
-				tag := "top/core"
-				if i == 0 {
+				var tag string
+				switch {
+				case s.nosePayloadCount > 0 && i >= seam:
+					tag = "nose payload"
+				case i == 0:
 					tag = "bottom/fires first"
-				} else if i != len(s.customStages)-1 {
+				case s.nosePayloadCount > 0 && i == seam-1:
+					tag = "core survivor"
+				case i == len(s.customStages)-1:
+					tag = "top/core"
+				default:
 					tag = "mid"
 				}
 				eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
@@ -418,7 +488,7 @@ func (s *SpawnCraft) Render(width int) string {
 			lines = append(lines, "  "+s.fieldValue(stackFieldIdx, "part: "+pickLabel))
 		}
 		lines = append(lines, "  "+s.theme.Footer.Render(
-			"[←/→] pick part  [a] add on top  [x] remove top"))
+			"[←/→] pick part  [a] add on top  [x] remove top  [d] dock seam"))
 	}
 
 	// Field 1: position mode — tri-state cycle. orbit (uses PARENT

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -157,6 +157,82 @@ func TestSpawnStackAddRemove(t *testing.T) {
 	}
 }
 
+// pickPart cycles the part-picker to the given catalog id (STACK field
+// must be focused). Bounded so a missing id can't loop forever.
+func pickPart(s *SpawnCraft, id string) {
+	for i := 0; i < len(spacecraft.StageCatalogOrder)+1; i++ {
+		if s.pickedPartID() == id {
+			return
+		}
+		s.HandleKey("right")
+	}
+}
+
+// TestSpawnDockSeamFromCSMLMModule — v0.14 / ADR 0011. Adding the
+// composite "CSM+LM" pick drops the four Apollo stages AND pre-sets the
+// Dock Seam, so SelectedNosePayloadPlan reports the LM (top 2) as a nose
+// payload without the player marking it by hand.
+func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+	selectCustom(s)
+	s.fieldIdx = stackFieldIdx
+
+	pickPart(s, spacecraft.StageModuleApolloCSMLMID)
+	s.HandleKey("a")
+
+	if got := len(s.SelectedCustomStages()); got != 4 {
+		t.Fatalf("CSM+LM pick added %d stages, want 4", got)
+	}
+	plan := s.SelectedNosePayloadPlan()
+	if len(plan) != 1 || plan[0] != 2 {
+		t.Errorf("SelectedNosePayloadPlan = %v, want [2] (the LM as nose payload)", plan)
+	}
+	if !strings.Contains(s.Render(80), "dock seam") {
+		t.Error("rendered stack does not show the dock seam divider")
+	}
+}
+
+// TestSpawnDockSeamCycleAndClamp — [d] cycles the Dock Seam over a
+// general custom stack, and removing stages clamps it so the core keeps
+// at least one stage. v0.14 / ADR 0011.
+func TestSpawnDockSeamCycleAndClamp(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "")
+	selectCustom(s)
+	s.fieldIdx = stackFieldIdx
+
+	// Two single-stage parts → no seam yet.
+	first := s.pickedPartID()
+	s.HandleKey("a")
+	s.HandleKey("right")
+	if s.pickedPartID() == first {
+		t.Fatal("part picker did not advance")
+	}
+	s.HandleKey("a")
+	if s.SelectedNosePayloadPlan() != nil {
+		t.Errorf("fresh 2-stack has a seam %v, want none", s.SelectedNosePayloadPlan())
+	}
+
+	// [d] marks the top stage as a nose payload; again wraps back to none.
+	s.HandleKey("d")
+	if plan := s.SelectedNosePayloadPlan(); len(plan) != 1 || plan[0] != 1 {
+		t.Errorf("after one [d]: plan = %v, want [1]", plan)
+	}
+	s.HandleKey("d")
+	if s.SelectedNosePayloadPlan() != nil {
+		t.Errorf("after wrap [d]: plan = %v, want none", s.SelectedNosePayloadPlan())
+	}
+
+	// Set the seam to 1, then remove a stage so only 1 remains — the seam
+	// must clamp to 0 (a 1-stage stack can't have a nose payload).
+	s.HandleKey("d") // seam = 1 (of 2)
+	s.HandleKey("x") // remove top → 1 stage left
+	if s.SelectedNosePayloadPlan() != nil {
+		t.Errorf("seam survived shrinking to a 1-stage stack: %v", s.SelectedNosePayloadPlan())
+	}
+}
+
 // TestSpawnRenderShowsStackEditor — the STACK block appears only
 // for Custom and reflects added parts.
 func TestSpawnRenderShowsStackEditor(t *testing.T) {


### PR DESCRIPTION
## What

Adds spawn-time **docked composites** so a custom CSM+LM build spawns in the correct post-transposition shape — SM as the firing core, LM as an Undock-able nose payload — instead of as a linear single-pop stack that splits the LM's Descent/Ascent in orbit. Implements ADR 0011.

## Why

A custom CSM+LM build spawned as a linear single-pop craft, so staging split the LM's Descent/Ascent stages in orbit rather than letting it descend as a unit and surface-stage. The Apollo arc is a *docking composite* (CSM fires; LM is an Undock-able nose payload), which a linear stack can't represent.

## How

- `SpawnSpec.NosePayloadPlan []int` marks a contiguous **top** group as a docked nose payload — the top-release counterpart to the bottom-up `DecouplePlan`. `newCustomCraft` splits the stack at the seam and reuses `dockedComponentFromStages` (the helper `Transpose` uses) to assemble a ready composite. Malformed seam falls back to linear.
- No schema bump — a spawned composite is an ordinary `DockedComponents` craft that already persists.
- Configurator: `[d]` cycles the **Dock Seam** in the STACK editor; a `csm-lm` composite pick drops the LM pre-seamed (`ModuleNosePayloadTop=2`) for one-pick lunar-ops repeat testing.

## Docs

- `CONTEXT.md` gains "Nose Payload Plan" / "Dock Seam".
- ADR 0011 records the decision.

## Tests

Composite assembly + Undock round-trip + linear control + malformed-seam fallback (sim); csm-lm module shape (spacecraft); seam cycle/clamp + module pre-set (screens). Full suite: 923 pass, `go vet` clean, `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
