### PR TITLE
feat(hud): fold the active-burns readout into the NODES chip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1553,13 +1553,17 @@ are now [[#hud--overlays|Chips]]).
 A compact (2–4 row) overlay composited onto a corner of the **Canvas**
 carrying one contextual readout — Target, Stages, Nodes, Launch, Capture.
 Most Chips render only when their Setting is enabled, they are contextually
-relevant, and Declutter is off. A few are **always-on** (non-toggleable):
-the current **Orbit** metrics (apo/peri/incl) and the active **● Burns**
-readout, which a player must never be able to hide from the **Settings
-screen** — too load-bearing to switch off. Always-on Chips still vanish
-under Declutter; only the **HUD** core Chip survives it. Distinct from the
-larger **Navball** panel, which is also a canvas overlay but a fixed
-instrument.
+relevant, and Declutter is off. The current **Orbit** metrics (apo/peri/incl)
+are **always-on** (non-toggleable) — a player must never be able to hide them
+from the **Settings screen** — though they still vanish under Declutter. The
+**Nodes** Chip carries any in-flight **Burn** as its firing head (the active
+● Burns readout was folded in here, v0.16); while a Burn is live it
+**force-shows** — overriding both its Setting toggle *and* Declutter — so a
+live Burn (safety-critical) can never be hidden. With nothing burning the
+Nodes Chip honours its toggle and Declutter like any other. The **HUD** core
+Chip and a live-Burn Nodes Chip are the only overlays that survive Declutter.
+Distinct from the larger **Navball** panel, which is also a canvas overlay
+but a fixed instrument.
 _Avoid_: Widget, card, badge, HUD block, panel (reserve panel for the
 Navball).
 
@@ -1572,7 +1576,9 @@ _Avoid_: Hide UI, clean mode, F2 mode, toggle overlays.
 **Settings screen**:
 The menu-reached screen where the player toggles each toggleable Chip's
 default visibility (and future preferences such as units). The always-on
-Orbit + Burns readouts are deliberately not listed. Persisted to a global
+Orbit readout is deliberately not listed; the **Nodes** Chip is listed
+(toggleable) but force-shows while a Burn is in flight regardless, so its
+firing-head Burn readout can't be switched off. Persisted to a global
 `settings.json` under `$XDG_CONFIG_HOME`, separate from the **Theme** —
 visibility versus colour are distinct concerns — and independent of any
 save game.

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -48,7 +48,9 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 		chips = append(chips, builtChip{id: id, corner: corner, lines: lines})
 	}
 	// Top-left transient stack (stacking order = listed order, downward).
-	add("", cornerTopLeft, v.buildBurnsChip(w)) // always-on safety readout
+	// The in-flight ● BURNS readout used to live here; v0.16 folds it into
+	// the bottom-right NODES chip (a live burn is the firing head of the
+	// burn schedule). See the force-show path below.
 	add(settings.ChipFrameTransition, cornerTopLeft, v.buildFrameTransitionChip(w))
 	add(settings.ChipCapture, cornerTopLeft, v.buildCaptureChip(w))
 	add(settings.ChipLaunch, cornerTopLeft, v.buildLaunchChip(w))
@@ -64,8 +66,29 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	add(settings.ChipTarget, cornerTopRight, v.buildTargetChip(w))
 	// Remaining fixed corners.
 	add(settings.ChipStages, cornerBottomLeft, v.buildStagesChip(w))
-	add(settings.ChipNodes, cornerBottomRight, v.buildNodesChip(w))
+	// NODES (bottom-right) now also carries any in-flight burn as its
+	// firing head (v0.16). A live burn is safety-critical, so when one is
+	// in flight the chip force-shows — bypassing both the ChipNodes
+	// Settings toggle and F2 declutter — so it can never be hidden. With
+	// nothing burning it honours the toggle + declutter like any chip.
+	if lines := v.buildNodesChip(w); lines != nil {
+		if v.anyActiveBurn(w) || v.chipEnabled(settings.ChipNodes) {
+			chips = append(chips, builtChip{id: settings.ChipNodes, corner: cornerBottomRight, lines: lines})
+		}
+	}
 	return chips
+}
+
+// anyActiveBurn reports whether any craft in the slate has an in-flight
+// finite/planted burn (ActiveBurn). Drives the NODES chip force-show
+// (v0.16) so a live burn is never hidden by the toggle or declutter.
+func (v *OrbitView) anyActiveBurn(w *sim.World) bool {
+	for _, c := range w.Crafts {
+		if c != nil && c.ActiveBurn != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // buildAttitudeChip surfaces the held attitude / nav mode / engine mode /
@@ -91,23 +114,19 @@ func (v *OrbitView) buildAttitudeChip(w *sim.World) []string {
 	}
 }
 
-// buildBurnsChip surfaces any in-flight burn across the whole craft slate
-// so a burn on a non-active craft can't sneak by. Returns nil when nothing
-// is burning. This is an always-on chip (no Settings toggle) — a live burn
-// is safety-critical.
-func (v *OrbitView) buildBurnsChip(w *sim.World) []string {
-	burning := []int{}
+// activeBurnLines renders the in-flight burn entries across the whole
+// craft slate — mode, Δv remaining, and a T-countdown (or a STALLED
+// warning) — each as a ● firing line in the warning style so it reads as
+// safety-critical. Returns nil when nothing is burning. v0.16 folds this
+// into buildNodesChip as the firing head of the burn schedule (it was the
+// standalone ● BURNS chip); walking all crafts still means a burn on a
+// non-active vessel can't sneak by.
+func (v *OrbitView) activeBurnLines(w *sim.World) []string {
+	var lines []string
 	for i, c := range w.Crafts {
-		if c != nil && c.ActiveBurn != nil {
-			burning = append(burning, i)
+		if c == nil || c.ActiveBurn == nil {
+			continue
 		}
-	}
-	if len(burning) == 0 {
-		return nil
-	}
-	lines := []string{v.theme.Warning.Render("● BURNS")}
-	for _, i := range burning {
-		c := w.Crafts[i]
 		ab := c.ActiveBurn
 		remaining := ab.EndTime.Sub(w.Clock.SimTime).Seconds()
 		if remaining < 0 {
@@ -115,19 +134,17 @@ func (v *OrbitView) buildBurnsChip(w *sim.World) []string {
 		}
 		tag := fmt.Sprintf("craft %d", i+1)
 		if i == w.ActiveCraftIdx {
-			tag = v.theme.Warning.Render(tag + " (active)")
-		} else {
-			tag = v.theme.Dim.Render(tag)
+			tag += " (active)"
 		}
 		if c.BurnStalled() {
 			lines = append(lines,
-				fmt.Sprintf("  %s — %s, Δv %.0f m/s", tag, ab.Mode.String(), ab.DVRemaining),
+				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s", tag, ab.Mode.String(), ab.DVRemaining)),
 				v.theme.Warning.Render("    ⚠ STALLED — stage to resume (x to cancel)"),
 			)
 		} else {
 			lines = append(lines,
-				fmt.Sprintf("  %s — %s, Δv %.0f m/s, T-%.0fs",
-					tag, ab.Mode.String(), ab.DVRemaining, remaining),
+				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s, T-%.0fs",
+					tag, ab.Mode.String(), ab.DVRemaining, remaining)),
 			)
 		}
 	}

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -284,20 +284,32 @@ func (v *OrbitView) buildStagesChip(w *sim.World) []string {
 	}
 }
 
-// buildNodesChip summarises the planted-node chain as the next node plus a
-// "(+N more → [m])" overflow count, bounding what was an unbounded
-// per-node list. The full enumerable/editable list lives on the maneuver
-// screen ([m]); clicking this chip opens it (ADR 0010). Returns nil when
-// no craft has a node planted.
+// buildNodesChip is the bottom-right burn-schedule chip: any in-flight
+// burn(s) as the firing head, then the planted-node chain summarised as
+// the next node plus a "(+N more → [m])" overflow count. The full
+// enumerable/editable list lives on the maneuver screen ([m]); clicking
+// this chip opens it (ADR 0010). Returns nil only when nothing is burning
+// and no craft has a node planted.
+//
+// v0.16 folded the standalone ● BURNS chip in here so a live burn and the
+// upcoming nodes read as one schedule. assembleChips force-shows the chip
+// whenever a burn is live, so the safety-critical firing head is never
+// hidden by the toggle or declutter.
 func (v *OrbitView) buildNodesChip(w *sim.World) []string {
+	burnLines := v.activeBurnLines(w)
 	total := 0
 	for _, c := range w.Crafts {
 		if c != nil {
 			total += len(c.Nodes)
 		}
 	}
-	if total == 0 {
+	if len(burnLines) == 0 && total == 0 {
 		return nil
+	}
+	lines := []string{v.theme.Primary.Render("NODES")}
+	lines = append(lines, burnLines...)
+	if total == 0 {
+		return lines // a burn in flight with no upcoming planted nodes
 	}
 	// The "next" node is the active craft's first node when it has one,
 	// else the first node on the first craft that has any.
@@ -315,7 +327,6 @@ func (v *OrbitView) buildNodesChip(w *sim.World) []string {
 			}
 		}
 	}
-	lines := []string{v.theme.Primary.Render("NODES")}
 	if nc != nil {
 		n := nc.Nodes[ni]
 		kind := "imp"

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -326,12 +326,13 @@ func TestDeclutterHidesChipsKeepsColumn(t *testing.T) {
 	}
 }
 
-// TestOrbitMetricsAndBurnsAlwaysOn: the ORBIT-metrics readout and an
-// active ● BURNS readout are non-toggleable — they render even when every
-// Settings Chip is disabled (a player can't permanently hide their current
-// orbit or a live burn). F2 declutter still clears them; only the pinned
-// VESSEL core survives.
-func TestOrbitMetricsAndBurnsAlwaysOn(t *testing.T) {
+// TestOrbitMetricsAlwaysOnAndLiveBurnForceShows: the ORBIT-metrics readout
+// is non-toggleable (renders with every Chip disabled) but F2 declutter
+// still clears it. A live burn now folds into the NODES chip and
+// force-shows — it renders even with every Chip disabled AND survives F2
+// declutter (v0.16: a live burn is safety-critical and can't be hidden).
+// Only the pinned VESSEL core also survives declutter.
+func TestOrbitMetricsAlwaysOnAndLiveBurnForceShows(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	v.Resize(120, 40)
 	w, err := sim.NewWorld()
@@ -339,7 +340,8 @@ func TestOrbitMetricsAndBurnsAlwaysOn(t *testing.T) {
 		t.Fatalf("NewWorld: %v", err)
 	}
 
-	// Disable every toggleable Chip; the always-on readouts must persist.
+	// Disable every toggleable Chip (incl. ChipNodes); the always-on
+	// ORBIT readout must persist.
 	s := settings.Default()
 	for _, c := range settings.AllChips {
 		s.SetChip(c, false)
@@ -351,7 +353,8 @@ func TestOrbitMetricsAndBurnsAlwaysOn(t *testing.T) {
 		t.Errorf("ORBIT metrics must render with all chips disabled (non-toggleable):\n%s", out)
 	}
 
-	// Light an active burn → ● BURNS must show even with all chips off.
+	// Light an active burn → the firing head force-shows inside NODES even
+	// with ChipNodes (and every other chip) disabled.
 	c := w.ActiveCraft()
 	if c == nil {
 		t.Fatal("expected an active craft")
@@ -362,21 +365,30 @@ func TestOrbitMetricsAndBurnsAlwaysOn(t *testing.T) {
 		EndTime:     w.Clock.SimTime.Add(30 * time.Second),
 	}
 	out = v.Render(w, 0, 120, 40)
-	if !strings.Contains(out, "BURNS") {
-		t.Errorf("active ● BURNS must render with all chips disabled:\n%s", out)
+	if !strings.Contains(out, "NODES") || !strings.Contains(out, "120 m/s") {
+		t.Errorf("a live burn must force-show in the NODES chip with all chips disabled:\n%s", out)
 	}
 
-	// F2 declutter clears both; the pinned VESSEL core survives.
+	// F2 declutter clears ORBIT metrics, but the live burn force-shows
+	// through it; the pinned VESSEL core also survives.
 	v.SetDeclutter(true)
 	out = v.Render(w, 0, 120, 40)
 	if strings.Contains(out, "ORBIT") {
 		t.Errorf("declutter must hide the ORBIT metrics chip:\n%s", out)
 	}
-	if strings.Contains(out, "BURNS") {
-		t.Errorf("declutter must hide the ● BURNS chip:\n%s", out)
+	if !strings.Contains(out, "120 m/s") {
+		t.Errorf("a live burn must survive declutter (force-shown, safety-critical):\n%s", out)
 	}
 	if !strings.Contains(out, "VESSEL") {
 		t.Errorf("pinned VESSEL core must survive declutter")
+	}
+
+	// Cut the burn → with every chip disabled the NODES chip (no nodes
+	// planted) returns to hidden.
+	c.ActiveBurn = nil
+	out = v.Render(w, 0, 120, 40)
+	if strings.Contains(out, "120 m/s") {
+		t.Errorf("burn readout lingered after the burn ended:\n%s", out)
 	}
 }
 
@@ -437,5 +449,58 @@ func TestBuildVesselChipCoreOnly(t *testing.T) {
 	// not carry apoapsis/periapsis rows.
 	if strings.Contains(out, "apoapsis") || strings.Contains(out, "periapsis") {
 		t.Errorf("vessel chip still carries orbit-shape rows (should be a separate chip):\n%s", out)
+	}
+}
+
+// TestBuildNodesChipMergesActiveBurn — the NODES chip carries an in-flight
+// burn as its firing head above the planted-node summary (v0.16), and
+// shows the firing head alone when a burn is live with no upcoming nodes.
+func TestBuildNodesChipMergesActiveBurn(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+
+	// Burn in flight + a planted node → both appear, burn first.
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnPrograde,
+		DVRemaining: 120,
+		EndTime:     w.Clock.SimTime.Add(30 * time.Second),
+	}
+	c.Nodes = []spacecraft.ManeuverNode{
+		{DV: 80, TriggerTime: w.Clock.SimTime.Add(30 * time.Minute)},
+	}
+	chip := v.buildNodesChip(w)
+	joined := strings.Join(chip, "\n")
+	if !strings.HasPrefix(chip[0], "NODES") {
+		t.Errorf("chip header should be NODES:\n%s", joined)
+	}
+	if !strings.Contains(joined, "120 m/s") {
+		t.Errorf("firing burn missing from merged chip:\n%s", joined)
+	}
+	if !strings.Contains(joined, "80 m/s") {
+		t.Errorf("planted node missing from merged chip:\n%s", joined)
+	}
+	// Firing head must come before the planted node.
+	if strings.Index(joined, "120 m/s") > strings.Index(joined, "80 m/s") {
+		t.Errorf("firing burn should head the chip, above planted nodes:\n%s", joined)
+	}
+
+	// Burn in flight, no planted nodes → chip still shows the firing head.
+	c.Nodes = nil
+	chip = v.buildNodesChip(w)
+	if chip == nil {
+		t.Fatal("chip nil with a live burn and no nodes; want the firing head")
+	}
+	if !strings.Contains(strings.Join(chip, "\n"), "120 m/s") {
+		t.Errorf("firing head missing when no nodes planted:\n%s", strings.Join(chip, "\n"))
+	}
+
+	// Nothing burning, no nodes → nil.
+	c.ActiveBurn = nil
+	if got := v.buildNodesChip(w); got != nil {
+		t.Errorf("chip should be nil with no burn and no nodes, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Moves the standalone top-left **● BURNS** chip into the bottom-right **NODES** chip, so a live burn and the upcoming planted nodes read as one burn-schedule readout instead of two separate overlays.

- An in-flight burn now renders as the **firing head** of the NODES chip — a `●` warning line with craft tag, mode, Δv remaining, and a T-countdown (or the STALLED warning) — with the planted-node summary (`next + (+N more → [m])`) below it.
- When a burn is live with no upcoming nodes, the chip shows the firing head alone.

## Safety: live burns can't be hidden

A live burn is safety-critical, so the NODES chip **force-shows whenever any craft has an `ActiveBurn`** — bypassing both the `ChipNodes` Settings toggle *and* F2 declutter. With nothing burning, the chip honours its toggle + declutter like any other chip. This is a slight *strengthening* of the old behaviour: the standalone `● BURNS` chip was actually F2-declutterable.

## Changes

- `buildBurnsChip` → `activeBurnLines` (headerless burn entries, folded into `buildNodesChip`).
- `assembleChips`: drop the top-left burns add; force-show the NODES chip while burning.
- Tests: `TestOrbitMetricsAlwaysOnAndLiveBurnForceShows` (rewritten for the force-show-through-declutter behaviour) + new `TestBuildNodesChipMergesActiveBurn`.
- `CONTEXT.md` Chip / Settings-screen glossary entries updated.

Full suite **999 passing**, `go vet` clean.

## Behaviour notes for review

- The burn readout **relocates top-left → bottom-right** (it's now the NODES chip).
- Clicking it opens the maneuver screen — the old `● BURNS` chip swallowed clicks; the merged chip carries the NODES click affordance.

Independent of #110 (Auto-Warp); branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)