### PR TITLE
cleanup(core): reconcile doc-comment drift & dead code (#92)

### DIFF
--- a/internal/orbital/kepler.go
+++ b/internal/orbital/kepler.go
@@ -222,9 +222,11 @@ func PerifocalBasis(el Elements) (Vec3, Vec3) {
 // Readout summarises the orbit's headline parameters for HUD use.
 // Distances are in metres from the primary's centre (not altitude);
 // caller subtracts body radius for altitude. Node angles are in
-// radians, measured from the +X axis of the primary's frame; for
-// equatorial / circular orbits the corresponding fields are NaN
-// (callers render "—" or skip).
+// radians, measured from the +X axis of the primary's frame. For
+// equatorial / circular orbits Ω is undefined; the fields are left at
+// their finite zero-derived values (AscNode = Ω, DescNode = Ω+π) — not
+// NaN — so callers must detect this via Inclination ≈ 0 / π and render
+// "—" or skip, rather than checking math.IsNaN.
 //
 // Closed (elliptical) orbits set ApoMeters > 0; hyperbolic / escape
 // trajectories return ApoMeters < 0 and Hyperbolic = true so the HUD

--- a/internal/planner/finiteburn.go
+++ b/internal/planner/finiteburn.go
@@ -156,11 +156,10 @@ func IterateForTarget(
 		} else if step < -maxStep {
 			step = -maxStep
 		}
-		next := dv + step
-		if next <= 0 {
-			next = dv * 0.5 // halving guard for negative-bound runaways
-		}
-		dv = next
+		// step is clamped to [-0.5·dv, +0.5·dv] and dv enters the loop
+		// strictly positive (guarded above), so next ∈ [0.5·dv, 1.5·dv]
+		// stays > 0 — no further non-negativity guard is needed.
+		dv += step
 	}
 	return dv, final, ErrFiniteBurnDiverged
 }

--- a/internal/planner/porkchop.go
+++ b/internal/planner/porkchop.go
@@ -27,7 +27,7 @@ type EphemerisFn func(epoch float64) (r, v orbital.Vec3)
 //   epoch0 + (depDays[i]+tofDays[j])*86400 for arrival.
 // - depState, arrState: body ephemerides (heliocentric r, v).
 // - muSun: gravitational parameter of the system primary.
-// - muDep, rPark: destination body μ + parking-orbit radius (for
+// - muDep, rPark: departure body μ + parking-orbit radius (for
 //   departure Δv via the patched-conic identity).
 // - muArr, rCapture: arrival body μ + capture-orbit radius.
 // - retrograde: forwarded to LambertSolve to select the prograde or

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -520,27 +520,10 @@ func payloadFromWorld(w *sim.World) Payload {
 		// v0.9.1+: serialize Stages so v6 saves carry per-stage
 		// detail. Single-stage craft still wire out a one-element
 		// Stages — round-trips through the same migrate path that
-		// v5 craft fall through.
-		for _, s := range c.Stages {
-			wc.Stages = append(wc.Stages, Stage{
-				LoadoutID:            s.LoadoutID,
-				Name:                 s.Name,
-				Glyph:                s.Glyph,
-				Color:                s.Color,
-				DryMass:              s.DryMass,
-				FuelMass:             s.FuelMass,
-				FuelCapacity:         s.FuelCapacity,
-				Thrust:               s.Thrust,
-				Isp:                  s.Isp,
-				MonopropMass:         s.MonopropMass,
-				MonopropCap:          s.MonopropCap,
-				RCSThrust:            s.RCSThrust,
-				RCSIsp:               s.RCSIsp,
-				BallisticCoefficient: s.BallisticCoefficient,
-				CanSoftLand:          s.CanSoftLand,
-				HasParachute:         s.HasParachute,
-			})
-		}
+		// v5 craft fall through. Shares simStagesToWire with
+		// DockedComponent.Stages so a new Stage field can't be dropped
+		// from one path but not the other.
+		wc.Stages = simStagesToWire(c.Stages)
 		for _, dc := range c.DockedComponents {
 			wc.DockedComponents = append(wc.DockedComponents, DockedComponent{
 				Name:             dc.Name,

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -241,6 +241,70 @@ func TestSaveLoadMultiStageDockedComponent(t *testing.T) {
 	}
 }
 
+// TestRoundtripTopLevelStageFields — the persisted spacecraft.Stage
+// fields on a craft's top-level Stages must survive Save+Load. Guards
+// the shared simStagesToWire path (Craft.Stages and DockedComponent.
+// Stages both go through it now): a new persisted field added to the
+// helper that a parallel copy path missed would silently drop on save.
+// Distinctive per-field values make any dropped field a mismatch. Only
+// the persisted fields are compared — the launch-sprite / fuel-type
+// cosmetics are intentionally re-derived from the catalog, not stored.
+func TestRoundtripTopLevelStageFields(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	want := []spacecraft.Stage{
+		{
+			LoadoutID: "lower", Name: "Booster", Glyph: "B", Color: "#112233",
+			DryMass: 1200, FuelMass: 8000, FuelCapacity: 9000,
+			Thrust: 750000, Isp: 282, MonopropMass: 12, MonopropCap: 40,
+			RCSThrust: 220, RCSIsp: 210, BallisticCoefficient: 350,
+			CanSoftLand: false, HasParachute: true,
+		},
+		{
+			LoadoutID: "upper", Name: "Payload", Glyph: "P", Color: "#445566",
+			DryMass: 300, FuelMass: 1500, FuelCapacity: 1600,
+			Thrust: 60000, Isp: 345, MonopropMass: 7.5, MonopropCap: 25,
+			RCSThrust: 110, RCSIsp: 205, BallisticCoefficient: 120,
+			CanSoftLand: true, HasParachute: false,
+		},
+	}
+	w.ActiveCraft().Stages = append([]spacecraft.Stage(nil), want...)
+	w.ActiveCraft().SyncFields()
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Project to just the persisted fields so the comparison ignores the
+	// catalog-re-derived cosmetics (LaunchSprite*, FuelType).
+	persisted := func(s spacecraft.Stage) spacecraft.Stage {
+		return spacecraft.Stage{
+			LoadoutID: s.LoadoutID, Name: s.Name, Glyph: s.Glyph, Color: s.Color,
+			DryMass: s.DryMass, FuelMass: s.FuelMass, FuelCapacity: s.FuelCapacity,
+			Thrust: s.Thrust, Isp: s.Isp, MonopropMass: s.MonopropMass,
+			MonopropCap: s.MonopropCap, RCSThrust: s.RCSThrust, RCSIsp: s.RCSIsp,
+			BallisticCoefficient: s.BallisticCoefficient,
+			CanSoftLand:          s.CanSoftLand, HasParachute: s.HasParachute,
+		}
+	}
+	gotStages := got.ActiveCraft().Stages
+	if len(gotStages) != len(want) {
+		t.Fatalf("Stages count: got %d want %d", len(gotStages), len(want))
+	}
+	for i := range want {
+		if persisted(gotStages[i]) != persisted(want[i]) {
+			t.Errorf("Stage[%d]: got %+v want %+v", i, gotStages[i], want[i])
+		}
+	}
+}
+
 // TestLoadOldSaveDockedComponentFallsBackSingleStage — a v6 save written
 // before ADR 0009 has DockedComponents with no "stages" array. Loading
 // it and undocking must fall back to the legacy single-stage rebuild

--- a/internal/sim/nav.go
+++ b/internal/sim/nav.go
@@ -13,7 +13,7 @@ import "github.com/jasonfen/terminal-space-program/internal/spacecraft"
 //                rotating atmosphere; useful for ascent. Only prograde
 //                / retrograde rebind in this mode (KSP shows orbital
 //                normal/radial on the surface navball too).
-//   NavTarget  — prograde ≡ unit(v_target − v_active), retrograde its
+//   NavTarget  — prograde ≡ unit(v_active − v_target), retrograde its
 //                flip; radial± rebinds to BurnTarget / BurnAntiTarget
 //                (toward / away from target). Only valid when
 //                World.Target.Kind == TargetCraft. v0.9.3+.

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -103,27 +103,22 @@ type SOISegment struct {
 	Points    []orbital.Vec3 // inertial, system-primary-centered
 }
 
-// PredictedSegments forward-integrates a post-burn state by totalSeconds
-// and partitions the trajectory into SOISegments. Pre-v0.3.0 the
+// PredictedSegmentsFrom forward-integrates a post-burn state by
+// totalSeconds and partitions the trajectory into SOISegments,
+// parameterised on the starting primary and clock. Pre-v0.3.0 the
 // predictor locked to the home primary's μ throughout, which made
 // post-escape segments geometrically wrong even though their coloring
 // was correct. v0.3.0: when a sub-step crosses a sphere-of-influence
 // boundary, rebase the state vector to the new primary's frame and
-// switch μ for subsequent steps. Output shape (a slice of SOISegments)
-// is unchanged so the renderer keeps working.
-func (w *World) PredictedSegments(post physics.StateVector, totalSeconds float64, samples int) []SOISegment {
-	return w.PredictedSegmentsFrom(post, w.ActiveCraft().Primary, w.Clock.SimTime, totalSeconds, samples)
-}
-
-// PredictedSegmentsFrom is the same trajectory predictor but
-// parameterised on the starting primary and clock. v0.6.1: used by
-// the multi-leg colored preview, where each leg starts in its own
-// node-planted frame (e.g. Hohmann departure leg in Earth, arrival
-// leg in Mars). v0.8.4: takes a startClock so body positions track
-// real time across the leg (per-sample refresh — sub-step refresh
-// would cost 60 % of a render frame on long horizons), and folds
-// atmospheric drag into the integrator via the active craft's
-// EffectiveBallisticCoefficient. Output shape unchanged.
+// switch μ for subsequent steps. v0.6.1: used by the multi-leg
+// colored preview, where each leg starts in its own node-planted
+// frame (e.g. Hohmann departure leg in Earth, arrival leg in Mars).
+// v0.8.4: takes a startClock so body positions track real time across
+// the leg (per-sample refresh — sub-step refresh would cost 60 % of a
+// render frame on long horizons), and folds atmospheric drag into the
+// integrator via the active craft's EffectiveBallisticCoefficient.
+// Output shape (a slice of SOISegments) is unchanged so the renderer
+// keeps working.
 func (w *World) PredictedSegmentsFrom(post physics.StateVector, startPrimary bodies.CelestialBody, startClock time.Time, totalSeconds float64, samples int) []SOISegment {
 	if w.ActiveCraft() == nil || samples < 2 {
 		return nil

--- a/internal/sim/predict_test.go
+++ b/internal/sim/predict_test.go
@@ -315,7 +315,7 @@ func TestPredictedSegmentsContinuousAtSOIBoundary(t *testing.T) {
 
 	const totalSecs = 3 * 86400.0 // 3 days
 	const samples = 600
-	segs := w.PredictedSegments(post, totalSecs, samples)
+	segs := w.PredictedSegmentsFrom(post, w.ActiveCraft().Primary, w.Clock.SimTime, totalSecs, samples)
 
 	if len(segs) < 2 {
 		t.Fatalf("expected ≥2 SOI segments after escape, got %d (no SOI crossing detected)", len(segs))
@@ -351,7 +351,7 @@ func TestPredictedSegmentsBoundOrbitStaysInOneSegment(t *testing.T) {
 
 	mu := w.ActiveCraft().Primary.GravitationalParameter()
 	period := 2 * math.Pi * math.Sqrt(math.Pow(post.R.Norm(), 3)/mu)
-	segs := w.PredictedSegments(post, period, 128)
+	segs := w.PredictedSegmentsFrom(post, w.ActiveCraft().Primary, w.Clock.SimTime, period, 128)
 
 	if len(segs) != 1 {
 		ids := make([]string, len(segs))


### PR DESCRIPTION
Closes #92.

Six verifier-confirmed LOW-severity findings from the core `/code-review` sweep — doc-comment drift, a dead guard, and dead code. All re-confirmed against current code during triage.

## Fixes
- **`orbital.Readout`** — struct doc claimed node fields are `NaN` for equatorial/circular orbits, but `OrbitReadout` unconditionally emits finite `Ω` / `Ω+π`. Doc corrected: callers must guard on inclination, not `math.IsNaN`. (Doc-only — behavior unchanged, in-repo callers already guard on inclination.)
- **`save`** — `payloadFromWorld` copied `Craft.Stages` with an inline 16-field literal duplicating `simStagesToWire`; only `DockedComponent.Stages` used the helper. Routed both through the helper so a new `Stage` field can't drop from one path but not the other. Added `TestRoundtripTopLevelStageFields` to lock the persisted fields across save/load.
- **`planner.PorkchopGrid`** — doc mislabeled `muDep`/`rPark` as "destination body"; they feed the **departure** escape burn. Fixed to "departure body".
- **`planner.IterateForTarget`** — removed the unreachable `next <= 0` halving guard (the Newton step is clamped to ±0.5·dv and `dv` stays strictly positive, so `next ∈ [0.5·dv, 1.5·dv]`).
- **`sim` NavTarget** — `NavMode` doc had target-prograde inverted (`v_target − v_active`); `BurnTargetPrograde` and the navball use `v_active − v_target`. Comment fixed.
- **`sim.PredictedSegments`** — deleted the dead wrapper (no non-test callers; re-grepped at apply time) that dereferenced `ActiveCraft().Primary` *before* the nil-guard in `PredictedSegmentsFrom`. Folded its v0.3.0 SOI-rebase history into that function's doc and redirected the two tests to call `PredictedSegmentsFrom` directly.

## Notes
No behavior change — the two save copy paths were field-identical, so this is doc/contract accuracy + dead-code removal only. Out of scope: the NaN-vs-finite node behavior (doc-only by design), warp/burn clamps, frame logic, and the HIGH-severity findings from the same sweep (already filed and closed as #87–#91).

## Test plan
- `go vet ./...` — clean
- `go test ./... -race -count=1` — all green
- New: `TestRoundtripTopLevelStageFields` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)