### PR TITLE
fix(hud): orbit-direction readout + lunar retrograde-burn regression guard (#63)

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -33,6 +33,7 @@ const (
 	ChipCapture         Chip = "capture"
 	ChipFrameTransition Chip = "frameTransition"
 	ChipAttitude        Chip = "attitude"
+	ChipProjectedOrbit  Chip = "projectedOrbit"
 )
 
 // Note: the Orbit-metrics readout and the active-burn (BURNS) readout are
@@ -57,6 +58,7 @@ var AllChips = []Chip{
 	ChipCapture,
 	ChipFrameTransition,
 	ChipAttitude,
+	ChipProjectedOrbit,
 }
 
 // chipLabels maps each Chip to the human-readable name the Settings
@@ -72,6 +74,7 @@ var chipLabels = map[Chip]string{
 	ChipCapture:         "Capture preview",
 	ChipFrameTransition: "Frame transition",
 	ChipAttitude:        "Attitude",
+	ChipProjectedOrbit:  "Projected orbit",
 }
 
 // Label returns the display name for c, falling back to the raw key for

--- a/internal/sim/retrograde_lunar_burn_test.go
+++ b/internal/sim/retrograde_lunar_burn_test.go
@@ -1,0 +1,194 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// retrograde_lunar_burn_test.go is the disambiguation harness for issue
+// #63: "retrograde burn at low lunar orbit appears to reverse direction."
+// The physics says a 1× retrograde burn lasting a few seconds delivers
+// only tens-to-hundreds of m/s — two orders of magnitude short of the
+// ~1.6 km/s needed to flip the orbit. These tests fire the REAL burn
+// path (ActiveBurn + World.Tick at 1× warp) on a craft deep inside the
+// Moon's SOI and assert:
+//
+//   - a modest retrograde Δv does NOT flip the specific-angular-momentum
+//     sign (no reversal) and leaves apo/peri sane — the "this can't be a
+//     real bug" guard (issue action 2), which also exercises the live-burn
+//     velocity frame for a secondary-SOI craft (issue action 3: the burn
+//     must read Moon-relative −v̂, not a frame-mixed velocity);
+//   - reversal only appears once the applied Δv approaches the circular
+//     speed (~1.66 km/s at 45 km), confirming the order-of-magnitude
+//     argument in the report.
+
+// lunarOrbitBurner binds the active craft to the Moon on a prograde
+// circular orbit at altKm, gives it a single high-thrust well-fuelled
+// stage, and plants a running retrograde finite burn owing dvRemaining.
+// The orbit is built in the body-equatorial frame so the
+// specific-angular-momentum vector points along +Z_eq (prograde); the
+// caller reads it back via equatorialAngularMomentumZ. Returns the craft
+// and the equatorial frame used to build the orbit.
+func lunarOrbitBurner(t *testing.T, w *World, altKm, dvRemaining float64) (*spacecraft.Spacecraft, orbital.BodyFrame) {
+	t.Helper()
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		t.Skip("Moon not in default system")
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	c.Primary = *moon
+
+	mu := moon.GravitationalParameter()
+	r := moon.RadiusMeters() + altKm*1000
+	vCirc := math.Sqrt(mu / r)
+
+	// Build the circular orbit in the equatorial basis: position along
+	// +X_eq, velocity along +Y_eq → h = r×v along +Z_eq (prograde), then
+	// rotate into the world inertial basis the state vector lives in.
+	frame := orbital.ReferenceFrameForPrimary(*moon)
+	rEq := orbital.Vec3{X: r, Y: 0, Z: 0}
+	vEq := orbital.Vec3{X: 0, Y: vCirc, Z: 0}
+
+	// Ample thrust + fuel so even the ~1.6 km/s reversal case completes
+	// in a bounded number of ticks; the burn path, not the stage, is the
+	// subject under test.
+	c.Stages = []spacecraft.Stage{
+		{Name: "S-IVB", DryMass: 11000, FuelMass: 90000, FuelCapacity: 90000, Thrust: 1_023_000, Isp: 421},
+	}
+	c.SyncFields()
+	c.State = physics.StateVector{
+		R: frame.ToWorld(rEq),
+		V: frame.ToWorld(vEq),
+		M: c.TotalMass(),
+	}
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnRetrograde,
+		DVRemaining: dvRemaining,
+		EndTime:     w.Clock.SimTime.Add(30 * time.Minute),
+		PrimaryID:   moon.ID,
+		Throttle:    1,
+	}
+	return c, frame
+}
+
+// equatorialAngularMomentumZ returns the Z component of the specific
+// angular momentum h = r×v expressed in the equatorial frame. Its sign
+// is the orbit-direction invariant: > 0 prograde, < 0 retrograde. The
+// burn cannot flip this without driving the tangential speed through
+// zero (Δv ≈ v_circ).
+func equatorialAngularMomentumZ(c *spacecraft.Spacecraft, frame orbital.BodyFrame) float64 {
+	hWorld := c.State.R.Cross(c.State.V)
+	return frame.FromWorld(hWorld).Z
+}
+
+// TestModestRetrogradeBurnDoesNotReverseLunarOrbit: a 300 m/s retrograde
+// burn (well above the few-seconds-at-1× figure in the report, still far
+// below v_circ) from a 45 km prograde lunar orbit lowers periapsis but
+// must NOT flip the angular-momentum sign, drive an apsis negative, or
+// tip the orbit past 90° inclination. This is the core "render artifact,
+// not a real reversal" guard.
+func TestModestRetrogradeBurnDoesNotReverseLunarOrbit(t *testing.T) {
+	w := mustWorld(t)
+	c, frame := lunarOrbitBurner(t, w, 45, 300)
+	mu := c.Primary.GravitationalParameter()
+
+	hBefore := equatorialAngularMomentumZ(c, frame)
+	if hBefore <= 0 {
+		t.Fatalf("setup: orbit should start prograde (h_z > 0), got %.3e", hBefore)
+	}
+
+	if _, ok := tickUntil(w, 20000, func() bool { return c.ActiveBurn == nil }); !ok {
+		t.Fatalf("burn never completed within tick budget (DVRemaining=%.1f)", c.ActiveBurn.DVRemaining)
+	}
+
+	hAfter := equatorialAngularMomentumZ(c, frame)
+	if hAfter <= 0 {
+		t.Errorf("angular-momentum sign flipped after a 300 m/s retrograde burn "+
+			"(h_z %.3e → %.3e): orbit reversed, which is physically impossible "+
+			"at this Δv — frame or direction bug", hBefore, hAfter)
+	}
+
+	el := orbital.ElementsFromStateInFrame(c.State.R, c.State.V, mu, frame)
+	if el.I >= math.Pi/2 {
+		t.Errorf("inclination tipped retrograde: %.2f° (want < 90°)", el.I*180/math.Pi)
+	}
+	if el.E >= 1 || math.IsNaN(el.A) || el.A <= 0 {
+		t.Fatalf("orbit became unbound/degenerate: a=%.0f e=%.3f", el.A, el.E)
+	}
+	moonR := c.Primary.RadiusMeters()
+	apoAlt := (el.Apoapsis() - moonR) / 1000
+	periAlt := (el.Periapsis() - moonR) / 1000
+	// A retrograde burn at this point pins it as the high apsis, so
+	// apoapsis stays ≈ 45 km and periapsis drops. Both must stay finite
+	// and apoapsis must not run away.
+	if apoAlt < 40 || apoAlt > 60 {
+		t.Errorf("apoapsis swung out of band: %.1f km alt (want ≈45)", apoAlt)
+	}
+	if periAlt >= apoAlt {
+		t.Errorf("periapsis %.1f km not below apoapsis %.1f km after retrograde burn", periAlt, apoAlt)
+	}
+	t.Logf("after 300 m/s retrograde: apo=%.1f km peri=%.1f km i=%.2f° h_z=%.3e",
+		apoAlt, periAlt, el.I*180/math.Pi, hAfter)
+}
+
+// TestLunarOrbitReversalNeedsNearCircularDV: reversal IS reachable, but
+// only once the applied retrograde Δv reaches the circular speed
+// (~1.66 km/s at 45 km) — two orders of magnitude beyond the tens-to-
+// hundreds of m/s a few-second 1× burn delivers. (A *sustained* burn
+// can't even get there: it drives periapsis into the surface and the
+// craft impacts before the orbit reverses, so the threshold is shown
+// impulsively.) Each impulse is applied along the production retrograde
+// direction — spacecraft.DirectionUnit(BurnRetrograde, r, v) — so this
+// also pins that vector to the Moon-relative −v̂ the live burn must use.
+func TestLunarOrbitReversalNeedsNearCircularDV(t *testing.T) {
+	w := mustWorld(t)
+	c, frame := lunarOrbitBurner(t, w, 45, 0) // dv unused; we apply impulses directly
+	mu := c.Primary.GravitationalParameter()
+
+	r0, v0 := c.State.R, c.State.V
+	vCirc := math.Sqrt(mu / r0.Norm())
+	if vCirc < 1500 || vCirc > 1800 {
+		t.Fatalf("setup: v_circ at 45 km = %.0f m/s, expected ≈1660 (issue's ~1.6 km/s)", vCirc)
+	}
+
+	// h_z(Δv) for a single retrograde impulse of magnitude dv applied to
+	// the circular state, read in the equatorial frame. The retrograde
+	// unit vector comes from production code, not hand-rolled here.
+	hZ := func(dv float64) float64 {
+		dir := spacecraft.DirectionUnit(spacecraft.BurnRetrograde, r0, v0)
+		v := v0.Add(dir.Scale(dv))
+		return frame.FromWorld(r0.Cross(v)).Z
+	}
+
+	cases := []struct {
+		dv       float64
+		wantSign string // "+" prograde (no reversal), "-" retrograde (reversed)
+	}{
+		{300, "+"},        // the report's worst-case 1× burn — nowhere near reversal
+		{vCirc - 50, "+"}, // still prograde right up to the circular speed
+		{vCirc + 50, "-"}, // just past v_circ the orbit finally reverses
+		{2000, "-"},       // comfortably reversed
+	}
+	for _, tc := range cases {
+		got := hZ(tc.dv)
+		sign := "+"
+		if got < 0 {
+			sign = "-"
+		}
+		if sign != tc.wantSign {
+			t.Errorf("Δv=%.0f m/s (v_circ=%.0f): h_z=%.3e sign %q, want %q",
+				tc.dv, vCirc, got, sign, tc.wantSign)
+		}
+	}
+	t.Logf("reversal threshold = v_circ = %.0f m/s; a 300 m/s 1× burn leaves h_z=%.3e (prograde)",
+		vCirc, hZ(300))
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -527,6 +527,7 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 				fmt.Sprintf("  apoapsis:  %.1f km alt", (ro.ApoMeters-primaryR)/1000),
 				fmt.Sprintf("  periapsis: %.1f km alt", (ro.PeriMeters-primaryR)/1000),
 				fmt.Sprintf("  inclin.:   %.2f°", ro.Inclination*180/math.Pi),
+				fmt.Sprintf("  direction: %s", v.orbitDirectionLabel(ro.Inclination)),
 			)
 			const equatorialTol = 1e-3
 			if ro.Inclination < equatorialTol || math.Abs(ro.Inclination-math.Pi) < equatorialTol {
@@ -568,6 +569,7 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		lines = append(lines, chipRow("t→peri:", formatDurationShort(tPeri)))
 	}
 	lines = append(lines, chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)))
+	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
 	}
@@ -691,6 +693,21 @@ const chipValueCol = 13
 // column instead of drifting per label. Padding is measured in display
 // cells (lipgloss.Width), so multibyte labels like "Δi:" and styled values
 // align correctly where byte-counted %-Ns padding would not.
+// orbitDirectionLabel renders the prograde/retrograde orbit-direction
+// readout for an equatorial-frame inclination (radians). i > 90° means
+// the orbit runs retrograde — against the primary's spin. This is the
+// instrument that disambiguates a genuine orbit reversal from a
+// projection / day-night-shading artifact near the disk edge (issue
+// #63): the on-screen position can mislead, but the direction label is
+// ground truth. Prograde is the unremarkable case (plain text);
+// retrograde is flagged.
+func (v *OrbitView) orbitDirectionLabel(incRad float64) string {
+	if incRad > math.Pi/2 {
+		return v.theme.Alert.Render("retrograde")
+	}
+	return "prograde"
+}
+
 func chipRow(label, value string) string {
 	prefix := "  " + label
 	pad := chipValueCol - lipgloss.Width(prefix)

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -63,6 +63,10 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// Settings screen, mirroring the always-on ● BURNS readout — both are
 	// too load-bearing to toggle off. F2 declutter still clears them.
 	add("", cornerTopRight, v.buildOrbitMetricsChip(w))
+	// PROJECTED ORBIT is its own chip beneath the always-on ORBIT readout
+	// (issue #63 follow-up) so current + projected show together during a
+	// burn. Toggleable, unlike the load-bearing live ORBIT above it.
+	add(settings.ChipProjectedOrbit, cornerTopRight, v.buildProjectedOrbitChip(w))
 	add(settings.ChipTarget, cornerTopRight, v.buildTargetChip(w))
 	// Remaining fixed corners.
 	add(settings.ChipStages, cornerBottomLeft, v.buildStagesChip(w))
@@ -493,12 +497,14 @@ func (v *OrbitView) buildChuteChip(w *sim.World) []string {
 	return lines
 }
 
-// buildOrbitMetricsChip is the top-right orbit-shape readout. It shows the
-// projected post-burn orbit once resolved nodes are planted (the old
-// PROJECTED ORBIT block) and otherwise the live current orbit shape (the
-// rows the slim column dropped from VESSEL). Suppressed during ascent —
-// the LAUNCH chip already carries ap/pe there. Returns nil when no
-// meaningful orbit shape exists (degenerate / no craft).
+// buildOrbitMetricsChip is the always-on top-right ORBIT readout: the
+// live current orbit shape (altitude / apo / peri / t→apo / t→peri /
+// inclination / direction). Suppressed during ascent — the LAUNCH chip
+// already carries ap/pe there — and for degenerate / hyperbolic states.
+// The projected post-burn orbit is a SEPARATE chip
+// (buildProjectedOrbitChip, issue #63 follow-up) so the player sees the
+// current and projected orbits side by side while planning a burn,
+// instead of the live orbit being replaced by the projection.
 func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	if !w.CraftVisibleHere() {
 		return nil
@@ -506,40 +512,6 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	c := w.ActiveCraft()
 	if c == nil {
 		return nil
-	}
-	if state, primary, ok := w.PredictedFinalOrbit(); ok {
-		mu := primary.GravitationalParameter()
-		frame := orbital.ReferenceFrameForPrimary(primary)
-		ro := orbital.OrbitReadoutInFrame(state.R, state.V, mu, frame)
-		primaryR := primary.RadiusMeters()
-		lines := []string{
-			v.theme.Primary.Render("PROJECTED ORBIT"),
-			fmt.Sprintf("  primary:   %s", primary.EnglishName),
-		}
-		if ro.Hyperbolic {
-			lines = append(lines,
-				"  "+v.theme.Warning.Render("hyperbolic — escape"),
-				fmt.Sprintf("  periapsis: %.1f km alt", (ro.PeriMeters-primaryR)/1000),
-				fmt.Sprintf("  e:         %.3f", ro.Eccentricity),
-			)
-		} else {
-			lines = append(lines,
-				fmt.Sprintf("  apoapsis:  %.1f km alt", (ro.ApoMeters-primaryR)/1000),
-				fmt.Sprintf("  periapsis: %.1f km alt", (ro.PeriMeters-primaryR)/1000),
-				fmt.Sprintf("  inclin.:   %.2f°", ro.Inclination*180/math.Pi),
-				fmt.Sprintf("  direction: %s", v.orbitDirectionLabel(ro.Inclination)),
-			)
-			const equatorialTol = 1e-3
-			if ro.Inclination < equatorialTol || math.Abs(ro.Inclination-math.Pi) < equatorialTol {
-				lines = append(lines, v.theme.Dim.Render("  AN/DN:     equatorial"))
-			} else {
-				lines = append(lines,
-					fmt.Sprintf("  AN angle:  %.1f°", normalizeDeg(ro.AscNode*180/math.Pi)),
-					fmt.Sprintf("  DN angle:  %.1f°", normalizeDeg(ro.DescNode*180/math.Pi)),
-				)
-			}
-		}
-		return lines
 	}
 	// Live current orbit shape. Suppressed during ascent (LAUNCH chip
 	// carries ap/pe) and for degenerate/hyperbolic states.
@@ -572,6 +544,56 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+	}
+	return lines
+}
+
+// buildProjectedOrbitChip is the PROJECTED ORBIT readout — the projected
+// post-burn orbit once resolved nodes (or a live burn) are planted,
+// expressed in the primary's reference frame. Returns nil when no
+// projection is available, so it surfaces only while a burn is
+// planned/in flight, stacked beneath the always-on ORBIT chip. Split out
+// of buildOrbitMetricsChip (issue #63 follow-up) so the current and
+// projected orbits show simultaneously rather than the projection
+// replacing the live readout.
+func (v *OrbitView) buildProjectedOrbitChip(w *sim.World) []string {
+	if !w.CraftVisibleHere() || w.ActiveCraft() == nil {
+		return nil
+	}
+	state, primary, ok := w.PredictedFinalOrbit()
+	if !ok {
+		return nil
+	}
+	mu := primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(primary)
+	ro := orbital.OrbitReadoutInFrame(state.R, state.V, mu, frame)
+	primaryR := primary.RadiusMeters()
+	lines := []string{
+		v.theme.Primary.Render("PROJECTED ORBIT"),
+		fmt.Sprintf("  primary:   %s", primary.EnglishName),
+	}
+	if ro.Hyperbolic {
+		lines = append(lines,
+			"  "+v.theme.Warning.Render("hyperbolic — escape"),
+			fmt.Sprintf("  periapsis: %.1f km alt", (ro.PeriMeters-primaryR)/1000),
+			fmt.Sprintf("  e:         %.3f", ro.Eccentricity),
+		)
+	} else {
+		lines = append(lines,
+			fmt.Sprintf("  apoapsis:  %.1f km alt", (ro.ApoMeters-primaryR)/1000),
+			fmt.Sprintf("  periapsis: %.1f km alt", (ro.PeriMeters-primaryR)/1000),
+			fmt.Sprintf("  inclin.:   %.2f°", ro.Inclination*180/math.Pi),
+			fmt.Sprintf("  direction: %s", v.orbitDirectionLabel(ro.Inclination)),
+		)
+		const equatorialTol = 1e-3
+		if ro.Inclination < equatorialTol || math.Abs(ro.Inclination-math.Pi) < equatorialTol {
+			lines = append(lines, v.theme.Dim.Render("  AN/DN:     equatorial"))
+		} else {
+			lines = append(lines,
+				fmt.Sprintf("  AN angle:  %.1f°", normalizeDeg(ro.AscNode*180/math.Pi)),
+				fmt.Sprintf("  DN angle:  %.1f°", normalizeDeg(ro.DescNode*180/math.Pi)),
+			)
+		}
 	}
 	return lines
 }

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -392,6 +392,40 @@ func TestOrbitMetricsAlwaysOnAndLiveBurnForceShows(t *testing.T) {
 	}
 }
 
+// TestOrbitMetricsShowsDirectionIndicator — issue #63: the ORBIT chip
+// carries an explicit prograde/retrograde orbit-direction readout so a
+// genuine reversal is never confused with a projection/shading artifact.
+// Default LEO reads prograde; flipping the velocity (h sign reverses →
+// inclination crosses 90°) flips the readout to retrograde.
+func TestOrbitMetricsShowsDirectionIndicator(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	joined := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if !strings.Contains(joined, "direction:") {
+		t.Fatalf("ORBIT chip missing the direction readout:\n%s", joined)
+	}
+	if !strings.Contains(joined, "prograde") {
+		t.Errorf("default LEO should read prograde:\n%s", joined)
+	}
+
+	// Reverse the orbit: negating v flips h = r×v, pushing inclination
+	// past 90° → retrograde.
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+	c.State.V = c.State.V.Scale(-1)
+	joined = strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if !strings.Contains(joined, "retrograde") {
+		t.Errorf("reversed orbit should read retrograde:\n%s", joined)
+	}
+}
+
 // TestActiveCraftGlyphWinsOverlappingCell — regression for the lunar-orbit
 // staging report ("descent module disappears when I stage it"). A
 // just-jettisoned stage spawns ~60 m from the active craft — sub-pixel at

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -426,6 +426,52 @@ func TestOrbitMetricsShowsDirectionIndicator(t *testing.T) {
 	}
 }
 
+// TestProjectedOrbitIsSeparateChip — issue #63 follow-up: the projected
+// post-burn orbit is its own PROJECTED ORBIT chip stacked beneath the
+// always-on ORBIT chip, so planting a node shows the current and
+// projected orbits simultaneously instead of the projection replacing
+// the live readout.
+func TestProjectedOrbitIsSeparateChip(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	// No node planted: the live ORBIT chip renders, the projected chip
+	// is absent.
+	if got := v.buildProjectedOrbitChip(w); got != nil {
+		t.Errorf("projected chip should be nil with no planted node, got:\n%s", strings.Join(got, "\n"))
+	}
+	cur := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if !strings.Contains(cur, "ORBIT") || strings.Contains(cur, "PROJECTED ORBIT") {
+		t.Fatalf("expected the live ORBIT chip with no node planted:\n%s", cur)
+	}
+
+	// Plant a resolved prograde node → both chips render together.
+	w.PlanNode(sim.ManeuverNode{
+		TriggerTime: w.Clock.SimTime.Add(30 * time.Minute),
+		Mode:        spacecraft.BurnPrograde,
+		DV:          100,
+		PrimaryID:   w.ActiveCraft().Primary.ID,
+	})
+	cur = strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	proj := strings.Join(v.buildProjectedOrbitChip(w), "\n")
+	if !strings.Contains(cur, "altitude:") || strings.Contains(cur, "PROJECTED ORBIT") {
+		t.Errorf("the current ORBIT chip must stay live (not replaced by the projection):\n%s", cur)
+	}
+	if !strings.Contains(proj, "PROJECTED ORBIT") {
+		t.Errorf("the projected chip must render once a node is planted:\n%s", proj)
+	}
+
+	// End to end: both headers appear in a rendered frame.
+	out := v.Render(w, 0, 120, 40)
+	if !strings.Contains(out, "ORBIT") || !strings.Contains(out, "PROJECTED ORBIT") {
+		t.Errorf("a rendered frame with a planted node must show both ORBIT and PROJECTED ORBIT:\n%s", out)
+	}
+}
+
 // TestActiveCraftGlyphWinsOverlappingCell — regression for the lunar-orbit
 // staging report ("descent module disappears when I stage it"). A
 // just-jettisoned stage spawns ~60 m from the active craft — sub-pixel at


### PR DESCRIPTION
Closes #63.

## What #63 was

A playtest reported that an **orbit-retrograde burn at ~45 km lunar altitude, at 1× warp**, *appeared* to reverse the orbit (vessel travelling backwards toward the dark side). The reporter (correctly) flagged it as likely a render/perception artifact and asked to disambiguate.

## Disambiguation

The physics rules out a real reversal from thrust:
- Reversing the orbit at 45 km means killing ~1.6 km/s (`v_circ` ≈ 1658 m/s).
- A few-second burn at 1× delivers only tens-to-hundreds of m/s — **two orders of magnitude short**.

So the on-screen "reversal" was a projection / day-night-terminator artifact near the disk edge. The real gap was **instrumentation** — the player had no readout to tell over-burn from frame-bug from illusion (matches issue action 1, the suspected real gap).

I also verified action 3: `StateVector.R/V` are primary-relative, and the live RK4 burn path resolves `DirectionUnit(BurnRetrograde, r, v)` on that Moon-relative state — retrograde is correctly `−v̂` in the Moon frame, **no frame bug**.

## Changes

**HUD orbit-direction indicator (action 1).** New `orbitDirectionLabel` adds an explicit `direction: prograde/retrograde` row to the **ORBIT** and **PROJECTED ORBIT** chips, keyed on the equatorial-frame inclination (>90° ⇒ retrograde, flagged). During a manual burn the live ORBIT chip updates each tick, so the player now has ground truth where the on-screen position misleads.

**Regression guard (actions 2 + 3).** `internal/sim/retrograde_lunar_burn_test.go` fires the **real `ActiveBurn` + `World.Tick` path at 1×** on an S-IVB in a 45 km prograde lunar orbit deep inside the Moon's SOI:
- A 300 m/s retrograde burn must **not** flip the equatorial-frame angular-momentum sign and must leave apo/peri sane.
- A Δv sweep through the production `DirectionUnit(BurnRetrograde)` vector pins the reversal threshold at `v_circ` — proving reversal needs ~1.6 km/s, never a 1× few-second burn. (A *sustained* burn can't even get there: it drives periapsis into the surface and the craft impacts first, so the threshold is shown impulsively.)

## Tests

- `go test ./... -race -count=1` → 1036 passed; `go vet ./...` clean.
- New: `TestModestRetrogradeBurnDoesNotReverseLunarOrbit`, `TestLunarOrbitReversalNeedsNearCircularDV`, `TestOrbitMetricsShowsDirectionIndicator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)