### PR TITLE
fix(sim): bind vessel targets by stable craft ID, not slate index (#87)

### DIFF
--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -38,8 +38,13 @@ import (
 // Stages slice (see migrateV5Craft). Load accepts any version in
 // [1, SchemaVersion]; pre-v6 envelopes are translated on load.
 // Bumps that need real migration logic should add a dedicated
-// upgrade pass keyed off File.Version.
-const SchemaVersion = 6
+// upgrade pass keyed off File.Version. v0.14.x bumps to v7 — vessels
+// gain a stable Spacecraft.ID and every target (world cursor, per-craft
+// binding, planted-node + in-flight-burn target slots) references a
+// craft by ID instead of slate index (ADR 0012, GH #87). v6 envelopes
+// migrate on load via migrateV6PayloadToV7, which assigns IDs by slate
+// position and rewrites the stored indices to IDs.
+const SchemaVersion = 7
 
 // File is the on-disk envelope.
 type File struct {
@@ -69,6 +74,7 @@ type Payload struct {
 	Craft          *Craft             `json:"craft,omitempty"`    // v1–v4 singular form; migrated to Crafts on load.
 	Crafts         []Craft            `json:"crafts,omitempty"`
 	ActiveCraftIdx int                `json:"active_craft_idx,omitempty"`
+	NextCraftID    uint64             `json:"next_craft_id,omitempty"` // v0.14.x / schema v7: monotonic craft-ID counter (ADR 0012).
 	Nodes          []Node             `json:"nodes,omitempty"`
 	ActiveBurn     *ActiveBurn        `json:"active_burn,omitempty"`
 	Missions       []missions.Mission `json:"missions,omitempty"`
@@ -81,14 +87,20 @@ type Focus struct {
 }
 
 // Target mirrors sim.Target by value. v0.9.0+. The zero value
-// (Kind=0=TargetNone, BodyIdx=0, CraftIdx=0) is suppressed by the
-// payload's `omitempty` tag, so saves predating v0.9.0 round-trip
-// without writing the field — and load fills sim.World.Target with
-// the zero value, matching pre-target behaviour.
+// (Kind=0=TargetNone, BodyIdx=0) is suppressed by the payload's
+// `omitempty` tag, so saves predating v0.9.0 round-trip without
+// writing the field — and load fills sim.World.Target with the zero
+// value, matching pre-target behaviour.
+//
+// CraftID (v0.14.x / schema v7, ADR 0012) is the target craft's stable
+// Spacecraft.ID. CraftIdx is the retired pre-v7 0-based slate index,
+// retained only to read v6 saves; migrateV6PayloadToV7 converts it to
+// CraftID. v7 saves write CraftID and leave CraftIdx zero.
 type Target struct {
-	Kind     int `json:"kind"`
-	BodyIdx  int `json:"body_idx,omitempty"`
-	CraftIdx int `json:"craft_idx,omitempty"`
+	Kind     int    `json:"kind"`
+	BodyIdx  int    `json:"body_idx,omitempty"`
+	CraftIdx int    `json:"craft_idx,omitempty"` // pre-v7 (read-only for migration)
+	CraftID  uint64 `json:"craft_id,omitempty"`  // v7+ stable ID
 }
 
 // Vec3 is the wire form of orbital.Vec3.
@@ -117,6 +129,7 @@ type Vec3 struct {
 // v5 reader (none in production, but possible for tooling) would
 // still see a coherent craft.
 type Craft struct {
+	ID               uint64  `json:"id,omitempty"` // v0.14.x / schema v7: stable Spacecraft.ID (ADR 0012). Pre-v7 saves omit it; migrateV6PayloadToV7 assigns one per slate position.
 	Name             string  `json:"name"`
 	DryMass          float64 `json:"dry_mass"`
 	Fuel             float64 `json:"fuel"`
@@ -272,12 +285,14 @@ type Node struct {
 	PrimaryID       string  `json:"primary_id"`
 	Event           int     `json:"event,omitempty"`
 	Throttle        float64 `json:"throttle,omitempty"`
-	// TargetCraftIdx (v0.9.3+) is the one-based slate idx the node
-	// is bound to for target-relative modes / TriggerNextClosest
-	// Approach event. Zero = no target. Additive — pre-v0.9.3 saves
-	// load with TargetCraftIdx=0, which is correct semantics for
-	// non-target nodes. No schema bump required.
+	// TargetCraftIdx is the retired pre-v7 one-based slate idx the node
+	// was bound to. Retained only to read v6 saves; migrateV6PayloadToV7
+	// converts it to TargetCraftID.
 	TargetCraftIdx int `json:"target_craft_idx,omitempty"`
+	// TargetCraftID (v0.14.x / schema v7, ADR 0012) is the bound target
+	// craft's stable Spacecraft.ID. Zero = no target. v7 saves write
+	// this and leave TargetCraftIdx zero.
+	TargetCraftID uint64 `json:"target_craft_id,omitempty"`
 	// PlaneChangeRad (v0.12.x, schema v6 additive) — the signed rotation
 	// angle for a BurnPlaneChange node (the `I` inclination plant + the
 	// Slice 5 split-strategy plane change). Pre-v0.12 saves omit it;
@@ -333,10 +348,12 @@ type ActiveBurn struct {
 	EndTimeNano int64   `json:"end_time_unix_nano"`
 	PrimaryID   string  `json:"primary_id"`
 	Throttle    float64 `json:"throttle,omitempty"`
-	// TargetCraftIdx (v0.9.3+) — see Node.TargetCraftIdx; mirrored
-	// onto in-flight finite burns so a save mid-rendezvous-burn
-	// reloads with the burn still tracking its bound target.
-	TargetCraftIdx int `json:"target_craft_idx,omitempty"`
+	// TargetCraftIdx — retired pre-v7 slate idx (see Node.TargetCraftIdx);
+	// read-only for v6 migration. TargetCraftID (v7+, ADR 0012) is the
+	// burn's bound target stable ID, mirrored onto in-flight finite burns
+	// so a save mid-rendezvous-burn reloads still tracking its target.
+	TargetCraftIdx int    `json:"target_craft_idx,omitempty"`
+	TargetCraftID  uint64 `json:"target_craft_id,omitempty"`
 	// PlaneChangeRad / BurnDirUnit (v0.12.x, schema v6 additive) — mirror
 	// the ManeuverNode fields onto an in-flight burn so a save mid
 	// plane-change / BurnVector burn reloads with the direction intact.
@@ -427,6 +444,12 @@ func Load(path string) (*sim.World, error) {
 	if f.BodyCatalogHash != currentHash {
 		return nil, fmt.Errorf("%w: save=%s current=%s", ErrCatalogMismatch, f.BodyCatalogHash, currentHash)
 	}
+	// v0.14.x / schema v7 (ADR 0012): pre-v7 saves bind targets by slate
+	// index; rewrite them to stable craft IDs on the wire payload before
+	// rehydration so worldFromPayload reads the ID fields uniformly.
+	if f.Version < 7 {
+		migrateV6PayloadToV7(&f.Payload)
+	}
 	return worldFromPayload(f.Payload, systems)
 }
 
@@ -461,6 +484,7 @@ func payloadFromWorld(w *sim.World) Payload {
 			continue
 		}
 		wc := Craft{
+			ID:                 c.ID,
 			Name:               c.Name,
 			DryMass:            c.DryMass,
 			Fuel:               c.Fuel,
@@ -549,7 +573,7 @@ func payloadFromWorld(w *sim.World) Payload {
 				PrimaryID:       n.PrimaryID,
 				Event:           int(n.Event),
 				Throttle:        n.Throttle,
-				TargetCraftIdx:  n.TargetCraftIdx,
+				TargetCraftID:   n.TargetCraftID,
 				PlaneChangeRad:  n.PlaneChangeRad,
 				BurnDirUnit:     vec3From(n.BurnDirUnit),
 			})
@@ -561,7 +585,7 @@ func payloadFromWorld(w *sim.World) Payload {
 				EndTimeNano:    c.ActiveBurn.EndTime.UnixNano(),
 				PrimaryID:      c.ActiveBurn.PrimaryID,
 				Throttle:       c.ActiveBurn.Throttle,
-				TargetCraftIdx: c.ActiveBurn.TargetCraftIdx,
+				TargetCraftID:  c.ActiveBurn.TargetCraftID,
 				PlaneChangeRad: c.ActiveBurn.PlaneChangeRad,
 				BurnDirUnit:    vec3From(c.ActiveBurn.BurnDirUnit),
 			}
@@ -571,14 +595,15 @@ func payloadFromWorld(w *sim.World) Payload {
 		// out the same minimal JSON they did pre-polish.
 		if c.Target.Kind != spacecraft.TargetNone {
 			wc.Target = &Target{
-				Kind:     int(c.Target.Kind),
-				BodyIdx:  c.Target.BodyIdx,
-				CraftIdx: c.Target.CraftIdx,
+				Kind:    int(c.Target.Kind),
+				BodyIdx: c.Target.BodyIdx,
+				CraftID: c.Target.CraftID,
 			}
 		}
 		p.Crafts = append(p.Crafts, wc)
 	}
 	p.ActiveCraftIdx = w.ActiveCraftIdx
+	p.NextCraftID = w.NextCraftID
 	p.Missions = missions.Clone(w.Missions)
 	return p
 }
@@ -665,6 +690,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 			stages = migrateV5CraftToStages(wc, monoprop, monoCap, rcsThrust, rcsIsp)
 		}
 		c := &spacecraft.Spacecraft{
+			ID:               wc.ID, // v7+ stable identity (ADR 0012); ensureCraftIDs stamps any zero.
 			Name:             wc.Name,
 			DryMass:          wc.DryMass,
 			Fuel:             wc.Fuel,
@@ -755,7 +781,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				PrimaryID:      n.PrimaryID,
 				Event:          sim.TriggerEvent(n.Event),
 				Throttle:       n.Throttle,
-				TargetCraftIdx: n.TargetCraftIdx,
+				TargetCraftID:  n.TargetCraftID,
 				PlaneChangeRad: n.PlaneChangeRad,
 				BurnDirUnit:    vec3To(n.BurnDirUnit),
 			})
@@ -767,7 +793,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				EndTime:        time.Unix(0, wc.ActiveBurn.EndTimeNano).UTC(),
 				PrimaryID:      wc.ActiveBurn.PrimaryID,
 				Throttle:       wc.ActiveBurn.Throttle,
-				TargetCraftIdx: wc.ActiveBurn.TargetCraftIdx,
+				TargetCraftID:  wc.ActiveBurn.TargetCraftID,
 				PlaneChangeRad: wc.ActiveBurn.PlaneChangeRad,
 				BurnDirUnit:    vec3To(wc.ActiveBurn.BurnDirUnit),
 			}
@@ -777,13 +803,14 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 		// (TargetNone) which is the fresh-craft default.
 		if wc.Target != nil {
 			c.Target = spacecraft.Target{
-				Kind:     spacecraft.TargetKind(wc.Target.Kind),
-				BodyIdx:  wc.Target.BodyIdx,
-				CraftIdx: wc.Target.CraftIdx,
+				Kind:    spacecraft.TargetKind(wc.Target.Kind),
+				BodyIdx: wc.Target.BodyIdx,
+				CraftID: wc.Target.CraftID,
 			}
 		}
 		w.Crafts = append(w.Crafts, c)
 	}
+	w.NextCraftID = p.NextCraftID
 	if p.ActiveCraftIdx >= 0 && p.ActiveCraftIdx < len(w.Crafts) {
 		w.ActiveCraftIdx = p.ActiveCraftIdx
 	}
@@ -794,9 +821,9 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	// Target (a polish-era save) so we don't clobber.
 	if p.Target != nil {
 		legacyTarget := spacecraft.Target{
-			Kind:     spacecraft.TargetKind(p.Target.Kind),
-			BodyIdx:  p.Target.BodyIdx,
-			CraftIdx: p.Target.CraftIdx,
+			Kind:    spacecraft.TargetKind(p.Target.Kind),
+			BodyIdx: p.Target.BodyIdx,
+			CraftID: p.Target.CraftID, // migrateV6PayloadToV7 fills this from CraftIdx for old saves
 		}
 		anyPerCraft := false
 		for _, c := range w.Crafts {
@@ -834,7 +861,7 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				PrimaryID:      n.PrimaryID,
 				Event:          sim.TriggerEvent(n.Event),
 				Throttle:       n.Throttle,
-				TargetCraftIdx: n.TargetCraftIdx,
+				TargetCraftID:  n.TargetCraftID,
 				PlaneChangeRad: n.PlaneChangeRad,
 				BurnDirUnit:    vec3To(n.BurnDirUnit),
 			})
@@ -846,12 +873,17 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				EndTime:        time.Unix(0, p.ActiveBurn.EndTimeNano).UTC(),
 				PrimaryID:      p.ActiveBurn.PrimaryID,
 				Throttle:       p.ActiveBurn.Throttle,
-				TargetCraftIdx: p.ActiveBurn.TargetCraftIdx,
+				TargetCraftID:  p.ActiveBurn.TargetCraftID,
 				PlaneChangeRad: p.ActiveBurn.PlaneChangeRad,
 				BurnDirUnit:    vec3To(p.ActiveBurn.BurnDirUnit),
 			}
 		}
 	}
+	// v0.14.x / ADR 0012: stamp any craft that still lacks a stable ID
+	// (a pre-v5 singular-craft save migrated into the slate) and prime
+	// NextCraftID past every ID in play, so a post-load spawn can't mint
+	// a colliding ID.
+	w.EnsureCraftIDs()
 	// v0.6.5: missions persist with status. v3+ saves carry an explicit
 	// (possibly-empty) Missions slice; v1/v2 saves wire-out as nil and
 	// get the embedded starter catalog seeded fresh so older saves

--- a/internal/save/save_migrate_v6_to_v7.go
+++ b/internal/save/save_migrate_v6_to_v7.go
@@ -1,0 +1,79 @@
+// v0.14.x: schema v6 → v7 migration (ADR 0012, GH #87). Pre-v7 saves
+// bind a target to a craft by its position in the slate: Target.CraftIdx
+// is a 0-based index, ManeuverNode/ActiveBurn.TargetCraftIdx is a
+// one-based index (zero = "no target"). v7 vessels carry a stable
+// Spacecraft.ID and targets reference that ID instead, so a slate
+// mutation can no longer re-point a stored target at the wrong vessel.
+//
+// The conversion is purely positional: assign each craft the ID
+// (slate index + 1), then rewrite every stored index to the matching
+// ID. With IDs handed out as index+1:
+//
+//   - a 0-based slate index i  → ID i+1   (Target.CraftIdx)
+//   - a one-based slate index j → ID j     (TargetCraftIdx; slot j-1 → ID (j-1)+1 = j)
+//
+// so a one-based TargetCraftIdx copies straight across to TargetCraftID.
+
+package save
+
+// migrateV6PayloadToV7 rewrites a pre-v7 wire payload in place: stamps
+// sequential craft IDs and converts every index-based target binding
+// (per-craft Target + Nodes + ActiveBurn, and the pre-polish/pre-v5
+// payload-level Target + Nodes + ActiveBurn) to ID-based.
+func migrateV6PayloadToV7(p *Payload) {
+	n := len(p.Crafts)
+
+	// Stamp sequential IDs by slate position and prime the counter.
+	for i := range p.Crafts {
+		p.Crafts[i].ID = uint64(i + 1)
+	}
+	p.NextCraftID = uint64(n + 1)
+
+	// Per-craft bindings.
+	for i := range p.Crafts {
+		c := &p.Crafts[i]
+		if c.Target != nil {
+			c.Target.CraftID = craftIDForIndex0(c.Target.CraftIdx, n)
+		}
+		for j := range c.Nodes {
+			c.Nodes[j].TargetCraftID = craftIDForIndex1(c.Nodes[j].TargetCraftIdx, n)
+		}
+		if c.ActiveBurn != nil {
+			c.ActiveBurn.TargetCraftID = craftIDForIndex1(c.ActiveBurn.TargetCraftIdx, n)
+		}
+	}
+
+	// Pre-polish (single payload-level Target) + pre-v5 (payload-level
+	// Nodes / ActiveBurn) bindings. These coexist with a single craft in
+	// practice, but convert defensively the same way.
+	if p.Target != nil {
+		p.Target.CraftID = craftIDForIndex0(p.Target.CraftIdx, n)
+	}
+	for j := range p.Nodes {
+		p.Nodes[j].TargetCraftID = craftIDForIndex1(p.Nodes[j].TargetCraftIdx, n)
+	}
+	if p.ActiveBurn != nil {
+		p.ActiveBurn.TargetCraftID = craftIDForIndex1(p.ActiveBurn.TargetCraftIdx, n)
+	}
+}
+
+// craftIDForIndex0 maps a 0-based slate index to its v7 craft ID
+// (index+1), returning 0 ("no target") for an out-of-range index — the
+// same silent-drop the pre-v7 bounds checks produced.
+func craftIDForIndex0(idx0, n int) uint64 {
+	if idx0 < 0 || idx0 >= n {
+		return 0
+	}
+	return uint64(idx0 + 1)
+}
+
+// craftIDForIndex1 maps a one-based slate index (the TargetCraftIdx
+// encoding, zero = no target) to its v7 craft ID. Slate slot j-1 was
+// stamped ID (j-1)+1 = j, so a valid one-based index copies straight to
+// the ID; zero and out-of-range map to 0 (no target).
+func craftIDForIndex1(idx1, n int) uint64 {
+	if idx1 <= 0 || idx1 > n {
+		return 0
+	}
+	return uint64(idx1)
+}

--- a/internal/save/save_migrate_v6_to_v7_test.go
+++ b/internal/save/save_migrate_v6_to_v7_test.go
@@ -1,0 +1,83 @@
+package save
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestMigrateV6PayloadToV7 — GH #87 / ADR 0012. A pre-v7 payload binds
+// targets by slate index (Target.CraftIdx 0-based, TargetCraftIdx
+// one-based). The migration must assign stable IDs by slate position and
+// rewrite every index binding to the matching ID so the loaded world
+// resolves targets by identity.
+func TestMigrateV6PayloadToV7(t *testing.T) {
+	craft := int(spacecraft.TargetCraft)
+	p := Payload{
+		Crafts: []Craft{
+			{ // idx 0 → ID 1; a node aimed at craft idx 2 (one-based 3)
+				Name:  "A",
+				Nodes: []Node{{TargetCraftIdx: 3}},
+			},
+			{ // idx 1 → ID 2; per-craft target aimed at craft idx 2 (0-based)
+				Name:   "B",
+				Target: &Target{Kind: craft, CraftIdx: 2},
+				ActiveBurn: &ActiveBurn{
+					TargetCraftIdx: 1, // one-based → craft idx 0 → ID 1
+				},
+			},
+			{Name: "C"}, // idx 2 → ID 3
+		},
+		// Pre-polish payload-level target aimed at craft idx 1 (0-based).
+		Target: &Target{Kind: craft, CraftIdx: 1},
+	}
+
+	migrateV6PayloadToV7(&p)
+
+	// Sequential IDs by slate position + primed counter.
+	for i, c := range p.Crafts {
+		if c.ID != uint64(i+1) {
+			t.Errorf("craft %d ID = %d, want %d", i, c.ID, i+1)
+		}
+	}
+	if p.NextCraftID != 4 {
+		t.Errorf("NextCraftID = %d, want 4", p.NextCraftID)
+	}
+
+	// Node bound to one-based idx 3 → craft idx 2 → ID 3.
+	if got := p.Crafts[0].Nodes[0].TargetCraftID; got != 3 {
+		t.Errorf("node TargetCraftID = %d, want 3 (craft C)", got)
+	}
+	// Per-craft target: 0-based idx 2 → ID 3.
+	if got := p.Crafts[1].Target.CraftID; got != 3 {
+		t.Errorf("craft B Target.CraftID = %d, want 3 (craft C)", got)
+	}
+	// ActiveBurn one-based idx 1 → craft idx 0 → ID 1.
+	if got := p.Crafts[1].ActiveBurn.TargetCraftID; got != 1 {
+		t.Errorf("ActiveBurn TargetCraftID = %d, want 1 (craft A)", got)
+	}
+	// Payload-level target: 0-based idx 1 → ID 2.
+	if got := p.Target.CraftID; got != 2 {
+		t.Errorf("payload Target.CraftID = %d, want 2 (craft B)", got)
+	}
+}
+
+// TestMigrateV6PayloadToV7OutOfRange — an index pointing past the slate
+// (stale binding) maps to "no target" (ID 0), matching the silent-drop
+// the pre-v7 bounds checks produced.
+func TestMigrateV6PayloadToV7OutOfRange(t *testing.T) {
+	craft := int(spacecraft.TargetCraft)
+	p := Payload{
+		Crafts: []Craft{
+			{Name: "A", Target: &Target{Kind: craft, CraftIdx: 9}}, // out of range
+			{Name: "B", Nodes: []Node{{TargetCraftIdx: 9}}},        // out of range
+		},
+	}
+	migrateV6PayloadToV7(&p)
+	if got := p.Crafts[0].Target.CraftID; got != 0 {
+		t.Errorf("out-of-range Target.CraftID = %d, want 0 (no target)", got)
+	}
+	if got := p.Crafts[1].Nodes[0].TargetCraftID; got != 0 {
+		t.Errorf("out-of-range node TargetCraftID = %d, want 0 (no target)", got)
+	}
+}

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -658,22 +658,23 @@ func TestEventRoundtrip(t *testing.T) {
 	}
 }
 
-// TestTargetCraftIdxRoundtrip — v0.9.3 target binding survives save/
-// load. Plant a target-relative node with a one-based TargetCraftIdx
-// and confirm it round-trips with the same value. Also confirms the
-// JSON omitempty tag works: a non-target node round-trips with
-// TargetCraftIdx == 0 (no field on disk → zero unmarshals).
+// TestTargetCraftIdxRoundtrip — target binding survives save/load.
+// Plant a target-relative node bound by stable craft ID (ADR 0012) and
+// confirm it round-trips with the same value. Also confirms the JSON
+// omitempty tag works: a non-target node round-trips with
+// TargetCraftID == 0 (no field on disk → zero unmarshals).
 func TestTargetCraftIdxRoundtrip(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	// Target-relative node bound to slate idx 0 (one-based: 1).
+	wantID := w.Crafts[0].ID
+	// Target-relative node bound to the craft by stable ID.
 	w.PlanNode(sim.ManeuverNode{
-		Mode:           spacecraft.BurnTargetPrograde,
-		DV:             10,
-		Event:          sim.TriggerNextClosestApproach,
-		TargetCraftIdx: 1,
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            10,
+		Event:         sim.TriggerNextClosestApproach,
+		TargetCraftID: wantID,
 	})
 	// Non-target node: no binding.
 	w.PlanNode(sim.ManeuverNode{
@@ -705,11 +706,11 @@ func TestTargetCraftIdxRoundtrip(t *testing.T) {
 	if bound == nil || free == nil {
 		t.Fatal("did not find both nodes after load")
 	}
-	if bound.TargetCraftIdx != 1 {
-		t.Errorf("bound node TargetCraftIdx: got %d, want 1", bound.TargetCraftIdx)
+	if bound.TargetCraftID != wantID {
+		t.Errorf("bound node TargetCraftID: got %d, want %d", bound.TargetCraftID, wantID)
 	}
-	if free.TargetCraftIdx != 0 {
-		t.Errorf("free node TargetCraftIdx: got %d, want 0", free.TargetCraftIdx)
+	if free.TargetCraftID != 0 {
+		t.Errorf("free node TargetCraftID: got %d, want 0", free.TargetCraftID)
 	}
 	if bound.Event != sim.TriggerNextClosestApproach {
 		t.Errorf("bound node Event: got %v, want TriggerNextClosestApproach", bound.Event)
@@ -956,7 +957,8 @@ func TestTargetCraftRoundtrip(t *testing.T) {
 	// Active is now idx 1 (the new sister); target idx 0 (the
 	// original LEO craft).
 	w.SetTargetCraft(0)
-	if w.Target.Kind != sim.TargetCraft || w.Target.CraftIdx != 0 {
+	wantID := w.Crafts[0].ID
+	if w.Target.Kind != sim.TargetCraft || w.Target.CraftID != wantID {
 		t.Fatalf("precondition: SetTargetCraft(0) → %+v", w.Target)
 	}
 
@@ -968,8 +970,8 @@ func TestTargetCraftRoundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got.Target.Kind != sim.TargetCraft || got.Target.CraftIdx != 0 {
-		t.Errorf("Target after roundtrip: got %+v, want {TargetCraft, 0}", got.Target)
+	if got.Target.Kind != sim.TargetCraft || got.Target.CraftID != wantID {
+		t.Errorf("Target after roundtrip: got %+v, want {TargetCraft, ID %d}", got.Target, wantID)
 	}
 }
 

--- a/internal/sim/craft_identity.go
+++ b/internal/sim/craft_identity.go
@@ -1,0 +1,85 @@
+package sim
+
+import "github.com/jasonfen/terminal-space-program/internal/spacecraft"
+
+// Craft identity (v0.14.x / ADR 0012). Vessels carry a stable
+// Spacecraft.ID; every target — the world cursor, per-craft bindings,
+// planted-node and in-flight-burn target slots — references a craft by
+// ID, not by its position in World.Crafts. A slate mutation that shifts
+// indices (end-flight, dock, undock, stage) therefore can no longer
+// re-point a stored target at the wrong vessel (GH #87); a removed
+// craft's ID simply stops resolving and the target degrades to "none".
+
+// stampCraftID assigns c the next stable ID when it enters the slate
+// without one. No-op for a craft that already has an ID (e.g. a docking
+// composite that inherits the lead's identity) or a nil entry.
+func (w *World) stampCraftID(c *spacecraft.Spacecraft) {
+	if c == nil || c.ID != 0 {
+		return
+	}
+	if w.NextCraftID == 0 {
+		w.NextCraftID = 1
+	}
+	c.ID = w.NextCraftID
+	w.NextCraftID++
+}
+
+// EnsureCraftIDs advances NextCraftID past any ID already in the slate
+// and stamps every craft still missing one. Idempotent; called from
+// NewWorld and the save loader so every live craft carries a unique
+// stable ID and the counter never hands out a colliding value.
+func (w *World) EnsureCraftIDs() {
+	var maxID uint64
+	for _, c := range w.Crafts {
+		if c != nil && c.ID > maxID {
+			maxID = c.ID
+		}
+	}
+	if w.NextCraftID <= maxID {
+		w.NextCraftID = maxID + 1
+	}
+	for _, c := range w.Crafts {
+		w.stampCraftID(c)
+	}
+}
+
+// craftByID returns the live craft with the given stable ID, its slate
+// index, and ok=false when no craft matches (id==0, or the craft was
+// removed from the slate). This is the single resolution chokepoint for
+// every identity-based target read (ADR 0012).
+func (w *World) craftByID(id uint64) (*spacecraft.Spacecraft, int, bool) {
+	if id == 0 {
+		return nil, -1, false
+	}
+	for i, c := range w.Crafts {
+		if c != nil && c.ID == id {
+			return c, i, true
+		}
+	}
+	return nil, -1, false
+}
+
+// targetCraft resolves the world cursor's bound craft (Kind==TargetCraft)
+// to a live craft and its slate index. ok=false for a non-craft target
+// or a stale/removed ID.
+func (w *World) targetCraft() (*spacecraft.Spacecraft, int, bool) {
+	if w.Target.Kind != spacecraft.TargetCraft {
+		return nil, -1, false
+	}
+	return w.craftByID(w.Target.CraftID)
+}
+
+// CraftByID is the exported resolver for readers outside the sim package
+// (the tui screens) that hold a stable craft ID — e.g. a node's
+// TargetCraftID — and need the live craft + its current slate index.
+// ok=false for id==0 or a craft no longer in the slate (ADR 0012).
+func (w *World) CraftByID(id uint64) (*spacecraft.Spacecraft, int, bool) {
+	return w.craftByID(id)
+}
+
+// ResolveTargetCraft is the exported form of targetCraft for the tui —
+// resolves the world target cursor to its live craft + slate index, or
+// ok=false for a non-craft / stale target (ADR 0012).
+func (w *World) ResolveTargetCraft() (*spacecraft.Spacecraft, int, bool) {
+	return w.targetCraft()
+}

--- a/internal/sim/craft_identity_test.go
+++ b/internal/sim/craft_identity_test.go
@@ -1,0 +1,203 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// threeCraftSlate spawns two siblings so the slate is [A, B, C] with
+// distinct stable IDs, and returns the three craft pointers. Active is
+// left at idx 0 (A).
+func threeCraftSlate(t *testing.T) (*World, *spacecraft.Spacecraft, *spacecraft.Spacecraft, *spacecraft.Spacecraft) {
+	t.Helper()
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft B: %v", err)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 700e3}); err != nil {
+		t.Fatalf("SpawnCraft C: %v", err)
+	}
+	if len(w.Crafts) != 3 {
+		t.Fatalf("want 3 crafts, got %d", len(w.Crafts))
+	}
+	a, b, c := w.Crafts[0], w.Crafts[1], w.Crafts[2]
+	// Distinct, nonzero IDs.
+	if a.ID == 0 || b.ID == 0 || c.ID == 0 || a.ID == b.ID || b.ID == c.ID || a.ID == c.ID {
+		t.Fatalf("craft IDs not distinct/nonzero: A=%d B=%d C=%d", a.ID, b.ID, c.ID)
+	}
+	w.SetActiveCraftIdx(0)
+	return w, a, b, c
+}
+
+// TestEndFlightKeepsSurvivingTargetBinding — GH #87 (#2, HIGH). A
+// surviving craft's target must keep pointing at the SAME vessel after a
+// crashed craft is removed from a lower slot. Pre-fix the stored slate
+// index went stale on the splice and silently dropped or mistargeted;
+// with ID binding (ADR 0012) the index shift is irrelevant.
+func TestEndFlightKeepsSurvivingTargetBinding(t *testing.T) {
+	w, a, b, c := threeCraftSlate(t)
+
+	// Fly B, target C. Then crash A (idx 0) and end its flight.
+	w.SetActiveCraftIdx(1)
+	w.SetTargetCraft(2)
+	if b.Target.Kind != TargetCraft || b.Target.CraftID != c.ID {
+		t.Fatalf("setup: B.Target = %+v, want craft C (ID %d)", b.Target, c.ID)
+	}
+
+	w.SetActiveCraftIdx(0) // fly A
+	a.Crashed = true
+	if !w.EndFlightActive() {
+		t.Fatal("EndFlightActive returned false for a crashed active craft")
+	}
+
+	// Slate is now [B, C]; B's binding must still resolve to C.
+	if len(w.Crafts) != 2 {
+		t.Fatalf("after end-flight: %d crafts, want 2", len(w.Crafts))
+	}
+	tc, idx, ok := w.craftByID(b.Target.CraftID)
+	if !ok {
+		t.Fatal("B's target binding was lost when A was removed")
+	}
+	if tc != c {
+		t.Errorf("B's target resolves to a different vessel after removal (idx %d) — mistarget", idx)
+	}
+}
+
+// TestEndFlightDoesNotClobberSuccessorTarget — GH #87 (#3, MEDIUM /
+// defect 2). Removing the active (crashed) craft must not write its live
+// target onto the successor that takes its slot. Pre-fix SetActiveCraftIdx
+// ran with a stale ActiveCraftIdx and checkpointed the removed craft's
+// target onto the successor, destroying the successor's own binding.
+func TestEndFlightDoesNotClobberSuccessorTarget(t *testing.T) {
+	w, a, b, c := threeCraftSlate(t)
+
+	// B (the successor that will take A's slot) targets C.
+	w.SetActiveCraftIdx(1)
+	w.SetTargetCraft(2)
+
+	// A (active, crashed) targets a body (Luna-ish: any body idx).
+	w.SetActiveCraftIdx(0)
+	w.SetTargetBody(1)
+	a.Crashed = true
+
+	if !w.EndFlightActive() {
+		t.Fatal("EndFlightActive returned false")
+	}
+
+	// B is now active at idx 0; its own C-binding must be intact, NOT
+	// overwritten with A's body target.
+	if b.Target.Kind != TargetCraft || b.Target.CraftID != c.ID {
+		t.Errorf("successor B's target was clobbered: got %+v, want craft C (ID %d)", b.Target, c.ID)
+	}
+	if w.Target.Kind != TargetCraft || w.Target.CraftID != c.ID {
+		t.Errorf("world cursor after end-flight = %+v, want B's craft-C binding", w.Target)
+	}
+}
+
+// TestDockDropPartnerTargetDoesNotAlias — GH #87 (docking.go:308/376).
+// When the lead docks with the craft it was targeting, the fused-away
+// partner's binding must resolve to nothing, never alias a different
+// vessel that shifted into the freed slot. Pre-fix the stale index could
+// resolve to whatever craft now occupied that slot.
+func TestDockDropPartnerTargetDoesNotAlias(t *testing.T) {
+	w, a, b, c := threeCraftSlate(t)
+	_, _ = a, c
+
+	// Fly A (idx 0), target B (idx 1, the dock partner).
+	w.SetActiveCraftIdx(0)
+	w.SetTargetCraft(1)
+	if w.Target.CraftID != b.ID {
+		t.Fatalf("setup: world target = %+v, want B (ID %d)", w.Target, b.ID)
+	}
+
+	// Dock A with B — B is consumed into the composite, C shifts left.
+	w.DockCrafts(0, 1)
+
+	// The composite (A's identity) inherits A's stale target (B's ID).
+	// B no longer exists, so it must resolve to nothing — not to C, which
+	// took the slot B's old index pointed at.
+	if _, _, ok := w.craftByID(b.ID); ok {
+		t.Error("dropped partner B still resolves by ID after the dock")
+	}
+	if tc, _, ok := w.ResolveTargetCraft(); ok {
+		t.Errorf("world target aliased to a surviving vessel %q after the partner fused away", tc.Name)
+	}
+}
+
+// TestUndockTailTargetSurvivesShift — GH #87 (docking.go:152). A target
+// aimed at a craft in the tail must keep resolving to that craft after an
+// undock inserts extra component slots ahead of it. Pre-fix the insert
+// shift left the stored index pointing one (or more) slots too low.
+func TestUndockTailTargetSurvivesShift(t *testing.T) {
+	w := mustWorld(t)
+	// Build a composite at idx 0 by docking two craft, then add a tail
+	// craft Z that something targets.
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("spawn partner: %v", err)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 700e3}); err != nil {
+		t.Fatalf("spawn Z: %v", err)
+	}
+	z := w.Crafts[2]
+	// Dock idx0 + idx1 → composite at idx0, Z shifts to idx1.
+	w.DockCrafts(0, 1)
+	if len(w.Crafts) != 2 {
+		t.Fatalf("after dock: %d crafts, want 2 (composite + Z)", len(w.Crafts))
+	}
+	zIdx := -1
+	for i, cc := range w.Crafts {
+		if cc == z {
+			zIdx = i
+		}
+	}
+	if zIdx < 0 {
+		t.Fatal("Z missing after dock")
+	}
+
+	// Fly the composite (idx 0), target Z.
+	w.SetActiveCraftIdx(0)
+	w.SetTargetCraft(zIdx)
+	if w.Target.CraftID != z.ID {
+		t.Fatalf("setup: target = %+v, want Z (ID %d)", w.Target, z.ID)
+	}
+
+	// Undock the composite — it splits into ≥2 components, shifting Z right.
+	if !w.Undock(0) {
+		t.Fatal("Undock returned false")
+	}
+	if len(w.Crafts) < 3 {
+		t.Fatalf("after undock: %d crafts, want ≥3", len(w.Crafts))
+	}
+
+	// Z must still resolve by its stable ID despite the index shift.
+	tc, _, ok := w.craftByID(z.ID)
+	if !ok || tc != z {
+		t.Errorf("Z's binding broke across the undock insert shift (ok=%v)", ok)
+	}
+}
+
+// TestStableIDsAreUniqueAcrossSpawnAndStage — every craft entering the
+// slate gets a distinct, nonzero ID and NextCraftID never hands out a
+// value already in use.
+func TestStableIDsAreUniqueAcrossSpawnAndStage(t *testing.T) {
+	w := mustWorld(t)
+	for i := 0; i < 4; i++ {
+		if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: float64(500+100*i) * 1e3}); err != nil {
+			t.Fatalf("spawn %d: %v", i, err)
+		}
+	}
+	seen := map[uint64]bool{}
+	for i, c := range w.Crafts {
+		if c.ID == 0 {
+			t.Errorf("craft %d (%q) has zero ID", i, c.Name)
+		}
+		if seen[c.ID] {
+			t.Errorf("duplicate craft ID %d at slate idx %d", c.ID, i)
+		}
+		seen[c.ID] = true
+		if c.ID >= w.NextCraftID {
+			t.Errorf("NextCraftID %d not ahead of live ID %d", w.NextCraftID, c.ID)
+		}
+	}
+}

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -147,6 +147,15 @@ func (w *World) Undock(idx int) bool {
 		restored = append(restored, s)
 	}
 
+	// Each restored component is a fresh vessel — stamp new stable IDs
+	// (ADR 0012). The composite's ID is retired with it; a target that
+	// pointed at the composite stops resolving rather than aliasing a
+	// component. Targets aimed at the unaffected tail crafts keep
+	// resolving by ID through the insert shift — no remap needed.
+	for _, s := range restored {
+		w.stampCraftID(s)
+	}
+
 	// Replace composite slot with restored components in place.
 	tail := append([]*spacecraft.Spacecraft{}, w.Crafts[idx+1:]...)
 	w.Crafts = append(w.Crafts[:idx], restored...)

--- a/internal/sim/end_flight.go
+++ b/internal/sim/end_flight.go
@@ -43,6 +43,13 @@ func (w *World) EndFlightActive() bool {
 	// append-trick: keep the prefix, skip idx, then append the
 	// suffix.
 	w.Crafts = append(w.Crafts[:idx], w.Crafts[idx+1:]...)
+	// The active (outgoing) craft was just removed, so there is no craft
+	// to checkpoint w.Target onto. Clear ActiveCraftIdx before
+	// reassigning: otherwise SetActiveCraftIdx's outgoing-checkpoint
+	// (still pointing at the old slot) would write the removed craft's
+	// live target onto whatever successor now occupies that slot,
+	// clobbering its own stored target binding (GH #87, defect 2).
+	w.ActiveCraftIdx = -1
 	switch {
 	case len(w.Crafts) == 0:
 		// Slate empty — no active vessel. Set sentinel so

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -244,18 +244,11 @@ func (w *World) resolveEventNodesFor(c *spacecraft.Spacecraft) {
 			dt = orbital.TimeToNodeCrossing(state, mu, false)
 		case TriggerNextClosestApproach:
 			// v0.9.3+: bound to the craft captured at plant time
-			// via n.TargetCraftIdx. Skip if the target slot is
-			// stale (out-of-range / nil craft / different primary
-			// — same-primary only for the manual rendezvous slice).
-			tIdx, ok := n.TargetCraftIdxValue()
+			// via n.TargetCraftID (ADR 0012). Skip if the target is
+			// stale (removed craft / different primary — same-primary
+			// only for the manual rendezvous slice).
+			tc, _, ok := w.craftByID(n.TargetCraftID)
 			if !ok {
-				continue
-			}
-			if tIdx < 0 || tIdx >= len(w.Crafts) {
-				continue
-			}
-			tc := w.Crafts[tIdx]
-			if tc == nil {
 				continue
 			}
 			if tc.Primary.ID != c.Primary.ID {
@@ -1785,15 +1778,13 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 			break
 		}
 		// v0.9.3+: resolve target snapshot for target-relative nodes
-		// at fire time. Bound via n.TargetCraftIdx (captured at
-		// plant), not the current World.Target — a target switch
-		// between plant and fire doesn't silently retarget the burn.
+		// at fire time. Bound via n.TargetCraftID (captured at plant,
+		// ADR 0012), not the current World.Target — a target switch or
+		// slate shift between plant and fire doesn't retarget the burn.
 		var rT, vT orbital.Vec3
 		if n.IsTargetRelative() {
-			if tIdx, ok := n.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
-				if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
-					rT, vT = tc.State.R, tc.State.V
-				}
+			if tc, _, ok := w.craftByID(n.TargetCraftID); ok && tc.Primary.ID == c.Primary.ID {
+				rT, vT = tc.State.R, tc.State.V
 			}
 		}
 		if n.Duration == 0 {
@@ -1813,7 +1804,7 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 				EndTime:        n.BurnEnd(),
 				PrimaryID:      n.PrimaryID,
 				Throttle:       n.EffectiveThrottle(),
-				TargetCraftIdx: n.TargetCraftIdx,
+				TargetCraftID:  n.TargetCraftID,
 				PlaneChangeRad: n.PlaneChangeRad,
 				BurnDirUnit:    n.BurnDirUnit,
 			}
@@ -1862,10 +1853,8 @@ func (w *World) nodeLeadActive(c *spacecraft.Spacecraft) (orbital.Vec3, bool) {
 	// state + the target bound at plant (mirrors executeDueNodesFor).
 	var rT, vT orbital.Vec3
 	if n.IsTargetRelative() {
-		if tIdx, ok := n.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
-			if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
-				rT, vT = tc.State.R, tc.State.V
-			}
+		if tc, _, ok := w.craftByID(n.TargetCraftID); ok && tc.Primary.ID == c.Primary.ID {
+			rT, vT = tc.State.R, tc.State.V
 		}
 	}
 	dir := c.BurnDirectionForBurn(n.Mode, rT, vT, n.PlaneChangeRad, n.BurnDirUnit)

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1112,10 +1112,10 @@ func TestResolveEventNodesFreezesNextClosestApproach(t *testing.T) {
 	w.ActiveCraftIdx = 0
 	w.SetTargetCraft(1)
 	w.PlanNode(ManeuverNode{
-		Event:          TriggerNextClosestApproach,
-		Mode:           spacecraft.BurnTargetRetrograde,
-		DV:             10,
-		TargetCraftIdx: 2, // one-based: refers to slate idx 1
+		Event:         TriggerNextClosestApproach,
+		Mode:          spacecraft.BurnTargetRetrograde,
+		DV:            10,
+		TargetCraftID: w.Crafts[1].ID, // bind by stable ID (ADR 0012)
 	})
 	if !w.ActiveCraft().Nodes[0].TriggerTime.IsZero() {
 		t.Fatalf("precondition: unresolved node has zero TriggerTime")
@@ -1135,16 +1135,16 @@ func TestResolveEventNodesFreezesNextClosestApproach(t *testing.T) {
 }
 
 // TestResolveEventNodesNextClosestApproachStaleTargetSkips — node
-// with TargetCraftIdx referencing a missing craft slot stays
-// unresolved (silent no-op, sits in slate for player to delete or
-// repoint). Stale-handling guard for v0.9.3+.
+// with TargetCraftID referencing a missing craft stays unresolved
+// (silent no-op, sits in slate for player to delete or repoint).
+// Stale-handling guard for v0.9.3+ / ADR 0012.
 func TestResolveEventNodesNextClosestApproachStaleTargetSkips(t *testing.T) {
 	w := mustWorld(t)
 	w.PlanNode(ManeuverNode{
-		Event:          TriggerNextClosestApproach,
-		Mode:           spacecraft.BurnTargetRetrograde,
-		DV:             10,
-		TargetCraftIdx: 99, // out-of-range — never spawned
+		Event:         TriggerNextClosestApproach,
+		Mode:          spacecraft.BurnTargetRetrograde,
+		DV:            10,
+		TargetCraftID: 9999, // no craft with this ID — never spawned
 	})
 	w.resolveEventNodes()
 	n := w.ActiveCraft().Nodes[0]

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -359,20 +359,18 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 	// drifts as the orbit advances — same drift KSP shows.
 	//
 	// Target-relative nodes resolve their target via the captured
-	// n.TargetCraftIdx (same path as executeDueNodesFor) — a target
-	// switch between plant and fire doesn't retarget the marker.
-	// Stale bindings (idx out of range, target on a different
-	// primary) produce zero direction and silently skip.
+	// n.TargetCraftID (same path as executeDueNodesFor, ADR 0012) — a
+	// target switch or slate shift between plant and fire doesn't
+	// retarget the marker. Stale bindings (removed craft, target on a
+	// different primary) produce zero direction and silently skip.
 	for i, n := range active.Nodes {
 		nrT, nvT := rT, vT
 		if n.IsTargetRelative() {
 			nrT, nvT = orbital.Vec3{}, orbital.Vec3{}
 			resolved := false
-			if tIdx, ok := n.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
-				if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == active.Primary.ID {
-					nrT, nvT = tc.State.R, tc.State.V
-					resolved = true
-				}
+			if tc, _, ok := w.craftByID(n.TargetCraftID); ok && tc.Primary.ID == active.Primary.ID {
+				nrT, nvT = tc.State.R, tc.State.V
+				resolved = true
 			}
 			// Stale / unbound target-relative node: skip the marker
 			// rather than letting DirectionUnitTarget's degenerate

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -290,9 +290,11 @@ func TestNavballMarkersTargetModeRadialSwapsToTarget(t *testing.T) {
 	target.State.R = active.State.R.Add(orbital.Vec3{X: 1000, Y: 0, Z: 0})
 	target.State.V = active.State.V.Add(orbital.Vec3{X: 0, Y: 1, Z: 0})
 	target.Name = "target-test"
+	target.ID = 0 // shallow copy inherited active's ID; mint a fresh one
 	w.Crafts = append(w.Crafts, &target)
+	w.stampCraftID(&target)
 	w.Target.Kind = TargetCraft
-	w.Target.CraftIdx = len(w.Crafts) - 1
+	w.Target.CraftID = target.ID
 	w.NavMode = NavTarget
 
 	got := w.NavballMarkers()
@@ -332,9 +334,11 @@ func TestNavballMarkersTargetModeProgradeIsTargetRelative(t *testing.T) {
 	target.State.R = active.State.R.Add(orbital.Vec3{X: 1000, Y: 0, Z: 0})
 	target.State.V = active.State.V.Add(orbital.Vec3{X: 0, Y: 1, Z: 0})
 	target.Name = "target-test"
+	target.ID = 0 // shallow copy inherited active's ID; mint a fresh one
 	w.Crafts = append(w.Crafts, &target)
+	w.stampCraftID(&target)
 	w.Target.Kind = TargetCraft
-	w.Target.CraftIdx = len(w.Crafts) - 1
+	w.Target.CraftID = target.ID
 	w.NavMode = NavTarget
 
 	for _, m := range w.NavballMarkers() {

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -35,7 +35,7 @@ var (
 type rendezvousAdvisoryCache struct {
 	lastSimTime time.Time
 	activeIdx   int
-	targetIdx   int
+	targetID    uint64 // stable Spacecraft.ID of the cached target (ADR 0012)
 	advisory    planner.RendezvousAdvisory
 	ok          bool
 	populated   bool
@@ -76,11 +76,8 @@ func (w *World) RecommendedRendezvousBurn() (planner.RendezvousAdvisory, bool) {
 		w.rendezvousCache = rendezvousAdvisoryCache{}
 		return planner.RendezvousAdvisory{}, false
 	}
-	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
-		return planner.RendezvousAdvisory{}, false
-	}
-	t := w.Crafts[w.Target.CraftIdx]
-	if t == nil || t.Primary.EnglishName != active.Primary.EnglishName {
+	t, _, ok := w.craftByID(w.Target.CraftID)
+	if !ok || t.Primary.EnglishName != active.Primary.EnglishName {
 		// Different-primary case is a gate, not an advisory — the
 		// HUD just hides the block (cross-SOI rendezvous is out of
 		// the v0.10.2 scope, matches v0.9.3 NextClosestApproach).
@@ -90,7 +87,7 @@ func (w *World) RecommendedRendezvousBurn() (planner.RendezvousAdvisory, bool) {
 	// Cache key: (active, target, sim-time within interval).
 	if w.rendezvousCache.populated &&
 		w.rendezvousCache.activeIdx == w.ActiveCraftIdx &&
-		w.rendezvousCache.targetIdx == w.Target.CraftIdx &&
+		w.rendezvousCache.targetID == w.Target.CraftID &&
 		w.Clock.SimTime.Sub(w.rendezvousCache.lastSimTime) < rendezvousRecomputeInterval {
 		return w.rendezvousCache.advisory, w.rendezvousCache.ok
 	}
@@ -99,7 +96,7 @@ func (w *World) RecommendedRendezvousBurn() (planner.RendezvousAdvisory, bool) {
 	w.rendezvousCache = rendezvousAdvisoryCache{
 		lastSimTime: w.Clock.SimTime,
 		activeIdx:   w.ActiveCraftIdx,
-		targetIdx:   w.Target.CraftIdx,
+		targetID:    w.Target.CraftID,
 		advisory:    advisory,
 		ok:          ok,
 		populated:   true,
@@ -210,11 +207,8 @@ func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
 	if w.Target.Kind != TargetCraft {
 		return nil, ErrRendezvousNoTarget
 	}
-	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
-		return nil, ErrRendezvousNoTarget
-	}
-	t := w.Crafts[w.Target.CraftIdx]
-	if t == nil {
+	t, _, ok := w.craftByID(w.Target.CraftID)
+	if !ok {
 		return nil, ErrRendezvousNoTarget
 	}
 	if t.Primary.EnglishName != c.Primary.EnglishName {
@@ -237,14 +231,14 @@ func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
 
 	mode := axisLabelToBurnMode(advisory.Axis)
 	node := ManeuverNode{
-		Mode:           mode,
-		DV:             advisory.DV,
-		Duration:       c.BurnTimeForDV(advisory.DV),
-		Event:          spacecraft.TriggerAbsolute,
-		TriggerTime:    w.Clock.SimTime.Add(leadBuffer),
-		PrimaryID:      c.Primary.ID,
-		Throttle:       1.0,
-		TargetCraftIdx: w.Target.CraftIdx + 1, // one-based per ManeuverNode.TargetCraftIdx convention
+		Mode:          mode,
+		DV:            advisory.DV,
+		Duration:      c.BurnTimeForDV(advisory.DV),
+		Event:         spacecraft.TriggerAbsolute,
+		TriggerTime:   w.Clock.SimTime.Add(leadBuffer),
+		PrimaryID:     c.Primary.ID,
+		Throttle:      1.0,
+		TargetCraftID: w.Target.CraftID, // bind by stable ID (ADR 0012)
 	}
 	w.PlanNode(node)
 	out := advisory

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -98,9 +98,9 @@ func TestPlanRendezvousNudge_PlantsOneNode(t *testing.T) {
 	if math.Abs(n.DV-adv.DV) > 1e-9 {
 		t.Errorf("DV = %.3f, want %.3f", n.DV, adv.DV)
 	}
-	if n.TargetCraftIdx != w.Target.CraftIdx+1 {
-		t.Errorf("TargetCraftIdx = %d, want %d (one-based encoding of slate idx %d)",
-			n.TargetCraftIdx, w.Target.CraftIdx+1, w.Target.CraftIdx)
+	if n.TargetCraftID != w.Target.CraftID {
+		t.Errorf("TargetCraftID = %d, want %d (the bound target's stable ID)",
+			n.TargetCraftID, w.Target.CraftID)
 	}
 	if n.PrimaryID != c.Primary.ID {
 		t.Errorf("PrimaryID = %q, want %q", n.PrimaryID, c.Primary.ID)

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -186,6 +186,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 			V: active.State.V,
 			M: c.TotalMass(),
 		}
+		w.stampCraftID(c) // stable identity before the craft enters the slate (ADR 0012)
 		w.Crafts = append(w.Crafts, c)
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
@@ -251,6 +252,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		// it. Player can override with any attitude key before
 		// engaging.
 		c.AttitudeMode = spacecraft.BurnRadialOut
+		w.stampCraftID(c) // stable identity before the craft enters the slate (ADR 0012)
 		w.Crafts = append(w.Crafts, c)
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)
 		w.StopManualBurn()
@@ -297,6 +299,7 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		V: frame.ToWorld(vBody),
 		M: c.TotalMass(),
 	}
+	w.stampCraftID(c) // stable identity before the craft enters the slate (ADR 0012)
 	w.Crafts = append(w.Crafts, c)
 	w.SetActiveCraftIdx(len(w.Crafts) - 1)
 	w.StopManualBurn()

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -120,6 +120,7 @@ func (w *World) StageActive(craftIdx int) (newActiveIdx, jettisonedIdx int, err 
 	jettisoned := buildJettisonedCraft(dropped, c)
 	jettisoned.Name = w.nextCraftName(jettisoned.Name)
 
+	w.stampCraftID(jettisoned) // the jettisoned stage is a new vessel (ADR 0012)
 	w.Crafts = append(w.Crafts, jettisoned)
 	jettisonedIdx = len(w.Crafts) - 1
 

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -39,18 +39,22 @@ func (w *World) SetTargetBody(idx int) {
 	w.reconcileNavMode()
 }
 
-// SetTargetCraft sets the craft target by slate index. The active
-// craft can't target itself; out-of-range or self-targeting clears.
+// SetTargetCraft sets the craft target by slate index, storing the
+// craft's stable ID (ADR 0012) so the binding survives slate shifts.
+// The active craft can't target itself; out-of-range or self-targeting
+// clears.
 func (w *World) SetTargetCraft(idx int) {
 	if idx < 0 || idx >= len(w.Crafts) || idx == w.ActiveCraftIdx {
 		w.ClearTarget()
 		return
 	}
-	if w.Crafts[idx] == nil {
+	c := w.Crafts[idx]
+	if c == nil {
 		w.ClearTarget()
 		return
 	}
-	w.Target = Target{Kind: TargetCraft, CraftIdx: idx}
+	w.stampCraftID(c) // defensive: never bind to a zero ID
+	w.Target = Target{Kind: TargetCraft, CraftID: c.ID}
 	w.mirrorTargetToActiveCraft()
 }
 
@@ -122,7 +126,8 @@ func (w *World) targetCycle() []Target {
 		if c == nil || i == w.ActiveCraftIdx {
 			continue
 		}
-		cycle = append(cycle, Target{Kind: TargetCraft, CraftIdx: i})
+		w.stampCraftID(c)
+		cycle = append(cycle, Target{Kind: TargetCraft, CraftID: c.ID})
 	}
 	for i := 1; i < len(w.System().Bodies); i++ {
 		cycle = append(cycle, Target{Kind: TargetBody, BodyIdx: i})
@@ -153,11 +158,8 @@ func (w *World) TargetState() (orbital.Vec3State, bool) {
 		v := w.bodyInertialVelocity(b)
 		return orbital.Vec3State{R: r, V: v}, true
 	case TargetCraft:
-		if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
-			return orbital.Vec3State{}, false
-		}
-		c := w.Crafts[w.Target.CraftIdx]
-		if c == nil {
+		c, _, ok := w.craftByID(w.Target.CraftID)
+		if !ok {
 			return orbital.Vec3State{}, false
 		}
 		primaryPos := w.BodyPosition(c.Primary)
@@ -201,11 +203,8 @@ func (w *World) TargetStateRelativeToActivePrimary() (rT, vT orbital.Vec3, ok bo
 	if active == nil {
 		return orbital.Vec3{}, orbital.Vec3{}, false
 	}
-	if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
-		return orbital.Vec3{}, orbital.Vec3{}, false
-	}
-	t := w.Crafts[w.Target.CraftIdx]
-	if t == nil {
+	t, _, ok := w.craftByID(w.Target.CraftID)
+	if !ok {
 		return orbital.Vec3{}, orbital.Vec3{}, false
 	}
 	if t.Primary.EnglishName == active.Primary.EnglishName {
@@ -229,10 +228,8 @@ func (w *World) TargetName() string {
 			return sys.Bodies[w.Target.BodyIdx].EnglishName
 		}
 	case TargetCraft:
-		if w.Target.CraftIdx >= 0 && w.Target.CraftIdx < len(w.Crafts) {
-			if c := w.Crafts[w.Target.CraftIdx]; c != nil {
-				return c.Name
-			}
+		if c, _, ok := w.craftByID(w.Target.CraftID); ok {
+			return c.Name
 		}
 	}
 	return ""

--- a/internal/sim/target_test.go
+++ b/internal/sim/target_test.go
@@ -131,8 +131,8 @@ func TestCycleTargetIncludesSiblingCrafts(t *testing.T) {
 	// must land on TargetCraft idx 0 (crafts before bodies).
 	w.ClearTarget()
 	w.CycleTarget(true)
-	if w.Target.Kind != TargetCraft || w.Target.CraftIdx != 0 {
-		t.Errorf("first CycleTarget after spawn: got %+v, want {TargetCraft, 0} (crafts must come before bodies)", w.Target)
+	if w.Target.Kind != TargetCraft || w.Target.CraftID != w.Crafts[0].ID {
+		t.Errorf("first CycleTarget after spawn: got %+v, want craft idx 0 (ID %d; crafts must come before bodies)", w.Target, w.Crafts[0].ID)
 	}
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -33,6 +33,14 @@ type World struct {
 	Crafts         []*spacecraft.Spacecraft
 	ActiveCraftIdx int
 
+	// NextCraftID is the monotonic source of stable Spacecraft.IDs
+	// (v0.14.x / ADR 0012). Stamped onto each craft as it enters the
+	// slate; never decremented or reused, so a target bound to an ID
+	// can never alias a different vessel after a slate mutation (GH #87).
+	// Persisted (save schema v7). Zero is pre-stamp; EnsureCraftIDs
+	// initialises it to len(Crafts)+1 and stamps any unstamped craft.
+	NextCraftID uint64
+
 	// LastDockEvent records the most recent fusion for HUD flash
 	// + diagnostic. Cleared by app.go after the message is shown.
 	// v0.8.3+.
@@ -263,6 +271,7 @@ func NewWorld() (*World, error) {
 		// frame from the first tick.
 		w.Focus = Focus{Kind: FocusCraft}
 	}
+	w.EnsureCraftIDs() // stamp the initial craft + prime NextCraftID (ADR 0012)
 	return w, nil
 }
 
@@ -1065,11 +1074,9 @@ func (w *World) attitudeContext(c *spacecraft.Spacecraft) (mode spacecraft.BurnM
 		planeRad = c.ActiveBurn.PlaneChangeRad
 		burnDir = c.ActiveBurn.BurnDirUnit
 	}
-	if c.ActiveBurn != nil && c.ActiveBurn.TargetCraftIdx != 0 {
-		if tIdx, ok := c.ActiveBurn.TargetCraftIdxValue(); ok && tIdx >= 0 && tIdx < len(w.Crafts) {
-			if tc := w.Crafts[tIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
-				rT, vT = tc.State.R, tc.State.V
-			}
+	if c.ActiveBurn != nil && c.ActiveBurn.TargetCraftID != 0 {
+		if tc, _, ok := w.craftByID(c.ActiveBurn.TargetCraftID); ok && tc.Primary.ID == c.Primary.ID {
+			rT, vT = tc.State.R, tc.State.V
 		}
 	} else {
 		rT, vT, _ = w.TargetStateRelativeToActivePrimary()

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -103,25 +103,20 @@ type ManeuverNode struct {
 	// planted burns from live `Craft.Throttle` so adjusting throttle
 	// mid-coast doesn't slow an in-flight planted burn.
 	Throttle float64
-	// TargetCraftIdx (v0.9.3+) is the World.Crafts index of the
-	// target craft this node was planted against, captured at plant
-	// time. Populated only for the four target-relative modes
-	// (BurnTargetPrograde / Retrograde / BurnTarget / AntiTarget) and
-	// for the TriggerNextClosestApproach event. Zero-value-omitempty:
-	// non-target nodes save without the field, no schema bump.
+	// TargetCraftID (v0.14.x / ADR 0012; was the one-based slate index
+	// TargetCraftIdx) is the stable Spacecraft.ID of the target craft
+	// this node was planted against, captured at plant time. Populated
+	// only for the four target-relative modes (BurnTargetPrograde /
+	// Retrograde / BurnTarget / AntiTarget) and for the
+	// TriggerNextClosestApproach event. Zero-value-omitempty: non-target
+	// nodes save without the field, no schema bump for that.
 	//
-	// Bound at plant time so a target switch later doesn't silently
-	// retarget the planted burn — the node remains aimed at the craft
-	// the player chose. Stale handling: if the referenced index falls
-	// out of range or w.Crafts[idx] is nil at fire time, the node
-	// degrades to no-op. v0.9.3+: TargetStaleAtLoad below also flags
-	// load-time staleness so the slate UI can surface it.
-	//
-	// One-based to allow JSON omitempty: encoded value is idx+1, so
-	// zero means "no target". Helpers (TargetCraftIdxValue / SetTarget
-	// CraftIdxValue) translate to the natural 0-based slate index;
-	// callers always work in 0-based.
-	TargetCraftIdx int `json:",omitempty"`
+	// Bound by identity at plant time so neither a later target switch
+	// nor a slate mutation (end-flight / dock / undock / stage) silently
+	// retargets the planted burn — the node stays aimed at the exact
+	// craft the player chose, or degrades to no-op if that craft is gone
+	// (resolve via World.craftByID at fire time). Zero means "no target".
+	TargetCraftID uint64 `json:",omitempty"`
 	// PlaneChangeRad (v0.10.4+) is the signed orbital-plane rotation
 	// angle (radians) for a BurnPlaneChange node — the angle the
 	// horizontal velocity is rotated through about the radial axis.
@@ -141,26 +136,23 @@ type ManeuverNode struct {
 	BurnDirUnit orbital.Vec3 `json:",omitempty"`
 }
 
-// TargetCraftIdxValue returns the 0-based slate index this node is
-// bound to, and ok=false if no target was bound at plant time. The
-// JSON-stored field is one-based so omitempty drops "no target"
-// nodes from the wire — translation lives here so callers don't need
-// to remember the offset. v0.9.3+.
-func (n ManeuverNode) TargetCraftIdxValue() (int, bool) {
-	if n.TargetCraftIdx == 0 {
+// TargetCraftIDValue returns the bound target craft's stable ID and
+// ok=false when no target was bound at plant time. omitempty drops
+// "no target" nodes from the wire. Resolve the ID to a live craft via
+// World.craftByID at use time. v0.14.x / ADR 0012 (was
+// TargetCraftIdxValue, which returned a slate index).
+func (n ManeuverNode) TargetCraftIDValue() (uint64, bool) {
+	if n.TargetCraftID == 0 {
 		return 0, false
 	}
-	return n.TargetCraftIdx - 1, true
+	return n.TargetCraftID, true
 }
 
-// SetTargetCraftIdx writes a 0-based slate index into the node's
-// stored target slot. v0.9.3+.
-func (n *ManeuverNode) SetTargetCraftIdx(idx int) {
-	n.TargetCraftIdx = idx + 1
-}
+// SetTargetCraftID binds the node to a craft by its stable ID. v0.14.x.
+func (n *ManeuverNode) SetTargetCraftID(id uint64) { n.TargetCraftID = id }
 
-// ClearTargetCraftIdx unbinds the node's target. v0.9.3+.
-func (n *ManeuverNode) ClearTargetCraftIdx() { n.TargetCraftIdx = 0 }
+// ClearTargetCraftID unbinds the node's target. v0.14.x.
+func (n *ManeuverNode) ClearTargetCraftID() { n.TargetCraftID = 0 }
 
 // IsTargetRelative reports whether this node's burn mode requires a
 // target craft state to resolve direction. v0.9.3+.
@@ -231,13 +223,13 @@ type ActiveBurn struct {
 	EndTime     time.Time
 	PrimaryID   string
 	Throttle    float64
-	// TargetCraftIdx (v0.9.3+) is one-based slate idx (matches
-	// ManeuverNode.TargetCraftIdx encoding) — zero means no target
+	// TargetCraftID (v0.14.x / ADR 0012; was TargetCraftIdx) is the
+	// stable Spacecraft.ID of the burn's target — zero means no target
 	// bound. Populated when a target-relative finite-burn node fires;
-	// the world's stepThrust resolves the target snapshot from this
-	// each tick so the burn keeps tracking even if the player swaps
-	// World.Target mid-burn.
-	TargetCraftIdx int `json:",omitempty"`
+	// the world's stepThrust resolves the target snapshot from this each
+	// tick (via craftByID) so the burn keeps tracking even if the player
+	// swaps World.Target or the slate shifts mid-burn.
+	TargetCraftID uint64 `json:",omitempty"`
 	// PlaneChangeRad (v0.10.4+) carries the BurnPlaneChange rotation
 	// angle from the firing node onto the running burn, so the
 	// attitude/thrust path can resolve the tilted plane-change
@@ -249,14 +241,14 @@ type ActiveBurn struct {
 	BurnDirUnit orbital.Vec3 `json:",omitempty"`
 }
 
-// TargetCraftIdxValue mirrors ManeuverNode.TargetCraftIdxValue —
-// returns the 0-based slate idx the burn is bound to, or ok=false
-// when no target was captured at fire time. v0.9.3+.
-func (b ActiveBurn) TargetCraftIdxValue() (int, bool) {
-	if b.TargetCraftIdx == 0 {
+// TargetCraftIDValue mirrors ManeuverNode.TargetCraftIDValue — returns
+// the stable ID the burn is bound to, or ok=false when no target was
+// captured at fire time. Resolve via World.craftByID. v0.14.x / ADR 0012.
+func (b ActiveBurn) TargetCraftIDValue() (uint64, bool) {
+	if b.TargetCraftID == 0 {
 		return 0, false
 	}
-	return b.TargetCraftIdx - 1, true
+	return b.TargetCraftID, true
 }
 
 // BurnStalled reports whether a planted burn is paused waiting for the

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -16,6 +16,15 @@ import (
 // Spacecraft is the player vessel. Mass split: DryMass is the bus, Fuel
 // is consumable. State is relative to Primary.
 type Spacecraft struct {
+	// ID is the vessel's stable identity (v0.14.x / ADR 0012). Assigned
+	// once from a monotonic World counter when the craft enters the
+	// slate; never reused. Targets reference a craft by ID (not by its
+	// slice position), so a slate mutation — end-flight, dock, undock,
+	// stage — that shifts indices can no longer re-point a stored target
+	// at the wrong vessel (GH #87). Zero means "unstamped"; the World
+	// stamps it on spawn/load. Persisted (save schema v7+).
+	ID uint64
+
 	Name    string
 	DryMass float64 // kg
 	Fuel    float64 // kg

--- a/internal/spacecraft/target.go
+++ b/internal/spacecraft/target.go
@@ -17,7 +17,8 @@ const (
 	TargetNone TargetKind = iota
 	// TargetBody references a body by index in System().Bodies.
 	TargetBody
-	// TargetCraft references a non-active craft by index in World.Crafts.
+	// TargetCraft references a non-active craft by its stable
+	// Spacecraft.ID (v0.14.x / ADR 0012; was a World.Crafts index).
 	TargetCraft
 	// TargetSite is reserved; not populated until landing-site
 	// targeting ships post-v0.9.
@@ -30,7 +31,7 @@ const (
 // own Target value so per-craft targeting persists across active-
 // craft switches.
 type Target struct {
-	Kind     TargetKind
-	BodyIdx  int // when Kind==TargetBody
-	CraftIdx int // when Kind==TargetCraft
+	Kind    TargetKind
+	BodyIdx int    // when Kind==TargetBody
+	CraftID uint64 // when Kind==TargetCraft — the target's stable Spacecraft.ID (ADR 0012)
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -200,35 +200,34 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// uses. Event is forwarded so resolved-then-edited
 				// event-relative nodes keep their semantic label.
 				a.world.PlanNode(sim.ManeuverNode{
-					TriggerTime:    m.TriggerTime,
-					Mode:           m.Mode,
-					DV:             m.DV,
-					Duration:       dur,
-					Event:          m.Event,
-					Throttle:       m.Throttle,
-					TargetCraftIdx: m.TargetCraftIdx,
+					TriggerTime:   m.TriggerTime,
+					Mode:          m.Mode,
+					DV:            m.DV,
+					Duration:      dur,
+					Event:         m.Event,
+					Throttle:      m.Throttle,
+					TargetCraftID: m.TargetCraftID,
 				})
 			case m.Event != sim.TriggerAbsolute:
 				// v0.6.0: event-relative nodes go through PlanNode so
 				// the resolver can freeze TriggerTime against the live
 				// orbit on the next Tick.
 				a.world.PlanNode(sim.ManeuverNode{
-					Mode:           m.Mode,
-					DV:             m.DV,
-					Duration:       dur,
-					Event:          m.Event,
-					Throttle:       m.Throttle,
-					TargetCraftIdx: m.TargetCraftIdx,
+					Mode:          m.Mode,
+					DV:            m.DV,
+					Duration:      dur,
+					Event:         m.Event,
+					Throttle:      m.Throttle,
+					TargetCraftID: m.TargetCraftID,
 				})
 			case dur == 0:
 				// v0.9.3+: target-relative impulsive needs the bound
-				// target snapshot for direction resolution.
-				if m.TargetCraftIdx != 0 {
-					if tIdx := m.TargetCraftIdx - 1; tIdx >= 0 && tIdx < len(a.world.Crafts) {
-						if tc := a.world.Crafts[tIdx]; tc != nil && tc.Primary.ID == a.world.ActiveCraft().Primary.ID {
-							a.world.ActiveCraft().ApplyImpulsiveWithTarget(m.Mode, m.DV, tc.State.R, tc.State.V)
-							break
-						}
+				// target snapshot for direction resolution. Resolve by
+				// stable ID (ADR 0012).
+				if m.TargetCraftID != 0 {
+					if tc, _, ok := a.world.CraftByID(m.TargetCraftID); ok && tc.Primary.ID == a.world.ActiveCraft().Primary.ID {
+						a.world.ActiveCraft().ApplyImpulsiveWithTarget(m.Mode, m.DV, tc.State.R, tc.State.V)
+						break
 					}
 				}
 				a.world.ActiveCraft().ApplyImpulsive(m.Mode, m.DV)
@@ -238,11 +237,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					effThrottle = 1.0
 				}
 				a.world.ActiveCraft().ActiveBurn = &sim.ActiveBurn{
-					Mode:           m.Mode,
-					DVRemaining:    m.DV,
-					EndTime:        a.world.Clock.SimTime.Add(dur),
-					Throttle:       effThrottle,
-					TargetCraftIdx: m.TargetCraftIdx,
+					Mode:          m.Mode,
+					DVRemaining:   m.DV,
+					EndTime:       a.world.Clock.SimTime.Add(dur),
+					Throttle:      effThrottle,
+					TargetCraftID: m.TargetCraftID,
 				}
 			}
 		}
@@ -1243,7 +1242,7 @@ func overlayBottomBorder(base, overlay string, border lipgloss.Style) string {
 // burn — the player closes + reopens to retarget. v0.9.3+.
 func (a *App) bindManeuverTarget() {
 	if a.world.Target.Kind == sim.TargetCraft {
-		a.maneuver.SetTargetCraft(true, a.world.Target.CraftIdx)
+		a.maneuver.SetTargetCraft(true, a.world.Target.CraftID)
 		return
 	}
 	a.maneuver.SetTargetCraft(false, 0)

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -54,29 +54,30 @@ type Maneuver struct {
 	editingIdx        int
 	loadedTriggerTime time.Time
 
-	// hasTargetCraft + targetCraftIdx carry the World.Target binding
+	// hasTargetCraft + targetCraftID carry the World.Target binding
 	// at form-open time, so the four target-relative burn modes and
 	// the TriggerNextClosestApproach event can resolve their
 	// direction / trigger against the captured target. Bound at open
 	// (not at every keypress) so a target switch while the form is
 	// open doesn't silently retarget a planted burn — the player
-	// closes + reopens the form to retarget. v0.9.3+.
+	// closes + reopens the form to retarget. v0.9.3+; bound by stable
+	// craft ID since v0.14.x (ADR 0012).
 	hasTargetCraft bool
-	targetCraftIdx int
+	targetCraftID  uint64
 }
 
-// SetTargetCraft binds (or unbinds) the target-craft slate index the
-// form's planted burn will be aimed at. Called by the app when
-// opening the form so the four target-relative burn modes and the
+// SetTargetCraft binds (or unbinds) the target craft (by stable ID) the
+// form's planted burn will be aimed at. Called by the app when opening
+// the form so the four target-relative burn modes and the
 // TriggerNextClosestApproach event can resolve at plant + fire time.
 // Pass ok=false to clear (no craft target set / target is a body).
-// v0.9.3+.
-func (m *Maneuver) SetTargetCraft(ok bool, idx int) {
+// v0.9.3+; binds by ID since v0.14.x (ADR 0012).
+func (m *Maneuver) SetTargetCraft(ok bool, id uint64) {
 	m.hasTargetCraft = ok
 	if ok {
-		m.targetCraftIdx = idx
+		m.targetCraftID = id
 	} else {
-		m.targetCraftIdx = 0
+		m.targetCraftID = 0
 	}
 	// If the currently-selected mode or trigger requires a target
 	// and we no longer have one, snap to safe defaults so the form
@@ -130,12 +131,12 @@ type BurnExecutedMsg struct {
 	// commanded value would have delivered (compensating finite-burn
 	// loss). Ignored for impulsive (zero-thrust) and Normal± burns.
 	IterateForTarget bool
-	// TargetCraftIdx (v0.9.3+) is the one-based encoding of the
-	// target slate idx the form was bound to at plant. Zero = no
-	// target. Mirrors ManeuverNode.TargetCraftIdx; the app passes it
-	// straight through. Only populated for target-relative modes /
-	// TriggerNextClosestApproach event.
-	TargetCraftIdx int
+	// TargetCraftID (v0.14.x / ADR 0012; was the one-based index
+	// TargetCraftIdx) is the stable Spacecraft.ID the form was bound to
+	// at plant. Zero = no target. Mirrors ManeuverNode.TargetCraftID;
+	// the app passes it straight through. Only populated for target-
+	// relative modes / TriggerNextClosestApproach event.
+	TargetCraftID uint64
 }
 
 // NodeDeleteMsg is emitted when the player presses ctrl+d in the
@@ -242,9 +243,9 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 	// expected to follow up with SetTargetCraft to reflect the
 	// CURRENT World.Target if the node's binding is stale, but the
 	// default-load behaviour preserves the original target.
-	if tIdx, ok := n.TargetCraftIdxValue(); ok {
+	if id, ok := n.TargetCraftIDValue(); ok {
 		m.hasTargetCraft = true
-		m.targetCraftIdx = tIdx
+		m.targetCraftID = id
 	}
 	m.applyFocus()
 }
@@ -293,14 +294,15 @@ func (m *Maneuver) Resize(cols, rows int) {
 // means the app should exit the maneuver screen (commit or cancel).
 //
 // Key bindings:
-//   tab / shift+tab        — cycle focus across mode / fire-at / Δv fields
-//   ←/→ (mode focused)     — cycle direction modes
-//   ←/→ (fire-at focused)  — cycle trigger events (Absolute / NextPeri / NextApo / NextAN / NextDN)
-//   enter                  — commit burn → emits BurnExecutedMsg with rocket-equation duration
-//   esc                    — cancel → plain exit (app handles)
-//   ctrl+d                 — delete the planted node being edited (no-op when creating new)
-//   c / C (or ctrl+k)      — clear ALL planted nodes for the active craft
-//   digits/backspace       — forwarded to focused text input
+//
+//	tab / shift+tab        — cycle focus across mode / fire-at / Δv fields
+//	←/→ (mode focused)     — cycle direction modes
+//	←/→ (fire-at focused)  — cycle trigger events (Absolute / NextPeri / NextApo / NextAN / NextDN)
+//	enter                  — commit burn → emits BurnExecutedMsg with rocket-equation duration
+//	esc                    — cancel → plain exit (app handles)
+//	ctrl+d                 — delete the planted node being edited (no-op when creating new)
+//	c / C (or ctrl+k)      — clear ALL planted nodes for the active craft
+//	digits/backspace       — forwarded to focused text input
 func (m *Maneuver) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 	const focusFields = 5 // mode / fireAt / dv / throttle / iterate
 	switch msg.String() {
@@ -405,12 +407,11 @@ func (m *Maneuver) commitCmd() tea.Cmd {
 		Throttle:         m.parsedThrottle(),
 		IterateForTarget: m.iterateForTarget,
 	}
-	// v0.9.3+: capture the bound target craft idx for target-relative
-	// modes and the TriggerNextClosestApproach event. One-based to
-	// match the ManeuverNode encoding (zero = no target, idx+1
-	// otherwise — JSON omitempty drops it for non-target nodes).
+	// v0.9.3+: capture the bound target craft for target-relative modes
+	// and the TriggerNextClosestApproach event. Bound by stable craft ID
+	// since v0.14.x (ADR 0012); zero = no target.
 	if m.hasTargetCraft && (spacecraft.IsTargetRelativeMode(mode) || event == sim.TriggerNextClosestApproach) {
-		msg.TargetCraftIdx = m.targetCraftIdx + 1
+		msg.TargetCraftID = m.targetCraftID
 	}
 	return func() tea.Msg { return msg }
 }
@@ -483,7 +484,6 @@ func (m *Maneuver) parsedDV() float64 {
 	return dv
 }
 
-
 // Render composes the preview canvas + form panel.
 func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	if w.ActiveCraft() == nil {
@@ -525,8 +525,8 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	// state vector (already primary-relative when same-primary) plots
 	// directly. Cross-primary targets are out of scope — the canvas
 	// frame is the wrong one for them.
-	if w.Target.Kind == sim.TargetCraft && w.Target.CraftIdx >= 0 && w.Target.CraftIdx < len(w.Crafts) {
-		if tc := w.Crafts[w.Target.CraftIdx]; tc != nil && tc.Primary.ID == c.Primary.ID {
+	if tc, _, ok := w.ResolveTargetCraft(); ok {
+		if tc.Primary.ID == c.Primary.ID {
 			tEl := orbital.ElementsFromState(tc.State.R, tc.State.V, mu)
 			tOrbitVisible := tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0)
 			if tOrbitVisible {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -698,8 +698,8 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// the craft's own color (dim when no Color is set, falling
 		// back to ColorDim — preserves pre-v0.8.2 behaviour).
 		targetCraftIdx := -1
-		if w.Target.Kind == sim.TargetCraft {
-			targetCraftIdx = w.Target.CraftIdx
+		if _, idx, ok := w.ResolveTargetCraft(); ok {
+			targetCraftIdx = idx
 		}
 		for i, other := range w.Crafts {
 			if i == w.ActiveCraftIdx || other == nil {

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -605,11 +605,8 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		lines = append(lines, chipRow("range:", formatRangeM(rangeM)))
 		return lines
 	case sim.TargetCraft:
-		if w.Target.CraftIdx < 0 || w.Target.CraftIdx >= len(w.Crafts) {
-			return nil
-		}
-		tc := w.Crafts[w.Target.CraftIdx]
-		if tc == nil {
+		tc, _, ok := w.ResolveTargetCraft()
+		if !ok {
 			return nil
 		}
 		lines := []string{v.theme.Primary.Render("TARGET"), chipRow("vessel:", tc.Name)}


### PR DESCRIPTION
The structural fix from the #87 core-review findings — vessels gain a stable identity and every target references it, so a slate mutation can no longer mistarget the wrong vessel. **ADR 0012.** **Closes #87.**

## The bug

`Target.CraftIdx` (and the one-based `ManeuverNode`/`ActiveBurn.TargetCraftIdx`) stored a craft by its position in `World.Crafts`. Four operations shift those positions — end-flight removal, dock, undock, stage — and **none remapped the stored indices**, so a surviving binding above the mutated slot silently re-pointed at a *different* vessel: an off-by-one *past* the bounds checks (which only catch out-of-range, returning "no target", never a wrong-but-in-range index). HIGH in `EndFlightActive`; MEDIUM across both dock paths + undock.

`EndFlightActive` had a second, independent defect: it spliced out the active craft, then called `SetActiveCraftIdx` while `ActiveCraftIdx` still pointed at the freed slot — so the outgoing-checkpoint wrote the *removed* craft's target onto the *successor* that shifted in, destroying its binding.

## The fix (ADR 0012 — stable craft identity)

- `Spacecraft.ID uint64`, assigned once from a monotonic `World.NextCraftID` when a craft enters the slate (`stampCraftID` at every spawn/jettison/undock site; `EnsureCraftIDs` on `NewWorld` + load). A docking composite inherits the lead's ID; undock mints fresh IDs for restored components.
- `Target.CraftID` / `ManeuverNode.TargetCraftID` / `ActiveBurn.TargetCraftID` replace the three index fields.
- One resolution chokepoint, `craftByID` (+ `ResolveTargetCraft`/`CraftByID` for the tui). **Slate mutations need no remap** — a removed craft's ID stops resolving and the target degrades to "none", the graceful drop the bounds checks always intended.
- `EndFlightActive` clears `ActiveCraftIdx` before reassigning (defect 2).

## Persistence — SchemaVersion 6 → 7

v7 writes `id`, `next_craft_id`, and the `*_craft_id` target fields. Pre-v7 envelopes run `migrateV6PayloadToV7` on the wire payload before rehydration: stamp IDs by slate position, rewrite each stored index to the matching ID (`0-based CraftIdx i → ID i+1`; `one-based TargetCraftIdx j → ID j`); out-of-range → no target. Retired index fields stay on the wire struct (read-only) so v6 JSON still unmarshals.

## Why identity over an index-remap helper

The alternative — one `reindexCraftTargets` helper every mutation calls — works but must be *remembered* at every present and future mutation site (the exact failure mode that produced this bug) and juggles two index encodings. Identity moves the invariant into the type: a binding is correct by construction. (Full rationale in ADR 0012.)

## Tests
New `craft_identity_test.go` covers the four mutation scenarios (end-flight survivor binding, end-flight successor non-clobber, dock-partner non-alias, undock tail-shift) + ID uniqueness; the EndFlight defect-2 test was **verified red without the fix**. `save_migrate_v6_to_v7_test.go` covers the index→ID mapping incl. out-of-range. Existing target/save round-trip tests updated to assert ID binding. `go vet ./...` clean; `go test ./... -race -count=1` → **961 pass (+7)**.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)