### PR TITLE
feat(hud): rename the LAUNCH chip header to SURFACE

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -66,7 +66,7 @@ var chipLabels = map[Chip]string{
 	ChipTarget:          "Target",
 	ChipStages:          "Stages",
 	ChipNodes:           "Maneuver nodes",
-	ChipLaunch:          "Launch",
+	ChipLaunch:          "Surface",
 	ChipDescent:         "Descent",
 	ChipChute:           "Chute",
 	ChipCapture:         "Capture preview",

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -286,7 +286,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		fpaOrbitLabel = fmt.Sprintf("%.0f° (inertial)", nzero(fpaOrbitDeg, 0))
 	}
 	lines := []string{
-		v.theme.Primary.Render("LAUNCH"),
+		v.theme.Primary.Render("SURFACE"),
 		fmt.Sprintf("  altitude:   %s", altLabel),
 		fmt.Sprintf("  v_vert:     %.1f m/s", nzero(vVert, 1)),
 		fmt.Sprintf("  v_horiz:    %.0f m/s (surface-rel)", vHoriz),

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -116,14 +116,14 @@ func TestAscentSuppressesOrbitMetricsChip(t *testing.T) {
 	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vAtPeri, 0
 
 	out := v.Render(w, 0, 200, 60)
-	if !strings.Contains(out, "LAUNCH") {
-		t.Fatal("expected LAUNCH chip during ascent")
+	if !strings.Contains(out, "SURFACE") {
+		t.Fatal("expected SURFACE (launch/ascent) chip during ascent")
 	}
 	if !strings.Contains(out, "  ap:") || !strings.Contains(out, "  sas:") {
-		t.Errorf("expected LAUNCH ap/sas rows during ascent.\nrender:\n%s", out)
+		t.Errorf("expected SURFACE ap/sas rows during ascent.\nrender:\n%s", out)
 	}
 	// The Orbit-metrics chip (its rows use the "apoapsis:" prefix) is
-	// suppressed during ascent — LAUNCH already carries ap/pe.
+	// suppressed during ascent — the SURFACE chip already carries ap/pe.
 	if strings.Contains(out, "apoapsis:") {
 		t.Errorf("expected Orbit-metrics chip suppressed during ascent (LAUNCH carries ap/pe).\nrender:\n%s", out)
 	}
@@ -136,8 +136,8 @@ func TestAscentSuppressesOrbitMetricsChip(t *testing.T) {
 	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vCirc, 0
 
 	out = v.Render(w, 0, 200, 60)
-	if strings.Contains(out, "LAUNCH") {
-		t.Errorf("expected LAUNCH chip to vanish once periapsis clears the atmosphere.\nrender:\n%s", out)
+	if strings.Contains(out, "SURFACE") {
+		t.Errorf("expected SURFACE chip to vanish once periapsis clears the atmosphere.\nrender:\n%s", out)
 	}
 	if !strings.Contains(out, "apoapsis:") {
 		t.Errorf("expected Orbit-metrics chip apoapsis row in stable orbit.\nrender:\n%s", out)
@@ -178,8 +178,8 @@ func TestOrbitMetricsChipShowsTimeToApsides(t *testing.T) {
 	c.State.V.X, c.State.V.Y, c.State.V.Z = 0, vAtPeri, 0
 
 	out := v.Render(w, 0, 200, 60)
-	if strings.Contains(out, "LAUNCH") {
-		t.Fatalf("expected the ORBIT chip, not LAUNCH, for an orbit clear of the atmosphere.\nrender:\n%s", out)
+	if strings.Contains(out, "SURFACE") {
+		t.Fatalf("expected the ORBIT chip, not SURFACE, for an orbit clear of the atmosphere.\nrender:\n%s", out)
 	}
 	if !strings.Contains(out, "t→apo:") {
 		t.Errorf("expected a t→apo row in the ORBIT chip.\nrender:\n%s", out)


### PR DESCRIPTION
The ascent instrument chip now reads **SURFACE** when it triggers.

- Chip header `LAUNCH` → `SURFACE`.
- Settings toggle label `Launch` → `Surface` so the toggle matches the renamed chip.
- Internal id (`ChipLaunch` / `"launch"`) unchanged — persisted settings still resolve.
- ViewLaunch chase-cam **screen title** (`LAUNCH — <craft>`) left as-is (this is the chip, not the screen title).
- `orbit_test.go` header assertions updated.

Full suite 1033 passing, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)