### PR TITLE
ci: pin goreleaser to '~> v2'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           # Creates the GitHub release + uploads archives (scoped to this repo).


### PR DESCRIPTION
Pins the GoReleaser **tool** version in `release.yml` from `latest` to `~> v2`.

**Why:** the v0.17.3 release run emitted a GoReleaser advisory — *"You are using 'latest' as default version. Will lock to '~> v2'."* Pinning to `~> v2` adopts that recommendation and guards against an unattended jump to a future GoReleaser v3 major (a `latest` that silently goes v3 could break a release).

v0.17.3 built clean on GoReleaser v2, so this only locks in the current behavior. Release-config only — not exercised until the next `v*` tag push. (Unrelated to the `goreleaser-action@v7` *action* major, which is the GitHub Action runtime and stays v7.)