### PR TITLE
tune(flight): pitch trim step 10° → 5° per keypress

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -65,8 +65,8 @@ A good first attempt:
    start.
 2. `z` for full throttle, `b` to light the engine. The first stage lifts off
    at a thrust-to-weight ratio of about 1.24.
-3. Around 3 km up, tap `>` once to tip 10° east. The rocket starts building
-   sideways speed.
+3. Around 3 km up, tap `>` a couple of times to tip ~5° east each. The rocket
+   starts building sideways speed.
 4. As your ground speed passes ~100 m/s, press `w` to have the autopilot point
    along your velocity, and `\` to clear the manual tip. From here the rocket
    tracks its own motion and gravity rounds the climb into orbit for you.
@@ -144,7 +144,7 @@ readout shows you why before you watch it fall back.
 | `k` | Steering style: smooth turning (the default) or instant snap |
 | `;` | Switch the autopilot's reference: Orbit → Surface → Target (skips Target when none is set) |
 | `W` / `S` | Point along / against your ground speed — matches your velocity relative to the spinning atmosphere. Use this for the launch gravity turn |
-| `>` / `<` | Tip the nose 10° east / west on top of whatever the autopilot is doing |
+| `>` / `<` | Tip the nose 5° east / west on top of whatever the autopilot is doing (hold to ramp) |
 | `\` | Clear the manual tip |
 
 The pointing keys only aim the craft — `b` is what actually fires the engine.

--- a/internal/spacecraft/burn_direction.go
+++ b/internal/spacecraft/burn_direction.go
@@ -170,9 +170,10 @@ func ApplyPitchTrim(dir, r, spinAxis orbital.Vec3, pitchRad float64) orbital.Vec
 }
 
 // PitchTrimStepRad is the per-keypress pitch trim adjustment in
-// radians. v0.9.2.1+: 10° (= π/18). v0.9.2 shipped at 5° but
-// playtest exposed that the user had to mash `>` 6+ times to get
-// the gravity turn going on a Saturn V — Apollo's actual ascent
-// program pitched 30–50° from vertical. Bump to 10° so 3 taps
-// gives a reasonable initial pitch-over.
-const PitchTrimStepRad = math.Pi / 18
+// radians. v0.16: 5° (= π/36) — finer control for the gravity turn.
+// History: v0.9.2 shipped at 5°, v0.9.2.1 bumped to 10° because a
+// Saturn V's gravity turn needed too many `>` taps to get going; the
+// 5° step is restored per playtest preference (the smaller stripped-back
+// Lumen vehicles steer better with finer granularity, and held `>`
+// ramps continuously at the terminal key-repeat rate for big pitch-overs).
+const PitchTrimStepRad = math.Pi / 36

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -264,8 +264,8 @@ func DefaultKeymap() Keymap {
 
 		AttitudeSurfacePrograde:   key.NewBinding(key.WithKeys("W"), key.WithHelp("W", "attitude: surface prograde")),
 		AttitudeSurfaceRetrograde: key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "attitude: surface retrograde")),
-		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +10° east")),
-		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -10° west")),
+		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +5° east")),
+		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -5° west")),
 		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
 		ToggleInstantSAS:          key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "SAS model: slew / instant (MANUAL/AUTO)")),
 		TiltUp:                    key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+↑", "tilt +5° (ViewTilted)")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -62,7 +62,7 @@ func (h *Help) Render() string {
 			{"a / d", "attitude normal+ / normal- (orient only in main; pulse-fire in rcs)"},
 			{"q / e", "attitude radial+ / radial- (orient only in main; pulse-fire in rcs)"},
 			{"W / S", "attitude surface prograde / retrograde — locks to v - ω×r (v0.9.2+)"},
-			{"< / >", "pitch trim ±10° east — held thrust direction tilts off the active mode (v0.9.2+)"},
+			{"< / >", "pitch trim ±5° east — held thrust direction tilts off the active mode (v0.9.2+)"},
 			{"\\", "reset pitch trim to 0 (v0.9.2+)"},
 			{"b", "engage / cut manual burn (main engine only)"},
 			{"r", "engine: main / rcs (RCS = monoprop pulse-fire on attitude keys)"},

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -551,7 +551,7 @@ const flameFrameMs = 100
 // climb, flipping the chase-cam east↔west until the player applied
 // pitch trim. v0.11.1 raises the floor above the warp-scaled lag
 // (≤ ~1e-4 rad at the 10× burn warp cap) but well below the
-// smallest meaningful pitch trim (10° = 0.17 rad) — the camera
+// smallest meaningful pitch trim (one step = 5° = 0.087 rad) — the camera
 // orients east during vertical climb (intent), then swings to the
 // pitch direction as the player gravity-turns.
 func chaseHorizontalAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) orbital.Vec3 {

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -473,13 +473,13 @@ func TestLaunchTowerRecedesAsRocketClimbs(t *testing.T) {
 
 // Counterpoint to the slew-lag fix: the threshold must remain low
 // enough that a real player-applied pitch trim still steers the
-// chase-cam. One `>` press = 10° east pitch trim, which puts a 0.17
-// east component on commanded attitude (sin 10°) — well above any
-// sane slew-lag noise. Assert that with PitchTrim = 10° the chase
+// chase-cam. One `>` press = 5° east pitch trim, which puts a 0.087
+// east component on commanded attitude (sin 5°) — well above any
+// sane slew-lag noise. Assert that with PitchTrim = one step the chase
 // hAxis points east, not the fallback default.
 func TestChaseHAxisFollowsPitchTrimAfterCommand(t *testing.T) {
 	w, c := spawnSaturnVOnPad(t)
-	c.PitchTrim = spacecraft.PitchTrimStepRad // 10° east
+	c.PitchTrim = spacecraft.PitchTrimStepRad // 5° east
 	w.StartManualBurn()
 	// One tick is enough for slew to advance CurrentAttitudeDir
 	// toward the trimmed direction (slew rate is degrees/sec; 1s of
@@ -496,7 +496,7 @@ func TestChaseHAxisFollowsPitchTrimAfterCommand(t *testing.T) {
 	eastR := render.BodyFrameEast(c.Primary, rR)
 	eastV := orbital.Vec3{X: eastR.X, Y: eastR.Y, Z: eastR.Z}
 	if dotEast := hAxis.Dot(eastV); dotEast < 0.5 {
-		t.Errorf("with +10° pitch trim, hAxis should still align with east-ish: "+
+		t.Errorf("with +5° pitch trim, hAxis should still align with east-ish: "+
 			"hAxis·east = %.4f (want > 0.5)", dotEast)
 	}
 }


### PR DESCRIPTION
## What

Halves the per-keypress pitch-trim step: `PitchTrimStepRad` π/18 (10°) → π/36 (5°).

This restores the **original v0.9.2 5° step** (v0.9.2.1 had bumped it to 10° because a Saturn V's gravity turn needed too many `>` taps). Finer granularity steers the smaller stripped-back Lumen vehicles better, and a **held `>` still ramps continuously** at the terminal key-repeat rate for big pitch-overs, so the coarse-step rationale no longer applies.

## Changes

- `internal/spacecraft/burn_direction.go` — `PitchTrimStepRad = math.Pi / 36`, comment updated with the history.
- Source-of-truth `?` help overlay (`help.go`), keybinding help strings (`input.go`), and `docs/controls.md` (README mirror) — all now say ±5°.
- Chase-axis epsilon comment + `TestChaseHAxisFollowsPitchTrimAfterCommand` comments updated. The 0.01 hAxis noise floor stays well below sin 5° = 0.087, so the test still passes unchanged.

## Tests

`go vet ./...` clean; `go test ./... -race -count=1` → **998 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)