### PR TITLE
fix(sim): floor preview Δv at active-stage fuel budget (#88 finding #4)

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2300,6 +2300,16 @@ func (w *World) PreviewBurnState(mode spacecraft.BurnMode, dv float64, duration 
 				effectiveDv = maxDv
 			}
 		}
+		// Floor by the active-stage fuel budget. The duration cap above
+		// lets massAfter fall below the stage's dry + upper-stage floor —
+		// but the live burn cuts at fuel exhaustion regardless of
+		// duration, so RemainingDeltaV (the same active-stage floor the
+		// node fire path caps at via capImpulsiveDV) is the hard ceiling
+		// on delivered Δv. Without this a long-duration preview projects
+		// Δv the firing engine can never supply (GH #88 finding #4 / #89).
+		if fuelDv := w.ActiveCraft().RemainingDeltaV(); fuelDv > 0 && effectiveDv > fuelDv {
+			effectiveDv = fuelDv
+		}
 		direction := func(r, v orbital.Vec3) orbital.Vec3 {
 			if targetMode {
 				return spacecraft.DirectionUnitTarget(mode, r, v, rT, vT)

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1952,6 +1952,102 @@ func TestPreviewBurnStateLongRetroAtLunaPeriCapsByDuration(t *testing.T) {
 	}
 }
 
+// TestPreviewBurnStateCapsByActiveStageFuel (GH #88 finding #4): the
+// finite-burn preview's rocket-equation cap previously floored the
+// post-burn mass at the *total* vehicle mass (massAfter > 0), letting
+// the projected Δv eat into dry mass and upper-stage propellant the
+// firing engine can never burn. When the form's duration is long
+// enough to exhaust the *active stage's* fuel, the live burn cuts at
+// fuel exhaustion — so the preview must floor delivered Δv at
+// RemainingDeltaV (the active-stage budget that #89's fire path now
+// caps at), not at the duration alone.
+//
+// Setup: drain the active stage so its RemainingDeltaV is a modest,
+// sub-vPeri value (keeps the post-burn orbit elliptical, so apoapsis is
+// a clean monotone proxy for delivered Δv), then request a huge Δv with
+// a duration that burns past fuel exhaustion. The pre-fix preview caps
+// by the duration-implied massAfter (which dips below the fuel floor)
+// and over-states AP; the fixed preview caps at RemainingDeltaV.
+func TestPreviewBurnStateCapsByActiveStageFuel(t *testing.T) {
+	w := mustWorld(t)
+	moon, rPeri, _, vPeri, seated := seatLunaCaptureOrbit(t, w)
+	if !seated {
+		t.Skip("Moon missing from Sol")
+	}
+	muMoon := moon.GravitationalParameter()
+	c := w.ActiveCraft()
+	const g0 = 9.80665
+
+	// Drain the active stage down to a RemainingDeltaV of ~300 m/s. The
+	// floor (total − active-stage fuel) is invariant under BurnFuel, so
+	// the target leftover fuel follows directly from the rocket equation.
+	const wantDV = 300.0
+	floor := c.TotalMass() - c.ActiveStageFuel()
+	if floor <= 0 {
+		t.Skip("active craft has no dry/upper floor — cannot construct fuel-limited case")
+	}
+	fuelToLeave := floor*math.Exp(wantDV/(c.Isp*g0)) - floor
+	if drain := c.ActiveStageFuel() - fuelToLeave; drain > 0 {
+		c.BurnFuel(drain)
+		c.State.M = c.TotalMass()
+	}
+	remainingDV := c.RemainingDeltaV()
+	if math.Abs(remainingDV-wantDV) > 5 {
+		t.Fatalf("setup: RemainingDeltaV=%.1f m/s, wanted ~%.0f — drain math wrong?", remainingDV, wantDV)
+	}
+
+	// Duration that drives massAfter to 0.95·floor — below the fuel
+	// floor (so the pre-fix duration cap over-states Δv) but still
+	// positive (so the existing massAfter>0 guard fires the wrong cap).
+	M := c.State.M
+	floor = M - c.ActiveStageFuel()
+	massAfter := 0.95 * floor
+	mdot := c.Thrust / (c.Isp * g0)
+	duration := time.Duration((M - massAfter) / mdot * float64(time.Second))
+
+	// The cap the pre-fix code would apply, and the correct fuel floor.
+	maxDvWrong := c.Isp * g0 * math.Log(M/massAfter)
+	if maxDvWrong <= remainingDV+50 {
+		t.Fatalf("setup: uncapped Δv %.1f not meaningfully above fuel floor %.1f m/s", maxDvWrong, remainingDV)
+	}
+	if maxDvWrong >= vPeri || remainingDV >= vPeri {
+		t.Fatalf("setup: caps (%.1f / %.1f) exceed vPeri %.1f — orbit would flip retrograde",
+			maxDvWrong, remainingDV, vPeri)
+	}
+
+	// Request far more Δv than either cap so the cap itself is what binds.
+	state, primary, ok := w.PreviewBurnState(spacecraft.BurnRetrograde, 1e6, duration, TriggerNextPeri)
+	if !ok {
+		t.Fatalf("PreviewBurnState returned ok=false")
+	}
+	if primary.ID != moon.ID {
+		t.Fatalf("preview escaped Luna SOI? primary=%q", primary.ID)
+	}
+	postApo := orbital.ElementsFromState(state.R, state.V, muMoon).Apoapsis()
+
+	// Impulsive apoapsis a given retrograde Δv at peri would produce.
+	apoFor := func(dv float64) float64 {
+		v := vPeri - dv
+		eps := 0.5*v*v - muMoon/rPeri
+		a := -muMoon / (2 * eps)
+		return 2*a - rPeri
+	}
+	apoCorrect := apoFor(remainingDV)
+	apoWrong := apoFor(maxDvWrong)
+
+	if math.Abs(postApo-apoWrong) <= math.Abs(postApo-apoCorrect) {
+		t.Errorf("preview AP %.0f km matched the uncapped duration projection (%.0f km, %.1f m/s) rather than the active-stage fuel floor (%.0f km, %.1f m/s) — RemainingDeltaV cap not applied",
+			postApo/1000, apoWrong/1000, maxDvWrong, apoCorrect/1000, remainingDV)
+	}
+	// Finite-burn deformation pulls AP slightly below the impulsive
+	// fuel-floor prediction; the cap is the test's job, not pinpoint
+	// finite precision.
+	if rel := math.Abs(postApo-apoCorrect) / apoCorrect; rel > 0.12 {
+		t.Errorf("preview AP %.0f km diverges from fuel-floor impulsive %.0f km by %.1f%% — expected < 12%%",
+			postApo/1000, apoCorrect/1000, rel*100)
+	}
+}
+
 // TestPreviewBurnStateFiniteVsImpulsiveAtLunaPeri (v0.6.3 polish): when
 // the requested Δv fits inside the duration window (200 m/s in 10 s
 // for the S-IVB-1), the finite-burn preview and the impulsive preview


### PR DESCRIPTION
## What

`PreviewBurnState`'s finite-burn rocket-equation cap floored the post-burn mass at **total vehicle mass** (`massAfter > 0`), so a form duration long enough to exhaust the **active stage's** propellant projected Δv that ate into dry mass and upper-stage fuel the firing engine can never burn. The live fire path cuts at fuel exhaustion (`capImpulsiveDV` / `RemainingDeltaV`, GH #89), so the preview over-stated the post-burn orbit.

This is **finding #4** from the deferred set on issue #88 — explicitly flagged in the #88 verdict comment as "better folded in after #89 lands." #89 is now merged, supplying the active-stage fuel floor (`RemainingDeltaV`).

## Fix

Cap `effectiveDv` at `w.ActiveCraft().RemainingDeltaV()` in the finite-burn branch — the same active-stage floor the node fire path caps at. The duration cap still binds when it's the tighter limit; the fuel floor only kicks in when the duration would drive `massAfter` below the stage's dry + upper-stage floor. The impulsive branch is untouched: in production it's only reached when `dv<=0` or `isp<=0` (where `RemainingDeltaV`→0 anyway); the real over-budget Δv flows through the finite branch because `BurnTimeForDV` returns a finite duration computed against total mass.

## Test (TDD, red→green)

`TestPreviewBurnStateCapsByActiveStageFuel` seats a Luna capture orbit, drains the active stage to a ~300 m/s `RemainingDeltaV`, then requests a huge Δv over a fuel-exhausting duration. Verified red with the fix reverted (preview projected ~511 m/s, AP matched the uncapped duration projection rather than the fuel floor); green with the fix. The four sibling `PreviewBurnState` tests (including the existing duration-cap test) are unaffected — `RemainingDeltaV` exceeds their short-burn duration caps, so the new floor never binds there.

## Gate

`go vet ./...` clean; `go test ./... -race -count=1` → **970 pass** (was 969).

Refs #88 (keeps the issue open for the remaining #3/#5 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)