### PR TITLE
fix(sim): don't drop a due finite burn; sort nodes by BurnStart (#88)

### DIFF
--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -1,0 +1,117 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestExecuteDueNodesFiniteBurnNotOverwritten — GH #88 (#1, HIGH).
+// When two finite nodes both come due in the same tick, the dispatcher
+// must start the *earlier* one's ActiveBurn and leave the later one
+// queued — not overwrite ActiveBurn with the second node and silently
+// drop the first node's Δv. Pre-fix the loop set c.ActiveBurn for node
+// A, kept iterating, overwrote it with node B, and popped both — so
+// node A's burn never executed.
+func TestExecuteDueNodesFiniteBurnNotOverwritten(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	now := w.Clock.SimTime
+
+	// Two finite nodes whose centered burn windows both straddle `now`,
+	// so both BurnStart() <= now on this tick. A triggers slightly
+	// before B; distinct Δv so we can tell which one started.
+	nodeA := spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          100,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    60 * time.Second, // BurnStart = now-20s
+	}
+	nodeB := spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          200,
+		TriggerTime: now.Add(15 * time.Second),
+		Duration:    60 * time.Second, // BurnStart = now-15s
+	}
+	c.Nodes = []spacecraft.ManeuverNode{nodeA, nodeB}
+	sortNodes(c.Nodes)
+
+	w.executeDueNodes()
+
+	if c.ActiveBurn == nil {
+		t.Fatal("no ActiveBurn started; expected node A's finite burn")
+	}
+	if c.ActiveBurn.DVRemaining != 100 {
+		t.Errorf("ActiveBurn.DVRemaining = %.0f, want 100 (node A) — node B overwrote node A's burn",
+			c.ActiveBurn.DVRemaining)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("len(Nodes) = %d after dispatch, want 1 (node B must stay queued, not be silently dropped)", len(c.Nodes))
+	}
+	if c.Nodes[0].DV != 200 {
+		t.Errorf("remaining node DV = %.0f, want 200 (node B) — wrong node was retained", c.Nodes[0].DV)
+	}
+}
+
+// TestExecuteDueNodesDoesNotOverwriteInFlightBurn — GH #88 (#1, HIGH),
+// cross-tick variant. A finite burn started on a previous tick must not
+// be overwritten when a second finite node comes due while the first is
+// still in flight; the due node stays queued until the active burn ends.
+func TestExecuteDueNodesDoesNotOverwriteInFlightBurn(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	now := w.Clock.SimTime
+
+	// Simulate an in-flight burn from a prior tick.
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnPrograde,
+		DVRemaining: 500,
+		EndTime:     now.Add(30 * time.Second),
+	}
+	// A second finite node that is already due this tick.
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          200,
+		TriggerTime: now.Add(5 * time.Second),
+		Duration:    40 * time.Second, // BurnStart = now-15s
+	}}
+
+	w.executeDueNodes()
+
+	if c.ActiveBurn == nil || c.ActiveBurn.DVRemaining != 500 {
+		t.Fatalf("in-flight ActiveBurn was overwritten: %+v", c.ActiveBurn)
+	}
+	if len(c.Nodes) != 1 {
+		t.Errorf("len(Nodes) = %d, want 1 — the due node must stay queued behind the in-flight burn", len(c.Nodes))
+	}
+}
+
+// TestSortNodesOrdersByBurnStart — GH #88 (#2, MEDIUM). executeDueNodesFor
+// fires/breaks on BurnStart() (= TriggerTime - Duration/2), so the node
+// slice must be sorted by BurnStart, not TriggerTime. A later-trigger but
+// longer-duration node has an earlier BurnStart and must dispatch first.
+func TestSortNodesOrdersByBurnStart(t *testing.T) {
+	base := time.Unix(0, 0).UTC()
+	// Node A: impulsive at T+100 (BurnStart = T+100).
+	a := spacecraft.ManeuverNode{Mode: spacecraft.BurnPrograde, DV: 10, TriggerTime: base.Add(100 * time.Second)}
+	// Node B: finite at T+110, Duration 40s (BurnStart = T+90 < A's).
+	b := spacecraft.ManeuverNode{Mode: spacecraft.BurnPrograde, DV: 20, TriggerTime: base.Add(110 * time.Second), Duration: 40 * time.Second}
+
+	nodes := []spacecraft.ManeuverNode{a, b}
+	sortNodes(nodes)
+
+	if !nodes[0].BurnStart().Before(nodes[1].BurnStart()) {
+		t.Errorf("nodes not ordered by BurnStart: [0]=%v [1]=%v",
+			nodes[0].BurnStart(), nodes[1].BurnStart())
+	}
+	if nodes[0].DV != 20 {
+		t.Errorf("node[0].DV = %.0f, want 20 (the earlier-BurnStart finite node B)", nodes[0].DV)
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -165,16 +165,26 @@ func (w *World) PlanNode(n ManeuverNode) {
 	sortNodes(c.Nodes)
 }
 
-// sortNodes orders nodes by TriggerTime ascending, with unresolved
+// sortNodes orders nodes by BurnStart ascending, with unresolved
 // event-relative nodes pushed to the end. Used by PlanNode and by
 // resolveEventNodes after it freezes a previously-unresolved node.
+//
+// The key is BurnStart() — not TriggerTime — because that is exactly
+// what executeDueNodesFor fires and breaks on (BurnStart = TriggerTime
+// - Duration/2 for finite nodes). Sorting by TriggerTime would let a
+// later-TriggerTime but longer-duration node have an earlier BurnStart
+// yet sit behind an impulsive node in the slice, so the dispatch loop's
+// break-on-first-future guard would skip it past its due moment and
+// ignite its centered burn late (GH #88). nextFiniteBurnTrigger already
+// clamps warp on BurnStart, so this aligns the sort, the dispatch, and
+// the clamp on one key.
 func sortNodes(nodes []ManeuverNode) {
 	sort.Slice(nodes, func(i, j int) bool {
 		ri, rj := nodes[i].IsResolved(), nodes[j].IsResolved()
 		if ri != rj {
 			return ri
 		}
-		return nodes[i].TriggerTime.Before(nodes[j].TriggerTime)
+		return nodes[i].BurnStart().Before(nodes[j].BurnStart())
 	})
 }
 
@@ -1380,6 +1390,17 @@ func (w *World) timeToBodyDirection(b, primary bodies.CelestialBody, dHat, nHat 
 			break
 		}
 		step := f / fp
+		// Divergence guard (GH #88): near apoapsis of an eccentric
+		// orbit the angular rate fp can be tiny-but-nonzero, making
+		// step blow up to a meaningless 1e13-scale value. The `fp==0`
+		// check only catches an exact zero, and `|step|<1` only fires
+		// on convergence — so without this a runaway step would leave
+		// dt as garbage. A correction larger than a full period is not
+		// a local root refinement; abandon Newton and keep the last
+		// good dt (the mean-motion seed on the first iteration).
+		if math.IsNaN(step) || math.IsInf(step, 0) || math.Abs(step) > period {
+			break
+		}
 		dt -= step
 		if math.Abs(step) < 1 {
 			break
@@ -1750,6 +1771,17 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 			break
 		}
 		if n.BurnStart().After(w.Clock.SimTime) {
+			break
+		}
+		// A finite burn occupies the craft exclusively: only one
+		// ActiveBurn can integrate at a time. If one is already in
+		// flight — started earlier this same tick, or carried over
+		// from a prior tick — stop dispatching and leave the remaining
+		// due nodes queued so the next one fires after this burn ends.
+		// Without this, a second finite node coming due in the same
+		// tick would overwrite c.ActiveBurn and its Δv would be popped
+		// and silently dropped (GH #88).
+		if c.ActiveBurn != nil {
 			break
 		}
 		// v0.9.3+: resolve target snapshot for target-relative nodes


### PR DESCRIPTION
Verify-then-fix pass over the #88 core-review findings (maneuver node firing & ordering). Each fix has a red-first regression test.

## Fixed (with tests)

**#1 (HIGH) — silently dropped finite burn.** `executeDueNodesFor` never broke after starting a finite `ActiveBurn`, so two finite nodes coming due in the same tick (the split-transfer plane-change + capture pair, or any closely-triggered pair) overwrote `c.ActiveBurn` while both were popped — the first burn's Δv vanished. Now the loop guards on an in-flight `ActiveBurn` and breaks; the remaining due nodes stay queued and fire after it ends. Also closes the **cross-tick** variant (a node coming due while a prior tick's burn is still running). Tests: `TestExecuteDueNodesFiniteBurnNotOverwritten`, `TestExecuteDueNodesDoesNotOverwriteInFlightBurn`.

**#2 (MEDIUM) — sort/fire key disagreement.** `sortNodes` ordered by `TriggerTime` but dispatch fires/breaks on `BurnStart()` (= `TriggerTime − Duration/2`). A later-trigger but longer-duration node had an earlier `BurnStart` yet sat behind an impulsive node, so the break-on-first-future guard skipped it past its due moment. `sortNodes` now keys on `BurnStart()`, aligning sort, dispatch, and the `nextFiniteBurnTrigger` warp clamp. Test: `TestSortNodesOrdersByBurnStart`.

**#6 (LOW) — unbounded Newton step in `timeToBodyDirection`.** Near apoapsis of an eccentric orbit `fp` can be tiny-but-nonzero, blowing the correction up with no divergence guard (only `fp==0` and convergence were caught). Now abandons Newton on a step larger than a full period and keeps the mean-motion seed. Covered by the existing split-transfer tests (which exercise this via `splitNodePhasing`).

## Documented, not changed (verdict below / on the issue)

- **#3 (MEDIUM)** — plane-change + capture planted at identical trigger time in the `found==false` degenerate-geometry fallback. The catastrophic symptom (the dropped Δv) is eliminated by the #1 dispatch fix — the two nodes now fire a tick apart instead of overwriting. The residual (stacked timing only when the transfer geometry was already degenerate enough that SOI entry isn't found within the horizon) is a planner-quality edge; fixing it risks the working split path, so deferred.
- **#4 (LOW)** — `PreviewBurnState` skips the rocket-equation Δv cap when the duration would exhaust all propellant. Preview-only; a correct cap needs the active-stage fuel floor, which is exactly what #89 reworks. Better folded in after #89 lands.
- **#5 (LOW, PLAUSIBLE)** — `RefinePlan` relocates the arrival node by `(TriggerTime, PrimaryID)` and can rewrite the wrong node when two arrival nodes coincide. Requires double-planting to the same body with a coinciding arrival time; needs stable node identity to fix properly.

## Test
`go vet ./...` clean; `go test ./... -race -count=1` → 957 pass (+3 new). Pre-existing gofmt drift untouched; added lines are gofmt-clean.

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)