### PR TITLE
fix(end-flight): orbit view survives empty slate, parks on home body

### DIFF
--- a/internal/sim/end_flight.go
+++ b/internal/sim/end_flight.go
@@ -39,6 +39,10 @@ func (w *World) EndFlightActive() bool {
 	if c == nil || !c.Crashed {
 		return false
 	}
+	// Remember the body this vessel was orbiting. If it was the last
+	// vessel, the camera parks on this body (an "orbital view of
+	// Earth") instead of going blank — see the empty-slate branch.
+	removedPrimaryID := c.Primary.ID
 	// Drop the entry and snap active to the next slot. Slice
 	// append-trick: keep the prefix, skip idx, then append the
 	// suffix.
@@ -57,6 +61,22 @@ func (w *World) EndFlightActive() bool {
 		w.ActiveCraftIdx = -1
 		w.Target = newEmptyTargetForCraft(nil)
 		w.reconcileNavMode()
+		// Park the camera on the body the vessel was orbiting so the
+		// orbit view shows that body (e.g. Earth) rather than snapping
+		// to a heliocentric origin or a blank frame. FocusCraft would
+		// resolve to nil now; FocusBody keeps a concrete anchor. Falls
+		// back to the whole-system view if that body isn't in the
+		// current camera system (cross-system vessel). The orbit/launch
+		// render paths are both nil-craft-safe, so ViewMode is left
+		// untouched — the player stays in whatever view they were in.
+		w.Focus = Focus{Kind: FocusSystem}
+		sys := w.System()
+		for i := range sys.Bodies {
+			if sys.Bodies[i].ID == removedPrimaryID {
+				w.Focus = Focus{Kind: FocusBody, BodyIdx: i}
+				break
+			}
+		}
 	case idx >= len(w.Crafts):
 		// Removed the tail — snap to the new last entry.
 		w.SetActiveCraftIdx(len(w.Crafts) - 1)

--- a/internal/sim/end_flight_test.go
+++ b/internal/sim/end_flight_test.go
@@ -85,6 +85,17 @@ func TestEndFlightFallsBackToNilActive(t *testing.T) {
 	if w.ActiveCraft() != nil {
 		t.Errorf("after empty-slate end-flight: ActiveCraft = %+v, want nil", w.ActiveCraft())
 	}
+	// After removing the last vessel the camera must park on a concrete
+	// body — the one the vessel was orbiting — so the orbit view shows
+	// that body rather than snapping to FocusCraft (which now resolves
+	// to nil) or a heliocentric blank. Regression: the orbit render path
+	// dereferenced ActiveCraft() unconditionally and panicked here.
+	if w.Focus.Kind != FocusBody {
+		t.Errorf("after empty-slate end-flight: Focus.Kind = %v, want FocusBody", w.Focus.Kind)
+	}
+	if w.Focus.BodyIdx < 0 || w.Focus.BodyIdx >= len(w.System().Bodies) {
+		t.Errorf("after empty-slate end-flight: Focus.BodyIdx = %d, out of range", w.Focus.BodyIdx)
+	}
 }
 
 // TestEndFlightNoOpOnLiveVessel — end-flight on a non-Crashed

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -328,7 +328,12 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	v.canvas.Clear()
 	v.canvas.SetBasis(viewBasis(w))
 	center := w.FocusPosition()
-	if w.ActiveCraft().ActiveBurn != nil {
+	// Burn-frozen camera: hold the center steady while a burn is live so
+	// the navball-anchored view doesn't drift. Guarded on a non-nil
+	// active craft — after end-flight clears the last vessel the orbit
+	// view still renders (a vessel-less system/home-body view), and
+	// FocusPosition() already falls through to a body/system center.
+	if c := w.ActiveCraft(); c != nil && c.ActiveBurn != nil {
 		if v.burnFrozenCenter == nil {
 			snapshot := center
 			v.burnFrozenCenter = &snapshot

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -46,6 +46,48 @@ func TestOrbitViewRendersAllSystems(t *testing.T) {
 	}
 }
 
+// TestOrbitViewRendersWithNoActiveVessel: ending the flight of the
+// last vessel empties the craft slate (ActiveCraft() == nil) and parks
+// the camera on the body the vessel was orbiting. The orbit view must
+// render that body-focused frame without panicking — regression for the
+// nil-pointer crash where Render dereferenced ActiveCraft().ActiveBurn
+// unconditionally (orbit.go burn-frozen-center check).
+func TestOrbitViewRendersWithNoActiveVessel(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	v.Resize(120, 40)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Crash + end-flight the only vessel so the slate empties.
+	c := w.ActiveCraft()
+	c.Crashed = true
+	if !w.EndFlightActive() {
+		t.Fatal("EndFlightActive: false on lone Crashed vessel; want true")
+	}
+	if w.ActiveCraft() != nil {
+		t.Fatalf("precondition: ActiveCraft = %+v, want nil after end-flight", w.ActiveCraft())
+	}
+	// Must not panic, must produce a frame, and must show the system name.
+	out := v.Render(w, 0, 120, 40)
+	if len(out) == 0 {
+		t.Error("empty render with no active vessel")
+	}
+	if !strings.Contains(out, w.System().Name) {
+		t.Errorf("expected system name %q in vessel-less render", w.System().Name)
+	}
+}
+
 // TestOrbitHUDRendersVesselAndPropellantSideBySide: at sufficiently
 // wide terminals the VESSEL and PROPELLANT block headers share a row
 // so the right-hand HUD doesn't get tall enough to push the layout


### PR DESCRIPTION
## Problem

Ending the flight of the **last** vessel (`[E]` → confirm) crashed the game:

```
runtime error: invalid memory address or nil pointer dereference
  screens.(*OrbitView).Render … orbit.go:331
  tui.(*App).View … app.go:1226
```

`EndFlightActive` empties the craft slate (`ActiveCraft()` → nil) and sets `ActiveCraftIdx = -1`, but nothing moved `ViewMode` off an orbit mode. The next `View()` routed to `OrbitView.Render`, which dereferenced `w.ActiveCraft().ActiveBurn` unconditionally.

## Root cause

The orbit view was already nil-craft-safe almost everywhere:
- `FocusPosition()` / `FocusZoomRadius()` / `FocusName()` fall through to a body/system view
- every HUD chip builder guards `c == nil`
- craft-orbit + glyph drawing is gated on `CraftVisibleHere()`
- the `CRAFT n/n` chip is gated on `len(Crafts) > 1`

The burn-frozen-camera check at `orbit.go:331` was the **single** unguarded `ActiveCraft()` dereference.

## Fix

- **`orbit.go`** — guard the burn-frozen-center check on a non-nil active craft. The orbit view now renders a vessel-less system/home-body frame.
- **`end_flight.go`** — on empty slate, park the camera on the body the vessel was orbiting (`Focus{Kind: FocusBody}`), falling back to the whole-system view if that body isn't in the current camera system. `ViewMode` is left untouched.

Net behavior: ending a flight in LEO leaves you looking at **Earth**, instead of crashing or snapping to a heliocentric blank.

## Tests
- `end_flight_test.go` — asserts the empty slate lands on `FocusBody` with a valid index.
- New `TestOrbitViewRendersWithNoActiveVessel` — renders the orbit view after end-flight (the test that would have caught the panic).

`go vet ./...` clean; `go test ./internal/sim/... ./internal/tui/... -race -count=1` → 579 pass; binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)