### PR TITLE
fix(orbit): keep vessel glyph in its own color over a body disk

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -744,7 +744,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				v.canvas.PlotColored(otherInertial, otherColor)
 				if other.Glyph != "" {
 					if g := []rune(other.Glyph); len(g) > 0 {
-						v.canvas.SetCellOverlay(otherInertial, g[0])
+						// Pin the glyph color (see active-craft note below)
+						// so non-active vessels also keep their own color
+						// over a body disk.
+						v.canvas.SetCellOverlayColored(otherInertial, g[0], otherColor)
 					}
 				}
 			}
@@ -764,7 +767,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			}
 			v.canvas.FillColoredDiskTagged(craftInertial, 1, widgets.CellTag{Color: activeColor, IsVessel: true})
 			if g := []rune(c.Glyph); len(g) > 0 {
-				v.canvas.SetCellOverlay(craftInertial, g[0])
+				// Pin the glyph color so it stays the vessel's own color
+				// instead of flipping to the body's color when the marker
+				// overlaps a body disk (e.g. low orbit over Earth).
+				v.canvas.SetCellOverlayColored(craftInertial, g[0], activeColor)
 			}
 		}
 	}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -224,6 +224,32 @@ func (c *Canvas) SetCellOverlay(w orbital.Vec3, glyph rune) {
 	c.cellOverlays[[2]int{cellX, cellY}] = glyph
 }
 
+// SetCellOverlayColored is SetCellOverlay that also pins the glyph's
+// foreground to color, so the overlay reads in that exact color rather
+// than the cell's pixelTag majority. Without the pin, a glyph whose
+// cell overlaps a body's projected disk picks up the body's color (the
+// body's pixels outvote the glyph's own tag) — so e.g. a vessel marker
+// flips to Earth-blue while passing in front of Earth. Pinning keeps
+// vessel glyphs in their own color regardless of what's behind them.
+func (c *Canvas) SetCellOverlayColored(w orbital.Vec3, glyph rune, color lipgloss.TerminalColor) {
+	px, py, ok := c.Project(w)
+	if !ok {
+		return
+	}
+	cellX, cellY := px/2, py/4
+	if cellX < 0 || cellX >= c.cols || cellY < 0 || cellY >= c.rows {
+		return
+	}
+	if c.cellOverlays == nil {
+		c.cellOverlays = make(map[[2]int]rune)
+	}
+	c.cellOverlays[[2]int{cellX, cellY}] = glyph
+	if c.cellOverlayColors == nil {
+		c.cellOverlayColors = make(map[[2]int]lipgloss.TerminalColor)
+	}
+	c.cellOverlayColors[[2]int{cellX, cellY}] = color
+}
+
 // ClearCellOverlay removes any overlay glyph at the cell containing
 // the given world coord so the cell's underlying braille pattern
 // renders through. Used by the v0.11.3 composed-rocket render path:
@@ -241,6 +267,9 @@ func (c *Canvas) ClearCellOverlay(w orbital.Vec3) {
 		return
 	}
 	delete(c.cellOverlays, [2]int{cellX, cellY})
+	// Also drop any pinned overlay color (SetCellOverlayColored) so it
+	// can't recolor the braille pattern that now renders through.
+	delete(c.cellOverlayColors, [2]int{cellX, cellY})
 }
 
 // SetCellLabel writes text into consecutive cells starting at

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -191,6 +191,39 @@ func TestSetCellLabelColored(t *testing.T) {
 	}
 }
 
+// TestSetCellOverlayColoredWinsOverBodyColor: a vessel glyph stamped
+// over a body's projected disk must render in the pinned (vessel) color,
+// not the body color. Without SetCellOverlayColored the glyph took the
+// cell's pixelTag majority — the body's disk pixels outvote the marker's
+// own tag — so the marker flipped to the body's color in low orbit.
+func TestSetCellOverlayColoredWinsOverBodyColor(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1") // force lipgloss to emit ANSI in tests
+
+	bodyColor := lipgloss.Color("#3A7BD5")   // "Earth" blue
+	vesselColor := lipgloss.Color("#FFD93D") // craft-marker yellow
+
+	c := NewCanvas(20, 10)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	// A large body disk centered at the origin tags the center cell's
+	// pixels with the body color (the majority for that cell).
+	c.FillColoredDisk(orbital.Vec3{}, 6, bodyColor)
+	// Stamp the vessel glyph at the same world point with a pinned color.
+	c.SetCellOverlayColored(orbital.Vec3{}, '^', vesselColor)
+
+	out := c.String()
+	// The glyph must be wrapped in the vessel foreground, not the body's.
+	wantVessel := lipgloss.NewStyle().Foreground(vesselColor).Render("^")
+	if !strings.Contains(out, wantVessel) {
+		t.Errorf("glyph not rendered in pinned vessel color %q:\n%q", wantVessel, out)
+	}
+	bodyGlyph := lipgloss.NewStyle().Foreground(bodyColor).Render("^")
+	if strings.Contains(out, bodyGlyph) {
+		t.Errorf("glyph rendered in body color (should be pinned to vessel):\n%q", out)
+	}
+}
+
 // TestRingOutlineHugeRadiusDoesNotHang: v0.5.15 regression — pre-fix
 // a ring with pxRadius in the millions (Saturn rings projected at
 // extreme zoom) looped pxRadius*8 ≈ billions of times, locking the
@@ -252,7 +285,7 @@ func TestPerPixelTagDoesNotBleed(t *testing.T) {
 // v0.6.4+.
 func TestUnprojectRoundTripDefaultBasis(t *testing.T) {
 	c := NewCanvas(60, 30)
-	c.SetScale(0.01)               // pixels per metre — 1 m ≈ 0.01 px
+	c.SetScale(0.01)                // pixels per metre — 1 m ≈ 0.01 px
 	c.Center(orbital.Vec3{X: 1000}) // off-origin to exercise centerW
 	cases := []orbital.Vec3{
 		{X: 1000, Y: 0},


### PR DESCRIPTION
## Problem

When a vessel orbits Earth (or any body), its marker glyph changes color depending on the body it's in front of — instead of staying its own color.

## Root cause

The vessel glyph is drawn as a **cell overlay**, and `Canvas.String()` colors each cell by the **majority** of its pixel tags. The marker stamps a radius-1 colored disk plus the glyph; when the marker overlaps a body's projected disk, the body's pixels in that cell outvote the marker's own tag, so the glyph renders in the **body's** color. Moving in front of different bodies → glyph changes color.

## Fix

Add `Canvas.SetCellOverlayColored`, which pins the overlay's foreground through the existing `cellOverlayColors` map — the same pin that already lets `SetCellLabelColored` win over the majority vote (canvas.go:1063). The orbit screen now uses it for **both** the active and non-active vessel glyphs, so each stays in its own color (`ColorCraftMarker` / per-craft `Color` / `TARGET` green) regardless of what's behind it.

`ClearCellOverlay` also drops the pinned color now, so a cleared glyph can't recolor the braille pattern that renders through.

## Test

`TestSetCellOverlayColoredWinsOverBodyColor` — stamps a glyph over a dominant body-color disk and asserts it renders in the pinned vessel color, not the body color.

`go vet ./...` clean; `go test ./... -race -count=1` → 1041 pass; binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)