### PR TITLE
Add boss key fake shell (backtick to hide the game)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -29,6 +29,7 @@ const (
 	screenMissions
 	screenSpawn    // v0.8.2+: craft-type pick form on `n`.
 	screenSettings // v0.13 slice 3: per-Chip visibility toggles, reached from the menu.
+	screenBoss     // boss key: full-screen fake developer shell (backtick from any screen).
 )
 
 // App is the root tea.Model. It owns the world, theme, keymap, and which
@@ -58,6 +59,14 @@ type App struct {
 	// edits write through to orbitView's settings.Settings and persist to
 	// settings.json immediately (see toggleChip).
 	settingsScreen *screens.SettingsScreen
+
+	// boss is the backtick "boss key" fake shell. bossReturnScreen records
+	// the screen that was active when it opened, and bossPrevPaused records
+	// the sim pause state at that moment; exit restores both so the player
+	// lands back exactly where they left, with the clock as it was.
+	boss             *screens.BossShell
+	bossReturnScreen screenID
+	bossPrevPaused   bool
 
 	// statusMsg flashes a one-line notice in the HUD footer for ~3
 	// seconds after save / load. Cleared by clearStatusAfter via a
@@ -116,6 +125,7 @@ func New() (*App, error) {
 		spawn:      screens.NewSpawnCraft(sth),
 
 		settingsScreen: screens.NewSettingsScreen(sth),
+		boss:           screens.NewBossShell(sth),
 	}, nil
 }
 
@@ -375,6 +385,29 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if key.Matches(m, a.keys.Quit) {
 			a.autosave()
 			return a, tea.Quit
+		}
+		// Boss key: a single global keypress (backtick) swaps the whole
+		// screen to a fake developer shell, and swaps back on
+		// exit/logout/ctrl+d. This block sits ABOVE every per-screen block
+		// and above endFlightConfirm so it fires from ANY screen and so the
+		// shell's own keystrokes never leak into game handlers — while the
+		// shell is active we return early for EVERY key. Checking
+		// screenBoss first also means a backtick typed inside the shell is
+		// consumed as text by HandleKey rather than re-triggering the open.
+		if a.active == screenBoss {
+			if a.boss.HandleKey(m.String()) == screens.BossActionExit {
+				a.active = a.bossReturnScreen
+				a.world.Clock.Paused = a.bossPrevPaused
+			}
+			return a, nil
+		}
+		if key.Matches(m, a.keys.BossKey) {
+			a.bossReturnScreen = a.active
+			a.bossPrevPaused = a.world.Clock.Paused
+			a.world.Clock.Paused = true // freeze the sim while "away"
+			a.boss.Reset()              // fresh lived-in session each open
+			a.active = screenBoss
+			return a, nil
 		}
 		// v0.11.4+ (ADR 0004): end-flight y/n confirm intercept. When
 		// the [E] prompt is open, y/Y commits the removal and n/N/Esc
@@ -1137,6 +1170,8 @@ func (a *App) View() string {
 		base = a.missions.Render(a.world, a.width)
 	case screenSettings:
 		base = a.settingsScreen.Render(a.orbitView.Settings(), a.width)
+	case screenBoss:
+		base = a.boss.Render(a.width, a.height)
 	default:
 		if a.world.ViewMode == sim.ViewLaunch {
 			base = a.launchView.Render(a.world, a.width, a.height)

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -192,6 +192,14 @@ type Keymap struct {
 	// clean orbit map. F2 matches the KSP "toggle UI" convention.
 	// Transient and unsaved; never hides the slim HUD column.
 	Declutter key.Binding
+
+	// BossKey: a single global keypress that swaps the whole screen to a
+	// fake developer shell and back. Backtick is chosen because it is a
+	// fast key right under Esc that the game does not otherwise use; while
+	// the shell is active it is consumed as shell text rather than a
+	// trigger, so being printable causes no collision. Deliberately NOT
+	// advertised in the help overlay (an empty WithHelp description).
+	BossKey key.Binding
 }
 
 func DefaultKeymap() Keymap {
@@ -265,5 +273,6 @@ func DefaultKeymap() Keymap {
 		EndFlight:                 key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "end flight (Crashed vessel)")),
 		JumpToLaunchView:          key.NewBinding(key.WithKeys("V"), key.WithHelp("V", "jump to launch view (active vessel)")),
 		Declutter:                 key.NewBinding(key.WithKeys("f2"), key.WithHelp("F2", "declutter (hide overlays)")),
+		BossKey:                   key.NewBinding(key.WithKeys("`"), key.WithHelp("`", "")),
 	}
 }

--- a/internal/tui/screens/bosskey.go
+++ b/internal/tui/screens/bosskey.go
@@ -1,0 +1,337 @@
+package screens
+
+import (
+	"strings"
+)
+
+// BossShell is the "boss key" fake terminal. A single global keypress
+// (the backtick — see app.go screenBoss) swaps the whole screen to this
+// convincing developer shell, and swaps back on exit/logout/ctrl+d. It is
+// deliberately NOT space-game themed: it should read as a plain login
+// shell so a passer-by sees "real work."
+//
+// The screen owns a one-line input buffer plus a scrollback of already-
+// rendered output rows. Typing + Enter runs a canned fake command and
+// appends its output. exit / logout / ctrl+d ask the App (via the returned
+// BossAction) to restore the previous screen.
+type BossShell struct {
+	theme  Theme
+	prompt string   // e.g. "user@workstation:~/projects/acme-api$ "
+	input  string   // current (unsubmitted) command line
+	scroll []string // rendered scrollback, one terminal row per entry
+}
+
+// BossAction is the outcome of a keypress, consumed by the App.
+type BossAction int
+
+const (
+	BossActionNone BossAction = iota // stay in the shell
+	BossActionExit                   // exit/logout/ctrl+d — return to the game
+)
+
+const bossPrompt = "user@workstation:~/projects/acme-api$ "
+
+func NewBossShell(th Theme) *BossShell {
+	b := &BossShell{theme: th, prompt: bossPrompt}
+	b.Reset()
+	return b
+}
+
+// Reset restores the "lived-in" initial scrollback and clears the input
+// line. The App calls it each time the boss key opens the screen so it
+// always looks freshly attached rather than showing the previous session's
+// typed history (or a stale `clear`).
+func (b *BossShell) Reset() {
+	b.input = ""
+	b.scroll = initialBossScrollback()
+}
+
+// initialBossScrollback seeds the screen so it looks like an existing
+// session, not a cold boot: a last-login line plus a couple of already-run
+// commands with their output.
+func initialBossScrollback() []string {
+	return []string{
+		"Last login: Mon Jun  1 09:14:07 2026 from 10.0.0.42",
+		bossPrompt + "git pull",
+		"Already up to date.",
+		bossPrompt + "npm run build",
+		"",
+		"> acme-api@2.4.1 build",
+		"> tsc -p tsconfig.json",
+		"",
+		"Compiled successfully in 4.21s.",
+	}
+}
+
+// HandleKey accumulates the typed line and runs canned commands on Enter.
+// Returns BossActionExit when the player types exit/logout or presses
+// ctrl+d; every other key returns BossActionNone. The key strings match
+// bubbletea's m.String() ("enter", "backspace", "ctrl+d", " " for space,
+// single runes for typed characters).
+func (b *BossShell) HandleKey(key string) BossAction {
+	switch key {
+	case "ctrl+d":
+		// Empty-line ctrl+d is the classic shell logout. We treat it as
+		// logout regardless of buffer contents (simpler, still believable).
+		return BossActionExit
+	case "enter":
+		return b.submit()
+	case "backspace":
+		if r := []rune(b.input); len(r) > 0 {
+			// Trim one UTF-8 rune, not one byte, so multibyte input
+			// doesn't corrupt the line.
+			b.input = string(r[:len(r)-1])
+		}
+		return BossActionNone
+	case " ":
+		b.input += " "
+		return BossActionNone
+	default:
+		// Only append genuine single-character text input. Named keys
+		// ("up", "tab", "ctrl+x", "f1"...) are ignored so they can't
+		// pollute the command line.
+		if isSingleRune(key) {
+			b.input += key
+		}
+		return BossActionNone
+	}
+}
+
+// isSingleRune reports whether s is exactly one rune. Used to distinguish
+// a typed character from a named key like "tab" or "ctrl+x".
+func isSingleRune(s string) bool {
+	n := 0
+	for range s {
+		n++
+		if n > 1 {
+			return false
+		}
+	}
+	return n == 1
+}
+
+// submit echoes the prompt+line into scrollback, runs the canned command,
+// appends its output, and clears the input line. Returns BossActionExit
+// for exit/logout.
+func (b *BossShell) submit() BossAction {
+	line := b.input
+	b.input = ""
+	// Echo the entered command as a terminal would.
+	b.scroll = append(b.scroll, b.prompt+line)
+
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return BossActionNone // bare Enter just adds a fresh prompt row
+	}
+	cmd := fields[0]
+
+	switch cmd {
+	case "exit", "logout":
+		b.scroll = append(b.scroll, "logout")
+		return BossActionExit
+	case "clear":
+		b.scroll = nil // wipe scrollback like a real `clear`
+		return BossActionNone
+	}
+
+	out, ok := bossCommandOutput(cmd, fields)
+	if !ok {
+		b.scroll = append(b.scroll, cmd+": command not found")
+		return BossActionNone
+	}
+	b.scroll = append(b.scroll, out...)
+	return BossActionNone
+}
+
+// bossCommandOutput returns the canned output rows for a recognized command
+// (keyed on argv[0]) and ok=false for an unknown command so the caller can
+// print the shell's "command not found". Output is fully static — no real
+// filesystem or process access — so it is safe, deterministic, and
+// testable. `clear`, `exit`, and `logout` are handled by the caller (they
+// mutate scrollback / signal exit) and are not here.
+func bossCommandOutput(cmd string, argv []string) ([]string, bool) {
+	switch cmd {
+	case "ls":
+		return []string{
+			"Dockerfile        README.md       node_modules  package.json",
+			"docs              jest.config.js  src           tsconfig.json",
+		}, true
+	case "pwd":
+		return []string{"/home/user/projects/acme-api"}, true
+	case "whoami":
+		return []string{"user"}, true
+	case "echo":
+		// Echo back the args (drop argv[0]).
+		return []string{strings.Join(argv[1:], " ")}, true
+	case "cat":
+		// Canned content regardless of the requested file — believable for
+		// a quick peek and avoids any real file access.
+		return []string{
+			"{",
+			`  "name": "acme-api",`,
+			`  "version": "2.4.1",`,
+			`  "private": true,`,
+			`  "scripts": {`,
+			`    "build": "tsc -p tsconfig.json",`,
+			`    "test": "jest",`,
+			`    "start": "node dist/index.js"`,
+			"  }",
+			"}",
+		}, true
+	case "git":
+		return bossGit(argv), true
+	case "npm":
+		return bossNpm(argv), true
+	case "make":
+		return []string{
+			"go build -o bin/acme-api ./cmd/server",
+			"go vet ./...",
+			"build complete: bin/acme-api",
+		}, true
+	case "ps":
+		return []string{
+			"  PID TTY          TIME CMD",
+			" 2114 pts/0    00:00:00 bash",
+			" 4582 pts/0    00:00:03 node",
+			" 4733 pts/0    00:00:00 ps",
+		}, true
+	case "top", "htop":
+		return []string{
+			"top - 09:21:44 up 3 days,  2:11,  1 user,  load average: 0.42, 0.51, 0.55",
+			"Tasks: 213 total,   1 running, 212 sleeping",
+			"%Cpu(s):  4.7 us,  1.2 sy,  0.0 ni, 93.6 id",
+			"MiB Mem :  16003.1 total,   2841.0 free,   6120.4 used",
+			"",
+			"  PID USER      PR  NI    VIRT    RES   %CPU  %MEM  COMMAND",
+			" 4582 user      20   0  982140 142880    3.7   0.9  node",
+			" 1190 user      20   0  712044  88112    0.7   0.5  tmux",
+		}, true
+	case "help":
+		return []string{
+			"GNU bash, version 5.2.21",
+			"These shell commands are defined internally.  Type `help name'.",
+			" cd        exit      jobs      pwd       umask",
+			" echo      export    kill      read      unset",
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+// bossGit returns canned output for the `git` subcommands the fake shell
+// recognizes; anything unrecognized falls through to a clean-tree status.
+func bossGit(argv []string) []string {
+	sub := ""
+	if len(argv) > 1 {
+		sub = argv[1]
+	}
+	switch sub {
+	case "status", "":
+		return []string{
+			"On branch feature/rate-limiter",
+			"Your branch is up to date with 'origin/feature/rate-limiter'.",
+			"",
+			"Changes not staged for commit:",
+			`  (use "git add <file>..." to update what will be committed)`,
+			"\tmodified:   src/middleware/rateLimit.ts",
+			"\tmodified:   src/server.ts",
+			"",
+			"Untracked files:",
+			"\tsrc/middleware/rateLimit.test.ts",
+			"",
+			`no changes added to commit (use "git add" and/or "git commit -a")`,
+		}
+	case "log":
+		return []string{
+			"commit 9f3a1c2  (HEAD -> feature/rate-limiter)",
+			"Author: user <user@workstation>",
+			"Date:   Mon Jun 1 09:02:11 2026 +0000",
+			"",
+			"    Add token-bucket rate limiter middleware",
+			"",
+			"commit 4b71e08",
+			"Author: user <user@workstation>",
+			"Date:   Fri May 29 17:48:30 2026 +0000",
+			"",
+			"    Wire request-id into structured logs",
+		}
+	default:
+		return []string{
+			"On branch feature/rate-limiter",
+			"nothing to commit, working tree clean",
+		}
+	}
+}
+
+// bossNpm returns canned output for the `npm` subcommands the fake shell
+// recognizes.
+func bossNpm(argv []string) []string {
+	sub := ""
+	if len(argv) > 1 {
+		sub = argv[1]
+	}
+	switch sub {
+	case "test":
+		return []string{
+			"> acme-api@2.4.1 test",
+			"> jest",
+			"",
+			"PASS  src/middleware/rateLimit.test.ts",
+			"PASS  src/server.test.ts",
+			"",
+			"Test Suites: 2 passed, 2 total",
+			"Tests:       18 passed, 18 total",
+			"Snapshots:   0 total",
+			"Time:        3.114 s",
+			"Ran all test suites.",
+		}
+	case "run", "build":
+		return []string{
+			"> acme-api@2.4.1 build",
+			"> tsc -p tsconfig.json",
+			"",
+			"Compiled successfully.",
+		}
+	case "install", "i", "ci":
+		return []string{
+			"added 1 package, and audited 642 packages in 1s",
+			"found 0 vulnerabilities",
+		}
+	default:
+		return []string{"npm <command> -- see `npm help`"}
+	}
+}
+
+// Render draws the fake terminal sized to width x height. The current input
+// line gets a block cursor; the whole buffer is bottom-anchored and clipped
+// to the last `height` rows so a long session scrolls like a real terminal.
+// Short buffers are top-padded so the frame fully covers the game screen
+// underneath. Rows are per-rune truncated to width so output never wraps and
+// breaks the illusion of a fixed-width terminal.
+func (b *BossShell) Render(width, height int) string {
+	if height < 1 {
+		height = 1
+	}
+	lines := make([]string, 0, len(b.scroll)+1)
+	lines = append(lines, b.scroll...)
+	lines = append(lines, b.prompt+b.input+"█")
+
+	// Clip to the last `height` rows (terminal-style scroll).
+	if len(lines) > height {
+		lines = lines[len(lines)-height:]
+	}
+	// Truncate each row to width so long output never wraps.
+	if width > 0 {
+		for i, ln := range lines {
+			if r := []rune(ln); len(r) > width {
+				lines[i] = string(r[:width])
+			}
+		}
+	}
+	// Top-pad so the rendered block always occupies the full height and no
+	// stale game frame shows through.
+	for len(lines) < height {
+		lines = append([]string{""}, lines...)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/tui/screens/bosskey_test.go
+++ b/internal/tui/screens/bosskey_test.go
@@ -1,0 +1,116 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+// typeLine feeds each rune of s through HandleKey as a single-rune key,
+// mirroring how bubbletea delivers typed characters.
+func typeLine(b *BossShell, s string) BossAction {
+	var last BossAction
+	for _, r := range s {
+		last = b.HandleKey(string(r))
+	}
+	return last
+}
+
+func TestBossShellTypingBuildsLine(t *testing.T) {
+	b := NewBossShell(Theme{})
+	typeLine(b, "whoami")
+	if b.input != "whoami" {
+		t.Fatalf("input = %q, want %q", b.input, "whoami")
+	}
+	if act := b.HandleKey("enter"); act != BossActionNone {
+		t.Fatalf("enter action = %v, want BossActionNone", act)
+	}
+	if b.input != "" {
+		t.Fatalf("input not cleared after enter: %q", b.input)
+	}
+	last := b.scroll[len(b.scroll)-1]
+	if last != "user" {
+		t.Fatalf("whoami output = %q, want %q", last, "user")
+	}
+}
+
+func TestBossShellBackspaceIsRuneSafe(t *testing.T) {
+	b := NewBossShell(Theme{})
+	typeLine(b, "héllo")
+	b.HandleKey("backspace")
+	if b.input != "héll" {
+		t.Fatalf("after backspace input = %q, want %q", b.input, "héll")
+	}
+}
+
+func TestBossShellNamedKeysIgnored(t *testing.T) {
+	b := NewBossShell(Theme{})
+	for _, k := range []string{"up", "tab", "ctrl+x", "f1", "left"} {
+		if act := b.HandleKey(k); act != BossActionNone {
+			t.Fatalf("key %q action = %v, want BossActionNone", k, act)
+		}
+	}
+	if b.input != "" {
+		t.Fatalf("named keys polluted input: %q", b.input)
+	}
+}
+
+func TestBossShellExitVariants(t *testing.T) {
+	for _, word := range []string{"exit", "logout"} {
+		b := NewBossShell(Theme{})
+		typeLine(b, word)
+		if act := b.HandleKey("enter"); act != BossActionExit {
+			t.Fatalf("%q action = %v, want BossActionExit", word, act)
+		}
+	}
+	// ctrl+d logs out regardless of buffer contents.
+	b := NewBossShell(Theme{})
+	if act := b.HandleKey("ctrl+d"); act != BossActionExit {
+		t.Fatalf("ctrl+d action = %v, want BossActionExit", act)
+	}
+}
+
+func TestBossShellClearWipesScrollback(t *testing.T) {
+	b := NewBossShell(Theme{})
+	if len(b.scroll) == 0 {
+		t.Fatal("expected lived-in initial scrollback")
+	}
+	typeLine(b, "clear")
+	b.HandleKey("enter")
+	if len(b.scroll) != 0 {
+		t.Fatalf("clear left %d rows, want 0", len(b.scroll))
+	}
+}
+
+func TestBossShellUnknownCommand(t *testing.T) {
+	b := NewBossShell(Theme{})
+	typeLine(b, "frobnicate")
+	b.HandleKey("enter")
+	last := b.scroll[len(b.scroll)-1]
+	if last != "frobnicate: command not found" {
+		t.Fatalf("unknown cmd output = %q", last)
+	}
+}
+
+func TestBossShellResetRestoresBanner(t *testing.T) {
+	b := NewBossShell(Theme{})
+	typeLine(b, "clear")
+	b.HandleKey("enter")
+	b.Reset()
+	if len(b.scroll) == 0 {
+		t.Fatal("Reset did not restore lived-in scrollback")
+	}
+	if b.input != "" {
+		t.Fatalf("Reset did not clear input: %q", b.input)
+	}
+}
+
+func TestBossShellRenderFillsHeight(t *testing.T) {
+	b := NewBossShell(Theme{})
+	out := b.Render(80, 24)
+	if got := strings.Count(out, "\n") + 1; got != 24 {
+		t.Fatalf("render produced %d rows, want 24", got)
+	}
+	if !strings.Contains(out, "█") {
+		t.Fatal("render missing block cursor")
+	}
+}


### PR DESCRIPTION
Pressing the backtick key from any screen instantly swaps the game for a
convincing fake developer shell — a login banner, lived-in scrollback, and
canned output for ls, pwd, whoami, cat, echo, git, npm, make, ps, top, and
help. Unknown commands return "command not found"; clear wipes the buffer.

Typing exit/logout or pressing ctrl+d returns to the exact screen the player
left, restoring the prior sim-pause state (the clock is frozen while the shell
is up so the flight looks unchanged on return).

The intercept lives at the top of the key dispatcher, before all per-screen
delegation, so it fires from anywhere and the shell's keystrokes never leak
into game handlers. Not advertised in the in-game help, by design.