### PR TITLE
fix(launch): orbit ellipse rendered only an apo marker, not a dotted line

### DIFF
--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -605,7 +605,8 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	}
 	canvasReach := v.canvas.Cols()*2 + v.canvas.Rows()*4
 	primaryPxR := BodyPixelRadius(craft.Primary, false, scale, canvasReach)
-	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, 360, 3, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
+	samples := launchOrbitSamples(el.Apoapsis() * scale)
+	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, samples, 3, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
 	peri := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, 0))
 	apo := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 	if !v.canvas.IsBehindBody(peri, bodyCentre, primaryPxR) {
@@ -614,6 +615,36 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	if !v.canvas.IsBehindBody(apo, bodyCentre, primaryPxR) {
 		v.canvas.FillDisk(apo, 3)
 	}
+}
+
+// launchOrbitSamples returns how many true-anomaly samples to walk when
+// drawing the current-orbit ellipse in the chase-cam scene. The orbit
+// map screens use a fixed 360 because the whole ellipse is on-canvas;
+// the launch / landing view centres on the craft and magnifies only a
+// few degrees of the orbit, so 360 samples scatter at most a handful of
+// dots onto the visible arc (an empirical 5 cells for a 200 km LEO) —
+// the orbit reads as just the apoapsis marker, not a line. Scale the
+// count to the projected orbit circumference (≈ 2π·apoapsisPx) at a
+// sub-pixel target spacing so the visible arc fills in, clamped to
+// [360, maxLaunchOrbitSamples] so a tiny orbit still gets the map's
+// density and a huge (off-canvas-apoapsis) transfer ellipse can't blow
+// up the per-frame sample loop. apoapsisPx is the apoapsis radius in
+// canvas pixels (el.Apoapsis() · canvas.Scale()).
+func launchOrbitSamples(apoapsisPx float64) int {
+	const (
+		arcSpacingPx          = 0.6 // sub-pixel: fully populate the visible arc
+		maxLaunchOrbitSamples = 8000
+	)
+	samples := 360
+	if apoapsisPx > 0 {
+		if n := int(2 * math.Pi * apoapsisPx / arcSpacingPx); n > samples {
+			samples = n
+		}
+	}
+	if samples > maxLaunchOrbitSamples {
+		samples = maxLaunchOrbitSamples
+	}
+	return samples
 }
 
 // drawPadMarker plots the launch site as a `+` glyph in ColorAccent

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -651,3 +651,53 @@ func TestLaunchViewLandedOrbitNotDrawn(t *testing.T) {
 		t.Error("landed-craft scene changed with orbit shape; orbit drawn despite Landed (phantom arc)")
 	}
 }
+
+// launchOrbitSamples must scale the ellipse sample count up for the
+// magnified chase-cam view. The orbit map's fixed 360 leaves only ~5
+// dots on the visible arc of a low orbit (the orbit reads as just the
+// apoapsis marker); the count must grow with the projected orbit size
+// so the visible arc fills in, while clamping at both ends.
+func TestLaunchOrbitSamplesScalesWithProjectedSize(t *testing.T) {
+	// A tiny projected orbit keeps the map's baseline density.
+	if got := launchOrbitSamples(10); got != 360 {
+		t.Errorf("tiny orbit: got %d samples, want 360 baseline", got)
+	}
+	// A 200 km LEO at launch zoom projects apoapsis to ~790 px; the
+	// shipped 360 produced ~5 on-canvas cells. The count must be far
+	// higher so the arc reads as a line.
+	if got := launchOrbitSamples(790); got <= 360 {
+		t.Errorf("LEO apoapsis 790px: got %d samples, want >> 360", got)
+	}
+	// A huge (off-canvas-apoapsis) transfer ellipse must clamp so the
+	// per-frame sample loop can't blow up.
+	if got := launchOrbitSamples(5e5); got != 8000 {
+		t.Errorf("transfer apoapsis 500k px: got %d samples, want 8000 cap", got)
+	}
+	// Monotonic non-decreasing in projected size.
+	if launchOrbitSamples(2000) < launchOrbitSamples(790) {
+		t.Error("sample count should not decrease as projected orbit grows")
+	}
+}
+
+// End-to-end: the magnified chase-cam must paint a current-orbit ellipse
+// that reads as a dotted line, not just the apo/peri markers. Render a
+// low circular orbit (nil hud to isolate the canvas) and confirm the
+// orbit colour lands on many distinct cells — far more than the marker
+// discs alone (a FillDisk-2 + FillDisk-3 cover only a handful of cells).
+func TestLaunchViewOrbitRendersAsLine(t *testing.T) {
+	w, c := spawnSaturnVOnPad(t)
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 200_000.0 // 200 km LEO
+	c.Landed = false
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	th := launchThemeForTest()
+	v := NewLaunchView(th, nil)
+	v.Render(w, 120, 40)
+
+	cells := v.canvas.CountColor(render.ColorCurrentOrbit)
+	if cells < 40 {
+		t.Errorf("orbit rendered on only %d cells; expected a dotted line (>=40), not just the apsis markers", cells)
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -1040,6 +1040,31 @@ func (c *Canvas) String() string {
 	return b.String()
 }
 
+// CountColor reports how many terminal cells resolve to `color` as their
+// dominant per-cell colour — the same majority rule String() uses to
+// paint each cell. Intended for render assertions (e.g. "the orbit
+// ellipse lands on enough cells to read as a line, not just a marker").
+func (c *Canvas) CountColor(color lipgloss.Color) int {
+	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
+	for coord, tag := range c.pixelTags {
+		if tag.Color == "" {
+			continue
+		}
+		key := [2]int{coord[0] / 2, coord[1] / 4}
+		if cellCounts[key] == nil {
+			cellCounts[key] = make(map[lipgloss.Color]int)
+		}
+		cellCounts[key][tag.Color]++
+	}
+	n := 0
+	for _, counts := range cellCounts {
+		if pickDominantColor(counts) == color {
+			n++
+		}
+	}
+	return n
+}
+
 // joinRows is the uncolored fast path used when no color regions are
 // registered.
 func (c *Canvas) joinRows(rows []string) string {


### PR DESCRIPTION
## Symptom

In the ground launch / landing chase-cam, the current-orbit ellipse (shipped in v0.14.1) showed **only the apoapsis marker** — no dotted orbit line.

## Root cause

`drawOrbitPath` reused the orbit map's fixed **360** true-anomaly samples. The orbit map renders the whole ellipse on-canvas, but the launch/landing view centres on the craft and magnifies only a few degrees of the orbit. With 360 samples spread around the *full* ellipse, only ~5 dots land on the tiny visible arc — swamped by the apoapsis `FillDisk` marker. Measured directly: a 200 km LEO produced **5 on-canvas orbit cells** at 360 samples, saturating near 120 at ~8000.

## Fix

`launchOrbitSamples(apoapsisPx)` scales the sample count to the projected orbit circumference (~`2π·apoapsisPx` at sub-pixel spacing), clamped to `[360, 8000]`:

- 200 km LEO: on-canvas orbit cells **5 → 94** — a proper dotted line.
- Tiny orbits keep the map's 360 baseline.
- A huge (off-canvas-apoapsis) transfer ellipse clamps at 8000 so the per-frame sample loop can't blow up (the craft sits near periapsis, which true-anomaly sampling already densifies).

Far-side dashing + body occlusion + the `Landed` gate are unchanged.

## Tests

- `TestLaunchOrbitSamplesScalesWithProjectedSize` — pins the scaling + both clamps + monotonicity.
- `TestLaunchViewOrbitRendersAsLine` — end-to-end render asserts the orbit colour lands on ≥40 cells (a line), not just the marker discs.
- Adds `Canvas.CountColor` (dominant-per-cell colour count) for the render assertion.

`go vet ./...` clean; `go test ./...` → all 13 packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)