### PR TITLE
feat(scale): Kern Stack loadout (ADR 0014 Slice C)

### DIFF
--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -174,6 +174,23 @@ const LoadoutApolloStackID = "Apollo-Stack"
 // Stack → orbit → four decouples, too slow to iterate on.
 const LoadoutCapsuleID = "Capsule"
 
+// LoadoutKernStack is the v0.15 / ADR 0014 scale-matched vehicle for
+// the stripped-back Lumen system: a simplified 4-stage Apollo analog —
+// Boost → Transfer → single Lander → parachute Pod, bottom-first —
+// sized to a ~6 km/s Cursor-landing-and-return budget on Lumen's
+// ~1/10-linear scale (~3.4 km/s to Kern orbit vs Sol's ~9.4). It is the
+// only Loadout tagged bodies.ScaleStrippedBack, so the spawn form's
+// Δv-to-orbit hint flags it as best-for-Lumen — but, per ADR 0014, the
+// tag never filters: the Kern Stack can still be spawned in Sol (where
+// it can't reach orbit) and the real fleet in Lumen. DecouplePlan
+// [1,1,1] drops Boost, Transfer and Lander one at a time; the engineless
+// parachute Pod is the surviving core that splashes down (ADR 0008
+// recovery model). Engine Isp values are KSP stock numbers collapsed to
+// the model's single-Isp-per-stage convention (no altitude-varying Isp):
+// Mainsail (Boost, sea-level 285), Poodle (Transfer, vac 350), Terrier
+// (Lander, vac 345).
+const LoadoutKernStackID = "Kern-Stack"
+
 // stageRCS builds the per-stage RCS pool for a stage of the given
 // dry mass via DefaultRCSLoadout — same scaling that single-stage
 // craft used pre-v0.9.1, so existing loadouts inherit identical
@@ -223,6 +240,29 @@ func stageWithBC(loadoutID, name, glyph, color string, dry, fuel, thrust, isp, b
 		CanSoftLand:          catalogCanSoftLandByName(name),
 		HasParachute:         catalogHasParachuteByName(name),
 	}
+}
+
+// kernStage builds a Kern Stack stage. The Kern Stack's stage names
+// (Boost / Transfer / Pod) are terminal-native and deliberately absent
+// from the StageCatalog (the catalog holds the real fleet's parts), so
+// the by-Name sprite/flag lookups in stage() return zero for them. This
+// helper layers the launch-sprite silhouette, fuel type, and the
+// soft-land / parachute capability flags on directly, keeping the Kern
+// Stack self-contained in loadouts.go (ADR 0014 ships no new catalog
+// parts). "Lander" does resolve in the catalog, but we set it here too so
+// all four stages read from one place.
+func kernStage(name, glyph, color string, dry, fuel, thrust, isp float64,
+	spriteRows, spriteWidth int, spriteColor, fuelType string,
+	hasLegs, canSoftLand, hasParachute bool) Stage {
+	s := stage(LoadoutKernStackID, name, glyph, color, dry, fuel, thrust, isp)
+	s.LaunchSpriteRowsPx = spriteRows
+	s.LaunchSpriteWidthPx = spriteWidth
+	s.LaunchSpriteColor = spriteColor
+	s.FuelType = fuelType
+	s.LaunchSpriteHasLegs = hasLegs
+	s.CanSoftLand = canSoftLand
+	s.HasParachute = hasParachute
+	return s
 }
 
 // catalogHasParachuteByName looks up the StageCatalog's hasParachute
@@ -573,6 +613,45 @@ var Loadouts = map[string]Loadout{
 			stage(LoadoutCapsuleID, "Capsule", "◓", "#B8C8E0", 5800, 0, 0, 0),
 		},
 	},
+	// Kern Stack (v0.15 / ADR 0014): the scale-matched Lumen vehicle.
+	// Four stages bottom-first [Boost, Transfer, Lander, Pod]. Masses are
+	// tuned for a ~6 km/s total ideal Δv (Boost ~2.3 + Transfer ~2.2 +
+	// Lander ~1.5 km/s) — enough for Lumen orbit (~3.4 km/s), a Cursor
+	// transfer + capture + descent, and the ascent/return, on the
+	// stripped-back scale. Lift-off TWR ≈ 1.20 against Kern's Earth-like
+	// surface g (250 kN vs ~21.3 t × g0). Isp values are KSP stock
+	// engines collapsed to one Isp per stage. ScaleClass tags it
+	// stripped-back for the spawn-form hint (never a filter, ADR 0014).
+	LoadoutKernStackID: {
+		ID:         LoadoutKernStackID,
+		Name:       "Kern Stack",
+		Role:       "mission-stack",
+		Glyph:      "▲",
+		Color:      "#7BD3FF", // Lumen-cyan — distinct from the real fleet's warm yellows
+		ScaleClass: bodies.ScaleStrippedBack,
+		Stages: []Stage{
+			// Boost: Mainsail-class kerolox first stage (Isp 285 sea-level —
+			// the only stage that fires in atmosphere). TWR > 1 off the pad.
+			kernStage("Boost", "▲", "#7BD3FF", 2000, 12000, 250000, 285,
+				14, 4, "#D8E6F0", FuelTypeKerolox, false, false, false),
+			// Transfer: Poodle-class vacuum stage (Isp 350) for the Kern
+			// orbit insertion and the Cursor transfer/capture burns.
+			kernStage("Transfer", "▲", "#9BE0FF", 1000, 3500, 60000, 350,
+				10, 3, "#C8E0F0", FuelTypeHydrolox, false, false, false),
+			// Lander: Terrier-class throttleable descent/ascent engine
+			// (Isp 345) with legs — fires the powered descent to Cursor and
+			// the return-to-orbit burn. Soft-land qualified.
+			kernStage("Lander", "▼", "#5FFF87", 800, 1000, 16000, 345,
+				5, 3, "#D4C088", FuelTypeHypergolic, true, true, false),
+			// Pod: engineless crew capsule, the surviving core. Recovers
+			// under parachute (ADR 0008) — the "return" half of the budget.
+			kernStage("Pod", "◓", "#B8C8E0", 1000, 0, 0, 0,
+				6, 3, "#C8C8D0", "", false, false, true),
+		},
+		// Drop Boost, Transfer, Lander one at a time; the Pod survives every
+		// decouple and splashes down. Sum (3) < 4 stages.
+		DecouplePlan: []int{1, 1, 1},
+	},
 }
 
 // LoadoutOrder lists loadouts in canonical UI cycle order — the
@@ -589,6 +668,7 @@ var LoadoutOrder = []string{
 	LoadoutFalcon9ID,
 	LoadoutApolloStackID,
 	LoadoutCapsuleID,
+	LoadoutKernStackID,
 }
 
 // LookupLoadout returns the catalog entry for the given ID, or the

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -3,6 +3,8 @@ package spacecraft
 import (
 	"math"
 	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 )
 
 // TestLoadoutsCatalogShape — every entry in LoadoutOrder must map
@@ -334,6 +336,102 @@ func TestLanderStageDeltaVBudgets(t *testing.T) {
 	}
 	if ascentDV < minAscentDV {
 		t.Errorf("ascent Δv = %.0f m/s, want ≥ %.0f (can't reach lunar orbit)", ascentDV, minAscentDV)
+	}
+}
+
+// stackDeltaV returns the ideal (rocket-equation) Δv of a bottom-first
+// stage list flown as a single drop-stage chain: each stage fires hauling
+// itself plus everything above it, then is jettisoned. Mirrors the mass
+// convention of TestLanderStageDeltaVBudgets (dry + main fuel only; RCS
+// monoprop is ignored). Engineless / fuelless stages (the parachute Pod)
+// contribute mass but no Δv.
+func stackDeltaV(stages []Stage) float64 {
+	massAtOrAbove := func(i int) float64 {
+		m := 0.0
+		for j := i; j < len(stages); j++ {
+			m += stages[j].DryMass + stages[j].FuelMass
+		}
+		return m
+	}
+	total := 0.0
+	for i, s := range stages {
+		if s.FuelMass <= 0 || s.Isp <= 0 {
+			continue
+		}
+		m0 := massAtOrAbove(i)
+		m1 := m0 - s.FuelMass
+		total += s.Isp * g0 * math.Log(m0/m1)
+	}
+	return total
+}
+
+// TestKernStackShape — ADR 0014 Slice C/D. The Kern Stack is the one
+// scale-matched vehicle for Lumen: a simplified 4-stage Apollo analog
+// [Boost, Transfer, Lander, Pod] bottom-first, DecouplePlan [1,1,1]
+// (drop each lower stage one at a time; the parachute Pod is the
+// surviving core), tagged bodies.ScaleStrippedBack so the spawn-form
+// hint flags it as best-for-Lumen. Lift-off TWR > 1 on Earth-like Kern
+// surface gravity.
+func TestKernStackShape(t *testing.T) {
+	l, ok := Loadouts[LoadoutKernStackID]
+	if !ok {
+		t.Fatal("Kern-Stack loadout missing")
+	}
+	if l.Scale() != bodies.ScaleStrippedBack {
+		t.Errorf("Kern Stack Scale() = %q, want %q (Lumen-matched)", l.Scale(), bodies.ScaleStrippedBack)
+	}
+	wantNames := []string{"Boost", "Transfer", "Lander", "Pod"}
+	if len(l.Stages) != len(wantNames) {
+		t.Fatalf("Kern Stack: %d stages, want %d", len(l.Stages), len(wantNames))
+	}
+	for i, n := range wantNames {
+		if l.Stages[i].Name != n {
+			t.Errorf("stage %d: name %q, want %q", i, l.Stages[i].Name, n)
+		}
+	}
+	wantPlan := []int{1, 1, 1}
+	if len(l.DecouplePlan) != len(wantPlan) {
+		t.Fatalf("Kern Stack DecouplePlan = %v, want %v", l.DecouplePlan, wantPlan)
+	}
+	for i, g := range wantPlan {
+		if l.DecouplePlan[i] != g {
+			t.Errorf("DecouplePlan[%d] = %d, want %d", i, l.DecouplePlan[i], g)
+		}
+	}
+	byName := map[string]Stage{}
+	for _, s := range l.Stages {
+		byName[s.Name] = s
+	}
+	// The Lander touches down (engine soft-land) and the Pod recovers
+	// under chute — the two halves of "landing-and-return".
+	if lander := byName["Lander"]; !lander.CanSoftLand {
+		t.Error("Lander must soft-land (it is the descent/return engine)")
+	}
+	if pod := byName["Pod"]; !pod.HasParachute {
+		t.Error("Pod must carry a parachute (engineless re-entry recovery)")
+	}
+	if pod := byName["Pod"]; pod.Thrust != 0 || pod.FuelMass != 0 {
+		t.Errorf("Pod should be engineless: Thrust=%.0f Fuel=%.0f", pod.Thrust, pod.FuelMass)
+	}
+	// Lift-off TWR > 1 against Kern's Earth-like surface gravity (g0).
+	totalMass := SumDryMass(l.Stages) + SumFuelMass(l.Stages)
+	twr := l.Stages[0].Thrust / (totalMass * g0)
+	if twr <= 1.0 {
+		t.Errorf("Kern Stack lift-off TWR = %.3f, want > 1", twr)
+	}
+}
+
+// TestKernStackDeltaVBudget — ADR 0014 sizes the Kern Stack to a ~6 km/s
+// Cursor-landing-and-return budget (Lumen ~3.4 km/s to orbit + transfer,
+// capture, descent and return on the stripped-back scale). Pin the total
+// ideal Δv so a future mass/Isp tweak can't silently strand the mission.
+func TestKernStackDeltaVBudget(t *testing.T) {
+	l := LookupLoadout(LoadoutKernStackID)
+	dv := stackDeltaV(l.Stages)
+	const wantDV = 6000.0
+	const tol = 400.0 // "~6 km/s"
+	if math.Abs(dv-wantDV) > tol {
+		t.Errorf("Kern Stack total Δv = %.0f m/s, want %.0f ± %.0f (Cursor land-and-return)", dv, wantDV, tol)
 	}
 }
 

--- a/internal/spacecraft/scaleclass_test.go
+++ b/internal/spacecraft/scaleclass_test.go
@@ -6,11 +6,16 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 )
 
-// The whole existing fleet carries real, Earth-sized Δv budgets, so every
-// catalog loadout reports real — including those that never set the field
-// (empty normalizes to real, ADR 0014). We do not rescale the real fleet.
+// The whole existing real fleet carries real, Earth-sized Δv budgets, so
+// every such catalog loadout reports real — including those that never set
+// the field (empty normalizes to real, ADR 0014). We do not rescale the
+// real fleet. The lone exception is the scale-matched Kern Stack (Slice
+// C/D), explicitly tagged stripped-back and asserted in TestKernStackShape.
 func TestLoadoutScaleDefaultsToReal(t *testing.T) {
 	for _, id := range LoadoutOrder {
+		if id == LoadoutKernStackID {
+			continue // the one stripped-back vehicle
+		}
 		l := Loadouts[id]
 		if got := l.Scale(); got != bodies.ScaleReal {
 			t.Errorf("loadout %q Scale() = %q, want %q", id, got, bodies.ScaleReal)


### PR DESCRIPTION
## Summary

Adds the **Kern Stack** — the one scale-matched vehicle for the stripped-back **Lumen** system (ADR 0014). A simplified 4-stage Apollo analog, sized so a player has a craft that can actually fly Lumen's ~1/10-linear scale instead of trivializing it with the real fleet.

- **Stages** (bottom-first): `[Boost, Transfer, Lander, Pod]`
- **DecouplePlan** `[1,1,1]` — drop Boost → Transfer → Lander one at a time; the engineless parachute **Pod** is the surviving core that splashes down (ADR 0008 recovery model)
- **ScaleClass** `bodies.ScaleStrippedBack` — surfaced only as the spawn-form Δv/"best for" hint; **never a filter** (any Loadout can spawn in any System, per ADR 0014)
- **Δv budget**: 6051.8 m/s ideal (~6 km/s) — enough for Lumen orbit (~3.4 km/s) + a Cursor transfer/capture/descent + ascent/return
- **Isp**: KSP stock engines collapsed to the model's single-Isp-per-stage convention — Mainsail (Boost, 285 sea-level), Poodle (Transfer, 350 vac), Terrier (Lander, 345 vac)
- Lift-off TWR ≈ 1.20 against Kern's Earth-like surface gravity

Mirrors the existing **Apollo Stack** structure. A new `kernStage` helper layers the launch sprite + soft-land/parachute flags on directly, so the terminal-native stage names stay self-contained in `loadouts.go` — **no new StageCatalog parts** (ADR 0014 ships none). Registered in `LoadoutOrder`.

## Tests (TDD)

- `TestKernStackDeltaVBudget` — pins total Δv at 6000 ± 400 m/s (**written first**, red before implementation)
- `TestKernStackShape` — stages, names, `DecouplePlan`, stripped-back scale tag, lift-off TWR > 1, Pod parachute, Lander soft-land
- `TestLoadoutScaleDefaultsToReal` updated to exclude the one stripped-back vehicle

`go vet ./...` clean · `go test ./... -race -count=1` → **981 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)