### PR TITLE
fix(core): numerical-robustness guards (#90)

### DIFF
--- a/internal/orbital/frame.go
+++ b/internal/orbital/frame.go
@@ -93,7 +93,11 @@ func PositionAtTrueAnomaly(el Elements, nu float64) Vec3 {
 		return Vec3{}
 	}
 	p := el.A * (1 - el.E*el.E)
-	if p == 0 {
+	// p = a(1−e²) is 0 for parabolic (e=1) and negative for hyperbolic
+	// (e>1); both are degenerate for this elliptic-only position formula
+	// and would otherwise yield a singular or negative radius. Guard
+	// `p <= 0`, matching VelocityAtTrueAnomaly below. (#90)
+	if p <= 0 {
 		return Vec3{}
 	}
 	r := p / (1 + el.E*math.Cos(nu))
@@ -269,10 +273,15 @@ func PlaneMatchInclination(target bodies.CelestialBody, primaryFrame BodyFrame) 
 // (sin Ω·sin i, −cos Ω·sin i, cos i). Returns the zero vector for a
 // body with no orbit (the system primary). v0.10.4+.
 func OrbitNormalWorld(b bodies.CelestialBody) Vec3 {
-	if b.SemimajorAxis == 0 {
+	// Guard the *computed* semimajor axis, which honors the
+	// OrbitalElements override (ElementsFromBody). Checking the
+	// top-level b.SemimajorAxis would wrongly zero the normal for a body
+	// whose orbit lives only in the override, collapsing
+	// PlaneMatchInclination to 0. (#90)
+	el := ElementsFromBody(b)
+	if el.A == 0 {
 		return Vec3{}
 	}
-	el := ElementsFromBody(b)
 	sI, cI := math.Sin(el.I), math.Cos(el.I)
 	sO, cO := math.Sin(el.Omega), math.Cos(el.Omega)
 	return Vec3{X: sO * sI, Y: -cO * sI, Z: cI}

--- a/internal/orbital/frame_test.go
+++ b/internal/orbital/frame_test.go
@@ -289,3 +289,52 @@ func TestRotatePreservesNorm(t *testing.T) {
 		t.Errorf("Rotate changed norm: |got|=%.9f |v|=%.9f (rel %.2e)", got.Norm(), v.Norm(), d)
 	}
 }
+
+// TestOrbitNormalWorldWithOrbitalElementsOverride — OrbitNormalWorld must
+// guard the *computed* semimajor axis (which honors the OrbitalElements
+// override), not the top-level SemimajorAxis field. A body with
+// top-level SemimajorAxis=0 but a populated override has a real orbit;
+// guarding the top-level field wrongly returned a zero normal, which
+// makes PlaneMatchInclination collapse to 0 and breaks transfer
+// planning. (#90)
+func TestOrbitNormalWorldWithOrbitalElementsOverride(t *testing.T) {
+	b := bodies.CelestialBody{
+		SemimajorAxis: 0, // top-level zero — the override carries the real orbit
+		OrbitalElements: &bodies.OrbitalElement{
+			SemimajorAxis:            1e8, // km
+			Inclination:              30,
+			LongitudeOfAscendingNode: 90,
+		},
+	}
+	n := OrbitNormalWorld(b)
+	if n.Norm() == 0 {
+		t.Fatal("OrbitNormalWorld returned zero for a body whose orbit lives in the OrbitalElements override")
+	}
+	// i=30°, Ω=90° → normal = {sinΩ·sinI, −cosΩ·sinI, cosI} = {0.5, 0, cos30°}.
+	want := Vec3{X: 0.5, Y: 0, Z: math.Cos(30 * math.Pi / 180)}
+	if math.Abs(n.X-want.X) > 1e-12 || math.Abs(n.Y-want.Y) > 1e-12 || math.Abs(n.Z-want.Z) > 1e-12 {
+		t.Errorf("normal = %+v, want %+v", n, want)
+	}
+}
+
+// TestPositionAtTrueAnomalyHyperbolic — for a hyperbolic orbit (e>1) the
+// semi-latus rectum p = a(1−e²) is negative, so the old `if p == 0`
+// guard let a negative radius through. Guarding `p <= 0` returns the
+// zero vector instead, matching VelocityAtTrueAnomaly. (#90)
+func TestPositionAtTrueAnomalyHyperbolic(t *testing.T) {
+	el := Elements{A: 1e7, E: 1.5}
+	for _, nu := range []float64{0, math.Pi} {
+		if got := PositionAtTrueAnomaly(el, nu); got != (Vec3{}) {
+			t.Errorf("PositionAtTrueAnomaly(e=1.5, ν=%.3f) = %+v, want zero vector", nu, got)
+		}
+	}
+}
+
+// TestPositionAtTrueAnomalyParabolic — parabolic (e=1) gives p=0; the
+// `p <= 0` guard covers it as before. (#90)
+func TestPositionAtTrueAnomalyParabolic(t *testing.T) {
+	el := Elements{A: 1e7, E: 1.0}
+	if got := PositionAtTrueAnomaly(el, 0); got != (Vec3{}) {
+		t.Errorf("PositionAtTrueAnomaly(e=1) = %+v, want zero vector", got)
+	}
+}

--- a/internal/physics/drag.go
+++ b/internal/physics/drag.go
@@ -30,6 +30,12 @@ func AtmosphericDensity(primary bodies.CelestialBody, altitude float64) float64 
 	return atm.SurfaceDensity * math.Exp(-altitude/atm.ScaleHeight)
 }
 
+// MinSpinPeriodSeconds is the floor on a body's rotation period when
+// computing its spin vector. No physical body rotates faster than once
+// per second; clamping here prevents corrupt catalog data from producing
+// an unbounded ω that would corrupt the drag integrator.
+const MinSpinPeriodSeconds = 1.0
+
 // AtmosphereOmega returns the body's spin angular-velocity vector
 // (rad/s) in the world inertial frame. Tilted along the body's
 // physical spin axis per AxialTilt + AxialAzimuth, matching
@@ -50,6 +56,15 @@ func AtmosphereOmega(primary bodies.CelestialBody) orbital.Vec3 {
 	periodSec := atmospherePeriodSeconds(primary)
 	if periodSec == 0 {
 		return orbital.Vec3{}
+	}
+	// Clamp pathologically small periods. The == 0 check above catches
+	// no-data; this catches garbage-data (a corrupt SideralRotation /
+	// SideralOrbit in a catalog or user overlay). No real body spins
+	// faster than once per second, so the floor is physically safe and
+	// keeps |ω| — and the AirRelativeVelocity / DragAccel terms it feeds
+	// into the integrator — bounded. (#90)
+	if periodSec < MinSpinPeriodSeconds {
+		periodSec = MinSpinPeriodSeconds
 	}
 	mag := 2 * math.Pi / periodSec
 	tiltRad := primary.AxialTilt * math.Pi / 180.0

--- a/internal/physics/drag_test.go
+++ b/internal/physics/drag_test.go
@@ -223,6 +223,24 @@ func TestAtmosphereOmegaTiltedEarth(t *testing.T) {
 	}
 }
 
+// TestAtmosphereOmegaTinyPeriodClamped — a corrupt/garbage rotation
+// period (here ~1 ms, well below any real body's once-per-second
+// physical limit) must not produce a runaway ω. The MinSpinPeriodSeconds
+// floor caps |ω| at 2π rad/s rather than the ~6283 rad/s an unclamped
+// 1 ms period would yield, keeping AirRelativeVelocity / DragAccel /
+// DynamicPressure — and thus the integrator core — finite. (#90)
+func TestAtmosphereOmegaTinyPeriodClamped(t *testing.T) {
+	earth := earthWithAtm()
+	earth.SideralRotation = 0.001 / 3600.0 // 1 ms expressed in hours: garbage data
+	w := AtmosphereOmega(earth)
+	mag := math.Sqrt(w.X*w.X + w.Y*w.Y + w.Z*w.Z)
+	// Unclamped this would be 2π/0.001 ≈ 6283; clamped to a ≥0.5 s
+	// period it must stay at or below 2π/0.5.
+	if mag > 2*math.Pi/0.5 {
+		t.Errorf("|ω| = %g, want ≤ %g (tiny period must be clamped, not amplified)", mag, 2*math.Pi/0.5)
+	}
+}
+
 // TestAtmosphereOmegaTidallyLockedUsesOrbit — tidally-locked bodies
 // rotate at their orbital period, not their (unused/zero/ignored)
 // sidereal-rotation period. Mirrors render.rotationPeriodSeconds so

--- a/internal/physics/kepler_step.go
+++ b/internal/physics/kepler_step.go
@@ -39,7 +39,12 @@ func KeplerStep(s StateVector, mu, dt float64) (StateVector, bool) {
 
 	// Mean anomaly at t=0 derived from current state.
 	var M0 float64
-	if el.E > 1e-9 {
+	// Match orbital.ElementsFromState's circularTol (1e-6). For e below
+	// it, cosE = (1 − r/a)/e amplifies float noise by ~1/e, clamping
+	// cosE to ±1 and snapping the craft back to periapsis (a warp-lock
+	// teleport). The perifocal-angle branch below is noise-free for that
+	// near-circular band. (#90)
+	if el.E > 1e-6 {
 		// Elliptic, non-circular. Standard formulas:
 		//   r = a(1 − e cos E)  →  cos E = (1 − r/a) / e
 		//   r·v = √(µa) · e · sin E

--- a/internal/physics/kepler_step_test.go
+++ b/internal/physics/kepler_step_test.go
@@ -1,0 +1,51 @@
+package physics
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestKeplerStepNearCircularConsistency — for a near-circular orbit with
+// e in the band (1e-9, 1e-6), the old elliptic branch computed
+// cosE = (1 − r/a)/e, amplifying float noise by ~1/e (1e6–1e9×) until
+// the clamp pinned cosE to ±1, forcing E0 = 0 and M0 ≈ 0. That snapped
+// the craft back to periapsis on every warp-locked Kepler step — a
+// visible teleport. Raising the circular threshold to match orbital's
+// circularTol (1e-6) routes this band through the perifocal-angle path,
+// which is noise-free. Here a craft one radian past periapsis must
+// advance ~n·dt further along, not jump back toward periapsis. (#90)
+func TestKeplerStepNearCircularConsistency(t *testing.T) {
+	const mu = 3.986004418e14
+	el := orbital.Elements{A: 7.0e6, E: 5e-7, I: 0.5, Omega: 0.3, Arg: 0.7}
+
+	nu0 := 1.0 // one radian past periapsis — far from the periapsis snap point
+	r0 := orbital.PositionAtTrueAnomaly(el, nu0)
+	v0 := orbital.VelocityAtTrueAnomaly(el, nu0, mu)
+
+	out, ok := KeplerStep(StateVector{R: r0, V: v0}, mu, 100)
+	if !ok {
+		t.Fatalf("KeplerStep returned ok=false for an elliptic near-circular orbit")
+	}
+
+	// Expected forward advance over 100 s.
+	n := math.Sqrt(mu / (el.A * el.A * el.A))
+	wantAdvance := n * 100 // ≈ 0.108 rad
+
+	// Angular separation between the start and stepped position.
+	cosSep := r0.Dot(out.R) / (r0.Norm() * out.R.Norm())
+	if cosSep > 1 {
+		cosSep = 1
+	} else if cosSep < -1 {
+		cosSep = -1
+	}
+	sep := math.Acos(cosSep)
+
+	// A teleport back to periapsis would put `out` ~nu0 (≈1 rad) away
+	// from r0; a correct step advances by ~wantAdvance. Allow generous
+	// slack but well below the ~0.89 rad a snap-to-periapsis produces.
+	if math.Abs(sep-wantAdvance) > 0.05 {
+		t.Errorf("stepped position moved %.4f rad from start, want ≈%.4f (advance by n·dt); large gap indicates a periapsis-snap teleport", sep, wantAdvance)
+	}
+}

--- a/internal/planner/lambert.go
+++ b/internal/planner/lambert.go
@@ -153,6 +153,14 @@ func LambertSolveRev(r1, r2 orbital.Vec3, dt, mu float64, nRev int, retrograde, 
 			for F(z) > 0 && z > -4*math.Pi*math.Pi {
 				z -= 0.1
 			}
+			// Exhaustion guard, mirroring the long-/short-branch loops
+			// above: if the walk hit the hyperbolic floor without F
+			// changing sign (or went NaN), there is no bracket and the
+			// Newton seed below would be unvalidated. Fail explicitly
+			// instead of feeding garbage to Newton. (#90)
+			if fv := F(z); math.IsNaN(fv) || fv > 0 {
+				return orbital.Vec3{}, orbital.Vec3{}, errors.New("lambert: bracket search failed — hyperbolic walk exhausted without sign change")
+			}
 		} else {
 			for {
 				fv := F(z)

--- a/internal/planner/lambert_test.go
+++ b/internal/planner/lambert_test.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -277,5 +278,26 @@ func TestLambertEarthToMarsHohmann(t *testing.T) {
 	if d := math.Abs(gotV1Mag-wantV1Mag) / wantV1Mag; d > 0.015 {
 		t.Errorf("Earth→Mars Hohmann |v1|: got %.1f m/s, want %.1f m/s (rel %.2e)",
 			gotV1Mag, wantV1Mag, d)
+	}
+}
+
+// TestLambertHyperbolicWalkExhaustion — for a single-rev (N=0) transfer
+// whose requested time-of-flight is too short to be achievable even at
+// the hyperbolic floor (z = −4π²), the negative bracket walk exhausts
+// without F changing sign. Pre-fix it fell through to Newton with an
+// unvalidated z ≈ −39.5 seed and surfaced a misleading "y went negative"
+// error; the bracket-exhaustion guard now fails explicitly at the
+// bracket stage with a clear message. (#90)
+func TestLambertHyperbolicWalkExhaustion(t *testing.T) {
+	mu := 3.986e14
+	// 90° apart, physically-impossible 10 s transfer of ~1.4e7 m.
+	r1 := orbital.Vec3{X: 1e7}
+	r2 := orbital.Vec3{Y: 1e7}
+	_, _, err := LambertSolveRev(r1, r2, 10, mu, 0, false, false)
+	if err == nil {
+		t.Fatal("expected an error for an unachievable hyperbolic transfer, got nil")
+	}
+	if !strings.Contains(err.Error(), "hyperbolic walk exhausted") {
+		t.Errorf("err = %q, want the bracket-exhaustion message (caught at bracket stage, not Newton)", err)
 	}
 }

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -587,6 +587,17 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	if p.SystemIdx < 0 || p.SystemIdx >= len(systems) {
 		return nil, fmt.Errorf("save: system_idx %d out of range (have %d systems)", p.SystemIdx, len(systems))
 	}
+	// Clamp a corrupt/out-of-range warp_idx at load. WarpUp/WarpDown
+	// keep the index in bounds during play, but a hand-edited or old
+	// save can carry a value outside [0, len(WarpFactors)) — left
+	// unchecked it panics WarpFactors[idx] on the first Tick
+	// (clock.go:52). Mirrors the SystemIdx (above) and ActiveCraftIdx
+	// (below) load-time guards; clamp to 1× rather than erroring so a
+	// corrupted save still opens. (#90)
+	warpIdx := p.WarpIdx
+	if warpIdx < 0 || warpIdx >= len(sim.WarpFactors) {
+		warpIdx = 0
+	}
 	simT := time.Unix(0, p.SimTimeNano).UTC()
 	clock := &sim.Clock{
 		SimTime: simT,
@@ -597,7 +608,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 		// reload, which is fine — rotation is an aesthetic, not
 		// authoritative state.
 		RotationTime: simT,
-		WarpIdx:      p.WarpIdx,
+		WarpIdx:      warpIdx,
 		Paused:       p.Paused,
 		BaseStep:     time.Duration(p.BaseStepNano),
 	}

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -394,6 +394,55 @@ func TestCatalogMismatchRejected(t *testing.T) {
 	}
 }
 
+// TestLoadOutOfBoundsWarpIdxClampsToValid — a forged warp_idx outside
+// [0, len(WarpFactors)-1] must clamp to a valid index at load instead of
+// surviving into the world, where the first Tick would panic on
+// WarpFactors[idx] (clock.go:52). Mirrors the SystemIdx/ActiveCraftIdx
+// load-time guards; WarpUp/WarpDown already keep the index in range, so
+// this is purely a load-time gap. (#90)
+func TestLoadOutOfBoundsWarpIdxClampsToValid(t *testing.T) {
+	for _, forged := range []int{6, -1, 999} {
+		w, err := sim.NewWorld()
+		if err != nil {
+			t.Fatalf("NewWorld: %v", err)
+		}
+		path := filepath.Join(t.TempDir(), "save.json")
+		if err := save.Save(w, path); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		var f save.File
+		if err := json.Unmarshal(data, &f); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		f.Payload.WarpIdx = forged
+		tampered, _ := json.Marshal(f)
+		if err := os.WriteFile(path, tampered, 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		got, err := save.Load(path)
+		if err != nil {
+			t.Fatalf("Load (warp_idx=%d): %v", forged, err)
+		}
+		if got.Clock.WarpIdx < 0 || got.Clock.WarpIdx >= len(sim.WarpFactors) {
+			t.Errorf("warp_idx=%d loaded as %d, want clamped into [0,%d)", forged, got.Clock.WarpIdx, len(sim.WarpFactors))
+		}
+		// And the clamp must actually prevent the Tick panic.
+		got.Clock.Paused = false
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("warp_idx=%d: Tick panicked after load: %v", forged, r)
+				}
+			}()
+			got.Tick()
+		}()
+	}
+}
+
 func TestSchemaMismatchRejected(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {

--- a/internal/sim/crash_test.go
+++ b/internal/sim/crash_test.go
@@ -7,6 +7,7 @@
 package sim
 
 import (
+	"math"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -127,6 +128,62 @@ func TestFalcon9CrashesSideways(t *testing.T) {
 	if c.Landed {
 		t.Errorf("Falcon-9 sideways impact: Landed=true, want Crashed-only")
 	}
+}
+
+// TestFalcon9SoftLandsAtExactNoseTol — a CanSoftLand vessel touching
+// down below V_CRIT with the nose at *exactly* the documented minimum
+// alignment (cosNose == NOSE_TOL == 0.7, ~45° off vertical) must land,
+// not crash. The route comments document "land when nose > NOSE_TOL" and
+// the velocity gates use >= (reject at-or-above), so the nose gate should
+// reject strictly below the tolerance. The old `<= CrashNoseTol` crashed
+// the boundary case it should accept. Exercises the pure
+// classifySurfaceArrival predicate directly: integrateOneCraft slews
+// CurrentAttitudeDir at the tick top, which would perturb an
+// exactly-on-the-boundary nose and mask the gate under test. (#90)
+func TestFalcon9SoftLandsAtExactNoseTol(t *testing.T) {
+	w, c := crashTestPrimaryFor(t)
+	c.CanSoftLand = true
+	// Use a unit preClampR so the predicate's localUp = R/|R| is exactly
+	// {1,0,0}; then nose.Dot(localUp) is just the normalized nose.X.
+	// classifySurfaceArrival is pure and frame-agnostic, so the small
+	// radius is irrelevant to the gate.
+	preClampR := orbital.Vec3{X: 1}
+	localUp := preClampR.Scale(1 / preClampR.Norm())
+
+	// `<` vs `<=` differ only at bit-exact equality, and the predicate
+	// re-normalizes the nose — so whether any given vector lands exactly
+	// on CrashNoseTol depends on the platform's float rounding (arm64 FMA
+	// vs amd64). Rather than hardcode a magic component that's only exact
+	// on one arch, search at runtime for a nose whose *post-normalization*
+	// dot is bit-identical to CrashNoseTol on whatever machine runs this.
+	noseAtTol := exactNoseTolDir(t, localUp)
+	c.CurrentAttitudeDir = noseAtTol
+	preClampV := orbital.Vec3{X: -2} // 2 m/s inward, below V_CRIT
+	outcome, _, _ := classifySurfaceArrival(c, preClampR, preClampV, w.Clock.SimTime)
+	if outcome != outcomeLanded {
+		t.Errorf("CanSoftLand + V=2 m/s + nose at exact NOSE_TOL: outcome=%v, want outcomeLanded", outcome)
+	}
+}
+
+// exactNoseTolDir returns a nose direction whose normalized dot with
+// localUp is bit-exactly CrashNoseTol — i.e. a nose sitting precisely on
+// the soft-land boundary the gate compares against. Found by search so
+// the construction is portable across float-rounding differences
+// (arm64 FMA vs amd64); fails the test if no such vector exists in the
+// neighbourhood (which would itself be a signal worth investigating).
+func exactNoseTolDir(t *testing.T, localUp orbital.Vec3) orbital.Vec3 {
+	t.Helper()
+	const x = CrashNoseTol
+	y0 := math.Sqrt(1 - x*x) // nominal complement; dot ≈ tol near here
+	for i := -200000; i <= 200000; i++ {
+		y := y0 + float64(i)*1e-16
+		n := orbital.Vec3{X: x, Y: y}
+		if n.Scale(1 / n.Norm()).Dot(localUp) == CrashNoseTol {
+			return n
+		}
+	}
+	t.Fatalf("could not construct a nose with normalized dot == CrashNoseTol near y=%.17g", y0)
+	return orbital.Vec3{}
 }
 
 // TestCrashedVesselSkipsIntegration — once a vessel is Crashed,

--- a/internal/sim/hohmann_guard.go
+++ b/internal/sim/hohmann_guard.go
@@ -44,8 +44,17 @@ const (
 // Pure (no World) so the geometry is unit-testable in isolation; the
 // World wrapper below only supplies nTarget.
 func hohmannGuardDetail(rC, vC orbital.Vec3, mu float64, nTarget orbital.Vec3, eTol, inclTolDeg float64) string {
+	// minNormalThreshold — orbit-normal magnitudes below this are treated
+	// as degenerate (unassessable). An exact `== 0` check is insufficient:
+	// when nTarget is built from two position samples a fixed interval
+	// apart, a custom short-period (<2h) moon advances ~180° between
+	// samples and the cross-product collapses to ~1e-9, not exactly 0 —
+	// which would otherwise divide the cosine below by ~1e-9 and emit a
+	// spurious tilt warning. Scaled up from the orbital frame.go `< 1e-12`
+	// pattern for orbit-normal cross magnitudes. (#90)
+	const minNormalThreshold = 1e-8
 	nCraft := rC.Cross(vC)
-	if nCraft.Norm() == 0 || nTarget.Norm() == 0 || mu <= 0 {
+	if nCraft.Norm() < minNormalThreshold || nTarget.Norm() < minNormalThreshold || mu <= 0 {
 		return "" // can't assess — stay silent rather than cry wolf
 	}
 	var problems []string

--- a/internal/sim/hohmann_guard_test.go
+++ b/internal/sim/hohmann_guard_test.go
@@ -68,6 +68,24 @@ func TestHohmannGuardDetailDegenerateSilent(t *testing.T) {
 	}
 }
 
+// TestHohmannGuardDetailShortPeriodMoonDegenerateSilent — when a target
+// normal is built from two position samples taken a fixed interval apart
+// (the World wrapper's sampling), a custom <2h moon advances nearly 180°
+// between samples, so the cross-product that forms nTarget collapses to a
+// ~1e-9-magnitude near-zero vector rather than exactly zero. The exact
+// `== 0` guard missed that, letting the cosine at the inclination check
+// divide by ~1e-9 and emit a spurious tilt warning. A magnitude
+// threshold treats the near-degenerate normal as unassessable and stays
+// silent. (#90)
+func TestHohmannGuardDetailShortPeriodMoonDegenerateSilent(t *testing.T) {
+	r, v := circularState(7.0e6, earthMuTest) // clean, non-degenerate craft normal
+	// nTarget with a ~1e-9 magnitude — what a 180°-apart sample pair yields.
+	nTarget := orbital.Vec3{X: 1e-9}
+	if got := hohmannGuardDetail(r, v, earthMuTest, nTarget, hohmannEccTol, hohmannInclTolDeg); got != "" {
+		t.Errorf("near-degenerate target normal (|n|≈1e-9) should be silent, got %q", got)
+	}
+}
+
 // moonIndex finds the Moon's body index in the active system, or -1.
 func moonIndex(w *World) int {
 	for i, b := range w.System().Bodies {

--- a/internal/sim/lifecycle.go
+++ b/internal/sim/lifecycle.go
@@ -166,7 +166,11 @@ func classifySurfaceArrival(
 			return outcomeCrashed, 0, 0
 		}
 		nose = nose.Scale(1 / nose.Norm())
-		if nose.Dot(localUp) <= CrashNoseTol {
+		// Strictly-below rejects; at-or-above NOSE_TOL lands. The route
+		// comments document "land when nose > NOSE_TOL" and the velocity
+		// gates use >= (reject at-or-above), so a craft sitting exactly at
+		// the 0.7 minimum is the boundary that should land. (#90)
+		if nose.Dot(localUp) < CrashNoseTol {
 			return outcomeCrashed, 0, 0
 		}
 	default:


### PR DESCRIPTION
Implements all confirmed findings from the core-review issue #90 flesh-out pass (7 confirmed + 1 verifier-confirmed adjacent), each with a red→green regression test. One PR per issue per the agreed slicing; #91 follows separately.

## Fixes (value order)
| Sev | Site | Fix | Test |
|---|---|---|---|
| **HIGH** | `physics/drag.go` | `MinSpinPeriodSeconds=1.0` clamp in `AtmosphereOmega` — corrupt rotation data no longer yields an unbounded ω that corrupts the drag integrator | `TestAtmosphereOmegaTinyPeriodClamped` |
| MED | `save/save.go` | Clamp out-of-range `warp_idx` at load (was panicking `WarpFactors[idx]` on first Tick) | `TestLoadOutOfBoundsWarpIdxClampsToValid` |
| MED | `physics/kepler_step.go` | Near-circular threshold `1e-9 → 1e-6` (match `circularTol`) — kills the warp-lock periapsis-snap teleport in the `(1e-9,1e-6)` eccentricity band | `TestKeplerStepNearCircularConsistency` |
| MED | `orbital/frame.go` | `OrbitNormalWorld` guards the *computed* SMA (honors `OrbitalElements` override); `PositionAtTrueAnomaly` guards `p<=0` for parabolic/hyperbolic (adjacent finding) | `TestOrbitNormalWorldWithOrbitalElementsOverride`, `TestPositionAtTrueAnomaly{Hyperbolic,Parabolic}` |
| MED | `planner/lambert.go` | Bracket-exhaustion guard on the N=0 hyperbolic walk (was feeding Newton an unvalidated seed) | `TestLambertHyperbolicWalkExhaustion` |
| MED | `sim/lifecycle.go` | Soft-land nose gate `<= → <` so a craft exactly at NOSE_TOL=0.7 lands (consistent with the `>` route comment and `>=` velocity gates) | `TestFalcon9SoftLandsAtExactNoseTol` |
| MED | `sim/hohmann_guard.go` | Degenerate-normal guard `== 0 → < 1e-8` so a short-period moon's near-antiparallel sample pair stays silent instead of crying a spurious tilt warning | `TestHohmannGuardDetailShortPeriodMoonDegenerateSilent` |

## Notes
- The nose-gate test is **runtime-adaptive**: `<` vs `<=` differ only at bit-exact equality and the predicate re-normalizes the nose, so the test searches for a nose whose post-normalization dot is bit-identical to `CrashNoseTol` on whatever architecture runs it (arm64 FMA vs amd64), rather than hardcoding an arch-specific constant.
- Dropped from #90 as correct-by-design (per the flesh-out verdicts): `soi.go FindPrimary` flat-scan and `rendezvous.go:114` refine-skip.

## Verification
`go vet ./...` and `go test ./... -race -count=1` both green.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)