### PR TITLE
docs: close ADR 0015/0016 owed doc gaps (v0.16.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ matter, the way they do in real life. Unlike KSP (without mods), the default gam
 
 Recently introduced: a familiar 1/10th-scale system named Lumen; home to a familiar planet, Kernel, with two moons, Cursor and Glyph - and a nearby red planet, Rust. A Lumen-specific vessel is scaled to that environment. It's a little rough appearance-wise as no textures have ported over to that system, but vessels fly and hit familiar Delta-V marks for launch, Cursor (Mun) transfers, etc. From a default game launch press TAB to cycle through the available solar systems until you reach Lumen. Press F to cycle to the planet Kernel, then press N to spawn a craft there.
 
+Each vessel is bound for its lifetime to the system it spawns in — the simulator flies every vessel against its own system and the camera follows your *active* vessel's system, so a craft parked in Sol keeps orbiting while you fly in Lumen (TAB stays a browse-only camera toggle). Adding Lumen also changed the body catalog, so the on-disk save format moved to v8; older saves auto-migrate on load.
+
 The visual foundation was lifted (with MIT attribution) from
 [furan917/go-solar-system](https://github.com/furan917/go-solar-system). See
 [NOTICE.md](NOTICE.md) for the full acknowledgments list.

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -105,6 +105,7 @@ var helpSections = []helpSection{
 		{"click node", "open the planner for that node (canvas glyph or NODES row)"},
 		{"click empty", "open the planner at the projected orbit point"},
 		{"click HUD", "open body info"},
+		{"[»Burn]", "toggle auto-warp to the next burn (same as G); [■Burn] while running, dimmed when none planned"},
 	}},
 }
 


### PR DESCRIPTION
The owed follow-up from v0.16: reconcile the last user-facing docs for **Auto-Warp** (ADR 0016) and **Vessels bound to a System** (ADR 0015). `docs/controls.md`, `CONTEXT.md`, and `docs/version-history.md` were already current (verified); two gaps remained.

## Changes

- **README.md** — add the vessel↔system binding mechanic (each vessel flies against its own system for its lifetime; camera follows the *active* vessel's system; TAB is a browse-only camera toggle) and the v7→v8 save-format move with auto-migration (ADR 0015, PR #108).
- **`internal/tui/screens/help.go`** — add the `[»Burn]` button to the F1 overlay MOUSE section (toggles auto-warp, same as `G`; `[■Burn]` while running, dimmed when none planned). The `G` / `/` TIME rows were already present.

## Verification

Driving the full interactive TUI flight isn't automatable here, but the load-bearing ADR 0015 behaviours — the exact symptoms the feature fixed — are pinned green by the existing suite:

- `TestCraftVisibleHereFollowsBinding` (HUD no longer suppressed for a non-Sol vessel)
- `TestIntegrateResolvesCraftOwnSystem` (integrator runs against the vessel's own system, no SOI-yank onto a Sol body)
- `TestSpawnBindsToViewedSystem`, `TestSetActiveCraftIdxSnapsView`, `TestStagingInheritsSystemIdx`, `TestAutoWarpScopedToActiveSystem`

`go vet ./...` clean; binary builds.