### PR TITLE
eval(sim): SOI-entry prediction fidelity harness + predictTuning knobs

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2519,6 +2519,21 @@ func (w *World) propagateCraftWithPrimary(dt float64) (physics.StateVector, bodi
 // of Kepler-ephemeris evaluation per Verlet sub-step, negligible vs the
 // integration itself.
 func (w *World) propagateStateWithPrimary(startState physics.StateVector, startPrimary bodies.CelestialBody, startClock time.Time, dt float64) (physics.StateVector, bodies.CelestialBody) {
+	state, primary, _ := w.propagateStateWithPrimaryTuned(startState, startPrimary, startClock, dt, predictTuning{})
+	return state, primary
+}
+
+// propagateStateWithPrimaryTuned is propagateStateWithPrimary
+// parameterised on predictTuning (zero value = shipped behavior — the
+// production wrapper above always passes it), additionally reporting
+// each SOI transition as a soiEntry for the eval harness. Note the two
+// deficiencies this site has that predict.go's segment loop does not:
+// the coast sub-step is bare period/100 with NO absolute cap (hours on
+// a transfer ellipse, so SOI detection quantizes to hours), and there
+// is no #91 post-rebase re-resolution (a lunar flyby keeps the
+// transfer ellipse's coarse dt). The CoastSubStepCap knob supplies
+// both; the eval harness measures what they're worth.
+func (w *World) propagateStateWithPrimaryTuned(startState physics.StateVector, startPrimary bodies.CelestialBody, startClock time.Time, dt float64, tu predictTuning) (physics.StateVector, bodies.CelestialBody, []soiEntry) {
 	current := startPrimary
 	muNow := current.GravitationalParameter()
 	state := startState
@@ -2526,23 +2541,36 @@ func (w *World) propagateStateWithPrimary(startState physics.StateVector, startP
 
 	sys := w.System()
 
-	period := orbitalPeriod(state, muNow)
-	maxStep := period / 100.0
-	if maxStep <= 0 || math.IsNaN(maxStep) || math.IsInf(maxStep, 0) {
-		maxStep = 1.0
+	// chainMaxStep mirrors the legacy period/100 (1 s degenerate
+	// fallback), with the CoastSubStepCap knob folded in.
+	chainMaxStep := func(period float64) float64 {
+		ms := period / 100.0
+		if ms <= 0 || math.IsNaN(ms) || math.IsInf(ms, 0) {
+			ms = 1.0
+		}
+		if tu.CoastSubStepCap > 0 && ms > tu.CoastSubStepCap {
+			ms = tu.CoastSubStepCap
+		}
+		return ms
 	}
+
+	period := orbitalPeriod(state, muNow)
+	maxStep := chainMaxStep(period)
 	nSteps := int(math.Ceil(dt / maxStep))
 	if nSteps < 1 {
 		nSteps = 1
 	}
-	if nSteps > 1024 {
-		nSteps = 1024
+	if nSteps > tu.chainSubStepClamp() {
+		nSteps = tu.chainSubStepClamp()
 	}
 	step := dt / float64(nSteps)
 	stepDur := time.Duration(step * float64(time.Second))
 	positions := make(map[string]orbital.Vec3, len(sys.Bodies))
 	bc := w.ActiveCraft().EffectiveBallisticCoefficient()
+	var entries []soiEntry
 	for i := 0; i < nSteps; i++ {
+		preState := state
+		preClock := clock
 		// v0.12.x (GH #66): propagate ballistic coast legs with analytic
 		// Kepler (predictStep), Verlet only for drag/hyperbolic/sub-
 		// surface. A long phasing wait (an inclined transfer can sit ~50
@@ -2550,13 +2578,13 @@ func (w *World) propagateStateWithPrimary(startState physics.StateVector, startP
 		// phase under the 1024-step Verlet cap — misplacing the departure
 		// point and, for the node-aligned split, the apoapsis off the
 		// line of nodes. Mirrors the predictor in predict.go.
-		state = predictStep(state, muNow, step, current, bc)
+		state = predictStepTuned(state, muNow, step, current, bc, tu)
 		// v0.8.5: terminate propagation at surface contact. Mirrors the
 		// live integrator (sim/world.go) and the trajectory predictor
 		// (sim/predict.go) so node-planning sees the same landed state
 		// the live craft would arrive at.
 		if clamped, hit := physics.ClampToSurface(state, current); hit {
-			return clamped, current
+			return clamped, current, entries
 		}
 		clock = clock.Add(stepDur)
 
@@ -2567,12 +2595,60 @@ func (w *World) propagateStateWithPrimary(startState physics.StateVector, startP
 		inertial := positions[current.ID].Add(state.R)
 		cand := physics.FindPrimary(sys, inertial, positions)
 		if cand.Body.ID != current.ID {
-			vOld := w.bodyInertialVelocityAt(current, clock)
-			vNew := w.bodyInertialVelocityAt(cand.Body, clock)
+			rebaseClock := clock
+			carry := 0.0
+			if tu.RefineCrossing {
+				tau, refined, refCand := w.refineCrossingTime(sys, preState, current, muNow, preClock, step, bc, tu)
+				if refCand.Body.ID == current.ID {
+					// Phantom crossing (see predictedSegmentsFromTuned):
+					// can't normally happen here — this site refreshes
+					// positions per sub-step — but guard against a no-op
+					// rebase and spurious soiEntry all the same.
+					state = refined
+					continue
+				}
+				state = refined
+				cand = refCand
+				rebaseClock = preClock.Add(time.Duration(tau * float64(time.Second)))
+				carry = step - tau
+				clock = rebaseClock
+				for _, b := range sys.Bodies {
+					positions[b.ID] = w.BodyPositionAt(b, rebaseClock)
+				}
+			}
+			vOld := w.bodyInertialVelocityAt(current, rebaseClock)
+			vNew := w.bodyInertialVelocityAt(cand.Body, rebaseClock)
 			state = physics.Rebase(state, positions[current.ID], cand.Inertial, vOld.Sub(vNew))
 			current = cand.Body
 			muNow = current.GravitationalParameter()
+			entries = append(entries, soiEntry{BodyID: current.ID, Clock: rebaseClock, State: state})
+
+			if tu.CoastSubStepCap > 0 || tu.RefineCrossing {
+				// #91-equivalent re-resolution: re-divide the remaining
+				// horizon for the new orbit (a lunar flyby needs ~1 s
+				// Verlet steps, not the transfer ellipse's hours), and
+				// fold in the refined crossing's un-integrated carry.
+				newMaxStep := chainMaxStep(orbitalPeriod(state, muNow))
+				effMax := newMaxStep
+				if maxStep < effMax {
+					effMax = maxStep
+				}
+				remainingTime := float64(nSteps-i-1)*step + carry
+				if remainingTime > 0 {
+					newNSub := int(math.Ceil(remainingTime / effMax))
+					if newNSub < 1 {
+						newNSub = 1
+					}
+					if newNSub > tu.chainSubStepClamp() {
+						newNSub = tu.chainSubStepClamp()
+					}
+					nSteps = i + 1 + newNSub
+					step = remainingTime / float64(newNSub)
+					stepDur = time.Duration(step * float64(time.Second))
+				}
+				maxStep = newMaxStep
+			}
 		}
 	}
-	return state, current
+	return state, current, entries
 }

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -103,6 +103,156 @@ type SOISegment struct {
 	Points    []orbital.Vec3 // inertial, system-primary-centered
 }
 
+// predictTuning selects fidelity variants of the SOI-aware propagation
+// loops (predictedSegmentsFromTuned and propagateStateWithPrimaryTuned).
+// The zero value reproduces today's shipped behavior exactly; production
+// callers always pass the zero value. The SOI-entry prediction eval
+// harness flips individual knobs to attribute moon-transfer Projected
+// Orbit error to each numeric artifact (vault: warp-orbit-accuracy.md
+// §"2026-06-09 — SOI-entry prediction fidelity"). Knobs that win the
+// attribution become the new defaults in the follow-up fix slice.
+type predictTuning struct {
+	// BodyPerSubStep refreshes body positions (and the SOI-test clock)
+	// every integrator sub-step instead of once per output sample.
+	// Targets the predictedSegmentsFromTuned staleness artifact: the
+	// per-sub-step FindPrimary test otherwise runs against a positions
+	// snapshot up to one sample interval old — hours on a multi-day
+	// transfer horizon, thousands of km of moon motion.
+	BodyPerSubStep bool
+
+	// RefineCrossing bisects the SOI crossing time inside the sub-step
+	// that detected the flip (~40 iterations of the same propagator),
+	// then rebases with body positions and velocities evaluated at the
+	// refined crossing time. Without it the crossing is quantized to
+	// the sub-step that noticed it and the rebase velocities come from
+	// an even staler clock. Same load-bearing trick as
+	// NextClosestApproach's parabolic refinement (CONTEXT.md "Closest
+	// Approach").
+	RefineCrossing bool
+
+	// BodyInterp linearly interpolates body positions between the
+	// sample-boundary ephemeris evaluations for every sub-step's SOI
+	// test — the cheap alternative to BodyPerSubStep (two Kepler
+	// ephemeris evals per sample instead of one, plus vector lerps).
+	// Within one sample a body's arc is <1°, so linearization error is
+	// tens of meters (warp-orbit-accuracy.md §"Analytic SOI crossing").
+	// Ignored when BodyPerSubStep is set.
+	BodyInterp bool
+
+	// CoastSubStepCap, when >0, applies an absolute cap (seconds) to
+	// the coast sub-step of propagateStateWithPrimaryTuned — which
+	// today uses bare period/100 (hours on a transfer ellipse, so SOI
+	// detection quantizes to hours) — and re-resolves the sub-step
+	// after a rebase into a tighter orbit (the #91 treatment, which
+	// predictedSegmentsFromTuned already has). predictMaxSubStepCap
+	// (120 s) is the natural value.
+	CoastSubStepCap float64
+
+	// HyperbolicDtCap, when >0, caps the Verlet dt (seconds) on arcs
+	// where analytic Kepler is ineligible (hyperbolic flyby inside the
+	// target moon's SOI, atmosphere, sub-surface periapsis) by
+	// splitting one sub-step into smaller Verlet steps. Kepler-eligible
+	// arcs are dt-independent and skip the split.
+	HyperbolicDtCap float64
+
+	// MaxSubSteps, when >0, overrides the per-sample / per-call
+	// sub-step perf clamps (256 in predictedSegmentsFromTuned, 1024 in
+	// propagateStateWithPrimaryTuned). The clamps silently re-coarsen
+	// dt on long horizons — the #91 re-resolution asks for ~1 s steps
+	// across a lunar flyby but the 256 clamp hands back ~30 s.
+	MaxSubSteps int
+}
+
+// segSubStepClamp returns the sub-step perf clamp for the segment
+// predictor (legacy 256 unless overridden).
+func (tu predictTuning) segSubStepClamp() int {
+	if tu.MaxSubSteps > 0 {
+		return tu.MaxSubSteps
+	}
+	return 256
+}
+
+// chainSubStepClamp returns the sub-step perf clamp for the node-chain
+// propagator (legacy 1024 unless overridden).
+func (tu predictTuning) chainSubStepClamp() int {
+	if tu.MaxSubSteps > 0 {
+		return tu.MaxSubSteps
+	}
+	return 1024
+}
+
+// soiEntry records one predicted SOI transition: the body whose sphere
+// was entered (or the parent re-entered on exit), the crossing
+// wall-clock — bisection-refined when predictTuning.RefineCrossing is
+// set, otherwise the end of the sub-step that detected the flip — and
+// the craft state in the new primary's frame immediately after rebase.
+// Diagnostic surface for the SOI-entry prediction eval harness;
+// production rendering ignores it.
+type soiEntry struct {
+	BodyID string
+	Clock  time.Time
+	State  physics.StateVector
+}
+
+// predictStepTuned is predictStep with the HyperbolicDtCap knob: when
+// the state is Kepler-ineligible (Verlet fallback territory) and the
+// requested dt exceeds the cap, the step is split into equal Verlet
+// sub-steps no longer than the cap. Kepler-eligible states pass
+// through — the analytic step is exact at any dt.
+func predictStepTuned(state physics.StateVector, mu, dt float64, primary bodies.CelestialBody, bc float64, tu predictTuning) physics.StateVector {
+	if tu.HyperbolicDtCap > 0 && dt > tu.HyperbolicDtCap && !canKeplerStepState(state, mu, primary) {
+		n := int(math.Ceil(dt / tu.HyperbolicDtCap))
+		sub := dt / float64(n)
+		for i := 0; i < n; i++ {
+			state = predictStep(state, mu, sub, primary, bc)
+		}
+		return state
+	}
+	return predictStep(state, mu, dt, primary, bc)
+}
+
+// refineCrossingTime bisects the SOI crossing inside (t0, t0+dt]: preState
+// is the craft state (current-primary frame) at wall-clock t0, known to be
+// inside `current`'s SOI; propagating it by dt flips FindPrimary to a
+// different primary. Returns tau ∈ (0, dt] — the offset of the earliest
+// detected flip — the state at t0+tau (still in the OLD primary's frame),
+// and the crossing candidate at that time. Body positions are evaluated
+// fresh at each probe time, so the sphere is tested where the moon
+// actually is at the candidate crossing instant.
+func (w *World) refineCrossingTime(sys bodies.System, preState physics.StateVector, current bodies.CelestialBody, mu float64, t0 time.Time, dt float64, bc float64, tu predictTuning) (float64, physics.StateVector, physics.Primary) {
+	probe := func(tau float64) (physics.StateVector, physics.Primary, bool) {
+		s := predictStepTuned(preState, mu, tau, current, bc, tu)
+		tc := t0.Add(time.Duration(tau * float64(time.Second)))
+		pos := make(map[string]orbital.Vec3, len(sys.Bodies))
+		for _, b := range sys.Bodies {
+			pos[b.ID] = w.BodyPositionAt(b, tc)
+		}
+		cand := physics.FindPrimary(sys, pos[current.ID].Add(s.R), pos)
+		return s, cand, cand.Body.ID != current.ID
+	}
+
+	lo, hi := 0.0, dt
+	state, cand, flipped := probe(hi)
+	if !flipped {
+		// The flip seen by the caller's (possibly stale-positions) test
+		// does not reproduce against fresh body positions — treat the
+		// sub-step end as the crossing and let the caller's rebase
+		// proceed; the next sub-step re-tests.
+		return dt, state, cand
+	}
+	const iters = 40 // ~dt/2^40 — sub-millisecond on any sane dt
+	for i := 0; i < iters && hi-lo > 1e-3; i++ {
+		mid := (lo + hi) / 2
+		s, c, f := probe(mid)
+		if f {
+			hi, state, cand = mid, s, c
+		} else {
+			lo = mid
+		}
+	}
+	return hi, state, cand
+}
+
 // PredictedSegmentsFrom forward-integrates a post-burn state by
 // totalSeconds and partitions the trajectory into SOISegments,
 // parameterised on the starting primary and clock. Pre-v0.3.0 the
@@ -120,8 +270,18 @@ type SOISegment struct {
 // Output shape (a slice of SOISegments) is unchanged so the renderer
 // keeps working.
 func (w *World) PredictedSegmentsFrom(post physics.StateVector, startPrimary bodies.CelestialBody, startClock time.Time, totalSeconds float64, samples int) []SOISegment {
+	segs, _ := w.predictedSegmentsFromTuned(post, startPrimary, startClock, totalSeconds, samples, predictTuning{})
+	return segs
+}
+
+// predictedSegmentsFromTuned is PredictedSegmentsFrom parameterised on
+// predictTuning (zero value = shipped behavior — the production wrapper
+// above always passes it). It additionally reports each SOI transition
+// as a soiEntry so the eval harness can score the predicted entry state
+// without re-deriving it from sampled points.
+func (w *World) predictedSegmentsFromTuned(post physics.StateVector, startPrimary bodies.CelestialBody, startClock time.Time, totalSeconds float64, samples int, tu predictTuning) ([]SOISegment, []soiEntry) {
 	if w.ActiveCraft() == nil || samples < 2 {
-		return nil
+		return nil, nil
 	}
 
 	sys := w.System()
@@ -145,6 +305,7 @@ func (w *World) PredictedSegmentsFrom(post physics.StateVector, startPrimary bod
 		PrimaryID: current.ID,
 		Points:    []orbital.Vec3{positions[current.ID].Add(state.R)},
 	}}
+	var entries []soiEntry
 
 predict:
 	for i := 1; i < samples; i++ {
@@ -152,13 +313,41 @@ predict:
 		if nSub < 1 {
 			nSub = 1
 		}
-		if nSub > 256 {
-			nSub = 256
+		if nSub > tu.segSubStepClamp() {
+			nSub = tu.segSubStepClamp()
 		}
 		dt := stepSecs / float64(nSub)
 		stepDur := time.Duration(stepSecs * float64(time.Second))
+		var posStart, posEnd map[string]orbital.Vec3
+		if tu.BodyInterp && !tu.BodyPerSubStep {
+			posStart = make(map[string]orbital.Vec3, len(sys.Bodies))
+			posEnd = make(map[string]orbital.Vec3, len(sys.Bodies))
+			endClock := clock.Add(stepDur)
+			for _, b := range sys.Bodies {
+				posStart[b.ID] = positions[b.ID]
+				posEnd[b.ID] = w.BodyPositionAt(b, endClock)
+			}
+		}
+		elapsed := 0.0 // seconds integrated into this sample so far
 		for j := 0; j < nSub; j++ {
-			state = predictStep(state, muNow, dt, current, bc)
+			preState := state
+			state = predictStepTuned(state, muNow, dt, current, bc, tu)
+			elapsed += dt
+
+			if tu.BodyPerSubStep {
+				subClock := clock.Add(time.Duration(elapsed * float64(time.Second)))
+				for _, b := range sys.Bodies {
+					positions[b.ID] = w.BodyPositionAt(b, subClock)
+				}
+			} else if tu.BodyInterp {
+				frac := elapsed / stepSecs
+				if frac > 1 {
+					frac = 1
+				}
+				for _, b := range sys.Bodies {
+					positions[b.ID] = posStart[b.ID].Scale(1 - frac).Add(posEnd[b.ID].Scale(frac))
+				}
+			}
 
 			// v0.8.5: stop the predicted line at surface contact so
 			// the dashed trajectory terminates on the body instead of
@@ -174,17 +363,51 @@ predict:
 			crossingInertial := positions[current.ID].Add(state.R)
 			cand := physics.FindPrimary(sys, crossingInertial, positions)
 			if cand.Body.ID != current.ID {
+				// Legacy rebase clock: the positions snapshot the flip was
+				// detected against — the start of this output sample.
+				rebaseClock := clock
+				carry := 0.0 // crossing-refined leftover of this sub-step
+				if tu.RefineCrossing {
+					t0 := clock.Add(time.Duration((elapsed - dt) * float64(time.Second)))
+					tau, refined, refCand := w.refineCrossingTime(sys, preState, current, muNow, t0, dt, bc, tu)
+					if refCand.Body.ID == current.ID {
+						// Phantom crossing: the flip came from the stale
+						// positions snapshot and does not reproduce against
+						// fresh ephemerides (the moving moon's SOI sphere
+						// "lagged" onto/off the craft). Adopt the fresh
+						// snapshot and keep integrating in-frame.
+						state = refined
+						subClock := clock.Add(time.Duration(elapsed * float64(time.Second)))
+						for _, b := range sys.Bodies {
+							positions[b.ID] = w.BodyPositionAt(b, subClock)
+						}
+						continue
+					}
+					state = refined
+					cand = refCand
+					rebaseClock = t0.Add(time.Duration(tau * float64(time.Second)))
+					carry = dt - tau
+					elapsed += tau - dt
+					for _, b := range sys.Bodies {
+						positions[b.ID] = w.BodyPositionAt(b, rebaseClock)
+					}
+					crossingInertial = positions[current.ID].Add(state.R)
+				} else if tu.BodyPerSubStep || tu.BodyInterp {
+					rebaseClock = clock.Add(time.Duration(elapsed * float64(time.Second)))
+				}
+
 				// Close the outgoing segment at the crossing so it
 				// terminates where the new segment begins (no time gap
 				// between the previous output sample and the rebase).
 				segments[len(segments)-1].Points = append(
 					segments[len(segments)-1].Points, crossingInertial)
 
-				vOld := w.bodyInertialVelocityAt(current, clock)
-				vNew := w.bodyInertialVelocityAt(cand.Body, clock)
+				vOld := w.bodyInertialVelocityAt(current, rebaseClock)
+				vNew := w.bodyInertialVelocityAt(cand.Body, rebaseClock)
 				state = physics.Rebase(state, positions[current.ID], cand.Inertial, vOld.Sub(vNew))
 				current = cand.Body
 				muNow = current.GravitationalParameter()
+				entries = append(entries, soiEntry{BodyID: current.ID, Clock: rebaseClock, State: state})
 
 				period = orbitalPeriod(state, muNow)
 				newMaxStep := predictMaxSubStep(period)
@@ -198,15 +421,35 @@ predict:
 				// steps across the encounter, grossly aliasing its geometry.
 				// Re-divide the remaining time into sub-steps sized for the
 				// new orbit (keeping the 256 perf clamp). (#91)
-				if newMaxStep < maxStep {
+				if tu.RefineCrossing {
+					// The refined crossing leaves carry seconds of the
+					// detecting sub-step un-integrated — always re-divide
+					// the remainder, even when the new orbit is no tighter.
+					remainingTime := float64(nSub-j-1)*dt + carry
+					if remainingTime > 0 {
+						effMax := newMaxStep
+						if maxStep < effMax {
+							effMax = maxStep
+						}
+						newNSub := int(math.Ceil(remainingTime / effMax))
+						if newNSub < 1 {
+							newNSub = 1
+						}
+						if newNSub > tu.segSubStepClamp() {
+							newNSub = tu.segSubStepClamp()
+						}
+						nSub = j + 1 + newNSub
+						dt = remainingTime / float64(newNSub)
+					}
+				} else if newMaxStep < maxStep {
 					remainingTime := float64(nSub-j-1) * dt
 					if remainingTime > 0 {
 						newNSub := int(math.Ceil(remainingTime / newMaxStep))
 						if newNSub < 1 {
 							newNSub = 1
 						}
-						if newNSub > 256 {
-							newNSub = 256
+						if newNSub > tu.segSubStepClamp() {
+							newNSub = tu.segSubStepClamp()
 						}
 						nSub = j + 1 + newNSub
 						dt = remainingTime / float64(newNSub)
@@ -225,7 +468,9 @@ predict:
 		// per-sub-step SOI rebase above keeps using the previous-sample
 		// snapshot accurately enough; doing this only at the sample
 		// boundary keeps the refresh count at one per sample (`samples`
-		// is the adaptive budget, capped at predictSamplesMax).
+		// is the adaptive budget, capped at predictSamplesMax). With
+		// tu.BodyPerSubStep the snapshot is already at the sample end;
+		// the refresh below recomputes the same values.
 		clock = clock.Add(stepDur)
 		for _, b := range sys.Bodies {
 			positions[b.ID] = w.BodyPositionAt(b, clock)
@@ -234,5 +479,5 @@ predict:
 		seg := &segments[len(segments)-1]
 		seg.Points = append(seg.Points, positions[current.ID].Add(state.R))
 	}
-	return segments
+	return segments, entries
 }

--- a/internal/sim/soi_entry_prediction_eval_test.go
+++ b/internal/sim/soi_entry_prediction_eval_test.go
@@ -1,0 +1,449 @@
+package sim
+
+// soi_entry_prediction_eval_test.go — DIAGNOSTIC harness (not a CI
+// assertion): quantifies how reliably the trajectory predictors report
+// a Hohmann moon transfer's SOI entry, and attributes the error to the
+// individual numeric artifacts via predictTuning knobs (vault:
+// warp-orbit-accuracy.md §"2026-06-09 — SOI-entry prediction fidelity").
+//
+// What it measures, per scenario (planet→moon transfer, both predictor
+// sites):
+//
+//   accuracy   — predicted moon-periapsis radius + entry-time error at
+//                checkpoints along the live approach, scored against the
+//                LIVE-FLOWN outcome (what integrateOneCraft actually
+//                does — the player's truth) and cross-checked against a
+//                converged reference variant ("ref").
+//   stability  — the swing of the predicted periapsis across
+//                checkpoints: the playtest symptom is that this number
+//                won't hold still enough to fine-tune against.
+//   tunability — predicted-periapsis response to a 1 m/s prograde
+//                correction vs the local checkpoint-to-checkpoint
+//                jitter: signal-to-noise for mid-course tuning.
+//   drawing    — post-entry: how far the sampled dashed path's closest
+//                approach is from the analytic periapsis implied by the
+//                (exact) entry state — the hyperbolic-Verlet artifact.
+//
+// Heavy (minutes, many full-horizon propagations); excluded from normal
+// runs. Run with:
+//
+//	TSP_SOI_EVAL=1 go test ./internal/sim -run TestSOIEntryPredictionEval -v
+//
+// It always passes; read the t.Log output.
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+type soiEvalScenario struct {
+	name       string
+	systemName string
+	planet     string // EnglishName
+	moon       string // EnglishName
+}
+
+type soiEvalVariant struct {
+	name string
+	tu   predictTuning
+}
+
+// soiEvalVariants: legacy plus one knob at a time, the combined
+// candidate fix, and the converged reference. "ref" doubles as the
+// convergence cross-check against "ref/2" (halved caps) — if those two
+// disagree the reference itself isn't converged and the scenario's
+// numbers are suspect.
+func soiEvalVariants() []soiEvalVariant {
+	return []soiEvalVariant{
+		{"legacy", predictTuning{}},
+		{"+bodies", predictTuning{BodyPerSubStep: true}},
+		{"+interp", predictTuning{BodyInterp: true}},
+		{"+refine", predictTuning{RefineCrossing: true}},
+		{"+cap120", predictTuning{CoastSubStepCap: 120}},
+		{"+hyp5", predictTuning{HyperbolicDtCap: 5, MaxSubSteps: 1 << 16}},
+		{"all", predictTuning{BodyPerSubStep: true, RefineCrossing: true, CoastSubStepCap: 120, HyperbolicDtCap: 5, MaxSubSteps: 1 << 16}},
+		// fix = the shippable candidate: interpolated bodies (cheap),
+		// refined crossings, capped node-chain sub-steps; no hyperbolic
+		// dt cap (the drawing metric shows it's worth only a few km once
+		// positions are fresh) and no perf-clamp lift.
+		{"fix", predictTuning{BodyInterp: true, RefineCrossing: true, CoastSubStepCap: 120}},
+		{"ref", predictTuning{BodyPerSubStep: true, RefineCrossing: true, CoastSubStepCap: 30, HyperbolicDtCap: 1, MaxSubSteps: 1 << 20}},
+		{"ref/2", predictTuning{BodyPerSubStep: true, RefineCrossing: true, CoastSubStepCap: 15, HyperbolicDtCap: 0.5, MaxSubSteps: 1 << 20}},
+	}
+}
+
+// soiEvalVariantByName panics on a missing name — eval-internal lookup.
+func soiEvalVariantByName(name string) soiEvalVariant {
+	for _, v := range soiEvalVariants() {
+		if v.name == name {
+			return v
+		}
+	}
+	panic("unknown eval variant " + name)
+}
+
+// periRadiusKm is the analytic periapsis radius (km) implied by a
+// primary-relative state — a(1−e), valid for elliptic and hyperbolic
+// arcs alike. All accuracy scoring runs through this single lens: a
+// prediction is exactly as good as the SOI-entry state it produces.
+func periRadiusKm(s physics.StateVector, mu float64) float64 {
+	el := orbital.ElementsFromState(s.R, s.V, mu)
+	return el.A * (1 - el.E) / 1000
+}
+
+// moonPlaneCircularState returns a circular parking orbit of radius r
+// in the moon's orbital plane (same construction as
+// coplanarLEOTowardMoon, generalised to any planet/moon).
+func moonPlaneCircularState(planet, moon bodies.CelestialBody, r float64) (orbital.Vec3, orbital.Vec3) {
+	mel := orbital.ElementsFromBody(moon)
+	sI, cI := math.Sin(mel.I), math.Cos(mel.I)
+	sO, cO := math.Sin(mel.Omega), math.Cos(mel.Omega)
+	moonN := orbital.Vec3{X: sO * sI, Y: -cO * sI, Z: cI}.Unit()
+	ref := orbital.Vec3{X: 1}
+	if math.Abs(moonN.Dot(ref)) > 0.9 {
+		ref = orbital.Vec3{Y: 1}
+	}
+	e1 := ref.Sub(moonN.Scale(moonN.Dot(ref))).Unit()
+	e2 := moonN.Cross(e1)
+	v := math.Sqrt(planet.GravitationalParameter() / r)
+	return e1.Scale(r), e2.Scale(v)
+}
+
+type soiEvalCheckpoint struct {
+	state    physics.StateVector
+	primary  bodies.CelestialBody
+	clock    time.Time
+	tToEntry float64 // seconds until the live-flown SOI entry
+}
+
+// predictEntry runs one tuned prediction from a checkpoint and returns
+// the first predicted entry into the target moon's SOI (ok=false when
+// the prediction misses the moon entirely — itself a reliability
+// signal). siteA = the segment predictor (the dashed Projected Orbit);
+// otherwise the node-chain propagator (feeds ArrivalCapturePreview).
+func predictEntry(w *World, cp soiEvalCheckpoint, moon bodies.CelestialBody, horizon float64, tu predictTuning, siteA bool) (soiEntry, bool) {
+	var entries []soiEntry
+	if siteA {
+		samples := adaptiveSampleCount(horizon, orbitalPeriod(cp.state, cp.primary.GravitationalParameter()))
+		_, entries = w.predictedSegmentsFromTuned(cp.state, cp.primary, cp.clock, horizon, samples, tu)
+	} else {
+		_, _, entries = w.propagateStateWithPrimaryTuned(cp.state, cp.primary, cp.clock, horizon, tu)
+	}
+	for _, e := range entries {
+		if e.BodyID == moon.ID {
+			return e, true
+		}
+	}
+	return soiEntry{}, false
+}
+
+func TestSOIEntryPredictionEval(t *testing.T) {
+	if os.Getenv("TSP_SOI_EVAL") == "" {
+		t.Skip("diagnostic eval harness; run with TSP_SOI_EVAL=1 go test ./internal/sim -run TestSOIEntryPredictionEval -v")
+	}
+
+	scenarios := []soiEvalScenario{
+		{"Sol Earth→Moon (slow moon, big SOI)", "Sol", "Earth", "Moon"},
+		{"Lumen Kern→Cursor (fast tiny moon)", "Lumen", "Kern", "Cursor"},
+		{"Lumen Daemon→Byte (inclined e=0.235 i=15°)", "Lumen", "Daemon", "Byte"},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) { runSOIEvalScenario(t, sc) })
+	}
+}
+
+func runSOIEvalScenario(t *testing.T, sc soiEvalScenario) {
+	w := mustWorld(t)
+
+	sysIdx := -1
+	for i, s := range w.Systems {
+		if s.Name == sc.systemName {
+			sysIdx = i
+		}
+	}
+	if sysIdx < 0 {
+		t.Skipf("system %q not loaded", sc.systemName)
+	}
+	w.SystemIdx = sysIdx
+	craft := w.ActiveCraft()
+	craft.SystemIdx = sysIdx
+	sys := w.System()
+
+	planetIdx, moonIdx := -1, -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == sc.planet {
+			planetIdx = i
+		}
+		if b.EnglishName == sc.moon {
+			moonIdx = i
+		}
+	}
+	if planetIdx < 0 || moonIdx < 0 {
+		t.Skipf("%s/%s not in system %s", sc.planet, sc.moon, sc.systemName)
+	}
+	planet, moon := sys.Bodies[planetIdx], sys.Bodies[moonIdx]
+	moonMu := moon.GravitationalParameter()
+
+	// Parking orbit: coplanar with the moon, above atmosphere/surface.
+	rPark := planet.RadiusMeters() * 1.08
+	if atm := planet.Atmosphere; atm != nil {
+		if min := planet.RadiusMeters() + atm.CutoffAltitude + 50e3; min > rPark {
+			rPark = min
+		}
+	}
+	craft.Primary = planet
+	craft.State.R, craft.State.V = moonPlaneCircularState(planet, moon, rPark)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Skipf("PlanTransfer(%s): %v", sc.moon, err)
+	}
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Skip("no predicted legs after PlanTransfer")
+	}
+	leg := legs[0]
+
+	// Jump to the post-departure-burn state and live-fly the coast with
+	// the production integrator in warp-sized chunks, snapshotting
+	// checkpoints. Burn-execution fidelity is out of scope — the studied
+	// phenomenon is coast→SOI-entry prediction.
+	const chunkSecs = 120.0
+	w.Clock.SimTime = leg.StartClock
+	craft.State = leg.State
+	craft.Primary = leg.Primary
+	craft.Nodes = nil
+
+	horizon := leg.HorizonSecs*1.6 + 86400
+	cpEvery := leg.HorizonSecs / 24
+	var cps []soiEvalCheckpoint
+	nextCp, elapsed := 0.0, 0.0
+	for elapsed < horizon && craft.Primary.ID != moon.ID {
+		if elapsed >= nextCp {
+			cps = append(cps, soiEvalCheckpoint{craft.State, craft.Primary, w.Clock.SimTime, 0})
+			nextCp += cpEvery
+		}
+		d := time.Duration(chunkSecs * float64(time.Second))
+		w.Clock.SimTime = w.Clock.SimTime.Add(d)
+		w.integrateOneCraft(craft, d)
+		elapsed += chunkSecs
+	}
+	if craft.Primary.ID != moon.ID {
+		t.Skipf("live coast never entered %s SOI within %.1f d — planner missed; scenario unusable (itself a data point)", sc.moon, horizon/86400)
+	}
+	flownEntryClock := w.Clock.SimTime
+	flownPeriKm := periRadiusKm(craft.State, moonMu)
+	flownEntryState := craft.State
+
+	totalCoast := flownEntryClock.Sub(leg.StartClock).Seconds()
+	kept := cps[:0]
+	for _, cp := range cps {
+		tte := flownEntryClock.Sub(cp.clock).Seconds()
+		if tte <= chunkSecs {
+			continue
+		}
+		cp.tToEntry = tte
+		kept = append(kept, cp)
+	}
+	cps = kept
+
+	t.Logf("=== %s ===", sc.name)
+	t.Logf("coast %.2f d · moon SOI R=%.0f km · FLOWN entry peri %.0f km (radius; moon R=%.0f km) at %s (±%.0f s live-chunk quantization)",
+		totalCoast/86400, physics.SOIRadius(moon, planet)/1000, flownPeriKm, moon.RadiusMeters()/1000,
+		flownEntryClock.Format("15:04:05"), chunkSecs)
+
+	variants := soiEvalVariants()
+	for _, siteA := range []bool{true, false} {
+		site := "site A (segment predictor — dashed Projected Orbit)"
+		if !siteA {
+			site = "site B (node-chain propagator — feeds ArrivalCapturePreview)"
+		}
+		t.Logf("--- %s ---", site)
+		header := fmt.Sprintf("%12s", "t-to-entry")
+		for _, v := range variants {
+			header += fmt.Sprintf(" │ %16s", v.name)
+		}
+		t.Logf("%s", header)
+		t.Logf("%s  (cells: peri-radius km / entry-time err s; '—' = prediction misses the moon)", strings.Repeat("·", len(header)/2))
+
+		// peris[v] collects each variant's predicted periapsis series for
+		// the stability stats; NaN marks a miss.
+		peris := make([][]float64, len(variants))
+		for vi := range variants {
+			peris[vi] = make([]float64, len(cps))
+		}
+		for ci, cp := range cps {
+			predHorizon := cp.tToEntry + 6*3600
+			row := fmt.Sprintf("%11.2fh", cp.tToEntry/3600)
+			for vi, v := range variants {
+				e, ok := predictEntry(w, cp, moon, predHorizon, v.tu, siteA)
+				if !ok {
+					peris[vi][ci] = math.NaN()
+					row += fmt.Sprintf(" │ %16s", "—")
+					continue
+				}
+				p := periRadiusKm(e.State, moonMu)
+				peris[vi][ci] = p
+				dtErr := e.Clock.Sub(flownEntryClock).Seconds()
+				row += fmt.Sprintf(" │ %9.0f/%+5.0f", p, dtErr)
+			}
+			t.Logf("%s", row)
+		}
+
+		// Stability: swing (max−min) of the predicted periapsis over all
+		// checkpoints and over the final approach (last third), plus the
+		// miss rate. The flown outcome is one number — a reliable
+		// predictor's series should be flat at it.
+		t.Logf("stability (swing = max−min of predicted peri, km; miss = %% of checkpoints with no moon entry predicted):")
+		for vi, v := range variants {
+			all, late := swingKm(peris[vi], cps, math.Inf(1)), swingKm(peris[vi], cps, totalCoast/3)
+			miss := 0
+			for _, p := range peris[vi] {
+				if math.IsNaN(p) {
+					miss++
+				}
+			}
+			t.Logf("  %8s: swing(all) %9.0f km · swing(final-third) %9.0f km · miss %d/%d · vs-flown bias(last) %+.0f km",
+				v.name, all, late, miss, len(peris[vi]), lastValid(peris[vi])-flownPeriKm)
+		}
+
+		// Tunability at the mid-course checkpoint: does a 1 m/s prograde
+		// correction move the predicted periapsis by more than the local
+		// checkpoint-to-checkpoint jitter? Ratio < 1 means the knob the
+		// player turns is below the noise floor.
+		if len(cps) >= 3 {
+			mid := len(cps) / 2
+			for _, vi := range []int{variantIdx(variants, "legacy"), variantIdx(variants, "fix")} {
+				v := variants[vi]
+				cp := cps[mid]
+				nudged := cp
+				nudged.state.V = cp.state.V.Add(cp.state.V.Unit().Scale(1.0))
+				base, okB := predictEntry(w, cp, moon, cp.tToEntry+6*3600, v.tu, siteA)
+				bumped, okN := predictEntry(w, nudged, moon, cp.tToEntry+6*3600, v.tu, siteA)
+				jitter := math.Abs(peris[vi][mid] - peris[vi][mid-1])
+				if okB && okN {
+					resp := math.Abs(periRadiusKm(bumped.State, moonMu) - periRadiusKm(base.State, moonMu))
+					t.Logf("tunability @%.1fh out, %s: 1 m/s prograde moves peri %.0f km · local jitter %.0f km · signal/noise %.2f",
+						cp.tToEntry/3600, v.name, resp, jitter, resp/math.Max(jitter, 1e-9))
+				} else {
+					t.Logf("tunability @%.1fh out, %s: unmeasurable (prediction misses the moon: base=%v nudged=%v)",
+						cp.tToEntry/3600, v.name, okB, okN)
+				}
+			}
+		}
+	}
+
+	// Post-entry drawing error: from the (exact, by construction) flown
+	// entry state, how far is the sampled dashed path's closest approach
+	// from the analytic periapsis? Isolates the hyperbolic-Verlet
+	// artifact — entry-state error is zero here.
+	// Perf: cost per prediction call at the longest horizon (the render
+	// loop re-predicts every frame — the v0.8.4 per-sample snapshot
+	// exists because sub-step refresh was estimated at "60% of a render
+	// frame"; the fix decision needs that measured, not estimated).
+	if len(cps) > 0 {
+		cp := cps[0]
+		predHorizon := cp.tToEntry + 6*3600
+		t.Logf("--- cost per site-A prediction call at %.1fh horizon (10-call mean) ---", predHorizon/3600)
+		for _, v := range soiEvalVariants() {
+			start := time.Now()
+			for i := 0; i < 10; i++ {
+				predictEntry(w, cp, moon, predHorizon, v.tu, true)
+			}
+			t.Logf("  %8s: %7.2f ms/call", v.name, float64(time.Since(start).Microseconds())/10000)
+		}
+	}
+
+	// Post-entry drawing: from the (exact, by construction) flown entry
+	// state, integrate the in-SOI arc at the PRODUCTION sample budget and
+	// compare each variant point-by-point against the converged "ref"
+	// variant evaluated at the same sample times. Isolates the
+	// hyperbolic-Verlet dt artifact at fixed sampling; the endpoint Δ is
+	// the drawn impact/exit-point error. (An earlier dense-sampled
+	// closest-approach version of this metric was useless: these
+	// transfers impact, so the line correctly clamps at the surface, and
+	// dense sampling shrinks the integration dt it was meant to measure.)
+	tPeri := 2 * flownEntryState.R.Norm() / flownEntryState.V.Norm()
+	drawSamples := adaptiveSampleCount(2*tPeri, orbitalPeriod(flownEntryState, moonMu))
+	variantsAll := soiEvalVariants()
+	refTu := soiEvalVariantByName("ref").tu
+	refSegs, _ := w.predictedSegmentsFromTuned(flownEntryState, moon, flownEntryClock, 2*tPeri, drawSamples, refTu)
+	refPts := flattenSegPoints(refSegs)
+	t.Logf("--- post-entry drawing (from flown entry state, %d production samples, vs ref; analytic peri %.0f km, moon R %.0f km) ---",
+		drawSamples, flownPeriKm, moon.RadiusMeters()/1000)
+	for _, v := range variantsAll {
+		if v.name == "ref" || v.name == "ref/2" {
+			continue
+		}
+		segs, _ := w.predictedSegmentsFromTuned(flownEntryState, moon, flownEntryClock, 2*tPeri, drawSamples, v.tu)
+		pts := flattenSegPoints(segs)
+		n := len(pts)
+		if len(refPts) < n {
+			n = len(refPts)
+		}
+		maxD := 0.0
+		for i := 0; i < n; i++ {
+			if d := pts[i].Sub(refPts[i]).Norm() / 1000; d > maxD {
+				maxD = d
+			}
+		}
+		endD := math.NaN()
+		if len(pts) > 0 && len(refPts) > 0 {
+			endD = pts[len(pts)-1].Sub(refPts[len(refPts)-1]).Norm() / 1000
+		}
+		t.Logf("  %8s: max path divergence %8.1f km · endpoint Δ %8.1f km · %d pts (ref %d)",
+			v.name, maxD, endD, len(pts), len(refPts))
+	}
+}
+
+// flattenSegPoints concatenates all segment points in order — sample
+// times line up index-wise across variants of the same call shape.
+func flattenSegPoints(segs []SOISegment) []orbital.Vec3 {
+	var pts []orbital.Vec3
+	for _, s := range segs {
+		pts = append(pts, s.Points...)
+	}
+	return pts
+}
+
+// swingKm is max−min over the checkpoints whose time-to-entry is below
+// the window (NaN misses excluded); NaN when fewer than two qualify.
+func swingKm(peris []float64, cps []soiEvalCheckpoint, window float64) float64 {
+	lo, hi, n := math.Inf(1), math.Inf(-1), 0
+	for i, p := range peris {
+		if math.IsNaN(p) || cps[i].tToEntry > window {
+			continue
+		}
+		n++
+		lo, hi = math.Min(lo, p), math.Max(hi, p)
+	}
+	if n < 2 {
+		return math.NaN()
+	}
+	return hi - lo
+}
+
+func variantIdx(vs []soiEvalVariant, name string) int {
+	for i, v := range vs {
+		if v.name == name {
+			return i
+		}
+	}
+	panic("unknown eval variant " + name)
+}
+
+func lastValid(peris []float64) float64 {
+	for i := len(peris) - 1; i >= 0; i-- {
+		if !math.IsNaN(peris[i]) {
+			return peris[i]
+		}
+	}
+	return math.NaN()
+}


### PR DESCRIPTION
## Quantify-first slice for the moon-transfer Projected Orbit wobble

Playtest report (2026-06-09): *Hohmann transfers to moons present unreliable projected orbits — predictions vary widely as the vessel approaches and enters the target's SOI, making mid-course fine-tuning pointless.* Grilled same day; plan + findings recorded in vault `warp-orbit-accuracy.md` §2026-06-09.

### What this adds
- **`predictTuning`** — fidelity variants of both SOI-aware propagation loops. Zero value = shipped behavior; **production callers are unchanged** (`PredictedSegmentsFrom` / `propagateStateWithPrimary` delegate with zero tuning; all 1066 tests green).
- **`soiEntry` events** — both tuned loops report each SOI transition (body, crossing clock, post-rebase state) so the harness scores the predicted entry state directly.
- **`soi_entry_prediction_eval_test.go`** — env-gated diagnostic (`TSP_SOI_EVAL=1 go test ./internal/sim -run TestSOIEntryPredictionEval -v`, ~35 s, always passes; read the t.Log output). Three scenarios: Sol Earth→Moon, Lumen Kern→Cursor (fast tiny moon), Lumen Daemon→Byte (inclined). Truth = live-flown outcome, cross-checked against a step-halving-converged reference (ref ≡ ref/2 everywhere ⇒ converged; live integrator exonerated).

### Findings (attribution)
| Site | Dominant artifact | Evidence | Fixed by |
|---|---|---|---|
| A — segment predictor (dashed Projected Orbit) | **Per-sample-stale body positions** at the per-sub-step SOI test | entry-time wobble 0→+3038 s frame-to-frame; peri error 32–46 km vs flown 0 on Daemon→Byte; phantom in-SOI exit flips (53 000 km post-exit divergence); impact point off 1647 km on Kern→Cursor | `BodyInterp` (lerp between sample-boundary ephemeris) |
| B — node-chain propagator (feeds ArrivalCapturePreview) | **Uncapped period/100 sub-step**, no #91 re-resolution | systematic entry-time bias **growing to +6720 s at 2 h out**; +37 km peri bias | `CoastSubStepCap=120` (+ re-resolution) or `RefineCrossing` |
| both | Unrefined crossing time | residual ±450 s quantization | `RefineCrossing` (bisection, fresh-ephemeris probes) |
| — | Hyperbolic Verlet legs | **exonerated**: <4 km once positions are fresh | not needed |

### The shippable candidate
`fix` = `BodyInterp + RefineCrossing + CoastSubStepCap=120`: **zero swing on both sites in all scenarios**, matches flown outcome and converged reference, **10.2 ms/call worst case vs legacy 6.6 ms** (brute-force per-sub-step refresh: 29 ms; converged stack: 155 ms).

Defaults are intentionally **unchanged** — flipping them is the follow-up fix slice (likely an ADR amending 0006C).