### PR TITLE
feat(planner): targeted Moon Return replaces minimum-escape (ADR 0013)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -105,7 +105,9 @@ _Avoid_: Payload boundary, Split point, Stack divider.
 The propulsive half of the Apollo command-and-service module: carries the
 SPS engine and all its storable propellant. Performs lunar-orbit
 insertion (**LOI**), mid-course corrections, and trans-Earth injection
-(**TEI**). Has no heat shield and is **never recovered** — jettisoned
+(**TEI** — the Apollo-specific Earth-return burn, distinct from the
+general **Moon Return** planner). Has no heat shield and is **never
+recovered** — jettisoned
 during re-entry prep. After **Transposition** it is the bottom/firing
 Stage of the surviving stack, pushing the **Command Module** plus the LM
 nose payload.
@@ -417,7 +419,9 @@ planet).
 A Body whose Primary is a Planet (encoded as `AroundPlanet` on the
 catalog entry). Encounters with Moons use the dedicated `moon_escape`
 planner, not the heliocentric transfer planners — the math and the UI
-flow are different.
+flow are different. The moon→parent direction of that planner is the
+targeted **Moon Return** (ADR 0013); the legacy `PlanMoonEscape`
+function name is retained.
 _Avoid_: Satellite (ambiguous with player-launched vessels), Subplanet.
 
 **Primary**:
@@ -1071,6 +1075,31 @@ change at apoapsis" with "plane change at the line of nodes": changing
 velocity at apoapsis rotates the orbit but does *not* move the Vessel
 into the target's plane unless apoapsis already lies on the line of
 nodes — the distinction is load-bearing for arrival (see GH #67).
+
+**Moon Return**:
+The moon→parent direction of an auto-planted **Transfer Plan**: a
+targeted **Departure** that injects a Vessel from a lunar **Parking
+Orbit** onto a parent-frame arc reaching a chosen perigee, with a
+zero-Δv **Arrival** marker at that perigee (the player finishes the
+capture by hand — aerobrake or powered). Unlike the outbound transfer,
+the Departure is a single **BurnVector** sized so the post-SOI
+parent-frame orbit's perigee is `parent radius + 200 km`, aimed so v∞
+leaves the SOI **retrograde to the moon's orbital motion, in the moon's
+orbital plane** — the cheapest controllable target (arrival inclination
+≈ the moon's plane). Folding the plane change into the one departure
+burn lets a (possibly inclined) Parking Orbit still inject cleanly; and
+because the target plane is the moon's *own* plane, there is **no
+around-parent phasing wait** — only a short intra-moon wait for the
+parking-orbit point that aims v∞ correctly. Replaces the v0.6.3
+minimum-escape objective, which spent the least to leave the SOI but
+dumped the Vessel in ≈ the moon's own orbit (perigee ~300 000 km),
+~590 m/s of avoidable departure waste plus uncontrolled phasing
+(ADR 0013, `adr/0013-moon-return-targeted-injection.md`). The legacy
+code function is still `PlanMoonEscape`.
+_Avoid_: Moon Escape (the retired minimum-escape objective — the planner
+now targets a perigee), TEI (that names the Apollo **Service Module**'s
+specific Earth-return burn, not this general planner — though a Moon
+Return *is* a TEI for the Earth / Luna case).
 
 **Line of Nodes**:
 The line where the Vessel's orbital plane intersects the target's

--- a/internal/planner/moon_escape.go
+++ b/internal/planner/moon_escape.go
@@ -4,80 +4,233 @@ import (
 	"errors"
 	"math"
 	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
 
-// PlanMoonEscape constructs a two-impulse plan to escape a moon's SOI
-// and rejoin the parent body's frame. The departure burn is a prograde
-// impulse at the moon-frame parking orbit periapsis sized so the
-// transfer ellipse's apolune kisses the moon's sphere-of-influence
-// boundary. When the craft reaches that apolune it crosses into the
-// parent's frame (via the standard SOI-aware integrator) and inherits
-// the moon's parent-relative velocity plus the small radial
-// component left over from the SOI exit.
+// PlanMoonEscape constructs a two-impulse Moon Return: a single targeted
+// departure (a full-3D BurnVector) that injects the craft from a moon
+// parking orbit onto a parent-frame transfer whose perigee reaches a
+// chosen target, plus a zero-Δv arrival marker at the SOI-exit moment.
 //
-// The arrival node is a zero-Δv marker positioned in the parent's
-// frame at the SOI-exit moment (depOffset + half-period). Its job is
-// to surface the frame transition in the maneuver list / HUD; the
-// player plants their own circularization burn manually after seeing
-// the post-escape parent-frame trajectory.
+// ADR 0013 replaced the v0.6.3 "minimum kiss-the-SOI escape" objective
+// (a prograde impulse sized so the transfer apolune merely touched the
+// moon's SOI, leaving the craft ≈ at rest relative to the moon and
+// inheriting roughly the moon's own parent orbit). The targeted return
+// instead leaves the SOI with a deliberate excess velocity v∞ aimed
+// *retrograde to the moon's orbital motion, in the moon's orbital
+// plane*, sized so the inherited parent-frame orbit drops to a usable
+// perigee — folding the perigee-lowering work into the deep-in-the-well
+// departure (Oberth) rather than paying for it separately later.
+//
+// Construction (ADR 0013 Decisions C/D):
+//   - v∞ direction is analytic: −v̂_moon (retrograde, in the moon's
+//     orbital plane). Because the target plane is the moon's own plane —
+//     true at any departure time — there is no around-parent phasing
+//     wait, only a short intra-moon wait for the parking-orbit point
+//     where a prograde burn aims v∞ correctly.
+//   - |v∞| is solved (1-D) so the analytic parent-frame perigee equals
+//     rTargetPeri. The arrival inclination is whatever the moon's plane
+//     is; only the perigee and the prograde-around-parent sense are
+//     controlled (the cheap, controllable goal).
+//   - The departure is a BurnVector: the escape-hyperbola periapsis
+//     velocity (vEsc = √(v∞² + 2µ/r_park)) aimed prograde in the moon's
+//     orbital plane at the periapsis direction whose outgoing asymptote
+//     is −v̂_moon. Any tilt between the parking orbit and the moon's
+//     orbital plane is folded into that one impulse (Δv = v_post − v_park).
+//
+// The arrival node stays a zero-Δv frame marker at the SOI-exit moment;
+// the player plants their own capture/aerobrake manually (the expensive
+// parent-capture term is theirs to choose — ADR 0013 Decision A).
 //
 // Inputs:
-//   - muMoon: GM of the moon (e.g., Luna's GM).
-//   - rPark:  craft's |R| in the moon's frame at plant time.
-//   - rSOI:   moon's sphere-of-influence radius. Apolune target.
-//   - minLeadSeconds: pad the departure offset so a centered finite
-//     burn fits inside the wait window. Pass 0 to skip padding.
-//   - moonID:    moon's body ID — populates the departure node's
-//     PrimaryID so the HUD renders the burn in the moon's frame.
-//   - parentID:  moon's parent ID — populates the arrival marker's
-//     PrimaryID so the HUD knows the SOI-exit lives in the parent
-//     frame.
-//
-// Phasing isn't enforced. v0.6.3 ships the simplest viable escape:
-// burn at periapsis, drop into parent frame, manual finish. Future
-// cycles can layer in a phasing model so the SOI-exit moment lands at
-// the player's preferred parent-frame angle.
+//   - muMoon, muParent: GM of the moon and of its parent.
+//   - craftR, craftV: craft state in the moon's (inertially-oriented)
+//     frame at plant time. |craftR| is the parking radius; the velocity
+//     fixes the parking-orbit plane and motion sense.
+//   - moonR, moonV: the moon's state relative to its parent at departure
+//     (from the ephemeris Calculator). Fixes the moon's orbital plane,
+//     motion direction, and parent distance.
+//   - rSOI: the moon's sphere-of-influence radius (arrival-marker timing).
+//   - rTargetPeri: desired parent-frame perigee (e.g. parent radius + 200 km).
+//   - minLeadSeconds: pad the departure offset by whole parking-orbit
+//     periods until it is ≥ this, so a centered finite burn fits ahead of
+//     "now". Pass 0 to skip padding.
+//   - moonID, parentID: PrimaryIDs so the HUD renders the departure in the
+//     moon's frame and the arrival marker in the parent's frame.
 func PlanMoonEscape(
-	muMoon, rPark, rSOI float64,
+	muMoon, muParent float64,
+	craftR, craftV orbital.Vec3,
+	moonR, moonV orbital.Vec3,
+	rSOI, rTargetPeri float64,
 	minLeadSeconds float64,
 	moonID, parentID string,
 ) (TransferPlan, error) {
-	if muMoon <= 0 || rPark <= 0 || rSOI <= 0 {
-		return TransferPlan{}, errors.New("planmoonescape: muMoon, rPark, rSOI must be positive")
+	rPark := craftR.Norm()
+	if muMoon <= 0 || muParent <= 0 || rPark <= 0 || rSOI <= 0 {
+		return TransferPlan{}, errors.New("planmoonescape: muMoon, muParent, rPark, rSOI must be positive")
 	}
 	if rSOI <= rPark {
 		return TransferPlan{}, errors.New("planmoonescape: SOI radius must exceed parking radius")
 	}
-
-	aT := (rPark + rSOI) / 2
-	vCirc := math.Sqrt(muMoon / rPark)
-	vTransAtPeri := math.Sqrt(muMoon * (2/rPark - 1/aT))
-	dvDep := vTransAtPeri - vCirc
-
-	// Half-period of the bound transfer ellipse — periapsis to the
-	// apolune that sits on the SOI boundary.
-	transferTime := math.Pi * math.Sqrt(aT*aT*aT/muMoon)
-
-	var depOffset time.Duration
-	if minLeadSeconds > 0 {
-		depOffset = time.Duration(minLeadSeconds * float64(time.Second))
+	rMoonDist := moonR.Norm()
+	vMoonSpeed := moonV.Norm()
+	if rMoonDist <= 0 || vMoonSpeed <= 0 {
+		return TransferPlan{}, errors.New("planmoonescape: degenerate moon state")
+	}
+	if rTargetPeri <= 0 || rTargetPeri >= rMoonDist {
+		return TransferPlan{}, errors.New("planmoonescape: target perigee must be positive and below the moon's parent distance")
 	}
 
+	nMoonHat := moonR.Cross(moonV)
+	if nMoonHat.Norm() == 0 {
+		return TransferPlan{}, errors.New("planmoonescape: degenerate moon orbital plane")
+	}
+	nMoonHat = nMoonHat.Unit()
+	dHat := moonV.Unit().Scale(-1) // v∞ direction: retrograde to moon's motion, in its plane
+
+	// ── 1-D solve |v∞| so the parent-frame perigee hits rTargetPeri. ──
+	// vExit = vMoon + v∞·d̂; perigee decreases monotonically as |v∞| grows
+	// (more retrograde → lower tangential speed at the moon's distance).
+	perigeeForVInf := func(vInf float64) float64 {
+		return parentPerigee(moonR, moonV.Add(dHat.Scale(vInf)), muParent)
+	}
+	lo, hi := 0.0, vMoonSpeed*0.999
+	if perigeeForVInf(hi) > rTargetPeri {
+		// Even a near-stop at the moon's distance can't drop the perigee to
+		// the target — unreachable with a coplanar retrograde injection.
+		return TransferPlan{}, errors.New("planmoonescape: target perigee unreachable")
+	}
+	for i := 0; i < 80; i++ {
+		mid := (lo + hi) / 2
+		if perigeeForVInf(mid) > rTargetPeri {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	vInf := (lo + hi) / 2
+
+	// ── Escape-hyperbola geometry in the moon's frame. ──
+	vCirc := math.Sqrt(muMoon / rPark)
+	vEsc := math.Sqrt(vInf*vInf + 2*muMoon/rPark) // periapsis speed
+	e := 1 + rPark*vInf*vInf/muMoon
+	nuInf := math.Acos(-1 / e) // true anomaly of the asymptote
+
+	// Match the escape's rotation sense to the parking orbit's so the burn
+	// is prograde-ish (cheap) rather than a reversal.
+	s := 1.0
+	if craftR.Cross(craftV).Dot(nMoonHat) < 0 {
+		s = -1.0
+	}
+	// Periapsis direction whose outgoing asymptote (at +s·νInf) is d̂.
+	pHat := orbital.Rotate(dHat, nMoonHat, -s*nuInf)
+	// Prograde velocity direction at periapsis, in the moon's orbital plane.
+	vPeriHat := orbital.Rotate(pHat, nMoonHat, s*math.Pi/2).Unit()
+
+	// Plant point: the craft-parking-orbit direction closest to pHat (which
+	// may be out of the parking plane for an inclined parking orbit). The
+	// impulse folds the residual plane change.
+	nCraft := craftR.Cross(craftV)
+	if nCraft.Norm() == 0 {
+		return TransferPlan{}, errors.New("planmoonescape: degenerate parking orbit")
+	}
+	nCraftHat := nCraft.Unit()
+	pInPlane := pHat.Sub(nCraftHat.Scale(pHat.Dot(nCraftHat)))
+	if pInPlane.Norm() == 0 {
+		// Parking plane is perpendicular to the periapsis direction — a
+		// polar/degenerate geometry ADR 0013 excludes from v1.
+		return TransferPlan{}, errors.New("planmoonescape: parking orbit too steep for a single-impulse return")
+	}
+	plantHat := pInPlane.Unit()
+	craftProHat := nCraftHat.Cross(plantHat).Unit() // prograde velocity dir at the plant point
+
+	// Departure Δv: from the (circular-parking) velocity at the plant point
+	// to the in-plane escape velocity. Folds the plane change in.
+	vPost := vPeriHat.Scale(vEsc)
+	dvVec := vPost.Sub(craftProHat.Scale(vCirc))
+	dvDep := dvVec.Norm()
+	if dvDep == 0 || math.IsNaN(dvDep) {
+		return TransferPlan{}, errors.New("planmoonescape: degenerate departure Δv")
+	}
+
+	// ── Phasing: wait for the craft to reach the plant direction. ──
+	nMean := math.Sqrt(muMoon / (rPark * rPark * rPark))
+	sweep := signedAngleInPlane(craftR.Unit(), plantHat, nCraftHat)
+	if sweep < 0 {
+		sweep += 2 * math.Pi
+	}
+	waitSeconds := sweep / nMean
+	period := 2 * math.Pi / nMean
+	for minLeadSeconds > 0 && waitSeconds < minLeadSeconds {
+		waitSeconds += period
+	}
+
+	// ── Coast time to SOI exit (hyperbolic TOF from periapsis). ──
+	tof := hyperbolicTimeToRadius(muMoon, vInf, e, rSOI)
+
+	depOffset := time.Duration(waitSeconds * float64(time.Second))
 	return TransferPlan{
 		Departure: TransferNode{
-			Leg:          LegDeparture,
-			PrimaryID:    moonID,
-			DV:           dvDep,
-			OffsetTime:   depOffset,
-			IsRetrograde: false,
+			Leg:        LegDeparture,
+			PrimaryID:  moonID,
+			DV:         dvDep,
+			OffsetTime: depOffset,
+			BurnDir:    dvVec.Scale(1 / dvDep),
 		},
 		Arrival: TransferNode{
-			Leg:          LegArrival,
-			PrimaryID:    parentID,
-			DV:           0,
-			OffsetTime:   depOffset + time.Duration(transferTime*float64(time.Second)),
-			IsRetrograde: false,
+			Leg:        LegArrival,
+			PrimaryID:  parentID,
+			DV:         0,
+			OffsetTime: depOffset + time.Duration(tof*float64(time.Second)),
 		},
-		TransferDt: time.Duration(transferTime * float64(time.Second)),
+		TransferDt: time.Duration(tof * float64(time.Second)),
 	}, nil
+}
+
+// parentPerigee returns the perigee radius of the orbit defined by state
+// (r, v) about a primary with gravitational parameter mu. For a hyperbolic
+// or parabolic state (energy ≥ 0) a is negative and the returned value is
+// still a·(1−e), the (positive) periapsis radius.
+func parentPerigee(r, v orbital.Vec3, mu float64) float64 {
+	rN := r.Norm()
+	energy := v.Dot(v)/2 - mu/rN
+	a := -mu / (2 * energy)
+	h := r.Cross(v).Norm()
+	ecc := math.Sqrt(math.Max(0, 1+2*energy*h*h/(mu*mu)))
+	return a * (1 - ecc)
+}
+
+// signedAngleInPlane returns the angle (rad, in (−π, π]) from `from` to `to`
+// measured about `axis` (right-handed). Both inputs should be unit vectors
+// lying in the plane normal to axis.
+func signedAngleInPlane(from, to, axis orbital.Vec3) float64 {
+	return math.Atan2(from.Cross(to).Dot(axis), from.Dot(to))
+}
+
+// hyperbolicTimeToRadius returns the coast time (s) from periapsis to
+// radius rTarget on an escape hyperbola about a primary with the given mu,
+// excess speed vInf, and eccentricity e. Used to time the zero-Δv SOI-exit
+// arrival marker.
+func hyperbolicTimeToRadius(mu, vInf, e, rTarget float64) float64 {
+	if vInf <= 0 || e <= 1 {
+		return 0
+	}
+	a := mu / (vInf * vInf) // |a| for the hyperbola
+	p := a * (e*e - 1)
+	cosNu := (p/rTarget - 1) / e
+	cosNu = math.Max(-1, math.Min(1, cosNu))
+	// Hyperbolic anomaly F at the target true anomaly, then Kepler's
+	// hyperbolic equation M = e·sinh F − F.
+	coshF := (e + cosNu) / (1 + e*cosNu)
+	if coshF < 1 {
+		coshF = 1
+	}
+	f := math.Acosh(coshF)
+	m := e*math.Sinh(f) - f
+	nHyp := math.Sqrt(mu / (a * a * a))
+	if nHyp == 0 {
+		return 0
+	}
+	return m / nHyp
 }

--- a/internal/planner/moon_escape_eval_test.go
+++ b/internal/planner/moon_escape_eval_test.go
@@ -1,0 +1,88 @@
+package planner
+
+// moon_escape_eval_test.go is the REGRESSION BAR for the ADR 0013 Moon
+// Return rewrite (it began life as a diagnostic probe quantifying why the
+// old "minimum escape" objective wasted ~590 m/s on the departure side).
+//
+// The game core is patched-conic, so this analytical patched-conic model
+// matches what the integrator actually produces (modulo finite-burn /
+// sample noise). It asserts the two headline ADR 0013 acceptance criteria
+// for a low-Luna → Earth return:
+//
+//  1. the planted departure reaches the target Earth-frame perigee
+//     (rEarthLEO), prograde around Earth; and
+//  2. the departure Δv is within a few percent of the analytic ideal
+//     single trans-Earth-injection (~822 m/s), NOT the old ~1414 m/s the
+//     min-escape objective spent (escape 645 + a separate 768 perigee
+//     drop the planner never planted).
+//
+// Run: go test ./internal/planner -run TestMoonReturnRegressionBar -v
+
+import (
+	"math"
+	"testing"
+)
+
+// Earth constants (game catalog values, internal/bodies/systems/sol.json).
+// muEarth is already a package-level const in transfer_test.go.
+const (
+	// aLuna is the Moon's orbital semimajor axis around Earth (384 399 km).
+	aLuna = 3.84399e8
+	// rEarthLEO is a 200-km-altitude parking orbit (R_earth = 6371 km).
+	rEarthLEO = 6.371e6 + 200e3
+)
+
+// circEarth returns circular-orbit speed at radius r about Earth.
+func circEarth(r float64) float64 { return math.Sqrt(muEarth / r) }
+
+// idealReturnDepartureDv is the analytic single-TEI departure Δv: one burn
+// at low lunar orbit sized so the inherited Earth-frame perigee is rEarthLEO
+// (retrograde exit at the Moon's distance), with no separate perigee-drop.
+func idealReturnDepartureDv(rPark float64) float64 {
+	vLuna := circEarth(aLuna)
+	atLEO := (aLuna + rEarthLEO) / 2
+	vApoTarget := math.Sqrt(muEarth * (2/aLuna - 1/atLEO))
+	vInf := vLuna - vApoTarget
+	vPeriHyper := math.Sqrt(vInf*vInf + 2*muLuna/rPark)
+	return vPeriHyper - math.Sqrt(muLuna/rPark)
+}
+
+func TestMoonReturnRegressionBar(t *testing.T) {
+	rPark := rLowLunarOrbit
+	craftR, craftV, moonR, moonV := coplanarReturnSetup(rPark)
+
+	plan, err := PlanMoonEscape(muLuna, muEarth, craftR, craftV, moonR, moonV,
+		rLunaSOI, rEarthLEO, 0, "moon", "earth")
+	if err != nil {
+		t.Fatalf("PlanMoonEscape: %v", err)
+	}
+
+	dvDep := plan.Departure.DV
+	dvIdeal := idealReturnDepartureDv(rPark)
+	peri, prograde := reconstructReturn(plan, rPark, moonR, moonV)
+
+	t.Logf("── Moon Return: low-Luna(%.0f km alt) → Earth (target peri %.0f km) ──",
+		(rPark-1.7374e6)/1e3, rEarthLEO/1e3)
+	t.Logf("departure Δv : planner %.0f m/s  vs ideal TEI %.0f m/s", dvDep, dvIdeal)
+	t.Logf("inherited Earth perigee: %.0f km (target %.0f km), prograde=%v",
+		peri/1e3, rEarthLEO/1e3, prograde)
+
+	// (1) Reaches the target perigee, prograde around Earth.
+	if !prograde {
+		t.Errorf("inherited Earth orbit is retrograde; want prograde (same sense as Earth's rotation)")
+	}
+	if rel := math.Abs(peri-rEarthLEO) / rEarthLEO; rel > 0.02 {
+		t.Errorf("inherited perigee = %.0f km, want %.0f km (%.2f%% off, tol 2%%)",
+			peri/1e3, rEarthLEO/1e3, rel*100)
+	}
+
+	// (2) Departure Δv within a few percent of the analytic ideal — and
+	// nowhere near the old ~1414 m/s min-escape-plus-separate-drop budget.
+	if rel := math.Abs(dvDep-dvIdeal) / dvIdeal; rel > 0.05 {
+		t.Errorf("departure Δv = %.0f m/s, want ≈ %.0f m/s (%.1f%% off, tol 5%%)",
+			dvDep, dvIdeal, rel*100)
+	}
+	if dvDep > 1000 {
+		t.Errorf("departure Δv = %.0f m/s — regressed toward the old min-escape budget (~1414 m/s)", dvDep)
+	}
+}

--- a/internal/planner/moon_escape_test.go
+++ b/internal/planner/moon_escape_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
 
 // muLuna is Luna's gravitational parameter (m³/s²).
@@ -11,113 +13,141 @@ const muLuna = 4.9028e12
 
 // rLunaSOI approximates Luna's sphere-of-influence radius around Earth
 // (a · (m_luna / m_earth)^0.4 ≈ 6.617e7 m). Tests use a constant so the
-// math doesn't drift with body-data changes — what we care about is
-// the planner's algebra against a fixed apolune target.
+// math doesn't drift with body-data changes.
 const rLunaSOI = 6.617e7
 
 // rLowLunarOrbit is a 100-km-altitude circular orbit around Luna
 // (Luna mean radius ≈ 1737.4 km). Standard test parking orbit.
 const rLowLunarOrbit = 1.7374e6 + 100e3
 
-// TestPlanMoonEscapeApoluneMatchesSOI: the bound-ellipse departure Δv
-// should produce a transfer ellipse whose apolune equals the SOI
-// radius to floating-point precision. This is the load-bearing
-// invariant — if the algebra is wrong, every downstream HUD prediction
-// is wrong.
-func TestPlanMoonEscapeApoluneMatchesSOI(t *testing.T) {
-	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
+// coplanarReturnSetup builds a coplanar (XY-plane) Moon Return scenario:
+// the moon on a circular Earth orbit at aLuna, and the craft on a circular
+// prograde parking orbit of radius rPark around the moon. Returns the
+// arguments PlanMoonEscape needs. The craft phase is arbitrary — the
+// planner phases the burn to the periapsis direction itself, so the
+// departure Δv is phase-independent in the coplanar case.
+func coplanarReturnSetup(rPark float64) (craftR, craftV, moonR, moonV orbital.Vec3) {
+	vLuna := math.Sqrt(muEarth / aLuna)
+	moonR = orbital.Vec3{X: aLuna, Y: 0, Z: 0}
+	moonV = orbital.Vec3{X: 0, Y: vLuna, Z: 0}
+	vCirc := math.Sqrt(muLuna / rPark)
+	craftR = orbital.Vec3{X: rPark, Y: 0, Z: 0}
+	craftV = orbital.Vec3{X: 0, Y: vCirc, Z: 0}
+	return craftR, craftV, moonR, moonV
+}
+
+// reconstructReturn replays the planner's departure BurnVector through the
+// patched-conic model (coplanar case) and returns the inherited Earth-frame
+// perigee and whether the inherited orbit is prograde around Earth.
+func reconstructReturn(plan TransferPlan, rPark float64, moonR, moonV orbital.Vec3) (perigee float64, prograde bool) {
+	nMoon := moonR.Cross(moonV).Unit()
+	// Post-burn periapsis state in the moon's frame: a prograde burn at the
+	// periapsis raises the circular speed to vEsc along BurnDir; the
+	// periapsis position sits 90° behind the velocity.
+	vEsc := math.Sqrt(muLuna/rPark) + plan.Departure.DV
+	v := plan.Departure.BurnDir.Scale(vEsc)
+	r := orbital.Rotate(plan.Departure.BurnDir, nMoon, -math.Pi/2).Scale(rPark)
+
+	vInf := math.Sqrt(math.Max(0, v.Dot(v)-2*muLuna/rPark))
+	eVec := r.Scale(v.Dot(v)/muLuna - 1/r.Norm()).Sub(v.Scale(r.Dot(v) / muLuna))
+	ecc := eVec.Norm()
+	nuInf := math.Acos(-1 / ecc)
+	asym := orbital.Rotate(eVec.Unit(), nMoon, nuInf) // outgoing asymptote direction
+	vEarth := moonV.Add(asym.Scale(vInf))
+	return parentPerigee(moonR, vEarth, muEarth), moonR.Cross(vEarth).Dot(nMoon) > 0
+}
+
+// TestPlanMoonEscapeReachesTargetPerigee: the planted return must inherit
+// an Earth-frame orbit whose perigee lands on the target, prograde around
+// Earth. This is the load-bearing invariant of the ADR 0013 rewrite.
+func TestPlanMoonEscapeReachesTargetPerigee(t *testing.T) {
+	rPark := rLowLunarOrbit
+	craftR, craftV, moonR, moonV := coplanarReturnSetup(rPark)
+	plan, err := PlanMoonEscape(muLuna, muEarth, craftR, craftV, moonR, moonV,
+		rLunaSOI, rEarthLEO, 0, "moon", "earth")
 	if err != nil {
 		t.Fatalf("PlanMoonEscape: %v", err)
 	}
-
-	// Reconstruct post-burn velocity at periapsis: v_circ + Δv.
-	vCirc := math.Sqrt(muLuna / rLowLunarOrbit)
-	vPeri := vCirc + plan.Departure.DV
-
-	// vis-viva: v² = µ · (2/r − 1/a) → a = 1 / (2/r − v²/µ)
-	a := 1 / (2/rLowLunarOrbit - vPeri*vPeri/muLuna)
-	apoFromBurn := 2*a - rLowLunarOrbit
-
-	if math.Abs(apoFromBurn-rLunaSOI) > 1.0 {
-		t.Errorf("apolune from burn = %.0f m, want %.0f m (SOI radius)",
-			apoFromBurn, rLunaSOI)
+	peri, prograde := reconstructReturn(plan, rPark, moonR, moonV)
+	if !prograde {
+		t.Errorf("inherited Earth orbit is retrograde; want prograde")
+	}
+	// 1% tolerance: the analytic solve targets perigee directly, but the
+	// reconstruction reintroduces the same rounding the solver bisected on.
+	if rel := math.Abs(peri-rEarthLEO) / rEarthLEO; rel > 0.01 {
+		t.Errorf("inherited perigee = %.0f km, want %.0f km (%.2f%% off)",
+			peri/1e3, rEarthLEO/1e3, rel*100)
 	}
 }
 
-// TestPlanMoonEscapeTransferTimeMatchesHalfPeriod: the planner's
-// TransferDt must equal half the transfer ellipse's period — that's
-// the time between periapsis and the SOI-boundary apolune.
-func TestPlanMoonEscapeTransferTimeMatchesHalfPeriod(t *testing.T) {
-	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
+// TestPlanMoonEscapeDepartureIsBurnVector: the departure carries a full 3D
+// BurnDir (so the sim plants a BurnVector), and the arrival stays a zero-Δv
+// frame marker ordered after it.
+func TestPlanMoonEscapeDepartureIsBurnVector(t *testing.T) {
+	craftR, craftV, moonR, moonV := coplanarReturnSetup(rLowLunarOrbit)
+	plan, err := PlanMoonEscape(muLuna, muEarth, craftR, craftV, moonR, moonV,
+		rLunaSOI, rEarthLEO, 0, "moon", "earth")
 	if err != nil {
 		t.Fatalf("PlanMoonEscape: %v", err)
 	}
-	aT := (rLowLunarOrbit + rLunaSOI) / 2
-	wantHalf := math.Pi * math.Sqrt(aT*aT*aT/muLuna)
-	gotSecs := plan.TransferDt.Seconds()
-	if math.Abs(gotSecs-wantHalf) > 1.0 {
-		t.Errorf("TransferDt = %.1f s, want %.1f s", gotSecs, wantHalf)
-	}
-}
-
-// TestPlanMoonEscapePrimaryIDsRouteFrames: departure node carries the
-// moon's ID (so the HUD renders the burn in lunar frame), arrival
-// marker carries the parent's ID (so the HUD shows it crossing into
-// Earth frame at SOI exit).
-func TestPlanMoonEscapePrimaryIDsRouteFrames(t *testing.T) {
-	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, 0, "moon", "earth")
-	if err != nil {
-		t.Fatalf("PlanMoonEscape: %v", err)
+	if n := plan.Departure.BurnDir.Norm(); math.Abs(n-1) > 1e-9 {
+		t.Errorf("departure BurnDir norm = %.6f, want unit vector", n)
 	}
 	if plan.Departure.PrimaryID != "moon" {
 		t.Errorf("departure PrimaryID = %q, want %q", plan.Departure.PrimaryID, "moon")
+	}
+	if plan.Departure.DV <= 0 {
+		t.Errorf("departure Δv = %.1f, want > 0", plan.Departure.DV)
 	}
 	if plan.Arrival.PrimaryID != "earth" {
 		t.Errorf("arrival PrimaryID = %q, want %q", plan.Arrival.PrimaryID, "earth")
 	}
 	if plan.Arrival.DV != 0 {
-		t.Errorf("arrival is a frame-marker — Δv should be 0, got %.3f", plan.Arrival.DV)
+		t.Errorf("arrival is a frame marker — Δv should be 0, got %.3f", plan.Arrival.DV)
 	}
-	if plan.Departure.IsRetrograde {
-		t.Errorf("escape burn should be prograde, got retrograde")
+	if plan.Arrival.OffsetTime <= plan.Departure.OffsetTime {
+		t.Errorf("arrival offset %v must follow departure offset %v",
+			plan.Arrival.OffsetTime, plan.Departure.OffsetTime)
+	}
+	if absDuration(plan.Arrival.OffsetTime-plan.Departure.OffsetTime-plan.TransferDt) > time.Second {
+		t.Errorf("arrival − departure (%v) should equal TransferDt (%v)",
+			plan.Arrival.OffsetTime-plan.Departure.OffsetTime, plan.TransferDt)
 	}
 }
 
-// TestPlanMoonEscapeMinLeadPadsBoth: when minLeadSeconds is non-zero,
-// the departure offset advances by that amount and the arrival offset
-// rides along (keeping arrival = departure + half-period).
-func TestPlanMoonEscapeMinLeadPadsBoth(t *testing.T) {
-	const lead = 90.0
-	plan, err := PlanMoonEscape(muLuna, rLowLunarOrbit, rLunaSOI, lead, "moon", "earth")
+// TestPlanMoonEscapeMinLeadPads: a non-zero minLead pushes the departure
+// offset to at least that lead (padded by whole parking-orbit periods).
+func TestPlanMoonEscapeMinLeadPads(t *testing.T) {
+	const lead = 3000.0
+	craftR, craftV, moonR, moonV := coplanarReturnSetup(rLowLunarOrbit)
+	plan, err := PlanMoonEscape(muLuna, muEarth, craftR, craftV, moonR, moonV,
+		rLunaSOI, rEarthLEO, lead, "moon", "earth")
 	if err != nil {
 		t.Fatalf("PlanMoonEscape: %v", err)
 	}
-	wantDep := time.Duration(lead * float64(time.Second))
-	if plan.Departure.OffsetTime != wantDep {
-		t.Errorf("departure OffsetTime = %v, want %v", plan.Departure.OffsetTime, wantDep)
-	}
-	gap := plan.Arrival.OffsetTime - plan.Departure.OffsetTime
-	if absDuration(gap-plan.TransferDt) > time.Second {
-		t.Errorf("arrival − departure = %v, want TransferDt = %v", gap, plan.TransferDt)
+	if plan.Departure.OffsetTime.Seconds() < lead {
+		t.Errorf("departure offset %.0f s < minLead %.0f s", plan.Departure.OffsetTime.Seconds(), lead)
 	}
 }
 
-// TestPlanMoonEscapeRejectsBadInputs: degenerate inputs (non-positive
-// mu / radii, or SOI inside parking orbit) must surface as errors so
-// the dispatch path falls back instead of planting nonsense.
+// TestPlanMoonEscapeRejectsBadInputs: degenerate inputs surface as errors
+// so the dispatch path falls back instead of planting nonsense.
 func TestPlanMoonEscapeRejectsBadInputs(t *testing.T) {
+	craftR, craftV, moonR, moonV := coplanarReturnSetup(rLowLunarOrbit)
 	cases := []struct {
-		name                string
-		muMoon, rPark, rSOI float64
+		name                         string
+		muMoon, muParent, rSOI, peri float64
 	}{
-		{"zero mu", 0, rLowLunarOrbit, rLunaSOI},
-		{"negative rPark", muLuna, -1, rLunaSOI},
-		{"zero rSOI", muLuna, rLowLunarOrbit, 0},
-		{"SOI ≤ rPark", muLuna, rLunaSOI, rLowLunarOrbit},
+		{"zero moon mu", 0, muEarth, rLunaSOI, rEarthLEO},
+		{"zero parent mu", muLuna, 0, rLunaSOI, rEarthLEO},
+		{"SOI ≤ rPark", muLuna, muEarth, rLowLunarOrbit, rEarthLEO},
+		{"perigee above moon distance", muLuna, muEarth, rLunaSOI, aLuna * 2},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if _, err := PlanMoonEscape(c.muMoon, c.rPark, c.rSOI, 0, "moon", "earth"); err == nil {
+			_, err := PlanMoonEscape(c.muMoon, c.muParent, craftR, craftV, moonR, moonV,
+				c.rSOI, c.peri, 0, "moon", "earth")
+			if err == nil {
 				t.Errorf("expected error for %s, got nil", c.name)
 			}
 		})

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -477,47 +477,57 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		return &plan, nil
 	}
 
-	// v0.6.3: target is the craft's primary's parent (e.g., craft in
-	// Luna's SOI, target Earth). The pre-v0.6.3 fallthrough sent these
-	// to the heliocentric Hohmann path, which treated Earth's
-	// heliocentric semimajor axis as the destination radius around
-	// Luna and produced nonsensical Δv. The moon-escape planner instead
-	// targets a bound transfer ellipse whose apolune sits on Luna's
-	// SOI; the SOI-aware integrator then drops the craft into Earth's
-	// frame automatically. The arrival node is a zero-Δv frame marker
-	// — the player plants their own circularization once they see the
-	// post-escape Earth-frame trajectory.
+	// v0.6.3 / ADR 0013: target is the craft's primary's parent (e.g.,
+	// craft in Luna's SOI, target Earth). The pre-v0.6.3 fallthrough sent
+	// these to the heliocentric Hohmann path, which produced nonsensical
+	// Δv. PlanMoonEscape (the Moon Return planner) instead plants a single
+	// targeted BurnVector that injects the craft onto a parent-frame
+	// transfer whose perigee reaches the target (parent radius + 200 km),
+	// leaving the SOI retrograde to the moon's motion in the moon's
+	// orbital plane; the SOI-aware integrator drops the craft into the
+	// parent's frame automatically. The arrival node is a zero-Δv frame
+	// marker — the player plants their own capture/aerobrake after seeing
+	// the post-escape parent-frame trajectory (Decision A, manual finish).
 	if w.ActiveCraft().Primary.ParentID != "" && target.ID == w.ActiveCraft().Primary.ParentID {
-		moon := w.ActiveCraft().Primary
+		c := w.ActiveCraft()
+		moon := c.Primary
 		moonParent := sys.ParentOf(moon)
 		if moonParent == nil {
 			return nil, errInvalidTransferTarget
 		}
 		muMoon := moon.GravitationalParameter()
+		muParent := moonParent.GravitationalParameter()
 		rSOI := physics.SOIRadius(moon, *moonParent)
 		if rSOI == 0 || rSOI <= rPark {
 			return nil, errInvalidTransferTarget
 		}
-		mass := w.ActiveCraft().TotalMass()
-		thrust := w.ActiveCraft().Thrust
-		// Pre-size the centered-finite-burn lead pad from the impulsive
-		// estimate, mirroring the intra-primary branch above.
-		aT := (rPark + rSOI) / 2
-		vCirc := math.Sqrt(muMoon / rPark)
-		vTransAtPeri := math.Sqrt(muMoon * (2/rPark - 1/aT))
-		dvEstimate := vTransAtPeri - vCirc
-		minLead := w.ActiveCraft().BurnTimeForDV(dvEstimate).Seconds() / 2
-		plan, err := planner.PlanMoonEscape(muMoon, rPark, rSOI, minLead, moon.ID, target.ID)
+		now := w.Clock.SimTime
+		// The moon's state relative to its parent fixes the target plane
+		// (the moon's own orbital plane) and the retrograde v∞ direction.
+		moonR, moonV := w.bodyParentRelativeState(moon, now)
+		// target IS the moon's parent here, so rCapture (parent radius +
+		// 200 km) is exactly the Moon Return's target perigee.
+		rTargetPeri := rCapture
+		// Pre-size the centered finite-burn lead pad from the analytic
+		// coplanar return estimate (ADR 0013 Decision D's |v∞| ideal).
+		rMoonDist, vMoonSpeed := moonR.Norm(), moonV.Norm()
+		atReturn := (rMoonDist + rTargetPeri) / 2
+		vApoTarget := math.Sqrt(muParent * (2/rMoonDist - 1/atReturn))
+		vInfEst := math.Max(0, vMoonSpeed-vApoTarget)
+		dvEstimate := math.Sqrt(vInfEst*vInfEst+2*muMoon/rPark) - math.Sqrt(muMoon/rPark)
+		minLead := c.BurnTimeForDV(dvEstimate).Seconds() / 2
+		plan, err := planner.PlanMoonEscape(
+			muMoon, muParent,
+			c.State.R, c.State.V,
+			moonR, moonV,
+			rSOI, rTargetPeri,
+			minLead, moon.ID, target.ID,
+		)
 		if err != nil {
 			return nil, err
 		}
-		// Reuse v0.6.2's iterator: target the SOI radius as apolune so
-		// finite-burn integration delivers the bound transfer ellipse
-		// the impulsive math designed.
-		refineFiniteDeparture(&plan, muMoon, rPark, mass, thrust, w.ActiveCraft().Isp, rSOI)
-		now := w.Clock.SimTime
-		w.PlanNode(transferNodeToManeuver(plan.Departure, now, w.ActiveCraft()))
-		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, w.ActiveCraft()))
+		w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
+		w.PlanNode(transferNodeToManeuver(plan.Arrival, now, c))
 		return &plan, nil
 	}
 
@@ -1691,6 +1701,26 @@ func (w *World) bodyHelioStateAt(b bodies.CelestialBody, epoch float64) (orbital
 	}
 	rParent, vParent := w.bodyHelioStateAt(*parent, epoch)
 	return rParent.Add(rRel), vParent.Add(vRel)
+}
+
+// bodyParentRelativeState returns body b's position and velocity relative
+// to its parent at sim time t — the moon-around-parent state the Moon
+// Return planner (PlanMoonEscape, ADR 0013) needs to aim v∞ in the moon's
+// orbital plane. Mirrors the per-body Keplerian math in bodyHelioStateAt
+// without the recursive parent-frame sum.
+func (w *World) bodyParentRelativeState(b bodies.CelestialBody, t time.Time) (orbital.Vec3, orbital.Vec3) {
+	sys := w.System()
+	parent := sys.ParentOf(b)
+	if parent == nil {
+		parent = sys.Primary()
+	}
+	M := w.Calculator.CalculateMeanAnomaly(b, t)
+	E := orbital.SolveKepler(M, b.Eccentricity)
+	nu := orbital.TrueAnomaly(E, b.Eccentricity)
+	el := orbital.ElementsFromBody(b)
+	r := orbital.PositionAtTrueAnomaly(el, nu)
+	v := orbital.VelocityAtTrueAnomaly(el, nu, parent.GravitationalParameter())
+	return r, v
 }
 
 // transferNodeToManeuver converts a planner.TransferNode into a

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -1880,36 +1880,49 @@ func TestPlanTransferMoonEscapePlantsTwoNodes(t *testing.T) {
 	if dep.DV <= 0 {
 		t.Errorf("departure Δv = %.3f m/s, want > 0", dep.DV)
 	}
-	if dep.Mode != spacecraft.BurnPrograde {
-		t.Errorf("departure Mode = %v, want BurnPrograde", dep.Mode)
+	// ADR 0013: the Moon Return departure is a full-3D BurnVector (folds
+	// the parking-plane → moon-plane change into the injection), not the
+	// old prograde escape scalar.
+	if dep.Mode != spacecraft.BurnVector {
+		t.Errorf("departure Mode = %v, want BurnVector", dep.Mode)
+	}
+	if n := dep.BurnDirUnit.Norm(); math.Abs(n-1) > 1e-9 {
+		t.Errorf("departure BurnDirUnit norm = %.6f, want unit vector", n)
 	}
 	if arr.DV != 0 {
 		t.Errorf("arrival is a frame marker — Δv should be 0, got %.3f", arr.DV)
 	}
 
-	// Sanity: planted Δv should match the bound-ellipse impulsive
-	// estimate within ≈5%. The iterator may refine the value; for a
-	// short LLO escape burn (≈30 s on the S-IVB-1) the impulsive
-	// guess is already very close.
 	rSOI := physics.SOIRadius(moon, earth)
 	if rSOI == 0 {
 		t.Fatal("SOIRadius(moon, earth) = 0 — body data missing mass / a")
 	}
-	aT := (rPark + rSOI) / 2
-	vTrans := math.Sqrt(muMoon * (2/rPark - 1/aT))
-	impulsiveDv := vTrans - vCirc
-	rel := math.Abs(dep.DV-impulsiveDv) / impulsiveDv
-	if rel > 0.05 {
-		t.Errorf("departure Δv %.1f m/s deviates >5%% from impulsive %.1f m/s (rel=%.4f)",
-			dep.DV, impulsiveDv, rel)
+
+	// Sanity: the planted Δv targets the parent-frame perigee, so it
+	// matches the analytic single-TEI return ideal (~822 m/s for LLO →
+	// LEO) rather than the old min-escape budget (~645 m/s). A real
+	// parking/moon-plane tilt can only add to the in-plane ideal, so the
+	// floor is the ideal less a small margin and the ceiling allows the
+	// folded plane change.
+	moonR, moonV := w.bodyParentRelativeState(moon, dep.TriggerTime)
+	muParent := earth.GravitationalParameter()
+	rMoonDist, vMoonSpeed := moonR.Norm(), moonV.Norm()
+	rTargetPeri := earth.RadiusMeters() + 200e3
+	atReturn := (rMoonDist + rTargetPeri) / 2
+	vApoTarget := math.Sqrt(muParent * (2/rMoonDist - 1/atReturn))
+	vInfIdeal := vMoonSpeed - vApoTarget
+	dvIdeal := math.Sqrt(vInfIdeal*vInfIdeal+2*muMoon/rPark) - vCirc
+	if dep.DV < 0.9*dvIdeal || dep.DV > dvIdeal+1500 {
+		t.Errorf("departure Δv %.1f m/s outside the Moon Return band [%.1f, %.1f] (ideal %.1f)",
+			dep.DV, 0.9*dvIdeal, dvIdeal+1500, dvIdeal)
 	}
 
-	// Arrival's TriggerTime should sit at departure-center +
-	// half-period of the bound transfer ellipse (within 1 s).
+	// The arrival marker sits at the SOI-exit moment — a positive
+	// hyperbolic coast after the departure, well short of the old
+	// bound-ellipse half-period.
 	gap := arr.TriggerTime.Sub(dep.TriggerTime).Seconds()
-	wantGap := math.Pi * math.Sqrt(aT*aT*aT/muMoon)
-	if math.Abs(gap-wantGap) > 1.0 {
-		t.Errorf("arrival − departure gap = %.1f s, want %.1f s (half-period)", gap, wantGap)
+	if gap <= 0 {
+		t.Errorf("arrival − departure gap = %.1f s, want > 0 (SOI-exit coast)", gap)
 	}
 }
 


### PR DESCRIPTION
## What

Changes the moon→parent `[H]` planner (`PlanMoonEscape`) from the v0.6.3 **minimum-escape** objective ("kiss the SOI") to a **targeted Moon Return**: one `BurnVector` departure sized so the post-SOI parent-frame orbit reaches a target perigee (`parent.R + 200 km`), leaving the SOI **retrograde to the moon's motion, in the moon's orbital plane**. Arrives prograde around the parent at a tunable perigee; arrival inclination falls out as the moon's plane. The plane change from a (possibly inclined) parking orbit is folded into the single impulse.

Implements **ADR 0013** (`adr/0013-moon-return-targeted-injection.md`, accepted 2026-06-06).

## Why

The old objective exited the SOI nearly at rest relative to the moon, so the vessel inherited ≈ the moon's own orbit (perigee ~300 000 km) and needed a separate perigee-lowering burn the planner never planted. Departure-side budget:

```
PLANNER (old) : escape 645 + lower-perigee 768 = 1414 m/s
IDEAL  (TEI)  : single departure              =  822 m/s
```

Regression bar (`TestMoonReturnRegressionBar`, low-Luna → LEO):
```
departure Δv : planner 822 m/s  vs ideal TEI 822 m/s
inherited Earth perigee: 6571 km (target 6571 km), prograde=true
```

## How (ADR 0013 Decisions C/D)

- Analytic v∞ direction (−v̂_moon, in-plane) → **1-D bisection on |v∞|** against the analytic parent-frame perigee → escape-hyperbola periapsis `BurnVector` → hyperbolic TOF for the zero-Δv SOI-exit marker.
- Arrival stays a manual-finish frame marker (Decision A); function keeps its legacy name (Decision E).
- sim: the `Primary.ParentID == target.ID` branch feeds parent μ, the moon's parent-relative state (new `bodyParentRelativeState` helper), and the target perigee; drops `refineFiniteDeparture` here (it targeted the retired apolune-kiss objective; still used by the split branch).

## Tests

- `moon_escape_test.go` rewritten to the perigee/BurnVector objective.
- `moon_escape_eval_test.go` flipped from diagnostic probe → **regression bar** (target perigee + Δv within a few % of ideal).
- `maneuver_test.go` integration test asserts the `BurnVector` departure.
- `go vet ./...` clean; `go test ./... -race -count=1` → 973 passed.

## Open items (not blocking)

- Glossary noun **"Moon Return"** flagged for veto in ADR 0013 (alternatives: "Return Transfer", "Trans-primary Injection").
- In-game `verify`: plant `[H]` from low lunar orbit targeting Earth, eyeball the projected Earth orbit (frame handoff — matches the existing fused/split BurnVector path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)