### PR TITLE
feat(hud): FlightPhase derivation vocabulary (no behavior change)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1429,6 +1429,114 @@ func shouldShowDescentHUD(c *spacecraft.Spacecraft) bool {
 	return false
 }
 
+// FlightPhase is a coarse classification of where a vessel is in its
+// flight — pad / ascent / cruise / transfer / approach / descent / landed.
+// It consolidates the signals the chip-relevance predicates above already
+// read (atmosphere, altitude bands, orbit eccentricity, radial-velocity
+// sign, the Landed flag) into one named vocabulary.
+//
+// v0.16.1 scaffolding (consolidation only): nothing renders against this
+// yet, so deriving it changes no on-screen behaviour. It exists so a later
+// chip timing+content slice can gate chips on a single phase value instead
+// of re-deriving the regime per chip. To stay a true consolidation rather
+// than a second source of truth, the atmospheric-ascent and airless-descent
+// branches defer to the authoritative shouldShowLaunchHUD /
+// shouldShowDescentHUD predicates rather than re-implementing their (subtle,
+// well-commented) gates.
+type FlightPhase int
+
+const (
+	// PhaseCoast is the zero value: a near-circular bound parking / cruise
+	// orbit, and the safe fallback for nil / degenerate state.
+	PhaseCoast FlightPhase = iota
+	PhasePrelaunch
+	PhaseAscent
+	PhaseTransfer
+	PhaseApproach
+	PhaseDescent
+	PhaseLanded
+)
+
+func (p FlightPhase) String() string {
+	switch p {
+	case PhasePrelaunch:
+		return "prelaunch"
+	case PhaseAscent:
+		return "ascent"
+	case PhaseTransfer:
+		return "transfer"
+	case PhaseApproach:
+		return "approach"
+	case PhaseDescent:
+		return "descent"
+	case PhaseLanded:
+		return "landed"
+	default:
+		return "coast"
+	}
+}
+
+// transferEccThreshold is the eccentricity above which a bound orbit reads
+// as a transfer/encounter arc rather than a parking-orbit Coast. 0.2 keeps
+// a slightly-elliptical LEO classed as Coast while a Hohmann transfer
+// ellipse (e ≈ 0.7 LEO→GEO, higher for lunar) reads as Transfer/Approach.
+const transferEccThreshold = 0.2
+
+// prelaunchAltM is the altitude below which an ascending atmospheric vessel
+// reads as just off the pad (Prelaunch) rather than in active climb
+// (Ascent). Matches the tower-clear scale used by the ascent guidance. Note
+// a vessel actually *on* the ground is PhaseLanded (the Landed flag wins);
+// Prelaunch is the brief airborne, below-tower-clear window right after
+// release. The on-ground state can't be told apart from a post-mission
+// landing by state alone, so both collapse to Landed.
+const prelaunchAltM = 1000.0
+
+// deriveFlightPhase classifies a vessel's current flight phase from its own
+// state. Pure (no World dependency) so it can be unit-tested in isolation.
+// See FlightPhase for the consolidation-only intent.
+func deriveFlightPhase(c *spacecraft.Spacecraft) FlightPhase {
+	if c == nil {
+		return PhaseCoast
+	}
+	if c.Landed {
+		return PhaseLanded
+	}
+	// Radial velocity sign separates outbound (climbing) from inbound
+	// (falling toward periapsis / an encounter).
+	var vUp float64
+	if r := c.State.R; r.Norm() > 0 {
+		vUp = c.State.V.Dot(r.Unit())
+	}
+	// Atmospheric ascent — defer to the authoritative launch predicate, then
+	// split pad-bound Prelaunch from active Ascent. A descending vessel low
+	// in the atmosphere (re-entry) is suborbital and would also satisfy the
+	// launch predicate, so require non-descending to count as ascent.
+	if shouldShowLaunchHUD(c) && vUp >= 0 {
+		if c.Altitude() < prelaunchAltM {
+			return PhasePrelaunch
+		}
+		return PhaseAscent
+	}
+	// Airless surface-proximity — defer to the authoritative descent predicate.
+	if shouldShowDescentHUD(c) {
+		return PhaseDescent
+	}
+	// Otherwise we're on an orbit / transfer arc; classify by shape + direction.
+	mu := c.Primary.GravitationalParameter()
+	if mu == 0 {
+		return PhaseCoast
+	}
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	bound := el.E < 1 && el.A > 0
+	if !bound || el.E >= transferEccThreshold {
+		if vUp < 0 {
+			return PhaseApproach // inbound — falling toward periapsis / encounter
+		}
+		return PhaseTransfer // outbound — climbing toward apoapsis
+	}
+	return PhaseCoast // near-circular parking / cruise orbit
+}
+
 // formatAltKm renders an altitude in metres as a signed kilometre
 // string with a sign that's friendly to ascent flight ("−2.8 km"
 // reads better than "−2840 m" for sub-orbital periapsis). Used by

--- a/internal/tui/screens/orbit_flight_phase_test.go
+++ b/internal/tui/screens/orbit_flight_phase_test.go
@@ -1,0 +1,188 @@
+// Package screens — FlightPhase derivation tests (v0.16.1).
+//
+// deriveFlightPhase consolidates the chip-relevance signals (atmosphere,
+// altitude bands, orbit eccentricity, radial-velocity sign, the Landed flag)
+// into one phase value. Nothing renders against it yet — these tests pin the
+// derivation directly so the vocabulary is trustworthy for a later
+// chip-timing slice. The atmospheric-ascent and airless-descent phases are
+// kept in lockstep with shouldShowLaunchHUD / shouldShowDescentHUD here so a
+// future change to those predicates can't silently drift the phase mapping.
+
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// phaseCraftOn builds a Lander on the named body of the default system with
+// the given inertial position radius and velocity vector, ready for
+// deriveFlightPhase. Velocity is supplied directly so each test can dial in
+// the eccentricity / radial-velocity sign it needs.
+func phaseCraftOn(t *testing.T, w *sim.World, body string, r orbital.Vec3, v orbital.Vec3) *spacecraft.Spacecraft {
+	t.Helper()
+	sys := w.System()
+	b := sys.FindBody(body)
+	if b == nil {
+		t.Fatalf("%s not in default system", body)
+	}
+	c := spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID)
+	c.Primary = *b
+	c.Landed = false
+	c.State = physics.StateVector{R: r, V: v, M: c.TotalMass()}
+	return c
+}
+
+func TestDeriveFlightPhaseNilIsCoast(t *testing.T) {
+	if got := deriveFlightPhase(nil); got != PhaseCoast {
+		t.Errorf("nil craft: got %v, want coast", got)
+	}
+}
+
+func TestDeriveFlightPhaseLandedWins(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// A craft on the Moon's surface — Landed flag set — reads as Landed even
+	// though the airless surface-proximity descent predicate would also fire.
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	c := phaseCraftOn(t, w, "Moon",
+		orbital.Vec3{X: moon.RadiusMeters() + 100, Y: 0, Z: 0},
+		orbital.Vec3{})
+	c.Landed = true
+	if got := deriveFlightPhase(c); got != PhaseLanded {
+		t.Errorf("landed craft: got %v, want landed", got)
+	}
+}
+
+func TestDeriveFlightPhasePrelaunchVsAscent(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	earth := sys.FindBody("Earth")
+	if earth == nil {
+		t.Fatal("Earth not in default system")
+	}
+	Re := earth.RadiusMeters()
+	// Just off the pad: airborne (Landed=false), climbing (radial-out
+	// velocity), below tower-clear → Prelaunch.
+	low := phaseCraftOn(t, w, "Earth",
+		orbital.Vec3{X: Re + 500, Y: 0, Z: 0},
+		orbital.Vec3{X: 60, Y: 0, Z: 0})
+	if !shouldShowLaunchHUD(low) {
+		t.Fatal("setup: expected launch HUD up for a low ascending Earth craft")
+	}
+	if got := deriveFlightPhase(low); got != PhasePrelaunch {
+		t.Errorf("just-off-pad craft: got %v, want prelaunch", got)
+	}
+	// Climbing through 8 km, still suborbital → Ascent.
+	climb := phaseCraftOn(t, w, "Earth",
+		orbital.Vec3{X: Re + 8_000, Y: 0, Z: 0},
+		orbital.Vec3{X: 200, Y: 400, Z: 0})
+	if !shouldShowLaunchHUD(climb) {
+		t.Fatal("setup: expected launch HUD up for an 8 km ascending Earth craft")
+	}
+	if got := deriveFlightPhase(climb); got != PhaseAscent {
+		t.Errorf("climbing craft at 8 km: got %v, want ascent", got)
+	}
+}
+
+func TestDeriveFlightPhaseCoastNearCircular(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	earth := sys.FindBody("Earth")
+	Re := earth.RadiusMeters()
+	mu := earth.GravitationalParameter()
+	// Circular LEO at 400 km — e≈0, well above the atmosphere → Coast.
+	r := Re + 400_000
+	vCirc := math.Sqrt(mu / r)
+	c := phaseCraftOn(t, w, "Earth",
+		orbital.Vec3{X: r, Y: 0, Z: 0},
+		orbital.Vec3{X: 0, Y: vCirc, Z: 0})
+	if got := deriveFlightPhase(c); got != PhaseCoast {
+		t.Errorf("circular LEO: got %v, want coast", got)
+	}
+}
+
+func TestDeriveFlightPhaseTransferVsApproach(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	earth := sys.FindBody("Earth")
+	Re := earth.RadiusMeters()
+	mu := earth.GravitationalParameter()
+	// An eccentric transfer ellipse (e≈0.66): perigee 400 km, apogee
+	// 35 786 km. At perigee, an outbound (prograde-climbing) velocity reads
+	// Transfer; the same orbit caught inbound (radial velocity negative)
+	// reads Approach.
+	rPeri := Re + 400_000
+	rApo := Re + 35_786_000
+	a := (rPeri + rApo) / 2
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	// Outbound just past perigee: mostly tangential with a small radial-out
+	// component so vUp > 0 (climbing toward apogee).
+	out := phaseCraftOn(t, w, "Earth",
+		orbital.Vec3{X: rPeri, Y: 0, Z: 0},
+		orbital.Vec3{X: 40, Y: vPeri, Z: 0})
+	if got := deriveFlightPhase(out); got != PhaseTransfer {
+		t.Errorf("outbound transfer ellipse: got %v, want transfer", got)
+	}
+	// Inbound approaching perigee: radial-in component so vUp < 0.
+	in := phaseCraftOn(t, w, "Earth",
+		orbital.Vec3{X: rPeri, Y: 0, Z: 0},
+		orbital.Vec3{X: -40, Y: vPeri, Z: 0})
+	if got := deriveFlightPhase(in); got != PhaseApproach {
+		t.Errorf("inbound transfer ellipse: got %v, want approach", got)
+	}
+}
+
+func TestDeriveFlightPhaseDescentAirless(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	// 5 km above the airless Moon, slow lateral drift → Descent.
+	c := phaseCraftOn(t, w, "Moon",
+		orbital.Vec3{X: moon.RadiusMeters() + 5_000, Y: 0, Z: 0},
+		orbital.Vec3{X: 0, Y: 30, Z: 0})
+	if !shouldShowDescentHUD(c) {
+		t.Fatal("setup: expected descent HUD up for a 5 km Moon craft")
+	}
+	if got := deriveFlightPhase(c); got != PhaseDescent {
+		t.Errorf("5 km Moon craft: got %v, want descent", got)
+	}
+}
+
+func TestFlightPhaseString(t *testing.T) {
+	cases := map[FlightPhase]string{
+		PhaseCoast:     "coast",
+		PhasePrelaunch: "prelaunch",
+		PhaseAscent:    "ascent",
+		PhaseTransfer:  "transfer",
+		PhaseApproach:  "approach",
+		PhaseDescent:   "descent",
+		PhaseLanded:    "landed",
+		FlightPhase(99): "coast", // unknown falls back to coast
+	}
+	for p, want := range cases {
+		if got := p.String(); got != want {
+			t.Errorf("FlightPhase(%d).String() = %q, want %q", int(p), got, want)
+		}
+	}
+}


### PR DESCRIPTION
Part of the v0.16.1 bundle (Slice C). **Consolidation only — nothing renders against this yet, so on-screen behavior is unchanged.**

## Why this shape

The plan floated a "chip phase-gating" slice on the premise that chips appear at the wrong time. On inspection that premise didn't hold: the orbit-screen chips already gate themselves cleanly by regime (LAUNCH only while ascending, DESCENT only airless surface-proximity, CAPTURE only on the last frame-change node, …), each with documented rationale. The only chip with no phase relevance is ATTITUDE — and gating it is a UX judgment best left to a playtest-driven v0.17 pass, not a point release.

What *was* missing is a single named vocabulary for a vessel's flight phase, so a later chip timing+content slice can gate on one value instead of re-deriving the regime per chip. This adds exactly that and nothing else.

## What's here

- `FlightPhase` {Coast, Prelaunch, Ascent, Transfer, Approach, Descent, Landed} + `String()`.
- `deriveFlightPhase(c *spacecraft.Spacecraft)` — pure, World-free. To stay a consolidation rather than a second source of truth, the ascent/descent branches **defer to the authoritative `shouldShowLaunchHUD` / `shouldShowDescentHUD` predicates**; the orbit branches split on eccentricity (`transferEccThreshold = 0.2`) and radial-velocity sign (outbound Transfer vs inbound Approach). On-ground is Landed (the flag wins — a pad craft and a post-mission landing aren't distinguishable from state); Prelaunch is the brief airborne below-tower window right after release.
- Tests pinning all seven phases directly, so the mapping can't silently drift if the predicates change.

## Verification

`go vet ./...` clean; `go test ./... -race -count=1` green — the full screens package passes unchanged, confirming no rendering behavior moved.