### PR TITLE
fix(spacecraft): correct thrust/Δv-budget/fuel accounting (#89)

### DIFF
--- a/internal/spacecraft/fuel_accounting_test.go
+++ b/internal/spacecraft/fuel_accounting_test.go
@@ -1,0 +1,168 @@
+package spacecraft
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// TestBurnTimeForDVIgnoresCutThrottle — GH #89 (thrust.go:496, MEDIUM).
+// BurnTimeForDV must derive the planned engine-on duration at the burn's
+// firing throttle (full), not the craft's live coast throttle. Pre-fix
+// it used s.MassFlowRate() (live throttle); with throttle cut to 0 the
+// mass flow was 0 so it returned Duration=0, collapsing every auto-plant
+// (inclination / circularise / transfer) into an impulsive node that
+// then fires the whole Δv instantaneously. The planned duration must be
+// independent of the coast throttle.
+func TestBurnTimeForDVIgnoresCutThrottle(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+
+	full := NewInLEO(*earth)
+	wantSecs := full.BurnTimeForDV(100).Seconds()
+	if wantSecs <= 0 {
+		t.Fatalf("precondition: full-throttle BurnTimeForDV should be >0, got %v", wantSecs)
+	}
+
+	cut := NewInLEO(*earth)
+	cut.Throttle = 0 // player coasting with throttle cut
+	got := cut.BurnTimeForDV(100).Seconds()
+	if got <= 0 {
+		t.Fatalf("BurnTimeForDV with cut throttle = %v, want the full-throttle duration (~%.3fs) — a cut coast throttle collapsed the planned finite burn to impulsive", got, wantSecs)
+	}
+	if math.Abs(got-wantSecs) > 1e-6 {
+		t.Errorf("BurnTimeForDV(cut throttle) = %.6fs, want %.6fs (independent of live throttle)", got, wantSecs)
+	}
+}
+
+// TestRemainingDeltaVUsesActiveStageFuel — GH #89 (thrust.go:443, MEDIUM).
+// RemainingDeltaV must budget only the active (bottom) stage's burnable
+// propellant. Pre-fix it used s.TotalMass()/(DryMass+Monoprop) where
+// s.Fuel is the SUMMED fuel across ALL stages, so a multi-stage craft
+// with a near-dry bottom stage but full upper stages reported a Δv
+// budget that counts upper-stage fuel as burnable through the spent
+// bottom engine.
+func TestRemainingDeltaVUsesActiveStageFuel(t *testing.T) {
+	// 2-stage craft: bottom stage near-dry, upper stage full. The active
+	// engine can only burn the bottom stage's small remaining fuel.
+	sc := &Spacecraft{
+		Isp: 300,
+		Stages: []Stage{
+			{Name: "S1", DryMass: 1000, FuelMass: 50, Thrust: 100000, Isp: 300},  // bottom, nearly dry
+			{Name: "S2", DryMass: 800, FuelMass: 20000, Thrust: 50000, Isp: 300}, // full upper
+		},
+	}
+	sc.SyncFields()
+
+	got := sc.RemainingDeltaV()
+
+	// The honest budget burns only the bottom stage's 50 kg of fuel
+	// against the whole stacked mass sitting on top of that engine.
+	stacked := sc.TotalMass()
+	floorActive := stacked - 50 // burn the 50 kg of active-stage fuel
+	want := 300 * g0 * math.Log(stacked/floorActive)
+
+	if math.Abs(got-want) > want*0.02 {
+		t.Errorf("RemainingDeltaV = %.1f m/s, want ~%.1f m/s (active bottom stage only); summing all-stage fuel over-reports the budget", got, want)
+	}
+	// Sanity: the summed-fuel overestimate would be far larger.
+	bogus := 300 * g0 * math.Log(stacked/(sc.DryMass+sc.Monoprop))
+	if math.Abs(got-bogus) < want {
+		t.Errorf("RemainingDeltaV = %.1f m/s looks like the summed-fuel overestimate (%.1f m/s), not the active-stage budget", got, bogus)
+	}
+}
+
+// TestApplyImpulsiveCapsAtFuelExhaustion — GH #89 (thrust.go:426, LOW).
+// An impulsive node requesting more Δv than the active stage's fuel
+// supports must deliver only the deliverable Δv, not the full request.
+// Pre-fix the velocity change was applied in full and BurnFuel silently
+// clamped the debit, granting free Δv past exhaustion.
+func TestApplyImpulsiveCapsAtFuelExhaustion(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+
+	budget := sc.RemainingDeltaV()
+	if budget <= 0 {
+		t.Fatalf("precondition: craft should have a Δv budget, got %v", budget)
+	}
+	v0 := sc.State.V
+
+	// Request 3× the available budget along prograde.
+	sc.ApplyImpulsive(BurnPrograde, budget*3)
+
+	delivered := sc.State.V.Sub(v0).Norm()
+	if delivered > budget*1.001 {
+		t.Errorf("delivered Δv = %.1f m/s exceeds the fuel budget %.1f m/s — impulsive path granted free Δv past exhaustion", delivered, budget)
+	}
+	if delivered < budget*0.999 {
+		t.Errorf("delivered Δv = %.1f m/s, want ~%.1f m/s (the full available budget)", delivered, budget)
+	}
+	if sc.ActiveStageFuel() > 1.0 {
+		t.Errorf("active stage still holds %.1f kg fuel after an over-budget burn — should be ~empty", sc.ActiveStageFuel())
+	}
+}
+
+// TestApolloCSMLMCompositeMatchesLoadoutLM — GH #89 (stages_catalog.go:231).
+// The "csm-lm" configurator composite is the post-transposition Apollo
+// stack, so its LM must carry the same ADR-0009 trimmed propellant as the
+// Apollo-Stack loadout — not the untrimmed standalone Lander modules.
+// Pre-fix the composite built a 9500/1800 LM vs the loadout's 6310/1269,
+// ~0.9 km/s of phantom descent Δv between two ways to fly one mission.
+func TestApolloCSMLMCompositeMatchesLoadoutLM(t *testing.T) {
+	stages, ok := BuildModule(StageModuleApolloCSMLMID)
+	if !ok || len(stages) != 4 {
+		t.Fatalf("BuildModule(csm-lm) = %d stages (ok=%v), want 4", len(stages), ok)
+	}
+	// Order is [SM, CM, Descent, Ascent].
+	descent, ascent := stages[2], stages[3]
+	if descent.Name != "Descent" || ascent.Name != "Ascent" {
+		t.Fatalf("stage order = [%q,%q] for the LM half, want [Descent, Ascent]", descent.Name, ascent.Name)
+	}
+
+	// Pull the canonical trimmed LM from the Apollo-Stack loadout.
+	lo, ok := Loadouts[LoadoutApolloStackID]
+	if !ok {
+		t.Fatal("Apollo-Stack loadout missing")
+	}
+	var loDescent, loAscent Stage
+	for _, st := range lo.Stages {
+		switch st.Name {
+		case "Descent":
+			loDescent = st
+		case "Ascent":
+			loAscent = st
+		}
+	}
+
+	if descent.FuelMass != loDescent.FuelMass {
+		t.Errorf("composite LM descent fuel = %.0f, want %.0f (Apollo-Stack loadout)", descent.FuelMass, loDescent.FuelMass)
+	}
+	if ascent.FuelMass != loAscent.FuelMass {
+		t.Errorf("composite LM ascent fuel = %.0f, want %.0f (Apollo-Stack loadout)", ascent.FuelMass, loAscent.FuelMass)
+	}
+	// Tanks must read full at the trimmed capacity.
+	if descent.FuelMass != descent.FuelCapacity || ascent.FuelMass != ascent.FuelCapacity {
+		t.Errorf("trimmed LM stages not full: descent %.0f/%.0f ascent %.0f/%.0f",
+			descent.FuelMass, descent.FuelCapacity, ascent.FuelMass, ascent.FuelCapacity)
+	}
+}
+
+// TestCatalogICPSMatchesStandaloneLoadout — GH #89 (stages_catalog.go:167).
+// A catalog part must fly identically to its canonical loadout stage. The
+// catalog ICPS thrust must match the standalone ICPS loadout (108000 N),
+// not the SLS-embedded variant (110000 N).
+func TestCatalogICPSMatchesStandaloneLoadout(t *testing.T) {
+	icps, ok := BuildStage(StageModuleICPSID)
+	if !ok {
+		t.Fatal("catalog ICPS missing")
+	}
+	lo, ok := Loadouts[LoadoutICPSID]
+	if !ok || len(lo.Stages) == 0 {
+		t.Fatal("standalone ICPS loadout missing")
+	}
+	if icps.Thrust != lo.Stages[0].Thrust {
+		t.Errorf("catalog ICPS thrust = %.0f N, want %.0f N (standalone ICPS loadout)", icps.Thrust, lo.Stages[0].Thrust)
+	}
+}

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -43,11 +43,15 @@ type Spacecraft struct {
 	Color     string
 
 	// Throttle is the engine power factor in [0, 1]; effective
-	// thrust = Thrust * Throttle. v0.7.3+. Zero is a sentinel for
-	// "legacy / unset" (treated as 1.0 by EffectiveThrottle) so
-	// pre-v0.7.3 Spacecraft constructions and v3 saves keep firing
-	// at full thrust. New callers that need the engine off route
-	// through ManualBurn = nil rather than a zero throttle.
+	// thrust = Thrust * Throttle. v0.7.3+. Zero means "engine off"
+	// (the live value after the player cuts throttle) — it is NOT a
+	// legacy/unset sentinel promoted to 1.0; Spacecraft.EffectiveThrottle
+	// returns it verbatim. Every constructor must therefore set Throttle
+	// explicitly (NewInLEO and the save-load path do); literal
+	// Spacecraft{} test fixtures use Thrust=0 so the engine path is
+	// never entered and the value is moot. (ManeuverNode.EffectiveThrottle
+	// is the one that maps 0→1.0, for the per-node firing throttle —
+	// that promotion is node-local and does not apply here.)
 	Throttle float64
 
 	// LastThrottleChangeAt is the sim-time at which Throttle most

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -128,6 +128,16 @@ const (
 	StageModuleRCSTugID  = "rcs-tug" // pure-monoprop proximity-ops module
 )
 
+// ADR-0009 trimmed Apollo LM propellant (kg). The csm-lm composite is
+// the post-transposition Apollo stack, so its LM carries these — the
+// same values the Apollo-Stack loadout uses (loadouts.go) — rather than
+// the untrimmed standalone Lander modules. Kept in sync with the
+// loadout by TestApolloCSMLMCompositeMatchesLoadoutLM (GH #89).
+const (
+	apolloLMDescentFuel = 6310.0 // descent 9500 → 6310 (real abort reserve, ~2500 m/s cap)
+	apolloLMAscentFuel  = 1269.0 // ascent  1800 → 1269 (~2200 m/s cap)
+)
+
 // StageCatalog indexes the parts library by ID. The numbers mirror
 // the inline loadout literals in loadouts.go (see file-level note).
 // The CSM is net-new in v0.10.1 — Apollo Command/Service Module:
@@ -164,7 +174,12 @@ var StageCatalog = map[string]StageModule{
 	},
 	StageModuleICPSID: {
 		ID: StageModuleICPSID, Name: "ICPS", Glyph: "◆", Color: "#5BB3FF",
-		Tier: "transfer", dry: 3500, fuel: 25000, thrust: 110000, isp: 462, bc: 6.25e-5,
+		// GH #89: thrust mirrors the standalone ICPS loadout (108000 N),
+		// the canonical referent for a configurator part named "ICPS" —
+		// not the 110000 N variant the SLS-Block1 loadout embeds. Was
+		// 110000, which violated the file-level "flies identically to its
+		// canonical loadout stage" promise for a player adding the part.
+		Tier: "transfer", dry: 3500, fuel: 25000, thrust: 108000, isp: 462, bc: 6.25e-5,
 		launchSpriteRowsPx:  8,
 		launchSpriteWidthPx: 3,
 		launchSpriteColor:   "#C0C8D0", // muted cool grey — tames the saturated slate-blue Color
@@ -203,6 +218,14 @@ var StageCatalog = map[string]StageModule{
 		launchSpriteWidthPx: 3,
 		fuelType:            FuelTypeKerolox,
 	},
+	// NOTE (GH #89): only this entry's sprite/name/flag fields are read —
+	// the catalog*ByName helpers resolve "LM"→"Lander" for sprite + soft-
+	// land + parachute lookups. Its dry/fuel/thrust are DEAD for stage
+	// construction: BuildModule intercepts StageModuleLanderID and expands
+	// to Descent+Ascent (the only stages ever built from this id), so no
+	// flying stage is ever constructed from the 4000/8000/45000 below.
+	// They are intentionally unreachable — do not trust them as the
+	// Lander's mass budget (the live numbers are the Descent+Ascent split).
 	StageModuleLanderID: {
 		ID: StageModuleLanderID, Name: "Lander", Glyph: "▼", Color: "#5FFF87",
 		Tier: "payload", dry: 4000, fuel: 8000, thrust: 45000, isp: 311, bc: 0,
@@ -433,6 +456,18 @@ func BuildModule(id string) ([]Stage, bool) {
 		if !okSM || !okCM || !okD || !okA {
 			return nil, false
 		}
+		// GH #89: this composite IS the post-transposition Apollo stack,
+		// so its LM must carry the ADR-0009 *trimmed* propellant — the
+		// same as the Apollo-Stack loadout — not the untrimmed shared
+		// Lander modules. Post-transposition the LM no longer doubles as
+		// the LOI engine (the SM does), so it sheds the surplus the
+		// standalone Lander keeps. Reusing the untrimmed descent/ascent
+		// gave this composite ~0.9 km/s more descent Δv than the loadout
+		// for the same mission. The trim is fuel-only (sprite, legs,
+		// soft-land, engine all shared), so override here rather than
+		// duplicating the catalog entries.
+		d.FuelMass, d.FuelCapacity = apolloLMDescentFuel, apolloLMDescentFuel
+		a.FuelMass, a.FuelCapacity = apolloLMAscentFuel, apolloLMAscentFuel
 		return []Stage{sm, cm, d, a}, true
 	}
 	st, ok := BuildStage(id)

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -398,11 +398,36 @@ func (s *Spacecraft) ApplyImpulsive(mode BurnMode, dv float64) {
 func (s *Spacecraft) ApplyImpulsiveWithTarget(mode BurnMode, dv float64, rT, vT orbital.Vec3) {
 	// v0.9.2+: route through BurnDirection so surface modes + trim feed through.
 	dir := s.BurnDirectionWithTarget(mode, rT, vT)
+	dv = s.capImpulsiveDV(dv)
 	if dir.Norm() == 0 || dv == 0 {
 		return
 	}
 	s.State.V = s.State.V.Add(dir.Scale(dv))
 	s.consumeFuel(math.Abs(dv))
+}
+
+// capImpulsiveDV limits an instantaneous Δv magnitude to what the active
+// (bottom) stage's propellant can actually deliver, so the one-shot
+// impulsive fire path can't grant free Δv past fuel exhaustion. The
+// finite-burn integrator self-limits step-by-step, but the impulsive
+// path applies the full velocity change before debiting fuel and
+// BurnFuel silently clamps the debit to the stage's remaining fuel —
+// leaving the craft with more Δv than its propellant supports (GH #89).
+// Capping at RemainingDeltaV() makes consumeFuel burn exactly the
+// available stage fuel. A craft with no rocket-equation model (Isp<=0,
+// i.e. legacy / thrust-less test fixtures) is left unmodified.
+func (s *Spacecraft) capImpulsiveDV(dv float64) float64 {
+	if s.Isp <= 0 {
+		return dv
+	}
+	maxDV := s.RemainingDeltaV()
+	if dv > maxDV {
+		return maxDV
+	}
+	if dv < -maxDV {
+		return -maxDV
+	}
+	return dv
 }
 
 // ApplyImpulsiveDir applies an instantaneous Δv of magnitude dv along
@@ -411,6 +436,7 @@ func (s *Spacecraft) ApplyImpulsiveWithTarget(mode BurnMode, dv float64, rT, vT 
 // degraded to impulsive — its tilted direction is resolved upstream
 // by NodeBurnDirection rather than from a plain BurnMode. v0.10.4+.
 func (s *Spacecraft) ApplyImpulsiveDir(dir orbital.Vec3, dv float64) {
+	dv = s.capImpulsiveDV(dv)
 	if dir.Norm() == 0 || dv == 0 {
 		return
 	}
@@ -436,15 +462,25 @@ func (s *Spacecraft) consumeFuel(dvUsed float64) {
 
 // RemainingDeltaV estimates how much more Δv the main engine's fuel
 // supports via the rocket equation: Δv = Isp·g0·ln(m0/m_after_fuel).
-// Monoprop is not burned through the main engine, so it counts as
-// dead weight in the m_after_fuel term — the floor is dry+monoprop,
-// not dry alone. v0.8.0+: pre-monoprop the floor was just DryMass.
+// Only the active (bottom) stage's propellant is burnable through the
+// firing engine, so m_after_fuel subtracts ActiveStageFuel() from the
+// stacked total — everything else (dry mass, monoprop, *upper-stage
+// propellant*) is dead weight to this engine.
+//
+// v0.14.x (GH #89): the floor was DryMass+Monoprop, but s.Fuel /
+// DryMass are the SUMMED values across all stages, so the implied
+// m_after_fuel counted every upper stage's propellant as burnable
+// through the bottom engine — the same all-stage overestimate
+// ActiveStageFuel() was introduced to kill. For a single-stage craft
+// TotalMass()-ActiveStageFuel() == DryMass+Monoprop, so behaviour is
+// unchanged there; only multi-stage budgets are corrected.
 func (s *Spacecraft) RemainingDeltaV() float64 {
-	floor := s.DryMass + s.Monoprop
-	if floor == 0 || s.TotalMass() == 0 {
+	total := s.TotalMass()
+	floor := total - s.ActiveStageFuel()
+	if floor <= 0 || total == 0 {
 		return 0
 	}
-	return s.Isp * g0 * math.Log(s.TotalMass()/floor)
+	return s.Isp * g0 * math.Log(total/floor)
 }
 
 // MassFlowRate returns the propellant mass-flow magnitude (kg/s) at
@@ -493,7 +529,14 @@ func (s *Spacecraft) BurnTimeForDV(dv float64) time.Duration {
 	if dv <= 0 || s.Isp <= 0 || s.Thrust <= 0 {
 		return 0
 	}
-	mDot := s.MassFlowRate()
+	// Use the full-throttle mass flow, not the craft's *live* throttle:
+	// this is the planned engine-on duration for a burn that fires at
+	// the node's own throttle (default full). Reading MassFlowRate()
+	// (= live EffectiveThrottle()) meant that planting an auto burn
+	// while coasting with throttle cut to 0 yielded mDot==0 → Duration
+	// 0, silently collapsing the finite burn into an impulsive node
+	// that then delivered the whole Δv instantaneously (GH #89).
+	mDot := s.MassFlowRateAt(1.0)
 	if mDot <= 0 {
 		return 0
 	}


### PR DESCRIPTION
Verify-then-fix pass over all seven #89 fuel/thrust accounting findings. Each has a red-first regression test. **Closes #89** — every finding addressed.

## Physics fixes (tested)

**`BurnTimeForDV` (MEDIUM)** — derived the planned engine-on duration from the craft's *live* throttle. Coasting with throttle cut to 0 gave `mDot==0` → `Duration 0`, collapsing every auto-planted finite burn (inclination / circularise / transfer) into an impulsive node that delivered the whole Δv instantaneously. Now computes at full throttle (`MassFlowRateAt(1.0)`) — the throttle the node actually fires at. Test: `TestBurnTimeForDVIgnoresCutThrottle`.

**`RemainingDeltaV` (MEDIUM)** — summed fuel across *all* stages, counting upper-stage propellant as burnable through the spent bottom engine (a 2-stage near-dry-bottom craft reported ~7344 m/s vs the real ~7 m/s). Floor is now `TotalMass() − ActiveStageFuel()`, which reduces to `DryMass+Monoprop` for single-stage craft (unchanged). Test: `TestRemainingDeltaVUsesActiveStageFuel`.

**Impulsive over-budget Δv (LOW)** — `ApplyImpulsive{,Dir,WithTarget}` applied the full requested Δv before debiting fuel, and `BurnFuel` silently clamps the debit — free Δv past exhaustion. New `capImpulsiveDV()` caps the applied Δv at `RemainingDeltaV` (no-op for `Isp<=0` legacy fixtures). Test: `TestApplyImpulsiveCapsAtFuelExhaustion`.

## Catalog fixes (tested)

**csm-lm composite LM (MEDIUM)** — the configurator's post-transposition Apollo composite already uses the trimmed split SM, but built its LM from the *untrimmed* shared Lander modules (9500/1800) vs the Apollo-Stack loadout's ADR-0009 trimmed LM (6310/1269) — ~0.9 km/s of phantom descent Δv between two ways to fly one mission. Composite LM now matches the loadout (fuel-only override; sprite/legs/engine shared). Test: `TestApolloCSMLMCompositeMatchesLoadoutLM`.

**Catalog ICPS thrust (LOW)** — mirrored the SLS-embedded variant (110000 N) rather than the standalone ICPS loadout (108000 N) the file-level contract says it should fly identically to. Aligned to the standalone loadout. Test: `TestCatalogICPSMatchesStandaloneLoadout`.

## Doc-only fixes

- **Dead single-stage Lander entry (LOW)** — documented that its mass/fuel/thrust are unreachable for stage construction (`BuildModule` expands the id to Descent+Ascent; only sprite/flags are read), so the drift the finding flagged can't mislead a reader.
- **`Spacecraft.Throttle` field doc (LOW)** — no longer claims a `0→1.0` legacy sentinel that `Spacecraft.EffectiveThrottle` doesn't perform (that promotion is `ManeuverNode`-local).

## Test
`go vet ./...` clean; `go test ./... -race -count=1` → 959 pass (+5 new). The load-bearing Apollo-Stack / Saturn V budget evals still pass. Pre-existing gofmt drift untouched; added lines gofmt-clean.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)