### PR TITLE
fix(transfer): coplanar capture geometry + live target readout + target view

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1123,9 +1123,17 @@ Vessel crosses the target's orbital plane — the **line of nodes** —
 which is both a cheap place to change planes and the *only* place a
 plane change leaves the Vessel actually *in* the target's plane).
 A correct Transfer Plan must arrive **coplanar** with the target (≈0°
-relative inclination) so the Capture Burn can insert; the HUD shows
-both candidate costs. This retires the old `I`-plane-match-then-`H`
-dance as a *requirement* (the manual tools remain available).
+relative inclination) **and at the Capture Orbit radius** — a safe
+periapsis (`destination radius + 200 km`), not the target's *centre*.
+Coplanar alone is insufficient: the combined Lambert solved to the
+target's centre arrives with a sub-surface perilune (a collision) while
+its Capture Burn Δv is sized for a periapsis it never reaches. So the
+combined Departure is aimed at an **in-plane offset** chosen so the
+natural flyby perilune lands at the Capture Orbit radius, **prograde**
+around the target (the affordable capture direction — see GH #68). The
+HUD shows both candidate costs. This retires the old
+`I`-plane-match-then-`H` dance as a *requirement* (the manual tools
+remain available).
 _Avoid_: Trajectory (the whole flight path; the Plan is the burns).
 The planner's internal `TransferNode` is not glossary-worthy — it's a
 handoff struct (see Flagged ambiguities). **Do not** conflate "plane

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -111,7 +111,7 @@ readout shows you why before you watch it fall back.
 | `+` / `-` | Zoom in / out |
 | `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your craft) |
 | `g` | Reset the camera to the whole system |
-| `v` | Cycle the view (tilted → top → right → bottom → left → flat). Tilted is the default — a 3D-style perspective that shows orbits leaning in space |
+| `v` | Cycle the view (tilted → top → right → bottom → left → flat → target). Tilted is the default — a 3D-style perspective that shows orbits leaning in space. **Target** (only offered when you have a body targeted) centers on the target and auto-frames your approach, zooming in as you close — so you can watch your projected orbit pass it while hand-flying corrections |
 | `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
 | `F2` | Declutter — hide all overlays (the corner chips and the navball) for a clean look at the orbit. Press again to bring them back. Your core telemetry column stays put |
 | `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build your own rocket stack: on the stack field, `←` / `→` browse parts, `a` adds one on top, `x` removes the top one |

--- a/internal/orbital/events.go
+++ b/internal/orbital/events.go
@@ -53,6 +53,39 @@ func TimeToPeriapsis(state Vec3State, mu float64) float64 {
 	return TimeToTrueAnomaly(nu, 0, el.A, el.E, mu)
 }
 
+// TimeToPeriapsisHyperbolic returns elapsed seconds until periapsis (ν=0)
+// for a hyperbolic state (e > 1) — the case TimeToPeriapsis/TimeToTrueAnomaly
+// reject (they assume a closed orbit). Positive on the inbound leg
+// (approaching periapsis, the SOI-capture geometry), negative once past it.
+// ok=false for non-hyperbolic states or a point already beyond the
+// asymptote (1 + e·cos ν ≤ 0, i.e. not on the physical arc).
+//
+// Standard hyperbolic Kepler: sinh H = √(e²−1)·sin ν / (1 + e·cos ν);
+// mean anomaly M = e·sinh H − H; mean motion n = √(μ/|a|³); the time since
+// periapsis is M/n, so time *to* periapsis is −M/n.
+func TimeToPeriapsisHyperbolic(state Vec3State, mu float64) (float64, bool) {
+	el := ElementsFromState(state.R, state.V, mu)
+	if el.E <= 1 || mu <= 0 || el.A >= 0 {
+		return 0, false
+	}
+	nu := TrueAnomalyFromState(state.R, state.V, mu, el)
+	// TrueAnomalyFromState wraps the inbound half-plane to (π, 2π); map it
+	// back to (−π, 0) so an approaching craft has ν < 0 ⇒ H < 0 ⇒ M < 0.
+	if nu > math.Pi {
+		nu -= 2 * math.Pi
+	}
+	denom := 1 + el.E*math.Cos(nu)
+	if denom <= 0 {
+		return 0, false
+	}
+	sinhH := math.Sqrt(el.E*el.E-1) * math.Sin(nu) / denom
+	H := math.Asinh(sinhH)
+	M := el.E*math.Sinh(H) - H
+	absA := -el.A
+	n := math.Sqrt(mu / (absA * absA * absA))
+	return -M / n, true
+}
+
 // TimeToApoapsis returns elapsed seconds to the next apoapsis (ν=π).
 // Convenience wrapper around TimeToTrueAnomaly.
 func TimeToApoapsis(state Vec3State, mu float64) float64 {

--- a/internal/orbital/events_test.go
+++ b/internal/orbital/events_test.go
@@ -100,6 +100,56 @@ func TestTimeToPeriapsisAndApoapsis(t *testing.T) {
 	}
 }
 
+// hyperbolicStateAtNu builds a hyperbolic state (e > 1) at the requested
+// true anomaly. Same perifocal construction as stateAtNu; the semi-latus
+// rectum p = a(1−e²) stays positive because a < 0 and (1−e²) < 0.
+func hyperbolicStateAtNu(a, e, nu float64) Vec3State {
+	p := a * (1 - e*e)
+	r := p / (1 + e*math.Cos(nu))
+	cosNu, sinNu := math.Cos(nu), math.Sin(nu)
+	rVec := Vec3{X: r * cosNu, Y: r * sinNu}
+	vr := math.Sqrt(muEarth/p) * e * sinNu
+	vp := math.Sqrt(muEarth/p) * (1 + e*cosNu)
+	vVec := Vec3{X: vr*cosNu - vp*sinNu, Y: vr*sinNu + vp*cosNu}
+	return Vec3State{R: rVec, V: vVec}
+}
+
+// TestTimeToPeriapsisHyperbolic: on a hyperbola (where TimeToPeriapsis
+// returns -1), the helper gives 0 at periapsis, a positive time inbound,
+// a negative time outbound, and is antisymmetric about ν=0.
+func TestTimeToPeriapsisHyperbolic(t *testing.T) {
+	const a, e = -1e7, 1.5 // a < 0, e > 1
+
+	// At periapsis (ν=0): zero time.
+	if dt, ok := TimeToPeriapsisHyperbolic(hyperbolicStateAtNu(a, e, 0), muEarth); !ok || math.Abs(dt) > 1e-3 {
+		t.Errorf("ν=0: got dt=%.6f ok=%v, want ~0", dt, ok)
+	}
+
+	// Inbound (ν<0): periapsis is in the future ⇒ positive.
+	in, okIn := TimeToPeriapsisHyperbolic(hyperbolicStateAtNu(a, e, -0.6), muEarth)
+	if !okIn || in <= 0 {
+		t.Errorf("inbound ν=-0.6: got %.3f ok=%v, want > 0", in, okIn)
+	}
+	// Outbound (ν>0): periapsis is in the past ⇒ negative, equal magnitude.
+	out, okOut := TimeToPeriapsisHyperbolic(hyperbolicStateAtNu(a, e, 0.6), muEarth)
+	if !okOut || out >= 0 {
+		t.Errorf("outbound ν=0.6: got %.3f ok=%v, want < 0", out, okOut)
+	}
+	if math.Abs(in+out) > 1.0 {
+		t.Errorf("antisymmetry broken: inbound %.3f, outbound %.3f (sum %.3f)", in, out, in+out)
+	}
+	// Farther out ⇒ longer to periapsis.
+	far, _ := TimeToPeriapsisHyperbolic(hyperbolicStateAtNu(a, e, -1.0), muEarth)
+	if far <= in {
+		t.Errorf("monotonicity: ν=-1.0 (%.3f) should exceed ν=-0.6 (%.3f)", far, in)
+	}
+
+	// Non-hyperbolic states are rejected.
+	if _, ok := TimeToPeriapsisHyperbolic(stateAtNu(math.Pi/4), muEarth); ok {
+		t.Error("elliptic state: ok=true, want false")
+	}
+}
+
 // TestTimeToNodeCrossingEquatorial: returns -1 for equatorial orbits
 // because there's no well-defined node crossing.
 func TestTimeToNodeCrossingEquatorial(t *testing.T) {

--- a/internal/sim/coplanar_capture_test.go
+++ b/internal/sim/coplanar_capture_test.go
@@ -1,0 +1,377 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// setupKernCursor places the active craft in a coplanar circular parking
+// orbit around Kern (Lumen system) with Cursor as the transfer target.
+// Returns the Cursor body index. Skips if Lumen/Kern/Cursor are absent.
+func setupKernCursor(t *testing.T, w *World) (cursorIdx int, kern, cursor bodies.CelestialBody) {
+	t.Helper()
+	sysIdx := -1
+	for i, s := range w.Systems {
+		if s.Name == "Lumen" {
+			sysIdx = i
+		}
+	}
+	if sysIdx < 0 {
+		t.Skip("Lumen not loaded")
+	}
+	w.SystemIdx = sysIdx
+	craft := w.ActiveCraft()
+	craft.SystemIdx = sysIdx
+	sys := w.System()
+
+	kernIdx := -1
+	cursorIdx = -1
+	for i, b := range sys.Bodies {
+		switch b.EnglishName {
+		case "Kern":
+			kernIdx = i
+		case "Cursor":
+			cursorIdx = i
+		}
+	}
+	if kernIdx < 0 || cursorIdx < 0 {
+		t.Skip("Kern/Cursor not in Lumen")
+	}
+	kern, cursor = sys.Bodies[kernIdx], sys.Bodies[cursorIdx]
+
+	rPark := kern.RadiusMeters() * 1.08
+	if atm := kern.Atmosphere; atm != nil {
+		if min := kern.RadiusMeters() + atm.CutoffAltitude + 50e3; min > rPark {
+			rPark = min
+		}
+	}
+	craft.Primary = kern
+	craft.State.R, craft.State.V = moonPlaneCircularState(kern, cursor, rPark)
+	return cursorIdx, kern, cursor
+}
+
+// TestCoplanarCaptureFiresAtPerilune is the regression for the Kern→Cursor
+// flight bug: the combined (fused-Lambert) transfer's retrograde capture
+// burn used to fire at the nominal Lambert arrival epoch — the moon-*centre*
+// crossing in Kern's frame — which sits ~26 min after the true perilune,
+// because the craft accelerates into Cursor's SOI and swings through
+// periapsis early. refineCombinedCapture rebases the SOI-entry state into
+// Cursor's frame and fires the capture at the analytic hyperbolic perilune.
+//
+// The oracle is a live patched-conic coast: fly the post-departure leg with
+// the production integrator and record the time of true closest approach to
+// Cursor. The planted capture must land within a few minutes of it (pre-fix
+// gap ≈ 26 min; the residual is the analytic-vs-integrated approximation
+// over a multi-hour transfer).
+func TestCoplanarCaptureFiresAtPerilune(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, _, cursor := setupKernCursor(t, w)
+
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	if w.LastTransfer.Strategy != "combined" {
+		t.Fatalf("strategy = %q, want combined (Kern→Cursor is coplanar)", w.LastTransfer.Strategy)
+	}
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	var capture *spacecraft.ManeuverNode
+	for i := range c.Nodes {
+		if c.Nodes[i].Mode == spacecraft.BurnRetrograde {
+			capture = &c.Nodes[i]
+		}
+	}
+	if capture == nil {
+		t.Fatalf("no retrograde capture node among %d planted nodes", len(c.Nodes))
+	}
+	captureOffset := capture.TriggerTime.Sub(now)
+
+	// Oracle: live-fly the post-departure coast with the production
+	// integrator and record the time of minimum craft↔Cursor distance.
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	const chunkSecs = 30.0
+	horizon := leg.HorizonSecs*1.6 + 86400
+	minD := math.Inf(1)
+	var tCAFromStart float64
+	elapsed := 0.0
+	for elapsed < horizon {
+		cursorRelPrimary := w.BodyPositionAt(cursor, w.Clock.SimTime).Sub(w.BodyPositionAt(c.Primary, w.Clock.SimTime))
+		d := c.State.R.Sub(cursorRelPrimary).Norm()
+		if c.Primary.ID == cursor.ID {
+			d = c.State.R.Norm() // already rebased into Cursor's frame
+		}
+		if d < minD {
+			minD = d
+			tCAFromStart = elapsed
+		}
+		dt := time.Duration(chunkSecs * float64(time.Second))
+		w.Clock.SimTime = w.Clock.SimTime.Add(dt)
+		w.integrateOneCraft(c, dt)
+		elapsed += chunkSecs
+	}
+	trueCAOffset := leg.StartClock.Add(time.Duration(tCAFromStart * float64(time.Second))).Sub(now)
+
+	gap := captureOffset - trueCAOffset
+	if gap < 0 {
+		gap = -gap
+	}
+	const tol = 5 * time.Minute
+	if gap > tol {
+		t.Errorf("capture fires %v from true perilune (capture off=%v, true CA off=%v); want within %v",
+			gap, captureOffset, trueCAOffset, tol)
+	}
+}
+
+// TestPredictedTargetApproachMatchesFlight: the live TARGET readout
+// (PredictedTargetApproach) must report the same encounter the craft
+// actually flies — it crosses Cursor's SOI, the perilune radius is a sane
+// in-SOI value, and the predicted time-to-closest-approach matches the
+// live-flown closest approach within a few minutes. This is the readout the
+// player reads while hand-flying a correction, so it has to track reality.
+func TestPredictedTargetApproachMatchesFlight(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, kern, cursor := setupKernCursor(t, w)
+
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	// Target Cursor so the readout resolves it.
+	w.SetTargetBody(cursorIdx)
+
+	ap, ok := w.PredictedTargetApproach()
+	if !ok {
+		t.Fatal("PredictedTargetApproach returned ok=false")
+	}
+	if !ap.EntersSOI {
+		t.Errorf("readout says the transfer misses Cursor's SOI; want an encounter")
+	}
+	soi := physics.SOIRadius(cursor, kern)
+	if ap.Dist <= 0 || ap.Dist > soi {
+		t.Errorf("perilune radius %.1f km outside (0, SOI=%.1f km]", ap.Dist/1e3, soi/1e3)
+	}
+
+	// Oracle: live-fly the post-departure coast and time the true closest
+	// approach, then compare the readout's TCA to it.
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	const chunkSecs = 30.0
+	horizon := leg.HorizonSecs*1.6 + 86400
+	minD := math.Inf(1)
+	var tCAFromStart float64
+	elapsed := 0.0
+	for elapsed < horizon {
+		cursorRel := w.BodyPositionAt(cursor, w.Clock.SimTime).Sub(w.BodyPositionAt(c.Primary, w.Clock.SimTime))
+		d := c.State.R.Sub(cursorRel).Norm()
+		if c.Primary.ID == cursor.ID {
+			d = c.State.R.Norm()
+		}
+		if d < minD {
+			minD = d
+			tCAFromStart = elapsed
+		}
+		dt := time.Duration(chunkSecs * float64(time.Second))
+		w.Clock.SimTime = w.Clock.SimTime.Add(dt)
+		w.integrateOneCraft(c, dt)
+		elapsed += chunkSecs
+	}
+	trueCAOffset := leg.StartClock.Add(time.Duration(tCAFromStart * float64(time.Second))).Sub(now).Seconds()
+
+	gap := math.Abs(ap.TCA - trueCAOffset)
+	if gap > 300 {
+		t.Errorf("readout TCA %.0fs vs live closest approach %.0fs (gap %.0fs); want within 300s",
+			ap.TCA, trueCAOffset, gap)
+	}
+}
+
+// TestCombinedTransferArrivesSafePeriapsis (ADR 0018): the planted combined
+// Kern→Cursor transfer must arrive at the Capture Orbit radius (Cursor
+// radius + 200 km), not the body centre — a safe periapsis above the
+// surface — and prograde (moon-frame angular momentum aligned with Cursor's
+// orbit normal). Live-flown with the production integrator: pre-ADR-0018 the
+// min distance to Cursor's centre clamped at the surface (impact).
+func TestCombinedTransferArrivesSafePeriapsis(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, kern, cursor := setupKernCursor(t, w)
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	if w.LastTransfer.Strategy != "combined" {
+		t.Fatalf("strategy = %q, want combined", w.LastTransfer.Strategy)
+	}
+	c := w.ActiveCraft()
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	const chunkSecs = 30.0
+	horizon := leg.HorizonSecs*1.6 + 86400
+	minD := math.Inf(1)
+	var relRAtMin, relVAtMin orbital.Vec3
+	elapsed := 0.0
+	for elapsed < horizon {
+		cursorRel := w.BodyPositionAt(cursor, w.Clock.SimTime).Sub(w.BodyPositionAt(c.Primary, w.Clock.SimTime))
+		rel := c.State.R.Sub(cursorRel)
+		if c.Primary.ID == cursor.ID {
+			rel = c.State.R // already Cursor-frame
+		}
+		if d := rel.Norm(); d < minD {
+			minD = d
+			relRAtMin = rel
+			cursorVel := w.bodyInertialVelocityAt(cursor, w.Clock.SimTime).Sub(w.bodyInertialVelocityAt(c.Primary, w.Clock.SimTime))
+			relVAtMin = c.State.V.Sub(cursorVel)
+		}
+		dt := time.Duration(chunkSecs * float64(time.Second))
+		w.Clock.SimTime = w.Clock.SimTime.Add(dt)
+		w.integrateOneCraft(c, dt)
+		elapsed += chunkSecs
+	}
+
+	rCapture := cursor.RadiusMeters() + 200e3
+	t.Logf("live perilune = %.1f km (Capture Orbit radius %.1f km, Cursor radius %.1f km)",
+		minD/1e3, rCapture/1e3, cursor.RadiusMeters()/1e3)
+	if minD <= cursor.RadiusMeters() {
+		t.Errorf("transfer still impacts Cursor: perilune %.1f km ≤ radius %.1f km", minD/1e3, cursor.RadiusMeters()/1e3)
+	}
+	// Within 25% of the Capture Orbit radius (analytic aim vs integrated flight).
+	if math.Abs(minD-rCapture) > 0.25*rCapture {
+		t.Errorf("perilune %.1f km not near Capture Orbit radius %.1f km", minD/1e3, rCapture/1e3)
+	}
+	// Prograde capture: moon-frame angular momentum aligned with Cursor's
+	// orbit normal about Kern.
+	hRel := relRAtMin.Cross(relVAtMin)
+	cursorOrbitNormal := w.BodyPosition(cursor).Sub(w.BodyPosition(kern)).Cross(
+		w.bodyInertialVelocityAt(cursor, w.Clock.SimTime).Sub(w.bodyInertialVelocityAt(kern, w.Clock.SimTime)))
+	if hRel.Dot(cursorOrbitNormal) <= 0 {
+		t.Errorf("capture is retrograde (h_rel·n_target = %.3g ≤ 0); want prograde", hRel.Dot(cursorOrbitNormal))
+	}
+}
+
+// TestSplitArrivalPeriapsisCharacterization (ADR 0018 D): measures the
+// split (inclined) transfer's actual arrival periapsis. ADR 0018 scoped the
+// capture-aim fix to the combined path; this characterizes whether the split
+// also arrives at the target's centre (a collision). It asserts only that an
+// encounter resolves and logs the perilune — a sub-surface value is the
+// signal that the split needs the same offset-aim treatment (logged as a
+// follow-up, not fixed here: the split is entangled with #67/#68).
+func TestSplitArrivalPeriapsisCharacterization(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, moon := findMoon(t, w)
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer(Moon): %v", err)
+	}
+	if w.LastTransfer.Strategy != "split" {
+		t.Skipf("strategy = %q, want split — default LEO must be inclined to Luna", w.LastTransfer.Strategy)
+	}
+	c := w.ActiveCraft()
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	const chunkSecs = 60.0
+	horizon := leg.HorizonSecs*1.6 + 86400
+	minD := math.Inf(1)
+	elapsed := 0.0
+	for elapsed < horizon {
+		moonRel := w.BodyPositionAt(moon, w.Clock.SimTime).Sub(w.BodyPositionAt(c.Primary, w.Clock.SimTime))
+		d := c.State.R.Sub(moonRel).Norm()
+		if c.Primary.ID == moon.ID {
+			d = c.State.R.Norm()
+		}
+		if d < minD {
+			minD = d
+		}
+		dt := time.Duration(chunkSecs * float64(time.Second))
+		w.Clock.SimTime = w.Clock.SimTime.Add(dt)
+		w.integrateOneCraft(c, dt)
+		elapsed += chunkSecs
+	}
+	alt := minD - moon.RadiusMeters()
+	t.Logf("split arrival perilune = %.1f km (Luna radius %.1f km, altitude %.1f km)",
+		minD/1e3, moon.RadiusMeters()/1e3, alt/1e3)
+	if math.IsInf(minD, 1) {
+		t.Fatal("split transfer never reached Luna — characterization unusable")
+	}
+	if alt <= 0 {
+		t.Logf("FOLLOW-UP (ADR 0018 D): the split also arrives sub-surface (impact) — it needs the same capture-aim offset; not fixed here (entangled with #67/#68)")
+	}
+}
+
+// TestPredictedTargetApproachDuringCoast: the readout must still report the
+// Cursor encounter once the departure burn has fired and the craft is
+// coasting toward the moon — the case the original legs-only scan went blind
+// on (the approach coast is no longer a primary-frame PredictedLegs leg, so
+// nothing was scanned and the chip showed nothing). Regression for the
+// "I don't see peri: IMPACT" playtest report.
+func TestPredictedTargetApproachDuringCoast(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, _, _ := setupKernCursor(t, w)
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	w.SetTargetBody(cursorIdx)
+	c := w.ActiveCraft()
+
+	// Advance onto the post-departure transfer leg and drop the (now-fired)
+	// departure node, leaving only the retrograde capture — the coasting
+	// state the player hand-flies in.
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	var capture []spacecraft.ManeuverNode
+	for _, n := range c.Nodes {
+		if n.Mode == spacecraft.BurnRetrograde {
+			capture = append(capture, n)
+		}
+	}
+	c.Nodes = capture
+
+	ap, ok := w.PredictedTargetApproach()
+	if !ok {
+		t.Fatal("ok=false during the coast — the readout went blind (the reported bug)")
+	}
+	if !ap.EntersSOI {
+		t.Errorf("readout missed the Cursor encounter during the coast (Dist=%.0f km)", ap.Dist/1e3)
+	}
+}

--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -135,6 +135,35 @@ func (w *World) FocusZoomRadius() float64 {
 	return w.systemOutermostRadius()
 }
 
+// TargetViewFraming returns the camera center and auto-fit radius for
+// ViewTarget: centered on the current body Target, with a radius that frames
+// the craft→target approach. The radius is the target's SOI (×1.3, so the
+// perilune geometry is legible on a close pass) widened to the craft→target
+// distance when the craft is still far out — so the approach line stays in
+// frame and the view zooms in automatically as the gap closes. ok=false when
+// there's no body target in the active system. v0.18+.
+func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok bool) {
+	if w.Target.Kind != TargetBody {
+		return orbital.Vec3{}, 0, false
+	}
+	sys := w.System()
+	if w.Target.BodyIdx <= 0 || w.Target.BodyIdx >= len(sys.Bodies) {
+		return orbital.Vec3{}, 0, false
+	}
+	b := sys.Bodies[w.Target.BodyIdx]
+	center = w.BodyPosition(b)
+	radius = physics.SOIRadius(b, sys.Bodies[0]) * 1.3
+	if radius <= 0 {
+		radius = b.RadiusMeters() * 50
+	}
+	if c := w.ActiveCraft(); c != nil && c.SystemIdx == w.SystemIdx {
+		if dist := w.CraftInertial().Sub(center).Norm(); dist > radius {
+			radius = dist
+		}
+	}
+	return center, radius, true
+}
+
 func (w *World) systemOutermostRadius() float64 {
 	var maxR float64
 	for _, b := range w.System().Bodies {

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -373,7 +373,9 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		//    change) + the capture braking burn. Wins for large departure
 		//    inclinations (an equatorial LEO sits ~25° off Luna's plane).
 		combinedDv := math.Inf(1)
-		combined, combinedErr := w.fusedIntraPrimaryDeparture(seed, muShared, target, muDestination, rCapture)
+		// Compare on the centre-aimed cost (ADR 0006 B); the capture-safe
+		// offset (ADR 0018) is applied only to the planted plan below.
+		combined, combinedErr := w.fusedIntraPrimaryDeparture(seed, muShared, target, muDestination, rCapture, false)
 		if combinedErr == nil {
 			combinedDv = combined.Departure.DV + combined.Arrival.DV
 		}
@@ -405,9 +407,23 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 
 		if combinedDv <= splitDv {
 			w.LastTransfer.Strategy = "combined"
-			w.PlanNode(transferNodeToManeuver(combined.Departure, now, c))
-			w.PlanNode(transferNodeToManeuver(combined.Arrival, now, c))
-			return &combined, nil
+			// Re-solve with the capture-safe offset aim (ADR 0018) so the
+			// planted transfer arrives at the Capture Orbit radius, prograde,
+			// instead of the target's centre. Fall back to the centre-aimed
+			// plan if the offset solve is degenerate.
+			plan := combined
+			if aimed, err := w.fusedIntraPrimaryDeparture(seed, muShared, target, muDestination, rCapture, true); err == nil {
+				plan = aimed
+			}
+			// The fused arrival node defaults to the nominal Lambert epoch
+			// (depOffset+tof), which is the moon-frame closest approach in the
+			// primary's frame. The craft accelerates as it falls into the
+			// moon's SOI and reaches perilune earlier, so the retrograde
+			// capture must fire there — refine the arrival to the perilune.
+			w.refineCombinedCapture(&plan, c, muShared, target)
+			w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
+			w.PlanNode(transferNodeToManeuver(plan.Arrival, now, c))
+			return &plan, nil
 		}
 
 		// Split: refine the finite coplanar departure (v0.6.2 iterator) so
@@ -1617,18 +1633,26 @@ func intraPlaneChangeAllowance(w *World, c *spacecraft.Spacecraft, target bodies
 	return 2 * vCirc * math.Sin(relIncl/2)
 }
 
-// fusedIntraPrimaryDeparture attempts the v0.12 combined plane-shift +
-// Hohmann fused-Lambert transfer for an intra-primary target, seeded off
+// fusedIntraPrimaryDeparture builds the v0.12 combined plane-shift + Hohmann
+// fused-Lambert transfer for an intra-primary target (ADR 0005), seeded off
 // the analytic plan's phasing (waitTime via Departure.OffsetTime, tof via
 // TransferDt). It propagates the craft analytically (Kepler — exact, no
-// Verlet drift over a multi-orbit phasing wait) to the departure epoch
-// and the target via ephemeris to the arrival epoch, both expressed in
-// the shared primary's frame, then solves a single-rev Lambert connecting
-// them. The departure Δv carries eccentricity + raise + plane change as a
-// BurnVector. Returns an error (caller falls back to the analytic seed)
-// when the craft orbit isn't elliptic or the Lambert solve is degenerate.
-// v0.12.x+ (ADR 0005).
-func (w *World) fusedIntraPrimaryDeparture(seed planner.TransferPlan, muShared float64, target bodies.CelestialBody, muTarget, rCapture float64) (planner.TransferPlan, error) {
+// Verlet drift over a multi-orbit phasing wait) to the departure epoch and
+// the target via ephemeris to the arrival epoch, both in the shared
+// primary's frame, then solves a single-rev Lambert connecting them; the
+// departure Δv carries eccentricity + raise + plane change as a BurnVector.
+// Returns an error (caller falls back to the analytic seed) when the craft
+// orbit isn't elliptic or the Lambert solve is degenerate.
+//
+// aimForCapture selects the arrival aim: false targets the target's centre
+// (used for the dual-strategy Δv comparison — keeps the near-coplanar
+// combined cost comparable to the split, ADR 0006 B), true offsets the aim
+// so the natural perilune lands at the Capture Orbit radius, prograde, for
+// the plan that's actually planted (ADR 0018). The offset barely shifts the
+// departure Δv, so comparing on the centre cost still picks the right
+// strategy; doing the offset only when planting stops it from flipping the
+// selection to the (still-centre-aimed, colliding) split.
+func (w *World) fusedIntraPrimaryDeparture(seed planner.TransferPlan, muShared float64, target bodies.CelestialBody, muTarget, rCapture float64, aimForCapture bool) (planner.TransferPlan, error) {
 	c := w.ActiveCraft()
 	waitTime := seed.Departure.OffsetTime
 	tof := seed.TransferDt.Seconds()
@@ -1643,9 +1667,296 @@ func (w *World) fusedIntraPrimaryDeparture(seed planner.TransferPlan, muShared f
 	arrEpoch := w.Clock.SimTime.Add(waitTime + seed.TransferDt)
 	rArr := w.BodyPositionAt(target, arrEpoch).Sub(w.BodyPositionAt(primary, arrEpoch))
 	vArr := w.bodyInertialVelocityAt(target, arrEpoch).Sub(w.bodyInertialVelocityAt(primary, arrEpoch))
+	aim := rArr
+	if aimForCapture {
+		aim = w.captureAimPoint(depState, rArr, vArr, primary, target, muShared, muTarget, rCapture, waitTime, tof)
+	}
 	return planner.PlanIntraPrimaryFused(
-		muShared, depState.R, depState.V, rArr, vArr, tof,
+		muShared, depState.R, depState.V, aim, vArr, tof,
 		waitTime, primary.ID, muTarget, rCapture, target.ID)
+}
+
+// captureAimPoint returns the arrival aim point for the fused transfer: an
+// in-plane offset from the target's centre (rArr) chosen so the natural
+// moon-frame perilune lands at rCapture, on the prograde side (ADR 0018).
+// It seeds the impact parameter analytically (b-plane relation) from the
+// centre-aimed approach v∞, then re-solves the Lambert to the offset aim and
+// measures the actual perilune, refining a few times (the offset perturbs
+// v∞, so one shot is only approximate). Falls back to the centre (no worse
+// than the pre-ADR-0018 behaviour) when the geometry is degenerate.
+//
+// Prograde side: with d̂ = v̂∞ × n̂_target, the approach angular momentum
+// r_rel × v_rel ≈ (b·d̂) × v∞ = +b·v∞·n̂_target (since (v̂∞ × n̂) × v̂∞ = +n̂),
+// i.e. aligned with the target's orbit normal — so this d̂ is the prograde-
+// capture side. (The opposite, n̂ × v̂∞, gives the retrograde side.)
+func (w *World) captureAimPoint(depState physics.StateVector, rArr, vArr orbital.Vec3, primary, target bodies.CelestialBody, muShared, muTarget, rCapture float64, waitTime time.Duration, tof float64) orbital.Vec3 {
+	depClock := w.Clock.SimTime.Add(waitTime)
+	// Centre-aimed solve to read the approach v∞ and its direction.
+	_, v2, err := planner.LambertSolve(depState.R, rArr, tof, muShared, false)
+	if err != nil {
+		return rArr
+	}
+	vInfVec := v2.Sub(vArr)
+	vInf := vInfVec.Norm()
+	nTarget := rArr.Cross(vArr)
+	if vInf == 0 || nTarget.Norm() == 0 {
+		return rArr
+	}
+	dHat := vInfVec.Unit().Cross(nTarget.Unit()) // in-plane, ⊥ v∞, prograde side
+	if dHat.Norm() == 0 {
+		return rArr
+	}
+	dHat = dHat.Unit()
+	// Analytic b-plane seed: perilune r_p ⇒ impact parameter b.
+	b := rCapture * math.Sqrt(1+2*muTarget/(rCapture*vInf*vInf))
+	aim := rArr.Add(dHat.Scale(b))
+	for iter := 0; iter < 6; iter++ {
+		peri, ok := w.aimPerilune(depState, aim, primary, target, muShared, depClock, tof)
+		if !ok {
+			// The offset skimmed past the SOI — pull it in and retry.
+			b *= 0.5
+			if b < 1 {
+				return rArr
+			}
+			aim = rArr.Add(dHat.Scale(b))
+			continue
+		}
+		if math.Abs(peri-rCapture) < 0.02*rCapture {
+			break
+		}
+		// Perilune grows ~monotonically with b; proportional correction.
+		b *= rCapture / peri
+		if b <= 0 || math.IsNaN(b) || math.IsInf(b, 0) {
+			return rArr
+		}
+		aim = rArr.Add(dHat.Scale(b))
+	}
+	return aim
+}
+
+// aimPerilune solves the fused departure to a candidate arrival aim point
+// and returns the resulting moon-frame perilune radius (ok=false when the
+// Lambert is degenerate or the arc misses the target's SOI). Shares
+// scanTargetEncounter with the live readout and the capture-time refinement.
+func (w *World) aimPerilune(depState physics.StateVector, aim orbital.Vec3, primary, target bodies.CelestialBody, muShared float64, depClock time.Time, tof float64) (float64, bool) {
+	v1, _, err := planner.LambertSolve(depState.R, aim, tof, muShared, false)
+	if err != nil {
+		return 0, false
+	}
+	post := depState
+	post.V = v1
+	enc, ok := w.scanTargetEncounter(post, primary, target, depClock, tof*1.4)
+	if !ok || !enc.EntersSOI {
+		return 0, false
+	}
+	return enc.Dist, true
+}
+
+// refineCombinedCapture moves the fused (combined) transfer's capture burn
+// from the nominal Lambert arrival epoch to the true perilune inside the
+// target's SOI. The fused Lambert aims the craft at the target's centre at
+// depOffset+tof, evaluated as a pure Kepler arc in the primary's frame —
+// which ignores the target's gravity, so it places the capture tens of
+// minutes late (the craft accelerates into the SOI and swings through
+// perilune early). This finds the SOI-entry time (transferEncounterTimes,
+// primary frame), rebases the entry state into the target's frame, and adds
+// the analytic hyperbolic time-to-periapsis. A no-op (leaves the analytic
+// epoch) when no encounter resolves or the entry geometry is past perilune.
+func (w *World) refineCombinedCapture(plan *planner.TransferPlan, c *spacecraft.Spacecraft, muShared float64, target bodies.CelestialBody) {
+	if plan.Departure.DV == 0 || plan.TransferDt <= 0 {
+		return
+	}
+	depState, ok := physics.KeplerStep(c.State, muShared, plan.Departure.OffsetTime.Seconds())
+	if !ok {
+		return
+	}
+	post := depState
+	post.V = depState.V.Add(plan.Departure.BurnDir.Scale(plan.Departure.DV))
+	depClock := w.Clock.SimTime.Add(plan.Departure.OffsetTime)
+	// Scan a little past the nominal tof — perilune sits before it, but
+	// give the SOI-entry detector margin for phasing slop.
+	tEntry, _, found := w.transferEncounterTimes(post, c.Primary, target, depClock, plan.TransferDt.Seconds()*1.4)
+	if !found {
+		return
+	}
+	stEntry, ok := physics.KeplerStep(post, muShared, tEntry)
+	if !ok {
+		return
+	}
+	entryClock := depClock.Add(time.Duration(tEntry * float64(time.Second)))
+	_, tPeri, ok := w.targetPerilune(stEntry, c.Primary, target, entryClock)
+	if !ok {
+		return
+	}
+	plan.Arrival.OffsetTime = plan.Departure.OffsetTime + time.Duration((tEntry+tPeri)*float64(time.Second))
+}
+
+// targetPerilune reads the perilune of a craft state that has just crossed
+// `target`'s SOI: it rebases the primary-frame state `stEntry` into the
+// target's frame (subtracting the target's position and velocity relative
+// to `primary` at `atClock`) and reads the resulting hyperbola. Returns the
+// perilune radius (distance to the target's centre; a·(1−e) is positive for
+// a<0, e>1) and the seconds from `atClock` to reach it. ok=false when the
+// relative orbit isn't hyperbolic or perilune is already behind the craft.
+// Shared by refineCombinedCapture and the live PredictedTargetApproach
+// readout so both agree on where the encounter periapsis is.
+func (w *World) targetPerilune(stEntry physics.StateVector, primary, target bodies.CelestialBody, atClock time.Time) (rp, tToPeri float64, ok bool) {
+	moonR := w.BodyPositionAt(target, atClock).Sub(w.BodyPositionAt(primary, atClock))
+	moonV := w.bodyInertialVelocityAt(target, atClock).Sub(w.bodyInertialVelocityAt(primary, atClock))
+	rel := orbital.Vec3State{R: stEntry.R.Sub(moonR), V: stEntry.V.Sub(moonV)}
+	muTarget := target.GravitationalParameter()
+	el := orbital.ElementsFromState(rel.R, rel.V, muTarget)
+	if el.E <= 1 || el.A >= 0 {
+		return 0, 0, false
+	}
+	t, okp := orbital.TimeToPeriapsisHyperbolic(rel, muTarget)
+	if !okp || t < 0 {
+		return 0, 0, false
+	}
+	return el.A * (1 - el.E), t, true
+}
+
+// TargetApproach summarises a craft's predicted closest approach to a body
+// target. Dist is the distance to the target's centre (perilune radius when
+// the trajectory enters the target's SOI, else the primary-frame miss
+// distance); TCA is seconds from now to that approach; EntersSOI reports
+// whether the path crosses the SOI (so a caller can show perilune altitude
+// vs. a flyby miss).
+type TargetApproach struct {
+	Dist      float64
+	TCA       float64
+	EntersSOI bool
+}
+
+// scanTargetEncounter walks the bound (elliptic) arc starting at `state`
+// (in `primary`'s frame) for its closest approach to `target` over
+// `horizon` seconds from `fromClock`. When the arc crosses the target's SOI
+// it returns the analytic moon-frame perilune (radius + time); otherwise the
+// primary-frame miss distance and its time. ok=false when the arc isn't
+// propagable. The TCA it returns is relative to `fromClock`. Shares
+// targetPerilune with the combined-capture refinement so the live readout
+// and the planted capture agree on the encounter geometry.
+func (w *World) scanTargetEncounter(state physics.StateVector, primary, target bodies.CelestialBody, fromClock time.Time, horizon float64) (TargetApproach, bool) {
+	mu := primary.GravitationalParameter()
+	soi := physics.SOIRadius(target, primary)
+	const n = 600
+	minD := math.Inf(1)
+	var minTime float64
+	tEntry := -1.0
+	propagable := false
+	for i := 0; i <= n; i++ {
+		dt := horizon * float64(i) / float64(n)
+		st, k := physics.KeplerStep(state, mu, dt)
+		if !k {
+			continue
+		}
+		propagable = true
+		tt := fromClock.Add(time.Duration(dt * float64(time.Second)))
+		rel := st.R.Sub(w.BodyPositionAt(target, tt).Sub(w.BodyPositionAt(primary, tt)))
+		d := rel.Norm()
+		if d < minD {
+			minD = d
+			minTime = dt
+		}
+		if tEntry < 0 && d < soi {
+			tEntry = dt
+		}
+	}
+	if !propagable {
+		return TargetApproach{}, false
+	}
+	if tEntry >= 0 {
+		if stEntry, k := physics.KeplerStep(state, mu, tEntry); k {
+			entryClock := fromClock.Add(time.Duration(tEntry * float64(time.Second)))
+			if rp, tPeri, okp := w.targetPerilune(stEntry, primary, target, entryClock); okp {
+				return TargetApproach{Dist: rp, TCA: tEntry + tPeri, EntersSOI: true}, true
+			}
+		}
+		// SOI entry but the relative hyperbola was degenerate — report the
+		// primary-frame minimum, still flagged as an encounter.
+		return TargetApproach{Dist: minD, TCA: minTime, EntersSOI: true}, true
+	}
+	return TargetApproach{Dist: minD, TCA: minTime, EntersSOI: false}, true
+}
+
+// PredictedTargetApproach returns the active craft's closest approach to its
+// current body Target, so the TARGET chip can show where the projected orbit
+// passes the target — updating live as the player hand-flies a correction.
+//
+// It scans two trajectories and prefers an actual SOI encounter (then the
+// closest of those):
+//
+//   - The craft's CURRENT state forward over a horizon reaching past the
+//     furthest planted node. This is the trajectory the player is actually
+//     flying — and the load-bearing case, because once the departure burn
+//     fires the approach coast is no longer a PredictedLegs leg (it's folded
+//     into the propagation to the next node), so a legs-only scan goes blind
+//     exactly during the coast.
+//   - The post-burn legs still in the craft's primary frame, so a transfer
+//     that's planted but not yet departed still previews its encounter.
+//
+// ok=false when there's no body target sharing the craft's primary or no
+// propagable trajectory.
+func (w *World) PredictedTargetApproach() (TargetApproach, bool) {
+	c := w.ActiveCraft()
+	if c == nil || w.Target.Kind != TargetBody {
+		return TargetApproach{}, false
+	}
+	sys := w.System()
+	if w.Target.BodyIdx <= 0 || w.Target.BodyIdx >= len(sys.Bodies) {
+		return TargetApproach{}, false
+	}
+	target := sys.Bodies[w.Target.BodyIdx]
+	if target.ParentID != c.Primary.ID {
+		return TargetApproach{}, false
+	}
+	now := w.Clock.SimTime
+
+	var cands []TargetApproach
+	// Live current trajectory. Horizon reaches 20% past the furthest planted
+	// node (the capture sits at perilune, so the encounter is within it),
+	// else a few orbital periods when nothing is planted.
+	horizon := 0.0
+	for _, n := range c.Nodes {
+		if dt := n.TriggerTime.Sub(now).Seconds(); dt > horizon {
+			horizon = dt
+		}
+	}
+	if horizon > 0 {
+		horizon *= 1.2
+	} else {
+		period := orbitalPeriod(c.State, c.Primary.GravitationalParameter())
+		if period <= 0 || math.IsNaN(period) || math.IsInf(period, 0) {
+			return TargetApproach{}, false
+		}
+		horizon = 3 * period
+	}
+	if enc, ok := w.scanTargetEncounter(c.State, c.Primary, target, now, horizon); ok {
+		cands = append(cands, enc)
+	}
+	// Planted-but-not-yet-departed plan: scan the post-burn legs so the
+	// readout previews the encounter before the departure fires.
+	for _, leg := range w.PredictedLegs() {
+		if leg.Primary.ID != c.Primary.ID {
+			continue
+		}
+		if enc, ok := w.scanTargetEncounter(leg.State, leg.Primary, target, leg.StartClock, leg.HorizonSecs); ok {
+			enc.TCA += leg.StartClock.Sub(now).Seconds()
+			cands = append(cands, enc)
+		}
+	}
+	if len(cands) == 0 {
+		return TargetApproach{}, false
+	}
+	best := cands[0]
+	for _, a := range cands[1:] {
+		// Prefer a real SOI encounter (the perilune) over a flyby miss; among
+		// the same kind, the closer one.
+		if (a.EntersSOI && !best.EntersSOI) || (a.EntersSOI == best.EntersSOI && a.Dist < best.Dist) {
+			best = a
+		}
+	}
+	return best, true
 }
 
 // primaryFrameAngle returns body b's angular position around its

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -51,6 +51,14 @@ const (
 	// (no craft, e ≥ 1, a ≤ 0). Useful for reading the orbit's
 	// actual shape as if i = 0.
 	ViewOrbitFlat
+	// ViewTarget (v0.18+) centers the canvas on the current body Target
+	// and auto-frames the craft→target approach (refitting every frame as
+	// the gap closes), so the player can watch the projected orbit pass the
+	// target while hand-flying engine/RCS corrections. Reuses the orbit-flat
+	// projection basis. Selected from the `v` cycle, but only reachable when
+	// a body target is set (CycleViewMode skips it otherwise); falls back to
+	// the ordinary focus center when the target is cleared mid-view.
+	ViewTarget
 	// ViewLaunch (v0.11.0+) is the chase-cam launch scene — a
 	// human-scale side view with the rocket centred, the horizon
 	// curving below in Body.SurfaceColor, and a body-fixed pad
@@ -79,6 +87,8 @@ func (m ViewMode) String() string {
 		return "left"
 	case ViewOrbitFlat:
 		return "orbit-flat"
+	case ViewTarget:
+		return "target"
 	case ViewLaunch:
 		return "launch"
 	}
@@ -97,6 +107,7 @@ var AllViewModes = [...]ViewMode{
 	ViewBottom,
 	ViewLeft,
 	ViewOrbitFlat,
+	ViewTarget,
 	ViewLaunch,
 }
 
@@ -110,7 +121,14 @@ func (w *World) CycleViewMode() {
 	if w.ViewMode == ViewLaunch {
 		w.LaunchSessionActive = false
 	}
-	w.ViewMode = (w.ViewMode + 1) % ViewMode(len(AllViewModes))
+	next := (w.ViewMode + 1) % ViewMode(len(AllViewModes))
+	// The target view has nothing to frame without a body target — skip it
+	// in the cycle so a player who isn't aiming at a body never lands on a
+	// dead view.
+	if next == ViewTarget && w.Target.Kind != TargetBody {
+		next = (next + 1) % ViewMode(len(AllViewModes))
+	}
+	w.ViewMode = next
 }
 
 // SetViewModeLaunch (v0.11.4+, ADR 0004) is the manual-jump path

--- a/internal/sim/view_target_test.go
+++ b/internal/sim/view_target_test.go
@@ -1,0 +1,56 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// TestCycleViewModeTargetGated: ViewTarget is reachable from the `v` cycle
+// only when a body target is set — otherwise it has nothing to frame and is
+// skipped, so a player not aiming at a body never lands on a dead view.
+func TestCycleViewModeTargetGated(t *testing.T) {
+	w := mustWorld(t)
+
+	// No target: cycling from orbit-flat skips ViewTarget straight to launch.
+	w.ViewMode = ViewOrbitFlat
+	w.CycleViewMode()
+	if w.ViewMode == ViewTarget {
+		t.Fatalf("cycled into ViewTarget with no target set")
+	}
+	if w.ViewMode != ViewLaunch {
+		t.Errorf("no-target cycle from orbit-flat = %v, want launch (target skipped)", w.ViewMode)
+	}
+
+	// With a body target: ViewTarget is reachable.
+	moonIdx, _ := findMoon(t, w)
+	w.SetTargetBody(moonIdx)
+	w.ViewMode = ViewOrbitFlat
+	w.CycleViewMode()
+	if w.ViewMode != ViewTarget {
+		t.Errorf("targeted cycle from orbit-flat = %v, want target", w.ViewMode)
+	}
+}
+
+// TestTargetViewFraming: the ViewTarget camera centers on the target body
+// and frames at least its SOI (so a close pass shows the perilune geometry),
+// and reports ok=false with no body target.
+func TestTargetViewFraming(t *testing.T) {
+	w := mustWorld(t)
+	if _, _, ok := w.TargetViewFraming(); ok {
+		t.Fatal("framing returned ok=true with no target")
+	}
+
+	moonIdx, moon := findMoon(t, w)
+	w.SetTargetBody(moonIdx)
+	center, radius, ok := w.TargetViewFraming()
+	if !ok {
+		t.Fatal("framing returned ok=false with a body target")
+	}
+	if want := w.BodyPosition(moon); center.Sub(want).Norm() > 1 {
+		t.Errorf("center = %v, want moon position %v", center, want)
+	}
+	if soi := physics.SOIRadius(moon, w.System().Bodies[0]); radius < soi {
+		t.Errorf("radius %.0f < moon SOI %.0f — perilune geometry wouldn't be framed", radius, soi)
+	}
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -247,7 +247,7 @@ func DefaultKeymap() Keymap {
 		Save:            key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
 		Load:            key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
 		RefinePlan:      key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat)")),
+		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat / target)")),
 
 		ThrottleFull:        key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "throttle 100%")),
 		ThrottleCut:         key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "throttle 0% / cut burn")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -44,7 +44,7 @@ var helpSections = []helpSection{
 		{"f / F", "cycle camera focus forward / back (system → bodies → craft)"},
 		{"g", "reset camera to the whole system"},
 		{"+ / -", "zoom in / out"},
-		{"v", "cycle view (tilted / top / right / bottom / left / flat)"},
+		{"v", "cycle view (tilted / top / right / bottom / left / flat / target)"},
 		{"shift+↑ / ↓", "tilt the 3D view up / down (tilted view only)"},
 		{"F2", "declutter — hide chips + navball (core column stays)"},
 	}},

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -357,6 +357,17 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	} else if v.burnFrozenCenter != nil {
 		v.burnFrozenCenter = nil
 	}
+	// ViewTarget overrides the focus center + zoom: center on the body
+	// target and refit every frame to frame the craft→target approach, so
+	// the projected orbit stays legible against the target as the gap closes
+	// (and as the player hand-flies a correction). Falls through to the
+	// ordinary focus center when no body target is set.
+	if w.ViewMode == sim.ViewTarget {
+		if tCenter, tRadius, ok := w.TargetViewFraming(); ok {
+			center = tCenter
+			v.canvas.FitTo(tRadius)
+		}
+	}
 	v.canvas.Center(center)
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
@@ -1114,7 +1125,7 @@ func (v *OrbitView) cameraDirForView(view sim.ViewMode) render.Vec3 {
 		return render.CameraDirRight
 	case sim.ViewLeft:
 		return render.CameraDirLeft
-	case sim.ViewTilted, sim.ViewOrbitFlat:
+	case sim.ViewTilted, sim.ViewOrbitFlat, sim.ViewTarget:
 		// Depth axis points out of screen toward the camera, which
 		// is exactly the body-to-camera direction the sub-observer
 		// math wants. For ViewOrbitFlat on a near-equatorial orbit
@@ -1867,7 +1878,9 @@ func viewBasis(w *sim.World) widgets.Basis {
 			X: orbital.Vec3{Y: -1},
 			Y: orbital.Vec3{Z: 1},
 		}
-	case sim.ViewOrbitFlat:
+	case sim.ViewOrbitFlat, sim.ViewTarget:
+		// ViewTarget reuses the orbit-plane basis so the approach reads as a
+		// clean curve; only its center + zoom differ (handled in Render).
 		el, ok := activeCraftElements(w)
 		if !ok {
 			return widgets.DefaultBasis()

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -63,10 +63,15 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// Settings screen, mirroring the always-on ● BURNS readout — both are
 	// too load-bearing to toggle off. F2 declutter still clears them.
 	add("", cornerTopRight, v.buildOrbitMetricsChip(w))
-	// PROJECTED ORBIT is its own chip beneath the always-on ORBIT readout
-	// (issue #63 follow-up) so current + projected show together during a
-	// burn. Toggleable, unlike the load-bearing live ORBIT above it.
-	add(settings.ChipProjectedOrbit, cornerTopRight, v.buildProjectedOrbitChip(w))
+	// PROJECTED ORBIT sits to the LEFT of the always-on ORBIT readout (issue
+	// #63 follow-up) so current + projected show together during a burn
+	// without growing the top-right column's height — leaving vertical room
+	// for TARGET to clear the bottom-right NODES chip. Toggleable, unlike the
+	// load-bearing live ORBIT beside it. leftOfPrev falls back to normal
+	// stacking when ORBIT is suppressed (e.g. ascent), so it's never orphaned.
+	if lines := v.buildProjectedOrbitChip(w); lines != nil && v.chipEnabled(settings.ChipProjectedOrbit) {
+		chips = append(chips, builtChip{id: settings.ChipProjectedOrbit, corner: cornerTopRight, lines: lines, leftOfPrev: true})
+	}
 	add(settings.ChipTarget, cornerTopRight, v.buildTargetChip(w))
 	// Remaining fixed corners.
 	add(settings.ChipStages, cornerBottomLeft, v.buildStagesChip(w))
@@ -644,6 +649,24 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		}
 		rangeM := w.BodyPosition(b).Sub(w.CraftInertial()).Norm()
 		lines = append(lines, chipRow("range:", formatRangeM(rangeM)))
+		// Predicted closest approach along the projected orbit — updates live
+		// as the player hand-flies a correction, so they can judge where the
+		// transfer actually passes the target rather than eyeballing the
+		// dashed curve. Perilune altitude when the path enters the SOI
+		// (negative ⇒ surface impact), else the flyby miss distance.
+		if ap, ok := w.PredictedTargetApproach(); ok {
+			if ap.EntersSOI {
+				alt := ap.Dist - b.RadiusMeters()
+				if alt <= 0 {
+					lines = append(lines, chipRow("peri:", v.theme.Warning.Render("IMPACT")))
+				} else {
+					lines = append(lines, chipRow("peri:", fmt.Sprintf("%.0f km", alt/1000)))
+				}
+			} else {
+				lines = append(lines, chipRow("approach:", formatRangeM(ap.Dist)))
+			}
+			lines = append(lines, chipRow("TCA:", formatTCA(ap.TCA)))
+		}
 		return lines
 	case sim.TargetCraft:
 		tc, _, ok := w.ResolveTargetCraft()

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -45,6 +45,15 @@ type builtChip struct {
 	id     settings.Chip
 	corner chipCorner
 	lines  []string
+	// leftOfPrev places this chip on the same top row as the previously
+	// placed chip in the same (top-right) corner, immediately to its left,
+	// instead of stacking below it — so two chips share a row band rather
+	// than growing the column's height. Used for PROJECTED ORBIT beside the
+	// always-on ORBIT chip so the top-right column stays short enough to
+	// leave room for TARGET above the bottom-right NODES chip. Honoured only
+	// for cornerTopRight; ignored (normal stacking) when there's no prior
+	// top-right chip to sit beside.
+	leftOfPrev bool
 }
 
 // chipRect is the absolute screen-cell rectangle a composited Chip
@@ -109,6 +118,10 @@ func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved
 	bottomLeftRow := cRows - 2 // above the "view:" label on row cRows-1
 	bottomRightRow := cRows - 1 - navballReserved
 
+	// Remember the last normally-placed top-right chip so a leftOfPrev chip
+	// can sit beside it (same top row, immediately to its left).
+	lastTRStartRow, lastTRCol, haveTR := 0, 0, false
+
 	for _, chip := range chips {
 		padded, w := padChipBlock(chip.lines)
 		if len(padded) == 0 || w == 0 {
@@ -125,8 +138,18 @@ func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved
 			atRow, atCol = topLeftRow, 0
 			topLeftRow += bh + chipGap
 		case cornerTopRight:
-			atRow, atCol = topRightRow, cCols-bw
-			topRightRow += bh + chipGap
+			if chip.leftOfPrev && haveTR {
+				// Sit beside the previous top-right chip rather than below it.
+				atRow, atCol = lastTRStartRow, lastTRCol-bw
+				if bottom := atRow + bh + chipGap; bottom > topRightRow {
+					topRightRow = bottom
+				}
+				lastTRCol = atCol // a further leftOfPrev chip chains leftward
+			} else {
+				atRow, atCol = topRightRow, cCols-bw
+				topRightRow += bh + chipGap
+				lastTRStartRow, lastTRCol, haveTR = atRow, atCol, true
+			}
 		case cornerBottomLeft:
 			atRow, atCol = bottomLeftRow-bh+1, 0
 			bottomLeftRow -= bh + chipGap

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -80,6 +80,40 @@ func TestComposeChipsPlacesAndRoutes(t *testing.T) {
 	}
 }
 
+// TestComposeChipsLeftOfPrevSharesRowBand: a leftOfPrev top-right chip
+// (PROJECTED ORBIT) sits on the same top row as the previously placed
+// top-right chip (ORBIT), immediately to its left — not stacked below it —
+// so the column stays short and a following TARGET chip drops below both
+// without overlapping. Regression for the right-column overflow that buried
+// TARGET under NODES.
+func TestComposeChipsLeftOfPrevSharesRowBand(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	chips := []builtChip{
+		{id: "", corner: cornerTopRight, lines: []string{"ORBIT", "  a", "  b"}},
+		{id: settings.ChipProjectedOrbit, corner: cornerTopRight, lines: []string{"PROJECTED", "  c"}, leftOfPrev: true},
+		{id: settings.ChipTarget, corner: cornerTopRight, lines: []string{"TARGET", "  d", "  e"}},
+	}
+	v.composeChips(blankCanvas(80, 24), 80, 24, 0, 0, 0, chips)
+	if len(v.chipRects) != 3 {
+		t.Fatalf("recorded %d rects, want 3", len(v.chipRects))
+	}
+	orbit, proj, target := v.chipRects[0], v.chipRects[1], v.chipRects[2]
+	if proj.rowStart != orbit.rowStart {
+		t.Errorf("projected rowStart %d != orbit rowStart %d — not side by side", proj.rowStart, orbit.rowStart)
+	}
+	if proj.colEnd >= orbit.colStart {
+		t.Errorf("projected (cols %d–%d) is not left of orbit (cols %d–%d)",
+			proj.colStart, proj.colEnd, orbit.colStart, orbit.colEnd)
+	}
+	maxBottom := orbit.rowEnd
+	if proj.rowEnd > maxBottom {
+		maxBottom = proj.rowEnd
+	}
+	if target.rowStart <= maxBottom {
+		t.Errorf("target rowStart %d not below the orbit/projected band bottom %d", target.rowStart, maxBottom)
+	}
+}
+
 func TestComposeChipsClipsOversizeChipWithoutPanic(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	tall := make([]string, 50) // taller than the 20-row canvas


### PR DESCRIPTION
Fixes a cluster of **Kern→Cursor** (coplanar planet→moon) transfer bugs found in playtest: `[H]` planted a guaranteed collision, the capture fired ~26 min late, and the HUD couldn't show where the transfer would land.

## Planner / physics
- **Capture fires at the true perilune.** The fused-Lambert capture node defaulted to the nominal Lambert arrival epoch (moon-centre crossing in the primary frame); now rebased into the target frame and fired at the analytic hyperbolic perilune (~2 min of the live-flown encounter, was ~26 min late).
- **Capture-aim periapsis targeting (ADR 0018).** The fused Lambert aimed at the target's *centre* → perilune at the surface (impact), with a Capture Burn Δv sized for a periapsis it never reached. Now aims at an in-plane offset (b-plane seed + iterate) so the natural perilune lands at the **Capture Orbit radius (~200 km alt), prograde**. Strategy selection compares on the centre cost (coplanar still picks combined); the offset applies only to the planted plan. **Split characterized** — does *not* collide (arrives loose/high), left as-is per ADR 0018 D.
- `orbital.TimeToPeriapsisHyperbolic` (the existing helpers bail on e≥1).

## HUD
- **TARGET chip** shows the predicted closest approach to a body target (`peri:` altitude / `IMPACT`, or `approach:` miss, + `TCA:`), live as you hand-fly. Body targets previously showed no closest-approach info.
- **ViewTarget** (`v` cycle): centers on the target, auto-frames the approach, zooming in as the gap closes. Skipped when no body is targeted.
- **PROJECTED ORBIT** chip moved to the left of ORBIT (shared top row) so the right column stays short enough for TARGET to clear NODES.

## Docs
CONTEXT.md Transfer Plan acceptance bar (coplanar **and** Capture Orbit radius, prograde); controls.md + F1 help overlay. ADR 0018 lives in the planning vault.

## Tests
Full suite green with `-race`. New: hyperbolic helper, capture-at-perilune, live readout (incl. post-departure coast), safe-prograde arrival, ViewTarget framing/gating, side-by-side chip layout, split characterization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)