### PR TITLE
feat(render): SOI Ring + entry/exit markers at the encounter body (#150)

### DIFF
--- a/internal/render/markers.go
+++ b/internal/render/markers.go
@@ -16,6 +16,8 @@ const (
 	MarkerPerilune // periapsis within an upcoming SOI Pass (ADR 0019)
 	MarkerClosestApproach
 	MarkerManeuver // per-node colour exception — see MarkerColor
+	MarkerSOIEntry // SOI Pass arc crosses INTO the pass Body's SOI Ring (ADR 0021 C)
+	MarkerSOIExit  // SOI Pass arc crosses back OUT of the SOI Ring
 )
 
 // MarkerState modifies a marker's brightness/variant to convey what is
@@ -58,6 +60,10 @@ func MarkerGlyph(t MarkerType) rune {
 		return '✕'
 	case MarkerManeuver:
 		return 'Δ'
+	case MarkerSOIEntry:
+		return '▷'
+	case MarkerSOIExit:
+		return '◁'
 	}
 	return '?'
 }
@@ -97,6 +103,10 @@ func markerTypeColor(t MarkerType, base lipgloss.Color) lipgloss.Color {
 		return ColorMarkerPerilune
 	case MarkerClosestApproach:
 		return ColorMarkerClosestApproach
+	case MarkerSOIEntry:
+		return ColorMarkerSOIEntry
+	case MarkerSOIExit:
+		return ColorMarkerSOIExit
 	case MarkerManeuver:
 		// Documented exception (ADR 0020): the maneuver marker's colour is
 		// the post-burn leg colour passed by the caller, not a fixed type

--- a/internal/render/markers_test.go
+++ b/internal/render/markers_test.go
@@ -18,6 +18,8 @@ func TestMarkerGlyph(t *testing.T) {
 		{MarkerPerilune, '⊕'},
 		{MarkerClosestApproach, '✕'},
 		{MarkerManeuver, 'Δ'},
+		{MarkerSOIEntry, '▷'},
+		{MarkerSOIExit, '◁'},
 	}
 	for _, c := range cases {
 		if got := MarkerGlyph(c.t); got != c.want {
@@ -41,6 +43,8 @@ func TestMarkerColorByType(t *testing.T) {
 		{MarkerDescendingNode, ColorMarkerDescendingNode},
 		{MarkerPerilune, ColorMarkerPerilune},
 		{MarkerClosestApproach, ColorMarkerClosestApproach},
+		{MarkerSOIEntry, ColorMarkerSOIEntry},
+		{MarkerSOIExit, ColorMarkerSOIExit},
 	}
 	for _, c := range cases {
 		if got := MarkerColor(c.t, MarkerNominal, ""); got != c.want {

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -63,6 +63,8 @@ var (
 	ColorMarkerDescendingNode  = lipgloss.Color("#AF5FFF") // violet — descending node ◆
 	ColorMarkerPerilune        = lipgloss.Color("#FFAF00") // amber — perilune ⊕ (the periapsis within a pass SOI; shares the apsis amber)
 	ColorMarkerClosestApproach = lipgloss.Color("#FF5FAF") // hot pink — craft-to-craft closest approach ✕
+	ColorMarkerSOIEntry        = ColorForeignSOI           // orchid — SOI entry ▷ (shares the foreign-SOI arc hue it brackets, like Perilune shares the apsis amber)
+	ColorMarkerSOIExit         = ColorForeignSOI           // orchid — SOI exit ◁
 )
 
 // maneuverSegmentPalette cycles through distinct colors per planted

--- a/internal/sim/camera_contract_test.go
+++ b/internal/sim/camera_contract_test.go
@@ -25,10 +25,14 @@ func moonCoast(t *testing.T, w *World) {
 
 // parentBody returns the body p orbits (its ParentID), or the system root when
 // p has no parent in the catalog. Test-side alias for the production lookup
-// the encounter-aware fit uses (ADR 0021 F / #143 — SOI must be
-// parent-relative, not root-relative).
+// behind BodySOIRadius, which the encounter-aware fit uses (ADR 0021 F /
+// #143 — SOI must be parent-relative, not root-relative).
 func parentBody(w *World, p bodies.CelestialBody) bodies.CelestialBody {
-	return w.parentBodyOf(p)
+	sys := w.System()
+	if par := sys.ParentOf(p); par != nil {
+		return *par
+	}
+	return sys.Bodies[0]
 }
 
 // TestViewModeCycleOrder pins ADR 0021 D: ViewTarget and ViewSOIPass left the

--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -1,9 +1,7 @@
 package sim
 
 import (
-	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
-	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 // FocusKind enumerates what the OrbitView canvas is centered on.
@@ -110,7 +108,7 @@ func (w *World) FocusZoomRadius() float64 {
 			// Framing Event, so the forward prediction behind bestSOIPass
 			// stays off the per-frame hot path.
 			if p, ok := w.bestSOIPass(); ok && p.Body.ID == b.ID {
-				if soi := physics.SOIRadius(b, w.parentBodyOf(b)); soi > 0 {
+				if soi := w.BodySOIRadius(b); soi > 0 {
 					return soi * 1.3
 				}
 			}
@@ -130,10 +128,10 @@ func (w *World) FocusZoomRadius() float64 {
 			if !hasChildren {
 				return b.RadiusMeters() * 8
 			}
-			// Use SOI relative to the system primary — gives a close-up
-			// that still shows any moons / nearby spacecraft.
-			primary := sys.Bodies[0]
-			if soi := physics.SOIRadius(b, primary); soi > 0 {
+			// Use the parent-relative SOI — gives a close-up that still
+			// shows any moons / nearby spacecraft. Parent, not the system
+			// root (#143): identical for a planet, correct for a moon.
+			if soi := w.BodySOIRadius(b); soi > 0 {
 				return soi
 			}
 			return b.RadiusMeters() * 50
@@ -151,20 +149,6 @@ func (w *World) FocusZoomRadius() float64 {
 		}
 	}
 	return w.systemOutermostRadius()
-}
-
-// parentBodyOf returns the body b orbits (matched by ParentID), falling back
-// to the system root when no parent is found in the catalog. The SOI used by
-// the encounter-aware fit must be parent-relative (#143 — a moon's SOI against
-// the system *root* is wildly oversized).
-func (w *World) parentBodyOf(b bodies.CelestialBody) bodies.CelestialBody {
-	sys := w.System()
-	for i := range sys.Bodies {
-		if sys.Bodies[i].ID == b.ParentID {
-			return sys.Bodies[i]
-		}
-	}
-	return sys.Bodies[0]
 }
 
 func (w *World) systemOutermostRadius() float64 {

--- a/internal/sim/soi_ring_test.go
+++ b/internal/sim/soi_ring_test.go
@@ -1,0 +1,147 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// TestPassEntryExitCrossingsLandOnRing: the SOI Pass arc's ring crossings
+// (ADR 0021 C) sit on the parent-relative SOI Ring — the body-relative
+// Entry/Exit offsets are ≈ the SOI radius, and the rebased arc's first and
+// last DRAWN samples (SegmentDrawPoints, anchored at the Body's current
+// position) land on the ring around the Body. This is the geometry the
+// Entry ▷ / Exit ◁ glyphs mark.
+func TestPassEntryExitCrossingsLandOnRing(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no live SOI Pass on the Moon coast")
+	}
+	soi := physics.SOIRadius(pass.Body, parentBody(w, pass.Body))
+	if got := w.BodySOIRadius(pass.Body); math.Abs(got-soi) > 1 {
+		t.Fatalf("BodySOIRadius = %.0f km, want parent-relative %.0f km", got/1e3, soi/1e3)
+	}
+
+	if !pass.HasEntry {
+		t.Fatal("pass has no SOI Entry crossing — the arc should open on the ring")
+	}
+	if d := pass.EntryRel.Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("EntryRel %.0f km from the Moon, want ring radius %.0f km (±5%%)", d/1e3, soi/1e3)
+	}
+	if !pass.HasExit {
+		t.Fatal("pass has no SOI Exit crossing — a non-impact flyby should close on the ring")
+	}
+	if d := pass.ExitRel.Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("ExitRel %.0f km from the Moon, want ring radius %.0f km (±5%%)", d/1e3, soi/1e3)
+	}
+
+	// The marker draw positions anchor at the Body's CURRENT position, the
+	// same anchor SegmentDrawPoints gives the arc.
+	bodyNow := w.BodyPosition(pass.Body)
+	if d := w.EntryPosition(pass).Sub(bodyNow).Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("EntryPosition %.0f km from the Moon's current position, want on the ring (%.0f km)", d/1e3, soi/1e3)
+	}
+	if d := w.ExitPosition(pass).Sub(bodyNow).Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("ExitPosition %.0f km from the Moon's current position, want on the ring (%.0f km)", d/1e3, soi/1e3)
+	}
+
+	// And the drawn arc itself: first and last rebased draw samples land
+	// on/near the ring, so the hyperbola visibly enters and exits on it.
+	homeID := w.ActiveCraft().Primary.ID
+	if len(pass.ArcSegments) == 0 {
+		t.Fatal("pass has no arc segments")
+	}
+	firstSeg := w.SegmentDrawPoints(pass.ArcSegments[0], homeID)
+	lastSeg := w.SegmentDrawPoints(pass.ArcSegments[len(pass.ArcSegments)-1], homeID)
+	if len(firstSeg) == 0 || len(lastSeg) == 0 {
+		t.Fatal("empty draw segments")
+	}
+	if d := firstSeg[0].Sub(bodyNow).Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("arc's first drawn sample %.0f km from the Moon, want ring radius %.0f km", d/1e3, soi/1e3)
+	}
+	if d := lastSeg[len(lastSeg)-1].Sub(bodyNow).Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("arc's last drawn sample %.0f km from the Moon, want ring radius %.0f km", d/1e3, soi/1e3)
+	}
+}
+
+// TestPassEntryTimePrecedesPerilune: the pass carries the predicted
+// SOI-entry clock for the chip (ADR 0021 C: the glyph marks where, the
+// chip carries when) — strictly between now and the perilune.
+func TestPassEntryTimePrecedesPerilune(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no live SOI Pass on the Moon coast")
+	}
+	if !pass.HasEntryTime {
+		t.Fatal("pass carries no entry time")
+	}
+	if pass.TimeToEntry <= 0 {
+		t.Errorf("TimeToEntry = %.0f s, want > 0 (entry is ahead)", pass.TimeToEntry)
+	}
+	if pass.TimeToEntry >= pass.TimeToPerilune {
+		t.Errorf("TimeToEntry %.0f s ≥ TimeToPerilune %.0f s — entry must precede the perilune", pass.TimeToEntry, pass.TimeToPerilune)
+	}
+}
+
+// TestPlannedPassEntryTimeRebasedToNow: the planned (node-modified) pass's
+// entry clock is rebased from the leg's start to now, like TimeToPerilune —
+// so the chip's T-entry counts down from the present even though the leg
+// begins when its node fires, in the future.
+func TestPlannedPassEntryTimeRebasedToNow(t *testing.T) {
+	w := mustWorld(t)
+	pass, _ := plantKernCursorPass(t, w)
+
+	if !pass.HasEntryTime {
+		t.Fatal("planned pass carries no entry time")
+	}
+	if pass.TimeToEntry <= 0 {
+		t.Errorf("TimeToEntry = %.0f s, want > 0", pass.TimeToEntry)
+	}
+	if pass.TimeToEntry >= pass.TimeToPerilune {
+		t.Errorf("TimeToEntry %.0f s ≥ TimeToPerilune %.0f s", pass.TimeToEntry, pass.TimeToPerilune)
+	}
+	// Rebased to now: the entry can't happen before the departure burn the
+	// leg starts from.
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs")
+	}
+	if offset := legs[0].StartClock.Sub(w.Clock.SimTime).Seconds(); pass.TimeToEntry < offset {
+		t.Errorf("TimeToEntry %.0f s precedes the departure burn at +%.0f s — not rebased to now", pass.TimeToEntry, offset)
+	}
+}
+
+// TestBodySOIRadiusIsParentRelative pins the #143 fix: a moon's SOI radius
+// comes from its parent planet, not the system root — SOIRadius(moon, sun)
+// is the absurd Sun-relative value the physics docs warn about (a Luna at
+// 384 000 km sized as if it orbited the Sun).
+func TestBodySOIRadiusIsParentRelative(t *testing.T) {
+	w := mustWorld(t)
+	sys := w.System()
+	_, moon := findMoon(t, w)
+	earth := parentBody(w, moon)
+	if earth.ID != moon.ParentID {
+		t.Fatalf("test setup: Moon's parent resolved to %q", earth.ID)
+	}
+
+	got := w.BodySOIRadius(moon)
+	wantParent := physics.SOIRadius(moon, earth)
+	rootSized := physics.SOIRadius(moon, sys.Bodies[0])
+	if math.Abs(got-wantParent) > 1 {
+		t.Errorf("BodySOIRadius(moon) = %.0f km, want parent-relative %.0f km", got/1e3, wantParent/1e3)
+	}
+	if got <= rootSized*2 {
+		t.Errorf("BodySOIRadius(moon) = %.0f km is root-sized (%.0f km) — #143 regressed", got/1e3, rootSized/1e3)
+	}
+	// The system root itself has no SOI.
+	if r := w.BodySOIRadius(sys.Bodies[0]); r != 0 {
+		t.Errorf("BodySOIRadius(root) = %g, want 0", r)
+	}
+}

--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -22,8 +22,23 @@ type SOIPass struct {
 	Impact         bool                 // perilune radius is below the Body surface
 	PeriluneRel    orbital.Vec3         // body-relative offset of perilune from Body centre (Local-to-Body, ADR 0021 B)
 	HasPerilunePt  bool                 // false when the arc couldn't place the marker point
+	EntryRel       orbital.Vec3         // body-relative offset of the arc's SOI-entry ring crossing (ADR 0021 C)
+	ExitRel        orbital.Vec3         // body-relative offset of the SOI-exit ring crossing
+	HasEntry       bool                 // false when the arc's first sample isn't on the SOI Ring
+	HasExit        bool                 // false when the arc never exits — impact, horizon-truncated, node-capped
+	TimeToEntry    float64              // seconds from now to SOI entry (the SOI PASS chip's T-entry readout)
+	HasEntryTime   bool                 // false when the predictor reported no entry transition for the Body
 	ArcSegments    []SOISegment         // foreign-SOI arc (PrimaryID == Body.ID); draw via SegmentDrawPoints
 }
+
+// soiRingCrossingTol is the ring-proximity gate for the SOI Entry / Exit
+// markers, as a fraction of the SOI radius: the predictor opens a foreign
+// segment with a sample rebased at the (bisection-refined) crossing and
+// closes it with one at the crossing back out, so a genuine ring crossing
+// sits on the boundary to well within this; an arc that ends in the
+// interior — surface impact, horizon truncation, the node-capped
+// counterfactual — misses it and draws no Exit marker.
+const soiRingCrossingTol = 0.05
 
 // PerilunePosition returns the Perilune marker's canvas position under the
 // Local-to-Body Arc rule (ADR 0021 B): the pass Body's CURRENT position plus
@@ -33,6 +48,20 @@ type SOIPass struct {
 // marker converges to the true perilune.
 func (w *World) PerilunePosition(p SOIPass) orbital.Vec3 {
 	return w.BodyPosition(p.Body).Add(p.PeriluneRel)
+}
+
+// EntryPosition returns the SOI Entry marker's canvas position under the
+// Local-to-Body Arc rule (ADR 0021 C): the pass Body's CURRENT position plus
+// the body-relative ring-crossing offset — the same anchoring
+// SegmentDrawPoints gives the arc and PerilunePosition gives the Perilune,
+// so the glyph rides the drawn ring crossing. Callers gate on HasEntry.
+func (w *World) EntryPosition(p SOIPass) orbital.Vec3 {
+	return w.BodyPosition(p.Body).Add(p.EntryRel)
+}
+
+// ExitPosition is EntryPosition for the SOI Exit crossing; gate on HasExit.
+func (w *World) ExitPosition(p SOIPass) orbital.Vec3 {
+	return w.BodyPosition(p.Body).Add(p.ExitRel)
 }
 
 // PeriluneAltitude is the perilune radius above the Body's surface; negative
@@ -98,7 +127,13 @@ func (w *World) PlannedSOIPass() (SOIPass, bool) {
 		if !ok {
 			continue
 		}
-		pass.TimeToPerilune += leg.StartClock.Sub(now).Seconds()
+		// Rebase the leg-relative clocks to now — the legs begin when their
+		// node fires, in the future.
+		offset := leg.StartClock.Sub(now).Seconds()
+		pass.TimeToPerilune += offset
+		if pass.HasEntryTime {
+			pass.TimeToEntry += offset
+		}
 		if pass.TimeToPerilune < bestTCA {
 			bestTCA = pass.TimeToPerilune
 			best = pass
@@ -224,15 +259,45 @@ func (w *World) soiPassFromState(state physics.StateVector, primary bodies.Celes
 
 	// Sample the trajectory over the bounded horizon and keep only the
 	// body's own segments — these span the transit (entry → perilune →
-	// exit), because PredictedSegmentsFrom rebases back out of the SOI on
+	// exit), because the predictor rebases back out of the SOI on
 	// exit, so any post-exit (escape / re-captured) samples land in a
 	// segment we drop here. A node-capped horizon naturally truncates the
 	// arc at the burn (ADR 0019 D: counterfactual never drawn past the node).
+	// The tuned call (same production tuning PredictedSegmentsFrom wraps)
+	// also reports each SOI transition, so the pass carries the predicted
+	// entry clock for the chip without re-deriving it from sampled points.
 	samples := adaptiveSampleCount(horizon, period)
-	segs := w.PredictedSegmentsFrom(state, primary, fromClock, horizon, samples)
+	segs, entries := w.predictedSegmentsFromTuned(state, primary, fromClock, horizon, samples, defaultPredictTuning())
 	for _, s := range segs {
 		if s.PrimaryID == best.Body.ID {
 			best.ArcSegments = append(best.ArcSegments, s)
+		}
+	}
+	for _, e := range entries {
+		if e.BodyID == best.Body.ID {
+			best.TimeToEntry = e.Clock.Sub(fromClock).Seconds()
+			best.HasEntryTime = true
+			break
+		}
+	}
+
+	// SOI Entry / Exit ring crossings (ADR 0021 C): the arc's first and
+	// last body-relative samples are the predictor's rebase points at the
+	// SOI boundary, so when they sit on the parent-relative ring (within
+	// soiRingCrossingTol) they place the Entry / Exit marker glyphs. soi
+	// is parent-relative by construction — the sibling scan above only
+	// admits bodies whose ParentID is `primary`.
+	if soi := physics.SOIRadius(best.Body, primary); soi > 0 && len(best.ArcSegments) > 0 {
+		onRing := func(rel orbital.Vec3) bool {
+			return math.Abs(rel.Norm()-soi) <= soi*soiRingCrossingTol
+		}
+		if first := best.ArcSegments[0].RelPoints; len(first) > 0 && onRing(first[0]) {
+			best.EntryRel = first[0]
+			best.HasEntry = true
+		}
+		if last := best.ArcSegments[len(best.ArcSegments)-1].RelPoints; len(last) > 0 && onRing(last[len(last)-1]) {
+			best.ExitRel = last[len(last)-1]
+			best.HasExit = true
 		}
 	}
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -474,6 +474,26 @@ func (w *World) BodyPositionAt(b bodies.CelestialBody, t time.Time) orbital.Vec3
 	return w.BodyPositionAt(*parent, t).Add(rRel)
 }
 
+// BodySOIRadius returns b's parent-relative sphere-of-influence radius in
+// the viewed system — a moon's SOI against its planet, a planet's against
+// the system root — falling back to the root when ParentID doesn't
+// resolve, exactly as physics.FindPrimary sizes its spheres. This is the
+// one radius the SOI Ring draws at and the framing fallbacks floor to
+// (ADR 0021 C, issue #143): computing it against the system root instead
+// hands a moon the absurd Sun-relative value the SOIRadius / FindPrimary
+// comments warn about. 0 for the system primary itself (no orbital data).
+func (w *World) BodySOIRadius(b bodies.CelestialBody) float64 {
+	sys := w.System()
+	parent := sys.ParentOf(b)
+	if parent == nil {
+		parent = sys.Primary()
+	}
+	if parent == nil {
+		return 0
+	}
+	return physics.SOIRadius(b, *parent)
+}
+
 // CraftInertial returns the spacecraft's inertial position (Sun-centered)
 // for rendering on the heliocentric canvas. Adds craft's primary-centric
 // position to the primary's inertial position.

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1599,6 +1599,36 @@ func (v *OrbitView) drawNodes(w *sim.World) {
 // bright node-modified path drawn in the same SOI (ADR 0019 D / ADR 0020 B).
 const soiCounterfactualDim = 0.5
 
+// soiRingDim scales the foreign-SOI hue for the SOI Ring (ADR 0021 C) —
+// dimmer than the counterfactual arc's 0.5, so the dotted boundary reads
+// as a quiet backdrop under both the bright pass arc and the dim no-burn
+// arc that cross it.
+const soiRingDim = 0.4
+
+// soiRingMinPixels skips the SOI Ring when its projected radius is too
+// small to read as a boundary (heliocentric zoom) — a handful of dots on
+// top of the body's own disk would smear, not inform.
+const soiRingMinPixels = 4
+
+// drawSOIRing draws the dim dotted SOI Ring around a pass Body (ADR 0021
+// C): a screen-space circle at the body's parent-relative SOI radius
+// (issue #143), anchored at the Body's CURRENT position — the same anchor
+// SegmentDrawPoints rebases the Local-to-Body Arc onto, so the arc
+// visibly enters and exits on the ring and the hyperbola gets scale.
+// Quiet bodies (no active pass) never reach here: drawSOIPass calls this
+// only for bodies a live / counterfactual / planned pass crosses.
+func (v *OrbitView) drawSOIRing(w *sim.World, b bodies.CelestialBody) {
+	soi := w.BodySOIRadius(b)
+	if soi <= 0 {
+		return
+	}
+	pxR := int(math.Round(soi * v.canvas.Scale()))
+	if pxR < soiRingMinPixels {
+		return
+	}
+	v.canvas.RingDottedColored(w.BodyPosition(b), pxR, render.Shade(render.ColorForeignSOI, soiRingDim))
+}
+
 // drawSOIPass renders the live trajectory's upcoming SOI Pass (ADR 0019):
 // the foreign-SOI arc as a single bright solid leg, plus a Perilune ⊕
 // marker at closest approach — or an Impact glyph (red+bright, the marker
@@ -1607,6 +1637,16 @@ const soiCounterfactualDim = 0.5
 // cached predictor keeps a stable orbit that reaches no SOI free.
 func (v *OrbitView) drawSOIPass(w *sim.World) {
 	arc := v.cachedSOIPass(w)
+
+	// SOI Ring (ADR 0021 C): every body with an active pass — and only
+	// those — wears its dotted boundary, drawn first so the arcs and
+	// marker glyphs paint over the ring's dots.
+	if arc.cfOK {
+		v.drawSOIRing(w, arc.counterfactual.Body)
+	}
+	if arc.plOK && (!arc.cfOK || arc.planned.Body.ID != arc.counterfactual.Body.ID) {
+		v.drawSOIRing(w, arc.planned.Body)
+	}
 
 	// The no-burn arc. With no node planted it IS the live pass, drawn
 	// bright; with a node planted it's the counterfactual ("what you'll hit
@@ -1636,17 +1676,38 @@ func (v *OrbitView) drawSOIPass(w *sim.World) {
 			}
 			drawMarker(v.canvas, w.PerilunePosition(arc.counterfactual), render.MarkerPerilune, st, "", widgets.CellTag{})
 		}
+		// SOI Entry / Exit glyphs at the arc's ring crossings (ADR 0021 C),
+		// in the same brightness=state vocabulary as the Perilune: dim when
+		// this arc is the counterfactual under a planted node, bright when
+		// it IS the live path. No Exit when the arc never leaves the SOI
+		// (impact / horizon-truncated / node-capped).
+		if arc.counterfactual.HasEntry {
+			drawMarker(v.canvas, w.EntryPosition(arc.counterfactual), render.MarkerSOIEntry, markerState, "", widgets.CellTag{})
+		}
+		if arc.counterfactual.HasExit {
+			drawMarker(v.canvas, w.ExitPosition(arc.counterfactual), render.MarkerSOIExit, markerState, "", widgets.CellTag{})
+		}
 	}
 
-	// The planned (node-modified) path's Perilune marker, drawn bright over
-	// the node legs (which drawNodes already paints) — the safe periapsis
-	// the burn produces, against the dim no-burn Impact (ADR 0019 D).
-	if arc.plOK && arc.planned.HasPerilunePt {
-		st := render.MarkerNominal
-		if arc.planned.Impact {
-			st = render.MarkerAlarm
+	// The planned (node-modified) path's markers, drawn bright over the
+	// node legs (which drawNodes already paints): the Perilune — the safe
+	// periapsis the burn produces, against the dim no-burn Impact (ADR
+	// 0019 D) — plus its own SOI Entry / Exit ring crossings. Drawn after
+	// the counterfactual so the bright planned glyph wins a shared cell.
+	if arc.plOK {
+		if arc.planned.HasPerilunePt {
+			st := render.MarkerNominal
+			if arc.planned.Impact {
+				st = render.MarkerAlarm
+			}
+			drawMarker(v.canvas, w.PerilunePosition(arc.planned), render.MarkerPerilune, st, "", widgets.CellTag{})
 		}
-		drawMarker(v.canvas, w.PerilunePosition(arc.planned), render.MarkerPerilune, st, "", widgets.CellTag{})
+		if arc.planned.HasEntry {
+			drawMarker(v.canvas, w.EntryPosition(arc.planned), render.MarkerSOIEntry, render.MarkerNominal, "", widgets.CellTag{})
+		}
+		if arc.planned.HasExit {
+			drawMarker(v.canvas, w.ExitPosition(arc.planned), render.MarkerSOIExit, render.MarkerNominal, "", widgets.CellTag{})
+		}
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -782,18 +782,26 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 		return fmt.Sprintf("%.0f km", p.PeriluneAltitude()/1000)
 	}
 	if arc.hasNodes {
-		// Dual arc: planned (bright path) + no-burn (counterfactual).
+		// Dual arc: planned (bright path) + no-burn (counterfactual). The
+		// planned path's SOI-entry clock rides under it (ADR 0021 C: the
+		// Entry glyph marks where, the chip carries when).
 		if arc.plOK {
-			lines = append(lines,
-				chipRow("planned:", periValue(arc.planned)),
-				chipRow("  T-peri:", formatTCA(arc.planned.TimeToPerilune)))
+			lines = append(lines, chipRow("planned:", periValue(arc.planned)))
+			if arc.planned.HasEntryTime {
+				lines = append(lines, chipRow("  T-entry:", formatTCA(arc.planned.TimeToEntry)))
+			}
+			lines = append(lines, chipRow("  T-peri:", formatTCA(arc.planned.TimeToPerilune)))
 		}
 		if arc.cfOK {
 			lines = append(lines, chipRow("no-burn:", periValue(arc.counterfactual)))
 		}
 		return lines
 	}
-	// Single live pass (no node planted).
+	// Single live pass (no node planted). T-entry is the predicted SOI-entry
+	// clock — the ring crossing the Entry glyph marks (ADR 0021 C).
+	if arc.counterfactual.HasEntryTime {
+		lines = append(lines, chipRow("T-entry:", formatTCA(arc.counterfactual.TimeToEntry)))
+	}
 	lines = append(lines,
 		chipRow("peri:", periValue(arc.counterfactual)),
 		chipRow("TCA:", formatTCA(arc.counterfactual.TimeToPerilune)))

--- a/internal/tui/screens/orbit_soi_ring_test.go
+++ b/internal/tui/screens/orbit_soi_ring_test.go
@@ -1,0 +1,157 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// The ring assertions key on the exact cell colour drawSOIRing paints —
+// render.Shade(ColorForeignSOI, soiRingDim) — which is unique on the canvas
+// (the counterfactual arc dims by soiCounterfactualDim=0.5, the ring by
+// 0.4), so CountColor isolates the ring's ink from the arcs that cross it.
+
+// TestSOIRingDrawsAtPassBody: coasting toward the Moon with a live pass,
+// focused on the Moon, the canvas carries the dim dotted SOI Ring — a
+// substantial count of cells in the ring's unique colour, scaling with the
+// ring's projected circumference (ADR 0021 C).
+func TestSOIRingDrawsAtPassBody(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := setupMoonCoast(t, w)
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	v.Render(w, 0, 200, 60)
+
+	moon := w.System().Bodies[moonIdx]
+	soi := w.BodySOIRadius(moon)
+	pxR := soi * v.canvas.Scale()
+	if pxR < float64(soiRingMinPixels) {
+		t.Fatalf("test setup: ring projects to only %.1f px — framing too wide to assert the ring", pxR)
+	}
+
+	got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiRingDim))
+	// One dot per ~ringDotSpacing(4) px of circumference; on-canvas cells
+	// can collapse dots, and part of the ring may project off-canvas, so
+	// demand a conservative fraction of the ideal count.
+	ideal := 2 * math.Pi * pxR / 4
+	if float64(got) < ideal/4 {
+		t.Errorf("only %d ring-coloured cells on the canvas, want ≥ %.0f (ring radius %.0f px) — SOI Ring not drawn", got, ideal/4, pxR)
+	}
+}
+
+// TestSOIRingAbsentForQuietBodies: a stable LEO reaches no SOI, so no body
+// has an active pass and no ring ink appears anywhere on the canvas —
+// quiet bodies draw no ring (ADR 0021 C).
+func TestSOIRingAbsentForQuietBodies(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	c.Nodes = nil
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	v.Render(w, 0, 200, 60)
+	if got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiRingDim)); got != 0 {
+		t.Errorf("%d ring-coloured cells on a stable LEO with no pass, want 0", got)
+	}
+}
+
+// glyphAtProjected returns the rune the rendered frame shows at the cell a
+// world position projects to. The canvas content sits 1 col in and 2 rows
+// down from the frame's top-left (title row + rounded border), the same
+// offsets the mouse dispatch uses (IsCanvasClick / composeChips).
+func glyphAtProjected(t *testing.T, v *OrbitView, out string, pos orbital.Vec3) rune {
+	t.Helper()
+	px, py, ok := v.canvas.Project(pos)
+	if !ok {
+		t.Fatalf("position %v projects off-canvas", pos)
+	}
+	col, row := px/2, py/4
+	lines := strings.Split(stripANSI(out), "\n")
+	frameRow := row + 2
+	frameCol := col + 1
+	if frameRow >= len(lines) {
+		t.Fatalf("frame row %d beyond rendered %d lines", frameRow, len(lines))
+	}
+	runes := []rune(lines[frameRow])
+	if frameCol >= len(runes) {
+		t.Fatalf("frame col %d beyond line width %d", frameCol, len(runes))
+	}
+	return runes[frameCol]
+}
+
+// TestSOIEntryExitMarkersDrawAtRingCrossings: the Entry ▷ and Exit ◁ glyphs
+// (ADR 0020 family) land in the exact cells the pass's ring crossings
+// project to — position asserted through the same Project mapping the
+// renderer uses, not a blind string search.
+func TestSOIEntryExitMarkersDrawAtRingCrossings(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := setupMoonCoast(t, w)
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	out := v.Render(w, 0, 200, 60)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no live SOI Pass on the Moon coast")
+	}
+	if !pass.HasEntry || !pass.HasExit {
+		t.Fatalf("precondition: pass missing ring crossings (entry=%v exit=%v)", pass.HasEntry, pass.HasExit)
+	}
+
+	if got, want := glyphAtProjected(t, v, out, w.EntryPosition(pass)), render.MarkerGlyph(render.MarkerSOIEntry); got != want {
+		t.Errorf("cell at the SOI-entry crossing shows %q, want the Entry glyph %q", got, want)
+	}
+	if got, want := glyphAtProjected(t, v, out, w.ExitPosition(pass)), render.MarkerGlyph(render.MarkerSOIExit); got != want {
+		t.Errorf("cell at the SOI-exit crossing shows %q, want the Exit glyph %q", got, want)
+	}
+}
+
+// TestSOIPassChipShowsEntryTime: the SOI PASS chip surfaces the predicted
+// SOI-entry countdown — the value half of the Entry marker (ADR 0020 C /
+// ADR 0021 C: glyph marks which/where, the chip carries the number). Both
+// chip forms carry it: the no-node single pass and the dual-arc planned row.
+func TestSOIPassChipShowsEntryTime(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupMoonCoast(t, w)
+	if out := v.Render(w, 0, 200, 60); !strings.Contains(out, "T-entry:") {
+		t.Errorf("no-node SOI PASS chip missing the T-entry row")
+	}
+
+	// Dual-arc form: transfer planted, craft still at LEO.
+	v2 := newSOIPassTestView()
+	w2, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	plantMoonTransferAtLEO(t, w2)
+	out := v2.Render(w2, 0, 200, 60)
+	if !strings.Contains(out, "planned") {
+		t.Fatalf("precondition: dual-arc chip missing its planned row:\n%s", out)
+	}
+	if !strings.Contains(out, "T-entry:") {
+		t.Errorf("dual-arc SOI PASS chip missing the planned T-entry row")
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -455,6 +455,48 @@ func (c *Canvas) RingColoredOutlineTagged(center orbital.Vec3, pxRadius int, tag
 	}
 }
 
+// ringDotSpacingPx is the circumference distance (pixels) between
+// successive dots of RingDottedColored — sparse enough that the ring
+// reads as a quiet dotted boundary cue rather than solid ink.
+const ringDotSpacingPx = 4
+
+// RingDottedColored draws a dotted screen-space circle of pxRadius
+// pixels around center — the SOI Ring (ADR 0021 C). A sphere's
+// orthographic projection is the same circle under every view basis, so
+// like RingColoredOutline the ring draws in screen space rather than as
+// a tilted world-plane ellipse. Dots are spaced ~ringDotSpacingPx of
+// circumference apart; the sample count carries the same
+// 4×(pxW+pxH) cap as the other ring primitives so an extreme-zoom
+// radius can't lock the render loop (the visible arc just goes sparse).
+func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipgloss.Color) {
+	if pxRadius < 1 {
+		return
+	}
+	cx, cy, _ := c.Project(center)
+	samples := int(math.Round(2 * math.Pi * float64(pxRadius) / ringDotSpacingPx))
+	if samples < 8 {
+		samples = 8
+	}
+	maxSamples := 4 * (c.pxW + c.pxH)
+	if samples > maxSamples {
+		samples = maxSamples
+	}
+	if c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	tag := CellTag{Color: color}
+	for i := 0; i < samples; i++ {
+		theta := 2 * math.Pi * float64(i) / float64(samples)
+		px := cx + int(math.Round(float64(pxRadius)*math.Cos(theta)))
+		py := cy + int(math.Round(float64(pxRadius)*math.Sin(theta)))
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			continue
+		}
+		c.dc.Set(px, py)
+		c.pixelTags[[2]int{px, py}] = tag
+	}
+}
+
 // RingTiltedOutline draws a ring of radius rMeters around center
 // in the plane spanned by basis vectors e1, e2 (both in world
 // inertial frame, both unit-length, mutually orthogonal). v0.8.5.7+

--- a/internal/tui/widgets/ring_dotted_test.go
+++ b/internal/tui/widgets/ring_dotted_test.go
@@ -1,0 +1,104 @@
+package widgets
+
+import (
+	"math"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// ringDottedPixels collects the pixel coords RingDottedColored tagged with
+// the given colour — white-box over pixelTags, the same store CountColor
+// aggregates.
+func ringDottedPixels(c *Canvas, color lipgloss.Color) [][2]int {
+	var px [][2]int
+	for coord, tag := range c.pixelTags {
+		if tag.Color == color {
+			px = append(px, coord)
+		}
+	}
+	return px
+}
+
+// TestRingDottedColoredDotsLieOnCircle: every dot sits at the requested
+// pixel radius from the projected center (±1.5 px rounding), and the dots
+// cover all four quadrants — a ring, not an arc or a smear.
+func TestRingDottedColoredDotsLieOnCircle(t *testing.T) {
+	c := NewCanvas(60, 30) // pixel grid 120 × 120
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	const pxRadius = 40
+	color := lipgloss.Color("#602A72")
+	c.RingDottedColored(orbital.Vec3{}, pxRadius, color)
+
+	dots := ringDottedPixels(c, color)
+	if len(dots) == 0 {
+		t.Fatal("RingDottedColored set no pixels")
+	}
+	cx, cy, _ := c.Project(orbital.Vec3{})
+	quadrants := map[[2]bool]bool{}
+	for _, d := range dots {
+		dx, dy := float64(d[0]-cx), float64(d[1]-cy)
+		r := math.Hypot(dx, dy)
+		if math.Abs(r-pxRadius) > 1.5 {
+			t.Errorf("dot (%d,%d) sits %.1f px from center, want %d ±1.5", d[0], d[1], r, pxRadius)
+		}
+		quadrants[[2]bool{dx >= 0, dy >= 0}] = true
+	}
+	if len(quadrants) < 4 {
+		t.Errorf("dots cover only %d quadrants, want 4 — not a full ring", len(quadrants))
+	}
+}
+
+// TestRingDottedColoredIsSparse: the dotted ring sets roughly one pixel
+// per ringDotSpacingPx of circumference — visibly sparser than the solid
+// ring primitive at the same radius, so the boundary reads as a quiet
+// dotted cue rather than solid ink.
+func TestRingDottedColoredIsSparse(t *testing.T) {
+	const pxRadius = 40
+	color := lipgloss.Color("#602A72")
+
+	dotted := NewCanvas(60, 30)
+	dotted.SetScale(1)
+	dotted.Center(orbital.Vec3{})
+	dotted.Clear()
+	dotted.RingDottedColored(orbital.Vec3{}, pxRadius, color)
+	nDotted := len(ringDottedPixels(dotted, color))
+
+	solid := NewCanvas(60, 30)
+	solid.SetScale(1)
+	solid.Center(orbital.Vec3{})
+	solid.Clear()
+	solid.RingColoredOutline(orbital.Vec3{}, pxRadius, color)
+	nSolid := len(ringDottedPixels(solid, color))
+
+	if nDotted == 0 || nSolid == 0 {
+		t.Fatalf("empty rings: dotted=%d solid=%d", nDotted, nSolid)
+	}
+	if nDotted*2 >= nSolid {
+		t.Errorf("dotted ring has %d pixels vs solid %d — not visibly dotted", nDotted, nSolid)
+	}
+	// And roughly the commanded density: one dot per ~ringDotSpacingPx of
+	// circumference (rounding collapses a few neighbours).
+	want := 2 * math.Pi * pxRadius / ringDotSpacingPx
+	if float64(nDotted) < want*0.6 || float64(nDotted) > want*1.4 {
+		t.Errorf("dotted ring has %d pixels, want ≈%.0f (±40%%)", nDotted, want)
+	}
+}
+
+// TestRingDottedColoredHugeRadiusDoesNotHang mirrors the v0.5.15 guard on
+// the other ring primitives: an extreme-zoom radius must stay bounded by
+// the 4×(pxW+pxH) sample cap instead of looping per circumference pixel.
+// If the cap regresses, this test never finishes — same sentinel style as
+// TestRingOutlineHugeRadiusDoesNotHang.
+func TestRingDottedColoredHugeRadiusDoesNotHang(t *testing.T) {
+	c := NewCanvas(40, 20)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	c.RingDottedColored(orbital.Vec3{}, 500_000_000, lipgloss.Color("#602A72"))
+}


### PR DESCRIPTION
## What this does

ADR 0021 decision C (folds in #143). A body with an active SOI Pass now draws a **dim dotted ring at its parent-relative SOI radius**, anchored at the body's CURRENT position — the same anchor `SegmentDrawPoints` rebases the Local-to-Body Arc onto (#147) — so the arc visibly enters and exits on a meaningful boundary and the hyperbola gets scale. Quiet bodies (no active pass) draw no ring.

**SOI Entry (▷) and SOI Exit (◁)** join the unified marker family (ADR 0020): glyphs at the arc's ring-crossing points, in the brightness=state vocabulary (dim counterfactual under a planted node, bright live/planned). The predicted **entry time surfaces via the SOI PASS chip** as a `T-entry` row in both chip forms (no-node single pass and the dual-arc planned block) — glyph marks *where*, chip carries *when*. No Exit marker when the arc never leaves the SOI (impact / horizon-truncated / node-capped counterfactual).

**#143 fix:** SOI floor/radius computations now route through the new `World.BodySOIRadius` (parent-relative via `ParentOf`, root fallback — exactly how `physics.FindPrimary` sizes its spheres). Fixed sites: `bodyApproachFallback` (the named #143 site) and `FocusZoomRadius`'s has-children branch. A grep sweep confirms no remaining `SOIRadius(…, Bodies[0])` where the parent is correct; `scanTargetEncounter` / `transferEncounterTimes` / `soiPassFromState` pass true sibling parents already.

## Where it landed

- `internal/sim/soipass.go` — `SOIPass` gains `EntryRel`/`ExitRel`/`HasEntry`/`HasExit` (ring-proximity-gated segment endpoints) + `TimeToEntry`/`HasEntryTime` (from the tuned predictor's `soiEntry` transitions); `EntryPosition`/`ExitPosition` mirror `PerilunePosition`; `PlannedSOIPass` rebases T-entry to now alongside T-peri.
- `internal/sim/world.go` — `BodySOIRadius`.
- `internal/sim/focus.go` — minimal one-line #143 radius-source fixes only (these framers are #151's lane).
- `internal/tui/widgets/canvas.go` — `RingDottedColored` screen-space dotted circle (sphere projects to the same circle under any basis), with the 4×(pxW+pxH) sample cap of the other ring primitives.
- `internal/tui/screens/orbit.go` — `drawSOIRing` + entry/exit glyph stamping in `drawSOIPass`; ring drawn first so arcs/markers paint over the dots; `soiRingDim=0.4` keeps the ring's colour unique vs the 0.5-dimmed counterfactual arc.
- `internal/tui/screens/orbit_chip_builders.go` — `T-entry` chip rows.
- `internal/render` — `MarkerSOIEntry`/`MarkerSOIExit` types, glyphs ▷/◁ (font-safe Geometric Shapes block), both sharing the foreign-SOI orchid they bracket (precedent: Perilune shares the apsis amber).

## Acceptance criteria → tests

- Ring at `SOIRadius(body, parent)` for pass bodies, none for quiet bodies → `TestSOIRingDrawsAtPassBody` (CountColor on the ring's unique colour, scaled to projected circumference), `TestSOIRingAbsentForQuietBodies`; circle geometry pinned in `internal/tui/widgets/ring_dotted_test.go` (dots at pxRadius ±1.5 px, 4 quadrants, sparse vs solid, huge-radius no-hang).
- Arc's first/last drawn samples land on the ring → `TestPassEntryExitCrossingsLandOnRing` (crossing distance ≈ ring radius ±5%, both `*Rel` offsets and rebased `SegmentDrawPoints` endpoints).
- Entry/Exit glyphs at the crossings in ADR 0020 state vocabulary → `TestSOIEntryExitMarkersDrawAtRingCrossings` (positional: rune at the exact cell the crossing projects to, not a blind string search), render-table tests for glyph/colour.
- Entry time in the SOI PASS chip → `TestSOIPassChipShowsEntryTime` (both chip forms), `TestPassEntryTimePrecedesPerilune`, `TestPlannedPassEntryTimeRebasedToNow`.
- #143 closed → `TestBodySOIRadiusIsParentRelative`, `TestBodyApproachFallbackFloorsToParentSOI` (craft parked inside the floor so the craft-distance widening can't mask a root-sized floor).
- `go vet ./...` clean; `go test ./... -race -count=1`: **1128 passed in 15 packages**.

## Merge-sequencing note (vs #151)

#151 deletes `ViewTarget`/`ViewSOIPass` and the per-frame framers in `internal/sim/focus.go` + the orbit Render override blocks. This PR deliberately keeps its focus.go touch to two one-line radius-source swaps (`bodyApproachFallback`, `FocusZoomRadius`) and does not touch the Render camera blocks. `FocusZoomRadius` survives #151; `bodyApproachFallback` may be deleted by it — whichever lands second resolves trivially.

Closes #150
Closes #143