### PR TITLE
fix(sim): separate stacked plane-change/capture in degenerate split (#88 finding #3)

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -453,6 +453,16 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 
 		w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
 		if pcDv > 0 {
+			// Degenerate fallback (transferEncounterTimes found no encounter,
+			// or no node/departure state): planeChangeOffset still equals
+			// captureOffset, so separate them — equal BurnStarts leave the
+			// fire order unspecified and the capture could ignite before the
+			// plane change (GH #88 finding #3). A no-op on the resolved path
+			// where the two offsets already differ.
+			depBurnEnd := plan.Departure.OffsetTime + c.BurnTimeForDV(plan.Departure.DV)/2
+			planeChangeOffset = splitFallbackPlaneChangeOffset(
+				planeChangeOffset, captureOffset,
+				c.BurnTimeForDV(pcDv), c.BurnTimeForDV(plan.Arrival.DV), depBurnEnd)
 			w.PlanNode(ManeuverNode{
 				TriggerTime:    now.Add(planeChangeOffset),
 				Mode:           spacecraft.BurnPlaneChange,
@@ -1545,6 +1555,31 @@ func (w *World) transferEncounterTimes(post physics.StateVector, primary, target
 		return 0, 0, false
 	}
 	return tEntry, tCA, true
+}
+
+// splitFallbackPlaneChangeOffset keeps the split's plane-change and
+// capture burns from being planted at the same instant in the degenerate
+// fallback. The normal path resolves a distinct SOI-entry time for the
+// plane change (transferEncounterTimes, found==true), so planeChangeOffset
+// and captureOffset already differ and this returns the former unchanged.
+// When they coincide — no encounter found in the horizon, or no
+// node/departure state — it pulls the plane change earlier by half of
+// each burn's duration plus a one-second gap, so the two finite burns are
+// ordered (plane change first) and non-overlapping rather than stacked.
+// Still near-apoapsis (the separation is seconds against an hours-long
+// transfer) so the apoapsis plane-change Δv stays a good estimate. Clamped
+// to no earlier than `earliest` (the end of the departure burn); the
+// caller guarantees earliest < captureOffset, so the result stays strictly
+// before the capture. GH #88 finding #3.
+func splitFallbackPlaneChangeOffset(planeChangeOffset, captureOffset, pcDur, capDur, earliest time.Duration) time.Duration {
+	if planeChangeOffset != captureOffset {
+		return planeChangeOffset
+	}
+	sep := (pcDur+capDur)/2 + time.Second
+	if planeChangeOffset-sep > earliest {
+		return planeChangeOffset - sep
+	}
+	return earliest
 }
 
 // intraPlaneChangeAllowance estimates the extra departure Δv a fused

--- a/internal/sim/split_node_test.go
+++ b/internal/sim/split_node_test.go
@@ -3,11 +3,58 @@ package sim
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
+
+// TestSplitFallbackPlaneChangeOffsetSeparatesStacked (GH #88 finding #3):
+// in the degenerate split fallback (no SOI encounter resolved, so
+// transferEncounterTimes can't place the plane change at SOI entry) the
+// plane-change and capture offsets both default to the arrival offset.
+// splitFallbackPlaneChangeOffset must pull the plane change strictly
+// earlier — and clear of the capture's burn window — so the two finite
+// burns are ordered and non-overlapping rather than stacked at one
+// instant. It must leave an already-distinct pair (the working found==
+// SOI-entry path) untouched.
+func TestSplitFallbackPlaneChangeOffsetSeparatesStacked(t *testing.T) {
+	const (
+		capture  = 100 * time.Minute
+		pcDur    = 30 * time.Second
+		capDur   = 50 * time.Second
+		earliest = 10 * time.Minute // end of the departure burn
+	)
+
+	// Stacked: equal offsets must separate into an ordered, non-overlapping pair.
+	got := splitFallbackPlaneChangeOffset(capture, capture, pcDur, capDur, earliest)
+	if got >= capture {
+		t.Fatalf("stacked offset not pulled earlier: got %v, capture %v", got, capture)
+	}
+	if gap := capture - got; gap < pcDur/2+capDur/2 {
+		t.Errorf("burn windows overlap: gap %v < half-burn sum %v", gap, pcDur/2+capDur/2)
+	}
+	if got <= earliest {
+		t.Errorf("plane change %v not after the departure burn end %v", got, earliest)
+	}
+
+	// Distinct (found==true path): returned unchanged.
+	const pcOff = 90 * time.Minute
+	if got := splitFallbackPlaneChangeOffset(pcOff, capture, pcDur, capDur, earliest); got != pcOff {
+		t.Errorf("distinct offset was rewritten: got %v, want %v", got, pcOff)
+	}
+
+	// Clamp: a transfer too short to fit the full separation after the
+	// departure burn clamps to earliest, still strictly before capture.
+	shortCap := earliest + 5*time.Second
+	if got := splitFallbackPlaneChangeOffset(shortCap, shortCap, pcDur, capDur, earliest); got != earliest {
+		t.Errorf("clamp to departure end: got %v, want %v", got, earliest)
+	}
+	if earliest >= shortCap {
+		t.Fatalf("test invariant broken: earliest %v must precede capture %v", earliest, shortCap)
+	}
+}
 
 // findMoon locates the Moon in the loaded Sol system (skips if absent).
 func findMoon(t *testing.T, w *World) (int, bodies.CelestialBody) {


### PR DESCRIPTION
## What

The intra-primary split fires its plane change just before SOI entry and its capture at perilune — distinct times — when `transferEncounterTimes` resolves the encounter (`61afcd6`, the #67 follow-up). But `planeChangeOffset` and `captureOffset` both **default** to `plan.Arrival.OffsetTime`, and the override only runs inside the `found==true` branch. In the **degenerate fallback** — no SOI encounter within the horizon, or no node/departure state (`!nodeOK`/`!depOK`) — the two stay equal, so the plane change and capture are planted at the **identical `TriggerTime`**.

This is **finding #3** from issue #88, the last deferred item. Its catastrophic symptom (the second node clobbering the first's Δv) was already eliminated by the #88 dispatch fix (`aac870c`) — but `sortNodes` keys on `BurnStart`, so equal times leave the fire order *unspecified*, and the capture can ignite before the plane change.

## Fix

`splitFallbackPlaneChangeOffset`: when the two offsets coincide, pull the plane change earlier by half of each burn's duration plus a 1 s gap, so the finite burns are **ordered** (plane change first) and **non-overlapping** rather than stacked. Clamped to no earlier than the departure burn's end. It's a **no-op on the resolved path** (where the offsets already differ), so the working split — guarded by `TestPlanTransferSplitBurnsAreDistinct` — is provably untouched. Still near-apoapsis (the separation is seconds against an hours-long transfer), so the apoapsis plane-change Δv stays a good estimate.

### Why a helper + unit test rather than an integration test

The degenerate fallback is hard to reach deterministically through `PlanTransfer` (forcing `found==false` while the node-aligned phasing is *designed* to hit the SOI, without also zeroing `pcDv`, requires pathological geometry) — which is precisely why the #88 verdict flagged this as risky to touch. Extracting the separation decision into a small pure helper makes the previously-untestable fallback logic deterministically testable, while the existing `TestPlanTransferSplitBurnsAreDistinct` continues to guard the working path against regression.

## Test (TDD, red→green)

`TestSplitFallbackPlaneChangeOffsetSeparatesStacked` — verified **red** (helper undefined) → **green**: stacked offsets separate into an ordered non-overlapping pair, distinct offsets pass through unchanged, and a too-short transfer clamps to the departure-burn end (still strictly before capture).

## Gate

`go vet ./...` clean; `go test ./... -race -count=1` → **972 pass** (was 971).

Refs #88 — this was the last of the three deferred findings (#3/#4/#5). Issue can be closed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)