### PR TITLE
feat(render): keep SOI Ring + draw the escape path while inside an SOI (#157)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -512,6 +512,13 @@ closest approach to the passed Body) and **Time to Perilune**. A SOI Pass
 whose Perilune falls below the Body's surface is an **Impact**. Once the
 player plants a Capture Burn at Perilune the Pass becomes a closed
 Capture Orbit — a different prediction (the node leg), not a SOI Pass.
+After SOI entry the Pass persists as the *in-SOI residence* variant
+(#157): while the Vessel is inside a non-root Body's SOI on a
+trajectory that leaves it, the same picture — ring, Local-to-Body arc,
+Perilune + SOI Exit markers, chip — draws around the current Primary
+(no Entry marker; that crossing is in the past) and continues past the
+exit into the onward path. A captured orbit (bound, apoapsis inside
+the SOI) quiets it.
 Distinct from **Encounter** (craft-to-craft — see Encounter math) and
 from the **Target** slot (a SOI Pass renders whether or not the Body is
 targeted). The HUD reports it as the SOI PASS block; on the orbit canvas
@@ -552,10 +559,16 @@ setting this deliberately is *not*).
 
 **SOI Ring**:
 The dim dotted ring drawn at a Body's parent-relative **Sphere of
-Influence** radius while a SOI Pass to it exists. Gives the
-**Local-to-Body Arc** its scale and a boundary to visibly enter and
-exit on; carries the SOI Entry and SOI Exit marker glyphs (ADR 0020
-family, per ADR 0021). Quiet bodies (no active Pass) draw no ring.
+Influence** radius while a SOI Pass to it exists — including the
+in-SOI escape-residence case (#157): while the active Vessel sits
+*inside* a non-root Body's SOI on a trajectory that leaves it
+(hyperbolic, or bound with apoapsis at/past the SOI radius), the ring
+persists around the current Primary, so SOI entry doesn't switch the
+boundary off mid-transit. Gives the **Local-to-Body Arc** its scale
+and a boundary to visibly enter and exit on; carries the SOI Entry and
+SOI Exit marker glyphs (ADR 0020 family, per ADR 0021). Quiet bodies —
+no active Pass, or a captured orbit wholly inside the SOI — draw no
+ring.
 _Avoid_: SOI circle, Influence boundary (informal).
 
 ### Launch & landing

--- a/internal/orbital/events.go
+++ b/internal/orbital/events.go
@@ -86,6 +86,76 @@ func TimeToPeriapsisHyperbolic(state Vec3State, mu float64) (float64, bool) {
 	return -M / n, true
 }
 
+// TimeToRadiusOutbound returns the elapsed seconds from the given state to
+// the next time the trajectory crosses radius r moving OUTBOUND (ṙ > 0) —
+// the SOI-exit geometry: a craft inside a body's sphere on an escaping
+// trajectory crosses r exactly once on the way out (#157). Works on both
+// sides of e = 1: closed orbits route through TimeToTrueAnomaly (the
+// outbound crossing sits at ν = +acos((p/r − 1)/e), the (0, π) half-plane),
+// open orbits through the hyperbolic Kepler equation — the same
+// M = e·sinh H − H machinery as TimeToPeriapsisHyperbolic.
+//
+// ok=false when the orbit never reaches r (bound with apoapsis < r, or r
+// below periapsis), is circular/degenerate, or the crossing isn't ahead.
+func TimeToRadiusOutbound(state Vec3State, mu, r float64) (float64, bool) {
+	if mu <= 0 || r <= 0 {
+		return 0, false
+	}
+	el := ElementsFromState(state.R, state.V, mu)
+	p := el.A * (1 - el.E*el.E) // semi-latus rectum, positive both sides of e=1
+	if el.E < 1e-9 || math.IsNaN(p) || p <= 0 {
+		return 0, false
+	}
+	cosNu := (p/r - 1) / el.E
+	if cosNu < -1 || cosNu > 1 {
+		return 0, false // r below periapsis or beyond apoapsis — never crossed
+	}
+	nuExit := math.Acos(cosNu) // ∈ (0, π): the outbound crossing
+
+	if el.E < 1 {
+		if el.A <= 0 {
+			return 0, false
+		}
+		nuNow := TrueAnomalyFromState(state.R, state.V, mu, el)
+		dt := TimeToTrueAnomaly(nuNow, nuExit, el.A, el.E, mu)
+		if dt < 0 {
+			return 0, false
+		}
+		return dt, true
+	}
+
+	// Hyperbolic branch. Map the inbound half-plane to (−π, 0) so an
+	// approaching craft has M < 0, exactly as TimeToPeriapsisHyperbolic.
+	if el.A >= 0 {
+		return 0, false
+	}
+	nuNow := TrueAnomalyFromState(state.R, state.V, mu, el)
+	if nuNow > math.Pi {
+		nuNow -= 2 * math.Pi
+	}
+	meanAnom := func(nu float64) (float64, bool) {
+		denom := 1 + el.E*math.Cos(nu)
+		if denom <= 0 {
+			return 0, false // beyond the asymptote — not on the physical arc
+		}
+		sinhH := math.Sqrt(el.E*el.E-1) * math.Sin(nu) / denom
+		H := math.Asinh(sinhH)
+		return el.E*math.Sinh(H) - H, true
+	}
+	mNow, okNow := meanAnom(nuNow)
+	mExit, okExit := meanAnom(nuExit)
+	if !okNow || !okExit {
+		return 0, false
+	}
+	absA := -el.A
+	n := math.Sqrt(mu / (absA * absA * absA))
+	dt := (mExit - mNow) / n
+	if dt <= 0 {
+		return 0, false
+	}
+	return dt, true
+}
+
 // TimeToApoapsis returns elapsed seconds to the next apoapsis (ν=π).
 // Convenience wrapper around TimeToTrueAnomaly.
 func TimeToApoapsis(state Vec3State, mu float64) float64 {

--- a/internal/orbital/events_test.go
+++ b/internal/orbital/events_test.go
@@ -197,3 +197,68 @@ func TestTimeToNodeCrossingInclined(t *testing.T) {
 		t.Errorf("AN and DN crossings too close: AN=%.3f DN=%.3f", dtAN, dtDN)
 	}
 }
+
+// TestTimeToRadiusOutbound pins the SOI-exit time helper (#157) on both
+// sides of e = 1: the elliptic branch against known true-anomaly timing,
+// the hyperbolic branch against TimeToPeriapsisHyperbolic's antisymmetry
+// (an inbound craft at radius r crosses r outbound exactly 2× its
+// time-to-periapsis later), plus the unreachable-radius rejections.
+func TestTimeToRadiusOutbound(t *testing.T) {
+	a := 6.578e6
+	e := 0.05
+	period := 2 * math.Pi * math.Sqrt(a*a*a/muEarth)
+
+	// Elliptic, from periapsis: the apoapsis radius is crossed (outbound,
+	// grazing) exactly half a period later.
+	state := stateAtNu(0)
+	ra := a * (1 + e)
+	if dt, ok := TimeToRadiusOutbound(state, muEarth, ra); !ok || math.Abs(dt-period/2) > 1.0 {
+		t.Errorf("peri → apoapsis radius: got dt=%.3f ok=%v, want %.3f", dt, ok, period/2)
+	}
+	// Beyond apoapsis / below periapsis: never crossed.
+	if _, ok := TimeToRadiusOutbound(state, muEarth, ra*1.01); ok {
+		t.Error("radius beyond apoapsis: ok=true, want false")
+	}
+	if _, ok := TimeToRadiusOutbound(state, muEarth, a*(1-e)*0.99); ok {
+		t.Error("radius below periapsis: ok=true, want false")
+	}
+
+	// Elliptic, inbound (ν=−π/4 i.e. 7π/4): crossing the current radius
+	// outbound is symmetric about periapsis — Δν = π/4 → π/4 of anomaly
+	// each side, so dt equals the ν=−π/4 → +π/4 flight time.
+	inb := stateAtNu(-math.Pi / 4)
+	rNow := inb.R.Norm()
+	want := TimeToTrueAnomaly(-math.Pi/4, math.Pi/4, a, e, muEarth)
+	if dt, ok := TimeToRadiusOutbound(inb, muEarth, rNow); !ok || math.Abs(dt-want) > 1.0 {
+		t.Errorf("elliptic inbound, own radius: got dt=%.3f ok=%v, want %.3f", dt, ok, want)
+	}
+
+	// Hyperbolic, inbound at ν=−0.6: by time symmetry about periapsis the
+	// outbound crossing of the current radius lands at 2× the
+	// time-to-periapsis.
+	ah, eh := -8.0e6, 1.5
+	hin := hyperbolicStateAtNu(ah, eh, -0.6)
+	tp, okP := TimeToPeriapsisHyperbolic(hin, muEarth)
+	if !okP || tp <= 0 {
+		t.Fatalf("setup: hyperbolic time-to-periapsis %.3f ok=%v", tp, okP)
+	}
+	if dt, ok := TimeToRadiusOutbound(hin, muEarth, hin.R.Norm()); !ok || math.Abs(dt-2*tp) > 1.0 {
+		t.Errorf("hyperbolic inbound, own radius: got dt=%.3f ok=%v, want 2×t_peri=%.3f", dt, ok, 2*tp)
+	}
+	// Hyperbolic outbound: a larger radius is still ahead…
+	hout := hyperbolicStateAtNu(ah, eh, 0.6)
+	if dt, ok := TimeToRadiusOutbound(hout, muEarth, hout.R.Norm()*2); !ok || dt <= 0 {
+		t.Errorf("hyperbolic outbound, 2× radius: got dt=%.3f ok=%v, want > 0", dt, ok)
+	}
+	// …but a radius already passed is not.
+	if _, ok := TimeToRadiusOutbound(hout, muEarth, hout.R.Norm()*0.9); ok {
+		t.Error("hyperbolic outbound, radius behind: ok=true, want false")
+	}
+
+	// Circular orbits never cross a different radius.
+	rc := 7.0e6
+	circ := Vec3State{R: Vec3{X: rc}, V: Vec3{Y: math.Sqrt(muEarth / rc)}}
+	if _, ok := TimeToRadiusOutbound(circ, muEarth, rc*1.5); ok {
+		t.Error("circular orbit: ok=true, want false")
+	}
+}

--- a/internal/sim/in_soi_pass_test.go
+++ b/internal/sim/in_soi_pass_test.go
@@ -1,0 +1,309 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// hyperbolicInMoonSOI parks the active craft INSIDE the Moon's SOI on an
+// inbound hyperbolic trajectory (e = 2, periapsis 500 km above the surface,
+// currently at 0.6× the SOI radius) — the post-entry, pre-capture state the
+// #157 in-SOI continuation must keep drawing. Constructed directly in the
+// Moon's frame: a = −rp gives e = 1 + rp/|a| = 2 and h = √(3·μ·rp); the
+// radial component points inward so the perilune is still ahead.
+func hyperbolicInMoonSOI(t *testing.T, w *World) (moon bodies.CelestialBody, soi float64) {
+	t.Helper()
+	_, moon = findMoon(t, w)
+	soi = physics.SOIRadius(moon, parentBody(w, moon))
+	mu := moon.GravitationalParameter()
+	rp := moon.RadiusMeters() + 500e3
+	r0 := 0.6 * soi
+	v0 := math.Sqrt(mu * (2/r0 + 1/rp)) // vis-viva with a = −rp
+	vt := math.Sqrt(3*mu*rp) / r0       // h = √(3·μ·rp) for e = 2
+	vr := -math.Sqrt(v0*v0 - vt*vt)     // inbound
+
+	c := w.ActiveCraft()
+	c.Primary = moon
+	c.Landed = false
+	c.Nodes = nil
+	c.State.R = orbital.Vec3{X: r0}
+	c.State.V = orbital.Vec3{X: vr, Y: vt}
+	return moon, soi
+}
+
+// TestInSOIPassPersistsAcrossEntry flies the LEO→Moon coast through the
+// actual SOI entry and pins the #157 fix: the encounter picture must NOT
+// switch off the moment the Moon becomes the primary. The residence pass
+// keeps the same Body, drops the (now past) Entry crossing, keeps the Exit,
+// and its perilune agrees with the pre-entry prediction.
+func TestInSOIPassPersistsAcrossEntry(t *testing.T) {
+	w := mustWorld(t)
+	moonCoast(t, w)
+	c := w.ActiveCraft()
+
+	pre, ok := w.LiveSOIPass()
+	if !ok || !pre.HasEntryTime {
+		t.Fatalf("precondition: live pass with entry time on the Moon coast (ok=%v hasEntryTime=%v)", ok, pre.HasEntryTime)
+	}
+	soi := physics.SOIRadius(pre.Body, parentBody(w, pre.Body))
+
+	// Warp the craft to 10 minutes after the predicted SOI entry.
+	dt := pre.TimeToEntry + 600
+	state, primary := w.propagateStateWithPrimary(c.State, c.Primary, w.Clock.SimTime, dt)
+	c.State, c.Primary = state, primary
+	w.Clock.SimTime = w.Clock.SimTime.Add(time.Duration(dt * float64(time.Second)))
+	if c.Primary.ID != pre.Body.ID {
+		t.Fatalf("craft did not enter the Moon's SOI: primary = %q after T-entry+600s", c.Primary.ID)
+	}
+
+	post, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("LiveSOIPass vanished at SOI entry — the #157 dead zone")
+	}
+	if post.Body.ID != pre.Body.ID {
+		t.Fatalf("residence pass body = %q, want the entered Moon %q", post.Body.ID, pre.Body.ID)
+	}
+	if post.HasEntry {
+		t.Error("entry crossing is in the past — the residence pass must not place an Entry marker")
+	}
+	if post.HasEntryTime {
+		t.Error("residence pass carries an entry time — there is no upcoming entry inside the SOI")
+	}
+	if !post.HasExit {
+		t.Error("flyby leaves the SOI — the residence pass should close on the ring with an Exit crossing")
+	}
+	if d := post.ExitRel.Norm(); math.Abs(d-soi) > soi*0.05 {
+		t.Errorf("ExitRel %.0f km from the Moon, want ring radius %.0f km (±5%%)", d/1e3, soi/1e3)
+	}
+
+	// Perilune continuity across the boundary: the pre-entry prediction and
+	// the in-SOI analytic perilune describe the same flyby.
+	tol := math.Max(0.1*pre.PeriluneRadius, 0.02*soi)
+	if d := math.Abs(post.PeriluneRadius - pre.PeriluneRadius); d > tol {
+		t.Errorf("perilune radius jumped %.0f km across SOI entry (pre %.0f km, post %.0f km, tol %.0f km)",
+			d/1e3, pre.PeriluneRadius/1e3, post.PeriluneRadius/1e3, tol/1e3)
+	}
+	if post.TimeToPerilune <= 0 {
+		t.Errorf("TimeToPerilune = %.0f s inside the SOI before perilune, want > 0", post.TimeToPerilune)
+	}
+	wantTCA := pre.TimeToPerilune - dt
+	if d := math.Abs(post.TimeToPerilune - wantTCA); d > math.Max(0.1*wantTCA, 600) {
+		t.Errorf("TimeToPerilune = %.0f s, want ≈ pre-entry TCA minus the warp = %.0f s", post.TimeToPerilune, wantTCA)
+	}
+}
+
+// TestInSOIPassGeometry pins the synthesized residence pass on a directly
+// constructed in-SOI hyperbola: the in-SOI leg draws Local-to-Body within
+// ~1× SOI of the Moon's current position (acceptance: ~1–2× SOI), the
+// onward continuation exists in the parent's frame, and the homeID trap is
+// closed — passing the craft's own primary as homeID would short-circuit
+// to inertial points whose tail sits where the Moon WILL be, off the drawn
+// ring (the #147 smear, reintroduced).
+func TestInSOIPassGeometry(t *testing.T) {
+	w := mustWorld(t)
+	moon, soi := hyperbolicInMoonSOI(t, w)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("no residence pass on an in-SOI escape hyperbola")
+	}
+	if pass.Body.ID != moon.ID {
+		t.Fatalf("pass body = %q, want the Moon", pass.Body.ID)
+	}
+	rp := moon.RadiusMeters() + 500e3
+	if math.Abs(pass.PeriluneRadius-rp) > rp*0.01 {
+		t.Errorf("PeriluneRadius = %.0f km, want the constructed periapsis %.0f km (±1%%)", pass.PeriluneRadius/1e3, rp/1e3)
+	}
+	if pass.Impact {
+		t.Error("500 km perilune flagged as Impact")
+	}
+	if pass.TimeToPerilune <= 0 {
+		t.Errorf("TimeToPerilune = %.0f s on the inbound leg, want > 0", pass.TimeToPerilune)
+	}
+	if !pass.HasPerilunePt {
+		t.Fatal("pass has no perilune marker point")
+	}
+	if d := pass.PeriluneRel.Norm(); d < rp*0.9 || d > soi*0.1 {
+		t.Errorf("sampled PeriluneRel = %.0f km, want near the %.0f km periapsis (sampling slack allowed)", d/1e3, rp/1e3)
+	}
+	if !pass.HasExit {
+		t.Fatal("escape hyperbola should exit on the ring")
+	}
+	if len(pass.OnwardSegments) == 0 {
+		t.Fatal("no onward continuation past the SOI exit — the path must keep going (#157)")
+	}
+	if got := pass.OnwardSegments[0].PrimaryID; got != moon.ParentID {
+		t.Errorf("first onward segment primary = %q, want the Moon's parent %q", got, moon.ParentID)
+	}
+
+	// Local-to-Body anchoring: drawn with the system root as homeID, every
+	// in-SOI sample lands within ~1× SOI of the Moon's CURRENT position.
+	rootID := w.System().Bodies[0].ID
+	moonNow := w.BodyPosition(moon)
+	maxRebased := 0.0
+	for _, seg := range pass.ArcSegments {
+		for _, p := range w.SegmentDrawPoints(seg, rootID) {
+			if d := p.Sub(moonNow).Norm(); d > maxRebased {
+				maxRebased = d
+			}
+		}
+	}
+	if maxRebased > 1.05*soi {
+		t.Errorf("rebased in-SOI arc extends %.2f×SOI from the Moon's current position, want ≤ ~1×SOI", maxRebased/soi)
+	}
+
+	// The homeID trap (#157 implementation note): with the craft's primary
+	// as homeID, SegmentDrawPoints short-circuits to the inertial Points —
+	// whose tail rides the Moon's future motion away from the drawn ring.
+	last := pass.ArcSegments[0]
+	trap := w.SegmentDrawPoints(last, moon.ID)
+	if len(trap) != len(last.Points) {
+		t.Fatalf("trap draw returned %d points for %d samples", len(trap), len(last.Points))
+	}
+	for i := range trap {
+		if trap[i] != last.Points[i] {
+			t.Fatal("primary-as-homeID no longer short-circuits to inertial points — trap premise gone stale")
+		}
+	}
+	rebasedEnd := moonNow.Add(last.RelPoints[len(last.RelPoints)-1])
+	inertialEnd := last.Points[len(last.Points)-1]
+	if d := inertialEnd.Sub(rebasedEnd).Norm(); d < 0.1*soi {
+		t.Errorf("inertial vs rebased exit differ by only %.2f×SOI — the smear premise is stale, trap test proves nothing", d/soi)
+	} else {
+		t.Logf("homeID trap: inertial exit sits %.2f×SOI off the drawn ring crossing (max rebased extent %.2f×SOI)", d/soi, maxRebased/soi)
+	}
+}
+
+// TestInSOIPassQuietWhenCaptured pins the quiet case: a captured (bound,
+// apoapsis inside the SOI) orbit synthesizes no residence pass — a parked
+// low lunar orbit and a stable LEO draw exactly as before, no ring.
+func TestInSOIPassQuietWhenCaptured(t *testing.T) {
+	w := mustWorld(t)
+	_, moon := findMoon(t, w)
+	c := w.ActiveCraft()
+	c.Primary = moon
+	c.Landed = false
+	c.Nodes = nil
+	mu := moon.GravitationalParameter()
+	r := moon.RadiusMeters() + 200e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	if _, ok := w.LiveSOIPass(); ok {
+		t.Error("captured low lunar orbit produced a pass — the quiet case regressed")
+	}
+	if _, ok := w.CounterfactualSOIPass(); ok {
+		t.Error("captured low lunar orbit produced a counterfactual pass")
+	}
+}
+
+// TestInSOIPassBoundButEscaping pins the third escape clause: a bound orbit
+// whose apoapsis reaches past the parent-relative SOI radius leaves the SOI
+// and gets the residence pass (the craft crosses the ring before apoapsis).
+func TestInSOIPassBoundButEscaping(t *testing.T) {
+	w := mustWorld(t)
+	_, moon := findMoon(t, w)
+	soi := physics.SOIRadius(moon, parentBody(w, moon))
+	c := w.ActiveCraft()
+	c.Primary = moon
+	c.Landed = false
+	c.Nodes = nil
+	mu := moon.GravitationalParameter()
+	rp := moon.RadiusMeters() + 200e3
+	ra := 1.2 * soi
+	a := (rp + ra) / 2
+	c.State.R = orbital.Vec3{X: rp}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu * (2/rp - 1/a))}
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("bound orbit with apoapsis past the SOI radius should synthesize a residence pass")
+	}
+	if pass.Body.ID != moon.ID {
+		t.Fatalf("pass body = %q, want the Moon", pass.Body.ID)
+	}
+	if !pass.HasExit {
+		t.Error("outbound ellipse crosses the ring before apoapsis — expected an Exit crossing")
+	}
+}
+
+// TestInSOICounterfactualCappedAtNode: with a capture node planted inside
+// the SOI, the dim no-burn residence arc truncates at the node (never drawn
+// past the burn, ADR 0019 D) so it ends in the interior with no Exit; the
+// planned legs keep drawing through the unchanged drawNodes path, where the
+// craft's primary as homeID short-circuits in-SOI legs to their inertial
+// samples exactly as before this change.
+func TestInSOICounterfactualCappedAtNode(t *testing.T) {
+	w := mustWorld(t)
+	moon, soi := hyperbolicInMoonSOI(t, w)
+	c := w.ActiveCraft()
+
+	live, ok := w.LiveSOIPass()
+	if !ok || live.TimeToPerilune <= 0 {
+		t.Fatalf("precondition: live residence pass with perilune ahead (ok=%v tca=%.0f)", ok, live.TimeToPerilune)
+	}
+
+	// Plant a node halfway to perilune — before the exit by construction.
+	c.Nodes = []spacecraft.ManeuverNode{{TriggerTime: w.Clock.SimTime.Add(time.Duration(live.TimeToPerilune / 2 * float64(time.Second)))}}
+	cf, ok := w.CounterfactualSOIPass()
+	if !ok {
+		t.Fatal("counterfactual residence pass vanished with a node planted — the ring would drop during capture planning")
+	}
+	if cf.Body.ID != moon.ID {
+		t.Fatalf("counterfactual body = %q, want the Moon", cf.Body.ID)
+	}
+	if cf.HasExit {
+		t.Error("node-capped counterfactual still reports an Exit crossing — arc drawn past the burn")
+	}
+	for _, seg := range cf.ArcSegments {
+		for _, r := range seg.RelPoints {
+			if d := r.Norm(); d > soi*1.05 {
+				t.Errorf("node-capped counterfactual sample %.2f×SOI from the Moon — escaped past the node", d/soi)
+			}
+		}
+	}
+
+	// Planned legs unchanged: drawNodes draws them with the craft's primary
+	// as homeID, and an in-SOI (home) leg short-circuits to its inertial
+	// sample positions — the pre-#157 behavior, byte for byte.
+	legs := w.PredictedLegs()
+	if len(legs) == 0 {
+		t.Fatal("no predicted legs with a node planted")
+	}
+	for _, seg := range w.PredictedSegmentsFrom(legs[0].State, legs[0].Primary, legs[0].StartClock, legs[0].HorizonSecs, legs[0].Samples) {
+		if seg.PrimaryID != moon.ID {
+			continue
+		}
+		draw := w.SegmentDrawPoints(seg, c.Primary.ID)
+		for i := range draw {
+			if draw[i] != seg.Points[i] {
+				t.Fatal("planted in-SOI leg no longer draws at its inertial samples — drawNodes behavior changed")
+			}
+		}
+	}
+}
+
+// TestFocusZoomRadiusInsideEscapingSOI extends the ADR 0021 F pin to the
+// residence case: focusing the body the craft is escaping fits to 1.3× its
+// parent-relative SOI — ring, arc, and markers land in frame. Still a
+// Framing-Event-only read (the Camera Contract is untouched; this test
+// calls FocusZoomRadius directly, as the orbit screen does once per event).
+func TestFocusZoomRadiusInsideEscapingSOI(t *testing.T) {
+	w := mustWorld(t)
+	moonIdx, _ := findMoon(t, w)
+	moon, soi := hyperbolicInMoonSOI(t, w)
+
+	w.Focus = Focus{Kind: FocusBody, BodyIdx: moonIdx}
+	got := w.FocusZoomRadius()
+	want := physics.SOIRadius(moon, parentBody(w, moon)) * 1.3
+	if math.Abs(got-want) > want*1e-9 {
+		t.Errorf("FocusZoomRadius inside the escaping SOI = %.0f km, want 1.3× parent-relative SOI = %.0f km (soi %.0f km)",
+			got/1e3, want/1e3, soi/1e3)
+	}
+}

--- a/internal/sim/soipass.go
+++ b/internal/sim/soipass.go
@@ -15,6 +15,13 @@ import (
 // always-on from the active craft's live state and is independent of the
 // Target slot — KSP shows the encounter whether or not the body is
 // targeted, and so do we.
+//
+// The in-SOI residence variant (#157) reuses the same shape after SOI
+// entry: while the craft sits inside a non-root Body's SOI on a trajectory
+// that leaves it, Body is the craft's *current* primary, HasEntry is false
+// (the crossing is in the past), and OnwardSegments carries the post-exit
+// continuation — so the ring/arc/marker pipeline keeps drawing through the
+// transit instead of switching off at the boundary.
 type SOIPass struct {
 	Body           bodies.CelestialBody // body whose SOI the live path crosses
 	PeriluneRadius float64              // distance to Body centre at closest approach (m)
@@ -29,6 +36,7 @@ type SOIPass struct {
 	TimeToEntry    float64              // seconds from now to SOI entry (the SOI PASS chip's T-entry readout)
 	HasEntryTime   bool                 // false when the predictor reported no entry transition for the Body
 	ArcSegments    []SOISegment         // foreign-SOI arc (PrimaryID == Body.ID); draw via SegmentDrawPoints
+	OnwardSegments []SOISegment         // in-SOI residence pass only (#157): the post-exit continuation (parent / heliocentric legs); nil for sibling passes
 }
 
 // soiRingCrossingTol is the ring-proximity gate for the SOI Entry / Exit
@@ -79,12 +87,21 @@ const soiPassHyperbolicHorizon = 24 * 3600.0
 // state, with no maneuver node required (ADR 0019 decisions A/B/C/E). This
 // is the always-on, Target-independent pass the canvas draws bright and the
 // SOI PASS chip reads when nothing is planted.
+//
+// When the sibling scan finds nothing AND the craft sits inside a non-root
+// body's SOI on a trajectory that leaves it, the in-SOI residence pass
+// takes over (#157) — the encounter picture used to switch off at the
+// exact moment of SOI entry, because the body had just become the primary
+// and so stopped being a sibling.
 func (w *World) LiveSOIPass() (SOIPass, bool) {
 	c := w.ActiveCraft()
 	if c == nil || c.Landed {
 		return SOIPass{}, false
 	}
-	return w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, math.Inf(1))
+	if p, ok := w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, math.Inf(1)); ok {
+		return p, true
+	}
+	return w.inSOIEscapePass(c.State, c.Primary, w.Clock.SimTime, math.Inf(1))
 }
 
 // CounterfactualSOIPass is the dual-arc "no-burn" pass (ADR 0019 D): the
@@ -104,7 +121,13 @@ func (w *World) CounterfactualSOIPass() (SOIPass, bool) {
 			return SOIPass{}, false
 		}
 	}
-	return w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, maxHorizon)
+	if p, ok := w.soiPassFromState(c.State, c.Primary, w.Clock.SimTime, maxHorizon); ok {
+		return p, true
+	}
+	// In-SOI residence fallback (#157), node-capped like the sibling scan:
+	// with a capture burn planted the dim no-burn arc shows the escape the
+	// craft flies if it doesn't fire, truncated at the node.
+	return w.inSOIEscapePass(c.State, c.Primary, w.Clock.SimTime, maxHorizon)
 }
 
 // PlannedSOIPass is the dual-arc "planned" pass (ADR 0019 D, bright path):
@@ -320,4 +343,124 @@ func (w *World) soiPassFromState(state physics.StateVector, primary bodies.Celes
 	}
 
 	return best, true
+}
+
+// inSOIEscapePass synthesizes the in-SOI residence variant of the SOI Pass
+// (#157): while `state` sits inside a non-root `primary`'s SOI on a
+// trajectory that LEAVES it — hyperbolic/parabolic (e ≥ 1, a ≤ 0) or bound
+// with apoapsis at/past the parent-relative SOI radius — the encounter
+// picture must not switch off at SOI entry. The pass it returns feeds the
+// same ring/arc/marker pipeline as a sibling pass: Body is the current
+// primary, ArcSegments is the remaining in-SOI leg (entry is in the past,
+// so HasEntry stays false), and OnwardSegments carries the post-exit
+// continuation into the parent / heliocentric frames.
+//
+// A captured orbit (bound, apoapsis inside the SOI) returns ok=false — the
+// quiet case: a parked LEO or low lunar orbit draws its ellipse exactly as
+// before, with no ring. maxHorizon caps the prediction at the first
+// planted node for the counterfactual, as in soiPassFromState.
+func (w *World) inSOIEscapePass(state physics.StateVector, primary bodies.CelestialBody, fromClock time.Time, maxHorizon float64) (SOIPass, bool) {
+	soi := w.BodySOIRadius(primary)
+	if soi <= 0 {
+		return SOIPass{}, false // root primary — no enclosing SOI to leave
+	}
+	mu := primary.GravitationalParameter()
+	el := orbital.ElementsFromState(state.R, state.V, mu)
+	if math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return SOIPass{}, false
+	}
+	if el.A > 0 && el.E < 1 && el.Apoapsis() < soi {
+		return SOIPass{}, false // captured — bound wholly inside the SOI, the quiet case
+	}
+
+	// Horizon: ~one period for a bound-but-escaping orbit (it crosses the
+	// ring before apoapsis); the sim-day wall for an open trajectory
+	// (ADR 0019 B). A slow flyby's remaining transit can far exceed that
+	// wall — a lunar arrival spends ~2 days inside a 66 000 km SOI at
+	// ~1 km/s relative — and a horizon-truncated arc would end in the
+	// interior with no Exit and no onward path, so the horizon extends to
+	// the analytic exit crossing (+25 %, so the onward continuation gets
+	// ink too). maxHorizon (the counterfactual's first-node cap) clamps
+	// last: the no-burn arc is never drawn past the burn (ADR 0019 D).
+	period := orbitalPeriod(state, mu)
+	horizon := soiPassHyperbolicHorizon
+	if el.A > 0 && period > 0 && !math.IsNaN(period) && !math.IsInf(period, 0) {
+		horizon = period
+	}
+	if tExit, ok := orbital.TimeToRadiusOutbound(orbital.Vec3State{R: state.R, V: state.V}, mu, soi); ok {
+		if h := tExit * 1.25; h > horizon {
+			horizon = h
+		}
+	}
+	if maxHorizon < horizon {
+		horizon = maxHorizon
+	}
+	if horizon <= 0 {
+		return SOIPass{}, false
+	}
+
+	pass := SOIPass{Body: primary}
+
+	// Closest approach: analytic while the periapsis is still ahead
+	// (inbound, r·v < 0); once outbound the craft only recedes, so the
+	// closest *future* approach is the current radius, now.
+	if state.R.Dot(state.V) < 0 {
+		pass.PeriluneRadius = el.A * (1 - el.E) // periapsis radius, valid both sides of e=1
+		pass.Impact = pass.PeriluneRadius < primary.RadiusMeters()
+		rel := orbital.Vec3State{R: state.R, V: state.V}
+		if el.E >= 1 {
+			if t, ok := orbital.TimeToPeriapsisHyperbolic(rel, mu); ok && t > 0 {
+				pass.TimeToPerilune = t
+			}
+		} else if t := orbital.TimeToPeriapsis(rel, mu); t > 0 {
+			pass.TimeToPerilune = t
+		}
+	} else {
+		pass.PeriluneRadius = state.R.Norm()
+	}
+
+	// Sample the remaining transit plus the onward continuation. Unlike
+	// the sibling scan, segments past the exit are KEPT (OnwardSegments):
+	// the whole path the craft will fly draws, with or without a capture
+	// burn planted (#157).
+	samples := adaptiveSampleCount(horizon, period)
+	segs, _ := w.predictedSegmentsFromTuned(state, primary, fromClock, horizon, samples, defaultPredictTuning())
+	for _, s := range segs {
+		if s.PrimaryID == primary.ID {
+			pass.ArcSegments = append(pass.ArcSegments, s)
+		} else {
+			pass.OnwardSegments = append(pass.OnwardSegments, s)
+		}
+	}
+	if len(pass.ArcSegments) == 0 {
+		return SOIPass{}, false
+	}
+
+	// SOI Exit ring crossing (ADR 0021 C): the in-SOI leg's last sample is
+	// the predictor's (bisection-refined) rebase point at the boundary, so
+	// when it sits on the parent-relative ring it places the Exit marker;
+	// an arc that ends in the interior — impact, node-capped,
+	// horizon-truncated — draws no Exit. No Entry marker: the craft is
+	// already inside, the entry crossing is in the past.
+	if last := pass.ArcSegments[0].RelPoints; len(last) > 0 {
+		if r := last[len(last)-1]; math.Abs(r.Norm()-soi) <= soi*soiRingCrossingTol {
+			pass.ExitRel = r
+			pass.HasExit = true
+		}
+	}
+
+	// Perilune marker offset: the in-SOI sample closest to the body centre
+	// — the same placement rule as the sibling pass (Local-to-Body,
+	// ADR 0021 B; the chip carries the analytic value above).
+	minD := math.Inf(1)
+	for _, s := range pass.ArcSegments {
+		for _, r := range s.RelPoints {
+			if d := r.Norm(); d < minD {
+				minD = d
+				pass.PeriluneRel = r
+				pass.HasPerilunePt = true
+			}
+		}
+	}
+	return pass, true
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -685,7 +685,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// live Keplerian ellipse in its home primary's frame, translated
 	// into the system frame so it renders alongside planet orbits.
 	// Only bound orbits (a > 0) render; hyperbolic escape trajectories
-	// are already shown by the maneuver-preview SOI-segmented trace.
+	// are shown by the maneuver-preview SOI-segmented trace when nodes
+	// are planted, and by the in-SOI residence pass arc (#157) on a
+	// node-free escape — drawSOIPass covers the no-node flyby that used
+	// to draw nothing here.
 	//
 	// v0.6.1: orbits whose apoapsis projects to fewer than
 	// minOrbitPixels (≈ a body's pixel-tier diameter) are skipped at
@@ -1663,8 +1666,31 @@ func (v *OrbitView) drawSOIPass(w *sim.World) {
 		// body-relative samples anchored at the pass Body's current
 		// position — the same rebase the planted-node legs get, so the dim
 		// counterfactual and the bright planned ink at one body agree.
+		//
+		// homeID trap (#157): for the in-SOI residence pass the pass Body
+		// IS the craft's primary, so the arc segments carry PrimaryID ==
+		// Primary.ID — and SegmentDrawPoints short-circuits home segments
+		// to their inertial sample positions, which would reintroduce the
+		// #147 smear for exactly this arc. Anchoring against the system
+		// root instead rebases the in-SOI leg at the Body's current
+		// position. A sibling pass never triggers the substitution — its
+		// Body is a sibling of the primary, not the primary itself.
 		homeID := w.ActiveCraft().Primary.ID
+		if arc.counterfactual.Body.ID == homeID {
+			homeID = w.System().Bodies[0].ID
+		}
 		for _, seg := range arc.counterfactual.ArcSegments {
+			for _, p := range w.SegmentDrawPoints(seg, homeID) {
+				v.canvas.PlotColored(p, arcColor)
+			}
+		}
+		// In-SOI residence pass (#157): the post-exit continuation draws in
+		// the same colour/brightness as the in-SOI leg — the whole onward
+		// path the craft will fly, with or without a capture burn. Foreign
+		// (parent-frame) onward legs rebase Local-to-Body; root-frame legs
+		// draw at their inertial samples, as always. Empty for sibling
+		// passes, so the pre-entry picture is untouched.
+		for _, seg := range arc.counterfactual.OnwardSegments {
 			for _, p := range w.SegmentDrawPoints(seg, homeID) {
 				v.canvas.PlotColored(p, arcColor)
 			}

--- a/internal/tui/screens/orbit_in_soi_test.go
+++ b/internal/tui/screens/orbit_in_soi_test.go
@@ -1,0 +1,233 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// setupHyperbolicInMoonSOI parks the active craft INSIDE the Moon's SOI on
+// an inbound escape hyperbola (e = 2, periapsis 500 km above the surface,
+// currently at 0.6× the SOI radius) — the post-entry, pre-capture state of
+// issue #157, where the orbit line and SOI circle used to vanish. Mirrors
+// the sim package's hyperbolicInMoonSOI, replicated here because that
+// helper isn't visible across packages.
+func setupHyperbolicInMoonSOI(t *testing.T, w *sim.World) (moonIdx int, moon bodies.CelestialBody, soi float64) {
+	t.Helper()
+	sys := w.System()
+	moonIdx = -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon not in loaded Sol system")
+	}
+	moon = sys.Bodies[moonIdx]
+	soi = w.BodySOIRadius(moon)
+	mu := moon.GravitationalParameter()
+	rp := moon.RadiusMeters() + 500e3
+	r0 := 0.6 * soi
+	v0 := math.Sqrt(mu * (2/r0 + 1/rp)) // vis-viva with a = −rp (e = 2)
+	vt := math.Sqrt(3*mu*rp) / r0       // h = √(3·μ·rp)
+	vr := -math.Sqrt(v0*v0 - vt*vt)     // inbound: perilune still ahead
+
+	c := w.ActiveCraft()
+	c.Primary = moon
+	c.Landed = false
+	c.Nodes = nil
+	c.State.R = orbital.Vec3{X: r0}
+	c.State.V = orbital.Vec3{X: vr, Y: vt}
+	return moonIdx, moon, soi
+}
+
+// TestInSOIRingAndPathPersist is the render-level acceptance for #157's
+// no-node case: inside the Moon's SOI on an escape trajectory, focused on
+// the Moon, the canvas still carries the dim dotted SOI Ring, the bright
+// in-SOI arc (plus its onward continuation), and the SOI PASS chip — the
+// whole encounter picture that used to switch off at SOI entry.
+func TestInSOIRingAndPathPersist(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx, moon, soi := setupHyperbolicInMoonSOI(t, w)
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	out := v.Render(w, 0, 200, 60)
+
+	// SOI Ring ink, in the ring's unique shade (same gauge as
+	// TestSOIRingDrawsAtPassBody).
+	pxR := soi * v.canvas.Scale()
+	if pxR < float64(soiRingMinPixels) {
+		t.Fatalf("test setup: ring projects to only %.1f px — framing too wide to assert the ring", pxR)
+	}
+	ideal := 2 * math.Pi * pxR / 4
+	if got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiRingDim)); float64(got) < ideal/4 {
+		t.Errorf("only %d ring-coloured cells inside the SOI, want ≥ %.0f — the SOI Ring vanished at entry (#157)", got, ideal/4)
+	}
+
+	// The predicted path: with no node planted the residence arc draws
+	// bright, in the undimmed foreign-SOI colour no other element uses.
+	if got := v.canvas.CountColor(render.ColorForeignSOI); got < 15 {
+		t.Errorf("only %d bright arc cells inside the SOI, want ≥ 15 — the escape path isn't drawn", got)
+	}
+
+	// The chip keeps reporting the pass.
+	if !strings.Contains(out, "SOI PASS") {
+		t.Errorf("SOI PASS chip absent inside the SOI on an escape trajectory")
+	}
+
+	// Camera Contract sanity: the Framing-Event fit covers the body the
+	// craft is inside — centered on the Moon at SOI scale.
+	if d := v.canvas.CenterWorld().Sub(w.BodyPosition(moon)).Norm(); d > 0.5*soi {
+		t.Errorf("canvas centered %.2f×SOI from the Moon — focus fit not covering the in-SOI pass", d/soi)
+	}
+}
+
+// TestInSOIExitAndPeriluneMarkersDraw: the residence pass keeps the Exit ◁
+// and Perilune glyphs on the in-SOI leg (entry is in the past, so the pass
+// carries no Entry crossing). Positions asserted through the same Project
+// mapping the renderer uses. Declutter hides the chips + navball so corner
+// overlays can't shadow a marker cell.
+func TestInSOIExitAndPeriluneMarkersDraw(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx, _, _ := setupHyperbolicInMoonSOI(t, w)
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	v.declutter = true
+	out := v.Render(w, 0, 200, 60)
+
+	pass, ok := w.LiveSOIPass()
+	if !ok {
+		t.Fatal("precondition: no residence pass inside the SOI")
+	}
+	if pass.HasEntry {
+		t.Error("residence pass reports an Entry crossing — entry is in the past")
+	}
+	if !pass.HasExit || !pass.HasPerilunePt {
+		t.Fatalf("precondition: pass missing exit/perilune (exit=%v perilune=%v)", pass.HasExit, pass.HasPerilunePt)
+	}
+
+	if got, want := glyphAtProjected(t, v, out, w.ExitPosition(pass)), render.MarkerGlyph(render.MarkerSOIExit); got != want {
+		t.Errorf("cell at the SOI-exit crossing shows %q, want the Exit glyph %q", got, want)
+	}
+	if got, want := glyphAtProjected(t, v, out, w.PerilunePosition(pass)), render.MarkerGlyph(render.MarkerPerilune); got != want {
+		t.Errorf("cell at the perilune shows %q, want the Perilune glyph %q", got, want)
+	}
+}
+
+// TestInSOIQuietLunarOrbitNoRing pins the quiet case at render level: a
+// captured (bound, apoapsis inside the SOI) low lunar orbit draws no ring
+// ink and no SOI PASS chip — parked orbits look exactly as they did before
+// the in-SOI continuation. The Earth-LEO twin of this regression guard is
+// TestSOIRingAbsentForQuietBodies.
+func TestInSOIQuietLunarOrbitNoRing(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" {
+			moonIdx = i
+		}
+	}
+	if moonIdx < 0 {
+		t.Skip("Moon not in loaded Sol system")
+	}
+	moon := sys.Bodies[moonIdx]
+	c := w.ActiveCraft()
+	c.Primary = moon
+	c.Landed = false
+	c.Nodes = nil
+	mu := moon.GravitationalParameter()
+	r := moon.RadiusMeters() + 200e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+
+	out := v.Render(w, 0, 200, 60)
+	if got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiRingDim)); got != 0 {
+		t.Errorf("%d ring-coloured cells on a captured low lunar orbit, want 0 — the quiet case regressed", got)
+	}
+	if strings.Contains(out, "SOI PASS") {
+		t.Errorf("captured low lunar orbit must not show a SOI PASS chip")
+	}
+}
+
+// TestInSOIRingPersistsWithCaptureNode covers #157's planted-node case: a
+// capture node inside the SOI keeps the ring drawing and demotes the
+// residence arc to the dim node-capped counterfactual, while the planned
+// overlay keeps rendering through the unchanged drawNodes path — pinned
+// here by the Δ node marker (anchored at the Body's current position via
+// NodeInertialPosition) and at the sim level by
+// TestInSOICounterfactualCappedAtNode's draw-identity check on the legs.
+func TestInSOIRingPersistsWithCaptureNode(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx, _, soi := setupHyperbolicInMoonSOI(t, w)
+
+	live, ok := w.LiveSOIPass()
+	if !ok || live.TimeToPerilune <= 0 {
+		t.Fatalf("precondition: live residence pass with perilune ahead (ok=%v tca=%.0f)", ok, live.TimeToPerilune)
+	}
+	// A retrograde burn on the outbound leg (1.5× TCA — past perilune,
+	// still well inside the SOI: the e=2 transit exits at ~2.3× TCA). The
+	// capped counterfactual then spans the true perilune, and the Δ node
+	// glyph sits in a different canvas cell than the ⊕ Perilune marker —
+	// a node planted *before* perilune makes the capped arc's closest
+	// approach the cap point itself, stacking both glyphs in one cell.
+	c := w.ActiveCraft()
+	c.Nodes = []spacecraft.ManeuverNode{{
+		TriggerTime: w.Clock.SimTime.Add(time.Duration(live.TimeToPerilune * 1.5 * float64(time.Second))),
+		Mode:        spacecraft.BurnRetrograde,
+		DV:          600,
+	}}
+
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: moonIdx}
+	v.declutter = true
+	out := v.Render(w, 0, 200, 60)
+
+	pxR := soi * v.canvas.Scale()
+	if pxR < float64(soiRingMinPixels) {
+		t.Fatalf("test setup: ring projects to only %.1f px", pxR)
+	}
+	ideal := 2 * math.Pi * pxR / 4
+	if got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiRingDim)); float64(got) < ideal/4 {
+		t.Errorf("only %d ring-coloured cells with a capture node planted, want ≥ %.0f — ring must persist through capture planning", got, ideal/4)
+	}
+	// The no-burn residence arc is now the dim counterfactual…
+	if got := v.canvas.CountColor(render.Shade(render.ColorForeignSOI, soiCounterfactualDim)); got < 5 {
+		t.Errorf("only %d dim counterfactual cells with a node planted, want ≥ 5", got)
+	}
+	// …and no longer paints in the bright no-node colour.
+	if got := v.canvas.CountColor(render.ColorForeignSOI); got != 0 {
+		t.Errorf("%d bright arc cells with a node planted, want 0 (brightness = state, ADR 0020 B)", got)
+	}
+	// The planned overlay still draws: the Δ node marker rides the in-SOI
+	// trajectory at the burn point.
+	if got, want := glyphAtProjected(t, v, out, w.NodeInertialPosition(c.Nodes[0])), render.MarkerGlyph(render.MarkerManeuver); got != want {
+		t.Errorf("cell at the planted node shows %q, want the maneuver glyph %q", got, want)
+	}
+}


### PR DESCRIPTION
Implements #157 — playtest feedback on the ADR 0021 work: entering the new SOI pre-capture made the orbit line and SOI circle vanish. The ring now stays, and the whole onward path draws — through perilune, out the SOI exit, and onward — with or without a capture burn.

## What changed

- **`internal/sim/soipass.go`** — new `inSOIEscapePass`: synthesizes an *in-SOI residence* pass for the current primary while the craft is inside a non-root body's SOI on a trajectory that leaves it (e ≥ 1, a ≤ 0, or apoapsis ≥ the parent-relative `BodySOIRadius`). `LiveSOIPass` / `CounterfactualSOIPass` fall back to it when the sibling scan finds nothing, so the existing dual-arc / ring / marker / chip pipeline keeps drawing. `SOIPass` gains `OnwardSegments` (the post-exit continuation; nil for sibling passes). `PlannedSOIPass` is deliberately untouched — giving the legs the fallback would let a departure hyperbola outbid a real arrival pass in its min-TCA selection.
- **`internal/orbital/events.go`** — new `TimeToRadiusOutbound` (sibling of `TimeToPeriapsisHyperbolic`, both e-branches): the residence pass extends its horizon to the analytic SOI-exit crossing (+25 % for onward ink). A slow lunar flyby spends ~2 days inside the 66 000 km SOI — past the one-sim-day hyperbolic wall, which would have truncated the arc in the interior with no Exit and no onward path. The counterfactual's first-node cap clamps **last** (ADR 0019 D unchanged: never drawn past the burn).
- **`internal/tui/screens/orbit.go`** — `drawSOIPass` draws `OnwardSegments` in the same colour/brightness as the arc, and closes the **homeID trap**: when the pass Body IS the craft's primary, `SegmentDrawPoints` is anchored against the system root instead of the primary (whose ID would short-circuit to inertial points and reintroduce the #147 smear — measured 10.6–46.9× SOI in the heliocentric frame for the in-SOI leg). Planted-node legs through `drawNodes` are untouched.
- **`internal/sim/focus.go`** — no code change needed: `FocusZoomRadius` inherits the residence pass through `bestSOIPass`, so focusing the body you're inside fits to 1.3× its parent-relative SOI. Still a Framing-Event-only read; **no per-frame fitting added** (Camera Contract, ADR 0021 A).
- **`CONTEXT.md`** — SOI Ring + SOI Pass glossary entries amended with the in-SOI escape-residence case.

No save-schema change; warp/burn clamps and the integrator switch untouched.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| No-node entry: ring persists + full predicted path draws (in-SOI hyperbola + post-exit continuation), counterfactual-dim; in-SOI samples anchor within ~1–2× SOI of the body's current position | `sim.TestInSOIPassPersistsAcrossEntry` (flies the LEO→Moon coast through the real entry), `sim.TestInSOIPassGeometry` (max rebased extent ≤ 1.05× SOI; onward segments in the parent frame), `screens.TestInSOIRingAndPathPersist` (ring ink + bright arc ink + SOI PASS chip on canvas) |
| Same scenario with a capture node planted: bright planned legs unchanged, ring persists | `sim.TestInSOICounterfactualCappedAtNode` (node-capped dim arc never past the burn; planted in-SOI legs draw at their inertial samples, byte-for-byte pre-#157), `screens.TestInSOIRingPersistsWithCaptureNode` (ring + dim counterfactual + Δ node marker; bright no-node colour gone) |
| SOI Exit + Perilune markers on the in-SOI leg; no Entry marker once inside | `sim.TestInSOIPassPersistsAcrossEntry` (`HasEntry`/`HasEntryTime` false, `HasExit` on the ring ±5 %), `screens.TestInSOIExitAndPeriluneMarkersDraw` (glyphs at the projected cells) |
| Captured/bound orbits draw no ring, look exactly as today | `sim.TestInSOIPassQuietWhenCaptured`, `screens.TestInSOIQuietLunarOrbitNoRing` (low lunar orbit: zero ring ink, no chip); existing `TestSOIRingAbsentForQuietBodies` covers stable LEO |
| No per-frame canvas fitting (Camera Contract intact) | `sim.TestFocusZoomRadiusInsideEscapingSOI` (fit value at a Framing Event = 1.3× parent-relative SOI); existing `orbit_camera_contract_test.go` suite unchanged and green |
| CONTEXT.md SOI Ring entry amended | done (SOI Ring + SOI Pass entries) |
| `go vet ./...` + `go test ./... -race -count=1` green | 1133 passed, 15 packages, vet clean |

Also: `orbital.TestTimeToRadiusOutbound` pins the new helper (elliptic timing vs `TimeToTrueAnomaly`, hyperbolic antisymmetry vs `TimeToPeriapsisHyperbolic`, unreachable-radius rejections), and the homeID trap is pinned by `sim.TestInSOIPassGeometry` (primary-as-homeID short-circuits to inertial points whose exit sits ~0.9× SOI off the drawn ring).

The escape rule also covers bound-but-escaping orbits (`sim.TestInSOIPassBoundButEscaping`) — apoapsis past the ring gets the residence pass too, per the issue's rule.

Closes #157