### PR TITLE
Draw the full SOI-pass transit (entry→perilune→exit)

### DIFF
--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -115,15 +115,16 @@ func (w *World) LiveSOIPass() (SOIPass, bool) {
 		return SOIPass{}, false
 	}
 
-	// Sample the live trajectory for the foreign-SOI arc + a perilune point
-	// to mark. Bound the sampling to just past perilune so the draw doesn't
-	// trail an unbounded escape tail (ADR 0019 B: time-capped).
-	arcHorizon := best.TimeToPerilune * 1.05
-	if arcHorizon <= 0 || arcHorizon > horizon {
-		arcHorizon = horizon
-	}
-	samples := adaptiveSampleCount(arcHorizon, period)
-	segs := w.PredictedSegmentsFrom(c.State, c.Primary, now, arcHorizon, samples)
+	// Sample the live trajectory over the full bounded horizon and keep only
+	// the body's own segments — these span the *whole* transit (entry →
+	// perilune → exit), because PredictedSegmentsFrom rebases back out of
+	// the SOI on exit, so any post-exit (escape / re-captured) samples land
+	// in a different segment we drop here. Drawing the complete flyby (not
+	// just the approach to perilune) reads as the single bright leg ADR
+	// 0019 E calls for, while the period/sim-day horizon keeps it bounded
+	// (ADR 0019 B: time-capped, ≤3 patches).
+	samples := adaptiveSampleCount(horizon, period)
+	segs := w.PredictedSegmentsFrom(c.State, c.Primary, now, horizon, samples)
 	for _, s := range segs {
 		if s.PrimaryID == best.Body.ID {
 			best.ArcSegments = append(best.ArcSegments, s)

--- a/internal/sim/soipass_test.go
+++ b/internal/sim/soipass_test.go
@@ -3,6 +3,7 @@ package sim
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
@@ -68,6 +69,29 @@ func TestLiveSOIPassDetectsMoonPass(t *testing.T) {
 	if alt := pass.PeriluneAltitude(); alt != pass.PeriluneRadius-pass.Body.RadiusMeters() {
 		t.Errorf("PeriluneAltitude() = %.0f, want radius-surface", alt)
 	}
+
+	// The drawn arc is the *full* transit (entry → perilune → exit), not
+	// truncated at perilune: the closest-approach sample sits mid-arc with
+	// exit samples after it that climb back away from the body.
+	moonAtTCA := w.BodyPositionAt(pass.Body, w.Clock.SimTime.Add(time.Duration(pass.TimeToPerilune*float64(time.Second))))
+	var pts []orbital.Vec3
+	for _, s := range pass.ArcSegments {
+		pts = append(pts, s.Points...)
+	}
+	periIdx, periD := 0, math.Inf(1)
+	for i, p := range pts {
+		if d := p.Sub(moonAtTCA).Norm(); d < periD {
+			periD = d
+			periIdx = i
+		}
+	}
+	if periIdx >= len(pts)-1 {
+		t.Errorf("perilune is the last arc sample (idx %d of %d) — arc truncated at perilune, exit leg not drawn", periIdx, len(pts))
+	}
+	if pts[len(pts)-1].Sub(moonAtTCA).Norm() <= periD {
+		t.Error("arc does not climb away from the body after perilune — exit leg of the transit is missing")
+	}
+
 	// The pass is independent of the Target slot — it surfaced with no
 	// target set.
 	if w.Target.Kind != TargetNone {


### PR DESCRIPTION
Follow-up to #135 (merged). Per review: the live SOI Pass arc bounded its sampling to just past perilune, so the bright foreign-SOI leg entered the SOI, curved to the Perilune marker, and **stopped** — reading as a truncated half-flyby.

This samples over the full bounded horizon and keeps the body's own segments. `PredictedSegmentsFrom` rebases back out of the SOI on exit, so the foreign segment naturally spans the **whole transit (entry → perilune → exit)**, while any post-exit (escape / re-capture) samples land in a segment that's dropped. The period / sim-day horizon still bounds it (ADR 0019 B: ≤3 patches, time-capped) — this is the "single bright leg" ADR 0019 E calls for.

Foundation for #136 (dual-arc draws two of these through one SOI) and consistent with #137 framing.

## Test
- `TestLiveSOIPassDetectsMoonPass` now asserts the closest-approach sample sits **mid-arc** with exit samples after it that climb away from the body (was the last sample when truncated).
- `go vet ./...` + `go test ./... -race -count=1` green (1097).