### PR TITLE
Frame an active SOI Pass from the v cycle (ADR 0019 F) — #137

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -111,7 +111,7 @@ readout shows you why before you watch it fall back.
 | `+` / `-` | Zoom in / out |
 | `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your craft) |
 | `g` | Reset the camera to the whole system |
-| `v` | Cycle the view (tilted → top → right → bottom → left → flat → target). Tilted is the default — a 3D-style perspective that shows orbits leaning in space. **Target** (only offered when you have a body targeted) centers on the target and auto-frames your approach, zooming in as you close — so you can watch your projected orbit pass it while hand-flying corrections |
+| `v` | Cycle the view (tilted → top → right → bottom → left → flat → target → soi-pass). Tilted is the default — a 3D-style perspective that shows orbits leaning in space. **Target** (only offered when you have a body targeted) centers on the target and auto-frames your approach, zooming in as you close — so you can watch your projected orbit pass it while hand-flying corrections. **SOI Pass** (only offered when your live trajectory is heading into a body's sphere of influence) frames that body and auto-fits to its SOI so the encounter arc + Perilune `⊕` marker fill the canvas — no need to target the body first, and it never changes your target |
 | `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
 | `F2` | Declutter — hide all overlays (the corner chips and the navball) for a clean look at the orbit. Press again to bring them back. Your core telemetry column stays put |
 | `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build your own rocket stack: on the stack field, `←` / `→` browse parts, `a` adds one on top, `x` removes the top one |

--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -164,6 +164,41 @@ func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok boo
 	return center, radius, true
 }
 
+// SOIPassViewFraming returns the camera center and auto-fit radius for
+// ViewSOIPass (ADR 0019 F): centered on the active SOI Pass's Body, with a
+// radius that frames the encounter arc + Perilune marker. It mirrors
+// TargetViewFraming's geometry — the Pass Body's SOI (×1.3, so the perilune
+// curvature is legible on a close pass) widened to the craft→Body distance
+// when the craft is still far out, so the approach stays in frame and the
+// view zooms in automatically as the gap closes. Unlike TargetViewFraming it
+// reads the Pass Body from LiveSOIPass, *not* the Target slot, so framing an
+// encounter never requires (or touches) the Target. ok=false when there's no
+// active SOI Pass — the orbit view then falls through to the ordinary focus
+// center, mirroring how ViewTarget degrades when the target clears. v0.18.0+.
+func (w *World) SOIPassViewFraming() (center orbital.Vec3, radius float64, ok bool) {
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		return orbital.Vec3{}, 0, false
+	}
+	b := pass.Body
+	center = w.BodyPosition(b)
+	radius = physics.SOIRadius(b, w.System().Bodies[0]) * 1.3
+	if radius <= 0 {
+		radius = b.RadiusMeters() * 50
+	}
+	// Small-SOI widening (ADR 0019 F watch-point): a tight SOI relative to the
+	// current approach distance would frame only the Body and drop the craft
+	// off-canvas during approach. Widen the fit to the craft→Body distance —
+	// same widening TargetViewFraming applies — so the craft and the full
+	// encounter arc stay in frame, tightening to the SOI as the gap closes.
+	if c := w.ActiveCraft(); c != nil && c.SystemIdx == w.SystemIdx {
+		if dist := w.CraftInertial().Sub(center).Norm(); dist > radius {
+			radius = dist
+		}
+	}
+	return center, radius, true
+}
+
 func (w *World) systemOutermostRadius() float64 {
 	var maxR float64
 	for _, b := range w.System().Bodies {

--- a/internal/sim/soipass_view_test.go
+++ b/internal/sim/soipass_view_test.go
@@ -1,0 +1,166 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// moonCoast puts the active craft on the node-free LEO→Moon coast where
+// LiveSOIPass returns ok with Body.ID == "moon" — the deterministic SOI-Pass
+// setup described in the predict_test helper's docstring.
+func moonCoast(t *testing.T, w *World) {
+	t.Helper()
+	leg := coplanarLEOTowardMoon(t, w)
+	c := w.ActiveCraft()
+	c.State = leg.State
+	c.Primary = leg.Primary
+	w.Clock.SimTime = leg.StartClock
+	c.Nodes = nil
+	c.Landed = false
+}
+
+// TestSOIPassViewFramingFramesPassBody: on the node-free LEO→Moon coast the
+// SOI-Pass framing centers on the Pass Body (the Moon), not the system origin,
+// and fits a positive radius — so ViewSOIPass has real geometry to frame
+// (ADR 0019 F, #137).
+func TestSOIPassViewFramingFramesPassBody(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no live SOI Pass on the Moon coast")
+	}
+
+	center, radius, ok := w.SOIPassViewFraming()
+	if !ok {
+		t.Fatal("SOIPassViewFraming returned ok=false with an active pass")
+	}
+	if radius <= 0 {
+		t.Errorf("fit radius = %v, want > 0", radius)
+	}
+	moonPos := w.BodyPosition(pass.Body)
+	if got := center.Sub(moonPos).Norm(); got > 1 {
+		t.Errorf("framing center is %v m from the Pass Body, want centered on it", got)
+	}
+}
+
+// TestSOIPassViewFramingNilWithoutPass: with no active SOI Pass (a stable LEO)
+// the framing reports ok=false, so ViewSOIPass falls through to the ordinary
+// focus center instead of framing nothing.
+func TestSOIPassViewFramingNilWithoutPass(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.Landed = false
+	c.Nodes = nil
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	if _, ok := w.LiveSOIPass(); ok {
+		t.Fatal("precondition: stable LEO should have no SOI Pass")
+	}
+	if _, _, ok := w.SOIPassViewFraming(); ok {
+		t.Error("SOIPassViewFraming should report ok=false without a pass")
+	}
+}
+
+// TestSOIPassViewFramingWidensForApproach: when the craft is still far outside
+// the Pass Body's SOI, the fit radius widens to the craft→Body distance so the
+// craft stays on-canvas during approach — the ADR 0019 F small-SOI watch-point
+// (the same widening TargetViewFraming applies).
+func TestSOIPassViewFramingWidensForApproach(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no live SOI Pass on the Moon coast")
+	}
+	center, radius, ok := w.SOIPassViewFraming()
+	if !ok {
+		t.Fatal("SOIPassViewFraming returned ok=false with an active pass")
+	}
+
+	// Early on the LEO→Moon coast the craft is far outside Luna's SOI, so the
+	// fit must have widened to at least the craft→Moon distance.
+	dist := w.CraftInertial().Sub(center).Norm()
+	if dist <= 0 {
+		t.Fatal("craft→Body distance is non-positive; setup is degenerate")
+	}
+	if radius < dist {
+		t.Errorf("fit radius %v < craft→Body distance %v: craft would fall off-canvas during approach", radius, dist)
+	}
+	_ = pass
+}
+
+// TestSOIPassViewSelectableInCycle: the `v` cycle offers ViewSOIPass only when
+// a pass is active (LiveSOIPass ok), and skips it otherwise — so a player who
+// isn't heading into a SOI never lands on a dead view (ADR 0019 F).
+func TestSOIPassViewSelectableInCycle(t *testing.T) {
+	w := mustWorld(t)
+
+	// Stable LEO: no pass → ViewSOIPass not selectable.
+	c := w.ActiveCraft()
+	c.Landed = false
+	c.Nodes = nil
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	if w.viewModeSelectable(ViewSOIPass) {
+		t.Error("ViewSOIPass should be unselectable on a stable LEO (no pass)")
+	}
+
+	// Moon coast: pass active → ViewSOIPass selectable, and a full forward
+	// cycle reaches it.
+	moonCoast(t, w)
+	if !w.viewModeSelectable(ViewSOIPass) {
+		t.Fatal("ViewSOIPass should be selectable while coasting toward the Moon")
+	}
+	reached := false
+	w.ViewMode = ViewTilted
+	for i := 0; i < len(AllViewModes); i++ {
+		w.CycleViewMode()
+		if w.ViewMode == ViewSOIPass {
+			reached = true
+			break
+		}
+	}
+	if !reached {
+		t.Error("cycling v never reached ViewSOIPass with an active pass")
+	}
+}
+
+// TestSOIPassViewDoesNotMutateTarget: entering and leaving ViewSOIPass via the
+// `v` cycle never touches w.Target — the SOI Pass is Target-independent (ADR
+// 0019 F, acceptance criterion 3, #137).
+func TestSOIPassViewDoesNotMutateTarget(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+
+	if w.Target.Kind != TargetNone {
+		t.Fatalf("precondition: Target should be unset, got %v", w.Target)
+	}
+	before := w.Target
+
+	// Cycle all the way around through ViewSOIPass and back; Target must be
+	// untouched at every step.
+	w.ViewMode = ViewTilted
+	sawPass := false
+	for i := 0; i < 2*len(AllViewModes); i++ {
+		w.CycleViewMode()
+		if w.ViewMode == ViewSOIPass {
+			sawPass = true
+		}
+		if w.Target != before {
+			t.Fatalf("cycling view mutated Target: %v -> %v", before, w.Target)
+		}
+	}
+	if !sawPass {
+		t.Error("cycle never visited ViewSOIPass; the no-mutate guarantee was not exercised")
+	}
+}

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -59,6 +59,20 @@ const (
 	// a body target is set (CycleViewMode skips it otherwise); falls back to
 	// the ordinary focus center when the target is cleared mid-view.
 	ViewTarget
+	// ViewSOIPass (v0.18.0+, ADR 0019 F) frames the Body of the active SOI
+	// Pass — the predicted transit of the live, unburned trajectory through a
+	// sibling Body's SOI — and auto-fits to that Body's SOI so the encounter
+	// arc + Perilune marker fill the canvas and the curvature near perilune
+	// reads clearly. Crucially it is *independent of the Target slot*: the SOI
+	// Pass renders whether or not the Body is targeted, and so does this view —
+	// entering/leaving it never touches w.Target. Reuses the orbit-flat
+	// projection basis and the TargetViewFraming widening geometry (against the
+	// Pass Body instead of the Target). Selected from the `v` cycle, but only
+	// reachable when LiveSOIPass() returns ok (CycleViewMode skips it
+	// otherwise); falls back to the ordinary focus center when the pass
+	// disappears mid-view (craft captured, or the orbit no longer reaches the
+	// SOI).
+	ViewSOIPass
 	// ViewLaunch (v0.11.0+) is the chase-cam launch scene — a
 	// human-scale side view with the rocket centred, the horizon
 	// curving below in Body.SurfaceColor, and a body-fixed pad
@@ -89,6 +103,8 @@ func (m ViewMode) String() string {
 		return "orbit-flat"
 	case ViewTarget:
 		return "target"
+	case ViewSOIPass:
+		return "soi-pass"
 	case ViewLaunch:
 		return "launch"
 	}
@@ -108,6 +124,7 @@ var AllViewModes = [...]ViewMode{
 	ViewLeft,
 	ViewOrbitFlat,
 	ViewTarget,
+	ViewSOIPass,
 	ViewLaunch,
 }
 
@@ -122,13 +139,34 @@ func (w *World) CycleViewMode() {
 		w.LaunchSessionActive = false
 	}
 	next := (w.ViewMode + 1) % ViewMode(len(AllViewModes))
-	// The target view has nothing to frame without a body target — skip it
-	// in the cycle so a player who isn't aiming at a body never lands on a
-	// dead view.
-	if next == ViewTarget && w.Target.Kind != TargetBody {
-		next = (next + 1) % ViewMode(len(AllViewModes))
+	// Skip view modes that have nothing to frame from the current world
+	// state, so a manual `v` cycle never lands on a dead view: ViewTarget
+	// needs a body Target, ViewSOIPass needs an active SOI Pass (ADR 0019 F —
+	// reachable only when LiveSOIPass returns ok, and entering it never
+	// touches w.Target). At most one full lap before giving up, so a state
+	// with every conditional mode unavailable can't spin forever.
+	for range AllViewModes {
+		if !w.viewModeSelectable(next) {
+			next = (next + 1) % ViewMode(len(AllViewModes))
+			continue
+		}
+		break
 	}
 	w.ViewMode = next
+}
+
+// viewModeSelectable reports whether the `v` cycle may land on mode m given
+// the current world state. The conditional modes are skipped when they'd
+// frame nothing; every other mode is always selectable.
+func (w *World) viewModeSelectable(m ViewMode) bool {
+	switch m {
+	case ViewTarget:
+		return w.Target.Kind == TargetBody
+	case ViewSOIPass:
+		_, ok := w.LiveSOIPass()
+		return ok
+	}
+	return true
 }
 
 // SetViewModeLaunch (v0.11.4+, ADR 0004) is the manual-jump path

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -247,7 +247,7 @@ func DefaultKeymap() Keymap {
 		Save:            key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "quicksave")),
 		Load:            key.NewBinding(key.WithKeys("f9"), key.WithHelp("F9", "quickload")),
 		RefinePlan:      key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "refine plan (re-Lambert arrival)")),
-		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat / target)")),
+		CycleView:       key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "cycle view (top / right / bottom / left / orbit-flat / target / soi-pass)")),
 
 		ThrottleFull:        key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "throttle 100%")),
 		ThrottleCut:         key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "throttle 0% / cut burn")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -44,7 +44,7 @@ var helpSections = []helpSection{
 		{"f / F", "cycle camera focus forward / back (system → bodies → craft)"},
 		{"g", "reset camera to the whole system"},
 		{"+ / -", "zoom in / out"},
-		{"v", "cycle view (tilted / top / right / bottom / left / flat / target)"},
+		{"v", "cycle view (tilted / top / right / bottom / left / flat / target / soi-pass)"},
 		{"shift+↑ / ↓", "tilt the 3D view up / down (tilted view only)"},
 		{"F2", "declutter — hide chips + navball (core column stays)"},
 	}},

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -378,6 +378,18 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			v.canvas.FitTo(tRadius)
 		}
 	}
+	// ViewSOIPass (ADR 0019 F) frames the active SOI Pass's Body without
+	// touching the Target slot — centers on the Pass Body and refits every
+	// frame so the encounter arc + Perilune marker fill the canvas. Falls
+	// through to the ordinary focus center when the pass disappears mid-view
+	// (craft captured / orbit no longer reaches the SOI), mirroring how
+	// ViewTarget degrades when its target clears.
+	if w.ViewMode == sim.ViewSOIPass {
+		if pCenter, pRadius, ok := w.SOIPassViewFraming(); ok {
+			center = pCenter
+			v.canvas.FitTo(pRadius)
+		}
+	}
 	v.canvas.Center(center)
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
@@ -1142,7 +1154,7 @@ func (v *OrbitView) cameraDirForView(view sim.ViewMode) render.Vec3 {
 		return render.CameraDirRight
 	case sim.ViewLeft:
 		return render.CameraDirLeft
-	case sim.ViewTilted, sim.ViewOrbitFlat, sim.ViewTarget:
+	case sim.ViewTilted, sim.ViewOrbitFlat, sim.ViewTarget, sim.ViewSOIPass:
 		// Depth axis points out of screen toward the camera, which
 		// is exactly the body-to-camera direction the sub-observer
 		// math wants. For ViewOrbitFlat on a near-equatorial orbit
@@ -1981,9 +1993,10 @@ func viewBasis(w *sim.World) widgets.Basis {
 			X: orbital.Vec3{Y: -1},
 			Y: orbital.Vec3{Z: 1},
 		}
-	case sim.ViewOrbitFlat, sim.ViewTarget:
-		// ViewTarget reuses the orbit-plane basis so the approach reads as a
-		// clean curve; only its center + zoom differ (handled in Render).
+	case sim.ViewOrbitFlat, sim.ViewTarget, sim.ViewSOIPass:
+		// ViewTarget / ViewSOIPass reuse the orbit-plane basis so the approach
+		// reads as a clean curve; only their center + zoom differ (handled in
+		// Render).
 		el, ok := activeCraftElements(w)
 		if !ok {
 			return widgets.DefaultBasis()

--- a/internal/tui/screens/orbit_soipass_view_test.go
+++ b/internal/tui/screens/orbit_soipass_view_test.go
@@ -1,0 +1,81 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestViewSOIPassRefitsToPassBody: with ViewSOIPass selected on the node-free
+// Moon coast, the orbit view refits the canvas to the SOI-Pass framing — and
+// that framing matches what ViewTarget would produce with the Moon targeted,
+// proving it reuses TargetViewFraming geometry against the Pass Body (ADR 0019
+// F) without ever setting the Target. The render must not panic and the SOI
+// PASS chip stays present (#137 acceptance 1+2).
+func TestViewSOIPassRefitsToPassBody(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := setupMoonCoast(t, w)
+
+	// SOI-Pass view, no Target set: record the auto-fit scale.
+	w.ViewMode = sim.ViewSOIPass
+	out := v.Render(w, 0, 200, 60)
+	passScale := v.canvas.Scale()
+	if w.Target.Kind != sim.TargetNone {
+		t.Fatalf("ViewSOIPass mutated the Target slot: %v", w.Target)
+	}
+
+	// The same canvas under ViewTarget with the Moon targeted must land on the
+	// identical fit — same framing geometry, just sourced from the Pass Body
+	// instead of the Target.
+	w.Target = sim.Target{Kind: sim.TargetBody, BodyIdx: moonIdx}
+	w.ViewMode = sim.ViewTarget
+	v.Render(w, 0, 200, 60)
+	targetScale := v.canvas.Scale()
+
+	if math.Abs(passScale-targetScale) > 1e-12 {
+		t.Errorf("ViewSOIPass scale %v != ViewTarget scale %v; framing geometry should match", passScale, targetScale)
+	}
+	if !strings.Contains(out, "SOI PASS") {
+		t.Errorf("SOI PASS chip should render in ViewSOIPass with no Target set")
+	}
+}
+
+// TestViewSOIPassFallsBackWhenPassClears: if the SOI Pass disappears while
+// ViewSOIPass is selected (here: the craft drops to a stable LEO with no
+// reachable SOI), the view must not leave the camera framing nothing — it
+// falls through to the ordinary focus center and still renders (ADR 0019 F /
+// #137 acceptance 4, graceful degradation).
+func TestViewSOIPassFallsBackWhenPassClears(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupMoonCoast(t, w)
+	w.ViewMode = sim.ViewSOIPass
+	v.Render(w, 0, 200, 60)
+
+	// Collapse to a stable LEO — no SOI Pass any more.
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	if _, _, ok := w.SOIPassViewFraming(); ok {
+		t.Fatal("precondition: pass should have cleared on the stable LEO")
+	}
+
+	// Still renders without panicking, and falls back rather than staying
+	// framed on the now-absent pass.
+	out := v.Render(w, 0, 200, 60)
+	if strings.TrimSpace(out) == "" {
+		t.Error("ViewSOIPass rendered empty after the pass cleared; expected graceful fallback")
+	}
+}


### PR DESCRIPTION
Closes #137. Stacks on #135 (merged). Independent of #136 (#141).

Lets the player **see the curvature** near perilune, not just the marker. At default orbit zoom the encounter body's SOI is a tiny blob, so the arc isn't legible until framed. Extends the `v` view cycle with a mode that frames an **active SOI Pass's Body** and auto-fits to its SOI — **without** requiring the body to be set as Target (SOI Pass is Target-independent). Implements ADR 0019 decision **F**.

## What changed
- **`internal/sim/view.go`** — new `ViewSOIPass` mode (label `soi-pass`), slotted in the `v` cycle after `ViewTarget`. `CycleViewMode` refactored to skip any conditional mode that has nothing to frame (`ViewTarget` needs a body Target; `ViewSOIPass` needs an active pass) via a new `viewModeSelectable` helper, capped at one lap so it can't spin.
- **`internal/sim/focus.go`** — `SOIPassViewFraming()` mirrors `TargetViewFraming` geometry but sources the body from `LiveSOIPass()` instead of `w.Target` — so framing an encounter never touches the Target. Includes the small-SOI widening (radius widened to the craft→Body distance) so the craft stays in frame on a long approach and tightens as the gap closes.
- **`internal/tui/screens/orbit.go`** — `ViewSOIPass` camera center + refit in `Render`, plus the orbit-plane basis/camera cases (reused from `ViewTarget`). Falls back to the ordinary focus center when the pass clears mid-view.
- **Doc-sync:** `?`/F1 help overlay (`help.go`), `input.go` keybinding help, and `docs/controls.md` all list the new `soi-pass` cycle state.

## Acceptance criteria
- [x] With an active SOI Pass and no Target set, the `v` cycle includes a mode framing the Pass Body.
- [x] That mode auto-fits to the Pass Body's SOI so the encounter curvature + Perilune marker are legible.
- [x] Entering/leaving the mode does not mutate the Target slot (asserted in tests).
- [x] Framing stays sensible when the SOI is small vs the approach distance (craft-distance widening, mirroring `ViewTarget`).
- [x] `?` help + `docs/controls.md` updated; `go vet` + `go test ./... -race` green (1104).

## Tests
- `sim/soipass_view_test.go` — frames the pass body, nil without a pass, widens for approach, selectable-in-cycle, does-not-mutate-target.
- `tui/screens/orbit_soipass_view_test.go` — refits to the pass body (framing matches `ViewTarget` while leaving Target `TargetNone`), falls back when the pass clears.

**Reviewer note:** `SOIPassViewFraming` computes the SOI floor with `physics.SOIRadius(b, Bodies[0])` (system root) — the same as the shipped `TargetViewFraming` it mirrors, and the test pins them equal. A moon's SOI is technically defined against its parent, not the root; both framers share this, masked by the craft-distance widening. Worth a separate follow-up for **both** framers if we want exact SOI fit — out of scope here to keep the two views consistent.

Part of the encounter-view series: #134 → #135 → #136 + **#137**.