### PR TITLE
feat(input): /-cancel-warp, Help→F1 + clear-trim→?, scrollable regrouped help

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -100,6 +100,7 @@ readout shows you why before you watch it fall back.
 | `0` | Pause / resume |
 | `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn) |
 | `G` | Auto-warp to the next burn — speeds time to 30 seconds before whichever burn fires first (any craft's), ramps back down, and hands you 1× to watch it arm. Tapping `.` / `,` cancels it back to your own warp; click the `[»Burn]` button to do the same |
+| `/` | Cancel warp — drop straight back to 1× from any warp level, and cancel auto-warp if it's running |
 
 ### Map view
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -1,6 +1,6 @@
 # Controls & flight guide
 
-How to actually fly the thing, then the full list of keys. The in-game `?`
+How to actually fly the thing, then the full list of keys. The in-game `F1`
 overlay is the quick reference; the tables below are the same thing with a
 little more explanation.
 
@@ -68,7 +68,7 @@ A good first attempt:
 3. Around 3 km up, tap `>` a couple of times to tip ~5° east each. The rocket
    starts building sideways speed.
 4. As your ground speed passes ~100 m/s, press `w` to have the autopilot point
-   along your velocity, and `\` to clear the manual tip. From here the rocket
+   along your velocity, and `?` to clear the manual tip. From here the rocket
    tracks its own motion and gravity rounds the climb into orbit for you.
 5. Press `space` to drop the empty first stage. You keep flying the upper
    stage and the stage list advances. Keep burning, drop the next stage, then
@@ -93,8 +93,8 @@ readout shows you why before you watch it fall back.
 |---|---|
 | `Esc` | Back, or open the save / load / settings / quit menu on the main view |
 | `Ctrl+C` | Quit immediately |
-| `?` | Toggle the help overlay |
-| `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game `?` overlay so it stays discreet |
+| `F1` | Toggle the help overlay |
+| `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
 | `i` | Body info screen |
 | `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
 | `0` | Pause / resume |
@@ -147,7 +147,7 @@ readout shows you why before you watch it fall back.
 | `;` | Switch the autopilot's reference: Orbit → Surface → Target (skips Target when none is set) |
 | `W` / `S` | Point along / against your ground speed — matches your velocity relative to the spinning atmosphere. Use this for the launch gravity turn |
 | `>` / `<` | Tip the nose 5° east / west on top of whatever the autopilot is doing (hold to ramp) |
-| `\` | Clear the manual tip |
+| `?` | Clear the manual tip (reset pitch trim to 0) |
 
 The pointing keys only aim the craft — `b` is what actually fires the engine.
 In RCS mode those same keys also fire one small thruster pulse per press (hold

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -93,7 +93,7 @@ readout shows you why before you watch it fall back.
 |---|---|
 | `Esc` | Back, or open the save / load / settings / quit menu on the main view |
 | `Ctrl+C` | Quit immediately |
-| `F1` | Toggle the help overlay |
+| `F1` | Toggle the help overlay (scroll it with `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End`) |
 | `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
 | `i` | Body info screen |
 | `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -525,6 +525,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, cmd
 		}
+		// Help: F1/esc close; every other key scrolls the overlay. Sits
+		// before the global switch so scroll keys (↑/↓, PgUp/PgDn, etc.)
+		// don't fall through to flight actions. Backtick/ctrl+c/end-flight
+		// are handled above this block, so the boss key etc. still work.
+		if a.active == screenHelp {
+			if key.Matches(m, a.keys.Help) || key.Matches(m, a.keys.Back) {
+				a.active = screenOrbit
+				return a, nil
+			}
+			a.help.HandleKey(m)
+			return a, nil
+		}
 		// Porkchop: ←/→/↑/↓ navigate cells, Esc returns.
 		if a.active == screenPorkchop {
 			_, done := a.porkchop.HandleKey(m)
@@ -541,6 +553,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.active == screenHelp {
 				a.active = screenOrbit
 			} else {
+				a.help.ResetScroll() // always open at the top
 				a.active = screenHelp
 			}
 			return a, nil
@@ -1189,7 +1202,7 @@ func (a *App) View() string {
 	var base string
 	switch a.active {
 	case screenHelp:
-		base = a.help.Render()
+		base = a.help.Render(a.width, a.height)
 	case screenBodyInfo:
 		base = a.bodyInfo.Render(a.world, a.selectedBody, a.width, a.height)
 	case screenManeuver:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -590,6 +590,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// no burn is eligible (engage returns false silently).
 			a.world.ToggleAutoWarp()
 			return a, nil
+		case key.Matches(m, a.keys.CancelWarp):
+			// Drop straight to 1× from any warp state: cancel Auto-Warp
+			// and reset Selected Warp to the 1× floor (WarpIdx 0). Pause
+			// state is left as-is — this stops accelerating time, it
+			// doesn't resume a paused clock.
+			a.world.DisengageAutoWarp()
+			a.world.Clock.WarpIdx = 0
+			return a, nil
 		case key.Matches(m, a.keys.Pause):
 			a.world.Clock.TogglePause()
 			return a, nil

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -325,3 +325,36 @@ func TestCancelWarpKeyDropsToOneX(t *testing.T) {
 		t.Errorf("`/` left WarpIdx at %d after cancelling auto-warp, want 0", a.world.Clock.WarpIdx)
 	}
 }
+
+// TestHelpOnF1AndTrimResetOnQuestion locks the v0.16 keybinding move:
+// Help opens on F1 (not `?`), and `?` now resets pitch trim.
+func TestHelpOnF1AndTrimResetOnQuestion(t *testing.T) {
+	a, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// F1 toggles the help overlay.
+	a.Update(tea.KeyMsg{Type: tea.KeyF1})
+	if a.active != screenHelp {
+		t.Errorf("F1 did not open help (active=%v)", a.active)
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyF1})
+	if a.active == screenHelp {
+		t.Error("second F1 did not close help")
+	}
+
+	// `?` resets pitch trim and does NOT open help.
+	c := a.world.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+	c.PitchTrim = 0.3
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	if a.active == screenHelp {
+		t.Error("`?` opened help; it should reset pitch trim now")
+	}
+	if c.PitchTrim != 0 {
+		t.Errorf("`?` did not reset pitch trim (PitchTrim=%v)", c.PitchTrim)
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -292,3 +292,36 @@ func TestEditedNodeKeepsIDForAutoWarp(t *testing.T) {
 		t.Error("Auto-Warp disengaged on the tick after a node edit")
 	}
 }
+
+// TestCancelWarpKeyDropsToOneX — `/` cancels Auto-Warp and resets
+// Selected Warp to 1× from any warp state.
+func TestCancelWarpKeyDropsToOneX(t *testing.T) {
+	a, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Manual warp up, no auto-warp → `/` drops to 1×.
+	a.world.Clock.WarpIdx = 4
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if a.world.Clock.WarpIdx != 0 {
+		t.Errorf("`/` left WarpIdx at %d, want 0 (1×)", a.world.Clock.WarpIdx)
+	}
+
+	// Auto-warp engaged → `/` cancels it and drops to 1×.
+	a.world.PlanNode(sim.ManeuverNode{
+		TriggerTime: a.world.Clock.SimTime.Add(2 * time.Hour),
+		DV:          10,
+		Mode:        spacecraft.BurnPrograde,
+	})
+	a.world.Clock.WarpIdx = 5
+	if !a.world.EngageAutoWarp() {
+		t.Fatal("engage failed")
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	if a.world.AutoWarpEngaged() {
+		t.Error("`/` did not cancel Auto-Warp")
+	}
+	if a.world.Clock.WarpIdx != 0 {
+		t.Errorf("`/` left WarpIdx at %d after cancelling auto-warp, want 0", a.world.Clock.WarpIdx)
+	}
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -217,7 +217,7 @@ func DefaultKeymap() Keymap {
 		// kept with no keys so the struct field stays stable; remove
 		// in v0.8 cleanup.
 		QuitAsk:  key.NewBinding(),
-		Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Help:     key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "help")),
 		BodyInfo: key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
 		Maneuver: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
 		NextBody: key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
@@ -275,7 +275,7 @@ func DefaultKeymap() Keymap {
 		AttitudeSurfaceRetrograde: key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "attitude: surface retrograde")),
 		PitchTrimEast:             key.NewBinding(key.WithKeys(">"), key.WithHelp(">", "pitch trim +5° east")),
 		PitchTrimWest:             key.NewBinding(key.WithKeys("<"), key.WithHelp("<", "pitch trim -5° west")),
-		PitchTrimReset:            key.NewBinding(key.WithKeys("\\"), key.WithHelp("\\", "reset pitch trim")),
+		PitchTrimReset:            key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "reset pitch trim")),
 		ToggleInstantSAS:          key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "SAS model: slew / instant (MANUAL/AUTO)")),
 		TiltUp:                    key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+↑", "tilt +5° (ViewTilted)")),
 		TiltDown:                  key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+↓", "tilt -5° (ViewTilted)")),

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -26,7 +26,10 @@ type Keymap struct {
 	// the next burn, then drop to 1×. Selected Warp (WarpUp/WarpDown) is
 	// untouched; a manual warp keypress cancels Auto-Warp first.
 	AutoWarp key.Binding
-	Pause    key.Binding
+	// CancelWarp drops straight to 1× from any warp state — sets Selected
+	// Warp to 1× and disengages Auto-Warp if engaged.
+	CancelWarp key.Binding
+	Pause      key.Binding
 	ZoomIn     key.Binding
 	ZoomOut    key.Binding
 	Back       key.Binding
@@ -224,6 +227,7 @@ func DefaultKeymap() Keymap {
 		WarpUp:     key.NewBinding(key.WithKeys("."), key.WithHelp(".", "warp up")),
 		WarpDown:   key.NewBinding(key.WithKeys(","), key.WithHelp(",", "warp down")),
 		AutoWarp:   key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "auto-warp to next burn (30s lead)")),
+		CancelWarp: key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "cancel warp — drop to 1× (cancels auto-warp)")),
 		// v0.9.1: dropped `space` from Pause; space is now Stage. `0`
 		// alone retains the pause binding (it never collided).
 		Pause:           key.NewBinding(key.WithKeys("0"), key.WithHelp("0", "pause")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -41,6 +41,7 @@ func (h *Help) Render() string {
 			{".", "warp up (1× … 100000×)"},
 			{",", "warp down"},
 			{"G", "auto-warp to 30 s before the next burn, then 1× (., cancels)"},
+			{"/", "cancel warp — drop to 1× (also cancels auto-warp)"},
 			{"0", "pause / resume"},
 		}},
 		{"FLIGHT (planted)", [][2]string{

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -2,123 +2,230 @@ package screens
 
 import (
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 )
 
-// Help is the keybinding reference overlay. Invoked via `?` from any
-// screen; `?` or `esc` returns.
+// Help is the keybinding reference overlay. Invoked via F1 from any
+// screen; F1 or esc returns. The content is taller than most terminals,
+// so the body scrolls between a sticky title and a sticky footer
+// (↑/↓ PgUp/PgDn Home/End); Render windows the body to the terminal
+// height and ANSI-truncates each row to width so one entry stays one row.
 type Help struct {
-	theme Theme
+	theme  Theme
+	scroll int
+	// viewH / maxScroll are cached from the last Render so HandleKey can
+	// page and clamp without re-deriving the layout. Zero until first
+	// Render (Render runs every frame, so this self-corrects immediately).
+	viewH     int
+	maxScroll int
 }
 
 func NewHelp(th Theme) *Help { return &Help{theme: th} }
 
-func (h *Help) Render() string {
-	title := h.theme.Title.Render("terminal-space-program — keybindings")
+type helpSection struct {
+	header string
+	rows   [][2]string
+}
 
-	sections := []struct {
-		header string
-		rows   [][2]string
-	}{
-		{"GLOBAL", [][2]string{
-			{"esc", "back / close (or open save/load/settings/quit menu on home)"},
-			{"ctrl+c", "quit (immediate)"},
-			{"F1", "toggle this help"},
-		}},
-		{"NAVIGATION", [][2]string{
-			{"→ / l", "select next body (info / porkchop cursor — not the [t] target)"},
-			{"← / h", "select previous body (info / porkchop cursor — not the [t] target)"},
-			{"tab", "next system"},
-			{"i", "body info"},
-			{"+ / -", "zoom in / out"},
-			{"f", "next focus target"},
-			{"F", "previous focus target"},
-			{"g", "reset to system-wide view"},
-			{"v", "cycle view (tilted / top / right / bottom / left / orbit-flat)"},
-			{"shift+↑ / shift+↓", "tilt +5° / -5° (ViewTilted only, v0.10.6+)"},
-			{"F2", "declutter — hide all overlays (chips + navball); HUD column stays (v0.13+)"},
-		}},
-		{"TIME", [][2]string{
-			{".", "warp up (1× … 100000×)"},
-			{",", "warp down"},
-			{"G", "auto-warp to 30 s before the next burn, then 1× (., cancels)"},
-			{"/", "cancel warp — drop to 1× (also cancels auto-warp)"},
-			{"0", "pause / resume"},
-		}},
-		{"FLIGHT (planted)", [][2]string{
-			{"m", "open maneuver planner (burn now)"},
-			{"enter", "commit burn"},
-			{"esc (in planner)", "cancel burn"},
-			{"ctrl+d (in planner)", "delete the node being edited"},
-			{"c / C (in planner)", "clear ALL planned nodes for active craft (ctrl+k still works)"},
-			{"H", "plant transfer to [t] target body (plane-aware: combined/split)"},
-			{"I", "plant inclination match ([t] target body / equatorial when none)"},
-			{"C", "plant circularize burn at next apoapsis"},
-			{"K", "plant rendezvous nudge to target craft (recommended single-burn)"},
-			{"P", "porkchop plot for selected body"},
-			{"R", "refine plan (re-Lambert arrival)"},
-		}},
-		{"MANUAL FLIGHT", [][2]string{
-			{"z / x", "throttle full / cut"},
-			{"Z / X", "throttle +10% / -10%"},
-			{"w / s", "attitude prograde / retrograde (orient only in main; pulse-fire in rcs)"},
-			{"a / d", "attitude normal+ / normal- (orient only in main; pulse-fire in rcs)"},
-			{"q / e", "attitude radial+ / radial- (orient only in main; pulse-fire in rcs)"},
-			{"W / S", "attitude surface prograde / retrograde — locks to v - ω×r (v0.9.2+)"},
-			{"< / >", "pitch trim ±5° east — held thrust direction tilts off the active mode (v0.9.2+)"},
-			{"?", "reset pitch trim to 0 (v0.9.2+)"},
-			{"b", "engage / cut manual burn (main engine only)"},
-			{"r", "engine: main / rcs (RCS = monoprop pulse-fire on attitude keys)"},
-			{"k", "SAS model: slew / instant (navball [MAN]/[AUT]) (v0.10.0+)"},
-			{";", "NavMode cycle: Orbit → Surface → Target (skips Target when none set) (v0.9.3+)"},
-		}},
-		{"MULTI-CRAFT (v0.8.1+)", [][2]string{
-			{"n", "open spawn form (loadout / position / parent / altitude / dir; Custom = stack builder, [d] dock-seam composites — spawn a CSM+LM ready to U-release, v0.14+)"},
-			{"[ / ]", "cycle active craft (no-op when only one craft)"},
-			{"1-9", "jump to craft N (no-op when slot empty) (v0.12.0+)"},
-			{"U", "undock active composite (v0.8.3+)"},
-			{"D", "transpose: SM → firing core, LM → releasable nose payload (U to release) (v0.12+)"},
-			{"t / T", "cycle / clear target (v0.9.0+)"},
-			{"space", "decouple bottom stage (v0.9.1+); on a bare chute capsule, arms the parachute (v0.12+)"},
-		}},
-		{"PERSISTENCE", [][2]string{
-			{"F5", "quicksave (XDG_STATE_HOME)"},
-			{"F9", "quickload"},
-			{"q", "quit (confirm + autosave)"},
-		}},
-		{"MOUSE (orbit canvas)", [][2]string{
-			{"click body", "focus body (same as ←/→ to land on it)"},
-			{"click vessel", "focus craft"},
-			{"click node", "open planner pre-loaded for that node (edit-replace, canvas glyph or HUD NODES row)"},
-			{"click empty", "open planner staged at projected orbit point"},
-			{"click HUD", "open body info"},
-		}},
-		{"PORKCHOP", [][2]string{
-			{"o", "open transfer-options sub-menu (nRev / direction / branch)"},
-			{"n / r / b", "(sub-menu) cycle nRev / toggle retrograde / toggle short-vs-long branch"},
-			{"enter / esc / o", "(sub-menu) close — re-solves grid with the new options"},
-		}},
-		{"MOUSE (porkchop)", [][2]string{
-			{"click cell", "select that (dep, tof) — press [enter] to plant"},
-		}},
+// helpSections groups every binding into logical sections (player-facing,
+// so no internal version tags). Keep each description short enough to read
+// at ~80 columns; longer rows are ANSI-truncated with an ellipsis.
+var helpSections = []helpSection{
+	{"GENERAL", [][2]string{
+		{"F1", "toggle this help"},
+		{"esc", "back / close (or save/load/settings/quit menu on home)"},
+		{"F5 / F9", "quicksave / quickload"},
+		{"q", "quit (confirm + autosave)"},
+		{"ctrl+c", "quit immediately"},
+	}},
+	{"CAMERA & VIEW", [][2]string{
+		{"f / F", "cycle camera focus forward / back (system → bodies → craft)"},
+		{"g", "reset camera to the whole system"},
+		{"+ / -", "zoom in / out"},
+		{"v", "cycle view (tilted / top / right / bottom / left / flat)"},
+		{"shift+↑ / ↓", "tilt the 3D view up / down (tilted view only)"},
+		{"F2", "declutter — hide chips + navball (core column stays)"},
+	}},
+	{"NAVIGATION", [][2]string{
+		{"→ / l", "move the body cursor next (info / porkchop — not [t] target)"},
+		{"← / h", "move the body cursor previous"},
+		{"tab", "switch star system"},
+		{"i", "body info screen"},
+	}},
+	{"TIME & WARP", [][2]string{
+		{".", "warp up (1× … 100000×)"},
+		{",", "warp down"},
+		{"G", "auto-warp to 30 s before the next burn, then 1×"},
+		{"/", "cancel warp — drop to 1× (also cancels auto-warp)"},
+		{"0", "pause / resume"},
+	}},
+	{"PLAN BURNS", [][2]string{
+		{"m", "open the maneuver planner"},
+		{"enter", "commit the burn (in planner)"},
+		{"ctrl+d", "delete the node being edited (in planner)"},
+		{"c / C", "clear ALL planned nodes for the active craft (in planner)"},
+		{"H", "plant transfer to [t] target body (plane-aware)"},
+		{"I", "plant inclination match ([t] target / equatorial)"},
+		{"C", "plant circularize burn at next apoapsis"},
+		{"K", "plant rendezvous nudge to the target craft"},
+		{"P", "porkchop plot for the body under the cursor"},
+		{"R", "refine plan (re-Lambert the arrival)"},
+	}},
+	{"MANUAL FLIGHT", [][2]string{
+		{"z / x", "throttle full / cut"},
+		{"Z / X", "throttle +10% / -10%"},
+		{"w / s", "attitude prograde / retrograde (rcs: pulse-fire)"},
+		{"a / d", "attitude normal+ / normal- (rcs: pulse-fire)"},
+		{"q / e", "attitude radial+ / radial- (rcs: pulse-fire)"},
+		{"W / S", "attitude surface prograde / retrograde (locks to ground)"},
+		{"< / >", "pitch trim ±5° east off the active mode"},
+		{"?", "reset pitch trim to 0"},
+		{"b", "engage / cut the manual burn (main engine)"},
+		{"r", "engine: main / rcs"},
+		{"k", "SAS model: slew / instant"},
+		{";", "NavMode cycle: Orbit → Surface → Target"},
+	}},
+	{"CRAFT", [][2]string{
+		{"n", "open spawn form (loadout / position / parent / altitude / dir)"},
+		{"[ / ]", "cycle active craft"},
+		{"1-9", "jump to craft N (no-op when the slot is empty)"},
+		{"U", "undock the active composite"},
+		{"D", "transpose: SM → firing core, LM → releasable nose payload"},
+		{"t / T", "cycle / clear the target"},
+		{"space", "decouple bottom stage (bare chute capsule: arm the chute)"},
+	}},
+	{"MOUSE & PORKCHOP", [][2]string{
+		{"click body", "focus that body"},
+		{"click vessel", "focus that craft"},
+		{"click node", "open the planner for that node (canvas glyph or NODES row)"},
+		{"click empty", "open the planner at the projected orbit point"},
+		{"click HUD", "open body info"},
+		{"o", "porkchop: transfer options (nRev / direction / branch)"},
+		{"n / r / b", "porkchop options: cycle nRev / retrograde / short-vs-long"},
+		{"click cell", "porkchop: select a (dep, tof) cell — enter plants it"},
+	}},
+}
+
+// bodyLines builds the scrollable section content (everything between the
+// sticky title and footer), one terminal row per slice element.
+func (h *Help) bodyLines() []string {
+	var lines []string
+	for si, s := range helpSections {
+		if si > 0 {
+			lines = append(lines, "") // blank gap between sections
+		}
+		lines = append(lines, h.theme.Primary.Render(s.header))
+		for _, r := range s.rows {
+			pad := strings.Repeat(" ", maxInt(0, 20-len([]rune(r[0]))))
+			lines = append(lines, "  "+h.theme.Primary.Render(r[0])+pad+r[1])
+		}
 	}
+	return lines
+}
+
+// Render windows the body to the terminal height between a sticky title
+// and footer, and truncates each row to width. Clamps + caches the scroll
+// geometry so HandleKey paging stays in range.
+func (h *Help) Render(width, height int) string {
+	title := h.theme.Title.Render("terminal-space-program — keybindings")
+	body := h.bodyLines()
+
+	const topChrome = 2 // title + blank line
+	const botChrome = 1 // footer
+	viewH := height - topChrome - botChrome
+	if viewH < 1 {
+		viewH = 1
+	}
+	maxScroll := len(body) - viewH
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	h.viewH, h.maxScroll = viewH, maxScroll
+	h.clamp()
+
+	end := h.scroll + viewH
+	if end > len(body) {
+		end = len(body)
+	}
+	window := body[h.scroll:end]
 
 	var b strings.Builder
-	b.WriteString(title)
+	b.WriteString(clipLine(title, width))
 	b.WriteString("\n\n")
-	for _, s := range sections {
-		b.WriteString(h.theme.Primary.Render(s.header))
-		b.WriteByte('\n')
-		for _, r := range s.rows {
-			b.WriteString("  ")
-			b.WriteString(h.theme.Primary.Render(r[0]))
-			b.WriteString(strings.Repeat(" ", maxInt(0, 20-len(r[0]))))
-			b.WriteString(r[1])
-			b.WriteByte('\n')
-		}
+	for _, ln := range window {
+		b.WriteString(clipLine(ln, width))
 		b.WriteByte('\n')
 	}
-	b.WriteString(h.theme.Footer.Render("[F1] or [esc] to close"))
+	// Pad so the footer sits on the bottom row even when the content is
+	// shorter than the viewport (short terminals, last page).
+	for i := len(window); i < viewH; i++ {
+		b.WriteByte('\n')
+	}
+	b.WriteString(clipLine(h.footer(), width))
 	return b.String()
+}
+
+// footer is the sticky bottom row: ▲/▼ markers when more content sits
+// above / below, plus the scroll + close controls.
+func (h *Help) footer() string {
+	marker := "   "
+	switch {
+	case h.scroll > 0 && h.scroll < h.maxScroll:
+		marker = "▲▼ "
+	case h.scroll > 0:
+		marker = "▲  "
+	case h.scroll < h.maxScroll:
+		marker = "▼  "
+	}
+	return h.theme.Footer.Render(marker + "[↑/↓ PgUp/PgDn] scroll   [F1/esc] close")
+}
+
+// HandleKey scrolls the body. Called by the app while the help screen is
+// active; F1/esc closing is handled by the app, not here.
+func (h *Help) HandleKey(msg tea.KeyMsg) {
+	switch msg.String() {
+	case "up", "k":
+		h.ScrollBy(-1)
+	case "down", "j":
+		h.ScrollBy(1)
+	case "pgup", "b":
+		h.Page(-1)
+	case "pgdown", " ":
+		h.Page(1)
+	case "home", "g":
+		h.scroll = 0
+	case "end", "G":
+		h.scroll = h.maxScroll
+	}
+	h.clamp()
+}
+
+// ScrollBy moves the window by n rows (clamped). ResetScroll returns to
+// the top, called when the overlay opens.
+func (h *Help) ScrollBy(n int) { h.scroll += n; h.clamp() }
+func (h *Help) ResetScroll()   { h.scroll = 0 }
+
+// Page moves a near-full viewport in dir (±1), overlapping one row.
+func (h *Help) Page(dir int) { h.ScrollBy(dir * maxInt(1, h.viewH-1)) }
+
+func (h *Help) clamp() {
+	if h.scroll > h.maxScroll {
+		h.scroll = h.maxScroll
+	}
+	if h.scroll < 0 {
+		h.scroll = 0
+	}
+}
+
+// clipLine truncates a (possibly ANSI-styled) line to width display
+// cells, appending an ellipsis only when it actually cuts.
+func clipLine(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	return ansi.Truncate(s, width, "…")
 }
 
 func maxInt(a, b int) int {

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -22,7 +22,7 @@ func (h *Help) Render() string {
 		{"GLOBAL", [][2]string{
 			{"esc", "back / close (or open save/load/settings/quit menu on home)"},
 			{"ctrl+c", "quit (immediate)"},
-			{"?", "toggle this help"},
+			{"F1", "toggle this help"},
 		}},
 		{"NAVIGATION", [][2]string{
 			{"→ / l", "select next body (info / porkchop cursor — not the [t] target)"},
@@ -65,7 +65,7 @@ func (h *Help) Render() string {
 			{"q / e", "attitude radial+ / radial- (orient only in main; pulse-fire in rcs)"},
 			{"W / S", "attitude surface prograde / retrograde — locks to v - ω×r (v0.9.2+)"},
 			{"< / >", "pitch trim ±5° east — held thrust direction tilts off the active mode (v0.9.2+)"},
-			{"\\", "reset pitch trim to 0 (v0.9.2+)"},
+			{"?", "reset pitch trim to 0 (v0.9.2+)"},
 			{"b", "engage / cut manual burn (main engine only)"},
 			{"r", "engine: main / rcs (RCS = monoprop pulse-fire on attitude keys)"},
 			{"k", "SAS model: slew / instant (navball [MAN]/[AUT]) (v0.10.0+)"},
@@ -117,7 +117,7 @@ func (h *Help) Render() string {
 		}
 		b.WriteByte('\n')
 	}
-	b.WriteString(h.theme.Footer.Render("[?] or [esc] to close"))
+	b.WriteString(h.theme.Footer.Render("[F1] or [esc] to close"))
 	return b.String()
 }
 

--- a/internal/tui/screens/help_test.go
+++ b/internal/tui/screens/help_test.go
@@ -1,0 +1,131 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// helpKey makes a KeyMsg from a key name for driving Help.HandleKey.
+func helpKey(s string) tea.KeyMsg {
+	switch s {
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "pgdown":
+		return tea.KeyMsg{Type: tea.KeyPgDown}
+	case "pgup":
+		return tea.KeyMsg{Type: tea.KeyPgUp}
+	case "end":
+		return tea.KeyMsg{Type: tea.KeyEnd}
+	case "home":
+		return tea.KeyMsg{Type: tea.KeyHome}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+// TestHelpScrollsToLastSection — the bottom section is unreachable in the
+// top window but visible after scrolling to the end (the reported bug).
+func TestHelpScrollsToLastSection(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	const w, ht = 100, 20
+
+	top := h.Render(w, ht)
+	if !strings.Contains(top, "keybindings") {
+		t.Error("title missing from the top of the overlay")
+	}
+	if strings.Contains(top, "MOUSE & PORKCHOP") {
+		t.Fatalf("setup invalid: last section already visible at height %d — pick a shorter height", ht)
+	}
+
+	h.HandleKey(helpKey("end"))
+	bottom := h.Render(w, ht)
+	if !strings.Contains(bottom, "MOUSE & PORKCHOP") || !strings.Contains(bottom, "click cell") {
+		t.Errorf("last section not reachable after End:\n%s", bottom)
+	}
+}
+
+// TestHelpScrollClamps — scroll can't go above the top or past the end.
+func TestHelpScrollClamps(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	const w, ht = 100, 20
+	h.Render(w, ht) // populate geometry
+
+	h.HandleKey(helpKey("up")) // already at top
+	if h.scroll != 0 {
+		t.Errorf("scroll went above the top: %d", h.scroll)
+	}
+
+	h.HandleKey(helpKey("end"))
+	atEnd := h.scroll
+	h.HandleKey(helpKey("down")) // past the end
+	h.HandleKey(helpKey("pgdown"))
+	if h.scroll != atEnd {
+		t.Errorf("scroll ran past the end: %d, want %d", h.scroll, atEnd)
+	}
+	if h.scroll != h.maxScroll {
+		t.Errorf("end scroll %d != maxScroll %d", h.scroll, h.maxScroll)
+	}
+}
+
+// TestHelpResetScroll — opening returns to the top.
+func TestHelpResetScroll(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	h.Render(100, 20)
+	h.HandleKey(helpKey("end"))
+	if h.scroll == 0 {
+		t.Fatal("setup: expected a non-zero scroll after End")
+	}
+	h.ResetScroll()
+	if h.scroll != 0 {
+		t.Errorf("ResetScroll left scroll at %d, want 0", h.scroll)
+	}
+}
+
+// TestHelpPageAdvancesViewport — PgDn moves a near-full viewport.
+func TestHelpPageAdvancesViewport(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	const ht = 24
+	h.Render(100, ht)
+	before := h.scroll
+	h.HandleKey(helpKey("pgdown"))
+	moved := h.scroll - before
+	if moved < h.viewH-2 || moved > h.viewH {
+		t.Errorf("PgDn moved %d rows, want ~viewH (%d)", moved, h.viewH)
+	}
+}
+
+// TestHelpTruncatesToWidth — no rendered row exceeds the width, so long
+// rows never wrap and desync the 1-entry-per-row scroll math.
+func TestHelpTruncatesToWidth(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	const w = 50
+	out := h.Render(w, 30)
+	for i, ln := range strings.Split(out, "\n") {
+		if lw := lipgloss.Width(ln); lw > w {
+			t.Errorf("row %d width %d exceeds %d: %q", i, lw, w, ln)
+		}
+	}
+}
+
+// TestHelpTitleAndFooterAlwaysShown — chrome is sticky regardless of
+// scroll position, even on a short terminal.
+func TestHelpTitleAndFooterAlwaysShown(t *testing.T) {
+	h := NewHelp(chipTestTheme())
+	for _, ht := range []int{8, 20, 60} {
+		h.ResetScroll()
+		top := h.Render(80, ht)
+		if !strings.Contains(top, "keybindings") || !strings.Contains(top, "close") {
+			t.Errorf("height %d: title/footer missing at top:\n%s", ht, top)
+		}
+		h.HandleKey(helpKey("end"))
+		bot := h.Render(80, ht)
+		if !strings.Contains(bot, "keybindings") || !strings.Contains(bot, "close") {
+			t.Errorf("height %d: title/footer missing at bottom:\n%s", ht, bot)
+		}
+	}
+}


### PR DESCRIPTION
Three related keybinding/UX changes (stacked).

## 1. `/` cancel-warp (`fcb247c`)
New `/` key: drop Selected Warp straight to 1× from any level and disengage Auto-Warp if engaged — a single "stop accelerating time" key. Pause state untouched.

## 2. Help → F1, clear-trim → `?` (`5efd10f`)
Frees the `/`–`?` physical key for flight: `?` now resets pitch trim (was `\`), pairing with `/` cancel-warp on one key. Help moves to the conventional **F1** (toggle + esc still close). Help overlay, `docs/controls.md`, and the `CLAUDE.md` source-of-truth note updated.

## 3. Scrollable, regrouped help overlay (`6cd8348`)
The ~84-line overlay overflowed any normal terminal with no way to reach the bottom. Now:
- `Help.Render(width, height)` windows the body between a sticky title + footer, ANSI-truncates each row to width (one entry = one row), clamps/caches the scroll geometry. `HandleKey` drives ↑/↓ (j/k), PgUp/PgDn (b/space), Home/End (g/G); footer shows ▲/▼ more-markers.
- `app.go` routes scroll keys in a `screenHelp` block before the global switch (no leak to flight); resets to top on open.
- Regrouped the 10 ad-hoc sections into 8 logical groups, dropped internal version tags, trimmed wordy rows. All bindings preserved.

## Tests
New coverage: `/` cancel-warp dispatch; F1=help / `?`=trim-reset lock; help scroll (last section reachable at End, clamps both ends, reset-on-open, page size, width-truncation, sticky chrome). Full suite **1033 passing**, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)