### PR TITLE
feat(cli): startup-scenario flags (system / body / orbit / launch site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,30 @@ go build ./cmd/terminal-space-program
 
 Requires Go 1.24 or newer.
 
+## Command-line flags
+
+By default the game opens with a vessel in low Earth orbit. Flags let you jump
+straight to a different start — a system, a body to orbit or launch from, an
+orbit altitude and inclination, or a named launch site:
+
+```bash
+terminal-space-program --orbit moon --altitude 100km          # 100 km lunar orbit
+terminal-space-program --system Lumen --orbit kern --loadout Kern-Stack
+terminal-space-program --orbit earth --altitude 400km --inclination 51.6
+terminal-space-program --launch-site KSC --loadout Saturn-V    # on the pad
+terminal-space-program --list-bodies --system Lumen           # discover names
+terminal-space-program --version
+```
+
+`--version` and the `--list-*` discovery flags print and exit. See the
+**[command-line reference](docs/cli.md)** for every flag, units, defaults, and
+more examples.
+
 ## Learn more
 
 - **[Controls & flight guide](docs/controls.md)** — a quick tour, a launch
   walkthrough, and the full list of keys.
+- **[Command-line reference](docs/cli.md)** — every startup flag with examples.
 - **[Version history](docs/version-history.md)** — what landed in each release.
 
 ## License

--- a/cmd/terminal-space-program/flags.go
+++ b/cmd/terminal-space-program/flags.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// rawFlags holds the parsed command-line values that shape the starting
+// scenario, plus the set of flags the user explicitly passed (so a 0 value
+// can be told apart from "unset" for the float flags). Kept separate from
+// flag registration so buildScenario is unit-testable without os.Args.
+type rawFlags struct {
+	system      string
+	body        string // --orbit / --parent / --body
+	altitude    string
+	loadout     string
+	launchSite  string
+	inclination float64
+	lat         float64
+	lon         float64
+	retrograde  bool
+	launchpad   bool
+
+	set map[string]bool // flag names the user actually provided
+}
+
+// buildScenario turns parsed flags into a *sim.StartScenario, or nil when no
+// scenario flag was given (→ the default start). Surface placement
+// (--launchpad/--launch-site/--lat/--lon) and orbital placement
+// (--altitude/--inclination/--retrograde) are mutually exclusive. Returns a
+// descriptive error on a conflict or an unknown launch site.
+func buildScenario(r rawFlags) (*sim.StartScenario, error) {
+	latSet, lonSet := r.set["lat"], r.set["lon"]
+	orbitalSet := r.set["altitude"] || r.set["inclination"] || r.set["retrograde"]
+	surfaceSet := r.launchpad || r.launchSite != "" || latSet || lonSet
+	anySet := orbitalSet || surfaceSet ||
+		r.system != "" || r.body != "" || r.loadout != ""
+	if !anySet {
+		return nil, nil // no scenario flags → standard default start
+	}
+	if orbitalSet && surfaceSet {
+		return nil, fmt.Errorf("orbital flags (--altitude/--inclination/--retrograde) can't be combined with surface flags (--launchpad/--launch-site/--lat/--lon)")
+	}
+
+	s := &sim.StartScenario{
+		SystemName: r.system,
+		BodyID:     r.body,
+		Loadout:    r.loadout,
+	}
+
+	if surfaceSet {
+		s.Surface = true
+		switch {
+		case r.launchSite != "":
+			if latSet || lonSet {
+				return nil, fmt.Errorf("--launch-site can't be combined with --lat/--lon")
+			}
+			site, ok := sim.LaunchSiteByName(r.launchSite)
+			if !ok {
+				return nil, fmt.Errorf("unknown launch site %q (have: %s)", r.launchSite, strings.Join(launchSiteKeys(), ", "))
+			}
+			s.LatDeg, s.LonDeg = site.LatitudeDeg, site.LongitudeEastDeg
+		case latSet || lonSet:
+			// Numeric site; a missing component defaults to 0 (equator /
+			// prime meridian).
+			s.LatDeg, s.LonDeg = r.lat, r.lon
+		default:
+			// --launchpad alone → the form's KSC default, so a bare
+			// --launchpad lands somewhere sensible rather than the equator.
+			s.LatDeg = sim.DefaultLaunchpadLatitude
+			s.LonDeg = sim.DefaultLaunchpadLongitudeEast
+		}
+		return s, nil
+	}
+
+	// Orbital placement (also the path when only --system/--body/--loadout
+	// are given — a plain orbital spawn at the default altitude).
+	if r.altitude != "" {
+		m, err := parseDistanceM(r.altitude)
+		if err != nil {
+			return nil, fmt.Errorf("--altitude: %w", err)
+		}
+		s.AltitudeM = m
+	}
+	s.InclDeg = r.inclination
+	s.Retrograde = r.retrograde
+	return s, nil
+}
+
+// parseDistanceM parses an altitude with an optional unit suffix: "400km",
+// "400000m", or a bare number treated as kilometres. Returns metres.
+func parseDistanceM(s string) (float64, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	mult := 1000.0 // bare number → kilometres
+	switch {
+	case strings.HasSuffix(s, "km"):
+		s, mult = strings.TrimSuffix(s, "km"), 1000
+	case strings.HasSuffix(s, "m"):
+		s, mult = strings.TrimSuffix(s, "m"), 1
+	}
+	val, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid distance %q", s)
+	}
+	if val < 0 {
+		return 0, fmt.Errorf("altitude must be non-negative")
+	}
+	return val * mult, nil
+}
+
+// launchSiteKeys lists the short CLI tokens for the named launch sites.
+func launchSiteKeys() []string {
+	keys := make([]string, len(sim.LaunchSites))
+	for i, s := range sim.LaunchSites {
+		keys[i] = s.Key
+	}
+	return keys
+}

--- a/cmd/terminal-space-program/flags_test.go
+++ b/cmd/terminal-space-program/flags_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseDistanceM(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    float64
+		wantErr bool
+	}{
+		{"400km", 400_000, false},
+		{"400000m", 400_000, false},
+		{"400", 400_000, false}, // bare → km
+		{"35786km", 35_786_000, false},
+		{" 100 km ", 100_000, false},
+		{"-5km", 0, true},
+		{"abc", 0, true},
+		{"", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseDistanceM(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseDistanceM(%q): want error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseDistanceM(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if math.Abs(got-c.want) > 1e-6 {
+			t.Errorf("parseDistanceM(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBuildScenarioNoFlags(t *testing.T) {
+	s, err := buildScenario(rawFlags{set: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s != nil {
+		t.Errorf("no flags should yield nil scenario (default start), got %+v", s)
+	}
+}
+
+func TestBuildScenarioOrbital(t *testing.T) {
+	s, err := buildScenario(rawFlags{
+		system:      "Lumen",
+		body:        "kernel",
+		altitude:    "400km",
+		inclination: 30,
+		loadout:     "Kern-Stack",
+		set:         map[string]bool{"altitude": true, "inclination": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected a scenario")
+	}
+	if s.Surface {
+		t.Error("orbital flags should not set Surface")
+	}
+	if s.SystemName != "Lumen" || s.BodyID != "kernel" || s.Loadout != "Kern-Stack" {
+		t.Errorf("system/body/loadout not threaded: %+v", s)
+	}
+	if math.Abs(s.AltitudeM-400_000) > 1e-6 || s.InclDeg != 30 {
+		t.Errorf("altitude/incl wrong: alt=%v incl=%v", s.AltitudeM, s.InclDeg)
+	}
+}
+
+func TestBuildScenarioLaunchSite(t *testing.T) {
+	s, err := buildScenario(rawFlags{
+		launchSite: "KSC",
+		loadout:    "Saturn-V",
+		set:        map[string]bool{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.Surface {
+		t.Error("--launch-site should set Surface")
+	}
+	if math.Abs(s.LatDeg-28.6083) > 1e-3 {
+		t.Errorf("KSC latitude not resolved: %v", s.LatDeg)
+	}
+}
+
+func TestBuildScenarioLaunchpadDefaultsKSC(t *testing.T) {
+	s, err := buildScenario(rawFlags{launchpad: true, set: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.Surface || math.Abs(s.LatDeg-28.6083) > 1e-3 {
+		t.Errorf("bare --launchpad should default to KSC, got Surface=%v lat=%v", s.Surface, s.LatDeg)
+	}
+}
+
+func TestBuildScenarioNumericSite(t *testing.T) {
+	s, err := buildScenario(rawFlags{
+		lat: 0, lon: 0,
+		set: map[string]bool{"lat": true, "lon": true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !s.Surface || s.LatDeg != 0 || s.LonDeg != 0 {
+		t.Errorf("explicit --lat 0 --lon 0 should be an equatorial surface spawn, got %+v", s)
+	}
+}
+
+func TestBuildScenarioConflict(t *testing.T) {
+	_, err := buildScenario(rawFlags{
+		altitude:  "400km",
+		launchpad: true,
+		set:       map[string]bool{"altitude": true},
+	})
+	if err == nil {
+		t.Error("orbital + surface flags should conflict")
+	}
+}
+
+func TestBuildScenarioSiteVsLatLonConflict(t *testing.T) {
+	_, err := buildScenario(rawFlags{
+		launchSite: "KSC",
+		lat:        10,
+		set:        map[string]bool{"lat": true},
+	})
+	if err == nil {
+		t.Error("--launch-site + --lat should conflict")
+	}
+}
+
+func TestBuildScenarioUnknownSite(t *testing.T) {
+	_, err := buildScenario(rawFlags{launchSite: "Nowhere", set: map[string]bool{}})
+	if err == nil {
+		t.Error("unknown launch site should error")
+	}
+}

--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -1,29 +1,66 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/settings"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
 	"github.com/jasonfen/terminal-space-program/internal/version"
 )
 
 func main() {
-	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+	var (
+		showVersion bool
+		raw         rawFlags
+		listSystems bool
+		listBodies  bool
+		listLoadout bool
+		listSites   bool
+	)
+	flag.BoolVar(&showVersion, "version", false, "print version + commit and exit")
+	flag.BoolVar(&showVersion, "v", false, "print version + commit and exit (shorthand)")
+	flag.StringVar(&raw.system, "system", "", "star system to start in (e.g. Sol, Lumen)")
+	flag.StringVar(&raw.body, "orbit", "", "body to orbit / launch from (ID or name)")
+	flag.StringVar(&raw.body, "parent", "", "alias for --orbit")
+	flag.StringVar(&raw.body, "body", "", "alias for --orbit")
+	flag.StringVar(&raw.altitude, "altitude", "", "circular-orbit altitude, e.g. 400km or 400000m (default 500km)")
+	flag.Float64Var(&raw.inclination, "inclination", 0, "orbit inclination in degrees")
+	flag.BoolVar(&raw.retrograde, "retrograde", false, "spawn into a retrograde orbit")
+	flag.BoolVar(&raw.launchpad, "launchpad", false, "spawn on the surface (launchpad) instead of in orbit")
+	flag.StringVar(&raw.launchSite, "launch-site", "", "named launch site (KSC, Baikonur, Plesetsk, Equator, North-Pole)")
+	flag.Float64Var(&raw.lat, "lat", 0, "launchpad latitude in degrees north (implies --launchpad)")
+	flag.Float64Var(&raw.lon, "lon", 0, "launchpad longitude in degrees east (implies --launchpad)")
+	flag.StringVar(&raw.loadout, "loadout", "", "craft loadout, e.g. Saturn-V or Kern-Stack (default S-IVB-1)")
+	flag.BoolVar(&listSystems, "list-systems", false, "list available star systems and exit")
+	flag.BoolVar(&listBodies, "list-bodies", false, "list bodies (honours --system) and exit")
+	flag.BoolVar(&listLoadout, "list-loadouts", false, "list craft loadouts and exit")
+	flag.BoolVar(&listSites, "list-launch-sites", false, "list named launch sites and exit")
+	flag.Parse()
+
+	if showVersion {
 		fmt.Printf("terminal-space-program %s (%s)\n", version.Version, version.Commit)
 		return
 	}
 
-	// Surface user-overlay + theme warnings before bubbletea takes the
-	// screen. Loading is cheap (<5 KB JSON each) so the double-load
-	// when tui.New rehydrates is negligible.
-	if _, warnings, err := bodies.LoadAllWithWarnings(); err == nil {
-		for _, w := range warnings {
+	// Record which flags the user actually passed, so buildScenario can tell
+	// an explicit 0 (e.g. --lat 0) from an unset float.
+	raw.set = map[string]bool{}
+	flag.Visit(func(f *flag.Flag) { raw.set[f.Name] = true })
+
+	// Load systems once (also surfaces user-overlay warnings before bubbletea
+	// takes the screen) — reused for the --list-* helpers below.
+	systems, sysWarnings, sysErr := bodies.LoadAllWithWarnings()
+	if sysErr == nil {
+		for _, w := range sysWarnings {
 			fmt.Fprintf(os.Stderr, "terminal-space-program: skipping %s: %v\n", w.Path, w.Err)
 		}
 	}
@@ -32,16 +69,27 @@ func main() {
 			fmt.Fprintf(os.Stderr, "terminal-space-program: skipping theme %s: %v\n", w.Path, w.Err)
 		}
 	}
-	// UI preferences (per-Chip visibility, ADR 0010). A missing file is
-	// the common case and yields all-on defaults silently; a malformed
-	// file degrades to defaults plus a warning here.
+	// UI preferences (per-Chip visibility, ADR 0010). A missing file is the
+	// common case and yields all-on defaults silently; a malformed file
+	// degrades to defaults plus a warning here.
 	if _, warnings := settings.Load(); len(warnings) > 0 {
 		for _, w := range warnings {
 			fmt.Fprintf(os.Stderr, "terminal-space-program: skipping settings %s: %v\n", w.Path, w.Err)
 		}
 	}
 
-	app, err := tui.New()
+	if listSystems || listBodies || listLoadout || listSites {
+		printLists(systems, raw.system, listSystems, listBodies, listLoadout, listSites)
+		return
+	}
+
+	scenario, err := buildScenario(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "terminal-space-program: %v\n", err)
+		os.Exit(2)
+	}
+
+	app, err := tui.New(scenario)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: %v\n", err)
 		os.Exit(1)
@@ -51,5 +99,44 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// printLists handles the --list-* discovery flags. --list-bodies scopes to
+// --system when given, else lists every system's bodies.
+func printLists(systems []bodies.System, systemFilter string, sys, bodiesL, loadouts, sites bool) {
+	if sys {
+		fmt.Println("Systems:")
+		for _, s := range systems {
+			fmt.Printf("  %-8s (%d bodies)\n", s.Name, len(s.Bodies))
+		}
+	}
+	if bodiesL {
+		fmt.Println("Bodies:")
+		for _, s := range systems {
+			if systemFilter != "" && !strings.EqualFold(s.Name, systemFilter) {
+				continue
+			}
+			fmt.Printf("  [%s]\n", s.Name)
+			for _, b := range s.Bodies {
+				parent := b.ParentID
+				if parent == "" {
+					parent = "—"
+				}
+				fmt.Printf("    %-12s %-14s parent=%s\n", b.ID, b.EnglishName, parent)
+			}
+		}
+	}
+	if loadouts {
+		fmt.Println("Loadouts:")
+		for _, id := range spacecraft.LoadoutOrder {
+			fmt.Printf("  %s\n", id)
+		}
+	}
+	if sites {
+		fmt.Println("Launch sites:")
+		for _, s := range sim.LaunchSites {
+			fmt.Printf("  %-12s %-28s %7.3f°N  %8.3f°E\n", s.Key, s.Name, s.LatitudeDeg, s.LongitudeEastDeg)
+		}
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,96 @@
+# Command-line reference
+
+`terminal-space-program` opens, by default, with a vessel in a 500 km low Earth
+orbit. The flags below let you boot straight into a different starting
+scenario — a system, a body to orbit or launch from, an orbit shape, a launch
+site, and a craft. They only shape a **fresh** game; loading a save from the
+in-game menu restores that save unchanged.
+
+All flags are optional. With none, the start is exactly as before.
+
+## Quick examples
+
+```bash
+# A 100 km circular orbit around the Moon
+terminal-space-program --orbit moon --altitude 100km
+
+# The Kern Stack in a 400 km orbit of Kern, in the Lumen system
+terminal-space-program --system Lumen --orbit kern --loadout Kern-Stack --altitude 400km
+
+# An ISS-like inclined low Earth orbit
+terminal-space-program --orbit earth --altitude 400km --inclination 51.6
+
+# A Saturn V on the pad at Kennedy Space Center
+terminal-space-program --launch-site KSC --loadout Saturn-V
+
+# A launchpad at an arbitrary surface point
+terminal-space-program --launchpad --lat -34.6 --lon -58.4 --loadout Falcon-9
+
+# Discover the valid names, then quit
+terminal-space-program --list-systems
+terminal-space-program --list-bodies --system Lumen
+terminal-space-program --list-loadouts
+terminal-space-program --list-launch-sites
+```
+
+## Flags
+
+### Discovery / info (print and exit)
+
+| Flag | Effect |
+|---|---|
+| `--version`, `-v` | Print the version + build commit. |
+| `--list-systems` | List the available star systems. |
+| `--list-bodies` | List bodies (their IDs). Honours `--system`; otherwise lists every system. |
+| `--list-loadouts` | List the craft loadout IDs. |
+| `--list-launch-sites` | List the named launch sites. |
+
+### Where to start
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--system NAME` | `Sol` | Star system, by name (`Sol`, `Lumen`, …). Case-insensitive. |
+| `--orbit BODY` | `earth` (or the system's first planet) | Body to orbit or launch from, by **ID** or English name (see `--list-bodies`). `--parent` and `--body` are accepted as synonyms. |
+| `--loadout NAME` | `S-IVB-1` | Craft loadout ID (`Saturn-V`, `Apollo-Stack`, `Kern-Stack`, …; see `--list-loadouts`). |
+
+A vessel is bound for its lifetime to the system it spawns in, and the camera
+follows it — so `--system Lumen` drops you straight into Lumen with the flight
+HUD live.
+
+### Orbital placement
+
+Used when **not** launching from a pad. Mutually exclusive with the surface
+flags below.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--altitude VAL` | `500km` | Circular-orbit altitude above the body's mean radius. Unit-suffixed: `400km`, `400000m`, or a bare number read as kilometres. |
+| `--inclination DEG` | `0` | Orbit inclination in degrees, relative to the body's equator. |
+| `--retrograde` | off | Spawn into a retrograde orbit. |
+
+The orbit is always circular; `--inclination` tilts its plane.
+
+### Surface (launchpad) placement
+
+Any of these switches to a surface spawn. Mutually exclusive with the orbital
+flags above.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--launchpad` | off | Spawn on the surface instead of in orbit. On its own, uses the KSC default site. |
+| `--launch-site NAME` | — | A named site: `Equator`, `KSC`, `Baikonur`, `Plesetsk`, `North-Pole` (see `--list-launch-sites`). Implies `--launchpad`. |
+| `--lat DEG`, `--lon DEG` | `0`, `0` | Numeric surface site — degrees north and degrees east of the prime meridian. Implies `--launchpad`. |
+
+Named sites are Earth-oriented; to launch from a pad on another body, give an
+explicit `--lat`/`--lon` (and `--orbit BODY` to choose the body).
+
+## Notes & errors
+
+- Combining orbital flags (`--altitude`/`--inclination`/`--retrograde`) with
+  surface flags (`--launchpad`/`--launch-site`/`--lat`/`--lon`) is an error.
+- `--launch-site` can't be combined with `--lat`/`--lon`.
+- An unknown system, body, loadout, or launch site prints a clear error that
+  lists the valid values, and exits non-zero.
+- Body and loadout names are the catalog **IDs** — run the matching `--list-*`
+  flag if a name is rejected (e.g. the Moon's ID is `moon`, Lumen's home planet
+  is `kern`).

--- a/internal/sim/launch_sites.go
+++ b/internal/sim/launch_sites.go
@@ -1,0 +1,44 @@
+package sim
+
+import "strings"
+
+// LaunchSitePreset bundles a named real-world launch site with its
+// latitude + longitude (east-positive, relative to the body's prime
+// meridian at simTime=0 — our pseudo-Greenwich convention; see
+// SpawnSpec.LongitudeOffset). The sites are Earth-oriented; for a
+// launchpad on another body, give an explicit lat/lon instead.
+//
+// v0.17: hoisted out of the spawn form (internal/tui/screens/spawn.go)
+// so the form's LATITUDE cycle and the --launch-site CLI flag resolve
+// the same set. Key is the short CLI token; Name is the display label.
+type LaunchSitePreset struct {
+	Key              string
+	Name             string
+	LatitudeDeg      float64
+	LongitudeEastDeg float64
+}
+
+// LaunchSites is the canonical named-site list. Index 1 (KSC) is the
+// spawn form's launchpad default, so opening the form with launchpad
+// selected lands a Saturn V at the historical Apollo pad; Equator at
+// index 0 is the textbook best-case baseline. KSC reuses the package
+// DefaultLaunchpad* consts so the default has a single source.
+var LaunchSites = []LaunchSitePreset{
+	{Key: "Equator", Name: "Equator", LatitudeDeg: 0.0, LongitudeEastDeg: 0.0},
+	{Key: "KSC", Name: "Cape Canaveral (KSC LC-39A)", LatitudeDeg: DefaultLaunchpadLatitude, LongitudeEastDeg: DefaultLaunchpadLongitudeEast},
+	{Key: "Baikonur", Name: "Baikonur Cosmodrome", LatitudeDeg: 45.965, LongitudeEastDeg: 63.342},
+	{Key: "Plesetsk", Name: "Plesetsk Cosmodrome", LatitudeDeg: 62.926, LongitudeEastDeg: 40.577},
+	{Key: "North-Pole", Name: "North Pole", LatitudeDeg: 90.0, LongitudeEastDeg: 0.0},
+}
+
+// LaunchSiteByName resolves a launch site by its short Key or display
+// Name, case-insensitively. Returns ok=false when no site matches.
+func LaunchSiteByName(name string) (LaunchSitePreset, bool) {
+	q := strings.TrimSpace(strings.ToLower(name))
+	for _, s := range LaunchSites {
+		if strings.ToLower(s.Key) == q || strings.ToLower(s.Name) == q {
+			return s, true
+		}
+	}
+	return LaunchSitePreset{}, false
+}

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -76,7 +76,14 @@ type SpawnSpec struct {
 	ParentBodyID string
 	AltitudeM    float64
 	Retrograde   bool
-	Alongside    bool
+	// Inclination (v0.17+) tilts the spawned circular orbit off the
+	// parent's equator by this many degrees, measured in the body-
+	// equatorial frame. Zero (the common case) spawns equatorial,
+	// byte-identical to the pre-v0.17 placement. The orbit stays
+	// circular; only the plane tilts (ascending node along body-frame
+	// +Y, the spawn-position axis). Used by the --inclination CLI flag.
+	Inclination float64
+	Alongside   bool
 
 	// CustomStages (v0.10.1+) is a player-assembled stage list from
 	// the spawn-form stack configurator, bottom-first (same
@@ -320,7 +327,13 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 	// (which sits at body-frame +X).
 	frame := orbital.ReferenceFrameForPrimary(primary)
 	rBody := orbital.Vec3{Y: r}
-	vBody := orbital.Vec3{X: -v}
+	// v0.17+: tilt the circular orbit off the equator by spec.Inclination.
+	// The spawn point (+Y) is the ascending node, so the plane rotates
+	// about the +Y axis: the prograde in-plane velocity (-X) tips toward
+	// +Z by the inclination angle. At i=0 this is exactly {X: -v} (and the
+	// retrograde sign flows through v), so the equatorial path is unchanged.
+	inc := spec.Inclination * math.Pi / 180
+	vBody := orbital.Vec3{X: -v * math.Cos(inc), Z: v * math.Sin(inc)}
 	c.Primary = primary
 	// v0.16 / ADR 0015: bind the new Vessel to the viewed System.
 	c.SystemIdx = w.SystemIdx

--- a/internal/sim/start_scenario.go
+++ b/internal/sim/start_scenario.go
@@ -1,0 +1,157 @@
+package sim
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// StartScenario is a resolved request to configure a fresh world's
+// starting craft from outside the TUI — built by the command-line flags
+// in cmd/terminal-space-program and applied via ApplyStartScenario. It
+// only ever shapes a fresh NewWorld (startup never auto-loads a save), so
+// there's no persisted-state interaction. v0.17.
+type StartScenario struct {
+	// SystemName selects the star system by System.Name (case-insensitive).
+	// Empty → Sol.
+	SystemName string
+	// BodyID is the parent body to spawn at (ID or English name, resolved
+	// via System.FindBody). Empty → the system's home planet (Earth in Sol,
+	// else the first planet).
+	BodyID string
+	// Loadout is the craft loadout ID (e.g. "Saturn-V"). Empty → S-IVB-1.
+	Loadout string
+
+	// Surface selects a launchpad spawn (LatDeg/LonDeg) over an orbital one
+	// (AltitudeM/InclDeg/Retrograde).
+	Surface bool
+
+	// Orbital placement.
+	AltitudeM  float64
+	InclDeg    float64
+	Retrograde bool
+
+	// Surface placement (degrees north / degrees east of pseudo-Greenwich).
+	LatDeg float64
+	LonDeg float64
+}
+
+// ApplyStartScenario reshapes the world's starting craft per s, replacing
+// the default LEO seed. It resolves the system + body, clears the default
+// slate, spawns a single craft from the scenario via SpawnCraft (so
+// launchpad co-rotation and ADR 0015 system binding come for free), and
+// leaves that craft active with the camera following it. Returns a
+// descriptive error (listing valid values) on an unknown system / body /
+// loadout, leaving the world untouched.
+func (w *World) ApplyStartScenario(s StartScenario) error {
+	// 1. Resolve the system (default Sol / index 0).
+	sysIdx := 0
+	if s.SystemName != "" {
+		idx := -1
+		for i := range w.Systems {
+			if strings.EqualFold(w.Systems[i].Name, s.SystemName) {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return fmt.Errorf("unknown system %q (have: %s)", s.SystemName, strings.Join(SystemNames(w.Systems), ", "))
+		}
+		sysIdx = idx
+	}
+
+	// 2. Resolve the body within that system before mutating any state.
+	sys := w.Systems[sysIdx]
+	bodyID := s.BodyID
+	if bodyID == "" {
+		bodyID = defaultStartBodyID(sys)
+	}
+	b := sys.FindBody(bodyID)
+	if b == nil {
+		return fmt.Errorf("unknown body %q in system %q (have: %s)", s.BodyID, sys.Name, strings.Join(bodyNames(sys), ", "))
+	}
+
+	// 3. Validate the loadout up front (SpawnCraft would silently fall back
+	//    to S-IVB-1 on an unknown ID — surface it as an error instead).
+	if s.Loadout != "" && !validLoadoutID(s.Loadout) {
+		return fmt.Errorf("unknown loadout %q (have: %s)", s.Loadout, strings.Join(spacecraft.LoadoutOrder, ", "))
+	}
+
+	// 4. Browse to the target system so SpawnCraft binds the craft there
+	//    (a craft binds to the viewed System at spawn time, ADR 0015), then
+	//    replace the default slate.
+	w.SystemIdx = sysIdx
+	w.Calculator = orbital.ForSystem(w.System())
+	w.Crafts = nil
+	w.ActiveCraftIdx = -1
+
+	spec := SpawnSpec{
+		LoadoutID:    s.Loadout,
+		ParentBodyID: b.ID,
+	}
+	if s.Surface {
+		spec.Launchpad = true
+		spec.Latitude = s.LatDeg
+		spec.LongitudeOffset = s.LonDeg
+	} else {
+		spec.AltitudeM = s.AltitudeM
+		spec.Inclination = s.InclDeg
+		spec.Retrograde = s.Retrograde
+	}
+	if _, err := w.SpawnCraft(spec); err != nil {
+		return err
+	}
+	// SpawnCraft already activated the craft, snapped the camera to its
+	// system, and set Focus=FocusCraft.
+	return nil
+}
+
+// SystemNames lists the loaded systems' display names, for discovery and
+// error messages. v0.17.
+func SystemNames(systems []bodies.System) []string {
+	names := make([]string, len(systems))
+	for i, s := range systems {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// bodyNames lists a system's body IDs (the canonical CLI tokens).
+func bodyNames(sys bodies.System) []string {
+	ids := make([]string, len(sys.Bodies))
+	for i, b := range sys.Bodies {
+		ids[i] = b.ID
+	}
+	return ids
+}
+
+// defaultStartBodyID picks the body to spawn at when none is given: Earth
+// when the system has it (keeps the familiar Sol default), else the first
+// planet (top-level, non-star body).
+func defaultStartBodyID(sys bodies.System) string {
+	if b := sys.FindBody("earth"); b != nil {
+		return b.ID
+	}
+	for i := 1; i < len(sys.Bodies); i++ {
+		if sys.Bodies[i].ParentID == "" {
+			return sys.Bodies[i].ID
+		}
+	}
+	if len(sys.Bodies) > 0 {
+		return sys.Bodies[0].ID
+	}
+	return ""
+}
+
+// validLoadoutID reports whether id is a known catalog loadout.
+func validLoadoutID(id string) bool {
+	for _, l := range spacecraft.LoadoutOrder {
+		if l == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sim/start_scenario_test.go
+++ b/internal/sim/start_scenario_test.go
@@ -1,0 +1,142 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// applyOrFatal runs ApplyStartScenario on a fresh world, failing the test on
+// error, and returns the world.
+func applyOrFatal(t *testing.T, s StartScenario) *World {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if err := w.ApplyStartScenario(s); err != nil {
+		t.Fatalf("ApplyStartScenario(%+v): %v", s, err)
+	}
+	return w
+}
+
+func TestApplyStartScenarioLunarOrbit(t *testing.T) {
+	w := applyOrFatal(t, StartScenario{BodyID: "moon", AltitudeM: 100_000})
+	if len(w.Crafts) != 1 {
+		t.Fatalf("want 1 craft, got %d", len(w.Crafts))
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	if c.Primary.ID != "moon" {
+		t.Errorf("primary = %q, want moon", c.Primary.ID)
+	}
+	alt := c.State.R.Norm() - c.Primary.RadiusMeters()
+	if math.Abs(alt-100_000) > 1_000 {
+		t.Errorf("altitude = %.0f m, want ~100 km", alt)
+	}
+	if w.Focus.Kind != FocusCraft {
+		t.Errorf("focus = %v, want FocusCraft", w.Focus.Kind)
+	}
+}
+
+func TestApplyStartScenarioLumenBinding(t *testing.T) {
+	w := applyOrFatal(t, StartScenario{SystemName: "Lumen", BodyID: "kern", AltitudeM: 400_000, Loadout: "Kern-Stack"})
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	// The craft must be bound to Lumen and the camera must follow it there
+	// (ADR 0015), so the flight HUD shows rather than staying suppressed.
+	if c.SystemIdx == 0 {
+		t.Errorf("craft SystemIdx = 0 (Sol), want Lumen's index")
+	}
+	if w.SystemIdx != c.SystemIdx {
+		t.Errorf("viewed system %d != craft system %d (camera not following)", w.SystemIdx, c.SystemIdx)
+	}
+	if !w.CraftVisibleHere() {
+		t.Error("CraftVisibleHere() = false — flight HUD would be suppressed")
+	}
+}
+
+func TestApplyStartScenarioLaunchpad(t *testing.T) {
+	w := applyOrFatal(t, StartScenario{
+		BodyID: "earth", Surface: true,
+		LatDeg: DefaultLaunchpadLatitude, LonDeg: DefaultLaunchpadLongitudeEast,
+		Loadout: "Saturn-V",
+	})
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	if !c.Landed {
+		t.Error("launchpad spawn should be Landed")
+	}
+	if c.Primary.ID != "earth" {
+		t.Errorf("primary = %q, want earth", c.Primary.ID)
+	}
+}
+
+func TestApplyStartScenarioInclination(t *testing.T) {
+	w := applyOrFatal(t, StartScenario{BodyID: "earth", AltitudeM: 400_000, InclDeg: 51.6})
+	c := w.ActiveCraft()
+	// Read the orbit in the body-equatorial frame, where inclination is
+	// measured relative to Earth's equator.
+	mu := c.Primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	el := orbital.ElementsFromStateInFrame(c.State.R, c.State.V, mu, frame)
+	if el.E > 1e-3 {
+		t.Errorf("inclined spawn should stay circular, got e=%.4f", el.E)
+	}
+	incDeg := el.I * 180 / math.Pi
+	if math.Abs(incDeg-51.6) > 0.5 {
+		t.Errorf("inclination = %.2f°, want ~51.6°", incDeg)
+	}
+}
+
+func TestApplyStartScenarioEquatorialUnchanged(t *testing.T) {
+	// inclination 0 must reduce to the pre-v0.17 equatorial placement.
+	w := applyOrFatal(t, StartScenario{BodyID: "earth", AltitudeM: 400_000})
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	el := orbital.ElementsFromStateInFrame(c.State.R, c.State.V, mu, frame)
+	if incDeg := el.I * 180 / math.Pi; incDeg > 0.01 {
+		t.Errorf("i=0 spawn inclination = %.4f°, want ~0", incDeg)
+	}
+}
+
+func TestApplyStartScenarioUnknownSystem(t *testing.T) {
+	w, _ := NewWorld()
+	if err := w.ApplyStartScenario(StartScenario{SystemName: "Nowhere"}); err == nil {
+		t.Error("unknown system should error")
+	}
+}
+
+func TestApplyStartScenarioUnknownBody(t *testing.T) {
+	w, _ := NewWorld()
+	if err := w.ApplyStartScenario(StartScenario{BodyID: "tatooine"}); err == nil {
+		t.Error("unknown body should error")
+	}
+}
+
+func TestApplyStartScenarioUnknownLoadout(t *testing.T) {
+	w, _ := NewWorld()
+	if err := w.ApplyStartScenario(StartScenario{BodyID: "earth", Loadout: "Millennium-Falcon"}); err == nil {
+		t.Error("unknown loadout should error")
+	}
+}
+
+func TestLaunchSiteByName(t *testing.T) {
+	if s, ok := LaunchSiteByName("ksc"); !ok || s.Key != "KSC" {
+		t.Errorf("LaunchSiteByName(ksc) = %+v ok=%v", s, ok)
+	}
+	if s, ok := LaunchSiteByName("Cape Canaveral (KSC LC-39A)"); !ok || s.Key != "KSC" {
+		t.Errorf("lookup by display name failed: %+v ok=%v", s, ok)
+	}
+	if _, ok := LaunchSiteByName("nope"); ok {
+		t.Error("unknown site should return ok=false")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -83,16 +83,29 @@ type App struct {
 	endFlightConfirm bool
 }
 
-// New builds a root App. Returns an error if systems can't load.
-func New() (*App, error) {
+// New builds a root App. Returns an error if systems can't load. When
+// scenario is non-nil, the fresh world's default LEO seed is replaced per
+// the command-line start scenario (system / body / orbit / launch site);
+// an unknown system / body / loadout there is surfaced as the error. Pass
+// nil for the standard default start. v0.17.
+func New(scenario *sim.StartScenario) (*App, error) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		return nil, err
 	}
-	// Open a fresh game a few hours before the next ideal Moon-transfer
-	// window instead of the ~10 days out the J2000 epoch yields. A false
-	// return just keeps the J2000 start — never fatal.
-	w.AdjustStartForLunarTransferWindow(sim.DefaultLunarTransferLead)
+	if scenario != nil {
+		// A custom start replaces the seed craft; the Earth-Moon lunar
+		// transfer-window adjust below is irrelevant (and wrong for a
+		// non-Earth / non-Sol start), so skip it.
+		if err := w.ApplyStartScenario(*scenario); err != nil {
+			return nil, err
+		}
+	} else {
+		// Open a fresh game a few hours before the next ideal Moon-transfer
+		// window instead of the ~10 days out the J2000 epoch yields. A false
+		// return just keeps the J2000 start — never fatal.
+		w.AdjustStartForLunarTransferWindow(sim.DefaultLunarTransferLead)
+	}
 	th := DefaultTheme()
 	sth := screens.Theme{
 		Primary: th.Primary,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -15,7 +15,7 @@ import (
 // Clicking the navball panel's [MODE] button cycles NavMode and
 // surfaces the same status toast the CycleNavMode key does.
 func TestDispatchNavballControlMode(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestDispatchNavballControlMode(t *testing.T) {
 // Clicking an axis button holds that SAS intent — same path as the
 // keyboard, with NavMode rebinding applied via ResolveAttitudeIntent.
 func TestDispatchNavballControlAxis(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestDispatchNavballControlAxis(t *testing.T) {
 
 // Clicking the RCS toggle flips EngineMode both ways and toasts.
 func TestDispatchNavballControlRCS(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestDispatchNavballControlRCS(t *testing.T) {
 // Clicking the [SAS] tag flips World.InstantSAS both ways and toasts
 // the new model name — the locked-decision non-silent surfacing.
 func TestDispatchNavballControlSAS(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestDispatchNavballControlSAS(t *testing.T) {
 // craft slot; an empty slot is a no-op. Guards the digit-parse +
 // binding wiring behind World.SwitchToCraftIdx.
 func TestCraftSlotKeyJumps(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestSettingsScreenRoundTripPersists(t *testing.T) {
 	// clobber the developer's real config.
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestSettingsScreenRoundTripPersists(t *testing.T) {
 
 // Clicking the target ± buttons holds BurnTarget / BurnAntiTarget.
 func TestDispatchNavballControlTarget(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDispatchNavballControlTarget(t *testing.T) {
 // an engaged driver, leaving Selected Warp to apply from the player's
 // own rate (ADR 0016).
 func TestAutoWarpKeyToggleAndManualCancel(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestAutoWarpKeyToggleAndManualCancel(t *testing.T) {
 // re-plant, so an engaged Auto-Warp target keeps resolving instead of
 // silently disengaging. Pre-fix the re-plant minted a fresh ID.
 func TestEditedNodeKeepsIDForAutoWarp(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestEditedNodeKeepsIDForAutoWarp(t *testing.T) {
 // TestCancelWarpKeyDropsToOneX — `/` cancels Auto-Warp and resets
 // Selected Warp to 1× from any warp state.
 func TestCancelWarpKeyDropsToOneX(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestCancelWarpKeyDropsToOneX(t *testing.T) {
 // TestHelpOnF1AndTrimResetOnQuestion locks the v0.16 keybinding move:
 // Help opens on F1 (not `?`), and `?` now resets pitch trim.
 func TestHelpOnF1AndTrimResetOnQuestion(t *testing.T) {
-	a, err := New()
+	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -20,7 +21,7 @@ type SpawnCraft struct {
 	fieldIdx int // 0=loadout, 1=position, 2=parent, 3=alt/lat, 4=direction, 5=stack(custom only)
 
 	loadoutIdx   int
-	posMode      spawnPosMode // v0.9.2+: tri-state — orbit / alongside / launchpad
+	posMode      spawnPosMode           // v0.9.2+: tri-state — orbit / alongside / launchpad
 	parentBodies []bodies.CelestialBody // populated by Reset
 	parentIdx    int
 	altIdx       int
@@ -63,32 +64,10 @@ const (
 // transfer alts, and high-Earth / interplanetary capture orbits.
 var altitudePresets = []int{200, 500, 1000, 2000, 5000, 10000, 35786}
 
-// LaunchSitePreset bundles a named real-world launch site with its
-// real-world latitude + longitude (east-positive, relative to Earth's
-// prime meridian). v0.9.2+. The form's LATITUDE field cycles through
-// these so picking "Cape Canaveral" lands the craft on KSC LC-39A,
-// not just at "the right latitude."
-type LaunchSitePreset struct {
-	Name      string
-	LatitudeDeg float64
-	// LongitudeEastDeg is east-positive longitude in degrees relative
-	// to the body's prime meridian at simTime=0 (our pseudo-Greenwich
-	// convention — see SpawnSpec.LongitudeOffset doc).
-	LongitudeEastDeg float64
-}
-
-// launchSitePresets is the form's named-site cycle. Default is
-// index 1 (Cape Canaveral KSC LC-39A), so opening the spawn form
-// with launchpad selected lands a Saturn V at the historical Apollo
-// pad. Equator at index 0 is the textbook best-case baseline; the
-// other entries pin to real-world Earth launch sites.
-var launchSitePresets = []LaunchSitePreset{
-	{Name: "Equator", LatitudeDeg: 0.0, LongitudeEastDeg: 0.0},
-	{Name: "Cape Canaveral (KSC LC-39A)", LatitudeDeg: 28.6083, LongitudeEastDeg: -80.604},
-	{Name: "Baikonur Cosmodrome", LatitudeDeg: 45.965, LongitudeEastDeg: 63.342},
-	{Name: "Plesetsk Cosmodrome", LatitudeDeg: 62.926, LongitudeEastDeg: 40.577},
-	{Name: "North Pole", LatitudeDeg: 90.0, LongitudeEastDeg: 0.0},
-}
+// The form's LATITUDE field cycles through the shared named-site list
+// sim.LaunchSites (v0.17: hoisted to internal/sim so the form and the
+// --launch-site CLI flag resolve the same set). Picking "Cape Canaveral"
+// lands the craft on KSC LC-39A, not just at "the right latitude."
 
 // NewSpawnCraft constructs the screen.
 func NewSpawnCraft(th Theme) *SpawnCraft { return &SpawnCraft{theme: th} }
@@ -203,20 +182,20 @@ func (s *SpawnCraft) SelectedLaunchpad() bool { return s.posMode == posLaunchpad
 // north) when SelectedLaunchpad is true. Defaults to KSC LC-39A
 // (28.6083°N) when the cursor is out of range. v0.9.2+.
 func (s *SpawnCraft) SelectedLatitudeDeg() float64 {
-	if s.latIdx < 0 || s.latIdx >= len(launchSitePresets) {
+	if s.latIdx < 0 || s.latIdx >= len(sim.LaunchSites) {
 		return 28.6083
 	}
-	return launchSitePresets[s.latIdx].LatitudeDeg
+	return sim.LaunchSites[s.latIdx].LatitudeDeg
 }
 
 // SelectedLongitudeEastDeg returns the chosen surface longitude
 // offset (degrees east of pseudo-Greenwich). Defaults to KSC
 // (-80.604°E) when the cursor is out of range. v0.9.2+.
 func (s *SpawnCraft) SelectedLongitudeEastDeg() float64 {
-	if s.latIdx < 0 || s.latIdx >= len(launchSitePresets) {
+	if s.latIdx < 0 || s.latIdx >= len(sim.LaunchSites) {
 		return -80.604
 	}
-	return launchSitePresets[s.latIdx].LongitudeEastDeg
+	return sim.LaunchSites[s.latIdx].LongitudeEastDeg
 }
 
 // fieldOrder returns the field indices in visual (top-to-bottom) order,
@@ -361,7 +340,7 @@ func (s *SpawnCraft) cycleField(step int) {
 		}
 	case 3:
 		if s.posMode == posLaunchpad {
-			s.latIdx = wrapIdx(s.latIdx+step, len(launchSitePresets))
+			s.latIdx = wrapIdx(s.latIdx+step, len(sim.LaunchSites))
 		} else {
 			s.altIdx = wrapIdx(s.altIdx+step, len(altitudePresets))
 		}
@@ -531,7 +510,7 @@ func (s *SpawnCraft) Render(width int) string {
 	lines = append(lines, "")
 	if s.posMode == posLaunchpad {
 		lines = append(lines, s.fieldHeader(3, "LAUNCH SITE"))
-		site := launchSitePresets[s.latIdx]
+		site := sim.LaunchSites[s.latIdx]
 		hemi := "N"
 		latAbs := site.LatitudeDeg
 		if latAbs < 0 {


### PR DESCRIPTION
Adds command-line switches (alongside the existing `--version`) that boot the game straight into a chosen starting scenario instead of the default Earth-LEO seed.

```bash
terminal-space-program --orbit moon --altitude 100km
terminal-space-program --system Lumen --orbit kern --loadout Kern-Stack --altitude 400km
terminal-space-program --orbit earth --altitude 400km --inclination 51.6
terminal-space-program --launch-site KSC --loadout Saturn-V
terminal-space-program --list-bodies --system Lumen
```

## Flags

`--system`, `--orbit`/`--parent`/`--body`, `--altitude` (unit-suffixed), `--inclination`, `--retrograde`, `--launchpad`, `--launch-site`, `--lat`/`--lon`, `--loadout`, and `--list-systems`/`--list-bodies`/`--list-loadouts`/`--list-launch-sites`. `--version`/`-v` preserved. Full reference in `docs/cli.md`; basics in the README.

## How it composes (reuse-first)

- **`sim.StartScenario` + `(*World).ApplyStartScenario`** resolves the system/body, clears the default slate, and spawns one craft through the existing `SpawnCraft` — so launchpad co-rotation and **ADR 0015 system binding** (camera follows the craft into Lumen, flight HUD live) come for free. Unknown system/body/loadout errors **list the valid values**.
- **`SpawnSpec.Inclination`** is the only new physics: it tilts the circular orbit about the `+Y` node axis. At `i=0` it's byte-identical to the prior equatorial placement (regression-safe; pinned by a test).
- The **named launch-site presets move from `tui/screens/spawn.go` to `internal/sim/launch_sites.go`** (`LaunchSiteByName`) so the CLI and the spawn form share one list; the form is repointed with **no behavior change**.
- **`tui.New(scenario)`** threads it; a custom start skips the Earth-Moon lunar-window time-skip. Startup still **never auto-loads a save**, so flags only shape a fresh world — no save interaction, no schema change.

## Mutual-exclusion / validation

Orbital flags (`--altitude`/`--inclination`/`--retrograde`) and surface flags (`--launchpad`/`--launch-site`/`--lat`/`--lon`) are mutually exclusive; `--launch-site` excludes `--lat`/`--lon`. Conflicts and unknown names exit non-zero with a helpful message.

## Verification

`go vet ./...` clean; `go test ./... -race -count=1` green. New tests: `parseDistance` units, scenario build + all conflict/unknown paths, `ApplyStartScenario` world-build (parent, **Lumen binding + `CraftVisibleHere`**, launchpad `Landed`, **inclination via `ElementsFromState`**, `i=0` equatorial regression), `LaunchSiteByName`. CLI smoke: `--version`, all `--list-*`, and the conflict error path verified against the built binary.

Natural **v0.17** anchor; own branch per convention. (Note: body/loadout names are catalog **IDs** — the Moon is `moon`, Lumen's home planet is `kern`; `--list-*` surfaces them.)