### PR TITLE
Live SOI Pass forward prediction + Perilune readout (ADR 0019) — #135

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -34,6 +34,7 @@ const (
 	ChipFrameTransition Chip = "frameTransition"
 	ChipAttitude        Chip = "attitude"
 	ChipProjectedOrbit  Chip = "projectedOrbit"
+	ChipSOIPass         Chip = "soiPass"
 )
 
 // Note: the Orbit-metrics readout and the active-burn (BURNS) readout are
@@ -59,6 +60,7 @@ var AllChips = []Chip{
 	ChipFrameTransition,
 	ChipAttitude,
 	ChipProjectedOrbit,
+	ChipSOIPass,
 }
 
 // chipLabels maps each Chip to the human-readable name the Settings
@@ -75,6 +77,7 @@ var chipLabels = map[Chip]string{
 	ChipFrameTransition: "Frame transition",
 	ChipAttitude:        "Attitude",
 	ChipProjectedOrbit:  "Projected orbit",
+	ChipSOIPass:         "SOI pass",
 }
 
 // Label returns the display name for c, falling back to the raw key for

--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -1,0 +1,150 @@
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// SOIPass is the predicted transit of the live, *unburned* trajectory
+// through a sibling Body's sphere of influence (ADR 0019). It is computed
+// always-on from the active craft's live state and is independent of the
+// Target slot — KSP shows the encounter whether or not the body is
+// targeted, and so do we.
+type SOIPass struct {
+	Body           bodies.CelestialBody // body whose SOI the live path crosses
+	PeriluneRadius float64              // distance to Body centre at closest approach (m)
+	TimeToPerilune float64              // seconds from now to perilune
+	Impact         bool                 // perilune radius is below the Body surface
+	PerilunePoint  orbital.Vec3         // inertial, system-frame — marker position
+	HasPerilunePt  bool                 // false when the arc couldn't place the marker point
+	ArcSegments    []SOISegment         // foreign-SOI arc (PrimaryID == Body.ID), system-frame
+}
+
+// PeriluneAltitude is the perilune radius above the Body's surface; negative
+// means the trajectory impacts.
+func (p SOIPass) PeriluneAltitude() float64 {
+	return p.PeriluneRadius - p.Body.RadiusMeters()
+}
+
+// soiPassHyperbolicHorizon caps the forward-prediction window for an escape
+// / hyperbolic live orbit at one sim-day — an unbound path never loops, so
+// there is no period to bound it (ADR 0019 B).
+const soiPassHyperbolicHorizon = 24 * 3600.0
+
+// LiveSOIPass computes the active craft's upcoming SOI pass from its live
+// state, with no maneuver node required (ADR 0019 decisions A/B/C/E).
+//
+// A cheap apoapsis-reach guard runs first: a bound orbit reaches at most
+// its apoapsis, so if that can't even reach within a sibling body's SOI of
+// the body's closest approach to the primary, no encounter is possible —
+// the call returns ok=false without forward-integrating, and a stable LEO
+// pays nothing. When the guard passes, the live trajectory is scanned per
+// reachable sibling (reusing scanTargetEncounter / the moon-frame
+// targetPerilune so the readout agrees with the TARGET chip), the earliest
+// SOI-entering pass wins, and its foreign-SOI arc is sampled via
+// PredictedSegmentsFrom for drawing.
+func (w *World) LiveSOIPass() (SOIPass, bool) {
+	c := w.ActiveCraft()
+	if c == nil || c.Landed {
+		return SOIPass{}, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	if math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return SOIPass{}, false
+	}
+
+	// A bound orbit (a>0) reaches at most its apoapsis; an unbound orbit
+	// reaches arbitrarily far, so it skips the geometric prune entirely.
+	bound := el.A > 0
+	craftReach := math.Inf(1)
+	if bound {
+		craftReach = el.Apoapsis()
+	}
+
+	// Forward-prediction horizon: ~one orbital period for a bound orbit
+	// (the encounter sits within the next revolution, ADR 0019 B); a
+	// sim-day wall for an escape/hyperbolic leg.
+	period := orbitalPeriod(c.State, mu)
+	horizon := soiPassHyperbolicHorizon
+	if bound && period > 0 && !math.IsNaN(period) && !math.IsInf(period, 0) {
+		horizon = period
+	}
+
+	sys := w.System()
+	now := w.Clock.SimTime
+
+	// Scan every sibling body the orbit can geometrically reach; keep the
+	// earliest SOI-entering pass.
+	var best SOIPass
+	bestTCA := math.Inf(1)
+	found := false
+	for _, b := range sys.Bodies {
+		if b.ParentID != c.Primary.ID {
+			continue // only siblings of the craft's primary have a sibling SOI
+		}
+		// Apoapsis-reach prune: the craft's farthest radius must reach
+		// within the body's SOI of the body's closest approach to the
+		// primary. Cheap geometry, no integration.
+		bEl := orbital.ElementsFromBody(b)
+		bodyPeri := bEl.A * (1 - bEl.E) // body's closest distance to the primary
+		soi := physics.SOIRadius(b, c.Primary)
+		if craftReach < bodyPeri-soi {
+			continue
+		}
+		enc, ok := w.scanTargetEncounter(c.State, c.Primary, b, now, horizon)
+		if !ok || !enc.EntersSOI {
+			continue
+		}
+		if enc.TCA < bestTCA {
+			bestTCA = enc.TCA
+			best = SOIPass{
+				Body:           b,
+				PeriluneRadius: enc.Dist,
+				TimeToPerilune: enc.TCA,
+				Impact:         enc.Dist < b.RadiusMeters(),
+			}
+			found = true
+		}
+	}
+	if !found {
+		return SOIPass{}, false
+	}
+
+	// Sample the live trajectory for the foreign-SOI arc + a perilune point
+	// to mark. Bound the sampling to just past perilune so the draw doesn't
+	// trail an unbounded escape tail (ADR 0019 B: time-capped).
+	arcHorizon := best.TimeToPerilune * 1.05
+	if arcHorizon <= 0 || arcHorizon > horizon {
+		arcHorizon = horizon
+	}
+	samples := adaptiveSampleCount(arcHorizon, period)
+	segs := w.PredictedSegmentsFrom(c.State, c.Primary, now, arcHorizon, samples)
+	for _, s := range segs {
+		if s.PrimaryID == best.Body.ID {
+			best.ArcSegments = append(best.ArcSegments, s)
+		}
+	}
+
+	// Perilune marker point: the foreign-arc sample closest to the body
+	// centre at the predicted time of closest approach. The glyph marks
+	// "which marker, what state" — the value lives in the chip (ADR 0020 C)
+	// — so the nearest-sample approximation is sufficient for placement.
+	moonAtTCA := w.BodyPositionAt(best.Body, now.Add(time.Duration(best.TimeToPerilune*float64(time.Second))))
+	minD := math.Inf(1)
+	for _, s := range best.ArcSegments {
+		for _, p := range s.Points {
+			if d := p.Sub(moonAtTCA).Norm(); d < minD {
+				minD = d
+				best.PerilunePoint = p
+				best.HasPerilunePt = true
+			}
+		}
+	}
+
+	return best, true
+}

--- a/internal/sim/soipass_test.go
+++ b/internal/sim/soipass_test.go
@@ -1,0 +1,102 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestLiveSOIPassGuardSkipsUnreachableOrbit: a stable LEO whose apoapsis
+// can't reach any sibling SOI must report no pass — the apoapsis-reach
+// guard (ADR 0019 C) short-circuits before any forward integration.
+func TestLiveSOIPassGuardSkipsUnreachableOrbit(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.Landed = false
+	c.Nodes = nil
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3 // 300 km circular — nowhere near the Moon
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	if pass, ok := w.LiveSOIPass(); ok {
+		t.Errorf("LEO that can't reach any sibling SOI must report no pass; got body %s", pass.Body.ID)
+	}
+}
+
+// TestLiveSOIPassDetectsMoonPass: coasting on an LEO→Moon transfer with no
+// maneuver node, LiveSOIPass surfaces the Moon pass — body, a positive
+// time-to-perilune, and a foreign-SOI arc to draw.
+func TestLiveSOIPassDetectsMoonPass(t *testing.T) {
+	w := mustWorld(t)
+	leg := coplanarLEOTowardMoon(t, w)
+	c := w.ActiveCraft()
+	// Simulate the post-departure coast: live state on the transfer, no node.
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("expected a live SOI pass toward the Moon, got none")
+	}
+	if pass.Body.ID != "moon" {
+		t.Errorf("pass body = %q, want \"moon\"", pass.Body.ID)
+	}
+	if pass.TimeToPerilune <= 0 {
+		t.Errorf("TimeToPerilune = %.1f s, want > 0", pass.TimeToPerilune)
+	}
+	if pass.PeriluneRadius <= 0 {
+		t.Errorf("PeriluneRadius = %.1f, want > 0", pass.PeriluneRadius)
+	}
+	if len(pass.ArcSegments) == 0 {
+		t.Error("expected foreign-SOI arc segments for drawing")
+	}
+	if !pass.HasPerilunePt {
+		t.Error("expected a placed Perilune marker point for the canvas glyph")
+	}
+	// Impact is exactly "perilune below the surface", and PeriluneAltitude
+	// is the radius above it — the relationship the chip + Impact marker
+	// branch on (ADR 0019 E).
+	wantImpact := pass.PeriluneRadius < pass.Body.RadiusMeters()
+	if pass.Impact != wantImpact {
+		t.Errorf("Impact = %v, want %v (perilune %.0f km vs body radius %.0f km)",
+			pass.Impact, wantImpact, pass.PeriluneRadius/1000, pass.Body.RadiusMeters()/1000)
+	}
+	if alt := pass.PeriluneAltitude(); alt != pass.PeriluneRadius-pass.Body.RadiusMeters() {
+		t.Errorf("PeriluneAltitude() = %.0f, want radius-surface", alt)
+	}
+	// The pass is independent of the Target slot — it surfaced with no
+	// target set.
+	if w.Target.Kind != TargetNone {
+		t.Fatalf("test precondition: expected no target set, got kind %v", w.Target.Kind)
+	}
+}
+
+// TestLiveSOIPassIndependentOfTarget: setting (or not) the Target slot must
+// not change whether the Moon pass is detected — SOI Pass is orthogonal to
+// Target (ADR 0019 A).
+func TestLiveSOIPassIndependentOfTarget(t *testing.T) {
+	w := mustWorld(t)
+	leg := coplanarLEOTowardMoon(t, w)
+	c := w.ActiveCraft()
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("expected a Moon pass with no target")
+	}
+
+	// Now clear any target explicitly and re-check — same result.
+	w.Target = Target{Kind: TargetNone}
+	pass2, ok2 := w.LiveSOIPass()
+	if !ok2 || pass2.Body.ID != pass.Body.ID {
+		t.Errorf("SOI pass changed with target cleared: ok=%v body=%q (want ok=true body=%q)",
+			ok2, pass2.Body.ID, pass.Body.ID)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -127,6 +127,16 @@ type OrbitView struct {
 	// test hook). ADR 0017 decision C.
 	predictCache         predictRenderCache
 	predictCacheComputes int
+
+	// soiPassCache memoizes the live SOI Pass (ADR 0019) the same way
+	// predictCache memoizes the node legs: the forward prediction is a
+	// pure function of the live craft + clock bucket (node-independent —
+	// the Pass is the *unburned* path), so a coast computes it once per
+	// quantized-element/clock-bucket change instead of every frame. The
+	// apoapsis-reach guard inside LiveSOIPass keeps a stable LEO's miss
+	// path cheap; this keeps a real pass off the per-frame hot path.
+	soiPassCache         soiPassRenderCache
+	soiPassCacheComputes int
 }
 
 // navballSubObserverDeadbandDeg is the great-circle angle the nose
@@ -809,6 +819,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// post-burn state. Only meaningful when the craft is visible here.
 	if w.CraftVisibleHere() {
 		v.drawNodes(w)
+		// Live SOI Pass (ADR 0019): the upcoming foreign-SOI encounter of
+		// the *unburned* trajectory, drawn ahead of arrival with a Perilune
+		// marker — always-on, independent of the Target slot.
+		v.drawSOIPass(w)
 	}
 
 	// Stamp the active projection in the canvas's bottom-left corner
@@ -1187,6 +1201,67 @@ type predictRenderCache struct {
 	data predictRenderData
 }
 
+// soiPassRenderCache memoizes the last LiveSOIPass result (ADR 0019) under
+// the predict-on-change discipline. ok records whether a pass exists so a
+// cached "no pass" (the common coast) doesn't re-run the guard each frame.
+type soiPassRenderCache struct {
+	has  bool
+	key  soiPassKey
+	pass sim.SOIPass
+	ok   bool
+}
+
+// soiPassKey fingerprints what the live SOI Pass depends on: the active
+// craft, its primary, the clock (bucketed), and the live orbital elements
+// (quantized). Deliberately omits the node fingerprint — the Pass is the
+// *unburned* path, independent of planted nodes (ADR 0019 A), so a node
+// edit must not bust it.
+type soiPassKey struct {
+	craftID     uint64
+	primaryID   string
+	clockBucket int64
+	aQ          int64
+	eQ          int64
+	iQ          int64
+	omegaQ      int64
+	argQ        int64
+}
+
+// cachedSOIPass returns the live SOI Pass for the active craft, recomputing
+// (the forward predictor + apoapsis-reach guard) only when the key changes.
+func (v *OrbitView) cachedSOIPass(w *sim.World) (sim.SOIPass, bool) {
+	if w.ActiveCraft() == nil {
+		return sim.SOIPass{}, false
+	}
+	key := v.soiPassKeyAt(w, w.Clock.SimTime)
+	if v.soiPassCache.has && v.soiPassCache.key == key {
+		return v.soiPassCache.pass, v.soiPassCache.ok
+	}
+	pass, ok := w.LiveSOIPass()
+	v.soiPassCache = soiPassRenderCache{has: true, key: key, pass: pass, ok: ok}
+	v.soiPassCacheComputes++
+	return pass, ok
+}
+
+// soiPassKeyAt builds the SOI-pass cache key for the active craft at clock
+// t. Mirrors predictRenderKeyAt minus the node fingerprint.
+func (v *OrbitView) soiPassKeyAt(w *sim.World, t time.Time) soiPassKey {
+	c := w.ActiveCraft()
+	key := soiPassKey{
+		craftID:     c.ID,
+		primaryID:   c.Primary.ID,
+		clockBucket: t.UnixNano() / v.predictClockBucketNanos(w),
+	}
+	if el, ok := activeCraftElements(w); ok {
+		key.aQ = quantize(el.A, 1000)
+		key.eQ = quantize(el.E, 1e-4)
+		key.iQ = quantize(el.I, 1e-4)
+		key.omegaQ = quantize(el.Omega, 1e-4)
+		key.argQ = quantize(el.Arg, 1e-4)
+	}
+	return key
+}
+
 // predictRenderKey is the cheap fingerprint of everything the predicted
 // node markers + dashed legs depend on for a coasting craft: which craft,
 // its primary, the planted nodes, the clock (bucketed), and the live
@@ -1451,6 +1526,34 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 				v.canvas.PlotColored(p, leg.color)
 			}
 		}
+	}
+}
+
+// drawSOIPass renders the live trajectory's upcoming SOI Pass (ADR 0019):
+// the foreign-SOI arc as a single bright solid leg, plus a Perilune ⊕
+// marker at closest approach — or an Impact glyph (red+bright, the marker
+// system's alarm state) when perilune dips below the surface. Always-on and
+// independent of the Target slot; the apoapsis-reach guard inside the
+// cached predictor keeps a stable orbit that reaches no SOI free.
+func (v *OrbitView) drawSOIPass(w *sim.World) {
+	pass, ok := v.cachedSOIPass(w)
+	if !ok {
+		return
+	}
+	// The foreign-SOI arc draws solid (every sample) and bright — the
+	// encounter is the thing the player is looking for, so unlike the
+	// dashed home-SOI ellipse it doesn't stipple.
+	for _, seg := range pass.ArcSegments {
+		for _, p := range seg.Points {
+			v.canvas.PlotColored(p, render.ColorForeignSOI)
+		}
+	}
+	if pass.HasPerilunePt {
+		state := render.MarkerNominal
+		if pass.Impact {
+			state = render.MarkerAlarm // sub-surface perilune → Impact
+		}
+		drawMarker(v.canvas, pass.PerilunePoint, render.MarkerPerilune, state, "", widgets.CellTag{})
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -73,6 +73,10 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 		chips = append(chips, builtChip{id: settings.ChipProjectedOrbit, corner: cornerTopRight, lines: lines, leftOfPrev: true})
 	}
 	add(settings.ChipTarget, cornerTopRight, v.buildTargetChip(w))
+	// SOI PASS sits beneath TARGET — the upcoming encounter of the live
+	// path, always-on and Target-independent (ADR 0019). De-dupes with
+	// TARGET inside the builder when they name the same body.
+	add(settings.ChipSOIPass, cornerTopRight, v.buildSOIPassChip(w))
 	// Remaining fixed corners.
 	add(settings.ChipStages, cornerBottomLeft, v.buildStagesChip(w))
 	// NODES (bottom-right) now also carries any in-flight burn as its
@@ -726,6 +730,44 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		return lines
 	}
 	return nil
+}
+
+// buildSOIPassChip surfaces the always-on SOI Pass readout (ADR 0019): the
+// upcoming foreign-SOI encounter of the live, *unburned* trajectory — body,
+// Perilune altitude (or IMPACT), and Time to Perilune — independent of the
+// Target slot. Returns nil when there is no pass, or when the Pass Body is
+// also the current body Target: the TARGET chip already shows the same
+// perilune/TCA, so the two readouts de-dupe into one (ADR 0019 E).
+func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
+	c := w.ActiveCraft()
+	if c == nil || !w.CraftVisibleHere() {
+		return nil
+	}
+	pass, ok := v.cachedSOIPass(w)
+	if !ok {
+		return nil
+	}
+	// De-dupe with TARGET: if the player has targeted the very body the
+	// pass crosses, the TARGET chip's peri/TCA rows already cover it.
+	if w.Target.Kind == sim.TargetBody {
+		sysT := w.System()
+		if w.Target.BodyIdx > 0 && w.Target.BodyIdx < len(sysT.Bodies) &&
+			sysT.Bodies[w.Target.BodyIdx].ID == pass.Body.ID {
+			return nil
+		}
+	}
+	nameStyle := lipgloss.NewStyle().Foreground(render.ColorFor(pass.Body)).Bold(true)
+	lines := []string{
+		v.theme.Primary.Render("SOI PASS"),
+		chipRow("body:", nameStyle.Render(pass.Body.EnglishName)),
+	}
+	if pass.Impact {
+		lines = append(lines, chipRow("peri:", v.theme.Warning.Render("IMPACT")))
+	} else {
+		lines = append(lines, chipRow("peri:", fmt.Sprintf("%.0f km", pass.PeriluneAltitude()/1000)))
+	}
+	lines = append(lines, chipRow("TCA:", formatTCA(pass.TimeToPerilune)))
+	return lines
 }
 
 // chipValueCol is the display column a chip row's value begins at, shared

--- a/internal/tui/screens/orbit_soipass_test.go
+++ b/internal/tui/screens/orbit_soipass_test.go
@@ -1,0 +1,167 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// setupMoonCoast aligns the active craft coplanar with the Moon, plants a
+// transfer to it, then drops the craft onto the post-departure coast (live
+// state, no maneuver node) — the no-node case the SOI Pass must render. It
+// returns the Moon's body index. Mirrors the sim package's
+// coplanarLEOTowardMoon, replicated here because that helper isn't visible
+// across packages.
+func setupMoonCoast(t *testing.T, w *sim.World) int {
+	t.Helper()
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon not in loaded Sol system")
+	}
+	moon := sys.Bodies[moonIdx]
+	mel := orbital.ElementsFromBody(moon)
+	sI, cI := math.Sin(mel.I), math.Cos(mel.I)
+	sO, cO := math.Sin(mel.Omega), math.Cos(mel.Omega)
+	moonN := orbital.Vec3{X: sO * sI, Y: -cO * sI, Z: cI}.Unit()
+	ref := orbital.Vec3{X: 1}
+	if math.Abs(moonN.Dot(ref)) > 0.9 {
+		ref = orbital.Vec3{Y: 1}
+	}
+	e1 := ref.Sub(moonN.Scale(moonN.Dot(ref))).Unit()
+	e2 := moonN.Cross(e1)
+
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	v := math.Sqrt(mu / r)
+	c.State.R = e1.Scale(r)
+	c.State.V = e2.Scale(v)
+
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs after PlanTransfer")
+	}
+	leg := legs[0]
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+	return moonIdx
+}
+
+func newSOIPassTestView() *OrbitView {
+	v := NewOrbitView(Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle(),
+	})
+	v.Resize(200, 60)
+	return v
+}
+
+// TestSOIPassChipAppearsCoastingToMoon: coasting on an LEO→Moon transfer
+// with no node, the SOI PASS chip renders — the encounter surfaces ahead of
+// SOI entry (ADR 0019, #135). (The Perilune marker glyph isn't asserted on
+// the rendered string: the navball's prograde marker is also ⊕, so a string
+// match can't isolate the canvas marker — the perilune point is covered at
+// the sim level by TestLiveSOIPassDetectsMoonPass, and the glyph draw by the
+// #134 marker tests.)
+func TestSOIPassChipAppearsCoastingToMoon(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupMoonCoast(t, w)
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "SOI PASS") {
+		t.Errorf("expected the SOI PASS chip while coasting toward the Moon")
+	}
+}
+
+// TestSOIPassCachedOnCoast: rendering a coasting craft repeatedly at the
+// same clock recomputes the SOI Pass only once — the predict-on-change
+// cache holds (ADR 0019 / ADR 0017 C), so the forward predictor stays off
+// the per-frame hot path even though both the canvas draw and the chip
+// consult it each frame.
+func TestSOIPassCachedOnCoast(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupMoonCoast(t, w)
+
+	for i := 0; i < 5; i++ {
+		v.Render(w, 0, 200, 60)
+	}
+	if v.soiPassCacheComputes != 1 {
+		t.Errorf("soiPassCacheComputes = %d after 5 coast renders, want 1 (predict-on-change cache)", v.soiPassCacheComputes)
+	}
+}
+
+// TestSOIPassChipDeDupesWithTarget: when the Pass Body is also the current
+// body Target, the SOI PASS chip suppresses (the TARGET chip already shows
+// perilune/TCA) — basic de-dupe per ADR 0019 E.
+func TestSOIPassChipDeDupesWithTarget(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := setupMoonCoast(t, w)
+
+	// Sanity: with no target, the SOI PASS chip is present.
+	if out := v.Render(w, 0, 200, 60); !strings.Contains(out, "SOI PASS") {
+		t.Fatalf("precondition: SOI PASS chip absent before targeting")
+	}
+
+	// Target the Moon — the chips should collapse to just TARGET.
+	w.Target = sim.Target{Kind: sim.TargetBody, BodyIdx: moonIdx}
+	out := v.Render(w, 0, 200, 60)
+	if strings.Contains(out, "SOI PASS") {
+		t.Errorf("SOI PASS chip should de-dupe away when the Moon is the Target")
+	}
+	if !strings.Contains(out, "TARGET") {
+		t.Errorf("TARGET chip should remain when the Moon is targeted")
+	}
+}
+
+// TestSOIPassAbsentForStableLEO: a stable LEO that reaches no sibling SOI
+// shows no SOI PASS chip and no Perilune marker (apoapsis-reach guard).
+func TestSOIPassAbsentForStableLEO(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	c.Nodes = nil
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	out := v.Render(w, 0, 200, 60)
+	if strings.Contains(out, "SOI PASS") {
+		t.Errorf("stable LEO must not show a SOI PASS chip")
+	}
+}


### PR DESCRIPTION
Closes #135. Stacks on #134 (merged).

Renders the upcoming SOI encounter **ahead of arrival**, driven from the live craft state with **no maneuver node required**. Previously an encounter only appeared once the craft physically crossed into the moon's SOI and the integrator switched Primary; now the foreign-SOI arc + Perilune marker paint the moment the trajectory intersects the SOI — the KSP behaviour the playtest asked for. Implements ADR 0019 decisions **A/B/C/E** (the no-node case); dual-arc (D, #136) and `v`-cycle framing (F, #137) build on this.

## What changed
- **`internal/sim/soipass.go`** — `World.LiveSOIPass()`: always-on, **independent of the Target slot** (A). A cheap **apoapsis-reach guard** (C) runs first — a stable LEO that can't reach any sibling SOI does **zero forward integration**. When reachable, the live trajectory is scanned per sibling body (reusing `scanTargetEncounter` / the moon-frame `targetPerilune`, so the numbers agree with the TARGET chip) and the earliest SOI-entering pass wins; its foreign-SOI arc is sampled via `PredictedSegmentsFrom`, bounded just past perilune (B).
- **`orbit.go`** — a parallel **predict-on-change cache** with a node-independent key (the Pass is the *unburned* path), plus `drawSOIPass`: the foreign arc as a bright solid leg + a **Perilune `⊕`** marker (the #134 unified glyph), or an **Impact** marker (alarm/red) when perilune dips below the surface (E).
- **SOI PASS chip** (`orbit_chip_builders.go` + `settings.ChipSOIPass`) — body, Perilune altitude (or `IMPACT`), Time to Perilune. **De-dupes with TARGET** when Pass Body == Target body (E); the canvas marker still draws.

## Acceptance criteria
- [x] Coasting toward a moon with no node → foreign-SOI arc + Perilune marker appear before SOI entry.
- [x] SOI PASS chip shows Perilune altitude + Time to Perilune, live.
- [x] Sub-surface Perilune → Impact marker + chip reads `IMPACT` (`pass.Impact` → `MarkerAlarm` / `IMPACT`).
- [x] Stable orbit reaching no SOI → no forward integration (apoapsis-reach guard), ellipse only.
- [x] Independent of the Target slot; de-dupes when Pass Body == Target.
- [x] Reuses the predict-on-change cache (1 compute across 5 coast renders).

## Tests
- `sim/soipass_test.go` — predictor detects the Moon pass on a node-free coast, apoapsis-reach guard skips a LEO, Target-independence, Impact/altitude consistency.
- `tui/screens/orbit_soipass_test.go` — SOI PASS chip appears on a coast / absent for a stable LEO / de-dupes when Moon is targeted, and the predict-on-change cache holds.
- `go vet ./...` + `go test ./... -race -count=1` green (1097). Self-reviewed at `/code-review high`.

**Note:** the Perilune `⊕` and the navball's prograde `⊕` share a glyph, but live in different panels (orbital map vs navball widget) — no on-canvas collision, and ADR 0020 chose `⊕` for Perilune deliberately.

Part of the encounter-view series: #134 → **#135** → {#136, #137}.