### PR TITLE
Dual-arc no-burn counterfactual for SOI Pass (ADR 0019 D) — #136

### DIFF
--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // SOIPass is the predicted transit of the live, *unburned* trajectory
@@ -36,24 +37,99 @@ func (p SOIPass) PeriluneAltitude() float64 {
 const soiPassHyperbolicHorizon = 24 * 3600.0
 
 // LiveSOIPass computes the active craft's upcoming SOI pass from its live
-// state, with no maneuver node required (ADR 0019 decisions A/B/C/E).
-//
-// A cheap apoapsis-reach guard runs first: a bound orbit reaches at most
-// its apoapsis, so if that can't even reach within a sibling body's SOI of
-// the body's closest approach to the primary, no encounter is possible —
-// the call returns ok=false without forward-integrating, and a stable LEO
-// pays nothing. When the guard passes, the live trajectory is scanned per
-// reachable sibling (reusing scanTargetEncounter / the moon-frame
-// targetPerilune so the readout agrees with the TARGET chip), the earliest
-// SOI-entering pass wins, and its foreign-SOI arc is sampled via
-// PredictedSegmentsFrom for drawing.
+// state, with no maneuver node required (ADR 0019 decisions A/B/C/E). This
+// is the always-on, Target-independent pass the canvas draws bright and the
+// SOI PASS chip reads when nothing is planted.
 func (w *World) LiveSOIPass() (SOIPass, bool) {
 	c := w.ActiveCraft()
 	if c == nil || c.Landed {
 		return SOIPass{}, false
 	}
-	mu := c.Primary.GravitationalParameter()
-	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	return w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, math.Inf(1))
+}
+
+// CounterfactualSOIPass is the dual-arc "no-burn" pass (ADR 0019 D): the
+// live trajectory's upcoming pass, but capped at the first planted node so
+// the counterfactual is never predicted — or drawn — past the burn the
+// craft will actually make. With no node planted it is identical to
+// LiveSOIPass. ok=false when the first node is already due (cap ≤ 0).
+func (w *World) CounterfactualSOIPass() (SOIPass, bool) {
+	c := w.ActiveCraft()
+	if c == nil || c.Landed {
+		return SOIPass{}, false
+	}
+	maxHorizon := math.Inf(1)
+	if t, ok := firstNodeTime(c.Nodes); ok {
+		maxHorizon = t.Sub(w.Clock.SimTime).Seconds()
+		if maxHorizon <= 0 {
+			return SOIPass{}, false
+		}
+	}
+	return w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, maxHorizon)
+}
+
+// PlannedSOIPass is the dual-arc "planned" pass (ADR 0019 D, bright path):
+// the SOI pass of the node-modified trajectory, scanned from the post-burn
+// legs so the player sees the safe periapsis their burns produce against
+// the no-burn Impact. Returns false with no node planted, or when the
+// planned path reaches no SOI. TimeToPerilune is rebased to now — the legs
+// begin when their node fires, in the future.
+func (w *World) PlannedSOIPass() (SOIPass, bool) {
+	c := w.ActiveCraft()
+	if c == nil || len(c.Nodes) == 0 {
+		return SOIPass{}, false
+	}
+	now := w.Clock.SimTime
+	var best SOIPass
+	bestTCA := math.Inf(1)
+	found := false
+	for _, leg := range w.PredictedLegs() {
+		pass, ok := w.soiPassFromState(leg.State, leg.Primary, leg.StartClock, math.Inf(1))
+		if !ok {
+			continue
+		}
+		pass.TimeToPerilune += leg.StartClock.Sub(now).Seconds()
+		if pass.TimeToPerilune < bestTCA {
+			bestTCA = pass.TimeToPerilune
+			best = pass
+			found = true
+		}
+	}
+	return best, found
+}
+
+// firstNodeTime returns the earliest planted-node trigger time.
+func firstNodeTime(nodes []spacecraft.ManeuverNode) (time.Time, bool) {
+	if len(nodes) == 0 {
+		return time.Time{}, false
+	}
+	first := nodes[0].TriggerTime
+	for _, n := range nodes[1:] {
+		if n.TriggerTime.Before(first) {
+			first = n.TriggerTime
+		}
+	}
+	return first, true
+}
+
+// soiPassFromState is the shared core behind LiveSOIPass /
+// CounterfactualSOIPass / PlannedSOIPass: the upcoming SOI pass of a
+// trajectory starting at `state` in `primary`'s frame at `fromClock`,
+// scanned and sampled out to at most maxHorizon seconds.
+//
+// A cheap apoapsis-reach guard runs first: a bound orbit reaches at most its
+// apoapsis, so if that can't even reach within a sibling body's SOI of the
+// body's closest approach to the primary, no encounter is possible — it
+// returns ok=false without forward-integrating, and a stable LEO pays
+// nothing. The period/sim-day window is the natural horizon; maxHorizon
+// tightens it for the node-capped counterfactual. When the guard passes,
+// the trajectory is scanned per reachable sibling (reusing
+// scanTargetEncounter / the moon-frame targetPerilune so the readout agrees
+// with the TARGET chip), the earliest SOI-entering pass wins, and its
+// foreign-SOI arc is sampled via PredictedSegmentsFrom for drawing.
+func (w *World) soiPassFromState(state physics.StateVector, primary bodies.CelestialBody, fromClock time.Time, maxHorizon float64) (SOIPass, bool) {
+	mu := primary.GravitationalParameter()
+	el := orbital.ElementsFromState(state.R, state.V, mu)
 	if math.IsNaN(el.A) || math.IsInf(el.A, 0) {
 		return SOIPass{}, false
 	}
@@ -68,15 +144,21 @@ func (w *World) LiveSOIPass() (SOIPass, bool) {
 
 	// Forward-prediction horizon: ~one orbital period for a bound orbit
 	// (the encounter sits within the next revolution, ADR 0019 B); a
-	// sim-day wall for an escape/hyperbolic leg.
-	period := orbitalPeriod(c.State, mu)
+	// sim-day wall for an escape/hyperbolic leg; tightened by maxHorizon
+	// (the counterfactual's first-node cap).
+	period := orbitalPeriod(state, mu)
 	horizon := soiPassHyperbolicHorizon
 	if bound && period > 0 && !math.IsNaN(period) && !math.IsInf(period, 0) {
 		horizon = period
 	}
+	if maxHorizon < horizon {
+		horizon = maxHorizon
+	}
+	if horizon <= 0 {
+		return SOIPass{}, false
+	}
 
 	sys := w.System()
-	now := w.Clock.SimTime
 
 	// Scan every sibling body the orbit can geometrically reach; keep the
 	// earliest SOI-entering pass.
@@ -84,19 +166,19 @@ func (w *World) LiveSOIPass() (SOIPass, bool) {
 	bestTCA := math.Inf(1)
 	found := false
 	for _, b := range sys.Bodies {
-		if b.ParentID != c.Primary.ID {
-			continue // only siblings of the craft's primary have a sibling SOI
+		if b.ParentID != primary.ID {
+			continue // only siblings of `primary` have a sibling SOI
 		}
 		// Apoapsis-reach prune: the craft's farthest radius must reach
 		// within the body's SOI of the body's closest approach to the
 		// primary. Cheap geometry, no integration.
 		bEl := orbital.ElementsFromBody(b)
 		bodyPeri := bEl.A * (1 - bEl.E) // body's closest distance to the primary
-		soi := physics.SOIRadius(b, c.Primary)
+		soi := physics.SOIRadius(b, primary)
 		if craftReach < bodyPeri-soi {
 			continue
 		}
-		enc, ok := w.scanTargetEncounter(c.State, c.Primary, b, now, horizon)
+		enc, ok := w.scanTargetEncounter(state, primary, b, fromClock, horizon)
 		if !ok || !enc.EntersSOI {
 			continue
 		}
@@ -115,16 +197,14 @@ func (w *World) LiveSOIPass() (SOIPass, bool) {
 		return SOIPass{}, false
 	}
 
-	// Sample the live trajectory over the full bounded horizon and keep only
-	// the body's own segments — these span the *whole* transit (entry →
-	// perilune → exit), because PredictedSegmentsFrom rebases back out of
-	// the SOI on exit, so any post-exit (escape / re-captured) samples land
-	// in a different segment we drop here. Drawing the complete flyby (not
-	// just the approach to perilune) reads as the single bright leg ADR
-	// 0019 E calls for, while the period/sim-day horizon keeps it bounded
-	// (ADR 0019 B: time-capped, ≤3 patches).
+	// Sample the trajectory over the bounded horizon and keep only the
+	// body's own segments — these span the transit (entry → perilune →
+	// exit), because PredictedSegmentsFrom rebases back out of the SOI on
+	// exit, so any post-exit (escape / re-captured) samples land in a
+	// segment we drop here. A node-capped horizon naturally truncates the
+	// arc at the burn (ADR 0019 D: counterfactual never drawn past the node).
 	samples := adaptiveSampleCount(horizon, period)
-	segs := w.PredictedSegmentsFrom(c.State, c.Primary, now, horizon, samples)
+	segs := w.PredictedSegmentsFrom(state, primary, fromClock, horizon, samples)
 	for _, s := range segs {
 		if s.PrimaryID == best.Body.ID {
 			best.ArcSegments = append(best.ArcSegments, s)
@@ -135,7 +215,7 @@ func (w *World) LiveSOIPass() (SOIPass, bool) {
 	// centre at the predicted time of closest approach. The glyph marks
 	// "which marker, what state" — the value lives in the chip (ADR 0020 C)
 	// — so the nearest-sample approximation is sufficient for placement.
-	moonAtTCA := w.BodyPositionAt(best.Body, now.Add(time.Duration(best.TimeToPerilune*float64(time.Second))))
+	moonAtTCA := w.BodyPositionAt(best.Body, fromClock.Add(time.Duration(best.TimeToPerilune*float64(time.Second))))
 	minD := math.Inf(1)
 	for _, s := range best.ArcSegments {
 		for _, p := range s.Points {

--- a/internal/sim/soipass_test.go
+++ b/internal/sim/soipass_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // TestLiveSOIPassGuardSkipsUnreachableOrbit: a stable LEO whose apoapsis
@@ -122,5 +123,70 @@ func TestLiveSOIPassIndependentOfTarget(t *testing.T) {
 	if !ok2 || pass2.Body.ID != pass.Body.ID {
 		t.Errorf("SOI pass changed with target cleared: ok=%v body=%q (want ok=true body=%q)",
 			ok2, pass2.Body.ID, pass.Body.ID)
+	}
+}
+
+// TestCounterfactualSOIPassCapsAtFirstNode: the no-burn counterfactual (ADR
+// 0019 D) is capped at the first planted node — suppressed when a node
+// fires before the encounter could be reached, intact when the node fires
+// after it.
+func TestCounterfactualSOIPassCapsAtFirstNode(t *testing.T) {
+	w := mustWorld(t)
+	leg := coplanarLEOTowardMoon(t, w)
+	c := w.ActiveCraft()
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+
+	live, ok := w.LiveSOIPass()
+	if !ok || live.Body.ID != "moon" {
+		t.Fatalf("precondition: live pass should reach the Moon; ok=%v", ok)
+	}
+
+	// A node an hour out — long before the multi-day encounter — caps the
+	// counterfactual before it can reach the SOI.
+	c.Nodes = []spacecraft.ManeuverNode{{TriggerTime: w.Clock.SimTime.Add(time.Hour)}}
+	if pass, ok := w.CounterfactualSOIPass(); ok {
+		t.Errorf("counterfactual should be suppressed by a node firing before the encounter; got body %q", pass.Body.ID)
+	}
+
+	// A node past the encounter leaves the counterfactual intact.
+	c.Nodes = []spacecraft.ManeuverNode{{TriggerTime: w.Clock.SimTime.Add(time.Duration(live.TimeToPerilune*2) * time.Second)}}
+	cf, ok := w.CounterfactualSOIPass()
+	if !ok || cf.Body.ID != "moon" {
+		t.Errorf("counterfactual should reach the Moon when the node fires after the encounter; ok=%v", ok)
+	}
+
+	// With no node, the counterfactual is identical to the live pass.
+	c.Nodes = nil
+	cf2, ok := w.CounterfactualSOIPass()
+	if !ok || cf2.Body.ID != live.Body.ID {
+		t.Errorf("counterfactual with no node = (ok=%v, body=%q), want the live pass body %q", ok, cf2.Body.ID, live.Body.ID)
+	}
+}
+
+// TestPlannedSOIPassFromLegs: with a transfer planted, the planned (node-
+// modified) path's SOI pass is scanned from the post-burn legs (ADR 0019 D
+// bright path). With no node planted there is no planned pass.
+func TestPlannedSOIPassFromLegs(t *testing.T) {
+	w := mustWorld(t)
+	coplanarLEOTowardMoon(t, w) // plants an LEO→Moon transfer
+
+	pass, ok := w.PlannedSOIPass()
+	if !ok {
+		t.Fatal("expected a planned SOI pass from the transfer legs")
+	}
+	if pass.Body.ID != "moon" {
+		t.Errorf("planned pass body = %q, want \"moon\"", pass.Body.ID)
+	}
+	if pass.TimeToPerilune <= 0 {
+		t.Errorf("planned TimeToPerilune = %.1f s, want > 0 (rebased to now)", pass.TimeToPerilune)
+	}
+
+	// No node → no planned pass.
+	w.ActiveCraft().Nodes = nil
+	if _, ok := w.PlannedSOIPass(); ok {
+		t.Error("PlannedSOIPass should be empty with no node planted")
 	}
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1201,24 +1201,38 @@ type predictRenderCache struct {
 	data predictRenderData
 }
 
-// soiPassRenderCache memoizes the last LiveSOIPass result (ADR 0019) under
-// the predict-on-change discipline. ok records whether a pass exists so a
-// cached "no pass" (the common coast) doesn't re-run the guard each frame.
+// soiPassRenderCache memoizes the dual-arc SOI Pass result (ADR 0019 D)
+// under the predict-on-change discipline.
 type soiPassRenderCache struct {
-	has  bool
-	key  soiPassKey
-	pass sim.SOIPass
-	ok   bool
+	has bool
+	key soiPassKey
+	arc soiDualArc
 }
 
-// soiPassKey fingerprints what the live SOI Pass depends on: the active
-// craft, its primary, the clock (bucketed), and the live orbital elements
-// (quantized). Deliberately omits the node fingerprint — the Pass is the
-// *unburned* path, independent of planted nodes (ADR 0019 A), so a node
-// edit must not bust it.
+// soiDualArc is the per-frame SOI Pass geometry the canvas + chip share.
+// With no node planted, only `counterfactual` is populated (it equals the
+// live pass) and is drawn bright. With a node planted, `counterfactual` is
+// the no-burn path (capped at the first node, drawn dim) and `planned` is
+// the node-modified path's pass (drawn as a bright Perilune marker over the
+// node legs) — the dual arc.
+type soiDualArc struct {
+	counterfactual sim.SOIPass
+	cfOK           bool
+	planned        sim.SOIPass
+	plOK           bool
+	hasNodes       bool
+}
+
+// soiPassKey fingerprints what the dual-arc SOI Pass depends on: the active
+// craft, its primary, the clock (bucketed), the live orbital elements
+// (quantized), and the planted-node fingerprint. The node fingerprint is
+// included because the *planned* (node-modified) arc depends on the nodes
+// (ADR 0019 D) — the no-burn counterfactual is also capped at the first
+// node, so a node edit legitimately busts this cache.
 type soiPassKey struct {
 	craftID     uint64
 	primaryID   string
+	nodeFinger  uint64
 	clockBucket int64
 	aQ          int64
 	eQ          int64
@@ -1227,29 +1241,35 @@ type soiPassKey struct {
 	argQ        int64
 }
 
-// cachedSOIPass returns the live SOI Pass for the active craft, recomputing
-// (the forward predictor + apoapsis-reach guard) only when the key changes.
-func (v *OrbitView) cachedSOIPass(w *sim.World) (sim.SOIPass, bool) {
+// cachedSOIPass returns the dual-arc SOI Pass for the active craft,
+// recomputing (the forward predictor + apoapsis-reach guard) only when the
+// key changes — ADR 0019 / ADR 0017 C.
+func (v *OrbitView) cachedSOIPass(w *sim.World) soiDualArc {
 	if w.ActiveCraft() == nil {
-		return sim.SOIPass{}, false
+		return soiDualArc{}
 	}
 	key := v.soiPassKeyAt(w, w.Clock.SimTime)
 	if v.soiPassCache.has && v.soiPassCache.key == key {
-		return v.soiPassCache.pass, v.soiPassCache.ok
+		return v.soiPassCache.arc
 	}
-	pass, ok := w.LiveSOIPass()
-	v.soiPassCache = soiPassRenderCache{has: true, key: key, pass: pass, ok: ok}
+	var arc soiDualArc
+	arc.hasNodes = len(w.ActiveCraft().Nodes) > 0
+	arc.counterfactual, arc.cfOK = w.CounterfactualSOIPass()
+	if arc.hasNodes {
+		arc.planned, arc.plOK = w.PlannedSOIPass()
+	}
+	v.soiPassCache = soiPassRenderCache{has: true, key: key, arc: arc}
 	v.soiPassCacheComputes++
-	return pass, ok
+	return arc
 }
 
-// soiPassKeyAt builds the SOI-pass cache key for the active craft at clock
-// t. Mirrors predictRenderKeyAt minus the node fingerprint.
+// soiPassKeyAt builds the SOI-pass cache key for the active craft at clock t.
 func (v *OrbitView) soiPassKeyAt(w *sim.World, t time.Time) soiPassKey {
 	c := w.ActiveCraft()
 	key := soiPassKey{
 		craftID:     c.ID,
 		primaryID:   c.Primary.ID,
+		nodeFinger:  nodeFingerprint(c.Nodes),
 		clockBucket: t.UnixNano() / v.predictClockBucketNanos(w),
 	}
 	if el, ok := activeCraftElements(w); ok {
@@ -1529,6 +1549,11 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 	}
 }
 
+// soiCounterfactualDim scales the no-burn arc's colour when a node is
+// planted, so the dim counterfactual reads as visibly secondary to the
+// bright node-modified path drawn in the same SOI (ADR 0019 D / ADR 0020 B).
+const soiCounterfactualDim = 0.5
+
 // drawSOIPass renders the live trajectory's upcoming SOI Pass (ADR 0019):
 // the foreign-SOI arc as a single bright solid leg, plus a Perilune ⊕
 // marker at closest approach — or an Impact glyph (red+bright, the marker
@@ -1536,24 +1561,42 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 // independent of the Target slot; the apoapsis-reach guard inside the
 // cached predictor keeps a stable orbit that reaches no SOI free.
 func (v *OrbitView) drawSOIPass(w *sim.World) {
-	pass, ok := v.cachedSOIPass(w)
-	if !ok {
-		return
-	}
-	// The foreign-SOI arc draws solid (every sample) and bright — the
-	// encounter is the thing the player is looking for, so unlike the
-	// dashed home-SOI ellipse it doesn't stipple.
-	for _, seg := range pass.ArcSegments {
-		for _, p := range seg.Points {
-			v.canvas.PlotColored(p, render.ColorForeignSOI)
+	arc := v.cachedSOIPass(w)
+
+	// The no-burn arc. With no node planted it IS the live pass, drawn
+	// bright; with a node planted it's the counterfactual ("what you'll hit
+	// if you don't burn"), drawn dim and capped at the node so it never
+	// trails past the burn (ADR 0019 D). brightness = state (ADR 0020 B).
+	if arc.cfOK {
+		arcColor := render.ColorForeignSOI
+		markerState := render.MarkerNominal
+		if arc.hasNodes {
+			arcColor = render.Shade(render.ColorForeignSOI, soiCounterfactualDim)
+			markerState = render.MarkerCounterfactual
+		}
+		for _, seg := range arc.counterfactual.ArcSegments {
+			for _, p := range seg.Points {
+				v.canvas.PlotColored(p, arcColor)
+			}
+		}
+		if arc.counterfactual.HasPerilunePt {
+			st := markerState
+			if arc.counterfactual.Impact {
+				st = render.MarkerAlarm // sub-surface perilune → Impact (red+bright even when counterfactual)
+			}
+			drawMarker(v.canvas, arc.counterfactual.PerilunePoint, render.MarkerPerilune, st, "", widgets.CellTag{})
 		}
 	}
-	if pass.HasPerilunePt {
-		state := render.MarkerNominal
-		if pass.Impact {
-			state = render.MarkerAlarm // sub-surface perilune → Impact
+
+	// The planned (node-modified) path's Perilune marker, drawn bright over
+	// the node legs (which drawNodes already paints) — the safe periapsis
+	// the burn produces, against the dim no-burn Impact (ADR 0019 D).
+	if arc.plOK && arc.planned.HasPerilunePt {
+		st := render.MarkerNominal
+		if arc.planned.Impact {
+			st = render.MarkerAlarm
 		}
-		drawMarker(v.canvas, pass.PerilunePoint, render.MarkerPerilune, state, "", widgets.CellTag{})
+		drawMarker(v.canvas, arc.planned.PerilunePoint, render.MarkerPerilune, st, "", widgets.CellTag{})
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -733,40 +733,70 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 }
 
 // buildSOIPassChip surfaces the always-on SOI Pass readout (ADR 0019): the
-// upcoming foreign-SOI encounter of the live, *unburned* trajectory — body,
-// Perilune altitude (or IMPACT), and Time to Perilune — independent of the
-// Target slot. Returns nil when there is no pass, or when the Pass Body is
-// also the current body Target: the TARGET chip already shows the same
-// perilune/TCA, so the two readouts de-dupe into one (ADR 0019 E).
+// upcoming foreign-SOI encounter of the live trajectory — independent of the
+// Target slot. With no node planted it shows the single live pass (body,
+// Perilune altitude or IMPACT, Time to Perilune). With a node planted it
+// stacks the dual arc (ADR 0019 D): a `planned` line (the node-modified
+// path's safe periapsis) and a `no-burn` line (the counterfactual Impact the
+// burn corrects). Returns nil when there is no pass, or when the Pass Body is
+// also the current body Target — the TARGET chip already covers it, so the
+// readouts de-dupe into one (ADR 0019 E).
 func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 	c := w.ActiveCraft()
 	if c == nil || !w.CraftVisibleHere() {
 		return nil
 	}
-	pass, ok := v.cachedSOIPass(w)
-	if !ok {
+	arc := v.cachedSOIPass(w)
+
+	// The body the chip names: the planned pass when present (the path the
+	// craft will fly), else the counterfactual/live pass.
+	var body bodies.CelestialBody
+	switch {
+	case arc.plOK:
+		body = arc.planned.Body
+	case arc.cfOK:
+		body = arc.counterfactual.Body
+	default:
 		return nil
 	}
+
 	// De-dupe with TARGET: if the player has targeted the very body the
 	// pass crosses, the TARGET chip's peri/TCA rows already cover it.
 	if w.Target.Kind == sim.TargetBody {
 		sysT := w.System()
 		if w.Target.BodyIdx > 0 && w.Target.BodyIdx < len(sysT.Bodies) &&
-			sysT.Bodies[w.Target.BodyIdx].ID == pass.Body.ID {
+			sysT.Bodies[w.Target.BodyIdx].ID == body.ID {
 			return nil
 		}
 	}
-	nameStyle := lipgloss.NewStyle().Foreground(render.ColorFor(pass.Body)).Bold(true)
+
+	nameStyle := lipgloss.NewStyle().Foreground(render.ColorFor(body)).Bold(true)
 	lines := []string{
 		v.theme.Primary.Render("SOI PASS"),
-		chipRow("body:", nameStyle.Render(pass.Body.EnglishName)),
+		chipRow("body:", nameStyle.Render(body.EnglishName)),
 	}
-	if pass.Impact {
-		lines = append(lines, chipRow("peri:", v.theme.Warning.Render("IMPACT")))
-	} else {
-		lines = append(lines, chipRow("peri:", fmt.Sprintf("%.0f km", pass.PeriluneAltitude()/1000)))
+	periValue := func(p sim.SOIPass) string {
+		if p.Impact {
+			return v.theme.Warning.Render("IMPACT")
+		}
+		return fmt.Sprintf("%.0f km", p.PeriluneAltitude()/1000)
 	}
-	lines = append(lines, chipRow("TCA:", formatTCA(pass.TimeToPerilune)))
+	if arc.hasNodes {
+		// Dual arc: planned (bright path) + no-burn (counterfactual).
+		if arc.plOK {
+			lines = append(lines,
+				chipRow("planned:", periValue(arc.planned)),
+				chipRow("  T-peri:", formatTCA(arc.planned.TimeToPerilune)))
+		}
+		if arc.cfOK {
+			lines = append(lines, chipRow("no-burn:", periValue(arc.counterfactual)))
+		}
+		return lines
+	}
+	// Single live pass (no node planted).
+	lines = append(lines,
+		chipRow("peri:", periValue(arc.counterfactual)),
+		chipRow("TCA:", formatTCA(arc.counterfactual.TimeToPerilune)))
 	return lines
 }
 

--- a/internal/tui/screens/orbit_soipass_test.go
+++ b/internal/tui/screens/orbit_soipass_test.go
@@ -165,3 +165,84 @@ func TestSOIPassAbsentForStableLEO(t *testing.T) {
 		t.Errorf("stable LEO must not show a SOI PASS chip")
 	}
 }
+
+// plantMoonTransferAtLEO aligns the craft coplanar with the Moon and plants
+// an LEO→Moon transfer, leaving the craft AT LEO with the node planted (not
+// moved onto the coast). The node-modified legs reach the Moon, so
+// PlannedSOIPass is populated while the no-burn live path (still LEO, capped
+// at the departure) is not — the node-present chip path.
+func plantMoonTransferAtLEO(t *testing.T, w *sim.World) {
+	t.Helper()
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon not in loaded Sol system")
+	}
+	moon := sys.Bodies[moonIdx]
+	mel := orbital.ElementsFromBody(moon)
+	sI, cI := math.Sin(mel.I), math.Cos(mel.I)
+	sO, cO := math.Sin(mel.Omega), math.Cos(mel.Omega)
+	moonN := orbital.Vec3{X: sO * sI, Y: -cO * sI, Z: cI}.Unit()
+	ref := orbital.Vec3{X: 1}
+	if math.Abs(moonN.Dot(ref)) > 0.9 {
+		ref = orbital.Vec3{Y: 1}
+	}
+	e1 := ref.Sub(moonN.Scale(moonN.Dot(ref))).Unit()
+	e2 := moonN.Cross(e1)
+
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	v := math.Sqrt(mu / r)
+	c.State.R = e1.Scale(r)
+	c.State.V = e2.Scale(v)
+	if _, err := w.PlanTransfer(moonIdx); err != nil {
+		t.Fatalf("PlanTransfer: %v", err)
+	}
+}
+
+// TestSOIPassChipNoNodeIsSinglePass: with no node planted, the SOI PASS chip
+// shows the single live pass (peri + TCA), not the dual-arc planned/no-burn
+// rows — behavior unchanged from the single-arc slice (ADR 0019, #136 #5).
+func TestSOIPassChipNoNodeIsSinglePass(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupMoonCoast(t, w) // clears nodes
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "SOI PASS") {
+		t.Fatal("expected the SOI PASS chip on a node-free coast")
+	}
+	if strings.Contains(out, "planned") || strings.Contains(out, "no-burn") {
+		t.Errorf("node-free SOI PASS chip must not show dual-arc rows:\n%s", out)
+	}
+}
+
+// TestSOIPassChipShowsPlannedWithNode: with a transfer planted, the SOI PASS
+// chip surfaces the dual-arc `planned` row for the node-modified path (ADR
+// 0019 D / #136 #4).
+func TestSOIPassChipShowsPlannedWithNode(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	plantMoonTransferAtLEO(t, w)
+
+	out := v.Render(w, 0, 200, 60)
+	if !strings.Contains(out, "SOI PASS") {
+		t.Fatalf("expected the SOI PASS chip with a transfer planted:\n%s", out)
+	}
+	if !strings.Contains(out, "planned") {
+		t.Errorf("expected a dual-arc 'planned' row with a node planted:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #136. Stacks on #135 + the full-transit arc fix (both merged).

When a maneuver node **is** planted, the live no-burn path is counterfactual beyond it. Rather than hide it, draw **both** trajectories through the SOI so the player sees the **Impact** their capture burn corrects against the **safe periapsis** it produces. Implements ADR 0019 decision **D**.

## What changed
- **`internal/sim/soipass.go`** — extracted `soiPassFromState(state, primary, fromClock, maxHorizon)` as the shared core; `LiveSOIPass` is now a thin wrapper over it. Two new methods:
  - `CounterfactualSOIPass()` — the no-burn pass, **capped at the first planted node** so the counterfactual is never predicted or drawn past the burn. Identical to `LiveSOIPass` with no node.
  - `PlannedSOIPass()` — the node-modified path's pass, scanned from the post-burn legs (TCA rebased to now).
- **`orbit.go`** — `cachedSOIPass` now returns a `soiDualArc` (counterfactual + planned), keyed on the node fingerprint too. `drawSOIPass` draws the no-burn arc **dim** (bright when no node) with a dim/alarm Perilune marker, plus a **bright** Perilune marker on the planned path — brightness = state per ADR 0020 B.
- **SOI PASS chip** stacks `planned` + `no-burn` rows when a node is planted, single `peri`/`TCA` otherwise; TARGET de-dupe unchanged.

## Acceptance criteria
- [x] With a node planted, both arcs render: bright node-modified (node legs + bright PL marker) + dim no-burn, each with a PL marker.
- [x] The dim no-burn arc truncates at the first planted node (horizon cap → arc never sampled past it).
- [x] A no-burn path that impacts shows a red Impact marker on the dim arc (`MarkerAlarm` overrides dim).
- [x] The SOI PASS chip stacks `planned` + `no-burn` lines.
- [x] With no node planted, behavior is unchanged from the single-arc slice (no spurious second arc).

## Tests
- `sim`: `CounterfactualSOIPass` cap (suppressed before / intact after the encounter, == live with no node); `PlannedSOIPass` from legs.
- `screens`: chip single-vs-dual (`planned` row with a node, single `peri`/`TCA` without); no-node behavior unchanged.
- `go vet ./...` + `go test ./... -race -count=1` green (1101). Self-reviewed at `/code-review high`.

Part of the encounter-view series: #134 → #135 → **#136** + #137.