### PR TITLE
feat(scale): shared Scale Class tag on System and Loadout (ADR 0014 Slice B)

### DIFF
--- a/internal/bodies/scaleclass.go
+++ b/internal/bodies/scaleclass.go
@@ -1,0 +1,37 @@
+package bodies
+
+// ScaleClass is a coarse size/difficulty tag shared by a System and a
+// Loadout (ADR 0014). It is purely a classification surfaced as the spawn
+// form's craft hint — the integrator derives all dynamics from a Body's
+// mass and radius, so a System needs no ScaleClass to work and craft are
+// never filtered by it: any Loadout can fly in any System.
+type ScaleClass string
+
+const (
+	// ScaleReal is the Sol-scale tag: Earth-class bodies, ~9.4 km/s to
+	// orbit. The zero value / default — every System and Loadout that
+	// does not set one normalizes to real via Scale().
+	ScaleReal ScaleClass = "real"
+	// ScaleStrippedBack is the Lumen-scale tag: ~1/10-linear bodies with
+	// Earth-like surface gravity, ~3.4 km/s to orbit, modelled on the
+	// Kerbal Space Program stock system.
+	ScaleStrippedBack ScaleClass = "stripped-back"
+)
+
+// Normalize maps the empty/unset value to ScaleReal and returns any other
+// value unchanged, so callers can compare scale classes without special-
+// casing the zero value. Unknown non-empty strings pass through verbatim
+// (forward-compatible with overlay-supplied tags).
+func (c ScaleClass) Normalize() ScaleClass {
+	if c == "" {
+		return ScaleReal
+	}
+	return c
+}
+
+// Scale returns the System's normalized ScaleClass (empty => real). Systems
+// loaded from JSON without a scaleClass field — the entire pre-Lumen
+// catalog — report real.
+func (s *System) Scale() ScaleClass {
+	return s.ScaleClass.Normalize()
+}

--- a/internal/bodies/scaleclass_test.go
+++ b/internal/bodies/scaleclass_test.go
@@ -1,0 +1,41 @@
+package bodies
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// An unset scaleClass means real (Sol-scale) — the integrator derives all
+// dynamics from a Body's mass and radius, so every existing system stays
+// real without touching its JSON (ADR 0014).
+func TestSystemScaleDefaultsToReal(t *testing.T) {
+	var s System
+	if got := s.Scale(); got != ScaleReal {
+		t.Errorf("empty System.Scale() = %q, want %q", got, ScaleReal)
+	}
+}
+
+// A System unmarshals the optional scaleClass field and Scale() reports it
+// verbatim — this is how Lumen (Slice D) declares itself stripped-back.
+func TestSystemScaleFromJSON(t *testing.T) {
+	var s System
+	if err := json.Unmarshal([]byte(`{"systemName":"Lumen","scaleClass":"stripped-back"}`), &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := s.Scale(); got != ScaleStrippedBack {
+		t.Errorf("Lumen Scale() = %q, want %q", got, ScaleStrippedBack)
+	}
+}
+
+// scaleClass is omitted when unset, so adding the field does not perturb
+// CatalogHash for the existing real-scale systems (ADR 0014).
+func TestSystemScaleOmittedWhenUnset(t *testing.T) {
+	data, err := json.Marshal(System{Name: "Sol"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(data); strings.Contains(got, "scaleClass") {
+		t.Errorf("marshaled real system carries scaleClass: %s", got)
+	}
+}

--- a/internal/bodies/systems.go
+++ b/internal/bodies/systems.go
@@ -22,6 +22,12 @@ type System struct {
 	Galaxy      string          `json:"galaxy"`
 	Bodies      []CelestialBody `json:"bodies"`
 
+	// ScaleClass is the System's spawn-form scale hint (ADR 0014).
+	// Optional in JSON: an absent/empty value normalizes to ScaleReal
+	// via Scale(), so the pre-Lumen catalog stays real untouched. Lumen
+	// sets "stripped-back". Never used for filtering.
+	ScaleClass ScaleClass `json:"scaleClass,omitempty"`
+
 	// Source is a runtime annotation: "embedded" for the built-in
 	// catalog, "user" for files loaded from
 	// $XDG_CONFIG_HOME/terminal-space-program/systems/*.json (v0.7.0+).

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -1,5 +1,7 @@
 package spacecraft
 
+import "github.com/jasonfen/terminal-space-program/internal/bodies"
+
 // Loadout describes a named craft archetype — propulsion numbers,
 // dry/wet mass sizing, default RCS pool, and visual differentiation
 // (glyph + color). v0.8.2 ship set + v0.9.1 Saturn-V multi-stage +
@@ -63,6 +65,13 @@ type Loadout struct {
 	// in v0.10.0; per-vehicle tuning is a follow-up dial.
 	SlewRateDegPerSec float64
 
+	// ScaleClass is the loadout's spawn-form scale hint (ADR 0014),
+	// shared with bodies.System. Optional: an unset value normalizes
+	// to bodies.ScaleReal via Scale(), so the existing real fleet needs
+	// no per-literal change. The scale-matched Kern Stack sets
+	// bodies.ScaleStrippedBack. Never used to filter craft by System —
+	// any Loadout can be spawned in any System.
+	ScaleClass bodies.ScaleClass
 }
 
 // DefaultSlewRateDegPerSec is the attitude slew-rate cap applied to
@@ -72,6 +81,14 @@ type Loadout struct {
 // be tedious (raised from 5°/s after v0.10.0 playtest). Cosine loss
 // is still a real consequence the player times burns around. v0.10.0+.
 const DefaultSlewRateDegPerSec = 15.0
+
+// Scale returns the loadout's normalized ScaleClass (empty =>
+// bodies.ScaleReal). The spawn form compares this against the target
+// System's Scale() to surface the Δv-to-orbit / "best for" hint; it is
+// never used to filter the craft list (ADR 0014).
+func (l Loadout) Scale() bodies.ScaleClass {
+	return l.ScaleClass.Normalize()
+}
 
 // DryMass returns the bottom stage's dry mass (single-stage
 // equivalent for pre-v0.9.1 readers; sum-across-stages is via

--- a/internal/spacecraft/scaleclass_test.go
+++ b/internal/spacecraft/scaleclass_test.go
@@ -1,0 +1,28 @@
+package spacecraft
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// The whole existing fleet carries real, Earth-sized Δv budgets, so every
+// catalog loadout reports real — including those that never set the field
+// (empty normalizes to real, ADR 0014). We do not rescale the real fleet.
+func TestLoadoutScaleDefaultsToReal(t *testing.T) {
+	for _, id := range LoadoutOrder {
+		l := Loadouts[id]
+		if got := l.Scale(); got != bodies.ScaleReal {
+			t.Errorf("loadout %q Scale() = %q, want %q", id, got, bodies.ScaleReal)
+		}
+	}
+}
+
+// An explicit stripped-back tag (how the Kern Stack, Slice D, declares
+// itself scale-matched to Lumen) is reported verbatim.
+func TestLoadoutScaleExplicit(t *testing.T) {
+	l := Loadout{ID: "Kern-Stack", ScaleClass: bodies.ScaleStrippedBack}
+	if got := l.Scale(); got != bodies.ScaleStrippedBack {
+		t.Errorf("stripped-back loadout Scale() = %q, want %q", got, bodies.ScaleStrippedBack)
+	}
+}


### PR DESCRIPTION
## Summary

Slice B of [ADR 0014](../designdocs/terminal-space-program/adr/0014-stripped-back-scale-systems-and-scale-class.md) — the **shared-interface** slice that the spawn-form hint (Slice C) and the Kern Stack / Lumen content (Slice D) depend on. Kept deliberately minimal.

Adds a **Scale Class** tag (`real` vs `stripped-back`) shared by `bodies.System` and `spacecraft.Loadout`. Per ADR 0014 it is a **spawn-form hint only** — it never filters craft by System; any Loadout can fly in any System.

## Changes

- **`internal/bodies/scaleclass.go`** (new): `ScaleClass` string enum — `ScaleReal` (`"real"`), `ScaleStrippedBack` (`"stripped-back"`) — plus `Normalize()` mapping the unset zero value to `ScaleReal`. Type lives in `bodies` (the lower package; `spacecraft` already imports it) so it is genuinely shared with no import cycle.
- **`internal/bodies/systems.go`**: `System` gains an optional `scaleClass` JSON field (`omitempty`) and a `Scale()` accessor. `omitempty` keeps the untagged real-scale catalog byte-identical under `json.Marshal`, so **`CatalogHash` is unchanged** until `lumen.json` ships (per the ADR's release-note consequence).
- **`internal/spacecraft/loadouts.go`**: `Loadout` gains a `ScaleClass` field and a `Scale()` accessor delegating to the same `Normalize()`. The whole real fleet defaults to `real` with **zero per-literal changes**; the scale-matched Kern Stack (Slice D) sets `stripped-back`.

No filtering logic, no integrator changes — exactly the ADR's stated consequence for this slice.

## Testing

- TDD, vertical slices (test → impl per behavior). New tests: `internal/bodies/scaleclass_test.go`, `internal/spacecraft/scaleclass_test.go` — empty→real default, explicit value, JSON round-trip, and `scaleClass`-omitted-when-unset (the CatalogHash-stability guarantee).
- `go vet ./...` clean; `go test ./... -race -count=1` → **979 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)