### PR TITLE
ci(release): publish to Homebrew tap + Scoop bucket via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,11 @@ jobs:
           version: latest
           args: release --clean
         env:
+          # Creates the GitHub release + uploads archives (scoped to this repo).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with contents:write on jasonfen/homebrew-tap and
+          # jasonfen/scoop-bucket — the default GITHUB_TOKEN can't push to
+          # other repos. Falls back to GITHUB_TOKEN if the secret is unset,
+          # so a release without the secret still publishes binaries (the
+          # cask/scoop steps will fail loudly rather than silently skip).
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,3 +64,54 @@ release:
     name: terminal-space-program
   draft: false
   prerelease: auto
+
+# Homebrew (macOS/Linux) — published to a personal tap, not homebrew-core.
+# Users: `brew install --cask jasonfen/tap/terminal-space-program`.
+# v2 note: `brews:` (formula) is deprecated → removed in v2.16; the cask
+# block is the supported path for pre-compiled binaries. Pushing to the
+# tap repo needs a PAT with write access (the release's default
+# GITHUB_TOKEN is scoped to this repo only) — see TAP_GITHUB_TOKEN below.
+homebrew_casks:
+  - name: terminal-space-program
+    binaries:
+      - terminal-space-program
+    directory: Casks
+    homepage: "https://github.com/jasonfen/terminal-space-program"
+    description: "Terminal-native orbital-mechanics rocket simulator (KSP in your terminal)"
+    commit_msg_template: "cask: update {{ .ProjectName }} to {{ .Tag }}"
+    repository:
+      owner: jasonfen
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: goreleaserbot@users.noreply.github.com
+    # The binary isn't code-signed/notarized, so strip the quarantine
+    # bit on install — otherwise macOS Gatekeeper blocks first launch.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/terminal-space-program"]
+          end
+
+# Scoop (Windows) — published to a personal bucket.
+# Users: `scoop bucket add jasonfen https://github.com/jasonfen/scoop-bucket`
+#        `scoop install terminal-space-program`.
+# Auto-selects the Windows archive; same PAT as the cask tap.
+scoops:
+  - name: terminal-space-program
+    directory: bucket
+    homepage: "https://github.com/jasonfen/terminal-space-program"
+    description: "Terminal-native orbital-mechanics rocket simulator (KSP in your terminal)"
+    license: MIT
+    commit_msg_template: "scoop: update {{ .ProjectName }} to {{ .Tag }}"
+    repository:
+      owner: jasonfen
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: goreleaserbot@users.noreply.github.com


### PR DESCRIPTION
Wires GoReleaser to auto-publish each release tag to a personal Homebrew tap and Scoop bucket.

## Install targets (after the next tag)
```
brew install --cask jasonfen/tap/terminal-space-program
scoop bucket add jasonfen https://github.com/jasonfen/scoop-bucket && scoop install terminal-space-program
```

## What changed
- **`.goreleaser.yaml`** — `homebrew_casks:` + `scoops:` publisher blocks.
- **`.github/workflows/release.yml`** — passes `TAP_GITHUB_TOKEN` to GoReleaser (falls back to `GITHUB_TOKEN`).

## Why `homebrew_casks`, not `brews`
The `brews:` (formula) block is **removed as of GoReleaser v2.16**, and the workflow pins `version: latest`. Casks are GoReleaser's supported path for pre-compiled binaries. Validated locally with `goreleaser check` against v2.16.0. The cask's post-install hook strips the macOS quarantine bit so the unsigned binary launches without a Gatekeeper prompt.

## Prerequisites (done / TODO)
- [x] `jasonfen/homebrew-tap` repo created (public, `main`)
- [x] `jasonfen/scoop-bucket` repo created (public, `main`)
- [ ] **Manual:** create a PAT with `contents:write` on both repos, store as repo secret `TAP_GITHUB_TOKEN`

Until the secret exists, a release still publishes binaries — only the cask/scoop push steps fail (loudly, not silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)