### PR TITLE
fix(spawn): allow spawning from an empty slate after end-flight

### DIFF
--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -146,10 +146,13 @@ const DefaultLaunchpadLongitudeEast = -80.604
 // position (or +Y if no offset is meaningful). After spawn the new
 // craft becomes active. v0.8.2+.
 func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
+	// The active craft is only required by the Alongside path (which
+	// clones its state) and as the *default* parent body. Launchpad and
+	// orbit-at-parent spawns place the craft from the spec alone, so
+	// they must work from an empty slate — e.g. spawning a fresh vessel
+	// after end-flight removed the last one. The nil guard therefore
+	// lives on the Alongside branch, not up here.
 	active := w.ActiveCraft()
-	if active == nil {
-		return nil, errNoActiveCraftToCopy
-	}
 
 	var c *spacecraft.Spacecraft
 	if len(spec.CustomStages) > 0 {
@@ -173,6 +176,11 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 	c.Name = w.nextCraftName(c.Name)
 
 	if spec.Alongside {
+		// Alongside clones the active craft's state + system, so it
+		// genuinely needs one. (Other paths don't reach here.)
+		if active == nil {
+			return nil, errNoActiveCraftToCopy
+		}
 		// v0.8.3+: place the new craft inside the docking gate of
 		// the active craft, matching its velocity. The 25 m offset
 		// is half the docking distance — close enough that one or
@@ -199,11 +207,23 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 		return c, nil
 	}
 
-	primary := active.Primary
+	// Default parent is the active craft's primary; an explicit
+	// ParentBodyID overrides. With an empty slate (no active craft) and
+	// no/unknown parent id, fall back to the system primary so a
+	// post-end-flight spawn still resolves a real body.
+	var primary bodies.CelestialBody
+	if active != nil {
+		primary = active.Primary
+	}
 	if spec.ParentBodyID != "" {
 		sys := w.System()
 		if b := sys.FindBody(spec.ParentBodyID); b != nil {
 			primary = *b
+		}
+	}
+	if primary.ID == "" {
+		if sys := w.System(); len(sys.Bodies) > 0 {
+			primary = sys.Bodies[0]
 		}
 	}
 

--- a/internal/sim/spawn_launchpad_test.go
+++ b/internal/sim/spawn_launchpad_test.go
@@ -32,6 +32,67 @@ func TestSpawnLaunchpadPrimaryStaysEarth(t *testing.T) {
 	}
 }
 
+// TestSpawnAfterEmptySlate — spawning a fresh vessel after end-flight
+// removed the last one must work. Regression: SpawnCraft required a
+// non-nil active craft up front (errNoActiveCraftToCopy), so every
+// spawn from an empty slate silently failed ("nothing happens" in the
+// UI, which swallowed the error). Only the Alongside clone path needs
+// an active craft now.
+func TestSpawnAfterEmptySlate(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Crash + end-flight the only vessel so the slate empties.
+	w.ActiveCraft().Crashed = true
+	if !w.EndFlightActive() {
+		t.Fatal("EndFlightActive: false on lone Crashed vessel; want true")
+	}
+	if w.ActiveCraft() != nil {
+		t.Fatalf("precondition: ActiveCraft = %+v, want nil", w.ActiveCraft())
+	}
+	// Launchpad spawn from the empty slate.
+	c, err := w.SpawnCraft(SpawnSpec{
+		LoadoutID:    spacecraft.LoadoutSaturnVID,
+		ParentBodyID: "earth",
+		Launchpad:    true,
+		Latitude:     28.6,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft from empty slate: %v", err)
+	}
+	if c == nil || w.ActiveCraft() != c {
+		t.Fatalf("after spawn: active craft = %+v, want the spawned craft", w.ActiveCraft())
+	}
+	if c.Primary.ID != "earth" {
+		t.Errorf("primary after empty-slate launchpad spawn: got %q, want %q", c.Primary.ID, "earth")
+	}
+	if len(w.Crafts) != 1 {
+		t.Errorf("slate length after spawn: got %d, want 1", len(w.Crafts))
+	}
+}
+
+// TestSpawnEmptySlateNoParentFallsBackToSystemPrimary — an empty-slate
+// spawn with no ParentBodyID and no active craft must still resolve a
+// real body (the system primary) rather than a zero-value CelestialBody.
+func TestSpawnEmptySlateNoParentFallsBackToSystemPrimary(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.ActiveCraft().Crashed = true
+	if !w.EndFlightActive() {
+		t.Fatal("EndFlightActive: false on lone Crashed vessel; want true")
+	}
+	c, err := w.SpawnCraft(SpawnSpec{LoadoutID: spacecraft.LoadoutSaturnVID})
+	if err != nil {
+		t.Fatalf("SpawnCraft (no parent) from empty slate: %v", err)
+	}
+	if c.Primary.ID == "" {
+		t.Error("spawned craft primary is the zero-value body; want the system primary")
+	}
+}
+
 // TestSpawnLaunchpadAtAltitudeZero — a launchpad spawn at the
 // default latitude must put the craft at altitude 0. c.State.R is
 // primary-relative; |R| should equal the primary's mean radius.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -487,6 +487,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if c, err := a.world.SpawnCraft(spec); err == nil {
 					a.statusMsg = fmt.Sprintf("spawned craft %d (%s)", a.world.ActiveCraftIdx+1, c.Name)
 					a.statusExpires = time.Now().Add(3 * time.Second)
+				} else {
+					// Surface the failure instead of silently returning to
+					// orbit — a swallowed error reads as "nothing happens".
+					a.statusMsg = fmt.Sprintf("spawn failed: %v", err)
+					a.statusExpires = time.Now().Add(3 * time.Second)
 				}
 				a.active = screenOrbit
 			case screens.SpawnActionCancel:


### PR DESCRIPTION
## Problem

After ending the flight of the last vessel (#117), opening the spawn form and confirming did **nothing** — no new craft, no error, just back to the orbit view.

## Root cause

`SpawnCraft` required a non-nil active craft up front:

```go
active := w.ActiveCraft()
if active == nil {
    return nil, errNoActiveCraftToCopy
}
```

But the active craft is only genuinely needed by the **Alongside** clone path (which copies its state) and as the **default** parent body. A launchpad or orbit-at-parent spawn places the craft from the spec alone. With an empty slate (`ActiveCraft() == nil`), every spawn was rejected — and the spawn-confirm handler swallowed the error (`if ... err == nil`), so the UI silently returned to orbit.

## Fix

- **`spawn.go`** — move the `active == nil` guard onto the `Alongside` branch only. Resolve `primary` from `spec.ParentBodyID` (the form always supplies one — `parentIdx` defaults to body 0), falling back to the system primary when there's no active craft and no/unknown parent id.
- **`app.go`** — flash `spawn failed: <err>` instead of silently returning to orbit, so any future spawn failure is visible rather than a no-op.

## Tests
- `TestSpawnAfterEmptySlate` — launchpad spawn after end-flight succeeds, becomes active, primary stays Earth.
- `TestSpawnEmptySlateNoParentFallsBackToSystemPrimary` — empty-slate spawn with no parent id still resolves a real body.

`go vet ./...` clean; `go test ./internal/sim/... ./internal/tui/... -race -count=1` → 581 pass; binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)