### PR TITLE
feat(input): rebind view yaw to shift+←/→ (was { / })

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -113,7 +113,7 @@ readout shows you why before you watch it fall back.
 | `g` | Reset the camera to the whole system |
 | `v` | Cycle the view (tilted → top → right → bottom → left → flat → launch). Tilted is the default — a 3D-style perspective that shows orbits leaning in space. Views are projections only: the camera re-frames once when you change focus, view, or system, and otherwise stays exactly where you put it — to read an upcoming encounter, focus the body it passes (`f`) and the camera fits to its sphere of influence so the capture curve fills the canvas |
 | `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
-| `{` / `}` | Yaw the 3D view left / right in 5° steps, wrapping all the way around (only in the tilted view) |
+| `shift+←` / `shift+→` | Yaw the 3D view left / right in 5° steps, wrapping all the way around (only in the tilted view) |
 | `F2` | Declutter — hide all overlays (the corner chips and the navball) for a clean look at the orbit. Press again to bring them back. Your core telemetry column stays put |
 | `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build your own rocket stack: on the stack field, `←` / `→` browse parts, `a` adds one on top, `x` removes the top one |
 | `H` | Plan a transfer to your target. To a moon of the planet you're at, it works out two ways to get there and plans the cheaper one, showing you both fuel costs. To another planet, it plans a standard Hohmann transfer. To a moon's parent planet, it plans an escape |

--- a/internal/sim/view.go
+++ b/internal/sim/view.go
@@ -183,7 +183,7 @@ func (w *World) NudgeViewTiltTheta(deltaDeg float64) float64 {
 	return w.ViewTilt.Theta
 }
 
-// ViewTiltPhiStep is the per-press yaw nudge for the { / } keys.
+// ViewTiltPhiStep is the per-press yaw nudge for the shift+←/→ keys.
 // Unlike Theta there is no min/max — yaw is a full turn around the
 // orbit, so the nudge wraps at 360° instead of clamping (ADR 0021 G).
 const ViewTiltPhiStep = 5.0

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -326,10 +326,10 @@ func TestCancelWarpKeyDropsToOneX(t *testing.T) {
 	}
 }
 
-// TestYawKeysNudgePhi (ADR 0021 G): `{` / `}` nudge ViewTilt.Phi ±5°
-// with 360° wrap while in ViewTilted, flashing the resulting yaw —
+// TestYawKeysNudgePhi (ADR 0021 G): shift+← / shift+→ nudge ViewTilt.Phi
+// ±5° with 360° wrap while in ViewTilted, flashing the resulting yaw —
 // and stay silent (no mutation, no toast) in any other ViewMode,
-// matching the Theta tilt keys' gating.
+// matching the Theta tilt keys' (shift+↑/↓) gating.
 func TestYawKeysNudgePhi(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
@@ -339,20 +339,20 @@ func TestYawKeysNudgePhi(t *testing.T) {
 		t.Fatalf("expected the default ViewTilted, got %v", a.world.ViewMode)
 	}
 
-	// `}` yaws +5° and toasts the new value.
-	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'}'}})
+	// shift+→ yaws +5° and toasts the new value.
+	a.Update(tea.KeyMsg{Type: tea.KeyShiftRight})
 	if a.world.ViewTilt.Phi != 5 {
-		t.Errorf("after `}`: Phi = %v, want 5", a.world.ViewTilt.Phi)
+		t.Errorf("after shift+→: Phi = %v, want 5", a.world.ViewTilt.Phi)
 	}
 	if a.statusMsg != "view: yaw 5°" {
 		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "view: yaw 5°")
 	}
 
-	// `{` twice crosses zero and wraps to 355° — no clamp.
-	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'{'}})
-	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'{'}})
+	// shift+← twice crosses zero and wraps to 355° — no clamp.
+	a.Update(tea.KeyMsg{Type: tea.KeyShiftLeft})
+	a.Update(tea.KeyMsg{Type: tea.KeyShiftLeft})
 	if a.world.ViewTilt.Phi != 355 {
-		t.Errorf("after `{` `{`: Phi = %v, want 355 (wrap below zero)", a.world.ViewTilt.Phi)
+		t.Errorf("after shift+← shift+←: Phi = %v, want 355 (wrap below zero)", a.world.ViewTilt.Phi)
 	}
 	if a.statusMsg != "view: yaw 355°" {
 		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "view: yaw 355°")
@@ -361,12 +361,12 @@ func TestYawKeysNudgePhi(t *testing.T) {
 	// Outside ViewTilted the keys are a silent no-op.
 	a.world.ViewMode = sim.ViewTop
 	a.statusMsg = ""
-	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'}'}})
+	a.Update(tea.KeyMsg{Type: tea.KeyShiftRight})
 	if a.world.ViewTilt.Phi != 355 {
-		t.Errorf("`}` in ViewTop mutated Phi to %v, want 355 (no-op)", a.world.ViewTilt.Phi)
+		t.Errorf("shift+→ in ViewTop mutated Phi to %v, want 355 (no-op)", a.world.ViewTilt.Phi)
 	}
 	if a.statusMsg != "" {
-		t.Errorf("`}` in ViewTop flashed %q, want silence", a.statusMsg)
+		t.Errorf("shift+→ in ViewTop flashed %q, want silence", a.statusMsg)
 	}
 }
 

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -177,10 +177,8 @@ type Keymap struct {
 
 	// YawLeft / YawRight (ADR 0021 G): nudge World.ViewTilt.Phi ±5°
 	// while ViewMode == ViewTilted, wrapping at 360° (no clamp —
-	// sim.World.NudgeViewTiltPhi owns step + wrap). Bound to { / },
-	// the shifted siblings of the [ / ] craft-cycle keys; a second
-	// shift+arrow pair was explicitly rejected because modified arrow
-	// keys are unreliable on common laptop keyboards/terminals.
+	// sim.World.NudgeViewTiltPhi owns step + wrap). Bound to shift+←/→,
+	// symmetric with TiltUp/TiltDown (shift+↑/↓).
 	YawLeft  key.Binding
 	YawRight key.Binding
 
@@ -286,8 +284,8 @@ func DefaultKeymap() Keymap {
 		ToggleInstantSAS:          key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "SAS model: slew / instant (MANUAL/AUTO)")),
 		TiltUp:                    key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+↑", "tilt +5° (ViewTilted)")),
 		TiltDown:                  key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+↓", "tilt -5° (ViewTilted)")),
-		YawLeft:                   key.NewBinding(key.WithKeys("{"), key.WithHelp("{", "yaw -5° (ViewTilted)")),
-		YawRight:                  key.NewBinding(key.WithKeys("}"), key.WithHelp("}", "yaw +5° (ViewTilted)")),
+		YawLeft:                   key.NewBinding(key.WithKeys("shift+left"), key.WithHelp("shift+←", "yaw -5° (ViewTilted)")),
+		YawRight:                  key.NewBinding(key.WithKeys("shift+right"), key.WithHelp("shift+→", "yaw +5° (ViewTilted)")),
 		EndFlight:                 key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "end flight (Crashed vessel)")),
 		JumpToLaunchView:          key.NewBinding(key.WithKeys("V"), key.WithHelp("V", "jump to launch view (active vessel)")),
 		Declutter:                 key.NewBinding(key.WithKeys("f2"), key.WithHelp("F2", "declutter (hide overlays)")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -46,7 +46,7 @@ var helpSections = []helpSection{
 		{"+ / -", "zoom in / out"},
 		{"v", "cycle view (tilted / top / right / bottom / left / flat / launch)"},
 		{"shift+↑ / ↓", "tilt the 3D view up / down (tilted view only)"},
-		{"{ / }", "yaw the 3D view left / right, wraps 360° (tilted view only)"},
+		{"shift+← / →", "yaw the 3D view left / right, wraps 360° (tilted view only)"},
 		{"F2", "declutter — hide chips + navball (core column stays)"},
 	}},
 	{"NAVIGATION", [][2]string{


### PR DESCRIPTION
Yaw the tilted 3D view with **shift+←** / **shift+→**, symmetric with the `shift+↑`/`shift+↓` tilt keys, instead of `{` / `}`.

### Changes
- `input.go` — binding + doc comment (drops the "shifted siblings of [ / ]" rationale; now mirrors the tilt keys)
- `help.go` — F1 overlay row
- `docs/controls.md` — keybinding table row
- `view.go` — `ViewTiltPhiStep` comment
- `app_test.go` — `TestYawKeysNudgePhi` now drives `tea.KeyShiftLeft`/`tea.KeyShiftRight`

`{` / `}` were reported as awkward; the shift+arrow pair keeps yaw next to tilt under one modifier.

CI gate green locally: `go vet ./...` + `go test ./... -race` (1134 passed).