### PR TITLE
fix(planner): capture-safe aim offset for the split strategy (#159)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1214,12 +1214,17 @@ plane change leaves the Vessel actually *in* the target's plane).
 A correct Transfer Plan must arrive **coplanar** with the target (≈0°
 relative inclination) **and at the Capture Orbit radius** — a safe
 periapsis (`destination radius + 200 km`), not the target's *centre*.
-Coplanar alone is insufficient: the combined Lambert solved to the
-target's centre arrives with a sub-surface perilune (a collision) while
-its Capture Burn Δv is sized for a periapsis it never reaches. So the
-combined Departure is aimed at an **in-plane offset** chosen so the
+Coplanar alone is insufficient: a transfer solved to the target's
+centre arrives with a sub-surface perilune (a collision) while its
+Capture Burn Δv is sized for a periapsis it never reaches. So the
+planted arrival is aimed at an **in-plane offset** chosen so the
 natural flyby perilune lands at the Capture Orbit radius, **prograde**
-around the target (the affordable capture direction — see GH #68). The
+around the target (the affordable capture direction — see GH #68): the
+combined Departure offsets its Lambert aim point, the split trims the
+raise's far apsis off the target's orbit ring by the impact parameter
+(GH #159 — pre-fix the split's node-aligned rendezvous dead-centred,
+a radial plunge when coplanar). The Δv *comparison* between the two
+stays centre-aimed so the offset never flips strategy selection. The
 HUD shows both candidate costs. This retires the old
 `I`-plane-match-then-`H` dance as a *requirement* (the manual tools
 remain available).

--- a/internal/sim/coplanar_capture_test.go
+++ b/internal/sim/coplanar_capture_test.go
@@ -277,13 +277,18 @@ func TestCombinedTransferArrivesSafePeriapsis(t *testing.T) {
 	}
 }
 
-// TestSplitArrivalPeriapsisCharacterization (ADR 0018 D): measures the
-// split (inclined) transfer's actual arrival periapsis. ADR 0018 scoped the
-// capture-aim fix to the combined path; this characterizes whether the split
-// also arrives at the target's centre (a collision). It asserts only that an
-// encounter resolves and logs the perilune — a sub-surface value is the
-// signal that the split needs the same offset-aim treatment (logged as a
-// follow-up, not fixed here: the split is entangled with #67/#68).
+// TestSplitArrivalPeriapsisCharacterization (ADR 0018 D, graduated by GH
+// #159): the split (inclined LEO→Luna) transfer's live-flown arrival
+// periapsis. ADR 0018 scoped the capture-aim fix to the combined path and
+// this test only *logged* the split's perilune — measured ~16,240 km radius
+// (~14,500 km altitude), a loose flyby far above the Capture Orbit radius
+// the capture Δv was sized for. GH #159 extends the capture-safe aim to the
+// split (apoapsis trimmed by the impact parameter), so this now asserts the
+// flown perilune lands near the Capture Orbit radius: above the surface and
+// within 2× rCapture. The 2× bound covers the impulsive-plan vs finite-burn
+// drift over a multi-day transfer flown with the production integrator at
+// 60 s sampling — the pre-fix 8.4× rCapture flyby fails it decisively, an
+// aimed arrival passes with margin.
 func TestSplitArrivalPeriapsisCharacterization(t *testing.T) {
 	w := mustWorld(t)
 	moonIdx, moon := findMoon(t, w)
@@ -323,13 +328,19 @@ func TestSplitArrivalPeriapsisCharacterization(t *testing.T) {
 		elapsed += chunkSecs
 	}
 	alt := minD - moon.RadiusMeters()
-	t.Logf("split arrival perilune = %.1f km (Luna radius %.1f km, altitude %.1f km)",
-		minD/1e3, moon.RadiusMeters()/1e3, alt/1e3)
+	rCapture := moon.RadiusMeters() + 200e3
+	t.Logf("split arrival perilune = %.1f km (Luna radius %.1f km, altitude %.1f km, Capture Orbit radius %.1f km)",
+		minD/1e3, moon.RadiusMeters()/1e3, alt/1e3, rCapture/1e3)
 	if math.IsInf(minD, 1) {
 		t.Fatal("split transfer never reached Luna — characterization unusable")
 	}
 	if alt <= 0 {
-		t.Logf("FOLLOW-UP (ADR 0018 D): the split also arrives sub-surface (impact) — it needs the same capture-aim offset; not fixed here (entangled with #67/#68)")
+		t.Errorf("split arrives sub-surface (impact): perilune %.1f km ≤ Luna radius %.1f km",
+			minD/1e3, moon.RadiusMeters()/1e3)
+	}
+	if minD > 2*rCapture {
+		t.Errorf("split perilune %.1f km is a loose flyby, not an aimed Capture Orbit arrival (want ≤ 2×rCapture = %.1f km; pre-#159 value ~16,240 km)",
+			minD/1e3, 2*rCapture/1e3)
 	}
 }
 

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -426,12 +426,16 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 			return &plan, nil
 		}
 
-		// Split: refine the finite coplanar departure (v0.6.2 iterator) so
-		// the burn delivers the target apoapsis under integration, then
-		// plant raise → plane change → capture.
+		// Split: plant raise → plane change → capture, with the arrival
+		// aimed at the Capture Orbit radius (GH #159, ADR 0018 extended to
+		// the split). The node-aligned phasing rendezvous with the target's
+		// CENTRE — exact when coplanar (a zero-angular-momentum radial
+		// plunge, the −200/−200 degenerate capture), loose when inclined —
+		// so the planted transfer trims the raise's far apsis off the
+		// target's ring by the impact parameter, putting the moon-frame
+		// perilune at rCapture on the prograde side.
 		w.LastTransfer.Strategy = "split"
 		plan := seed
-		refineFiniteDeparture(&plan, muShared, rPark, mass, thrust, c.Isp, rArrival)
 		// Override the seed's opposition phasing with the node-aligned
 		// departure/arrival so apoapsis lands on the node where the target
 		// is (the Δv magnitudes above are phasing-independent).
@@ -454,7 +458,27 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 		planeChangeOffset := plan.Arrival.OffsetTime
 		captureOffset := plan.Arrival.OffsetTime
 		pcDv, pcTheta := planeChangeDv, planeChangeTheta
-		if nodeOK && depOK {
+		rFarAim := rArrival
+		aimed := false
+		if depOK {
+			if arr, ok := w.splitCaptureAim(c, target, muShared, muDestination,
+				rPark, rArrival, rCapture, splitWait, plan.TransferDt.Seconds(), depState); ok {
+				aimed = true
+				rFarAim = arr.RFar
+				pcDv, pcTheta = arr.PcDv, arr.PcTheta
+				planeChangeOffset = time.Duration((splitWait + arr.TEntry) * float64(time.Second))
+				captureOffset = time.Duration((splitWait + arr.TCapture) * float64(time.Second))
+				plan.Departure.DV = math.Abs(splitRaiseDv(muShared, rPark, rFarAim))
+				// Capture Δv re-sized for the actual hyperbolic perilune
+				// speed — the seed's analytic value assumed the ideal
+				// centre-aimed geometry it never flies.
+				plan.Arrival.DV = arr.CaptureDV
+			}
+		}
+		if !aimed && nodeOK && depOK {
+			// Capture-safe trim couldn't resolve the arrival — keep the
+			// pre-#159 centre-aimed timing refinement as the fallback (no
+			// worse than the prior behaviour).
 			raiseDir := spacecraft.DirectionUnit(spacecraft.BurnPrograde, depState.R, depState.V)
 			post := depState
 			post.V = depState.V.Add(raiseDir.Scale(seed.Departure.DV))
@@ -469,6 +493,9 @@ func (w *World) PlanTransfer(targetIdx int) (*planner.TransferPlan, error) {
 				captureOffset = time.Duration((nodeTau + tCA) * float64(time.Second))
 			}
 		}
+		// Refine the finite coplanar departure (v0.6.2 iterator) so the
+		// burn delivers the (trimmed) far apsis under integration.
+		refineFiniteDeparture(&plan, muShared, rPark, mass, thrust, c.Isp, rFarAim)
 
 		w.PlanNode(transferNodeToManeuver(plan.Departure, now, c))
 		if pcDv > 0 {
@@ -1613,6 +1640,185 @@ func splitFallbackPlaneChangeOffset(planeChangeOffset, captureOffset, pcDur, cap
 		return planeChangeOffset - sep
 	}
 	return earliest
+}
+
+// splitRaiseDv is the signed analytic departure Δv from a circular parking
+// orbit at rPark onto the coplanar transfer ellipse whose far apsis is rFar:
+// positive (prograde) for an outbound raise, negative for an inbound drop.
+func splitRaiseDv(mu, rPark, rFar float64) float64 {
+	a := (rPark + rFar) / 2
+	return math.Sqrt(mu*(2/rPark-1/a)) - math.Sqrt(mu/rPark)
+}
+
+// applyPlaneChangeImpulse applies the impulsive effect of a BurnPlaneChange
+// to a state: the horizontal velocity component rotates about the radial by
+// theta, the radial component is unchanged — the same geometry the planted
+// burn realises via spacecraft.planeChangeDirection (Δv = 2·v_hor·sin(θ/2)).
+func applyPlaneChangeImpulse(st physics.StateVector, theta float64) physics.StateVector {
+	rHat := st.R.Unit()
+	vRad := rHat.Scale(st.V.Dot(rHat))
+	vHor := st.V.Sub(vRad)
+	out := st
+	out.V = vRad.Add(vHor.Scale(math.Cos(theta))).Add(rHat.Cross(vHor).Scale(math.Sin(theta)))
+	return out
+}
+
+// splitArrival is the capture-safe split arrival geometry resolved by
+// splitCaptureAim (GH #159): the trimmed far-apsis aim plus the encounter
+// timing, plane-change sizing, and capture Δv measured on the trimmed arc.
+type splitArrival struct {
+	RFar      float64 // trimmed transfer far-apsis aim (m)
+	TEntry    float64 // s from departure to target-SOI entry (plane-change fire time)
+	TCapture  float64 // s from departure to the moon-frame perilune (capture fire time)
+	PcDv      float64 // plane-change Δv at SOI entry (≈0 for a coplanar arrival)
+	PcTheta   float64 // signed plane rotation for the BurnPlaneChange node
+	CaptureDV float64 // capture Δv from the actual hyperbolic perilune speed
+}
+
+// splitCaptureAim gives the split strategy the capture-safe arrival the
+// combined branch got from captureAimPoint (GH #159, extending ADR 0018 —
+// its decision D deferred exactly this). The node-aligned phasing (ADR 0006
+// A) rendezvous with the target's centre, so the natural moon-frame perilune
+// is a surface impact when coplanar and an unaimed high pass when inclined.
+// The split's only in-plane aim lever is the raise's far apsis: trimming it
+// off the target's orbit ring by the impact parameter b makes the craft
+// cross the ring radially offset — perpendicular to the (near-tangential)
+// approach v∞, i.e. a true b-plane offset — while along-track phasing slop
+// stays parallel to v∞ and only shifts the encounter time, which the
+// capture-fire refinement absorbs anyway.
+//
+// Prograde side: an outbound transfer arrives slower than the target, so
+// v∞ points anti-tangential and v̂∞ × n̂_target (captureAimPoint's prograde
+// convention) is radially INWARD — under the ring. An inbound transfer
+// arrives faster (v∞ tangential), flipping the prograde side to above the
+// ring. Both are the lever direction d(b_prograde)/d(rFar) = ∓1 used below.
+//
+// Like captureAimPoint it seeds analytically (b = r_p·√(1 + 2μ_t/(r_p·v∞²))
+// with r_p = rCapture and v∞ measured from the centre-aimed approach), then
+// re-measures the actual perilune — including the plane change applied at
+// SOI entry, mirroring the planted burn — and refines a few times. The
+// linear update pulls a too-high perilune DOWN to rCapture (the inclined
+// case: residual out-of-plane miss already exceeds b) as well as pushing
+// the coplanar centre-hit UP. ok=false when no candidate resolves a
+// prograde hyperbolic encounter; the caller keeps the pre-#159 plant.
+func (w *World) splitCaptureAim(c *spacecraft.Spacecraft, target bodies.CelestialBody,
+	muShared, muTarget, rPark, rFarSeed, rCapture, splitWait, tTransfer float64,
+	depState physics.StateVector) (splitArrival, bool) {
+	if muTarget <= 0 || rCapture <= 0 || tTransfer <= 0 || rPark <= 0 || rFarSeed == rPark {
+		return splitArrival{}, false
+	}
+	primary := c.Primary
+	depClock := w.Clock.SimTime.Add(time.Duration(splitWait * float64(time.Second)))
+	progradeDir := spacecraft.DirectionUnit(spacecraft.BurnPrograde, depState.R, depState.V)
+	if progradeDir.Norm() == 0 {
+		return splitArrival{}, false
+	}
+
+	type measurement struct {
+		arr      splitArrival
+		rp       float64 // moon-frame perilune radius (m)
+		vInf     float64 // hyperbolic excess speed (m/s)
+		b        float64 // achieved impact parameter |h|/v∞ (m)
+		prograde bool    // moon-frame angular momentum along the target's orbit normal
+	}
+	measure := func(rFar float64) (measurement, bool) {
+		post := depState
+		post.V = depState.V.Add(progradeDir.Scale(splitRaiseDv(muShared, rPark, rFar)))
+		tEntry, _, found := w.transferEncounterTimes(post, primary, target, depClock, tTransfer*1.2)
+		if !found {
+			return measurement{}, false
+		}
+		entry, ok := physics.KeplerStep(post, muShared, tEntry)
+		if !ok {
+			return measurement{}, false
+		}
+		var pcDv, pcTheta float64
+		if _, nTgt, okN := w.craftTargetPlaneNormals(c, target); okN {
+			pcDv, pcTheta = planeChangeAtState(entry, nTgt)
+			entry = applyPlaneChangeImpulse(entry, pcTheta)
+		}
+		entryClock := depClock.Add(time.Duration(tEntry * float64(time.Second)))
+		moonR := w.BodyPositionAt(target, entryClock).Sub(w.BodyPositionAt(primary, entryClock))
+		moonV := w.bodyInertialVelocityAt(target, entryClock).Sub(w.bodyInertialVelocityAt(primary, entryClock))
+		rel := orbital.Vec3State{R: entry.R.Sub(moonR), V: entry.V.Sub(moonV)}
+		el := orbital.ElementsFromState(rel.R, rel.V, muTarget)
+		if el.E <= 1 || el.A >= 0 {
+			return measurement{}, false
+		}
+		tPeri, okP := orbital.TimeToPeriapsisHyperbolic(rel, muTarget)
+		if !okP || tPeri < 0 {
+			return measurement{}, false
+		}
+		rp := el.A * (1 - el.E)
+		if rp <= 0 {
+			return measurement{}, false
+		}
+		vInf := math.Sqrt(muTarget / -el.A)
+		h := rel.R.Cross(rel.V)
+		vPeri := math.Sqrt(vInf*vInf + 2*muTarget/rp)
+		return measurement{
+			arr: splitArrival{
+				RFar:      rFar,
+				TEntry:    tEntry,
+				TCapture:  tEntry + tPeri,
+				PcDv:      pcDv,
+				PcTheta:   pcTheta,
+				CaptureDV: vPeri - math.Sqrt(muTarget/rp),
+			},
+			rp:       rp,
+			vInf:     vInf,
+			b:        h.Norm() / vInf,
+			prograde: h.Dot(moonR.Cross(moonV)) > 0,
+		}, true
+	}
+
+	// Centre-aimed (natural) arrival: reads the approach v∞ that sizes the
+	// desired impact parameter.
+	nat, ok := measure(rFarSeed)
+	if !ok {
+		return splitArrival{}, false
+	}
+	bDes := rCapture * math.Sqrt(1+2*muTarget/(rCapture*nat.vInf*nat.vInf))
+	// Lever sign: outbound trims the apsis BELOW the ring for a prograde
+	// offset, inbound trims it above.
+	lever := -1.0
+	if rFarSeed < rPark {
+		lever = 1.0
+	}
+	rFar := rFarSeed
+	var best measurement
+	haveBest := false
+	for iter := 0; iter < 6; iter++ {
+		m, ok := measure(rFar)
+		if !ok {
+			// Overshot past the SOI or a degenerate hyperbola — pull the
+			// trim halfway back toward the ring and retry.
+			rFar = (rFar + rFarSeed) / 2
+			if math.Abs(rFar-rFarSeed) < 1 {
+				break
+			}
+			continue
+		}
+		if m.prograde && (!haveBest || math.Abs(m.rp-rCapture) < math.Abs(best.rp-rCapture)) {
+			best, haveBest = m, true
+		}
+		if m.prograde && math.Abs(m.rp-rCapture) < 0.02*rCapture {
+			break
+		}
+		bSigned := m.b
+		if !m.prograde {
+			bSigned = -bSigned
+		}
+		next := rFar + lever*(bDes-bSigned)
+		if next <= 0 || (rFarSeed > rPark && next <= rPark) || (rFarSeed < rPark && next >= rPark) {
+			break
+		}
+		rFar = next
+	}
+	if !haveBest || best.rp <= target.RadiusMeters() {
+		return splitArrival{}, false
+	}
+	return best.arr, true
 }
 
 // intraPlaneChangeAllowance estimates the extra departure Δv a fused

--- a/internal/sim/split_capture_aim_test.go
+++ b/internal/sim/split_capture_aim_test.go
@@ -27,18 +27,13 @@ func rotAbout(v, k orbital.Vec3, deg float64) orbital.Vec3 {
 // split plant must show a planned pass at a positive, ≈capture altitude
 // and a bound, non-degenerate predicted final orbit at Cursor.
 //
-// The strategy *selection* must stay centre-aimed (ADR 0006 B): the
-// combined/split pick per phase is pinned against the pre-fix sweep.
+// The strategy *selection* must stay centre-aimed (ADR 0006 B): the pick
+// must follow the centre-aimed CombinedDv ≤ SplitDv comparison — the
+// capture-safe trim applies to the planted plan only and must not feed
+// back into the costs being compared. (An exact per-phase combined/split
+// table is deliberately NOT pinned: several phases are near-ties that
+// flip on platform math differences — darwin/arm64 vs linux/amd64 CI.)
 func TestSplitCaptureAimPhaseSweep(t *testing.T) {
-	// Strategy per phase measured on main (pre-fix, 4a107a3-era planner) —
-	// the capture-safe trim must not flip any of these (ADR 0006 B: the
-	// comparison stays centre-aimed for both strategies).
-	wantStrategy := [24]string{
-		"combined", "combined", "combined", "combined", "combined", "split",
-		"split", "split", "split", "combined", "combined", "split",
-		"combined", "combined", "combined", "split", "split", "combined",
-		"combined", "split", "combined", "split", "split", "split",
-	}
 	splitSeen := 0
 	for i := 0; i < 24; i++ {
 		phase := float64(i) * 15
@@ -53,9 +48,13 @@ func TestSplitCaptureAimPhaseSweep(t *testing.T) {
 			t.Fatalf("phase %.0f°: PlanTransfer(Cursor): %v", phase, err)
 		}
 		strategy := w.LastTransfer.Strategy
-		if strategy != wantStrategy[i] {
-			t.Errorf("phase %.0f°: strategy = %q, want %q (selection must stay centre-aimed, ADR 0006 B)",
-				phase, strategy, wantStrategy[i])
+		wantStrategy := "split"
+		if w.LastTransfer.CombinedDv <= w.LastTransfer.SplitDv {
+			wantStrategy = "combined"
+		}
+		if strategy != wantStrategy {
+			t.Errorf("phase %.0f°: strategy = %q but CombinedDv=%.1f SplitDv=%.1f implies %q — the planted trim leaked into the centre-aimed comparison (ADR 0006 B)",
+				phase, strategy, w.LastTransfer.CombinedDv, w.LastTransfer.SplitDv, wantStrategy)
 		}
 		if strategy != "split" {
 			continue

--- a/internal/sim/split_capture_aim_test.go
+++ b/internal/sim/split_capture_aim_test.go
@@ -1,0 +1,109 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// rotAbout rotates v about the unit axis k by deg degrees (Rodrigues).
+func rotAbout(v, k orbital.Vec3, deg float64) orbital.Vec3 {
+	th := deg * math.Pi / 180
+	s, c := math.Sin(th), math.Cos(th)
+	return v.Scale(c).Add(k.Cross(v).Scale(s)).Add(k.Scale(k.Dot(v) * (1 - c)))
+}
+
+// TestSplitCaptureAimPhaseSweep (GH #159, ADR 0018 extended to the split):
+// a 24-point departure-phase sweep of the coplanar Kern→Cursor transfer.
+// Pre-fix, every phase where the dual-strategy plant picked the split
+// produced a collision course: the node-aligned phasing rendezvous with
+// Cursor's CENTRE (exact when coplanar), so the planned pass perilune sat
+// at −186 km altitude and the predicted final orbit was the degenerate
+// −200/−200 zero-angular-momentum radial plunge Jason flew into.
+//
+// Post-fix the split's arrival is trimmed so the moon-frame perilune lands
+// at the Capture Orbit radius (Cursor radius + 200 km), prograde — every
+// split plant must show a planned pass at a positive, ≈capture altitude
+// and a bound, non-degenerate predicted final orbit at Cursor.
+//
+// The strategy *selection* must stay centre-aimed (ADR 0006 B): the
+// combined/split pick per phase is pinned against the pre-fix sweep.
+func TestSplitCaptureAimPhaseSweep(t *testing.T) {
+	// Strategy per phase measured on main (pre-fix, 4a107a3-era planner) —
+	// the capture-safe trim must not flip any of these (ADR 0006 B: the
+	// comparison stays centre-aimed for both strategies).
+	wantStrategy := [24]string{
+		"combined", "combined", "combined", "combined", "combined", "split",
+		"split", "split", "split", "combined", "combined", "split",
+		"combined", "combined", "combined", "split", "split", "combined",
+		"combined", "split", "combined", "split", "split", "split",
+	}
+	splitSeen := 0
+	for i := 0; i < 24; i++ {
+		phase := float64(i) * 15
+		w := mustWorld(t)
+		cursorIdx, _, cursor := setupKernCursor(t, w)
+		c := w.ActiveCraft()
+		n := c.State.R.Cross(c.State.V).Unit()
+		c.State.R = rotAbout(c.State.R, n, phase)
+		c.State.V = rotAbout(c.State.V, n, phase)
+
+		if _, err := w.PlanTransfer(cursorIdx); err != nil {
+			t.Fatalf("phase %.0f°: PlanTransfer(Cursor): %v", phase, err)
+		}
+		strategy := w.LastTransfer.Strategy
+		if strategy != wantStrategy[i] {
+			t.Errorf("phase %.0f°: strategy = %q, want %q (selection must stay centre-aimed, ADR 0006 B)",
+				phase, strategy, wantStrategy[i])
+		}
+		if strategy != "split" {
+			continue
+		}
+		splitSeen++
+
+		pass, ok := w.PlannedSOIPass()
+		if !ok {
+			t.Errorf("phase %.0f°: split plant produced no PlannedSOIPass", phase)
+			continue
+		}
+		if pass.Body.ID != cursor.ID {
+			t.Errorf("phase %.0f°: planned pass at %s, want Cursor", phase, pass.Body.ID)
+			continue
+		}
+		alt := pass.PeriluneAltitude()
+		const captureAlt = 200e3
+		t.Logf("phase %3.0f°: split planned pass perilune alt = %8.1f km", phase, alt/1e3)
+		if alt <= 0 {
+			t.Errorf("phase %.0f°: split plant is a collision course (perilune alt %.1f km ≤ 0)", phase, alt/1e3)
+		} else if math.Abs(alt-captureAlt) > 0.5*captureAlt {
+			t.Errorf("phase %.0f°: split perilune alt %.1f km not near Capture Orbit alt %.1f km",
+				phase, alt/1e3, captureAlt/1e3)
+		}
+
+		// Predicted final orbit at Cursor: bound and non-degenerate.
+		state, primary, okFinal := w.PredictedFinalOrbit()
+		if !okFinal {
+			t.Errorf("phase %.0f°: PredictedFinalOrbit ok=false after split plant", phase)
+			continue
+		}
+		if primary.ID != cursor.ID {
+			t.Errorf("phase %.0f°: predicted final orbit around %s, want Cursor", phase, primary.ID)
+			continue
+		}
+		el := orbital.ElementsFromState(state.R, state.V, cursor.GravitationalParameter())
+		rp := el.A * (1 - el.E)
+		t.Logf("phase %3.0f°: final orbit e=%.3f a=%.1f km rp=%.1f km", phase, el.E, el.A/1e3, rp/1e3)
+		if el.E >= 1 || el.A <= 0 {
+			t.Errorf("phase %.0f°: predicted final orbit unbound (e=%.3f, a=%.1f km)", phase, el.E, el.A/1e3)
+		}
+		if rp <= cursor.RadiusMeters() {
+			t.Errorf("phase %.0f°: predicted final orbit periapsis %.1f km inside Cursor (radius %.1f km) — degenerate capture",
+				phase, rp/1e3, cursor.RadiusMeters()/1e3)
+		}
+	}
+	if splitSeen == 0 {
+		t.Fatal("sweep never selected the split strategy — the regression case is untested")
+	}
+	t.Logf("split selected on %d of 24 phases", splitSeen)
+}


### PR DESCRIPTION
## Confirmed hypothesis

Exactly as diagnosed in #159: the dual-strategy plant in `internal/sim/maneuver.go` gave only the **combined** branch the ADR 0018 capture-safe aim (`fusedIntraPrimaryDeparture(..., aimForCapture=true)` → `captureAimPoint`). The **split** planted its analytic seed centre-aimed — `splitNodePhasing` puts the transfer apoapsis exactly ON the node where the target will be. Coplanar (Kern→Cursor) that rendezvous is exact → zero-angular-momentum radial plunge, perilune **−186 km**, the degenerate −200/−200 "capture". Inclined (LEO→Luna) it arrived loose at **14,501 km altitude** — survivable but useless, with a capture Δv sized for a periapsis never reached. This is the gap ADR 0018 decision D explicitly deferred; this PR closes it.

## What changed

New `splitCaptureAim` (mirrors `captureAimPoint`'s solve-and-refine house style):

- **Lever: far-apsis trim, not phasing lead/lag.** The design guidance suggested leading/lagging the node-aligned τ by `b / (relative track speed)` — but in the split's geometry both the timing-induced miss and the target's motion are **along-track, i.e. parallel to v∞** (the arrival v∞ is near-tangential), so a timing offset shifts the encounter *time*, not the impact parameter, to first order. The split's actual in-plane b-plane lever is **radial**: trim the raise's far apsis off the target's orbit ring by b, so the craft crosses the ring radially offset, perpendicular to v∞. Outbound trims *below* the ring (the prograde side, matching `captureAimPoint`'s `v̂∞ × n̂_target` convention); inbound flips above.
- **Analytic seed, then iterate** (ADR 0018 C): `b = rp·√(1 + 2μ_t/(rp·v∞²))` with `rp = rCapture` and v∞ measured from the centre-aimed approach; each iteration re-measures the actual moon-frame perilune — **with the plane change applied impulsively at SOI entry**, mirroring the planted burn — via `transferEncounterTimes` + the relative hyperbola. The signed linear update (`b` measured as `|h|/v∞`, signed by `h·n̂_target`) pulls a too-high perilune **down** to rCapture (the inclined case) as well as pushing the coplanar centre-hit **up**. Converges to 2% in ≤6 iterations; best-prograde fallback if it can't.
- **Capture Δv recomputed** from the actual hyperbolic perilune speed vs circular at the actual perilune: `√(v∞² + 2μ_t/rp) − √(μ_t/rp)`, fired at the refined perilune time (`tEntry + tPeri`, the same hyperbolic-perilune treatment the combined branch's `refineCombinedCapture` uses — slightly better than the previous primary-frame tCA).
- **Selection unchanged** (ADR 0006 B): `CombinedDv`/`SplitDv` still computed centre-aimed from the seed; the trim applies only to the planted plan, exactly like the combined branch. The pre-#159 centre-aimed timing refinement is kept verbatim as the fallback when the trim can't resolve an encounter.
- Plane-change *placement* (just before SOI entry, GH #67 follow-up; GH #88 equal-offset ordering fallback) unchanged; its Δv/θ is now measured on the trimmed arc.

## Measured before → after

| Case | Pre-fix perilune | Post-fix |
|---|---|---|
| Coplanar Kern→Cursor sweep (every split-selected phase, 11/24) | **−186.0 km alt** (collision), final orbit degenerate −200/−200 | **+287.5 km alt**, final orbit at Cursor bound: e=0.196, rp=420.6 km radius |
| Inclined LEO→Luna (live-flown, production integrator) | **16,238.5 km radius** (14,501 km alt) | **2,290.7 km radius** (553 km alt; 1.18× Capture Orbit radius 1,937.4 km) |
| LEO→Luna planted Δv | raise 3054 + pc 69 + capture ~806 (analytic, mis-sized) | capture re-sized **789.2 m/s**; comparison SplitDv unchanged at 3930.5 |

## Acceptance criteria → tests

- **Phase sweep regression (written RED first)**: `TestSplitCaptureAimPhaseSweep` — 24 coplanar phases; every split plant must show `PlannedSOIPass` perilune alt > 0 and within 50% of the Capture Orbit altitude, plus a bound, non-degenerate `PredictedFinalOrbit` at Cursor. Pre-fix: all 11 split phases fail at −186 km / e=0.000 degenerate.
- **Selection pinned**: the same test pins the pre-fix combined/split choice for all 24 phases (measured on main before the fix) — the trim flips none.
- **Inclined split graduates**: `TestSplitArrivalPeriapsisCharacterization` goes log-only → asserting: flown perilune above the surface and ≤ 2× rCapture. Tolerance justification: the bound covers impulsive-plan vs finite-burn drift over a multi-day transfer flown at 60 s sampling; the pre-fix 8.4× flyby fails decisively, the aimed arrival (1.18×) passes with margin. The factor-2 lower bound would sit below the lunar surface, so "above the surface" is the effective floor.
- **Combined untouched**: `TestCoplanarCaptureFiresAtPerilune`, `TestCombinedTransferArrivesSafePeriapsis`, `TestPredictedTargetApproach*` all green.
- `go vet ./...` clean; `go test ./... -race -count=1`: **1134 passed in 15 packages**.

Also updated the `CONTEXT.md` **Transfer Plan** arrival bar: the in-plane offset aim now covers both strategies, with the comparison-stays-centre-aimed rule stated.

Closes #159