### PR TITLE
fix(planner/sim): planner/predictor guards (#91)

### DIFF
--- a/internal/planner/inclination_test.go
+++ b/internal/planner/inclination_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 // rLEO is a 500 km circular LEO around Earth (the v0.6.1 default
@@ -204,5 +205,78 @@ func TestPlanInclinationPrimaryIDPropagates(t *testing.T) {
 	}
 	if plan.PrimaryID != "earth" {
 		t.Errorf("PrimaryID = %q, want %q", plan.PrimaryID, "earth")
+	}
+}
+
+// TestPlanInclinationRetrogradeReachesTarget — guards that the
+// NormalSign rule already produces a correct plane change for retrograde
+// (i > π/2) orbits. Core-review #91 flagged the prograde-derived sign
+// rule as needing a `sign = -sign` inversion for retrograde (the
+// equatorial helper has an analogous correction); executing the physics
+// proves that's a FALSE POSITIVE — adding the inversion drives the
+// inclination the WRONG way at both nodes. Rather than hand-assert a
+// sign convention, this propagates the circular orbit to the planned
+// burn node, applies the exact rotation the burn performs (rotate the
+// horizontal velocity by PlaneChangeRad about r̂, preserving |v| — see
+// spacecraft.planeChangeDirection), and asserts the resulting
+// inclination lands on the target. It fails if anyone applies the
+// proposed inversion. (#91)
+func TestPlanInclinationRetrogradeReachesTarget(t *testing.T) {
+	inclinationOf := func(r, v orbital.Vec3) float64 {
+		h := r.Cross(v)
+		return math.Acos(h.Z / h.Norm())
+	}
+	v := math.Sqrt(muEarth / rLEO)
+	// startAtAN places the craft on the equator rising (next node = DN);
+	// startAtDN places it on the equator descending (next node = AN). We
+	// exercise BOTH so the retrograde sign rule is tested at each node.
+	startAtAN := func(inc float64) orbital.Vec3State { return circularInclinedState(rLEO, inc, muEarth) }
+	startAtDN := func(inc float64) orbital.Vec3State {
+		return orbital.Vec3State{
+			R: orbital.Vec3{X: -rLEO},
+			V: orbital.Vec3{Y: -v * math.Cos(inc), Z: -v * math.Sin(inc)},
+		}
+	}
+	cases := []struct {
+		name           string
+		fromDeg, toDeg float64
+		start          func(float64) orbital.Vec3State
+	}{
+		{"retro increase 100→110, burn at DN", 100, 110, startAtAN},
+		{"retro decrease 110→100, burn at DN", 110, 100, startAtAN},
+		{"retro increase 100→110, burn at AN", 100, 110, startAtDN},
+		{"retro decrease 110→100, burn at AN", 110, 100, startAtDN},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inc := tc.fromDeg * math.Pi / 180
+			target := tc.toDeg * math.Pi / 180
+			state := tc.start(inc)
+			plan, err := PlanInclinationChange(state, muEarth, target, "earth")
+			if err != nil {
+				t.Fatalf("PlanInclinationChange: %v", err)
+			}
+			// Propagate analytically to the burn node (exact for circular).
+			sv, ok := physics.KeplerStep(
+				physics.StateVector{R: state.R, V: state.V},
+				muEarth, plan.OffsetTime.Seconds())
+			if !ok {
+				t.Fatalf("KeplerStep to burn node failed")
+			}
+			// Execute the plane-change burn: rotate v_horizontal by
+			// PlaneChangeRad about r̂. rHat×vHor points along +ĥ, so this
+			// matches planeChangeDirection's "positive θ rotates toward +ĥ".
+			theta := plan.PlaneChangeRad
+			rHat := sv.R.Unit()
+			vRad := rHat.Scale(sv.V.Dot(rHat))
+			vHor := sv.V.Sub(vRad)
+			newVHor := vHor.Scale(math.Cos(theta)).Add(rHat.Cross(vHor).Scale(math.Sin(theta)))
+			newV := vRad.Add(newVHor)
+
+			got := inclinationOf(sv.R, newV) * 180 / math.Pi
+			if math.Abs(got-tc.toDeg) > 1e-6 {
+				t.Errorf("after plane-change burn i=%.5f°, want %.5f° — retrograde sign drove inclination the wrong way (NormalSign=%d)", got, tc.toDeg, plan.NormalSign)
+			}
+		})
 	}
 }

--- a/internal/planner/predictor.go
+++ b/internal/planner/predictor.go
@@ -39,8 +39,15 @@ func Predict(start physics.StateVector, mu, totalSeconds float64, samples int) [
 		if nSub < 1 {
 			nSub = 1
 		}
-		if nSub > 256 {
-			nSub = 256
+		// Raise the perf clamp high enough to preserve the dt < period/100
+		// invariant (line 27) for any realistic horizon. The old 256 cap
+		// broke it for long-horizon / low-sample callers — e.g. 100 periods
+		// in 2 samples clamped dt to ≈0.39·period, well past the Verlet
+		// stability knee, and the orbit diverged. 10000 keeps dt ≤ period/100
+		// out to ~100 sample-periods while still bounding pathological work. (#91)
+		const maxNSubSteps = 10000
+		if nSub > maxNSubSteps {
+			nSub = maxNSubSteps
 		}
 		dt := stepSecs / float64(nSub)
 		for j := 0; j < nSub; j++ {

--- a/internal/planner/predictor_test.go
+++ b/internal/planner/predictor_test.go
@@ -61,3 +61,30 @@ func TestPredictPreservesRadiusForCircularOrbit(t *testing.T) {
 	}
 }
 
+// TestPredictLargeHorizonSmallSamples — Predict must honor its documented
+// dt < period/100 sub-step invariant even when the caller asks for a long
+// horizon with very few samples. The old unconditional `nSub > 256` clamp
+// capped sub-steps at 256 regardless of horizon, so a 100-period / 2-sample
+// request produced dt ≈ 0.39·period — far past the Verlet stability knee —
+// and the orbit diverged energetically (radius ran off toward escape).
+// Raising the clamp to a perf ceiling that still respects the invariant
+// keeps dt at period/100, where symplectic Verlet conserves energy and the
+// radius stays put. We assert radius preservation, not positional closure:
+// over 100 periods Verlet accrues harmless *phase* drift even with a
+// correct dt, but the *energy* (the radius of a circular orbit) must not
+// diverge — that divergence is exactly the clamp bug. (#91)
+func TestPredictLargeHorizonSmallSamples(t *testing.T) {
+	mu := 3.986e14
+	r0 := 6.371e6 + 200e3
+	v0 := math.Sqrt(mu / r0)
+	start := physics.StateVector{R: orbital.Vec3{X: r0}, V: orbital.Vec3{Y: v0}}
+	period := 2 * math.Pi * math.Sqrt(r0*r0*r0/mu)
+
+	// 100 periods, only 2 samples (start + end) — forces nSub past the old
+	// 256 cap. The end radius of this circular orbit must stay near r0.
+	pts := Predict(start, mu, 100*period, 2)
+	endR := pts[len(pts)-1].Norm()
+	if d := math.Abs(endR-r0) / r0; d > 0.02 {
+		t.Errorf("100-period/2-sample end radius %.3e m = %.2f·r0 — sub-step clamp violated dt<period/100 and the orbit diverged", endR, endR/r0)
+	}
+}

--- a/internal/sim/hohmann.go
+++ b/internal/sim/hohmann.go
@@ -75,6 +75,27 @@ func (w *World) HohmannPreviewFor(bodyIdx int) HohmannPreview {
 			TargetName: target.EnglishName,
 			Note:       "moon → parent — use [H] for escape transfer",
 		}
+	case target.ParentID != "" && target.ParentID == w.ActiveCraft().Primary.ParentID && target.ID != w.ActiveCraft().Primary.ID:
+		// Sibling moons: the craft orbits one moon and the target is a
+		// different moon of the same parent (e.g. a craft at Io targeting
+		// Europa). The honest preview is a parent-frame Hohmann between
+		// the two moons' orbital radii — NOT the heliocentric transfer the
+		// default case would compute, which produced wildly wrong Δv
+		// (~28 / ~242 km/s) by mixing the craft's solar distance with a
+		// moon's planet-relative SMA. r1 is the craft's *moon's* SMA
+		// around the parent (the craft is bound near that moon, so its
+		// parent-frame radius is the moon's orbital radius, not the
+		// craft's moon-relative |R| — that intra-primary form would
+		// understate r1 by ~2 orders of magnitude). Latent in the stock
+		// Sol catalog (Luna is Earth's only moon); live the moment a
+		// multi-moon system is added.
+		parent, found := bodies.LookupByID(w.Systems, target.ParentID)
+		if !found {
+			return HohmannPreview{TargetName: target.EnglishName, Note: "parent body not found"}
+		}
+		mu = parent.GravitationalParameter()
+		r1 = w.ActiveCraft().Primary.SemimajorAxisMeters()
+		r2 = target.SemimajorAxisMeters()
 	default:
 		// Heliocentric: craft and target both ultimately orbit the
 		// system primary (LEO craft + Mars). Patched-conic textbook

--- a/internal/sim/hohmann_test.go
+++ b/internal/sim/hohmann_test.go
@@ -123,3 +123,48 @@ func within(got, want, tol float64) bool {
 	}
 	return math.Abs(got-want)/math.Abs(want) <= tol
 }
+
+// TestHohmannPreviewForSiblingMoonUsesParentFrame — a craft orbiting one
+// moon, previewing a transfer to a *sibling* moon of the same parent,
+// must compute a parent-frame Hohmann between the two moons' orbits — not
+// fall through to the heliocentric default, which mixes the craft's solar
+// distance with a planet-relative SMA and yields nonsense Δv (~tens of
+// km/s). Latent in the stock Sol catalog (Luna is Earth's only moon), so
+// this synthesises a second Earth moon to exercise the case. (#91)
+func TestHohmannPreviewForSiblingMoonUsesParentFrame(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	lunaIdx := -1
+	for i, b := range sys.Bodies {
+		if b.ID == "moon" || b.EnglishName == "Moon" {
+			lunaIdx = i
+			break
+		}
+	}
+	if lunaIdx < 0 {
+		t.Skip("Luna not found in Sol system")
+	}
+	luna := sys.Bodies[lunaIdx]
+
+	// Synthesise a second moon of Earth ~1.5× Luna's orbital radius.
+	luna2 := luna
+	luna2.ID = "moon2"
+	luna2.EnglishName = "Luna II"
+	luna2.SemimajorAxis = luna.SemimajorAxis * 1.5
+	w.Systems[w.SystemIdx].Bodies = append(w.Systems[w.SystemIdx].Bodies, luna2)
+	luna2Idx := len(w.Systems[w.SystemIdx].Bodies) - 1
+
+	// Put the active craft in orbit around the first moon.
+	w.ActiveCraft().Primary = luna
+
+	p := w.HohmannPreviewFor(luna2Idx)
+	if !p.Valid {
+		t.Fatalf("sibling-moon preview invalid: %s", p.Note)
+	}
+	// Parent-frame (Earth μ) Hohmann from Luna's SMA (~384 400 km) to 1.5×
+	// that is a low-energy moon-to-moon transfer (Δv ≈ 100 m/s each leg).
+	// The heliocentric default would instead report km/s-scale Δv.
+	if p.DV1 > 1000 || p.DV2 > 1000 {
+		t.Errorf("sibling-moon Δv1=%.0f Δv2=%.0f m/s — expected parent-frame moon-to-moon (≲ few hundred m/s), not heliocentric", p.DV1, p.DV2)
+	}
+}

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -192,7 +192,32 @@ predict:
 				muNow = current.GravitationalParameter()
 
 				period = orbitalPeriod(state, muNow)
-				maxStep = predictMaxSubStep(period)
+				newMaxStep := predictMaxSubStep(period)
+				// Re-resolve the sub-step for the REST of this sample after
+				// the rebase. The new SOI's orbit can be far tighter than
+				// the one we entered with (e.g. an Earth-transfer leg with
+				// dt≈120 s crossing into a fast lunar hyperbolic flyby whose
+				// cap is ~1 s) — and only the Verlet path is affected, since
+				// analytic Kepler is dt-independent. Leaving the coarse
+				// pre-crossing dt in place integrated ~37 remaining 120 s
+				// steps across the encounter, grossly aliasing its geometry.
+				// Re-divide the remaining time into sub-steps sized for the
+				// new orbit (keeping the 256 perf clamp). (#91)
+				if newMaxStep < maxStep {
+					remainingTime := float64(nSub-j-1) * dt
+					if remainingTime > 0 {
+						newNSub := int(math.Ceil(remainingTime / newMaxStep))
+						if newNSub < 1 {
+							newNSub = 1
+						}
+						if newNSub > 256 {
+							newNSub = 256
+						}
+						nSub = j + 1 + newNSub
+						dt = remainingTime / float64(newNSub)
+					}
+				}
+				maxStep = newMaxStep
 
 				segments = append(segments, SOISegment{
 					PrimaryID: current.ID,

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -64,9 +64,12 @@ const rendezvousBurnLeadPad = 5 * time.Second
 // TARGET HUD just hides the block.
 //
 // The returned advisory is the same struct callers see from the
-// underlying planner.RecommendRendezvousNudge; ok=false-with-advisory
-// is the "no improvement available" path (advisory.Reason populated)
-// the HUD surfaces as a faint single-line tag.
+// underlying planner.RecommendRendezvousNudge. ok=true-with-advisory
+// where advisory.Ok=false is the "computed, but no improvement
+// available" path (advisory.Reason populated — "no useful nudge" or
+// "docked") the HUD surfaces as a faint single-line tag; ok=false means
+// the advisory couldn't be computed at all (no craft target, different
+// primaries, degenerate state) and the HUD hides the block.
 func (w *World) RecommendedRendezvousBurn() (planner.RendezvousAdvisory, bool) {
 	active := w.ActiveCraft()
 	if active == nil || w.Target.Kind != TargetCraft {
@@ -127,7 +130,7 @@ func (w *World) computeRendezvousAdvisory(active, target *spacecraft.Spacecraft)
 		return planner.RendezvousAdvisory{
 			Ok:     false,
 			Reason: "docked",
-		}, false
+		}, true
 	}
 
 	// Horizon mirrors v0.9.3 NextClosestApproach defaults: ~2× the

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -181,6 +181,32 @@ func TestPlanRendezvousNudge_DifferentPrimaries(t *testing.T) {
 	}
 }
 
+// TestPlanRendezvousNudge_DockedCraft — when the active and target
+// craft are already within DOCK READY range (< 50 m, |v_rel| < 0.1 m/s),
+// PlanRendezvousNudge must return the specific ErrRendezvousAlreadyDocked
+// (not the generic ErrRendezvousNoImprovement) and plant no node. The
+// docked gate in computeRendezvousAdvisory used to return ok=false,
+// which tripped the outer `if !ok` gate and made the docked branch
+// unreachable; it now returns ok=true with advisory.Reason="docked",
+// consistent with the no-improvement path. (#91)
+func TestPlanRendezvousNudge_DockedCraft(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	// Park the target right alongside the active craft: 10 m away with a
+	// 0.01 m/s relative drift — inside the docked gate.
+	target.State.R = active.State.R.Add(orbital.Vec3{X: 10})
+	target.State.V = active.State.V.Add(orbital.Vec3{X: 0.01})
+
+	_, err := w.PlanRendezvousNudge()
+	if !errors.Is(err, ErrRendezvousAlreadyDocked) {
+		t.Errorf("err = %v, want ErrRendezvousAlreadyDocked", err)
+	}
+	if got := len(active.Nodes); got != 0 {
+		t.Errorf("docked craft should plant no node; got %d", got)
+	}
+}
+
 // TestRecommendedRendezvousBurn_CacheReusesWithinInterval — two
 // back-to-back calls without advancing the sim clock return
 // identical advisories (cache hit; not a recompute). Indirect: we


### PR DESCRIPTION
Implements the core-review issue #91 findings, with **diagnostic verification of each before applying** — two turned out to need no code change. One PR per issue per the agreed slicing; companion to #93 (#90).

## Applied fixes
| Site | Fix | Test |
|---|---|---|
| `sim/rendezvous.go` | Docked gate returns `ok=true` (was `false`) → `PlanRendezvousNudge` reaches the docked branch and returns the specific `ErrRendezvousAlreadyDocked`, not the generic no-improvement error. Contract doc corrected. **Resolves both rendezvous findings** (same root cause). | `TestPlanRendezvousNudge_DockedCraft` |
| `planner/predictor.go` | Raise the `Predict` sub-step clamp `256 → 10000` so long-horizon/low-sample callers keep `dt ≤ period/100`; the old cap let `dt ≈ 0.39·period` and the orbit diverged energetically. | `TestPredictLargeHorizonSmallSamples` |
| `sim/hohmann.go` | Sibling-moon case: a craft at one moon previewing a transfer to another moon of the same parent gets a parent-frame Hohmann (was heliocentric default → ~28/242 km/s nonsense). **Corrected the filed spec's `r1`** to use the craft's moon's parent-relative SMA. Latent (no multi-moon catalog); test synthesises one. | `TestHohmannPreviewForSiblingMoonUsesParentFrame` |
| `sim/predict.go` | After an SOI rebase, re-resolve the sub-step for the rest of the sample at the new orbit's cap. Confirmed by instrumentation: an Earth→Luna leg crossing into a hyperbolic lunar flyby ran ~37 remaining substeps at the stale 120 s dt (new cap ~1 s) on the Verlet path. | (see note) |

## Diagnostic outcomes — no code change
- **Inclination retrograde sign — FALSE POSITIVE.** The filed finding proposed a `sign = -sign` inversion for retrograde (i>π/2). A ground-truth physical-execution test (propagate to the burn node, apply the exact plane-change rotation, check the resulting inclination) proves the **existing** rule already reaches the target at both nodes — and the proposed inversion *breaks* all four cases. Added `TestPlanInclinationRetrogradeReachesTarget` as a guard against anyone applying it.
- **predict.go nSub-saturation cap — not applied.** Analytic Kepler coast (post-#66) is dt-independent, so the saturation has no effect on bound orbits; the filed fix would *double* the substep work on the common path for zero accuracy gain.

## Note on the predict.go rebase test
The rebase fix is correct and instrumentation-validated, but its output impact (~17 km) sits below the sampling-density floor (~316 km at the adaptive sample count) on a 66 000 km+ encounter — so no output-level red/green test can cleanly isolate it. The rebase path stays covered by the existing `TestPredictedSegmentsTransferEncounterStable` (segment-topology stability across sample densities). Kept as low-risk defense-in-depth (a tighter SOI / smaller body would amplify the effect).

## Verification
`go vet ./...` and `go test ./... -race -count=1` both green.

Refs #91 (closes the rendezvous, predictor.go, and hohmann findings; documents the inclination + cap findings as verified-no-change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)