### PR TITLE
feat(spawn): Scale Class spawn-form hint (ADR 0014 Slice D)

### DIFF
--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -622,6 +622,12 @@ func (s *SpawnCraft) currentParent() *bodies.CelestialBody {
 // v0.9.1+ multi-stage loadouts list a stage count next to the dry
 // mass so the player can see at a glance that the Saturn-V is a
 // 3-stage chain instead of a single tank.
+//
+// ADR 0014 Slice D appends a Scale Class hint — the Δv-to-orbit /
+// "best for" line — branching on the loadout's Scale() tag. It is a
+// display hint only: the craft list is never filtered by scale, so a
+// real-fleet craft can still be spawned in a stripped-back System (it
+// will simply be over-powered) and vice-versa.
 func propulsionSummary(l spacecraft.Loadout) string {
 	dry := spacecraft.SumDryMass(l.Stages)
 	fuel := spacecraft.SumFuelMass(l.Stages)
@@ -631,9 +637,26 @@ func propulsionSummary(l spacecraft.Loadout) string {
 	if len(l.Stages) > 1 {
 		stageNote = fmt.Sprintf(" (%d stages)", len(l.Stages))
 	}
+	var summary string
 	if bottomThrust == 0 {
-		return fmt.Sprintf("dry %.0fkg%s, RCS-only", dry, stageNote)
+		summary = fmt.Sprintf("dry %.0fkg%s, RCS-only", dry, stageNote)
+	} else {
+		summary = fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0fs",
+			dry, fuel, stageNote, bottomThrust/1000, bottomIsp)
 	}
-	return fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0fs",
-		dry, fuel, stageNote, bottomThrust/1000, bottomIsp)
+	return summary + " · " + scaleHint(l.Scale())
+}
+
+// scaleHint maps a normalized ScaleClass to its spawn-form "best for"
+// line. The Δv-to-orbit figures come from ADR 0014: ~9.4 km/s for the
+// real (Sol) fleet, ~3.4 km/s for the stripped-back (Lumen) fleet. An
+// unrecognized tag falls through to the real-scale wording so a future
+// overlay class never renders blank.
+func scaleHint(scale bodies.ScaleClass) string {
+	switch scale {
+	case bodies.ScaleStrippedBack:
+		return "stripped-back scale, ~3.4 km/s to orbit"
+	default:
+		return "real scale, ~9.4 km/s to orbit"
+	}
 }

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -4,8 +4,35 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
+
+// TestPropulsionSummaryScaleHint — ADR 0014 Slice D. propulsionSummary
+// appends a spawn-form scale hint driven by the loadout's Scale() tag:
+// real fleet reads ~9.4 km/s to orbit, the stripped-back fleet ~3.4 km/s.
+// An unset ScaleClass normalizes to real (it must not read stripped-back).
+// This is a display hint only — it never gates which craft can spawn.
+func TestPropulsionSummaryScaleHint(t *testing.T) {
+	real := spacecraft.Loadout{ScaleClass: bodies.ScaleReal}
+	if got := propulsionSummary(real); !strings.Contains(got, "real scale") ||
+		!strings.Contains(got, "9.4 km/s") {
+		t.Errorf("real-scale hint missing: %q", got)
+	}
+
+	stripped := spacecraft.Loadout{ScaleClass: bodies.ScaleStrippedBack}
+	if got := propulsionSummary(stripped); !strings.Contains(got, "stripped-back scale") ||
+		!strings.Contains(got, "3.4 km/s") {
+		t.Errorf("stripped-back hint missing: %q", got)
+	}
+
+	// Unset ScaleClass normalizes to real, not stripped-back.
+	unset := spacecraft.Loadout{}
+	if got := propulsionSummary(unset); !strings.Contains(got, "real scale") ||
+		strings.Contains(got, "stripped-back") {
+		t.Errorf("unset ScaleClass should read real-scale: %q", got)
+	}
+}
 
 // selectCustom cycles the CRAFT TYPE field to the synthetic
 // "Custom…" row (one past the last catalog loadout).


### PR DESCRIPTION
## Summary

Implements **Slice D** of ADR 0014 — the spawn-form Scale Class hint.

`propulsionSummary` (`internal/tui/screens/spawn.go`) now appends a Δv-to-orbit / "best for" line that branches on the loadout's `Scale()` accessor:

- **real** fleet → `· real scale, ~9.4 km/s to orbit`
- **stripped-back** (Lumen) fleet → `· stripped-back scale, ~3.4 km/s to orbit`

An unset `ScaleClass` normalizes to `real` via `Scale()`, so the existing fleet needs no per-literal change. The branch falls through to the real-scale wording for any unrecognized tag (forward-compatible with overlay-supplied classes).

Per ADR 0014 this is a **display hint only** — it does **not** filter or restrict which craft can spawn in which System. Any Loadout can still be spawned in any System.

## Test

`TestPropulsionSummaryScaleHint` (TDD: written RED first) asserts the real / stripped-back wording and that an unset class reads real-scale (never stripped-back).

## Verification

- `go vet ./...` — clean
- `go test ./... -race -count=1` — 980 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)