### PR TITLE
feat(view): retire ViewLaunch auto-release (#148)

### DIFF
--- a/internal/sim/launch_route_test.go
+++ b/internal/sim/launch_route_test.go
@@ -1,7 +1,9 @@
-// Package sim — v0.11.0 Slice 1 regression suite for the ViewLaunch
-// route/release state machine. Tests exercise the per-tick handler
+// Package sim — regression suite for the ViewLaunch route/release
+// state machine (v0.11.0 Slice 1). Tests exercise the per-tick handler
 // installed in World.Tick that detects active-slot Landed-false→true
-// transitions and apo-crossing auto-release.
+// transitions, plus the ADR 0021 D contract that no ambient sim state
+// ends a session — leaving the chase cam is a manual `v` cycle (or a
+// player-initiated switch onto a flying vessel).
 package sim
 
 import (
@@ -18,7 +20,7 @@ import (
 // Landed=true), the next World.Tick fires the per-tick route handler:
 // ViewMode switches to ViewLaunch, a session opens
 // (LaunchSessionActive=true), and the prior ViewMode is stashed in
-// PrevViewMode so auto-release can later restore it.
+// PrevViewMode so the switch-end release can later restore it.
 //
 // Proves the path end-to-end: the route handler is wired into
 // World.Tick, the Landed-transition detection (wasActiveLanded
@@ -124,79 +126,6 @@ func TestLaunchRouteSeedsSessionState(t *testing.T) {
 	}
 }
 
-// TestLaunchAutoReleaseAtApoFloor — when the active craft is in
-// a circular orbit whose apoapsis is clear of the atmosphere and whose
-// circularisation Δv is within the cap, the per-tick handler's
-// auto-release predicate fires: PrevViewMode is restored to ViewMode,
-// LaunchSessionActive flips false, and the session-scoped state (T0,
-// MaxQ, trail, zoom) clears so the next route doesn't see stale data.
-//
-// The release predicate (launchAscentNearlyOrbital) is deliberately
-// stricter than the ORBIT READY / LaunchAnchor LaunchMissionFloorM gate:
-// it also requires the ascent to be near circularisation (see
-// TestLaunchNoReleaseWhenEccentric / TestLaunchReleaseWithinCircDvCap).
-// A 201 km circular orbit satisfies both halves (apo 201 km > Earth's
-// 150 km atmosphere cutoff; Δv→circ = 0).
-func TestLaunchAutoReleaseAtApoFloor(t *testing.T) {
-	w, err := NewWorld()
-	if err != nil {
-		t.Fatalf("NewWorld: %v", err)
-	}
-	earth := w.Systems[0].FindBody("earth")
-	if earth == nil {
-		t.Fatal("setup: earth not found in default system")
-	}
-	mu := earth.GravitationalParameter()
-	primaryR := earth.RadiusMeters()
-
-	// 201 km circular orbit — apoAlt = 201 km, just past the 200 km
-	// floor. Same construction pattern as launch_anchor_test.go's
-	// `craftAt` helper.
-	r := primaryR + 201_000
-	v := math.Sqrt(mu / r)
-	c := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
-	c.Primary = *earth
-	c.State = physics.StateVector{
-		R: orbital.Vec3{X: r},
-		V: orbital.Vec3{Y: v},
-		M: c.TotalMass(),
-	}
-	// Replace the default LEO craft with our synthesized 201 km craft.
-	w.Crafts = []*spacecraft.Spacecraft{c}
-	w.ActiveCraftIdx = 0
-
-	// Plant the world mid-session: route already fired, ViewMode is
-	// ViewLaunch, PrevViewMode remembers ViewTop.
-	w.LaunchSessionActive = true
-	w.PrevViewMode = ViewTop
-	w.ViewMode = ViewLaunch
-	w.LaunchT0 = w.Clock.SimTime
-	w.LaunchMaxQ = 1234.0
-	w.LaunchTrail = []TrailPoint{{LatDeg: 5, LonDeg: 6, AltM: 100_000}}
-	w.LaunchZoom = 0.5
-
-	w.Tick()
-
-	if w.LaunchSessionActive {
-		t.Error("after apo>floor + Tick: LaunchSessionActive still true, want false (auto-release)")
-	}
-	if w.ViewMode != ViewTop {
-		t.Errorf("ViewMode = %v, want ViewTop (restored from PrevViewMode)", w.ViewMode)
-	}
-	if w.LaunchMaxQ != 0 {
-		t.Errorf("LaunchMaxQ = %v, want 0 (release must clear)", w.LaunchMaxQ)
-	}
-	if w.LaunchZoom != 0 {
-		t.Errorf("LaunchZoom = %v, want 0 (release must clear)", w.LaunchZoom)
-	}
-	if len(w.LaunchTrail) != 0 {
-		t.Errorf("LaunchTrail len = %d, want 0 (release must clear)", len(w.LaunchTrail))
-	}
-	if !w.LaunchT0.IsZero() {
-		t.Errorf("LaunchT0 = %v, want zero (release must clear)", w.LaunchT0)
-	}
-}
-
 // launchSessionCraftAtApo plants the world mid-ViewLaunch-session with a
 // single active craft sitting AT apoapsis: position (R+apoAltM, 0, 0)
 // with a purely tangential velocity equal to the local circular speed
@@ -235,114 +164,33 @@ func launchSessionCraftAtApo(t *testing.T, apoAltM, dvToCircMS float64) (*World,
 	return w, orbital.ElementsFromState(c.State.R, c.State.V, mu)
 }
 
-// TestLaunchNoReleaseWhenEccentric — an orbit whose apoapsis is well
-// clear of the atmosphere but whose circularisation Δv exceeds the cap
-// (an ascent that has raised apoapsis but not yet built orbital speed)
-// must NOT auto-release: the chase-cam stays until the upper stage is
-// near circularisation.
-func TestLaunchNoReleaseWhenEccentric(t *testing.T) {
-	// 300 km apoapsis (> 150 km atmosphere), Δv→circ 1000 m/s (> 750 cap).
-	w, el := launchSessionCraftAtApo(t, 300_000, 1000)
+// TestLaunchNoAutoReleaseWhenOrbital — ADR 0021 D pin. A mid-session
+// ascent that goes fully orbital (apoapsis well clear of the
+// atmosphere, circular — the strongest trigger of the retired
+// apoapsis-floor auto-release) must NOT change ViewMode or end the
+// session: the chase cam stays until the player cycles `v`. Before
+// ADR 0021 this exact state restored PrevViewMode.
+func TestLaunchNoAutoReleaseWhenOrbital(t *testing.T) {
+	// 300 km circular orbit (apo > 150 km atmosphere cutoff, Δv→circ 0).
+	w, el := launchSessionCraftAtApo(t, 300_000, 0)
 	if el.E >= 1 || el.A <= 0 {
 		t.Fatalf("setup: orbit not bound (e=%.3f, a=%.0f)", el.E, el.A)
 	}
+	t0Before := w.LaunchT0
 
 	w.Tick()
 
 	if !w.LaunchSessionActive {
-		t.Error("eccentric ascent (Δv→circ 1000 > 750): session auto-released, want it to stay active")
+		t.Error("orbital ascent ended the session, want it to stay active (auto-release is retired)")
 	}
 	if w.ViewMode != ViewLaunch {
-		t.Errorf("ViewMode = %v, want ViewLaunch (no release until near circularisation)", w.ViewMode)
+		t.Errorf("ViewMode = %v, want ViewLaunch (no ambient sim state may change the view)", w.ViewMode)
 	}
-}
-
-// TestLaunchReleaseWithinCircDvCap — once the apoapsis is clear of the
-// atmosphere AND the circularisation Δv falls within the cap, the
-// session auto-releases even though the orbit is not perfectly circular.
-func TestLaunchReleaseWithinCircDvCap(t *testing.T) {
-	// 300 km apoapsis, Δv→circ 500 m/s (< 750 cap).
-	w, _ := launchSessionCraftAtApo(t, 300_000, 500)
-	w.Tick()
-
-	if w.LaunchSessionActive {
-		t.Error("ascent within Δv→circ cap (500 < 750): session still active, want auto-release")
+	if !w.LaunchT0.Equal(t0Before) {
+		t.Errorf("LaunchT0 changed %v → %v, want untouched (no release fired)", t0Before, w.LaunchT0)
 	}
-	if w.ViewMode != ViewTop {
-		t.Errorf("ViewMode = %v, want ViewTop (restored from PrevViewMode)", w.ViewMode)
-	}
-}
-
-// TestLaunchNoReleaseApoInsideAtmosphere — even a circular orbit whose
-// apoapsis is still inside the atmosphere must NOT auto-release: drag
-// would decay it, so it isn't a real orbit yet. Guards the atmosphere
-// half of the predicate independently of the Δv half.
-func TestLaunchNoReleaseApoInsideAtmosphere(t *testing.T) {
-	// 120 km apoapsis (< 150 km cutoff), circular (Δv→circ 0).
-	w, _ := launchSessionCraftAtApo(t, 120_000, 0)
-	w.Tick()
-
-	if !w.LaunchSessionActive {
-		t.Error("apoapsis inside the atmosphere: session auto-released, want it to stay active")
-	}
-	if w.ViewMode != ViewLaunch {
-		t.Errorf("ViewMode = %v, want ViewLaunch (apoapsis still in atmosphere)", w.ViewMode)
-	}
-}
-
-// TestLaunchAutoReleaseSkipsHyperbolic — a launch session whose
-// active craft is on a hyperbolic (e ≥ 1) or degenerate (a ≤ 0)
-// trajectory must NOT auto-release. Apoapsis is undefined on
-// hyperbolic orbits; the plan's contract is that the session stays
-// open until the trajectory becomes bound again (the player is in
-// a state they should be looking at anyway).
-//
-// Setup: craft at 100 km altitude with 1.5× local escape velocity,
-// guaranteeing e > 1.
-func TestLaunchAutoReleaseSkipsHyperbolic(t *testing.T) {
-	w, err := NewWorld()
-	if err != nil {
-		t.Fatalf("NewWorld: %v", err)
-	}
-	earth := w.Systems[0].FindBody("earth")
-	if earth == nil {
-		t.Fatal("setup: earth not found")
-	}
-	mu := earth.GravitationalParameter()
-	primaryR := earth.RadiusMeters()
-
-	r := primaryR + 100_000
-	vEsc := math.Sqrt(2 * mu / r)
-	v := vEsc * 1.5 // generously hyperbolic
-	c := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
-	c.Primary = *earth
-	c.State = physics.StateVector{
-		R: orbital.Vec3{X: r},
-		V: orbital.Vec3{Y: v},
-		M: c.TotalMass(),
-	}
-	// Pre-flight check: confirm the orbit is actually hyperbolic, so
-	// a future change to constants doesn't silently turn this test
-	// into a bound-orbit test that vacuously passes.
-	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-	if el.E < 1 {
-		t.Fatalf("setup: orbit not hyperbolic (e = %.3f); test cannot exercise the exempt branch", el.E)
-	}
-
-	w.Crafts = []*spacecraft.Spacecraft{c}
-	w.ActiveCraftIdx = 0
-	w.LaunchSessionActive = true
-	w.PrevViewMode = ViewTop
-	w.ViewMode = ViewLaunch
-	w.LaunchT0 = w.Clock.SimTime
-
-	w.Tick()
-
-	if !w.LaunchSessionActive {
-		t.Error("hyperbolic orbit: session was auto-released, want it to stay active")
-	}
-	if w.ViewMode != ViewLaunch {
-		t.Errorf("ViewMode = %v, want ViewLaunch (no release on hyperbolic)", w.ViewMode)
+	if w.LastLaunchReleaseEvent != nil {
+		t.Errorf("LastLaunchReleaseEvent = %+v, want nil (no release toast without a release)", w.LastLaunchReleaseEvent)
 	}
 }
 
@@ -353,9 +201,8 @@ func TestLaunchAutoReleaseSkipsHyperbolic(t *testing.T) {
 // ViewTilted), matching the player's mental model: cycle = move
 // forward, not "go back."
 //
-// Auto-release will not fire again for this session even if apo
-// later crosses the floor — the sentinel is cleared, the player has
-// taken over view selection.
+// With ADR 0021 D this manual cycle is THE way out of the chase cam —
+// the sentinel clears and the player owns view selection from here.
 func TestManualCycleClearsSessionWithoutRestore(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -380,13 +227,14 @@ func TestManualCycleClearsSessionWithoutRestore(t *testing.T) {
 	}
 }
 
-// TestManualLaunchEntryNeverAutoReleases — a player who cycles into
+// TestManualLaunchEntryStaysPut — a player who cycles into
 // ViewLaunch outside of a session (LaunchSessionActive == false)
-// gets a standalone chase-cam view: the auto-release predicate
-// stays gated off, even when the active craft's apoapsis exceeds
-// LaunchMissionFloorM. Locks the contract that auto-release only
-// fires for *route-opened* sessions, not manually-entered views.
-func TestManualLaunchEntryNeverAutoReleases(t *testing.T) {
+// gets a standalone chase-cam view: the view stays put and no
+// session opens, even when the active craft is already orbital
+// (apoapsis past LaunchMissionFloorM). Pre-ADR-0021 this locked the
+// session gate on the auto-release predicate; with the release
+// retired it pins that ticking a manual entry perturbs nothing.
+func TestManualLaunchEntryStaysPut(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -395,8 +243,8 @@ func TestManualLaunchEntryNeverAutoReleases(t *testing.T) {
 	mu := earth.GravitationalParameter()
 	primaryR := earth.RadiusMeters()
 
-	// 201 km circular orbit — would trigger auto-release if a session
-	// were active.
+	// 201 km circular orbit — past the old apoapsis floor, so this
+	// would have been the strongest release trigger pre-ADR-0021.
 	r := primaryR + 201_000
 	v := math.Sqrt(mu / r)
 	c := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
@@ -518,9 +366,10 @@ func TestSwitchInSessionToLandedHandsOff(t *testing.T) {
 // PrevViewMode, session state clears. Player gets their saved view
 // back, focused on the new flying vessel.
 //
-// Critically the substitute vessel orbits at <200km apo, so the
-// auto-release predicate cannot fire and cover for an unimplemented
-// end-branch — the test isolates the switch handler's end quadrant.
+// The substitute vessel orbits at <200km apo — historically that kept
+// the (since-retired, ADR 0021 D) auto-release from covering for an
+// unimplemented end-branch; today the switch handler is the only
+// sim-side release, so the test isolates it by construction.
 func TestSwitchInSessionToFlyingEndsSession(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -530,9 +379,9 @@ func TestSwitchInSessionToFlyingEndsSession(t *testing.T) {
 	mu := earth.GravitationalParameter()
 	primaryR := earth.RadiusMeters()
 
-	// Replace the default LEO craft (apo > 200km would let auto-release
-	// fake the end behavior) with a 100km-circular craft — well below
-	// LaunchMissionFloorM so auto-release stays off.
+	// Replace the default LEO craft with a 100km-circular craft —
+	// below LaunchMissionFloorM (kept from the pre-ADR-0021 setup;
+	// harmless now that no apoapsis-floor release exists).
 	r := primaryR + 100_000
 	v := math.Sqrt(mu / r)
 	cLow := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
@@ -599,8 +448,9 @@ func TestSwitchNotInSessionToLandedOpensFreshSession(t *testing.T) {
 	mu := earth.GravitationalParameter()
 	primaryR := earth.RadiusMeters()
 
-	// Replace default LEO with a 100km craft so auto-release doesn't
-	// muddy the switch-handler behavior.
+	// Replace default LEO with a 100km craft (kept from the
+	// pre-ADR-0021 setup, when the apoapsis-floor auto-release could
+	// muddy switch-handler behavior).
 	r := primaryR + 100_000
 	v := math.Sqrt(mu / r)
 	cLow := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
@@ -666,9 +516,8 @@ func TestSwitchBetweenFlyingVesselsIsNoOp(t *testing.T) {
 	mu := earth.GravitationalParameter()
 	primaryR := earth.RadiusMeters()
 
-	// Two crafts at sub-floor circular orbits (well below the 200km
-	// auto-release predicate). Replace default idx 0 + a second
-	// craft appended at idx 1.
+	// Two crafts at low circular orbits. Replace default idx 0 + a
+	// second craft appended at idx 1.
 	craftAt := func(altM float64) *spacecraft.Spacecraft {
 		r := primaryR + altM
 		v := math.Sqrt(mu / r)
@@ -710,13 +559,13 @@ func TestSwitchBetweenFlyingVesselsIsNoOp(t *testing.T) {
 // with `ViewMode=ViewLaunch` and `LaunchSessionActive=false`. The
 // first post-load tick then re-fires routeToLaunchView on the
 // Landed vessel — and without a guard would capture
-// `PrevViewMode = ViewLaunch`, making auto-release a no-op when apo
-// later crosses the floor (the screen would stay on LAUNCH forever).
+// `PrevViewMode = ViewLaunch`, making the switch-end release a no-op
+// (it would "restore" back to ViewLaunch).
 //
 // Guard contract: when ViewMode is already ViewLaunch at the moment
 // of route, leave PrevViewMode at whatever it was (its zero value,
-// ViewTilted, on a fresh post-load World). Subsequent auto-release
-// restores to that non-ViewLaunch fallback.
+// ViewTilted, on a fresh post-load World). A subsequent switch-end
+// release restores to that non-ViewLaunch fallback.
 func TestLaunchRouteIgnoresViewLaunchAsPrevView(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -745,7 +594,7 @@ func TestLaunchRouteIgnoresViewLaunchAsPrevView(t *testing.T) {
 		t.Fatal("post-load tick: route handler didn't open a session, can't exercise the guard")
 	}
 	if w.PrevViewMode == ViewLaunch {
-		t.Errorf("PrevViewMode = ViewLaunch — guard failed; auto-release would later 'restore' back to ViewLaunch, a no-op")
+		t.Errorf("PrevViewMode = ViewLaunch — guard failed; a switch-end release would 'restore' back to ViewLaunch, a no-op")
 	}
 	if w.PrevViewMode != ViewTilted {
 		t.Errorf("PrevViewMode = %v, want ViewTilted (the zero-value fallback when guard suppresses the capture)", w.PrevViewMode)

--- a/internal/sim/launch_trail.go
+++ b/internal/sim/launch_trail.go
@@ -3,8 +3,8 @@
 // LaunchTrail is the body-fixed (lat, lon, alt, sampledAt) FIFO that
 // the chase-cam scene re-projects each render so the trace visibly
 // rotates with the body — the geographic launch site stays
-// geographic. Stored on World; cleared at session open / auto-release
-// / hand-off; survives a manual `v` cycle out + back.
+// geographic. Stored on World; cleared at session open / switch-end
+// release / hand-off; survives a manual `v` cycle out + back.
 //
 // Plan reference: designdocs/terminal-space-program/v0.11-plan.md → Slice v0.11.0 (Trail is
 // body-fixed locked decision).
@@ -29,8 +29,8 @@ type TrailPoint struct {
 
 // launchTrailCap is the FIFO cap on LaunchTrail. 256 points at the
 // 1 s sampling cadence give ~4 minutes of trail — long enough to
-// cover the full ascent from pad to the 200 km auto-release floor
-// at typical climb profiles. Older samples evict from the front.
+// cover the full ascent from pad to a ~200 km apoapsis at typical
+// climb profiles. Older samples evict from the front.
 const launchTrailCap = 256
 
 // launchTrailIntervalSec is the minimum sim-time gap between

--- a/internal/sim/launch_trail_test.go
+++ b/internal/sim/launch_trail_test.go
@@ -137,8 +137,8 @@ func TestLaunchTrailFIFOCap(t *testing.T) {
 // ViewLaunch clears the sentinel but must NOT clear LaunchTrail.
 // Player intuition: cycle out to OrbitView mid-ascent to read
 // instruments, cycle back to ViewLaunch and the breadcrumbs are
-// still there. Locks the asymmetry vs auto-release / hand-off,
-// which DO clear.
+// still there. Locks the asymmetry vs the switch-end release /
+// hand-off, which DO clear.
 func TestLaunchTrailSurvivesManualCycleOut(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -79,12 +79,14 @@ const (
 	// human-scale side view with the rocket centred, the horizon
 	// curving below in Body.SurfaceColor, and a body-fixed pad
 	// marker + breadcrumb trail. Routed into automatically on
-	// active-slot Landed-false→true transitions; auto-released when
-	// the ascent goes nearly orbital (apoapsis clear of the atmosphere
-	// and within the circularisation-Δv cap). Appended to
-	// the cycle (NOT prepended) so ViewTilted stays the zero-value
-	// default. ADR-0002 captures the rationale for shipping this as
-	// a distinct ViewMode instead of extending ViewTilted.
+	// active-slot Landed-false→true transitions (a named Camera
+	// Contract carve-out — it answers the player's launch command);
+	// left via a manual `v` cycle. ADR 0021 D retired the old
+	// apoapsis-floor auto-release — no ambient sim state moves the
+	// camera. Appended to the cycle (NOT prepended) so ViewTilted
+	// stays the zero-value default. ADR-0002 captures the rationale
+	// for shipping this as a distinct ViewMode instead of extending
+	// ViewTilted.
 	ViewLaunch
 )
 
@@ -132,10 +134,10 @@ var AllViewModes = [...]ViewMode{
 
 // CycleViewMode advances ViewMode to the next mode in cycle order.
 // Wraps around — modes are a small finite set. v0.11.0+: leaving
-// ViewLaunch via manual cycle clears LaunchSessionActive — the
-// player has taken over, no auto-release will fire even if apo
-// crosses the floor later. ViewMode still advances by one
-// (cycle semantics are *advance*, not *restore* PrevViewMode).
+// ViewLaunch via manual cycle clears LaunchSessionActive — and with
+// ADR 0021 D this `v` cycle is THE way out of the chase cam (the
+// apoapsis-floor auto-release is retired). ViewMode still advances
+// by one (cycle semantics are *advance*, not *restore* PrevViewMode).
 func (w *World) CycleViewMode() {
 	if w.ViewMode == ViewLaunch {
 		w.LaunchSessionActive = false
@@ -179,11 +181,11 @@ func (w *World) viewModeSelectable(m ViewMode) bool {
 // for the `V` (shift+v) keybinding: short-circuits the lowercase
 // `v` cycle and drops the player into ViewLaunch focused on the
 // active vessel. Stashes the prior ViewMode into PrevViewMode (so
-// the existing apo-floor auto-release can restore on liftoff) and
-// opens a session — same surface as routeToLaunchView, just
-// player-initiated rather than auto-routed. No active vessel is
-// not a precondition; the LaunchView.Render path covers the
-// nil-active case (sub-scope 5).
+// a switch-end release can restore it) and opens a session — same
+// surface as routeToLaunchView, just player-initiated rather than
+// auto-routed. Leaving is a manual `v` cycle (ADR 0021 D). No
+// active vessel is not a precondition; the LaunchView.Render path
+// covers the nil-active case (sub-scope 5).
 func (w *World) SetViewModeLaunch() {
 	w.routeToLaunchView()
 }

--- a/internal/sim/view_launch.go
+++ b/internal/sim/view_launch.go
@@ -3,28 +3,27 @@
 // ViewLaunch is the chase-cam launch scene routed into automatically
 // when an active vessel transitions Landed false→true (Launchpad
 // spawn today; future Touchdown semantics will extend the trigger).
-// Auto-release fires when the ascent is essentially orbital: the orbit's
-// apoapsis has climbed clear of the primary's atmosphere AND the
-// impulsive circularisation Δv at that apoapsis is within
-// LaunchCircularizeDvCapMS — so the player stays in the chase-cam until
-// the upper stage has built most of its orbital velocity, then hands off
-// to the orbit view. (The ORBIT READY callout and the ViewTilted
-// LaunchAnchor keep their own LaunchMissionFloorM gate; this release is
-// deliberately stricter.)
+// Leaving the chase cam is a manual `v` cycle — ADR 0021 D retired the
+// apoapsis-floor auto-release, the one camera change driven by ambient
+// sim state. (The ORBIT READY callout and the ViewTilted LaunchAnchor
+// keep their LaunchMissionFloorM gate; only the view restore went.)
+// A session still ends without a `v` press when the player switches
+// active onto a flying vessel — that restore answers the player's
+// switch, not ambient sim state.
 //
 // This file owns the per-tick handler called from World.Tick and the
 // session-open/close helpers. Render-side (the chase-cam scene
 // itself) lives in internal/tui/screens/launch.go.
 //
 // Plan reference: designdocs/terminal-space-program/v0.11-plan.md → Slice v0.11.0.
-// Architectural rationale: designdocs/terminal-space-program/adr/0002-launch-view-as-distinct-viewmode.md.
+// Architectural rationale: designdocs/terminal-space-program/adr/0002-launch-view-as-distinct-viewmode.md
+// (auto-release clause superseded by adr/0021-player-owned-camera-local-to-body-arcs.md, decision D).
 package sim
 
 import (
 	"math"
 	"time"
 
-	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -33,13 +32,13 @@ import (
 // ViewLaunch. Called from World.Tick after integration so the
 // authoritative post-tick Landed state is visible.
 //
-// v0.11.0 Slice 1 tracer-bullet shape: detects the Landed-false→true
-// transition on the active craft and routes into ViewLaunch by
-// opening a session; releases the session when the orbit's apoapsis
-// crosses LaunchMissionFloorM (parity with v0.10.7's
-// LaunchAnchorPhi predicate). Subsequent slice-time tests will
-// extend this with the active-switch handler, manual-cycle clearing,
-// and pointer-keyed shadow disambiguation.
+// Detects the Landed-false→true transition on the active craft and
+// routes into ViewLaunch by opening a session; dispatches the
+// active-switch handler on pointer changes; samples the breadcrumb
+// trail while a session is open. There is no ambient release — ADR
+// 0021 D retired the apoapsis-floor auto-release, so the session ends
+// only on a manual `v` cycle (CycleViewMode) or a switch onto a
+// flying vessel (handleActiveCraftSwitch's end branch).
 func (w *World) tickLaunchView() {
 	active := w.ActiveCraft()
 
@@ -72,17 +71,14 @@ func (w *World) tickLaunchView() {
 		w.routeToLaunchView()
 	}
 
-	// 3. Auto-release once the ascent is essentially orbital (apoapsis
-	// clear of the atmosphere AND within the circularisation Δv cap).
-	// Gated on LaunchSessionActive so a manually-entered ViewLaunch (no
-	// session) stays put even when the predicate is satisfied.
-	if w.LaunchSessionActive && active != nil && launchAscentNearlyOrbital(active) {
-		w.releaseLaunchSession()
-	}
+	// 3. (Retired) Auto-release. Pre-ADR-0021 a session ended here when
+	// the ascent went nearly orbital (apoapsis clear of the atmosphere
+	// AND within a circularisation-Δv cap). ADR 0021 D retired it: the
+	// chase cam stays until the player cycles `v` — no ambient sim
+	// state moves the camera.
 
 	// 4. Trail sampling — gated on LaunchSessionActive (no breadcrumbs
-	// outside a real session). Runs after release so a freshly-
-	// released session doesn't sample one last point on the way out.
+	// outside a real session).
 	if w.LaunchSessionActive {
 		w.maybeSampleLaunchTrail()
 		w.updateLaunchMaxQ()
@@ -126,8 +122,9 @@ func (w *World) handleActiveCraftSwitch(newActive *spacecraft.Spacecraft) {
 		w.LaunchZoom = 0
 	case inSession && !newLanded:
 		// End: player switched onto a flying vessel mid-session.
-		// Restore PrevViewMode and clear all session state. Same
-		// effect as auto-release without the apo-floor predicate.
+		// Restore PrevViewMode and clear all session state. This is
+		// the only sim-side session end left after ADR 0021 D — it
+		// answers the player's switch, not ambient sim state.
 		w.releaseLaunchSession()
 	case !inSession && newLanded && newOnPad:
 		// Fresh inline session: player switched onto a fresh
@@ -148,49 +145,6 @@ func (w *World) handleActiveCraftSwitch(newActive *spacecraft.Spacecraft) {
 	// is moving between flying vessels with no launch state on either.
 }
 
-// LaunchCircularizeDvCapMS is the impulsive circularisation-Δv budget
-// (m/s) at or below which an ascent counts as "essentially orbital" —
-// the second half of the ViewLaunch auto-release predicate (the first
-// being an apoapsis clear of the atmosphere). At ~750 m/s the upper
-// stage has built nearly all of its orbital velocity, so the chase-cam
-// has served its purpose and the orbit view takes over. Chosen to be
-// comfortably above a clean low-orbit circularisation burn yet well
-// below the multi-km/s gap of an ascent still mid-gravity-turn.
-const LaunchCircularizeDvCapMS = 750.0
-
-// launchAscentNearlyOrbital reports whether the craft's current orbit is
-// far enough along to release the ViewLaunch session: its apoapsis sits
-// above the primary's atmosphere (above the surface for an airless body)
-// AND the impulsive circularisation Δv at that apoapsis is within
-// LaunchCircularizeDvCapMS. Hyperbolic / degenerate orbits (a ≤ 0,
-// e ≥ 1) return false — apoapsis is undefined there, and the session
-// stays open until the trajectory becomes bound.
-func launchAscentNearlyOrbital(c *spacecraft.Spacecraft) bool {
-	mu := c.Primary.GravitationalParameter()
-	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-	// Apoapsis undefined on unbound / degenerate orbits.
-	if el.A <= 0 || el.E >= 1 {
-		return false
-	}
-	rApo := el.Apoapsis()
-	apoAlt := rApo - c.Primary.RadiusMeters()
-	// 1. Apoapsis must clear the atmosphere so drag can't decay it
-	// (above the surface for an airless body, where atmTop = 0).
-	atmTop := 0.0
-	if c.Primary.Atmosphere != nil {
-		atmTop = c.Primary.Atmosphere.CutoffAltitude
-	}
-	if apoAlt <= atmTop {
-		return false
-	}
-	// 2. Impulsive circularisation Δv at apoapsis: vis-viva speed there
-	// vs. the local circular speed (mirrors the LAUNCH HUD's Δv→circ
-	// readout in tui/screens/orbit.go). A circular orbit reads 0.
-	vApo := math.Sqrt(mu * (2/rApo - 1/el.A))
-	vCirc := math.Sqrt(mu / rApo)
-	return vCirc-vApo <= LaunchCircularizeDvCapMS
-}
-
 // LaunchReleaseEvent records a ViewLaunch session ending so the App's
 // status flash can surface a `"ORBIT READY — returning to <prev view>"`
 // toast. Same shape as LastDockEvent — App reads and clears.
@@ -201,9 +155,9 @@ type LaunchReleaseEvent struct {
 // releaseLaunchSession ends the current session: stamps the toast
 // event with the restored ViewMode's label, restores ViewMode to
 // PrevViewMode, clears the sentinel, and zeroes all session-scoped
-// state so the next route handler entry sees a clean slate. Called
-// from tickLaunchView when the auto-release predicate fires; also
-// invoked from the active-switch handler's "end" branch.
+// state so the next route handler entry sees a clean slate. Invoked
+// from the active-switch handler's "end" branch (ADR 0021 D retired
+// the per-tick apoapsis-floor auto-release that used to call this).
 func (w *World) releaseLaunchSession() {
 	w.LastLaunchReleaseEvent = &LaunchReleaseEvent{PrevView: w.PrevViewMode.String()}
 	w.ViewMode = w.PrevViewMode
@@ -269,12 +223,12 @@ func (w *World) NudgeLaunchZoom(dir int, currentAutoScale float64) {
 }
 
 // routeToLaunchView opens a fresh ViewLaunch session. Stashes the
-// current ViewMode in PrevViewMode so auto-release can later restore
-// it, sets the sentinel, switches ViewMode, and seeds the rest of
-// the session-scoped state: stamps LaunchT0 to current sim-time
-// (HUD T+ anchor), zeroes LaunchMaxQ, clears the breadcrumb trail,
-// resets LaunchZoom to auto. Idempotent guard lives in the caller
-// (tickLaunchView checks !LaunchSessionActive).
+// current ViewMode in PrevViewMode so the switch-end release can
+// later restore it, sets the sentinel, switches ViewMode, and seeds
+// the rest of the session-scoped state: stamps LaunchT0 to current
+// sim-time (HUD T+ anchor), zeroes LaunchMaxQ, clears the breadcrumb
+// trail, resets LaunchZoom to auto. Idempotent guard lives in the
+// caller (tickLaunchView checks !LaunchSessionActive).
 //
 // The `ViewMode != ViewLaunch` guard on the PrevViewMode capture
 // matters for save-load: persisted saves carry ViewMode but not
@@ -282,9 +236,9 @@ func (w *World) NudgeLaunchZoom(dir int, currentAutoScale float64) {
 // ViewMode=ViewLaunch and LaunchSessionActive=false. The first
 // post-load tick then re-fires this handler on the already-Landed
 // vessel; without the guard, PrevViewMode would capture ViewLaunch
-// and auto-release would later "restore" to ViewLaunch (a no-op).
-// Leaving PrevViewMode at its zero value (ViewTilted) on this path
-// is the correct fallback.
+// and the switch-end release would later "restore" to ViewLaunch
+// (a no-op). Leaving PrevViewMode at its zero value (ViewTilted) on
+// this path is the correct fallback.
 func (w *World) routeToLaunchView() {
 	if w.ViewMode != ViewLaunch {
 		w.PrevViewMode = w.ViewMode

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -62,10 +62,11 @@ type World struct {
 	LastDockEvent *DockEvent
 
 	// LastLaunchReleaseEvent records the most recent ViewLaunch
-	// auto-release / hand-off-end so the App can surface an
+	// switch-end release so the App can surface an
 	// `"ORBIT READY — returning to <prev view>"` toast. Cleared by
 	// app.go after the message fires; same pattern as LastDockEvent.
-	// v0.11.0+.
+	// v0.11.0+ (the apoapsis-floor auto-release that also stamped
+	// this was retired by ADR 0021 D).
 	LastLaunchReleaseEvent *LaunchReleaseEvent
 
 	// Focus selects what the OrbitView canvas is centered on. Zero value
@@ -103,9 +104,9 @@ type World struct {
 
 	// LaunchSessionActive is the v0.11.0+ ViewLaunch session sentinel.
 	// True between the per-tick route handler firing on an active-slot
-	// Landed-false→true transition and the auto-release (ascent goes
-	// nearly orbital — apoapsis clear of the atmosphere and within the
-	// circularisation-Δv cap) or manual `v` cycle out. Distinguished from
+	// Landed-false→true transition and the manual `v` cycle out (or a
+	// switch onto a flying vessel — ADR 0021 D retired the apoapsis-
+	// floor auto-release). Distinguished from
 	// PrevViewMode because PrevViewMode's zero value (ViewTilted)
 	// collides with "no session" — the boolean is the unambiguous
 	// signal that session-scoped state (PrevViewMode, LaunchT0,
@@ -115,7 +116,8 @@ type World struct {
 	LaunchSessionActive bool
 
 	// PrevViewMode is the ViewMode the player was in when the route
-	// handler routed into ViewLaunch — restored by auto-release.
+	// handler routed into ViewLaunch — restored by the switch-end
+	// release (a manual `v` cycle advances instead of restoring).
 	// Meaningful only when LaunchSessionActive == true. Not persisted.
 	PrevViewMode ViewMode
 
@@ -135,13 +137,13 @@ type World struct {
 	// alt) samples the chase-cam scene re-projects each render so the
 	// trace visibly rotates with the body. FIFO cap 256, sampled at
 	// 1 s sim-time cadence. Cleared by the route handler at session
-	// open and by the auto-release / hand-off. Not persisted.
+	// open and by the switch-end release / hand-off. Not persisted.
 	LaunchTrail []TrailPoint
 
 	// LaunchZoom is the player's `+/-` zoom override for the chase-cam
 	// scene. 0 means auto-altitude-driven scale; non-zero pins the
-	// scale until session end (auto-release, switch-end, hand-off, or
-	// next route). Multiplicative ×0.8 per `+`, ×1.25 per `-`. Not
+	// scale until session end (manual `v` cycle, switch-end, hand-off,
+	// or next route). Multiplicative ×0.8 per `+`, ×1.25 per `-`. Not
 	// persisted.
 	LaunchZoom float64
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -161,8 +161,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.statusExpires = time.Now().Add(4 * time.Second)
 			a.world.LastDockEvent = nil
 		}
-		// v0.11.0+: ViewLaunch auto-release / hand-off toast. Same
-		// flash surface as docking; cleared after one fire.
+		// v0.11.0+: ViewLaunch switch-end release toast (ADR 0021 D
+		// retired the apoapsis-floor auto-release). Same flash
+		// surface as docking; cleared after one fire.
 		if e := a.world.LastLaunchReleaseEvent; e != nil {
 			a.statusMsg = fmt.Sprintf("ORBIT READY — returning to %s", e.PrevView)
 			a.statusExpires = time.Now().Add(4 * time.Second)


### PR DESCRIPTION
## What changed

ADR 0021 D (ViewLaunch part): the apoapsis-floor **auto-release** was the one camera change driven by ambient sim state. It's gone — reaching apoapsis past the mission floor (or full circularisation) during an ascent no longer touches `ViewMode`. Leaving the chase cam is a manual `v` cycle.

### Kept
- **Auto-route into ViewLaunch on pad launch** — named Camera Contract carve-out (answers the player's launch command). Unchanged.
- **`V` manual jump** (`SetViewModeLaunch`). Unchanged.
- **Switch-end release** — switching active onto a flying vessel mid-session still restores `PrevViewMode` (answers the player's switch, not ambient state). `releaseLaunchSession` and the `LaunchReleaseEvent` toast survive for this path.
- **`LaunchMissionFloorM` and its other consumers** — the ORBIT READY callout and the ViewTilted LaunchAnchor release keep their gate untouched.

### Deleted
- `tickLaunchView` step 3 (the per-tick auto-release call) in `internal/sim/view_launch.go`.
- `launchAscentNearlyOrbital` predicate + `LaunchCircularizeDvCapMS` — no other consumers.

### Tests
- New `TestLaunchNoAutoReleaseWhenOrbital` pins the new behavior: a mid-session ascent going fully orbital keeps `ViewMode == ViewLaunch`, keeps the session active, and stamps no release toast.
- Removed the four release-predicate tests (`TestLaunchAutoReleaseAtApoFloor`, `TestLaunchNoReleaseWhenEccentric`, `TestLaunchReleaseWithinCircDvCap`, `TestLaunchNoReleaseApoInsideAtmosphere`, `TestLaunchAutoReleaseSkipsHyperbolic`).
- Renamed `TestManualLaunchEntryNeverAutoReleases` → `TestManualLaunchEntryStaysPut`; refreshed stale comments across the launch state-machine files.

### Docs
F1 help overlay and README never described the auto-release (verified by grep), so no user-facing doc text changes were needed.

## Verification

- `go vet ./...` — clean
- `go test ./... -race -count=1` — 1108 passed in 15 packages

Closes #148