### PR TITLE
feat(help): move porkchop keys into the PLAN BURNS section

### DIFF
--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -70,8 +70,11 @@ var helpSections = []helpSection{
 		{"I", "plant inclination match ([t] target / equatorial)"},
 		{"C", "plant circularize burn at next apoapsis"},
 		{"K", "plant rendezvous nudge to the target craft"},
-		{"P", "porkchop plot for the body under the cursor"},
 		{"R", "refine plan (re-Lambert the arrival)"},
+		{"P", "porkchop plot for the body under the cursor"},
+		{"o", "porkchop: transfer options (nRev / direction / branch)"},
+		{"n / r / b", "porkchop options: cycle nRev / retrograde / short-vs-long"},
+		{"click cell", "porkchop: select a (dep, tof) cell — enter plants it"},
 	}},
 	{"MANUAL FLIGHT", [][2]string{
 		{"z / x", "throttle full / cut"},
@@ -96,15 +99,12 @@ var helpSections = []helpSection{
 		{"t / T", "cycle / clear the target"},
 		{"space", "decouple bottom stage (bare chute capsule: arm the chute)"},
 	}},
-	{"MOUSE & PORKCHOP", [][2]string{
+	{"MOUSE", [][2]string{
 		{"click body", "focus that body"},
 		{"click vessel", "focus that craft"},
 		{"click node", "open the planner for that node (canvas glyph or NODES row)"},
 		{"click empty", "open the planner at the projected orbit point"},
 		{"click HUD", "open body info"},
-		{"o", "porkchop: transfer options (nRev / direction / branch)"},
-		{"n / r / b", "porkchop options: cycle nRev / retrograde / short-vs-long"},
-		{"click cell", "porkchop: select a (dep, tof) cell — enter plants it"},
 	}},
 }
 

--- a/internal/tui/screens/help_test.go
+++ b/internal/tui/screens/help_test.go
@@ -38,13 +38,13 @@ func TestHelpScrollsToLastSection(t *testing.T) {
 	if !strings.Contains(top, "keybindings") {
 		t.Error("title missing from the top of the overlay")
 	}
-	if strings.Contains(top, "MOUSE & PORKCHOP") {
+	if strings.Contains(top, "click HUD") {
 		t.Fatalf("setup invalid: last section already visible at height %d — pick a shorter height", ht)
 	}
 
 	h.HandleKey(helpKey("end"))
 	bottom := h.Render(w, ht)
-	if !strings.Contains(bottom, "MOUSE & PORKCHOP") || !strings.Contains(bottom, "click cell") {
+	if !strings.Contains(bottom, "MOUSE") || !strings.Contains(bottom, "click HUD") {
 		t.Errorf("last section not reachable after End:\n%s", bottom)
 	}
 }


### PR DESCRIPTION
Porkchop is transfer planning, so its keys belong with the maneuver/plan group rather than under MOUSE.

- `P` plot, `o` / `n / r / b` options, and `click cell` select now cluster at the end of the **PLAN BURNS** section.
- The trailing section is plain **MOUSE** (orbit-canvas clicks only).
- Scroll-reachability test updated for the new last section.

Help-overlay content only; `docs/controls.md` already has its own dedicated Porkchop section, so no bindings desync. Full suite 1033 passing, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)