### PR TITLE
Unified single-glyph orbital markers (ADR 0020) — #134

### DIFF
--- a/internal/render/markers.go
+++ b/internal/render/markers.go
@@ -1,0 +1,111 @@
+package render
+
+import "github.com/charmbracelet/lipgloss"
+
+// MarkerType enumerates the orbital-marker vocabulary shared across the
+// orbit screen (ADR 0020). Every marker renders as a single colored glyph
+// stamped at its projected point via Canvas.SetCellOverlayColored — color
+// encodes the type, brightness/variant encodes the state (MarkerState).
+type MarkerType int
+
+const (
+	MarkerApoapsis MarkerType = iota
+	MarkerPeriapsis
+	MarkerAscendingNode
+	MarkerDescendingNode
+	MarkerPerilune // periapsis within an upcoming SOI Pass (ADR 0019)
+	MarkerClosestApproach
+	MarkerManeuver // per-node colour exception — see MarkerColor
+)
+
+// MarkerState modifies a marker's brightness/variant to convey what is
+// happening to it (ADR 0020 B): nominal renders at full type colour, a
+// counterfactual (e.g. the no-burn arc of ADR 0019's dual-arc) dims, and
+// an alarm (e.g. a perilune below the surface → impact) overrides to the
+// bright alert red regardless of type.
+type MarkerState int
+
+const (
+	MarkerNominal MarkerState = iota
+	MarkerCounterfactual
+	MarkerAlarm
+)
+
+// markerCounterfactualDim scales a marker's RGB for the counterfactual
+// state so the dimmed arc stays readable but visibly secondary to the
+// nominal one drawn in the same SOI.
+const markerCounterfactualDim = 0.5
+
+// MarkerGlyph returns the font-safe geometric glyph rune for a marker
+// type (ADR 0020 decision A). The set is deliberately basic so it renders
+// in virtually any monospace font (honouring the v0.11.4 palette caution
+// against exotic Unicode that shows as tofu). An unknown type falls back
+// to '?' rather than 0, so a mis-wired caller draws something visible
+// instead of silently nothing.
+func MarkerGlyph(t MarkerType) rune {
+	switch t {
+	case MarkerApoapsis:
+		return '▲'
+	case MarkerPeriapsis:
+		return '▼'
+	case MarkerAscendingNode:
+		return '◇'
+	case MarkerDescendingNode:
+		return '◆'
+	case MarkerPerilune:
+		return '⊕'
+	case MarkerClosestApproach:
+		return '✕'
+	case MarkerManeuver:
+		return 'Δ'
+	}
+	return '?'
+}
+
+// MarkerColor resolves the rendered colour for a marker from its type and
+// state (ADR 0020 decision B). Colour encodes type; state adjusts
+// brightness: MarkerAlarm overrides to ColorAlert (bright red, "what's
+// wrong" beats "what it is"); MarkerCounterfactual dims the type colour;
+// MarkerNominal uses it as-is.
+//
+// base is consulted only for MarkerManeuver — the one type whose colour is
+// positional (it matches the post-burn leg, ManeuverSegmentColor, an
+// ADR-0006-era design) rather than fixed by type. For every other type
+// base is ignored.
+func MarkerColor(t MarkerType, state MarkerState, base lipgloss.Color) lipgloss.Color {
+	if state == MarkerAlarm {
+		return ColorAlert
+	}
+	c := markerTypeColor(t, base)
+	if state == MarkerCounterfactual {
+		return Shade(c, markerCounterfactualDim)
+	}
+	return c
+}
+
+func markerTypeColor(t MarkerType, base lipgloss.Color) lipgloss.Color {
+	switch t {
+	case MarkerApoapsis:
+		return ColorMarkerApoapsis
+	case MarkerPeriapsis:
+		return ColorMarkerPeriapsis
+	case MarkerAscendingNode:
+		return ColorMarkerAscendingNode
+	case MarkerDescendingNode:
+		return ColorMarkerDescendingNode
+	case MarkerPerilune:
+		return ColorMarkerPerilune
+	case MarkerClosestApproach:
+		return ColorMarkerClosestApproach
+	case MarkerManeuver:
+		// Documented exception (ADR 0020): the maneuver marker's colour is
+		// the post-burn leg colour passed by the caller, not a fixed type
+		// hue. Fall back to the planned-node cyan if the caller passes no
+		// base (e.g. an unresolved leg).
+		if base == "" {
+			return ColorPlannedNode
+		}
+		return base
+	}
+	return ColorTrajectory
+}

--- a/internal/render/markers_test.go
+++ b/internal/render/markers_test.go
@@ -1,0 +1,87 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestMarkerGlyph(t *testing.T) {
+	cases := []struct {
+		t    MarkerType
+		want rune
+	}{
+		{MarkerApoapsis, '▲'},
+		{MarkerPeriapsis, '▼'},
+		{MarkerAscendingNode, '◇'},
+		{MarkerDescendingNode, '◆'},
+		{MarkerPerilune, '⊕'},
+		{MarkerClosestApproach, '✕'},
+		{MarkerManeuver, 'Δ'},
+	}
+	for _, c := range cases {
+		if got := MarkerGlyph(c.t); got != c.want {
+			t.Errorf("MarkerGlyph(%d) = %q, want %q", c.t, got, c.want)
+		}
+	}
+	// Unknown type renders something visible, never the zero rune.
+	if got := MarkerGlyph(MarkerType(999)); got == 0 {
+		t.Errorf("MarkerGlyph(unknown) = 0, want a visible fallback glyph")
+	}
+}
+
+func TestMarkerColorByType(t *testing.T) {
+	cases := []struct {
+		t    MarkerType
+		want lipgloss.Color
+	}{
+		{MarkerApoapsis, ColorMarkerApoapsis},
+		{MarkerPeriapsis, ColorMarkerPeriapsis},
+		{MarkerAscendingNode, ColorMarkerAscendingNode},
+		{MarkerDescendingNode, ColorMarkerDescendingNode},
+		{MarkerPerilune, ColorMarkerPerilune},
+		{MarkerClosestApproach, ColorMarkerClosestApproach},
+	}
+	for _, c := range cases {
+		if got := MarkerColor(c.t, MarkerNominal, ""); got != c.want {
+			t.Errorf("MarkerColor(%d, nominal) = %q, want %q", c.t, got, c.want)
+		}
+	}
+}
+
+func TestMarkerColorManeuverUsesBase(t *testing.T) {
+	// The maneuver marker is the documented positional-colour exception:
+	// it must echo the per-node base colour, not a fixed type hue.
+	base := lipgloss.Color("#ABCDEF")
+	if got := MarkerColor(MarkerManeuver, MarkerNominal, base); got != base {
+		t.Errorf("MarkerColor(maneuver, base=%q) = %q, want the base", base, got)
+	}
+	// No base supplied → fall back to the planned-node cyan, not empty.
+	if got := MarkerColor(MarkerManeuver, MarkerNominal, ""); got != ColorPlannedNode {
+		t.Errorf("MarkerColor(maneuver, no base) = %q, want ColorPlannedNode %q", got, ColorPlannedNode)
+	}
+}
+
+func TestMarkerColorAlarmOverridesType(t *testing.T) {
+	// Alarm beats type for every marker, including the maneuver exception.
+	for _, mt := range []MarkerType{MarkerApoapsis, MarkerPerilune, MarkerManeuver} {
+		if got := MarkerColor(mt, MarkerAlarm, lipgloss.Color("#123456")); got != ColorAlert {
+			t.Errorf("MarkerColor(%d, alarm) = %q, want ColorAlert %q", mt, got, ColorAlert)
+		}
+	}
+}
+
+func TestMarkerColorCounterfactualDims(t *testing.T) {
+	// Counterfactual must darken the nominal type colour (each channel
+	// strictly lower for a non-black hue), matching ADR 0020's dim=
+	// counterfactual rule used by the dual-arc render.
+	nominal := MarkerColor(MarkerApoapsis, MarkerNominal, "")
+	dim := MarkerColor(MarkerApoapsis, MarkerCounterfactual, "")
+	if dim == nominal {
+		t.Fatalf("counterfactual colour %q must differ from nominal %q", dim, nominal)
+	}
+	if dim != Shade(nominal, markerCounterfactualDim) {
+		t.Errorf("counterfactual = %q, want Shade(nominal, %v) = %q",
+			dim, markerCounterfactualDim, Shade(nominal, markerCounterfactualDim))
+	}
+}

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -49,6 +49,22 @@ var (
 	ColorRCSPuffTip    = ColorDim                  // dim grey — fading trail tip
 )
 
+// Orbital-marker type colours (ADR 0020). The unified marker convention
+// is: one glyph rune per marker type, colour encodes *type*, brightness
+// encodes *state* (see internal/render/markers.go). These are the fixed
+// per-type hues; the Maneuver marker is the one documented exception
+// whose colour is positional (per post-burn leg, ManeuverSegmentColor)
+// rather than drawn from this table. Chosen to stay mutually distinct and
+// distinct from the orbit/leg/body palettes already in play.
+var (
+	ColorMarkerApoapsis        = lipgloss.Color("#5FC9E8") // sky cyan — apoapsis ▲
+	ColorMarkerPeriapsis       = lipgloss.Color("#FFAF00") // amber — periapsis ▼
+	ColorMarkerAscendingNode   = lipgloss.Color("#5FD75F") // green — ascending node ◇
+	ColorMarkerDescendingNode  = lipgloss.Color("#AF5FFF") // violet — descending node ◆
+	ColorMarkerPerilune        = lipgloss.Color("#FFAF00") // amber — perilune ⊕ (the periapsis within a pass SOI; shares the apsis amber)
+	ColorMarkerClosestApproach = lipgloss.Color("#FF5FAF") // hot pink — craft-to-craft closest approach ✕
+)
+
 // maneuverSegmentPalette cycles through distinct colors per planted
 // maneuver node so the player can read which post-burn leg belongs
 // to which burn. Indices wrap around once exhausted; the cycle is

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -389,6 +389,16 @@ func catalogLaunchSpriteHasLegsByName(name string) bool {
 	return false
 }
 
+// VesselGlyph is the single marker every craft collapses to on the
+// orbit map (ADR 0020). Vessels are distinguished by Colour, not shape:
+// the orbital-marker vocabulary (▲ apo / ▼ peri / ◇ AN / ◆ DN / ⊕
+// perilune / ✕ closest / Δ node) owns the geometric shapes, so a vessel
+// must not reuse any of them or the player can't tell a ship from an
+// apsis. ➤ (U+27A4, Dingbats — same well-supported block as the marker
+// ✕) is a heading-chevron reserved for craft. Every Loadout/Stage glyph
+// below references this constant; do not hand-pick a per-craft glyph.
+const VesselGlyph = "➤"
+
 // Loadouts indexes the v0.8.2 launch set + v0.9.1 Saturn-V by ID.
 // Future patches may load user overlays (similar to bodies/themes)
 // but the embedded catalog is canonical for now.
@@ -403,37 +413,37 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutSIVB1ID,
 		Name:  "S-IVB",
 		Role:  "transfer-stage",
-		Glyph: "▲",
+		Glyph: VesselGlyph,
 		Color: "#FFD93D", // saturated yellow (matches v0.7.1+ ColorCraftMarker)
 		Stages: []Stage{
-			stage(LoadoutSIVB1ID, "S-IVB", "▲", "#FFD93D", 11000, 40000, 1023000, 421),
+			stage(LoadoutSIVB1ID, "S-IVB", VesselGlyph, "#FFD93D", 11000, 40000, 1023000, 421),
 		},
 	},
 	LoadoutICPSID: {
 		ID:    LoadoutICPSID,
 		Name:  "ICPS",
 		Role:  "transfer-stage",
-		Glyph: "◆",
+		Glyph: VesselGlyph,
 		Color: "#5BB3FF", // ocean blue
 		Stages: []Stage{
-			stage(LoadoutICPSID, "ICPS", "◆", "#5BB3FF", 3500, 25000, 108000, 462),
+			stage(LoadoutICPSID, "ICPS", VesselGlyph, "#5BB3FF", 3500, 25000, 108000, 462),
 		},
 	},
 	LoadoutRCSTugID: {
 		ID:    LoadoutRCSTugID,
 		Name:  "RCS Tug",
 		Role:  "tug",
-		Glyph: "●",
+		Glyph: VesselGlyph,
 		Color: "#FF87D7", // pink
 		Stages: []Stage{
-			stage(LoadoutRCSTugID, "RCS Tug", "●", "#FF87D7", 200, 0, 0, 0),
+			stage(LoadoutRCSTugID, "RCS Tug", VesselGlyph, "#FF87D7", 200, 0, 0, 0),
 		},
 	},
 	LoadoutLanderID: {
 		ID:    LoadoutLanderID,
 		Name:  "Lander",
 		Role:  "lander",
-		Glyph: "▼",
+		Glyph: VesselGlyph,
 		Color: "#5FFF87", // mint
 		// v0.12 Slice 2 / ADR 0007: the Apollo-LM-style Lander is two
 		// stages — Descent (bottom: legs + soft-land + the powered-
@@ -448,8 +458,8 @@ var Loadouts = map[string]Loadout{
 		// silhouette ride per-Stage via the StageCatalog by-Name
 		// lookups (Descent / Ascent entries).
 		Stages: []Stage{
-			stage(LoadoutLanderID, "Descent", "▼", "#5FFF87", 2500, 9500, 45000, 311),
-			stage(LoadoutLanderID, "Ascent", "▲", "#7BFFA0", 1200, 1800, 16000, 311),
+			stage(LoadoutLanderID, "Descent", VesselGlyph, "#5FFF87", 2500, 9500, 45000, 311),
+			stage(LoadoutLanderID, "Ascent", VesselGlyph, "#7BFFA0", 1200, 1800, 16000, 311),
 		},
 	},
 	// Saturn-V (v0.9.1+): the canonical Apollo launch vehicle.
@@ -462,24 +472,24 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutSaturnVID,
 		Name:  "Saturn V",
 		Role:  "launch-vehicle",
-		Glyph: "▲",
+		Glyph: VesselGlyph,
 		Color: "#FFD93D",
 		Stages: []Stage{
 			// S-IC booster: F-1 cluster, sea-level Isp (the only
 			// stage that fires in atmosphere). BC tuned for the
 			// real S-IC's ~80 m² cross-section and ~2.9 Mkg wet
 			// mass: BC = C_D · A / m ≈ 0.3 · 80 / 2.9e6 ≈ 8e-6.
-			stageWithBC(LoadoutSaturnVID, "S-IC", "▲", "#FF8C42",
+			stageWithBC(LoadoutSaturnVID, "S-IC", VesselGlyph, "#FF8C42",
 				130000, 2160000, 35100000, 263, 8e-6),
 			// S-II sustainer: J-2 cluster, vacuum Isp. Smaller
 			// cross-section ~40 m² but mostly vacuum flight, so
 			// drag is negligible regardless. BC ≈ 0.3·40/480e3 ≈ 2.5e-5.
-			stageWithBC(LoadoutSaturnVID, "S-II", "▲", "#FFC042",
+			stageWithBC(LoadoutSaturnVID, "S-II", VesselGlyph, "#FFC042",
 				40000, 440000, 5140000, 421, 2.5e-5),
 			// S-IVB insertion: J-2 single, vacuum Isp. Same shape
 			// as the standalone S-IVB-1 loadout but lives as the
 			// top stage of the Saturn-V chain.
-			stageWithBC(LoadoutSaturnVID, "S-IVB", "▲", "#FFD93D",
+			stageWithBC(LoadoutSaturnVID, "S-IVB", VesselGlyph, "#FFD93D",
 				11000, 109000, 1023000, 421, 6.25e-5),
 		},
 	},
@@ -495,7 +505,7 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutSLSBlock1ID,
 		Name:  "SLS Block 1",
 		Role:  "launch-vehicle",
-		Glyph: "▲",
+		Glyph: VesselGlyph,
 		Color: "#FF6B35",
 		Stages: []Stage{
 			// Twin 5-segment solid rocket boosters. Casings dropped
@@ -503,18 +513,18 @@ var Loadouts = map[string]Loadout{
 			// wet → BC ≈ 0.3 · 12 / 1.47e6 ≈ 2.4e-6, but two long
 			// skinny solids alongside the core have higher effective
 			// drag — round to 8e-6 to match Saturn V S-IC scale.
-			stageWithBC(LoadoutSLSBlock1ID, "SRBs", "▲", "#E0E0E0",
+			stageWithBC(LoadoutSLSBlock1ID, "SRBs", VesselGlyph, "#E0E0E0",
 				198000, 1270000, 32000000, 268, 8e-6),
 			// Core stage: 4× RS-25 cluster, vacuum Isp (fires through
 			// most of the ascent above the dense atmosphere by the
 			// time SRBs separate at ~50 km). BC similar to S-II.
-			stageWithBC(LoadoutSLSBlock1ID, "Core", "▲", "#FF6B35",
+			stageWithBC(LoadoutSLSBlock1ID, "Core", VesselGlyph, "#FF6B35",
 				85275, 979452, 9290000, 452, 2.5e-5),
 			// ICPS (Interim Cryogenic Propulsion Stage): RL10B-2,
 			// vacuum Isp. Same shape as the standalone ICPS loadout
 			// but lives as the top of the SLS chain. TLI-class burn,
 			// not orbital insertion — TWR is very low (~0.1).
-			stageWithBC(LoadoutSLSBlock1ID, "ICPS", "◆", "#5BB3FF",
+			stageWithBC(LoadoutSLSBlock1ID, "ICPS", VesselGlyph, "#5BB3FF",
 				3500, 25000, 110000, 462, 6.25e-5),
 		},
 	},
@@ -527,18 +537,18 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutFalcon9ID,
 		Name:  "Falcon 9",
 		Role:  "launch-vehicle",
-		Glyph: "▲",
+		Glyph: VesselGlyph,
 		Color: "#E8E8E8",
 		Stages: []Stage{
 			// First stage: 9× Merlin 1D, sea-level Isp. 3.7 m
 			// diameter, ~10.75 m² cross-section, ~437 t wet →
 			// BC ≈ 0.3 · 10.75 / 437e3 ≈ 7.4e-6.
-			stageWithBC(LoadoutFalcon9ID, "F9-S1", "▲", "#E8E8E8",
+			stageWithBC(LoadoutFalcon9ID, "F9-S1", VesselGlyph, "#E8E8E8",
 				25600, 411000, 7607000, 282, 7.4e-6),
 			// Second stage: 1× Merlin Vacuum, vacuum Isp. Above the
 			// atmosphere by ignition, BC matters less — pick a
 			// vacuum-stage value similar to S-IVB.
-			stageWithBC(LoadoutFalcon9ID, "F9-S2", "▲", "#B0D8FF",
+			stageWithBC(LoadoutFalcon9ID, "F9-S2", VesselGlyph, "#B0D8FF",
 				3900, 107500, 934000, 348, 5e-5),
 		},
 		// CanSoftLand is per-Stage: F9-S1 carries it (retro-burn
@@ -559,14 +569,14 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutApolloStackID,
 		Name:  "Apollo Stack",
 		Role:  "mission-stack",
-		Glyph: "▲",
+		Glyph: VesselGlyph,
 		Color: "#FFD93D",
 		Stages: []Stage{
-			stageWithBC(LoadoutApolloStackID, "S-IC", "▲", "#FF8C42",
+			stageWithBC(LoadoutApolloStackID, "S-IC", VesselGlyph, "#FF8C42",
 				130000, 2160000, 35100000, 263, 8e-6),
-			stageWithBC(LoadoutApolloStackID, "S-II", "▲", "#FFC042",
+			stageWithBC(LoadoutApolloStackID, "S-II", VesselGlyph, "#FFC042",
 				40000, 440000, 5140000, 421, 2.5e-5),
-			stageWithBC(LoadoutApolloStackID, "S-IVB", "▲", "#FFD93D",
+			stageWithBC(LoadoutApolloStackID, "S-IVB", VesselGlyph, "#FFD93D",
 				11000, 109000, 1023000, 421, 6.25e-5),
 			// Lunar Module — split into Descent + Ascent (v0.12 Slice 2
 			// / ADR 0007). Post-transposition (ADR 0009) the LM rides as
@@ -577,9 +587,9 @@ var Loadouts = map[string]Loadout{
 			// no longer double-duties as the LOI engine, so it can shed
 			// the surplus. The LM is a negligible fraction of the
 			// ~2.93 Mkg stack, so lift-off TWR stays ~1.22.
-			stage(LoadoutApolloStackID, "Descent", "▼", "#5FFF87",
+			stage(LoadoutApolloStackID, "Descent", VesselGlyph, "#5FFF87",
 				2500, 6310, 45000, 311),
-			stage(LoadoutApolloStackID, "Ascent", "▲", "#7BFFA0",
+			stage(LoadoutApolloStackID, "Ascent", VesselGlyph, "#7BFFA0",
 				1200, 1269, 16000, 311),
 			// Command/Service Module — split into a propulsive Service
 			// Module + a passive Command Module (v0.12 / ADR 0009). The
@@ -589,9 +599,9 @@ var Loadouts = map[string]Loadout{
 			// 6000 + CM dry 5900 = the pre-split CSM dry 11900 → the
 			// split is mass-neutral and lift-off TWR is unchanged. SM
 			// below CM so the firing SPS sits beneath the passive capsule.
-			stage(LoadoutApolloStackID, "SM", "◉", "#C0C0FF",
+			stage(LoadoutApolloStackID, "SM", VesselGlyph, "#C0C0FF",
 				6000, 16000, 91000, 314),
-			stage(LoadoutApolloStackID, "CM", "◓", "#B8C8E0",
+			stage(LoadoutApolloStackID, "CM", VesselGlyph, "#B8C8E0",
 				5900, 0, 0, 0),
 		},
 		// v0.12 / ADR 0009: drop S-IC, S-II, S-IVB individually, then the
@@ -616,10 +626,10 @@ var Loadouts = map[string]Loadout{
 		ID:    LoadoutCapsuleID,
 		Name:  "Capsule",
 		Role:  "capsule",
-		Glyph: "◓",
+		Glyph: VesselGlyph,
 		Color: "#B8C8E0", // pale bare-metal command module
 		Stages: []Stage{
-			stage(LoadoutCapsuleID, "Capsule", "◓", "#B8C8E0", 5800, 0, 0, 0),
+			stage(LoadoutCapsuleID, "Capsule", VesselGlyph, "#B8C8E0", 5800, 0, 0, 0),
 		},
 	},
 	// Kern Stack (v0.15 / ADR 0014): the scale-matched Lumen vehicle.
@@ -639,7 +649,7 @@ var Loadouts = map[string]Loadout{
 		ID:         LoadoutKernStackID,
 		Name:       "Kern Stack",
 		Role:       "mission-stack",
-		Glyph:      "▲",
+		Glyph:      VesselGlyph,
 		Color:      "#7BD3FF", // Lumen-cyan — distinct from the real fleet's warm yellows
 		ScaleClass: bodies.ScaleStrippedBack,
 		Stages: []Stage{
@@ -647,24 +657,24 @@ var Loadouts = map[string]Loadout{
 			// the only stage that fires in atmosphere). TWR ≈ 1.50 off the
 			// pad. BC 7e-6 (slender ~2.5 m stack, like Saturn-V S-IC) so
 			// Kern's thick air doesn't cap the climb.
-			kernStage("Boost", "▲", "#7BD3FF", 2000, 12000, 320000, 285, 7e-6,
+			kernStage("Boost", VesselGlyph, "#7BD3FF", 2000, 12000, 320000, 285, 7e-6,
 				14, 4, "#D8E6F0", FuelTypeKerolox, false, false, false),
 			// Transfer: Poodle-class vacuum stage (Isp 350) for the Kern
 			// orbit insertion and the Cursor transfer/capture burns. BC is a
 			// vacuum-stage value (drag negligible once Boost separates).
-			kernStage("Transfer", "▲", "#9BE0FF", 1000, 3500, 60000, 350, 2.5e-5,
+			kernStage("Transfer", VesselGlyph, "#9BE0FF", 1000, 3500, 60000, 350, 2.5e-5,
 				10, 3, "#C8E0F0", FuelTypeHydrolox, false, false, false),
 			// Lander: Terrier-class throttleable descent/ascent engine
 			// (Isp 345) with legs — fires the powered descent to Cursor and
 			// the return-to-orbit burn. Soft-land qualified. (Cursor is
 			// airless; BC only matters if it ever flies in atmosphere.)
-			kernStage("Lander", "▼", "#5FFF87", 800, 1000, 16000, 345, 5e-5,
+			kernStage("Lander", VesselGlyph, "#5FFF87", 800, 1000, 16000, 345, 5e-5,
 				5, 3, "#D4C088", FuelTypeHypergolic, true, true, false),
 			// Pod: engineless crew capsule, the surviving core. Recovers
 			// under parachute (ADR 0008) — the "return" half of the budget.
 			// Deployed chute overrides BC (ChuteDeployedBC), so this value
 			// only applies to the brief pre-deploy free-fall.
-			kernStage("Pod", "◓", "#B8C8E0", 1000, 0, 0, 0, 5e-5,
+			kernStage("Pod", VesselGlyph, "#B8C8E0", 1000, 0, 0, 0, 5e-5,
 				6, 3, "#C8C8D0", "", false, false, true),
 		},
 		// Drop Boost, Transfer, Lander one at a time; the Pod survives every
@@ -769,7 +779,7 @@ func NewFromStages(stages []Stage) *Spacecraft {
 	}
 	glyph := core.Glyph
 	if glyph == "" {
-		glyph = "▲"
+		glyph = VesselGlyph
 	}
 	color := core.Color
 	if color == "" {

--- a/internal/spacecraft/loadouts_glyph_test.go
+++ b/internal/spacecraft/loadouts_glyph_test.go
@@ -1,0 +1,65 @@
+package spacecraft
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/render"
+)
+
+// reservedMarkerGlyphs is the set of orbital-marker runes (ADR 0020) that
+// no vessel may use — a craft sharing a marker's glyph is exactly the
+// ship-looks-like-an-apsis collision this guard exists to prevent.
+func reservedMarkerGlyphs() map[rune]render.MarkerType {
+	types := []render.MarkerType{
+		render.MarkerApoapsis,
+		render.MarkerPeriapsis,
+		render.MarkerAscendingNode,
+		render.MarkerDescendingNode,
+		render.MarkerPerilune,
+		render.MarkerClosestApproach,
+		render.MarkerManeuver,
+	}
+	set := make(map[rune]render.MarkerType, len(types))
+	for _, t := range types {
+		set[render.MarkerGlyph(t)] = t
+	}
+	return set
+}
+
+// TestCatalogGlyphsAreUnifiedVesselGlyph locks two invariants together:
+// every loadout + stage + stage-module glyph is the single VesselGlyph
+// (vessels are told apart by Colour, not shape), and therefore none of
+// them collides with a reserved orbital-marker glyph. A new catalog
+// entry that hand-picks a marker shape trips this test.
+func TestCatalogGlyphsAreUnifiedVesselGlyph(t *testing.T) {
+	reserved := reservedMarkerGlyphs()
+
+	check := func(label, glyph string) {
+		t.Helper()
+		if glyph != VesselGlyph {
+			t.Errorf("%s glyph = %q, want the unified VesselGlyph %q", label, glyph, VesselGlyph)
+		}
+		for _, r := range glyph {
+			if mt, clash := reserved[r]; clash {
+				t.Errorf("%s glyph %q collides with reserved marker glyph (marker type %d)", label, glyph, mt)
+			}
+		}
+	}
+
+	for id, l := range Loadouts {
+		check("loadout "+id, l.Glyph)
+		for _, s := range l.Stages {
+			check("loadout "+id+" stage "+s.Name, s.Glyph)
+		}
+	}
+	for id, m := range StageCatalog {
+		check("stage module "+id, m.Glyph)
+	}
+
+	// Sanity: VesselGlyph itself must not be a marker glyph.
+	for _, r := range VesselGlyph {
+		if _, clash := reserved[r]; clash {
+			t.Fatalf("VesselGlyph %q is itself a reserved marker glyph", VesselGlyph)
+		}
+	}
+}

--- a/internal/spacecraft/stage.go
+++ b/internal/spacecraft/stage.go
@@ -100,8 +100,10 @@ type Stage struct {
 
 	// Glyph + Color override the canvas marker for this stage
 	// when it's jettisoned and spawned as a passive craft. Empty
-	// resolves via LoadoutID lookup (default: "▲" / "#FFD93D"
-	// like the S-IVB-1 main loadout).
+	// resolves via LoadoutID lookup (default: VesselGlyph /
+	// "#FFD93D" like the S-IVB-1 main loadout). Every catalog craft
+	// uses VesselGlyph — vessels are told apart by Colour, not shape
+	// (ADR 0020 reserves the geometric glyphs for orbital markers).
 	Glyph string
 	Color string
 

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -146,7 +146,7 @@ const (
 // which is what makes it a rendezvous-relevant payload tier.
 var StageCatalog = map[string]StageModule{
 	StageModuleSICID: {
-		ID: StageModuleSICID, Name: "S-IC", Glyph: "▲", Color: "#FF8C42",
+		ID: StageModuleSICID, Name: "S-IC", Glyph: VesselGlyph, Color: "#FF8C42",
 		Tier: "booster", dry: 130000, fuel: 2160000, thrust: 35100000, isp: 263, bc: 8e-6,
 		launchSpriteRowsPx:  24,
 		launchSpriteWidthPx: 5,
@@ -157,7 +157,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType:          FuelTypeKerolox,
 	},
 	StageModuleSIIID: {
-		ID: StageModuleSIIID, Name: "S-II", Glyph: "▲", Color: "#FFC042",
+		ID: StageModuleSIIID, Name: "S-II", Glyph: VesselGlyph, Color: "#FFC042",
 		Tier: "sustainer", dry: 40000, fuel: 440000, thrust: 5140000, isp: 421, bc: 2.5e-5,
 		launchSpriteRowsPx:  20,
 		launchSpriteWidthPx: 4,
@@ -165,7 +165,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType:            FuelTypeHydrolox,
 	},
 	StageModuleSIVBID: {
-		ID: StageModuleSIVBID, Name: "S-IVB", Glyph: "▲", Color: "#FFD93D",
+		ID: StageModuleSIVBID, Name: "S-IVB", Glyph: VesselGlyph, Color: "#FFD93D",
 		Tier: "transfer", dry: 11000, fuel: 109000, thrust: 1023000, isp: 421, bc: 6.25e-5,
 		launchSpriteRowsPx:  12,
 		launchSpriteWidthPx: 3,
@@ -173,7 +173,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType:            FuelTypeHydrolox,
 	},
 	StageModuleICPSID: {
-		ID: StageModuleICPSID, Name: "ICPS", Glyph: "◆", Color: "#5BB3FF",
+		ID: StageModuleICPSID, Name: "ICPS", Glyph: VesselGlyph, Color: "#5BB3FF",
 		// GH #89: thrust mirrors the standalone ICPS loadout (108000 N),
 		// the canonical referent for a configurator part named "ICPS" —
 		// not the 110000 N variant the SLS-Block1 loadout embeds. Was
@@ -186,7 +186,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType:            FuelTypeHydrolox,
 	},
 	StageModuleSRBID: {
-		ID: StageModuleSRBID, Name: "SRBs", Glyph: "▲", Color: "#E0E0E0",
+		ID: StageModuleSRBID, Name: "SRBs", Glyph: VesselGlyph, Color: "#E0E0E0",
 		Tier: "booster", dry: 198000, fuel: 1270000, thrust: 32000000, isp: 268, bc: 8e-6,
 		launchSpriteRowsPx:  28,
 		launchSpriteWidthPx: 5,
@@ -194,7 +194,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType: FuelTypeSolid,
 	},
 	StageModuleCoreRS25ID: {
-		ID: StageModuleCoreRS25ID, Name: "Core", Glyph: "▲", Color: "#FF6B35",
+		ID: StageModuleCoreRS25ID, Name: "Core", Glyph: VesselGlyph, Color: "#FF6B35",
 		Tier: "sustainer", dry: 85275, fuel: 979452, thrust: 9290000, isp: 452, bc: 2.5e-5,
 		launchSpriteRowsPx:  24,
 		launchSpriteWidthPx: 4,
@@ -204,7 +204,7 @@ var StageCatalog = map[string]StageModule{
 		fuelType:          FuelTypeHydrolox,
 	},
 	StageModuleF9S1ID: {
-		ID: StageModuleF9S1ID, Name: "F9-S1", Glyph: "▲", Color: "#E8E8E8",
+		ID: StageModuleF9S1ID, Name: "F9-S1", Glyph: VesselGlyph, Color: "#E8E8E8",
 		Tier: "booster", dry: 25600, fuel: 411000, thrust: 7607000, isp: 282, bc: 7.4e-6,
 		launchSpriteRowsPx:  20,
 		launchSpriteWidthPx: 3,
@@ -212,7 +212,7 @@ var StageCatalog = map[string]StageModule{
 		canSoftLand:         true,
 	},
 	StageModuleF9S2ID: {
-		ID: StageModuleF9S2ID, Name: "F9-S2", Glyph: "▲", Color: "#B0D8FF",
+		ID: StageModuleF9S2ID, Name: "F9-S2", Glyph: VesselGlyph, Color: "#B0D8FF",
 		Tier: "transfer", dry: 3900, fuel: 107500, thrust: 934000, isp: 348, bc: 5e-5,
 		launchSpriteRowsPx:  8,
 		launchSpriteWidthPx: 3,
@@ -227,7 +227,7 @@ var StageCatalog = map[string]StageModule{
 	// They are intentionally unreachable — do not trust them as the
 	// Lander's mass budget (the live numbers are the Descent+Ascent split).
 	StageModuleLanderID: {
-		ID: StageModuleLanderID, Name: "Lander", Glyph: "▼", Color: "#5FFF87",
+		ID: StageModuleLanderID, Name: "Lander", Glyph: VesselGlyph, Color: "#5FFF87",
 		Tier: "payload", dry: 4000, fuel: 8000, thrust: 45000, isp: 311, bc: 0,
 		launchSpriteRowsPx:  5,
 		launchSpriteWidthPx: 3,
@@ -250,7 +250,7 @@ var StageCatalog = map[string]StageModule{
 	// 6000 kg gave only ~2.1 km/s and ran dry mid-landing). Thrust
 	// stays 45 kN (the original single-Lander descent engine).
 	StageModuleLanderDescentID: {
-		ID: StageModuleLanderDescentID, Name: "Descent", Glyph: "▼", Color: "#5FFF87",
+		ID: StageModuleLanderDescentID, Name: "Descent", Glyph: VesselGlyph, Color: "#5FFF87",
 		Tier: "payload", dry: 2500, fuel: 9500, thrust: 45000, isp: 311, bc: 0,
 		launchSpriteRowsPx:  5,
 		launchSpriteWidthPx: 3,
@@ -267,7 +267,7 @@ var StageCatalog = map[string]StageModule{
 	// stage back down soft-lands rather than crashes; see ADR 0007
 	// decision 5).
 	StageModuleLanderAscentID: {
-		ID: StageModuleLanderAscentID, Name: "Ascent", Glyph: "▲", Color: "#7BFFA0",
+		ID: StageModuleLanderAscentID, Name: "Ascent", Glyph: VesselGlyph, Color: "#7BFFA0",
 		Tier: "payload", dry: 1200, fuel: 1800, thrust: 16000, isp: 311, bc: 0,
 		launchSpriteRowsPx:  3,
 		launchSpriteWidthPx: 2,
@@ -276,7 +276,7 @@ var StageCatalog = map[string]StageModule{
 		canSoftLand:         true,
 	},
 	StageModuleCSMID: {
-		ID: StageModuleCSMID, Name: "CSM", Glyph: "◉", Color: "#C0C0FF",
+		ID: StageModuleCSMID, Name: "CSM", Glyph: VesselGlyph, Color: "#C0C0FF",
 		Tier: "payload", dry: 11900, fuel: 18400, thrust: 91000, isp: 314, bc: 0,
 		launchSpriteRowsPx:  10,
 		launchSpriteWidthPx: 2,
@@ -295,7 +295,7 @@ var StageCatalog = map[string]StageModule{
 	// silhouette (silver, slim) so the post-transposition Stages[0]=SM
 	// renders an engine bell.
 	StageModuleServiceModuleID: {
-		ID: StageModuleServiceModuleID, Name: "SM", Glyph: "◉", Color: "#C8C8D0",
+		ID: StageModuleServiceModuleID, Name: "SM", Glyph: VesselGlyph, Color: "#C8C8D0",
 		Tier: "payload", dry: 6000, fuel: 16000, thrust: 91000, isp: 314, bc: 0,
 		launchSpriteRowsPx:  6,
 		launchSpriteWidthPx: 2,
@@ -307,7 +307,7 @@ var StageCatalog = map[string]StageModule{
 	// recovery parachute (ADR 0008 model); the only piece that splashes
 	// down. Dry ~5,900 kg (CSM dry 11,900 − SM 6,000). No main engine.
 	StageModuleCommandModuleID: {
-		ID: StageModuleCommandModuleID, Name: "CM", Glyph: "◓", Color: "#B8C8E0",
+		ID: StageModuleCommandModuleID, Name: "CM", Glyph: VesselGlyph, Color: "#B8C8E0",
 		Tier: "payload", dry: 5900, fuel: 0, thrust: 0, isp: 0, bc: 0,
 		launchSpriteRowsPx:  6,
 		launchSpriteWidthPx: 3,
@@ -321,7 +321,7 @@ var StageCatalog = map[string]StageModule{
 	// Ascent] stages (the numbers here are the SM's, for any sum-less
 	// reader). Glyph is the SM/CSM marker since the SM is the firing core.
 	StageModuleApolloCSMLMID: {
-		ID: StageModuleApolloCSMLMID, Name: "CSM+LM", Glyph: "◉", Color: "#C0C0FF",
+		ID: StageModuleApolloCSMLMID, Name: "CSM+LM", Glyph: VesselGlyph, Color: "#C0C0FF",
 		Tier: "payload", dry: 6000, fuel: 16000, thrust: 91000, isp: 314, bc: 0,
 		// Sprite fields mirror the SM (the firing core). BuildModule
 		// intercepts this id and expands it to real [SM, CM, Descent,
@@ -343,7 +343,7 @@ var StageCatalog = map[string]StageModule{
 	// default; only the deployed chute's ChuteDeployedBC matters for its
 	// descent.
 	StageModuleCapsuleID: {
-		ID: StageModuleCapsuleID, Name: "Capsule", Glyph: "◓", Color: "#B8C8E0",
+		ID: StageModuleCapsuleID, Name: "Capsule", Glyph: VesselGlyph, Color: "#B8C8E0",
 		Tier: "payload", dry: 5800, fuel: 0, thrust: 0, isp: 0, bc: 0,
 		launchSpriteRowsPx:  6,
 		launchSpriteWidthPx: 3,
@@ -352,7 +352,7 @@ var StageCatalog = map[string]StageModule{
 		hasParachute: true,
 	},
 	StageModuleRCSTugID: {
-		ID: StageModuleRCSTugID, Name: "RCS Tug", Glyph: "●", Color: "#FF87D7",
+		ID: StageModuleRCSTugID, Name: "RCS Tug", Glyph: VesselGlyph, Color: "#FF87D7",
 		Tier: "tug", dry: 200, fuel: 0, thrust: 0, isp: 0, bc: 0,
 		launchSpriteRowsPx:  4,
 		launchSpriteWidthPx: 2,

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -617,11 +617,13 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, samples, 3, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
 	peri := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, 0))
 	apo := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
+	// Unified single-glyph apsis markers (ADR 0020) — same ▼/▲ as the
+	// orbit map, replacing the FillDisk blobs.
 	if !v.canvas.IsBehindBody(peri, bodyCentre, primaryPxR) {
-		v.canvas.FillDisk(peri, 2)
+		drawMarker(v.canvas, peri, render.MarkerPeriapsis, render.MarkerNominal, "", widgets.CellTag{})
 	}
 	if !v.canvas.IsBehindBody(apo, bodyCentre, primaryPxR) {
-		v.canvas.FillDisk(apo, 3)
+		drawMarker(v.canvas, apo, render.MarkerApoapsis, render.MarkerNominal, "", widgets.CellTag{})
 	}
 }
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -661,11 +661,14 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			v.canvas.DrawEllipseOffsetFarSideDashed(el, primaryPos, 360, 3, primaryPos, primaryPxR, render.ColorCurrentOrbit)
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
+			// Unified single-glyph markers (ADR 0020): ▼ periapsis / ▲
+			// apoapsis in their type colours, replacing the chunky FillDisk
+			// blobs. Occlusion behind the primary still hides them.
 			if !v.canvas.IsBehindBody(peri, primaryPos, primaryPxR) {
-				v.canvas.FillDisk(peri, 2)
+				drawMarker(v.canvas, peri, render.MarkerPeriapsis, render.MarkerNominal, "", widgets.CellTag{})
 			}
 			if !v.canvas.IsBehindBody(apo, primaryPos, primaryPxR) {
-				v.canvas.FillDisk(apo, 3)
+				drawMarker(v.canvas, apo, render.MarkerApoapsis, render.MarkerNominal, "", widgets.CellTag{})
 			}
 		}
 		craftInertial := w.CraftInertial()
@@ -1150,24 +1153,24 @@ func (v *OrbitView) plotCluster(center orbital.Vec3, n int) {
 	}
 }
 
-// plotClusterColored is plotCluster with each cell tagged with the
-// given color. v0.6.1: maneuver-node markers share the color of
-// their resulting orbit leg, so the player sees node N at the
-// position where the post-burn orbit (also color N) begins.
-func (v *OrbitView) plotClusterColored(center orbital.Vec3, n int, color lipgloss.Color) {
-	v.plotClusterTagged(center, n, widgets.CellTag{Color: color})
-}
-
-// plotClusterTagged is plotClusterColored that records the supplied
-// CellTag (color + hit-test metadata) on every pixel it sets. v0.6.4+
-// — node draws use this with NodeIdx so HitAt can resolve a click
-// back to the planted node it lands on.
-func (v *OrbitView) plotClusterTagged(center orbital.Vec3, n int, tag widgets.CellTag) {
-	step := 1.0 / v.canvas.Scale()
-	for i := -n / 2; i <= n/2; i++ {
-		v.canvas.PlotColoredTagged(center.Add(orbital.Vec3{X: float64(i) * step}), tag)
-		v.canvas.PlotColoredTagged(center.Add(orbital.Vec3{Y: float64(i) * step}), tag)
+// drawMarker stamps a single unified orbital marker (ADR 0020) at an
+// inertial point: one glyph rune whose colour encodes the marker type and
+// whose brightness encodes its state, drawn through SetCellOverlayColored
+// the same way Vessels and Bodies collapse to a glyph. When tag carries
+// hit-test metadata (a NodeIdx for maneuver nodes, a vessel/body flag), a
+// single tagged pixel is plotted under the glyph so a click on the cell
+// still resolves to the sim object — the glyph overlay then paints over
+// it, so the pixel is invisible but selectable. base supplies the
+// positional colour for MarkerManeuver and is ignored for every other
+// type. Occlusion is the caller's call: apsis markers gate on
+// IsBehindBody before calling; maneuver markers do not.
+func drawMarker(canvas *widgets.Canvas, pos orbital.Vec3, t render.MarkerType, state render.MarkerState, base lipgloss.Color, tag widgets.CellTag) {
+	color := render.MarkerColor(t, state, base)
+	if tag.NodeIdx != 0 || tag.IsVessel || tag.BodyID != "" {
+		tag.Color = color
+		canvas.PlotColoredTagged(pos, tag)
 	}
+	canvas.SetCellOverlayColored(pos, render.MarkerGlyph(t), color)
 }
 
 // drawNodes plots every planned maneuver node at its projected inertial
@@ -1215,9 +1218,8 @@ type predictRenderData struct {
 }
 
 type predictMarker struct {
-	pos  orbital.Vec3
-	size int
-	tag  widgets.CellTag
+	pos orbital.Vec3
+	tag widgets.CellTag
 }
 
 type predictLegDraw struct {
@@ -1350,23 +1352,15 @@ func (v *OrbitView) cachedPredictedRender(w *sim.World) predictRenderData {
 // loops but returns plot-ready geometry instead of plotting.
 func (v *OrbitView) computePredictedRender(w *sim.World) predictRenderData {
 	c := w.ActiveCraft()
-	homeID := c.Primary.ID
 	var data predictRenderData
 
 	for i, n := range c.Nodes {
-		// Frame-distinct cluster size: home-frame nodes get a tight cross,
-		// foreign-frame (heliocentric or destination-SOI) a larger one so
-		// the player can read which leg is which on auto-planted transfers.
-		size := 6
-		if n.PrimaryID != "" && n.PrimaryID != homeID {
-			size = 10
-		}
 		// v0.6.1: each node's marker matches the color of its resulting
-		// orbit leg, so the cluster glyph and the post-burn dashed orbit
-		// read as a matched pair.
+		// orbit leg, so the glyph and the post-burn dashed orbit read as a
+		// matched pair. ADR 0020: a single Δ glyph, drawn at plot time;
+		// the per-leg colour rides on the tag.
 		data.markers = append(data.markers, predictMarker{
-			pos:  w.NodeInertialPosition(n),
-			size: size,
+			pos: w.NodeInertialPosition(n),
 			tag: widgets.CellTag{
 				Color:   render.ManeuverSegmentColor(i),
 				NodeIdx: i + 1, // 0 = none; planted node i is 1+i in the tag.
@@ -1428,7 +1422,13 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 	data := v.cachedPredictedRender(w)
 
 	for _, m := range data.markers {
-		v.plotClusterTagged(m.pos, m.size, m.tag)
+		// Unified marker (ADR 0020): a single Δ glyph in the node's
+		// per-leg colour (the documented positional-colour exception),
+		// over a tagged pixel that carries NodeIdx so a click still
+		// resolves to the planted node. Maneuver markers are not
+		// occlusion-culled (a node behind the body still shows), so we
+		// don't gate on IsBehindBody here.
+		drawMarker(v.canvas, m.pos, render.MarkerManeuver, render.MarkerNominal, m.tag.Color, m.tag)
 	}
 	for _, leg := range data.legs {
 		// Skip legs whose orbit projects too small to convey shape

--- a/internal/tui/screens/orbit_markers_test.go
+++ b/internal/tui/screens/orbit_markers_test.go
@@ -47,6 +47,12 @@ func TestApsisMarkersRenderAsUnifiedGlyphs(t *testing.T) {
 	if !strings.ContainsRune(out, render.MarkerGlyph(render.MarkerPeriapsis)) {
 		t.Errorf("periapsis glyph %q not found in orbit render", render.MarkerGlyph(render.MarkerPeriapsis))
 	}
+	// The vessel renders as the unified VesselGlyph (ADR 0020) — never a
+	// marker shape, so it can't be confused with an apsis.
+	vesselGlyph := []rune(spacecraft.VesselGlyph)[0]
+	if !strings.ContainsRune(out, vesselGlyph) {
+		t.Errorf("vessel glyph %q not found in orbit render", spacecraft.VesselGlyph)
+	}
 }
 
 // TestManeuverMarkerRendersGlyphAndKeepsClickTag verifies that the

--- a/internal/tui/screens/orbit_markers_test.go
+++ b/internal/tui/screens/orbit_markers_test.go
@@ -1,0 +1,79 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestApsisMarkersRenderAsUnifiedGlyphs locks the ADR 0020 conversion:
+// the live orbit's apoapsis/periapsis render as the ▲/▼ glyphs (via
+// SetCellOverlayColored), not the retired FillDisk blobs.
+func TestApsisMarkersRenderAsUnifiedGlyphs(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	// A roomy eccentric orbit so both apsides project clear of the body
+	// disk and above the minOrbitPixels zoom-skip, placed at periapsis.
+	rPeri := primaryR + 400e3
+	rApo := primaryR + 4000e3
+	// Place the craft at true anomaly 90° (on the minor axis) with the
+	// line of apsides along ±X, so the vessel glyph doesn't sit on top of
+	// — and overdraw — either apsis marker cell.
+	e := (rApo - rPeri) / (rApo + rPeri)
+	p := rPeri * (1 + e) // semi-latus rectum
+	vScale := math.Sqrt(mu / p)
+	c.State.R.X, c.State.R.Y, c.State.R.Z = 0, p, 0
+	c.State.V.X, c.State.V.Y, c.State.V.Z = -vScale, vScale*e, 0
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.ContainsRune(out, render.MarkerGlyph(render.MarkerApoapsis)) {
+		t.Errorf("apoapsis glyph %q not found in orbit render", render.MarkerGlyph(render.MarkerApoapsis))
+	}
+	if !strings.ContainsRune(out, render.MarkerGlyph(render.MarkerPeriapsis)) {
+		t.Errorf("periapsis glyph %q not found in orbit render", render.MarkerGlyph(render.MarkerPeriapsis))
+	}
+}
+
+// TestManeuverMarkerRendersGlyphAndKeepsClickTag verifies that the
+// maneuver marker is a single Δ glyph (ADR 0020) while still carrying the
+// NodeIdx hit tag so a click on its cell resolves to the planted node.
+func TestManeuverMarkerRendersGlyphAndKeepsClickTag(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft from NewWorld")
+	}
+	c.Nodes = append(c.Nodes,
+		spacecraft.ManeuverNode{DV: 100, TriggerTime: w.Clock.SimTime.Add(15 * time.Minute)},
+		spacecraft.ManeuverNode{DV: 100, TriggerTime: w.Clock.SimTime.Add(45 * time.Minute)},
+	)
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.ContainsRune(out, render.MarkerGlyph(render.MarkerManeuver)) {
+		t.Errorf("maneuver glyph %q not found in orbit render", render.MarkerGlyph(render.MarkerManeuver))
+	}
+	// Click tag preserved (same assertion path HitHudNode routes through).
+	if countNodeTaggedCells(v) == 0 {
+		t.Error("maneuver markers carry no NodeIdx hit tag — node clicks would not resolve")
+	}
+}


### PR DESCRIPTION
Closes #134.

Establishes the shared orbital-marker convention from **ADR 0020**: every orbital marker is **one colored glyph** stamped via `SetCellOverlayColored` — colour encodes the marker *type*, a state modifier encodes what's *happening* to it (nominal / counterfactual-dim / alarm-red). Retires the chunky `FillDisk` apsis blobs. Also de-conflicts the vessel fleet, which shared shapes with the new markers.

## Markers
- **`internal/render/markers.go`** (new) — `MarkerType` / `MarkerState` enums + `MarkerGlyph` and `MarkerColor`. `MarkerColor` reuses the existing `render.Shade` for the counterfactual-dim state and `ColorAlert` for alarm. Palette (`palette.go`) gains the per-type marker colours.
  - The table covers all seven types now; **AN/DN, Perilune, and Closest Approach are forward-looking entries** — they aren't drawn on the canvas today (they're HUD-chip readouts), so #135 wires them. This slice converts what's drawn today: AP/PE and maneuver nodes.
- **`orbit.go` / `launch.go`** — apoapsis/periapsis render as `▲`/`▼` through a package-level `drawMarker` helper (occlusion behind the primary preserved). Maneuver nodes become a single `Δ` glyph in their per-node leg colour (the documented positional-colour exception), drawn over a tagged pixel that preserves the `NodeIdx` click-to-select tag.
- Drops the now-dead `plotClusterColored` / `plotClusterTagged` helpers and the frame-distinct node-cluster sizing.

## Vessels (folded in after review)
The marker set claimed `▲ ▼ ◆`, which were *also* the vessel role-glyphs (booster/ascent ▲, lander ▼, transfer-stage ◆) — a ship on its apoapsis became indistinguishable from the apoapsis marker. Resolved on the vessel side per maintainer call: **every craft now collapses to one `VesselGlyph` (`➤`)**, with **colour carrying identity** instead of shape. Swept both catalogs (`Loadouts` + `StageCatalog`) and the `NewFromStages` fallback to the shared constant, so the map, spawn menu, jettisoned-stage and docking-composite craft all render `➤`. A guard test asserts no catalog glyph ever collides with a reserved marker glyph. (Pre-existing save files keep their persisted glyph until re-spawned; not migrated.)

## Behaviour notes
- Maneuver node **click-target narrows** from a multi-cell cross to the glyph's single cell — intended consequence of the single-glyph convention; clicks still resolve via the preserved `NodeIdx` tag, and nodes remain editable from the HUD chip + keyboard.
- Vessels lose role-by-shape (booster vs lander vs capsule); they're now told apart by colour only.

## Tests
- `render/markers_test.go` — type→glyph/colour + state→brightness modifier (incl. maneuver base-colour exception and alarm override).
- `orbit_markers_test.go` — draw-path: AP/PE `▲`/`▼` and the vessel `➤` appear in the render; maneuver `Δ` renders and keeps its `NodeIdx` hit tag.
- `loadouts_glyph_test.go` — every catalog glyph == `VesselGlyph` and collides with no reserved marker glyph.
- `go vet ./...` + `go test ./... -race -count=1` green (1090 tests). Self-reviewed at `/code-review high`.

Part of the encounter-view series: **#134 → #135 → {#136, #137}**.