### PR TITLE
feat(predict): local-to-body arcs for foreign-SOI segments (#147)

### DIFF
--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -137,45 +137,34 @@ func (w *World) FocusZoomRadius() float64 {
 }
 
 // encounterFrame returns the camera center and auto-fit radius that frame body
-// b's predicted SOI-pass arc, when a pass reaches b. The orbit canvas draws the
-// arc at its system-frame (heliocentric) sample positions — at the body's
-// *arrival* location (where b will be when the craft reaches perilune), which
-// diverges from b's *current* position by the body's transit motion during the
-// transfer (dominated, in the system frame, by the parent translating along its
-// own orbit). For a short-period moon or a multi-day coast that gap dwarfs the
-// SOI, so centering on the current position leaves the drawn arc off-canvas
-// entirely — the #144 bug.
-//
-// Crucially the arc is NOT a tight conic in the system frame: the body keeps
-// moving through the pass, so the in-SOI hyperbola is smeared along the body's
-// path across many times the SOI (measured ~24× for Kern→Cursor). Fitting to
-// the SOI would frame a single point of it (verified by rendering an empty
-// canvas). So we center on PerilunePoint — itself a drawn arc sample — and fit
-// to the arc's actual extent (the farthest arc sample from that center, ×1.15),
-// which frames the whole drawn encounter and sidesteps SOIRadius entirely (and
-// with it the Bodies[0]-root SOI-floor of #143). ok=false when no pass reaches b
-// or it couldn't place its arc — callers then fall back to b's current position.
+// b's predicted SOI-pass arc, when a pass reaches b. The arc draws
+// Local-to-Body (ADR 0021 B): body-relative samples anchored at b's CURRENT
+// position, so the frame centers on the drawn perilune next to b's disk and
+// fits to the arc's SOI-scale extent. ok=false when no pass reaches b or it
+// couldn't place its arc — callers then fall back to b's current position.
 func (w *World) encounterFrame(b bodies.CelestialBody) (center orbital.Vec3, radius float64, ok bool) {
 	p, hit := w.bestSOIPass()
 	if !hit || p.Body.ID != b.ID || !p.HasPerilunePt {
 		return orbital.Vec3{}, 0, false
 	}
-	center, radius = framePass(p)
+	center, radius = w.framePass(p)
 	return center, radius, true
 }
 
-// framePass is the pure geometry behind encounterFrame: center on the pass's
-// PerilunePoint (a drawn arc sample) and fit to the arc's extent — the farthest
-// arc sample from that center, ×1.15 — so the whole drawn capture curve fills
-// the canvas. Falls back to a body-radius multiple for a degenerate single-point
-// arc. Takes an already-fetched pass so callers that have one (SOIPassViewFraming)
-// don't re-run the forward prediction. Caller guarantees p.HasPerilunePt.
-func framePass(p SOIPass) (center orbital.Vec3, radius float64) {
-	center = p.PerilunePoint
+// framePass is the geometry behind encounterFrame: center on the pass's drawn
+// Perilune (PerilunePosition — the Body's current position plus the relative
+// offset) and fit to the rebased arc's extent — the farthest body-relative
+// sample from the perilune offset, ×1.15 — so the whole drawn capture curve,
+// Body disk included, fills the canvas (ADR 0021 B). Falls back to a
+// body-radius multiple for a degenerate single-point arc. Takes an
+// already-fetched pass so callers that have one (SOIPassViewFraming) don't
+// re-run the forward prediction. Caller guarantees p.HasPerilunePt.
+func (w *World) framePass(p SOIPass) (center orbital.Vec3, radius float64) {
+	center = w.PerilunePosition(p)
 	var maxd float64
 	for _, s := range p.ArcSegments {
-		for _, pt := range s.Points {
-			if d := pt.Sub(center).Norm(); d > maxd {
+		for _, rel := range s.RelPoints {
+			if d := rel.Sub(p.PeriluneRel).Norm(); d > maxd {
 				maxd = d
 			}
 		}
@@ -188,12 +177,12 @@ func framePass(p SOIPass) (center orbital.Vec3, radius float64) {
 }
 
 // bodyApproachFraming frames body b for the approach views (ViewTarget /
-// ViewSOIPass). When an SOI pass reaches b it centers on the predicted
-// encounter arc and fits to its extent, so the drawn capture curve fills the
-// canvas at the body's *arrival* position — with no craft widening, since the
-// craft is a whole transfer away from that point and widening to it would shrink
-// the arc back to a dot (issue #144). With no pass it falls back to the
-// pre-encounter approach frame (current position + craft-distance widening).
+// ViewSOIPass). When an SOI pass reaches b it centers on the drawn encounter
+// arc — Local-to-Body, at b's current position (ADR 0021 B) — and fits to its
+// extent, with no craft widening, since the craft is a whole transfer away
+// and widening to it would shrink the arc back to a dot (issue #144). With no
+// pass it falls back to the pre-encounter approach frame (current position +
+// craft-distance widening).
 func (w *World) bodyApproachFraming(b bodies.CelestialBody) (center orbital.Vec3, radius float64, ok bool) {
 	if center, radius, hit := w.encounterFrame(b); hit {
 		return center, radius, true
@@ -224,9 +213,9 @@ func (w *World) bodyApproachFallback(b bodies.CelestialBody) (center orbital.Vec
 // predicted it centers on the body Target's current position and widens the fit
 // to the craft→target distance so the approach line stays in frame and zooms in
 // as the gap closes; once an SOI pass to the target resolves it centers on the
-// encounter arc (drawn at the body's arrival position) and fits to the arc's
-// extent so the capture curve fills the canvas (issue #144). ok=false when
-// there's no body target in the active system. v0.17.3+.
+// encounter arc (drawn Local-to-Body at the body's current position, ADR 0021
+// B) and fits to the arc's extent so the capture curve fills the canvas.
+// ok=false when there's no body target in the active system. v0.17.3+.
 func (w *World) TargetViewFraming() (center orbital.Vec3, radius float64, ok bool) {
 	if w.Target.Kind != TargetBody {
 		return orbital.Vec3{}, 0, false
@@ -257,7 +246,7 @@ func (w *World) SOIPassViewFraming() (center orbital.Vec3, radius float64, ok bo
 	// second forward prediction); fall back to the approach frame only when the
 	// pass couldn't place its arc.
 	if pass.HasPerilunePt {
-		center, radius = framePass(pass)
+		center, radius = w.framePass(pass)
 		return center, radius, true
 	}
 	return w.bodyApproachFallback(pass.Body)

--- a/internal/sim/focus_encounter_test.go
+++ b/internal/sim/focus_encounter_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
-// TestEncounterFramingCentersOnArrivalPosition is the regression for #144: a
-// planted Kern→Cursor transfer draws its capture geometry at Cursor's *arrival*
-// position (where Cursor will be when the craft gets there), but the framing
-// paths used to center on Cursor's *current* position. For a short-period moon
-// the two diverge by far more than the SOI, leaving the predicted capture curve
-// off-canvas — "focus on Cursor shows nothing until the maneuvers finish."
+// TestEncounterFramingCentersOnLocalArc: a planted Kern→Cursor transfer draws
+// its capture geometry Local-to-Body — body-relative samples anchored at
+// Cursor's CURRENT position (ADR 0021 B) — so the framing paths must center
+// on that drawn ink, next to Cursor's disk. (Pre-ADR-0021 the arc drew at its
+// heliocentric sample positions near Cursor's *arrival* point and the framers
+// chased it there — the #144 fix this supersedes.)
 //
 // All three encounter framers — FocusEncounterFraming (plain focus),
-// TargetViewFraming (ViewTarget), SOIPassViewFraming (ViewSOIPass) — must center
-// on the encounter (≈ the arrival position), not the current body position.
-func TestEncounterFramingCentersOnArrivalPosition(t *testing.T) {
+// TargetViewFraming (ViewTarget), SOIPassViewFraming (ViewSOIPass) — must
+// center within the SOI of Cursor's current position.
+func TestEncounterFramingCentersOnLocalArc(t *testing.T) {
 	w := mustWorld(t)
 	cursorIdx, kern, cursor := setupKernCursor(t, w)
 	if _, err := w.PlanTransfer(cursorIdx); err != nil {
@@ -41,24 +41,21 @@ func TestEncounterFramingCentersOnArrivalPosition(t *testing.T) {
 	current := w.BodyPosition(cursor)
 	soi := physics.SOIRadius(cursor, kern)
 
-	// Premise check: the bug only bites because Cursor moves much farther than
-	// its SOI during the transfer. If this ever fails the repro has gone stale.
+	// Premise check: the rebase only matters because Cursor moves much farther
+	// than its SOI during the transfer. If this ever fails the repro is stale.
 	if gap := arrival.Sub(current).Norm(); gap < 10*soi {
 		t.Fatalf("Cursor moved only %.0f km (SOI %.0f km) — repro premise gone", gap/1e3, soi/1e3)
 	}
 
-	// Every framer must land within the SOI of the arrival position (where the
-	// capture curve is drawn) and nowhere near the current position.
+	// Every framer must land within the SOI of Cursor's CURRENT position —
+	// where the Local-to-Body arc and the body's disk are drawn.
 	check := func(name string, center orbital.Vec3, ok bool) {
 		if !ok {
 			t.Errorf("%s returned ok=false; expected an encounter frame", name)
 			return
 		}
-		if d := center.Sub(arrival).Norm(); d > soi {
-			t.Errorf("%s centered %.0f km from Cursor's arrival position (SOI %.0f km) — encounter off-canvas", name, d/1e3, soi/1e3)
-		}
-		if d := center.Sub(current).Norm(); d < 10*soi {
-			t.Errorf("%s centered only %.0f km from Cursor's CURRENT position — the #144 bug", name, d/1e3)
+		if d := center.Sub(current).Norm(); d > soi {
+			t.Errorf("%s centered %.0f km from Cursor's current position (SOI %.0f km) — not framing the Local-to-Body arc", name, d/1e3, soi/1e3)
 		}
 	}
 

--- a/internal/sim/local_to_body_arc_test.go
+++ b/internal/sim/local_to_body_arc_test.go
@@ -1,0 +1,268 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// plantKernCursorPass plants the Kern→Cursor transfer and returns the
+// planned pass plus the SOI radius the rebased arc must live within —
+// the shared setup for the Local-to-Body Arc tests (ADR 0021 B).
+func plantKernCursorPass(t *testing.T, w *World) (SOIPass, float64) {
+	t.Helper()
+	cursorIdx, kern, cursor := setupKernCursor(t, w)
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	pass, ok := w.PlannedSOIPass()
+	if !ok {
+		t.Fatal("PlannedSOIPass returned ok=false; expected the planted capture pass")
+	}
+	if pass.Body.ID != cursor.ID {
+		t.Fatalf("pass body = %q, want Cursor", pass.Body.EnglishName)
+	}
+	if len(pass.ArcSegments) == 0 {
+		t.Fatal("pass has no arc segments")
+	}
+	return pass, physics.SOIRadius(cursor, kern)
+}
+
+// TestForeignSegmentsRecordBodyRelativePoints: every predicted segment
+// carries body-relative samples (offset from its owning primary at each
+// sample's clock) alongside the inertial ones — the Local-to-Body Arc's
+// raw material, recorded at prediction time in the shared predictor
+// (ADR 0021 B). For the foreign Cursor segment those offsets are in-SOI
+// by construction, and the smallest one is the drawn perilune.
+func TestForeignSegmentsRecordBodyRelativePoints(t *testing.T) {
+	w := mustWorld(t)
+	pass, soi := plantKernCursorPass(t, w)
+
+	minD := math.Inf(1)
+	for _, s := range pass.ArcSegments {
+		if len(s.RelPoints) != len(s.Points) {
+			t.Fatalf("segment %q: %d RelPoints for %d Points — body-relative samples missing",
+				s.PrimaryID, len(s.RelPoints), len(s.Points))
+		}
+		for _, r := range s.RelPoints {
+			if d := r.Norm(); d > soi*1.05 {
+				t.Errorf("body-relative sample %.0f km from Cursor exceeds its SOI (%.0f km)", d/1e3, soi/1e3)
+			} else if d < minD {
+				minD = d
+			}
+		}
+	}
+	if !pass.HasPerilunePt {
+		t.Fatal("pass has no perilune point")
+	}
+	if got := pass.PeriluneRel.Norm(); math.Abs(got-minD) > 1 {
+		t.Errorf("PeriluneRel norm = %.0f km, want the min body-relative sample distance %.0f km", got/1e3, minD/1e3)
+	}
+	// The sampled minimum approximates the analytic perilune from above.
+	if minD < pass.PeriluneRadius*0.5 || minD > pass.PeriluneRadius*2+soi*0.05 {
+		t.Errorf("min body-relative distance %.0f km disagrees with PeriluneRadius %.0f km", minD/1e3, pass.PeriluneRadius/1e3)
+	}
+}
+
+// TestLocalToBodyArcExtentIsSOIScale pins the drawn extent of the rebased
+// foreign-SOI arc to SOI scale: anchored at Cursor's CURRENT position the
+// draw points all land within ~1× the SOI of the body, while the same
+// samples at their heliocentric (absolute) positions smear across many
+// times the SOI (measured ~24× for Kern→Cursor — the #144/#147 straight
+// line). The before/after ratio is logged for the record.
+func TestLocalToBodyArcExtentIsSOIScale(t *testing.T) {
+	w := mustWorld(t)
+	pass, soi := plantKernCursorPass(t, w)
+	c := w.ActiveCraft()
+	cursorNow := w.BodyPosition(pass.Body)
+
+	var maxDraw, maxAbs float64
+	var abs []orbital.Vec3
+	for _, s := range pass.ArcSegments {
+		for _, p := range w.SegmentDrawPoints(s, c.Primary.ID) {
+			if d := p.Sub(cursorNow).Norm(); d > maxDraw {
+				maxDraw = d
+			}
+		}
+		for _, p := range s.Points {
+			abs = append(abs, p)
+			if d := p.Sub(cursorNow).Norm(); d > maxAbs {
+				maxAbs = d
+			}
+		}
+	}
+	// The arc's own smear — max distance between absolute samples — is the
+	// ADR 0021 "~24× the SOI" measurement (the body keeps moving through
+	// the transit, stretching the drawn hyperbola along its path).
+	var smear float64
+	for i := range abs {
+		for j := i + 1; j < len(abs); j++ {
+			if d := abs[i].Sub(abs[j]).Norm(); d > smear {
+				smear = d
+			}
+		}
+	}
+	t.Logf("arc extent around Cursor's current position: rebased %.2f×SOI, heliocentric %.2f×SOI; heliocentric smear %.2f×SOI (SOI %.0f km)",
+		maxDraw/soi, maxAbs/soi, smear/soi, soi/1e3)
+
+	// Premise: the heliocentric samples really do smear far past the SOI
+	// (Cursor moves between "now" and the transit). If this goes stale the
+	// repro no longer demonstrates anything.
+	if maxAbs < 5*soi {
+		t.Fatalf("heliocentric arc extent only %.1f×SOI — smear premise gone stale", maxAbs/soi)
+	}
+	// The rebased ink wraps the body: every draw point within ~1×SOI of
+	// Cursor's current position (in-SOI offsets anchored at the body).
+	if maxDraw > soi*1.05 {
+		t.Errorf("rebased arc extends %.1f×SOI from Cursor's current position, want ≤ ~1×SOI (Local-to-Body)", maxDraw/soi)
+	}
+}
+
+// TestLivePassAndPlantedLegAgree: the same encounter rebased through both
+// prediction paths — the SOI Pass arc (soiPassFromState) and the
+// planted-node leg segments (PredictedSegmentsFrom, what drawNodes plots)
+// — produces the same body-relative geometry. Both sites share one step
+// core (the #66 two-site lesson); this pins that the Local-to-Body rebase
+// lives in that shared layer, so the bright pass arc and the planted leg
+// at one body can never disagree.
+func TestLivePassAndPlantedLegAgree(t *testing.T) {
+	w := mustWorld(t)
+	planned, soi := plantKernCursorPass(t, w)
+	c := w.ActiveCraft()
+
+	// Path 1: the planted transfer leg's segments, exactly as the node
+	// renderer draws them. Only the transfer leg (leg 0) — the later legs
+	// fly the post-capture orbit, a different trajectory than the flyby.
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	leg := legs[0]
+	legMin := math.Inf(1)
+	found := false
+	for _, s := range w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples) {
+		if s.PrimaryID != planned.Body.ID {
+			continue
+		}
+		found = true
+		for _, r := range s.RelPoints {
+			if d := r.Norm(); d < legMin {
+				legMin = d
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no planted leg segment reaches Cursor's SOI")
+	}
+
+	// Path 2: the live pass from the post-departure coast — same state the
+	// transfer leg starts from, flown with no nodes.
+	w.Clock.SimTime = leg.StartClock
+	c.State = leg.State
+	c.Primary = leg.Primary
+	c.Nodes = nil
+	live, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("live pass absent on the post-departure coast")
+	}
+	if live.Body.ID != planned.Body.ID {
+		t.Fatalf("live pass body %q != planned pass body %q", live.Body.ID, planned.Body.ID)
+	}
+
+	// Same body-relative geometry, both ways. The legs and the pass sample
+	// at different densities, so the perilune-sample agreement tolerance is
+	// a small fraction of the SOI, not bitwise.
+	tol := soi * 0.05
+	if d := live.PeriluneRel.Sub(planned.PeriluneRel).Norm(); d > tol {
+		t.Errorf("live vs planned PeriluneRel differ by %.0f km (tol %.0f km) — the two rebase paths disagree", d/1e3, tol/1e3)
+	}
+	if d := math.Abs(legMin - live.PeriluneRel.Norm()); d > tol {
+		t.Errorf("planted-leg min body-relative distance %.0f km vs live pass perilune %.0f km (tol %.0f km)",
+			legMin/1e3, live.PeriluneRel.Norm()/1e3, tol/1e3)
+	}
+}
+
+// TestCounterfactualRebasesLikeBrightArc: with a node planted *after* the
+// encounter, the dim node-capped counterfactual arc carries the same
+// body-relative samples as the bright live pass — one rebase rule for all
+// foreign-SOI ink (ADR 0021 B), so the two arcs at the Moon can't split.
+func TestCounterfactualRebasesLikeBrightArc(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+	c := w.ActiveCraft()
+
+	live, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: live pass should reach the Moon")
+	}
+	soi := physics.SOIRadius(live.Body, parentBody(w, live.Body))
+
+	// Node well past the encounter: the counterfactual still reaches the SOI.
+	c.Nodes = []spacecraft.ManeuverNode{{TriggerTime: w.Clock.SimTime.Add(time.Duration(live.TimeToPerilune * 2 * float64(time.Second)))}}
+	cf, ok := w.CounterfactualSOIPass()
+	if !ok || cf.Body.ID != live.Body.ID {
+		t.Fatalf("counterfactual should still reach the Moon with a post-encounter node; ok=%v", ok)
+	}
+
+	for _, s := range cf.ArcSegments {
+		if len(s.RelPoints) != len(s.Points) {
+			t.Fatalf("counterfactual segment missing body-relative samples (%d vs %d)", len(s.RelPoints), len(s.Points))
+		}
+		for _, r := range s.RelPoints {
+			if d := r.Norm(); d > soi*1.05 {
+				t.Errorf("counterfactual rel sample %.1f×SOI from the Moon — not rebased like the bright arc", d/soi)
+			}
+		}
+	}
+	if d := cf.PeriluneRel.Sub(live.PeriluneRel).Norm(); d > soi*0.05 {
+		t.Errorf("counterfactual PeriluneRel differs from live by %.0f km — rebase paths split", d/1e3)
+	}
+}
+
+// TestPerilunePositionConvergesTowardBody: the Perilune marker draws at
+// the body's CURRENT position plus the body-relative offset, so it stays
+// glued to the body's neighborhood (≤ SOI) and converges on the true
+// perilune as arrival nears — the body's current position closes on its
+// encounter position (ADR 0021 B).
+func TestPerilunePositionConvergesTowardBody(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+	c := w.ActiveCraft()
+
+	errAt := func() (float64, float64) {
+		pass, ok := w.LiveSOIPass()
+		if !ok {
+			t.Fatal("live pass absent")
+		}
+		if !pass.HasPerilunePt {
+			t.Fatal("pass has no perilune point")
+		}
+		marker := w.PerilunePosition(pass)
+		bodyNow := w.BodyPosition(pass.Body)
+		soi := physics.SOIRadius(pass.Body, parentBody(w, pass.Body))
+		if d := marker.Sub(bodyNow).Norm(); d > soi {
+			t.Errorf("Perilune marker %.0f km from the Moon's current position (SOI %.0f km) — not anchored Local-to-Body", d/1e3, soi/1e3)
+		}
+		// Truth proxy: the body's position at TCA plus the same offset.
+		truth := w.BodyPositionAt(pass.Body, w.Clock.SimTime.Add(time.Duration(pass.TimeToPerilune*float64(time.Second)))).Add(pass.PeriluneRel)
+		return marker.Sub(truth).Norm(), pass.TimeToPerilune
+	}
+
+	err0, tca := errAt()
+
+	// Coast half-way to the encounter and re-read: the marker must have
+	// closed on the truth.
+	dt := tca / 2
+	state, primary := w.propagateStateWithPrimary(c.State, c.Primary, w.Clock.SimTime, dt)
+	c.State, c.Primary = state, primary
+	w.Clock.SimTime = w.Clock.SimTime.Add(time.Duration(dt * float64(time.Second)))
+	err1, _ := errAt()
+
+	if err1 > err0*0.75 {
+		t.Errorf("Perilune marker error did not converge: %.0f km at plant, %.0f km half-way to arrival", err0/1e3, err1/1e3)
+	}
+}

--- a/internal/sim/predict.go
+++ b/internal/sim/predict.go
@@ -98,9 +98,53 @@ func predictStep(state physics.StateVector, mu, dt float64, primary bodies.Celes
 // share the same owning SOI primary. PrimaryID == craft's home primary
 // means "still in the home SOI"; a different ID means the segment has
 // crossed into another body's sphere of influence.
+//
+// Each sample is recorded twice: at its inertial (system-primary-
+// centered) position, and as the body-relative offset from the owning
+// primary's center at that sample's clock. The offsets are the
+// Local-to-Body Arc's raw material (ADR 0021 B): a foreign-SOI segment
+// draws them anchored at the body's CURRENT position (SegmentDrawPoints),
+// because at the inertial sample positions the body's own motion smears
+// the in-SOI hyperbola across many times the SOI (~24×, measured
+// Kern→Cursor) and the encounter reads as a straight line.
 type SOISegment struct {
 	PrimaryID string
-	Points    []orbital.Vec3 // inertial, system-primary-centered
+	Points    []orbital.Vec3 // inertial, system-primary-centered, at each sample's clock
+	RelPoints []orbital.Vec3 // offset from the owning primary's center at each sample's clock
+}
+
+// SegmentDrawPoints returns the canvas plot positions for a predicted
+// segment under the Local-to-Body Arc rule (ADR 0021 B): a segment in the
+// craft's home SOI draws at its inertial sample positions, unchanged; a
+// foreign-SOI segment draws each body-relative sample anchored at the
+// owning body's CURRENT position, so the hyperbola wraps the body's drawn
+// disk and converges to truth as arrival nears. Every foreign-SOI consumer
+// — the live SOI Pass arc, the dim counterfactual, and the planted-node
+// legs — routes through this one helper, so the pictures at one body can
+// never disagree (the #66 two-site lesson, applied to drawing).
+func (w *World) SegmentDrawPoints(seg SOISegment, homeID string) []orbital.Vec3 {
+	if seg.PrimaryID == homeID || len(seg.RelPoints) != len(seg.Points) {
+		return seg.Points
+	}
+	var anchor orbital.Vec3
+	found := false
+	for _, b := range w.System().Bodies {
+		if b.ID == seg.PrimaryID {
+			anchor = w.BodyPosition(b)
+			found = true
+			break
+		}
+	}
+	// Unknown primary, or one anchored at the origin (the system root —
+	// its rel offsets ARE the inertial positions): nothing to rebase.
+	if !found || anchor == (orbital.Vec3{}) {
+		return seg.Points
+	}
+	pts := make([]orbital.Vec3, len(seg.RelPoints))
+	for i, r := range seg.RelPoints {
+		pts[i] = anchor.Add(r)
+	}
+	return pts
 }
 
 // predictTuning selects fidelity variants of the SOI-aware propagation
@@ -340,6 +384,7 @@ func (w *World) predictedSegmentsFromTuned(post physics.StateVector, startPrimar
 	segments := []SOISegment{{
 		PrimaryID: current.ID,
 		Points:    []orbital.Vec3{positions[current.ID].Add(state.R)},
+		RelPoints: []orbital.Vec3{state.R},
 	}}
 	var entries []soiEntry
 
@@ -391,8 +436,9 @@ predict:
 			if clamped, hit := physics.ClampToSurface(state, current); hit {
 				state = clamped
 				impact := positions[current.ID].Add(state.R)
-				segments[len(segments)-1].Points = append(
-					segments[len(segments)-1].Points, impact)
+				seg := &segments[len(segments)-1]
+				seg.Points = append(seg.Points, impact)
+				seg.RelPoints = append(seg.RelPoints, state.R)
 				break predict
 			}
 
@@ -435,8 +481,9 @@ predict:
 				// Close the outgoing segment at the crossing so it
 				// terminates where the new segment begins (no time gap
 				// between the previous output sample and the rebase).
-				segments[len(segments)-1].Points = append(
-					segments[len(segments)-1].Points, crossingInertial)
+				outgoing := &segments[len(segments)-1]
+				outgoing.Points = append(outgoing.Points, crossingInertial)
+				outgoing.RelPoints = append(outgoing.RelPoints, state.R)
 
 				vOld := w.bodyInertialVelocityAt(current, rebaseClock)
 				vNew := w.bodyInertialVelocityAt(cand.Body, rebaseClock)
@@ -496,6 +543,7 @@ predict:
 				segments = append(segments, SOISegment{
 					PrimaryID: current.ID,
 					Points:    []orbital.Vec3{positions[current.ID].Add(state.R)},
+					RelPoints: []orbital.Vec3{state.R},
 				})
 			}
 		}
@@ -514,6 +562,7 @@ predict:
 
 		seg := &segments[len(segments)-1]
 		seg.Points = append(seg.Points, positions[current.ID].Add(state.R))
+		seg.RelPoints = append(seg.RelPoints, state.R)
 	}
 	return segments, entries
 }

--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -20,9 +20,19 @@ type SOIPass struct {
 	PeriluneRadius float64              // distance to Body centre at closest approach (m)
 	TimeToPerilune float64              // seconds from now to perilune
 	Impact         bool                 // perilune radius is below the Body surface
-	PerilunePoint  orbital.Vec3         // inertial, system-frame — marker position
+	PeriluneRel    orbital.Vec3         // body-relative offset of perilune from Body centre (Local-to-Body, ADR 0021 B)
 	HasPerilunePt  bool                 // false when the arc couldn't place the marker point
-	ArcSegments    []SOISegment         // foreign-SOI arc (PrimaryID == Body.ID), system-frame
+	ArcSegments    []SOISegment         // foreign-SOI arc (PrimaryID == Body.ID); draw via SegmentDrawPoints
+}
+
+// PerilunePosition returns the Perilune marker's canvas position under the
+// Local-to-Body Arc rule (ADR 0021 B): the pass Body's CURRENT position plus
+// the body-relative perilune offset — the same anchoring SegmentDrawPoints
+// gives the arc, so the marker rides the drawn hyperbola. As arrival nears
+// the Body's current position closes on its encounter position, so the
+// marker converges to the true perilune.
+func (w *World) PerilunePosition(p SOIPass) orbital.Vec3 {
+	return w.BodyPosition(p.Body).Add(p.PeriluneRel)
 }
 
 // PeriluneAltitude is the perilune radius above the Body's surface; negative
@@ -225,17 +235,19 @@ func (w *World) soiPassFromState(state physics.StateVector, primary bodies.Celes
 		}
 	}
 
-	// Perilune marker point: the foreign-arc sample closest to the body
-	// centre at the predicted time of closest approach. The glyph marks
-	// "which marker, what state" — the value lives in the chip (ADR 0020 C)
-	// — so the nearest-sample approximation is sufficient for placement.
-	moonAtTCA := w.BodyPositionAt(best.Body, fromClock.Add(time.Duration(best.TimeToPerilune*float64(time.Second))))
+	// Perilune marker offset: the foreign-arc sample closest to the body
+	// centre. RelPoints are body-relative at each sample's clock, so the
+	// minimum-norm sample IS the drawn closest approach (Local-to-Body,
+	// ADR 0021 B) — the draw site anchors it at the Body's current
+	// position via PerilunePosition. The glyph marks "which marker, what
+	// state" — the value lives in the chip (ADR 0020 C) — so the
+	// nearest-sample approximation is sufficient for placement.
 	minD := math.Inf(1)
 	for _, s := range best.ArcSegments {
-		for _, p := range s.Points {
-			if d := p.Sub(moonAtTCA).Norm(); d < minD {
+		for _, r := range s.RelPoints {
+			if d := r.Norm(); d < minD {
 				minD = d
-				best.PerilunePoint = p
+				best.PeriluneRel = r
 				best.HasPerilunePt = true
 			}
 		}

--- a/internal/sim/soipass_view_test.go
+++ b/internal/sim/soipass_view_test.go
@@ -24,12 +24,12 @@ func moonCoast(t *testing.T, w *World) {
 }
 
 // TestSOIPassViewFramingFramesEncounter: on the node-free LEO→Moon coast the
-// SOI-Pass framing centers on the drawn encounter — the pass's PerilunePoint, a
-// sample on the foreign-SOI arc at the Moon's *arrival* location — not the
-// Moon's *current* position (ADR 0019 F, #137; #144). The two diverge by far
-// more than the SOI over a multi-day coast (the Earth–Moon system translates
-// along Earth's heliocentric orbit), so centering on the current position pushes
-// the encounter off-canvas — the bug this regression pins.
+// SOI-Pass framing centers on the drawn encounter — the pass's Perilune at
+// its Local-to-Body draw position (the Moon's CURRENT position plus the
+// body-relative offset, ADR 0021 B), so the capture curve and the Moon's
+// drawn disk frame together. Pre-ADR-0021 the arc drew at its heliocentric
+// sample positions a transit-translation away from the Moon (#144); the
+// rebase moved the ink — and with it the frame — back to the body.
 func TestSOIPassViewFramingFramesEncounter(t *testing.T) {
 	w := mustWorld(t)
 	moonCoast(t, w)
@@ -46,15 +46,15 @@ func TestSOIPassViewFramingFramesEncounter(t *testing.T) {
 	if radius <= 0 {
 		t.Errorf("fit radius = %v, want > 0", radius)
 	}
-	if got := center.Sub(pass.PerilunePoint).Norm(); got > 1 {
-		t.Errorf("framing center is %v m from the drawn PerilunePoint, want centered on it", got)
+	if got := center.Sub(w.PerilunePosition(pass)).Norm(); got > 1 {
+		t.Errorf("framing center is %v m from the drawn Perilune position, want centered on it", got)
 	}
+	// The drawn encounter now lives at the Moon: center within the Moon's
+	// parent-relative SOI of its current position.
 	current := w.BodyPosition(pass.Body)
-	// The encounter sits a whole transit-translation away from the Moon's
-	// current position — far more than the Moon's true SOI.
 	soiVsParent := physics.SOIRadius(pass.Body, parentBody(w, pass.Body))
-	if got := center.Sub(current).Norm(); got <= soiVsParent {
-		t.Fatalf("encounter only %v m from the Moon's current position (SOI %v m) — #144 repro premise stale", got, soiVsParent)
+	if got := center.Sub(current).Norm(); got > soiVsParent {
+		t.Errorf("framing center %v m from the Moon's current position (SOI %v m) — arc not framed Local-to-Body", got, soiVsParent)
 	}
 }
 
@@ -91,13 +91,11 @@ func TestSOIPassViewFramingNilWithoutPass(t *testing.T) {
 }
 
 // TestSOIPassViewFramingFitsToArcExtent: once an encounter resolves, the fit
-// frames the *drawn arc's* extent — every foreign-SOI arc sample lands within
-// the radius — so the whole capture curve fills the canvas. In the system frame
-// the body translates through the pass, smearing the in-SOI hyperbola across
-// many times the SOI, so an SOI-sized fit would frame a single point (issue
-// #144). The fit is also *not* widened to the craft→encounter distance: the
-// craft is a whole transfer away, and widening to it would shrink the arc back
-// to a dot.
+// frames the *drawn arc's* extent — every foreign-SOI draw position (the
+// Local-to-Body rebase of each sample, ADR 0021 B) lands within the radius —
+// so the whole capture curve fills the canvas at SOI scale. The fit is *not*
+// widened to the craft→encounter distance: the craft is a whole transfer
+// away, and widening to it would shrink the arc back to a dot.
 func TestSOIPassViewFramingFitsToArcExtent(t *testing.T) {
 	w := mustWorld(t)
 	moonCoast(t, w)
@@ -111,12 +109,13 @@ func TestSOIPassViewFramingFitsToArcExtent(t *testing.T) {
 		t.Fatal("SOIPassViewFraming returned ok=false with an active pass")
 	}
 
-	// Every drawn arc sample is within the fit radius — the curve fills the
-	// canvas rather than overflowing it.
+	// Every drawn arc position is within the fit radius — the curve fills
+	// the canvas rather than overflowing it.
+	homeID := w.ActiveCraft().Primary.ID
 	for _, s := range pass.ArcSegments {
-		for _, p := range s.Points {
+		for _, p := range w.SegmentDrawPoints(s, homeID) {
 			if d := p.Sub(center).Norm(); d > radius {
-				t.Errorf("arc sample %.0f km from center exceeds fit radius %.0f km — capture curve overflows the canvas", d/1e3, radius/1e3)
+				t.Errorf("arc draw position %.0f km from center exceeds fit radius %.0f km — capture curve overflows the canvas", d/1e3, radius/1e3)
 			}
 		}
 	}

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -68,8 +68,9 @@ const (
 	// entering/leaving it never touches w.Target. Reuses the orbit-flat
 	// projection basis and the TargetViewFraming widening geometry (against the
 	// Pass Body instead of the Target). When an encounter resolves it centers on
-	// the predicted *arrival*-position perilune, not the body's current position
-	// (issue #144). Selected from the `v` cycle, but only reachable when an
+	// the drawn perilune — the Body's current position plus the body-relative
+	// offset, where the Local-to-Body arc lives (ADR 0021 B; supersedes the
+	// #144 arrival-position centering). Selected from the `v` cycle, but only reachable when an
 	// upcoming SOI pass exists — the planted (node-modified) one while flying a
 	// transfer, else the live one (CycleViewMode skips it otherwise); falls back
 	// to the ordinary focus center when the pass disappears mid-view (craft

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -425,8 +425,8 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	}
 	// Encounter framing for the ordinary focus paths (issue #144): ViewTarget /
 	// ViewSOIPass override the camera above; for every other view, when the
-	// focused body has an upcoming SOI pass, center on the predicted encounter
-	// (drawn at the body's *arrival* position, not its current one) and fit to
+	// focused body has an upcoming SOI pass, center on the drawn encounter
+	// (Local-to-Body — at the body's current position, ADR 0021 B) and fit to
 	// the drawn arc's extent so the capture curve fills the canvas. Refits every
 	// frame like the two view overrides, so a burn planted *after* focusing the
 	// body still snaps the curve into frame regardless of focus-vs-plant
@@ -1607,7 +1607,10 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 			if seg.PrimaryID != homeID {
 				stride = 1 // foreign SOI — solid, eye-catching
 			}
-			for i, p := range seg.Points {
+			// Foreign-SOI samples draw Local-to-Body — body-relative,
+			// anchored at the owning body's current position (ADR 0021 B);
+			// home-SOI samples draw at their inertial positions, unchanged.
+			for i, p := range w.SegmentDrawPoints(seg, homeID) {
 				if stride > 1 && i%stride == 0 {
 					continue
 				}
@@ -1642,8 +1645,13 @@ func (v *OrbitView) drawSOIPass(w *sim.World) {
 			arcColor = render.Shade(render.ColorForeignSOI, soiCounterfactualDim)
 			markerState = render.MarkerCounterfactual
 		}
+		// The arc and its Perilune marker draw Local-to-Body (ADR 0021 B):
+		// body-relative samples anchored at the pass Body's current
+		// position — the same rebase the planted-node legs get, so the dim
+		// counterfactual and the bright planned ink at one body agree.
+		homeID := w.ActiveCraft().Primary.ID
 		for _, seg := range arc.counterfactual.ArcSegments {
-			for _, p := range seg.Points {
+			for _, p := range w.SegmentDrawPoints(seg, homeID) {
 				v.canvas.PlotColored(p, arcColor)
 			}
 		}
@@ -1652,7 +1660,7 @@ func (v *OrbitView) drawSOIPass(w *sim.World) {
 			if arc.counterfactual.Impact {
 				st = render.MarkerAlarm // sub-surface perilune → Impact (red+bright even when counterfactual)
 			}
-			drawMarker(v.canvas, arc.counterfactual.PerilunePoint, render.MarkerPerilune, st, "", widgets.CellTag{})
+			drawMarker(v.canvas, w.PerilunePosition(arc.counterfactual), render.MarkerPerilune, st, "", widgets.CellTag{})
 		}
 	}
 
@@ -1664,7 +1672,7 @@ func (v *OrbitView) drawSOIPass(w *sim.World) {
 		if arc.planned.Impact {
 			st = render.MarkerAlarm
 		}
-		drawMarker(v.canvas, arc.planned.PerilunePoint, render.MarkerPerilune, st, "", widgets.CellTag{})
+		drawMarker(v.canvas, w.PerilunePosition(arc.planned), render.MarkerPerilune, st, "", widgets.CellTag{})
 	}
 }
 

--- a/internal/tui/screens/orbit_local_arc_test.go
+++ b/internal/tui/screens/orbit_local_arc_test.go
@@ -1,0 +1,175 @@
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// setupKernCursorTransfer places the active craft in a coplanar circular
+// parking orbit around Kern (Lumen system) and plants the transfer to
+// Cursor — the measured Local-to-Body repro (the heliocentric smear was
+// ~24× the SOI on this pair). Mirrors the sim package's setupKernCursor,
+// replicated here because that helper isn't visible across packages.
+func setupKernCursorTransfer(t *testing.T, w *sim.World) (cursorIdx int, kern, cursor bodies.CelestialBody) {
+	t.Helper()
+	sysIdx := -1
+	for i, s := range w.Systems {
+		if s.Name == "Lumen" {
+			sysIdx = i
+		}
+	}
+	if sysIdx < 0 {
+		t.Skip("Lumen not loaded")
+	}
+	w.SystemIdx = sysIdx
+	craft := w.ActiveCraft()
+	craft.SystemIdx = sysIdx
+	sys := w.System()
+
+	kernIdx := -1
+	cursorIdx = -1
+	for i, b := range sys.Bodies {
+		switch b.EnglishName {
+		case "Kern":
+			kernIdx = i
+		case "Cursor":
+			cursorIdx = i
+		}
+	}
+	if kernIdx < 0 || cursorIdx < 0 {
+		t.Skip("Kern/Cursor not in Lumen")
+	}
+	kern, cursor = sys.Bodies[kernIdx], sys.Bodies[cursorIdx]
+
+	rPark := kern.RadiusMeters() * 1.08
+	if atm := kern.Atmosphere; atm != nil {
+		if min := kern.RadiusMeters() + atm.CutoffAltitude + 50e3; min > rPark {
+			rPark = min
+		}
+	}
+	// Circular parking orbit in Cursor's orbital plane (the sim package's
+	// moonPlaneCircularState construction).
+	mel := orbital.ElementsFromBody(cursor)
+	sI, cI := math.Sin(mel.I), math.Cos(mel.I)
+	sO, cO := math.Sin(mel.Omega), math.Cos(mel.Omega)
+	moonN := orbital.Vec3{X: sO * sI, Y: -cO * sI, Z: cI}.Unit()
+	ref := orbital.Vec3{X: 1}
+	if math.Abs(moonN.Dot(ref)) > 0.9 {
+		ref = orbital.Vec3{Y: 1}
+	}
+	e1 := ref.Sub(moonN.Scale(moonN.Dot(ref))).Unit()
+	e2 := moonN.Cross(e1)
+	craft.Primary = kern
+	craft.Landed = false
+	craft.State.R = e1.Scale(rPark)
+	craft.State.V = e2.Scale(math.Sqrt(kern.GravitationalParameter() / rPark))
+
+	if _, err := w.PlanTransfer(cursorIdx); err != nil {
+		t.Fatalf("PlanTransfer(Cursor): %v", err)
+	}
+	return cursorIdx, kern, cursor
+}
+
+// countBraille counts non-blank braille cells (U+2801–U+28FF) in a rendered
+// frame — drawn trajectory/orbit ink, excluding the blank braille space.
+func countBraille(s string) int {
+	n := 0
+	for _, r := range stripANSI(s) {
+		if r > 0x2800 && r <= 0x28FF {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPlantedKernCursorArcWrapsCursorDisk is the render-level acceptance for
+// the Local-to-Body Arc (ADR 0021 B / #147): a planted Kern→Cursor transfer,
+// focused on Cursor, draws the capture hyperbola wrapping Cursor's drawn
+// disk — the foreign-SOI ink anchors at Cursor's CURRENT position at SOI
+// scale, with visible curvature near perilune, instead of smearing along
+// Cursor's transit path at heliocentric sample positions (~24× the SOI,
+// where the arc reads as a straight line).
+func TestPlantedKernCursorArcWrapsCursorDisk(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	cursorIdx, kern, cursor := setupKernCursorTransfer(t, w)
+	soi := physics.SOIRadius(cursor, kern)
+
+	// Plain body focus — the KSP model: reading an encounter = focus the body.
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: cursorIdx}
+	out := v.Render(w, 0, 200, 60)
+
+	// Ink is on the canvas at all.
+	if n := countBraille(out); n < 20 {
+		t.Fatalf("only %d non-blank braille cells rendered — canvas effectively empty", n)
+	}
+
+	cursorNow := w.BodyPosition(cursor)
+
+	// Camera: centered near Cursor's current position (where the rebased arc
+	// and the disk now live), framed at SOI scale — not the heliocentric
+	// smear (~24×SOI) and not centered a transfer away at the arrival point.
+	center := v.canvas.CenterWorld()
+	if d := center.Sub(cursorNow).Norm(); d > 1.5*soi {
+		t.Errorf("canvas centered %.1f×SOI from Cursor's current position — not framing the Local-to-Body arc", d/soi)
+	}
+	if px := soi * v.canvas.Scale(); px < 25 {
+		t.Errorf("Cursor's SOI spans only %.1f braille px — framed to the heliocentric smear (~24×SOI), not SOI scale", px)
+	}
+
+	// Geometry of the drawn (rebased) arc: gather the foreign-SOI draw
+	// points the node legs plot.
+	var draw []orbital.Vec3
+	for _, leg := range w.PredictedLegs() {
+		for _, seg := range w.PredictedSegmentsFrom(leg.State, leg.Primary, leg.StartClock, leg.HorizonSecs, leg.Samples) {
+			if seg.PrimaryID != cursor.ID {
+				continue
+			}
+			draw = append(draw, w.SegmentDrawPoints(seg, kern.ID)...)
+		}
+	}
+	if len(draw) < 3 {
+		t.Fatalf("only %d foreign-SOI draw points — no arc to assert on", len(draw))
+	}
+
+	// Wraps the disk: every draw point within ~1×SOI of the disk, and the
+	// whole arc projects onto the canvas.
+	periIdx, periD := 0, math.Inf(1)
+	for i, p := range draw {
+		if d := p.Sub(cursorNow).Norm(); d > 1.05*soi {
+			t.Fatalf("draw point %d sits %.1f×SOI from Cursor's disk — arc not anchored at the body", i, d/soi)
+		} else if d < periD {
+			periD = d
+			periIdx = i
+		}
+	}
+	for _, p := range []orbital.Vec3{draw[0], draw[periIdx], draw[len(draw)-1]} {
+		if _, _, ok := v.canvas.Project(p); !ok {
+			t.Errorf("rebased arc point %v projects off-canvas — encounter not in frame", p)
+		}
+	}
+
+	// Visible curvature near perilune: the perilune sample must sit well off
+	// the entry→exit chord. At heliocentric sample positions the transit is
+	// smeared nearly straight (sagitta ≪ extent) — that's the bug this pins.
+	entry, exit, peri := draw[0], draw[len(draw)-1], draw[periIdx]
+	chord := exit.Sub(entry)
+	sagitta := 0.0
+	if chord.Norm() > 0 {
+		rel := peri.Sub(entry)
+		along := chord.Unit().Scale(rel.Dot(chord.Unit()))
+		sagitta = rel.Sub(along).Norm()
+	}
+	if sagitta < 0.05*soi {
+		t.Errorf("perilune sits only %.3f×SOI off the entry→exit chord — arc reads as a straight line, no visible curvature", sagitta/soi)
+	}
+}

--- a/internal/tui/screens/orbit_soipass_view_test.go
+++ b/internal/tui/screens/orbit_soipass_view_test.go
@@ -48,12 +48,13 @@ func TestViewSOIPassRefitsToPassBody(t *testing.T) {
 	}
 }
 
-// TestPlainViewFocusBodyCentersOnEncounter is the screen-level regression for
-// the #144 playtest path: "focus on Cursor" in an ordinary view (ViewTilted —
-// not the v-cycle ViewTarget/ViewSOIPass). With an upcoming encounter the
-// canvas must re-center on the body's *arrival* position so the capture curve
-// is on-canvas, not its *current* position (off by the heliocentric transit
-// translation — the curve "not displayed until the maneuvers finish").
+// TestPlainViewFocusBodyCentersOnEncounter is the screen-level check for the
+// "focus on Cursor" playtest path (#144, reshaped by ADR 0021 B): "focus on
+// the Moon" in an ordinary view (ViewTilted — not the v-cycle
+// ViewTarget/ViewSOIPass). With an upcoming encounter the canvas re-centers
+// on the drawn encounter — which now lives Local-to-Body, at the Moon's
+// CURRENT position plus the body-relative perilune offset — so the capture
+// curve and the Moon's drawn disk are both on-canvas.
 func TestPlainViewFocusBodyCentersOnEncounter(t *testing.T) {
 	v := newSOIPassTestView()
 	w, err := sim.NewWorld()
@@ -76,10 +77,17 @@ func TestPlainViewFocusBodyCentersOnEncounter(t *testing.T) {
 	if d := got.Sub(eCenter).Norm(); d > 1 {
 		t.Errorf("canvas centered %.0f km off the encounter frame; the override didn't fire in ViewTilted", d/1e3)
 	}
-	// And that center is nowhere near the Moon's *current* position (the bug).
-	soi := physics.SOIRadius(moon, w.System().Bodies[0])
-	if d := got.Sub(w.BodyPosition(moon)).Norm(); d <= soi {
-		t.Errorf("canvas centered on the Moon's current position (%.0f km, SOI %.0f km) — #144 not fixed", d/1e3, soi/1e3)
+	// And that center is at the Moon — within the parent-relative SOI of its
+	// current position, where the Local-to-Body arc is drawn (ADR 0021 B).
+	moonParent := w.System().Bodies[0]
+	for _, b := range w.System().Bodies {
+		if b.ID == moon.ParentID {
+			moonParent = b
+		}
+	}
+	soi := physics.SOIRadius(moon, moonParent)
+	if d := got.Sub(w.BodyPosition(moon)).Norm(); d > soi {
+		t.Errorf("canvas centered %.0f km from the Moon's current position (SOI %.0f km) — not framing the Local-to-Body arc", d/1e3, soi/1e3)
 	}
 }
 


### PR DESCRIPTION
## What

ADR 0021 decision B — the **Local-to-Body Arc**. Foreign-SOI predicted segments were drawn at their heliocentric sample positions, so the encounter body's own motion smeared the in-SOI hyperbola far past the SOI (measured on the planted Kern→Cursor pass arc: max pairwise smear **47.8× SOI**; **126.9× SOI** measured from Cursor's current position) — an SOI Pass read as a straight line.

Now every segment records a **body-relative offset at each sample's clock** (`SOISegment.RelPoints`), populated in the shared predictor core (`predictedSegmentsFromTuned`) that **both** prediction sites use (the #66 two-site lesson). All foreign-SOI ink draws those offsets anchored at the owning body's **current** position through one helper, `World.SegmentDrawPoints` — live SOI Pass arc, dim counterfactual, and planted-node legs alike. The Perilune marker rebases identically (`SOIPass.PeriluneRel` + `World.PerilunePosition`). Measured result: the rebased arc spans **1.00× SOI** around Cursor's current position.

The encounter framers (`framePass`/`encounterFrame`) follow the ink — they center on the drawn perilune next to the body's disk and fit to the rebased SOI-scale extent. (Framer *retirement* and the Camera Contract are #151; this PR only moves their geometry to where the arc now lives, which the focused-on-Cursor acceptance test requires.)

## Acceptance criteria → tests

- **Capture hyperbola wraps Cursor's drawn disk, visible curvature near perilune** — `TestPlantedKernCursorArcWrapsCursorDisk` (screens): render with non-blank-braille floor, canvas centered ≤1.5×SOI from Cursor's current position, SOI ≥25 braille px, all rebased draw points ≤1.05×SOI from the disk, entry/perilune/exit project on-canvas, perilune sagitta ≥0.05×SOI off the entry→exit chord (straight-line guard).
- **Drawn extent pinned to SOI scale, not the smear** — `TestLocalToBodyArcExtentIsSOIScale`: rebased extent ≤1.05×SOI (measures 1.00×); heliocentric premise pinned ≥5×SOI (measures 126.9× from current position, 47.8× max-pairwise smear, logged).
- **Live-pass vs planted-leg agreement** — `TestLivePassAndPlantedLegAgree`: same encounter through `PredictedSegmentsFrom` (planted transfer leg) and `LiveSOIPass` (coast) produces matching body-relative geometry (PeriluneRel and min-rel-distance within 5% of SOI).
- **Counterfactual rebases identically** — `TestCounterfactualRebasesLikeBrightArc`: node-capped counterfactual's RelPoints all in-SOI, PeriluneRel matches the live pass.
- **Perilune marker = body-current + offset, converges** — `TestPerilunePositionConvergesTowardBody`: marker ≤SOI from the body's current position; coasting halfway to arrival shrinks the marker-vs-truth error.
- **RelPoints recorded in the shared layer** — `TestForeignSegmentsRecordBodyRelativePoints`: len parity, in-SOI offsets, min-norm sample = PeriluneRel ≈ PeriluneRadius.
- **Home-SOI unchanged** — `SegmentDrawPoints` returns `seg.Points` untouched for home segments and origin-anchored (system-root) segments; full suite confirms no behavior change elsewhere.
- **CI** — `go vet ./...` clean, `go test ./... -race -count=1`: 1118 passed.

## Also in this PR

- The #144 framing regressions (`TestEncounterFramingCentersOnArrivalPosition`, `TestPlainViewFocusBodyCentersOnEncounter`, `TestSOIPassViewFramingFramesEncounter/FitsToArcExtent`) pinned the superseded arrival-position smear framing; rewritten to pin the Local-to-Body geometry.
- Stale arrival-position doc comments updated (`focus.go`, `view.go`, `orbit.go`).
- No save-schema change (nothing here persists).

Closes #147