### PR TITLE
fix(warp): Auto-Warp used the Verlet slow path → eccentric coast escaped to solar orbit

### DIFF
--- a/internal/sim/auto_warp_coast_test.go
+++ b/internal/sim/auto_warp_coast_test.go
@@ -1,0 +1,115 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestCanKeplerStepGatesOnEffectiveWarp is the unit-level guard for the
+// same bug: the analytic warp-lock fast path must be chosen by the
+// effective warp this tick (the step size simDelta implies), not by the
+// player's Selected Warp. Auto-Warp leaves WarpIdx at 0 (Clock.Warp()==1)
+// while driving a large simDelta, so a Clock.Warp() gate wrongly forced
+// the Verlet slow path.
+func TestCanKeplerStepGatesOnEffectiveWarp(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft() // default bound LEO orbit (peri above atmosphere)
+	base := w.Clock.BaseStep
+
+	w.Clock.WarpIdx = 0 // the Auto-Warp state: Selected Warp 1×
+	if w.Clock.Warp() != 1 {
+		t.Fatalf("setup: Clock.Warp()=%v, want 1", w.Clock.Warp())
+	}
+
+	if w.canKeplerStep(c, base) {
+		t.Error("canKeplerStep true at effective 1× (realtime step); want the Verlet path")
+	}
+	if w.canKeplerStep(c, 0) {
+		t.Error("canKeplerStep true at simDelta=0 (paused); want false")
+	}
+	big := time.Duration(float64(base) * 100000) // Auto-Warp's max-seeded step
+	if !w.canKeplerStep(c, big) {
+		t.Error("canKeplerStep false for a high effective-warp step while WarpIdx=0 — the escape bug")
+	}
+}
+
+// TestAutoWarpLunarTransferStaysBound is the regression for the
+// "Auto-Warp to the plane change flings the craft into solar orbit" bug.
+//
+// Root cause: canKeplerStep gated the analytic warp-lock fast path on the
+// player's Selected Warp (Clock.Warp()), but Auto-Warp drives the
+// effective warp through clampedWarp's max-seed without touching WarpIdx.
+// After a prior Auto-Warp leg set WarpIdx=0, Clock.Warp() read 1×, the
+// gate rejected Kepler, and the integrator took a single ~5000 s Verlet
+// step (period/100 for a ~10-day transfer orbit) through perigee —
+// aliasing the bound trans-lunar ellipse into a hyperbolic Earth escape.
+//
+// Repro: new game, target Moon, [H] split transfer, Auto-Warp to the TLI
+// burn (it fires), then Auto-Warp to the plane-change node. The craft must
+// stay bound to Earth on the trans-lunar trajectory.
+func TestAutoWarpLunarTransferStaysBound(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx := -1
+	for i, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon missing from Sol")
+	}
+	w.SetTargetBody(moonIdx)
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	c := w.ActiveCraft()
+	nodesBefore := len(c.Nodes)
+	if nodesBefore < 2 {
+		t.Fatalf("expected a multi-node split transfer, got %d nodes", nodesBefore)
+	}
+
+	// Leg 1: Auto-Warp to the TLI burn, then let it fire and finish.
+	if !w.EngageAutoWarp() {
+		t.Fatal("engage 1 (TLI) failed")
+	}
+	if _, ok := tickUntil(w, 5_000_000, func() bool { return w.AutoWarp == nil }); !ok {
+		t.Fatal("Auto-Warp leg 1 never disengaged")
+	}
+	if _, ok := tickUntil(w, 5_000_000, func() bool { return len(c.Nodes) < nodesBefore }); !ok {
+		t.Fatal("TLI node never fired")
+	}
+	if _, ok := tickUntil(w, 5_000_000, func() bool { return c.ActiveBurn == nil }); !ok {
+		t.Fatal("TLI burn never completed")
+	}
+	if c.Primary.ID != "earth" {
+		t.Fatalf("escaped Earth before the plane change (primary=%s)", c.Primary.ID)
+	}
+	postTLI := orbital.ElementsFromState(c.State.R, c.State.V, c.Primary.GravitationalParameter())
+	if postTLI.E >= 1 {
+		t.Fatalf("TLI left a hyperbolic orbit (e=%.4f); setup invalid", postTLI.E)
+	}
+
+	// Leg 2: Auto-Warp to the plane-change node — the buggy leg.
+	if !w.EngageAutoWarp() {
+		t.Fatal("engage 2 (plane change) failed")
+	}
+	if _, ok := tickUntil(w, 5_000_000, func() bool { return w.AutoWarp == nil }); !ok {
+		t.Fatal("Auto-Warp leg 2 never disengaged")
+	}
+
+	if c.Primary.ID != "earth" {
+		t.Fatalf("vessel escaped to %s orbit during the warp to the plane change (was bound trans-lunar)", c.Primary.ID)
+	}
+	el := orbital.ElementsFromState(c.State.R, c.State.V, c.Primary.GravitationalParameter())
+	if el.E >= 1 {
+		t.Fatalf("vessel on a hyperbolic Earth-escape trajectory after the warp (e=%.4f)", el.E)
+	}
+	// Energy conserved across the analytic coast: semi-major axis should
+	// track the post-TLI ellipse, not balloon toward escape.
+	if el.A > postTLI.A*1.5 {
+		t.Errorf("orbit energy grew during the coast: a %.0f → %.0f km (warp-step aliasing)",
+			postTLI.A/1e3, el.A/1e3)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1307,7 +1307,20 @@ func (w *World) canKeplerStep(c *spacecraft.Spacecraft, simDelta time.Duration) 
 	if c.ActiveBurn != nil || c.ManualBurn != nil {
 		return false
 	}
-	if w.Clock.Warp() <= 1 {
+	// Gate on the EFFECTIVE warp this tick — the step size simDelta
+	// actually implies — not the player's Selected Warp (Clock.Warp()).
+	// Auto-Warp (ADR 0016) drives a high effective warp through
+	// clampedWarp's max-seed WITHOUT touching WarpIdx, so Clock.Warp() can
+	// read 1× while simDelta is thousands of seconds (e.g. right after a
+	// prior Auto-Warp leg set WarpIdx=0). Gating on Clock.Warp() then sent
+	// Auto-Warp down the Verlet slow path, which sub-steps at period/100 —
+	// a single ~5000 s step through the perigee of a long-period eccentric
+	// transfer orbit, aliasing it into a hyperbolic escape (the "Auto-Warp
+	// to the plane change flings the craft into solar orbit" bug). At ≤1×
+	// (realtime / paused) Verlet's fine sub-stepping is correct and we want
+	// it for parity with the live integrator.
+	base := w.Clock.BaseStep.Seconds()
+	if base <= 0 || simDelta.Seconds() <= base {
 		return false
 	}
 	return canKeplerStepState(c.State, c.Primary.GravitationalParameter(), c.Primary)


### PR DESCRIPTION
## Bug

Auto-Warp to a planted node after a TLI burn could fling the vessel into a heliocentric orbit. Repro: new game → target Moon → `H` (split transfer) → Auto-Warp to the TLI burn (fires) → Auto-Warp to the plane-change node → the bound trans-lunar ellipse turns hyperbolic and escapes Earth.

## Root cause

`canKeplerStep` gated the analytic warp-lock fast path on the player's **Selected** Warp (`Clock.Warp()`), but Auto-Warp (ADR 0016) drives the **effective** warp through `clampedWarp`'s max-seed *without touching `WarpIdx`* — and the prior Auto-Warp leg sets `WarpIdx = 0`. So `Clock.Warp()` read 1×, the gate rejected Kepler, and the integrator fell to Verlet, which sub-steps at `period/100`: for a ~10-day transfer orbit that's a single ~5000 s step through perigee, aliasing the orbit (`e=0.96` → `e=4.34`) into a hyperbolic escape in one tick.

- **Manual warp** was unaffected (`Clock.Warp() > 1` selected Kepler).
- **Leg 1 (LEO)** survived — short period gives 93 fine Verlet sub-steps; only the long-period eccentric transfer orbit aliases.

This is exactly the Selected-vs-Effective Warp distinction the ADR 0016 glossary calls load-bearing — the gate read the wrong one.

## Fix

Gate `canKeplerStep` on the effective warp the tick's `simDelta` implies (`simDelta > BaseStep`) instead of `Clock.Warp()`. Realtime/paused still take Verlet (parity with the live integrator); Auto-Warp now gets the same analytic coast manual warp always used. Audited the other `Clock.Warp()` readers — no other integration-path gate has the bug.

## Tests

- `TestAutoWarpLunarTransferStaysBound` — full repro through `Tick` (fails before, passes after; orbit holds `a≈196000 km, e=0.965` across the coast).
- `TestCanKeplerStepGatesOnEffectiveWarp` — unit gate (high effective warp with `WarpIdx=0` → Kepler).

Full suite **1025 passing**, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)