### PR TITLE
feat(tui): render the view readout in the HUD primary color

### DIFF
--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -593,7 +593,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	if labelCol < 0 {
 		labelCol = 0
 	}
-	m.canvas.SetCellLabel(labelCol, m.canvas.Rows()-1, viewLabel)
+	m.canvas.SetCellLabelColored(labelCol, m.canvas.Rows()-1, viewLabel, m.theme.Primary.GetForeground())
 
 	canvasPanel := m.theme.HUDBox.Render(m.canvas.String())
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -794,7 +794,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			viewLabel = fmt.Sprintf("view: tilted %g°", w.ViewTilt.Theta)
 		}
 	}
-	v.canvas.SetCellLabel(0, v.canvas.Rows()-1, viewLabel)
+	v.canvas.SetCellLabelColored(0, v.canvas.Rows()-1, viewLabel, v.theme.Primary.GetForeground())
 	// v0.13: the "focus:" indicator moved to the title bar (renderTitleBar)
 	// — the canvas top-left corner is now home to the pinned VESSEL chip,
 	// and "focus: <craft>" was redundant with the chip's vessel name.

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -139,6 +139,14 @@ type Canvas struct {
 	// distinctly even at small pixel-radius. Overlay color comes from
 	// the cell's pixelTags as usual.
 	cellOverlays map[[2]int]rune
+
+	// cellOverlayColors optionally pins an overlay cell to a specific
+	// foreground color, independent of any pixelTags under it. Used by
+	// SetCellLabelColored so HUD-style corner labels (e.g. the "view:"
+	// readout) can render in the theme palette even though they sit on
+	// untagged background cells. Cells absent from this map fall back to
+	// the pixelTag-derived color (terminal default when untagged).
+	cellOverlayColors map[[2]int]lipgloss.TerminalColor
 }
 
 // NewCanvas builds a canvas sized to fit cols × rows terminal cells.
@@ -192,6 +200,7 @@ func (c *Canvas) Clear() {
 	c.dc.Clear()
 	c.pixelTags = nil
 	c.cellOverlays = nil
+	c.cellOverlayColors = nil
 }
 
 // SetCellOverlay places a Unicode glyph at the cell containing the
@@ -256,6 +265,26 @@ func (c *Canvas) SetCellLabel(col, row int, text string) {
 			continue
 		}
 		c.cellOverlays[[2]int{x, row}] = ch
+	}
+}
+
+// SetCellLabelColored is SetCellLabel that also pins the label's
+// foreground to color, so corner-overlay HUD text reads in the theme
+// palette instead of the terminal default. Same right-going,
+// one-rune-per-cell, skip-out-of-bounds behavior as SetCellLabel.
+func (c *Canvas) SetCellLabelColored(col, row int, text string, color lipgloss.TerminalColor) {
+	c.SetCellLabel(col, row, text)
+	if c.cellOverlayColors == nil {
+		c.cellOverlayColors = make(map[[2]int]lipgloss.TerminalColor)
+	}
+	i := 0
+	for range text {
+		x := col + i
+		i++
+		if x < 0 || x >= c.cols || row < 0 || row >= c.rows {
+			continue
+		}
+		c.cellOverlayColors[[2]int{x, row}] = color
 	}
 }
 
@@ -1027,8 +1056,15 @@ func (c *Canvas) String() string {
 				ch = overlay
 			}
 			color, hasColor := cellColor[[2]int{x, i}]
+			var fg lipgloss.TerminalColor = color
+			// A pinned overlay color (SetCellLabelColored) wins over the
+			// pixelTag-derived cell color so labels render in the theme
+			// palette even on untagged background cells.
+			if oc, ok := c.cellOverlayColors[[2]int{x, i}]; ok {
+				fg, hasColor = oc, true
+			}
 			if hasColor && ch != ' ' {
-				b.WriteString(lipgloss.NewStyle().Foreground(color).Render(string(ch)))
+				b.WriteString(lipgloss.NewStyle().Foreground(fg).Render(string(ch)))
 			} else {
 				b.WriteRune(ch)
 			}

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -157,6 +157,40 @@ func TestColoredDiskEmitsAnsiOnRender(t *testing.T) {
 	}
 }
 
+// TestSetCellLabelColored: a plain SetCellLabel renders the label in
+// the terminal default (no ANSI), while SetCellLabelColored wraps each
+// label glyph in the requested foreground — even though the label sits
+// on untagged background cells. Guards the HUD "view:" readout color.
+func TestSetCellLabelColored(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1") // force lipgloss to emit ANSI in tests
+
+	c := NewCanvas(20, 10)
+	c.Clear()
+	c.SetCellLabel(0, 0, "view: top")
+	plain := c.String()
+	if strings.Contains(plain, "\x1b[") {
+		t.Errorf("uncolored label emitted ANSI: %q", plain)
+	}
+	if !strings.Contains(plain, "view: top") {
+		t.Errorf("label text missing from output: %q", plain)
+	}
+
+	fg := lipgloss.Color("#5FD7FF")
+	c.Clear()
+	c.SetCellLabelColored(0, 0, "view: top", fg)
+	colored := c.String()
+	if !strings.Contains(colored, "\x1b[") {
+		t.Error("colored label missing ANSI escape sequence")
+	}
+	// Compare against what lipgloss itself emits for this foreground, so
+	// the assertion holds regardless of the test env's color profile
+	// (truecolor vs ANSI256 downsample).
+	want := lipgloss.NewStyle().Foreground(fg).Render("v")
+	if !strings.Contains(colored, want) {
+		t.Errorf("colored label missing the primary foreground %q: %q", want, colored)
+	}
+}
+
 // TestRingOutlineHugeRadiusDoesNotHang: v0.5.15 regression — pre-fix
 // a ring with pxRadius in the millions (Saturn rings projected at
 // extreme zoom) looped pxRadius*8 ≈ billions of times, locking the


### PR DESCRIPTION
The bottom-corner `view:` readout (orbit + maneuver screens) read white/grey while the rest of the HUD uses the primary cyan (`#5FD7FF`). It was stamped via `Canvas.SetCellLabel`, which renders overlay glyphs in the terminal default because the label sits on untagged background cells.

## Change
- New `Canvas.SetCellLabelColored(col, row, text, color)` — pins the label's foreground via a parallel `cellOverlayColors` map, honored in `String()` (a pinned overlay color wins over the pixelTag-derived cell color). Takes `lipgloss.TerminalColor` so `Style.GetForeground()` flows through directly — no hardcoded hex.
- Orbit + maneuver screens pass `theme.Primary.GetForeground()`, so the readout now matches the rest of the HUD.

## Test plan
- New `TestSetCellLabelColored`: plain `SetCellLabel` emits no ANSI; `SetCellLabelColored` wraps each glyph in the requested foreground (compared against what lipgloss itself emits, so it's robust to truecolor-vs-ANSI256 downsampling in CI).
- `go vet ./...` clean; `go test ./... -race -count=1` green (974 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)