### PR TITLE
fix(view): frame the predicted encounter arc, not the body's current position (#144)

### DIFF
--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
@@ -135,24 +136,78 @@ func (w *World) FocusZoomRadius() float64 {
 	return w.systemOutermostRadius()
 }
 
-// TargetViewFraming returns the camera center and auto-fit radius for
-// ViewTarget: centered on the current body Target, with a radius that frames
-// the craft→target approach. The radius is the target's SOI (×1.3, so the
-// perilune geometry is legible on a close pass) widened to the craft→target
-// distance when the craft is still far out — so the approach line stays in
-// frame and the view zooms in automatically as the gap closes. ok=false when
-// there's no body target in the active system. v0.17.3+.
-func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok bool) {
-	if w.Target.Kind != TargetBody {
+// encounterFrame returns the camera center and auto-fit radius that frame body
+// b's predicted SOI-pass arc, when a pass reaches b. The orbit canvas draws the
+// arc at its system-frame (heliocentric) sample positions — at the body's
+// *arrival* location (where b will be when the craft reaches perilune), which
+// diverges from b's *current* position by the body's transit motion during the
+// transfer (dominated, in the system frame, by the parent translating along its
+// own orbit). For a short-period moon or a multi-day coast that gap dwarfs the
+// SOI, so centering on the current position leaves the drawn arc off-canvas
+// entirely — the #144 bug.
+//
+// Crucially the arc is NOT a tight conic in the system frame: the body keeps
+// moving through the pass, so the in-SOI hyperbola is smeared along the body's
+// path across many times the SOI (measured ~24× for Kern→Cursor). Fitting to
+// the SOI would frame a single point of it (verified by rendering an empty
+// canvas). So we center on PerilunePoint — itself a drawn arc sample — and fit
+// to the arc's actual extent (the farthest arc sample from that center, ×1.15),
+// which frames the whole drawn encounter and sidesteps SOIRadius entirely (and
+// with it the Bodies[0]-root SOI-floor of #143). ok=false when no pass reaches b
+// or it couldn't place its arc — callers then fall back to b's current position.
+func (w *World) encounterFrame(b bodies.CelestialBody) (center orbital.Vec3, radius float64, ok bool) {
+	p, hit := w.bestSOIPass()
+	if !hit || p.Body.ID != b.ID || !p.HasPerilunePt {
 		return orbital.Vec3{}, 0, false
 	}
-	sys := w.System()
-	if w.Target.BodyIdx <= 0 || w.Target.BodyIdx >= len(sys.Bodies) {
-		return orbital.Vec3{}, 0, false
+	center, radius = framePass(p)
+	return center, radius, true
+}
+
+// framePass is the pure geometry behind encounterFrame: center on the pass's
+// PerilunePoint (a drawn arc sample) and fit to the arc's extent — the farthest
+// arc sample from that center, ×1.15 — so the whole drawn capture curve fills
+// the canvas. Falls back to a body-radius multiple for a degenerate single-point
+// arc. Takes an already-fetched pass so callers that have one (SOIPassViewFraming)
+// don't re-run the forward prediction. Caller guarantees p.HasPerilunePt.
+func framePass(p SOIPass) (center orbital.Vec3, radius float64) {
+	center = p.PerilunePoint
+	var maxd float64
+	for _, s := range p.ArcSegments {
+		for _, pt := range s.Points {
+			if d := pt.Sub(center).Norm(); d > maxd {
+				maxd = d
+			}
+		}
 	}
-	b := sys.Bodies[w.Target.BodyIdx]
+	radius = maxd * 1.15
+	if radius <= 0 {
+		radius = p.Body.RadiusMeters() * 50
+	}
+	return center, radius
+}
+
+// bodyApproachFraming frames body b for the approach views (ViewTarget /
+// ViewSOIPass). When an SOI pass reaches b it centers on the predicted
+// encounter arc and fits to its extent, so the drawn capture curve fills the
+// canvas at the body's *arrival* position — with no craft widening, since the
+// craft is a whole transfer away from that point and widening to it would shrink
+// the arc back to a dot (issue #144). With no pass it falls back to the
+// pre-encounter approach frame (current position + craft-distance widening).
+func (w *World) bodyApproachFraming(b bodies.CelestialBody) (center orbital.Vec3, radius float64, ok bool) {
+	if center, radius, hit := w.encounterFrame(b); hit {
+		return center, radius, true
+	}
+	return w.bodyApproachFallback(b)
+}
+
+// bodyApproachFallback frames body b's craft→body approach before any encounter
+// resolves: centered on b's *current* position, fit to its SOI and widened to
+// the craft→body distance so the approach line stays in frame and tightens as
+// the gap closes (ADR 0019 F). Always ok=true.
+func (w *World) bodyApproachFallback(b bodies.CelestialBody) (center orbital.Vec3, radius float64, ok bool) {
 	center = w.BodyPosition(b)
-	radius = physics.SOIRadius(b, sys.Bodies[0]) * 1.3
+	radius = physics.SOIRadius(b, w.System().Bodies[0]) * 1.3
 	if radius <= 0 {
 		radius = b.RadiusMeters() * 50
 	}
@@ -164,39 +219,66 @@ func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok boo
 	return center, radius, true
 }
 
+// TargetViewFraming returns the camera center and auto-fit radius for
+// ViewTarget: framing the craft→target approach. Before an encounter is
+// predicted it centers on the body Target's current position and widens the fit
+// to the craft→target distance so the approach line stays in frame and zooms in
+// as the gap closes; once an SOI pass to the target resolves it centers on the
+// encounter arc (drawn at the body's arrival position) and fits to the arc's
+// extent so the capture curve fills the canvas (issue #144). ok=false when
+// there's no body target in the active system. v0.17.3+.
+func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok bool) {
+	if w.Target.Kind != TargetBody {
+		return orbital.Vec3{}, 0, false
+	}
+	sys := w.System()
+	if w.Target.BodyIdx <= 0 || w.Target.BodyIdx >= len(sys.Bodies) {
+		return orbital.Vec3{}, 0, false
+	}
+	return w.bodyApproachFraming(sys.Bodies[w.Target.BodyIdx])
+}
+
 // SOIPassViewFraming returns the camera center and auto-fit radius for
-// ViewSOIPass (ADR 0019 F): centered on the active SOI Pass's Body, with a
-// radius that frames the encounter arc + Perilune marker. It mirrors
-// TargetViewFraming's geometry — the Pass Body's SOI (×1.3, so the perilune
-// curvature is legible on a close pass) widened to the craft→Body distance
-// when the craft is still far out, so the approach stays in frame and the
-// view zooms in automatically as the gap closes. Unlike TargetViewFraming it
-// reads the Pass Body from LiveSOIPass, *not* the Target slot, so framing an
-// encounter never requires (or touches) the Target. ok=false when there's no
-// active SOI Pass — the orbit view then falls through to the ordinary focus
-// center, mirroring how ViewTarget degrades when the target clears. v0.18.0+.
+// ViewSOIPass (ADR 0019 F): framing the active SOI Pass's Body and its
+// encounter arc + Perilune marker. It mirrors TargetViewFraming's geometry but
+// sources the Pass Body from the pass itself, *not* the Target slot, so framing
+// an encounter never requires (or touches) the Target. The pass is the planted
+// (node-modified) one when nodes exist — so the view is available, and centered
+// on the encounter, while flying a planted transfer (issue #144) — else the
+// live pass. ok=false when there's no upcoming SOI Pass — the orbit view then
+// falls through to the ordinary focus center, mirroring how ViewTarget degrades
+// when the target clears. v0.18.0+.
 func (w *World) SOIPassViewFraming() (center orbital.Vec3, radius float64, ok bool) {
-	pass, ok := w.LiveSOIPass()
+	pass, ok := w.bestSOIPass()
 	if !ok {
 		return orbital.Vec3{}, 0, false
 	}
-	b := pass.Body
-	center = w.BodyPosition(b)
-	radius = physics.SOIRadius(b, w.System().Bodies[0]) * 1.3
-	if radius <= 0 {
-		radius = b.RadiusMeters() * 50
+	// Frame the drawn arc directly from the pass we already fetched (avoids a
+	// second forward prediction); fall back to the approach frame only when the
+	// pass couldn't place its arc.
+	if pass.HasPerilunePt {
+		center, radius = framePass(pass)
+		return center, radius, true
 	}
-	// Small-SOI widening (ADR 0019 F watch-point): a tight SOI relative to the
-	// current approach distance would frame only the Body and drop the craft
-	// off-canvas during approach. Widen the fit to the craft→Body distance —
-	// same widening TargetViewFraming applies — so the craft and the full
-	// encounter arc stay in frame, tightening to the SOI as the gap closes.
-	if c := w.ActiveCraft(); c != nil && c.SystemIdx == w.SystemIdx {
-		if dist := w.CraftInertial().Sub(center).Norm(); dist > radius {
-			radius = dist
-		}
+	return w.bodyApproachFallback(pass.Body)
+}
+
+// FocusEncounterFraming frames the predicted encounter for the currently
+// focused body in the ordinary (non-Target / non-SOIPass) views: when an SOI
+// pass reaches the focus body it centers on the encounter arc and fits to its
+// extent, so a plain "focus the body" view shows the same capture curve
+// ViewTarget / ViewSOIPass would (issue #144 — the playtest "focus on Cursor"
+// path). ok=false unless the focus is a body with an active encounter, so the
+// orbit screen falls through to the ordinary focus center + zoom.
+func (w *World) FocusEncounterFraming() (center orbital.Vec3, radius float64, ok bool) {
+	if w.Focus.Kind != FocusBody {
+		return orbital.Vec3{}, 0, false
 	}
-	return center, radius, true
+	sys := w.System()
+	if w.Focus.BodyIdx < 0 || w.Focus.BodyIdx >= len(sys.Bodies) {
+		return orbital.Vec3{}, 0, false
+	}
+	return w.encounterFrame(sys.Bodies[w.Focus.BodyIdx])
 }
 
 func (w *World) systemOutermostRadius() float64 {

--- a/internal/sim/focus_encounter_test.go
+++ b/internal/sim/focus_encounter_test.go
@@ -1,0 +1,112 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// TestEncounterFramingCentersOnArrivalPosition is the regression for #144: a
+// planted Kern→Cursor transfer draws its capture geometry at Cursor's *arrival*
+// position (where Cursor will be when the craft gets there), but the framing
+// paths used to center on Cursor's *current* position. For a short-period moon
+// the two diverge by far more than the SOI, leaving the predicted capture curve
+// off-canvas — "focus on Cursor shows nothing until the maneuvers finish."
+//
+// All three encounter framers — FocusEncounterFraming (plain focus),
+// TargetViewFraming (ViewTarget), SOIPassViewFraming (ViewSOIPass) — must center
+// on the encounter (≈ the arrival position), not the current body position.
+func TestEncounterFramingCentersOnArrivalPosition(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, kern, cursor := setupKernCursor(t, w)
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+
+	pass, ok := w.PlannedSOIPass()
+	if !ok {
+		t.Fatal("PlannedSOIPass returned ok=false; expected the planted capture pass")
+	}
+	if pass.Body.ID != cursor.ID {
+		t.Fatalf("pass body = %q, want Cursor", pass.Body.EnglishName)
+	}
+	if !pass.HasPerilunePt {
+		t.Fatal("pass has no perilune point to frame")
+	}
+
+	now := w.Clock.SimTime
+	arrival := w.BodyPositionAt(cursor, now.Add(time.Duration(pass.TimeToPerilune*float64(time.Second))))
+	current := w.BodyPosition(cursor)
+	soi := physics.SOIRadius(cursor, kern)
+
+	// Premise check: the bug only bites because Cursor moves much farther than
+	// its SOI during the transfer. If this ever fails the repro has gone stale.
+	if gap := arrival.Sub(current).Norm(); gap < 10*soi {
+		t.Fatalf("Cursor moved only %.0f km (SOI %.0f km) — repro premise gone", gap/1e3, soi/1e3)
+	}
+
+	// Every framer must land within the SOI of the arrival position (where the
+	// capture curve is drawn) and nowhere near the current position.
+	check := func(name string, center orbital.Vec3, ok bool) {
+		if !ok {
+			t.Errorf("%s returned ok=false; expected an encounter frame", name)
+			return
+		}
+		if d := center.Sub(arrival).Norm(); d > soi {
+			t.Errorf("%s centered %.0f km from Cursor's arrival position (SOI %.0f km) — encounter off-canvas", name, d/1e3, soi/1e3)
+		}
+		if d := center.Sub(current).Norm(); d < 10*soi {
+			t.Errorf("%s centered only %.0f km from Cursor's CURRENT position — the #144 bug", name, d/1e3)
+		}
+	}
+
+	w.Focus = Focus{Kind: FocusBody, BodyIdx: cursorIdx}
+	fc, _, fok := w.FocusEncounterFraming()
+	check("FocusEncounterFraming", fc, fok)
+
+	w.SetTargetBody(cursorIdx)
+	tc, _, tok := w.TargetViewFraming()
+	check("TargetViewFraming", tc, tok)
+
+	sc, _, sok := w.SOIPassViewFraming()
+	check("SOIPassViewFraming", sc, sok)
+}
+
+// TestViewSOIPassSelectableDuringPlantedTransfer pins the second compounding
+// gap in #144: ViewSOIPass used to gate on LiveSOIPass, which is false while
+// flying a *planted* transfer — the pre-burn orbit can't reach the moon, so the
+// soi-pass view was unavailable in exactly the case it's most useful. After the
+// fix the `v` cycle reaches it whenever any pass exists (planted or live).
+func TestViewSOIPassSelectableDuringPlantedTransfer(t *testing.T) {
+	w := mustWorld(t)
+	cursorIdx, _, _ := setupKernCursor(t, w)
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+
+	// The unburned parking orbit can't reach Cursor — the gap the old gate hit.
+	if _, ok := w.LiveSOIPass(); ok {
+		t.Skip("pre-burn parking orbit already reaches Cursor — can't exercise the planted-only gate")
+	}
+	if _, ok := w.PlannedSOIPass(); !ok {
+		t.Fatal("planted transfer produced no PlannedSOIPass to frame")
+	}
+	if !w.viewModeSelectable(ViewSOIPass) {
+		t.Error("ViewSOIPass unselectable during a planted transfer — the #144 second gap")
+	}
+
+	reached := false
+	w.ViewMode = ViewTilted
+	for range AllViewModes {
+		w.CycleViewMode()
+		if w.ViewMode == ViewSOIPass {
+			reached = true
+			break
+		}
+	}
+	if !reached {
+		t.Error("cycling v never reached ViewSOIPass during a planted transfer")
+	}
+}

--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -98,6 +98,20 @@ func (w *World) PlannedSOIPass() (SOIPass, bool) {
 	return best, found
 }
 
+// bestSOIPass returns the most relevant upcoming SOI pass for framing: the
+// planned (node-modified) pass when nodes are planted — the bright path the
+// burns actually produce — else the live pass. Encounter-centered framing
+// (issue #144) reads it so "focus the body" / ViewTarget / ViewSOIPass all
+// center on the same predicted encounter the canvas draws, even while flying a
+// planted transfer whose *pre-burn* orbit can't yet reach the body (in which
+// case LiveSOIPass alone is false).
+func (w *World) bestSOIPass() (SOIPass, bool) {
+	if p, ok := w.PlannedSOIPass(); ok {
+		return p, true
+	}
+	return w.LiveSOIPass()
+}
+
 // firstNodeTime returns the earliest planted-node trigger time.
 func firstNodeTime(nodes []spacecraft.ManeuverNode) (time.Time, bool) {
 	if len(nodes) == 0 {

--- a/internal/sim/soipass_view_test.go
+++ b/internal/sim/soipass_view_test.go
@@ -4,7 +4,9 @@ import (
 	"math"
 	"testing"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 // moonCoast puts the active craft on the node-free LEO→Moon coast where
@@ -21,11 +23,14 @@ func moonCoast(t *testing.T, w *World) {
 	c.Landed = false
 }
 
-// TestSOIPassViewFramingFramesPassBody: on the node-free LEO→Moon coast the
-// SOI-Pass framing centers on the Pass Body (the Moon), not the system origin,
-// and fits a positive radius — so ViewSOIPass has real geometry to frame
-// (ADR 0019 F, #137).
-func TestSOIPassViewFramingFramesPassBody(t *testing.T) {
+// TestSOIPassViewFramingFramesEncounter: on the node-free LEO→Moon coast the
+// SOI-Pass framing centers on the drawn encounter — the pass's PerilunePoint, a
+// sample on the foreign-SOI arc at the Moon's *arrival* location — not the
+// Moon's *current* position (ADR 0019 F, #137; #144). The two diverge by far
+// more than the SOI over a multi-day coast (the Earth–Moon system translates
+// along Earth's heliocentric orbit), so centering on the current position pushes
+// the encounter off-canvas — the bug this regression pins.
+func TestSOIPassViewFramingFramesEncounter(t *testing.T) {
 	w := mustWorld(t)
 	moonCoast(t, w)
 
@@ -41,10 +46,27 @@ func TestSOIPassViewFramingFramesPassBody(t *testing.T) {
 	if radius <= 0 {
 		t.Errorf("fit radius = %v, want > 0", radius)
 	}
-	moonPos := w.BodyPosition(pass.Body)
-	if got := center.Sub(moonPos).Norm(); got > 1 {
-		t.Errorf("framing center is %v m from the Pass Body, want centered on it", got)
+	if got := center.Sub(pass.PerilunePoint).Norm(); got > 1 {
+		t.Errorf("framing center is %v m from the drawn PerilunePoint, want centered on it", got)
 	}
+	current := w.BodyPosition(pass.Body)
+	// The encounter sits a whole transit-translation away from the Moon's
+	// current position — far more than the Moon's true SOI.
+	soiVsParent := physics.SOIRadius(pass.Body, parentBody(w, pass.Body))
+	if got := center.Sub(current).Norm(); got <= soiVsParent {
+		t.Fatalf("encounter only %v m from the Moon's current position (SOI %v m) — #144 repro premise stale", got, soiVsParent)
+	}
+}
+
+// parentBody returns the body p orbits (its ParentID), or the system root when
+// p has no parent in the catalog. Test helper for SOI-vs-parent checks.
+func parentBody(w *World, p bodies.CelestialBody) bodies.CelestialBody {
+	for _, b := range w.System().Bodies {
+		if b.ID == p.ParentID {
+			return b
+		}
+	}
+	return w.System().Bodies[0]
 }
 
 // TestSOIPassViewFramingNilWithoutPass: with no active SOI Pass (a stable LEO)
@@ -68,11 +90,15 @@ func TestSOIPassViewFramingNilWithoutPass(t *testing.T) {
 	}
 }
 
-// TestSOIPassViewFramingWidensForApproach: when the craft is still far outside
-// the Pass Body's SOI, the fit radius widens to the craft→Body distance so the
-// craft stays on-canvas during approach — the ADR 0019 F small-SOI watch-point
-// (the same widening TargetViewFraming applies).
-func TestSOIPassViewFramingWidensForApproach(t *testing.T) {
+// TestSOIPassViewFramingFitsToArcExtent: once an encounter resolves, the fit
+// frames the *drawn arc's* extent — every foreign-SOI arc sample lands within
+// the radius — so the whole capture curve fills the canvas. In the system frame
+// the body translates through the pass, smearing the in-SOI hyperbola across
+// many times the SOI, so an SOI-sized fit would frame a single point (issue
+// #144). The fit is also *not* widened to the craft→encounter distance: the
+// craft is a whole transfer away, and widening to it would shrink the arc back
+// to a dot.
+func TestSOIPassViewFramingFitsToArcExtent(t *testing.T) {
 	w := mustWorld(t)
 	moonCoast(t, w)
 
@@ -85,16 +111,20 @@ func TestSOIPassViewFramingWidensForApproach(t *testing.T) {
 		t.Fatal("SOIPassViewFraming returned ok=false with an active pass")
 	}
 
-	// Early on the LEO→Moon coast the craft is far outside Luna's SOI, so the
-	// fit must have widened to at least the craft→Moon distance.
-	dist := w.CraftInertial().Sub(center).Norm()
-	if dist <= 0 {
-		t.Fatal("craft→Body distance is non-positive; setup is degenerate")
+	// Every drawn arc sample is within the fit radius — the curve fills the
+	// canvas rather than overflowing it.
+	for _, s := range pass.ArcSegments {
+		for _, p := range s.Points {
+			if d := p.Sub(center).Norm(); d > radius {
+				t.Errorf("arc sample %.0f km from center exceeds fit radius %.0f km — capture curve overflows the canvas", d/1e3, radius/1e3)
+			}
+		}
 	}
-	if radius < dist {
-		t.Errorf("fit radius %v < craft→Body distance %v: craft would fall off-canvas during approach", radius, dist)
+	// And the fit is the arc's extent, not the craft→encounter distance: the
+	// distant craft is intentionally left off-canvas so the curve fills it.
+	if dist := w.CraftInertial().Sub(center).Norm(); radius >= dist {
+		t.Errorf("fit radius %.0f km ≥ craft→encounter distance %.0f km: framing widened to include the distant craft (pre-#144 behavior)", radius/1e3, dist/1e3)
 	}
-	_ = pass
 }
 
 // TestSOIPassViewSelectableInCycle: the `v` cycle offers ViewSOIPass only when

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -67,11 +67,13 @@ const (
 	// Pass renders whether or not the Body is targeted, and so does this view —
 	// entering/leaving it never touches w.Target. Reuses the orbit-flat
 	// projection basis and the TargetViewFraming widening geometry (against the
-	// Pass Body instead of the Target). Selected from the `v` cycle, but only
-	// reachable when LiveSOIPass() returns ok (CycleViewMode skips it
-	// otherwise); falls back to the ordinary focus center when the pass
-	// disappears mid-view (craft captured, or the orbit no longer reaches the
-	// SOI).
+	// Pass Body instead of the Target). When an encounter resolves it centers on
+	// the predicted *arrival*-position perilune, not the body's current position
+	// (issue #144). Selected from the `v` cycle, but only reachable when an
+	// upcoming SOI pass exists — the planted (node-modified) one while flying a
+	// transfer, else the live one (CycleViewMode skips it otherwise); falls back
+	// to the ordinary focus center when the pass disappears mid-view (craft
+	// captured, or the orbit no longer reaches the SOI).
 	ViewSOIPass
 	// ViewLaunch (v0.11.0+) is the chase-cam launch scene — a
 	// human-scale side view with the rocket centred, the horizon
@@ -141,9 +143,9 @@ func (w *World) CycleViewMode() {
 	next := (w.ViewMode + 1) % ViewMode(len(AllViewModes))
 	// Skip view modes that have nothing to frame from the current world
 	// state, so a manual `v` cycle never lands on a dead view: ViewTarget
-	// needs a body Target, ViewSOIPass needs an active SOI Pass (ADR 0019 F —
-	// reachable only when LiveSOIPass returns ok, and entering it never
-	// touches w.Target). At most one full lap before giving up, so a state
+	// needs a body Target, ViewSOIPass needs an upcoming SOI Pass (ADR 0019 F —
+	// reachable when bestSOIPass returns ok, planted or live, and entering it
+	// never touches w.Target). At most one full lap before giving up, so a state
 	// with every conditional mode unavailable can't spin forever.
 	for range AllViewModes {
 		if !w.viewModeSelectable(next) {
@@ -163,7 +165,11 @@ func (w *World) viewModeSelectable(m ViewMode) bool {
 	case ViewTarget:
 		return w.Target.Kind == TargetBody
 	case ViewSOIPass:
-		_, ok := w.LiveSOIPass()
+		// Any upcoming pass — the planted (node-modified) one while flying a
+		// transfer whose pre-burn orbit can't yet reach the body, else the live
+		// pass (issue #144). Gating on LiveSOIPass alone made the view
+		// unreachable during exactly the planted transfer it's most useful for.
+		_, ok := w.bestSOIPass()
 		return ok
 	}
 	return true

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -390,6 +390,20 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			v.canvas.FitTo(pRadius)
 		}
 	}
+	// Encounter framing for the ordinary focus paths (issue #144): ViewTarget /
+	// ViewSOIPass override the camera above; for every other view, when the
+	// focused body has an upcoming SOI pass, center on the predicted encounter
+	// (drawn at the body's *arrival* position, not its current one) and fit to
+	// the drawn arc's extent so the capture curve fills the canvas. Refits every
+	// frame like the two view overrides, so a burn planted *after* focusing the
+	// body still snaps the curve into frame regardless of focus-vs-plant
+	// ordering — the fitted-gate at the top of Render only refits on focus change.
+	if w.ViewMode != sim.ViewTarget && w.ViewMode != sim.ViewSOIPass {
+		if eCenter, eRadius, ok := w.FocusEncounterFraming(); ok {
+			center = eCenter
+			v.canvas.FitTo(eRadius)
+		}
+	}
 	v.canvas.Center(center)
 
 	// Dotted orbit ellipses for each body with a nonzero semimajor axis.

--- a/internal/tui/screens/orbit_soipass_view_test.go
+++ b/internal/tui/screens/orbit_soipass_view_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
@@ -44,6 +45,41 @@ func TestViewSOIPassRefitsToPassBody(t *testing.T) {
 	}
 	if !strings.Contains(out, "SOI PASS") {
 		t.Errorf("SOI PASS chip should render in ViewSOIPass with no Target set")
+	}
+}
+
+// TestPlainViewFocusBodyCentersOnEncounter is the screen-level regression for
+// the #144 playtest path: "focus on Cursor" in an ordinary view (ViewTilted —
+// not the v-cycle ViewTarget/ViewSOIPass). With an upcoming encounter the
+// canvas must re-center on the body's *arrival* position so the capture curve
+// is on-canvas, not its *current* position (off by the heliocentric transit
+// translation — the curve "not displayed until the maneuvers finish").
+func TestPlainViewFocusBodyCentersOnEncounter(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := setupMoonCoast(t, w)
+	moon := w.System().Bodies[moonIdx]
+
+	// Ordinary view, focused on the Moon — the plain "look at the body" case.
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	v.Render(w, 0, 200, 60)
+
+	got := v.canvas.CenterWorld()
+	eCenter, _, ok := w.FocusEncounterFraming()
+	if !ok {
+		t.Fatal("FocusEncounterFraming ok=false on the Moon coast; expected an encounter")
+	}
+	if d := got.Sub(eCenter).Norm(); d > 1 {
+		t.Errorf("canvas centered %.0f km off the encounter frame; the override didn't fire in ViewTilted", d/1e3)
+	}
+	// And that center is nowhere near the Moon's *current* position (the bug).
+	soi := physics.SOIRadius(moon, w.System().Bodies[0])
+	if d := got.Sub(w.BodyPosition(moon)).Norm(); d <= soi {
+		t.Errorf("canvas centered on the Moon's current position (%.0f km, SOI %.0f km) — #144 not fixed", d/1e3, soi/1e3)
 	}
 }
 

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -573,6 +573,10 @@ func (c *Canvas) Rows() int { return c.rows }
 // Center sets the world coordinate that maps to the pixel grid center.
 func (c *Canvas) Center(w orbital.Vec3) { c.centerW = w }
 
+// CenterWorld returns the world coordinate currently mapped to the pixel grid
+// center (the inverse of Center). Test/diagnostic accessor.
+func (c *Canvas) CenterWorld() orbital.Vec3 { return c.centerW }
+
 // Scale returns the current pixels-per-meter.
 func (c *Canvas) Scale() float64 { return c.scale }
 


### PR DESCRIPTION
Fixes #144.

## The bug

The encounter view (`ViewSOIPass` / `ViewTarget`) and the plain "focus the body" path all centered the camera on the body's **current** position, while the predicted capture orbit is drawn at the body's **arrival** position. In the system frame the two diverge by the body's transit motion during the transfer — **269,512 km** for Kern→Cursor (~169× the old zoom radius) — so "focus on Cursor" showed an empty frame until the maneuvers physically finished. Correct prediction, wrong framing.

## The fix

Centering on the encounter alone wasn't enough — `/verify` rendering surfaced two deeper facts the issue's "fit to the SOI" direction didn't anticipate:

1. **The arc is not a tight conic in the system frame.** The body keeps moving through the pass, so the in-SOI hyperbola is smeared along the body's path across **~24× the SOI** (measured, Kern→Cursor). Fitting to the SOI frames a single point — verified by rendering a blank canvas.
2. **#143 was load-bearing.** The SOI radius used `Bodies[0]` (the system root, not the body's parent), giving a garbage 15 km radius for Cursor. The old craft-distance widening masked it; encounter-fit exposed it.

So `framePass` centers on the pass's `PerilunePoint` (a drawn arc sample) and fits to the **arc's actual extent**. This frames the whole drawn encounter and sidesteps `SOIRadius` entirely — leaving **#143 a separate, no-longer-blocking cleanup** (kept separate per request).

Applied to all three framers:
- `TargetViewFraming` / `SOIPassViewFraming` — encounter frame when a pass exists, else the pre-encounter approach frame (current position + craft-distance widening).
- `FocusEncounterFraming` + a new orbit-screen override — the same framing for ordinary views (the playtest "focus on Cursor" path), per the request to cover any view with the orbit visible.

**Second gap closed:** `bestSOIPass` sources the planted (node-modified) pass when nodes exist, so `ViewSOIPass` is now reachable — and centered on the encounter — while flying a planted transfer, where the pre-burn `LiveSOIPass` is false.

## Verification

Rendered the real Kern→Cursor repro: the dotted encounter arc + ⊕ perilune marker now fill the canvas (was completely off-canvas/empty before).

Tests added/updated:
- Arc framing centers near the arrival position and far from the current one (sim layer + screen render).
- `ViewSOIPass` selectable + reachable via the `v` cycle during a planted transfer.
- The fit covers every arc sample without widening to the distant craft.

`go vet ./...` clean; `go test ./... -race -count=1` → 1111 passed.

## Scope notes
- **#143** (the `Bodies[0]` SOI-floor) is intentionally left separate — it no longer blocks anything now that encounter framing doesn't use `SOIRadius`. The pre-encounter approach fallback still uses the old root-relative SOI (masked by widening, as before).
- Target a **v0.18.1** point release (v0.18.0 regression-class bug).