### PR TITLE
fix(sim): RefinePlan rewrites the selected arrival, not a key collision (#88 finding #5)

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -625,10 +625,28 @@ func (w *World) RefinePlan() (correctionDv, arrivalDv float64, err error) {
 		return 0, 0, err
 	}
 
+	// Rebuild the arrival node in place with refined Δv. Update it by the
+	// index the reverse scan selected, *before* planting the correction —
+	// PlanNode re-sorts the slice, and re-finding the node by
+	// (TriggerTime, PrimaryID) afterward could rewrite the wrong one when
+	// two arrival nodes share that key (a double-plant to the same body
+	// at a coinciding arrival time; GH #88 finding #5). arrIdx is still
+	// valid here: nothing has mutated Nodes since the scan.
+	w.ActiveCraft().Nodes[arrIdx] = ManeuverNode{
+		TriggerTime: arrNode.TriggerTime,
+		Mode:        arrNode.Mode,
+		DV:          arrivalDv,
+		Duration:    w.ActiveCraft().BurnTimeForDV(arrivalDv),
+		PrimaryID:   arrNode.PrimaryID,
+	}
+
 	// Plant the correction burn at now (tiny offset to avoid firing the
 	// same tick it lands if executeDueNodes has already run). v0.6.5:
 	// duration via the rocket-equation form so it matches the
-	// transferNodeToManeuver path.
+	// transferNodeToManeuver path. PlanNode re-sorts the slice, which
+	// also re-orders the refined arrival if its new duration shifted its
+	// BurnStart; when there's no correction burn, sort explicitly to
+	// preserve that invariant.
 	if correctionDv > 0 {
 		w.PlanNode(ManeuverNode{
 			TriggerTime: now.Add(time.Second),
@@ -637,22 +655,8 @@ func (w *World) RefinePlan() (correctionDv, arrivalDv float64, err error) {
 			Duration:    w.ActiveCraft().BurnTimeForDV(correctionDv),
 			PrimaryID:   w.ActiveCraft().Primary.ID,
 		})
-	}
-
-	// Rebuild the arrival node in place with refined Δv.
-	newArrival := ManeuverNode{
-		TriggerTime: arrNode.TriggerTime,
-		Mode:        arrNode.Mode,
-		DV:          arrivalDv,
-		Duration:    w.ActiveCraft().BurnTimeForDV(arrivalDv),
-		PrimaryID:   arrNode.PrimaryID,
-	}
-	// Find arrNode again by index after PlanNode sorted the slice.
-	for i, n := range w.ActiveCraft().Nodes {
-		if n.TriggerTime.Equal(arrNode.TriggerTime) && n.PrimaryID == arrNode.PrimaryID {
-			w.ActiveCraft().Nodes[i] = newArrival
-			break
-		}
+	} else {
+		sortNodes(w.ActiveCraft().Nodes)
 	}
 	return correctionDv, arrivalDv, nil
 }

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1736,6 +1736,97 @@ func TestRefinePlanUpdatesArrivalAfterPlanTransferAt(t *testing.T) {
 	}
 }
 
+// TestRefinePlanRewritesSelectedArrivalNotKeyCollision (GH #88 finding
+// #5): RefinePlan selects the arrival node by a *reverse* scan (latest
+// pending non-home node) but pre-fix re-located it after PlanNode
+// re-sorted the slice by a forward search on (TriggerTime, PrimaryID).
+// When two arrival nodes share that key — a double-plant to the same
+// body at a coinciding arrival time — the forward search rewrites the
+// FIRST match, which need not be the node the reverse scan selected, so
+// the refined Δv lands on the wrong node and the intended one keeps its
+// stale value.
+//
+// Construct the collision deterministically: a decoy arrival sharing
+// the real arrival's (TriggerTime, mars) key but with a long duration,
+// so it sorts to an earlier BurnStart (lower index) than the real
+// arrival. The reverse scan therefore selects the real arrival (higher
+// index) while the buggy forward search would hit the decoy first. The
+// decoy must come out untouched.
+func TestRefinePlanRewritesSelectedArrivalNotKeyCollision(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	marsIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Mars" {
+			marsIdx = i
+			break
+		}
+	}
+	if marsIdx < 0 {
+		t.Skip("Mars not in loaded Sol system")
+	}
+	mars := sys.Bodies[marsIdx]
+
+	if _, err := w.PlanTransferAt(marsIdx, 0, 260, TransferOptions{}); err != nil {
+		t.Fatalf("PlanTransferAt: %v", err)
+	}
+
+	// Locate the real arrival node (PrimaryID == mars) and record its key.
+	var arrTT time.Time
+	var arrMode spacecraft.BurnMode
+	found := false
+	for _, n := range w.ActiveCraft().Nodes {
+		if n.PrimaryID == mars.ID {
+			arrTT, arrMode, found = n.TriggerTime, n.Mode, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no mars-arrival node after PlanTransferAt")
+	}
+
+	// Decoy: same (TriggerTime, mars) key, distinctive DV + long duration.
+	// The long duration pins it to an earlier BurnStart → lower index than
+	// the real arrival, so the buggy forward re-find would rewrite it.
+	const decoyDV = 7777.0
+	const decoyDur = 9999 * time.Second
+	w.PlanNode(ManeuverNode{
+		TriggerTime: arrTT,
+		Mode:        arrMode,
+		DV:          decoyDV,
+		Duration:    decoyDur,
+		PrimaryID:   mars.ID,
+	})
+
+	_, arr, err := w.RefinePlan()
+	if err != nil {
+		t.Fatalf("RefinePlan: %v", err)
+	}
+
+	// The decoy must survive untouched (identifiable by its distinctive
+	// Δv), and the refined Δv must land on the *other* mars node — the
+	// one the reverse scan selected. The buggy forward re-find rewrites
+	// the decoy (lower index) instead, wiping its Δv.
+	decoySurvived, realRefined := false, false
+	for _, n := range w.ActiveCraft().Nodes {
+		if n.PrimaryID != mars.ID {
+			continue
+		}
+		if math.Abs(n.DV-decoyDV) < 1e-6 {
+			decoySurvived = true
+		} else if math.Abs(n.DV-arr) < 1e-6 {
+			realRefined = true
+		}
+	}
+	if !decoySurvived {
+		t.Errorf("decoy arrival (Δv %.1f) was overwritten — RefinePlan rewrote the wrong key-collision node instead of the reverse-scan-selected arrival",
+			decoyDV)
+	}
+	if !realRefined {
+		t.Errorf("no mars-arrival node carries the refined Δv %.1f — the selected node was not updated", arr)
+	}
+}
+
 // TestPlanTransferMoonEscapePlantsTwoNodes (v0.6.3): with the craft in
 // low lunar orbit, PlanTransfer(earth) should plant a moon-frame
 // departure burn (Δv > 0, prograde) followed by an Earth-frame


### PR DESCRIPTION
## What

`RefinePlan` selects the arrival node to refine via a **reverse** scan (the latest pending node whose `PrimaryID` is a non-home body), but then re-located it with a **forward** search on `(TriggerTime, PrimaryID)` *after* `PlanNode` re-sorted the slice. When two arrival nodes share that key — a double-plant to the same body at a coinciding arrival time — the forward search rewrites the **first** match, which need not be the node the reverse scan selected. The refined Δv lands on the wrong node and the intended one keeps its stale value.

This is **finding #5** from the deferred set on issue #88. The verdict comment flagged it as needing "stable node identity to fix properly" — but the search-by-value is only there because `PlanNode` sorts the slice *before* the overwrite, invalidating the index. Updating in place by the already-found index sidesteps the need for any node identity.

## Fix

Update the arrival node in place by the reverse-scan `arrIdx` **before** planting the correction burn (`arrIdx` is still valid — nothing mutates `Nodes` between the scan and the update). This drops the fragile search-by-value entirely. `PlanNode` re-sorts after; when there's no correction burn, an explicit `sortNodes` preserves the sorted invariant now that the refined arrival's new duration can shift its `BurnStart` (a latent mis-sort the old code could also leave behind).

## Test (TDD, red→green)

`TestRefinePlanRewritesSelectedArrivalNotKeyCollision` plants a Mars transfer, then adds a decoy arrival sharing the real arrival's `(TriggerTime, mars)` key but with a long duration so it deterministically sorts to a lower index than the real arrival. The reverse scan selects the real arrival (higher index) while the buggy forward search hits the decoy first. Verified **red** (decoy's distinctive Δv was overwritten) → **green** (decoy survives untouched, refined Δv lands on the selected node). The two existing `RefinePlan` tests are unaffected.

## Gate

`go vet ./...` clean; `go test ./... -race -count=1` → **971 pass** (was 970).

Refs #88 (this was the last of the three deferred findings — #3 remains the only open item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)