### PR TITLE
feat(render): data-driven body-texture engine (ADR 0024 PR1)

### DIFF
--- a/internal/bodies/body.go
+++ b/internal/bodies/body.go
@@ -102,6 +102,12 @@ type CelestialBody struct {
 	// varied pole directions; populating this field lets each one
 	// tip the right way once we have data.
 	AxialAzimuth float64 `json:"axialAzimuth,omitempty"`
+
+	// Texture is the optional data-driven surface-texture spec
+	// (ADR 0024). nil renders a flat solid disk; the generic render
+	// engine consumes a non-nil block. Cosmetic, not semantic —
+	// deliberately excluded from CatalogHash (see catalog.go).
+	Texture *Texture `json:"texture,omitempty"`
 }
 
 // Atmosphere is an exponential-density atmospheric model:

--- a/internal/bodies/catalog.go
+++ b/internal/bodies/catalog.go
@@ -16,17 +16,41 @@ import (
 // Hash is over re-marshalled structs, not raw file bytes, so cosmetic
 // JSON whitespace edits don't churn the hash. Only semantic catalog
 // changes (new bodies, mass / element edits) bump it.
+//
+// The body Texture spec (ADR 0024) is cosmetic, not semantic, so it is
+// zeroed in a hash-specific view before hashing — adding or editing a
+// texture must never reject an existing save. `json:"-"` can't be used
+// on the field itself because that would also block *loading* it; the
+// exclusion lives here, at the hash boundary.
 func CatalogHash() (string, error) {
 	systems, err := LoadAll()
 	if err != nil {
 		return "", fmt.Errorf("load systems for catalog hash: %w", err)
 	}
-	b, err := json.Marshal(systems)
+	b, err := json.Marshal(hashView(systems))
 	if err != nil {
 		return "", fmt.Errorf("marshal canonical systems: %w", err)
 	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// hashView returns a shallow copy of the loaded systems with every
+// body's cosmetic Texture zeroed, so CatalogHash tracks only semantic
+// catalog shape. The originals are untouched (the Bodies slices are
+// copied, not aliased) so the live catalog keeps its textures.
+func hashView(systems []System) []System {
+	out := make([]System, len(systems))
+	for i, s := range systems {
+		bodies := make([]CelestialBody, len(s.Bodies))
+		copy(bodies, s.Bodies)
+		for j := range bodies {
+			bodies[j].Texture = nil
+		}
+		s.Bodies = bodies
+		out[i] = s
+	}
+	return out
 }
 
 // LookupByID searches every system for a body with the given ID and

--- a/internal/bodies/catalog_texture_test.go
+++ b/internal/bodies/catalog_texture_test.go
@@ -1,0 +1,57 @@
+package bodies
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestHashViewExcludesTexture is the load-bearing save-compat guard for
+// ADR 0024: the catalog hash must be identical whether or not bodies
+// carry a cosmetic texture block, so adding textures (PR2+) never
+// rejects an existing save with ErrCatalogMismatch.
+func TestHashViewExcludesTexture(t *testing.T) {
+	plain := []System{{
+		Name: "Test",
+		Bodies: []CelestialBody{
+			{ID: "a", Name: "A", MeanRadius: 100},
+			{ID: "b", Name: "B", MeanRadius: 200},
+		},
+	}}
+	withTex := []System{{
+		Name: "Test",
+		Bodies: []CelestialBody{
+			{ID: "a", Name: "A", MeanRadius: 100, Texture: &Texture{
+				Base:       "#123456",
+				Continents: []TextureEllipse{{Lat: 1, Lon: 2, LatR: 3, LonR: 4, Color: "#abcdef"}},
+			}},
+			{ID: "b", Name: "B", MeanRadius: 200, Texture: &Texture{Base: "#000000"}},
+		},
+	}}
+
+	a, err := json.Marshal(hashView(plain))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(hashView(withTex))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("hashView differs with vs. without texture:\n plain: %s\n   tex: %s", a, b)
+	}
+}
+
+// TestHashViewDoesNotMutateInput confirms hashView copies rather than
+// aliases — zeroing texture for the hash must not strip textures off
+// the live catalog the renderer reads.
+func TestHashViewDoesNotMutateInput(t *testing.T) {
+	in := []System{{
+		Name:   "Test",
+		Bodies: []CelestialBody{{ID: "a", Texture: &Texture{Base: "#123456"}}},
+	}}
+	_ = hashView(in)
+	if in[0].Bodies[0].Texture == nil {
+		t.Fatal("hashView zeroed the texture on its input; must copy")
+	}
+}

--- a/internal/bodies/systems.go
+++ b/internal/bodies/systems.go
@@ -178,6 +178,19 @@ func mergeUserOverlay(systems []System, dir string) ([]System, []LoadWarning) {
 			continue
 		}
 		s.Source = "user"
+		// Fail-soft on broken/partial texture specs (ADR 0024): a
+		// cosmetic texture problem must never reject a user system.
+		// Drop the offending body's texture (→ flat disk) and surface
+		// a warning, but keep loading the system.
+		for i := range s.Bodies {
+			if err := s.Bodies[i].Texture.Validate(); err != nil {
+				warnings = append(warnings, LoadWarning{
+					Path: path,
+					Err:  fmt.Errorf("body %q: %w (rendering flat disk)", s.Bodies[i].ID, err),
+				})
+				s.Bodies[i].Texture = nil
+			}
+		}
 		// Conflict policy: user files win on system.Name match,
 		// otherwise append.
 		replaced := false

--- a/internal/bodies/texture.go
+++ b/internal/bodies/texture.go
@@ -1,0 +1,180 @@
+package bodies
+
+import "fmt"
+
+// Texture is the optional data-driven surface-texture spec for a body
+// (ADR 0024). It replaces the hardcoded per-body Go shaders in
+// internal/render: a single generic engine consumes this block, so any
+// system — including user overlays in $XDG_CONFIG_HOME — can be
+// textured, which the old `switch b.ID` model structurally could not.
+//
+// The spec carries *typed* feature kinds rather than one flat list, so
+// each kind can render kind-specific detail. The presence of a kind
+// selects the look; an empty block (or a body with no Texture at all)
+// renders as a flat base-color disk.
+//
+// PR1 (this slice) renders the ellipse kinds (continents / craters /
+// spots) and bands. The mask / limb-tint / star kinds are carried in
+// the schema from PR1 — so the field round-trips through JSON and is
+// covered by the catalog-hash exclusion (see catalog.go) — but are
+// consumed by the engine starting in PR3 (ADR 0024 rollout).
+//
+// Texture is excluded from bodies.CatalogHash: it is cosmetic, not
+// semantic, so it must never bump the hash and reject existing saves.
+type Texture struct {
+	// Base is the disk's underlying surface color (hex, e.g. "#6E5F50").
+	// Empty falls back to the body's Color.
+	Base string `json:"base,omitempty"`
+
+	// Bands are latitude sweeps for gas/ice giants — ordered, first
+	// match wins per pixel.
+	Bands []TextureBand `json:"bands,omitempty"`
+
+	// Continents are filled ellipse features (maria, albedo regions,
+	// land masses). Layered in table order — last match wins.
+	Continents []TextureEllipse `json:"continents,omitempty"`
+
+	// Craters are ellipse features with optional rim + rayed ejecta —
+	// rendered on top of continents/bands. Last match wins.
+	Craters []TextureEllipse `json:"craters,omitempty"`
+
+	// Spots are storm/feature ellipses (e.g. a Great Red Spot)
+	// layered over bands. Last match wins.
+	Spots []TextureEllipse `json:"spots,omitempty"`
+
+	// Mask is the Earth-class polygon land/ocean/biome mask kind.
+	// Carried from PR1; rendered starting PR3.
+	Mask *TextureMask `json:"mask,omitempty"`
+
+	// LimbTint is an atmospheric-halo color painted over the outer
+	// ring of the disk (hex). Carried from PR1; rendered starting PR3.
+	LimbTint string `json:"limbTint,omitempty"`
+
+	// Star is the self-luminous star-surface kind (limb darkening +
+	// granulation, light-source exempt). Carried from PR1; rendered
+	// starting PR3.
+	Star *TextureStar `json:"star,omitempty"`
+}
+
+// TextureBand is a latitude sweep: every pixel whose body-latitude is
+// in [LatMin, LatMax) takes Color.
+type TextureBand struct {
+	LatMin float64 `json:"latMin"`
+	LatMax float64 `json:"latMax"`
+	Color  string  `json:"color"`
+}
+
+// TextureEllipse is a lat/lon-axis-aligned ellipse feature. Lat/Lon is
+// the center (degrees); LatR/LonR are the semi-axes along latitude and
+// longitude (degrees). Color fills the ellipse. For craters, Rim (when
+// set) colors the outer ring and Rays marks bright ejecta.
+type TextureEllipse struct {
+	Lat   float64 `json:"lat"`
+	Lon   float64 `json:"lon"`
+	LatR  float64 `json:"latR"`
+	LonR  float64 `json:"lonR"`
+	Color string  `json:"color,omitempty"`
+	Rim   string  `json:"rim,omitempty"`
+	Rays  bool    `json:"rays,omitempty"`
+}
+
+// TextureMask is the Earth-class polygon land/ocean mask kind. Polys
+// is a list of named regions (land / desert / ice) given as polygon
+// vertex lists; Biomes maps a region kind to a hex color. Carried in
+// the schema from PR1; the engine consumes it starting PR3.
+type TextureMask struct {
+	Polys  []TextureRegion   `json:"polys,omitempty"`
+	Biomes map[string]string `json:"biomes,omitempty"`
+}
+
+// TextureRegion is one named polygon in a TextureMask.
+type TextureRegion struct {
+	Kind     string       `json:"kind,omitempty"`
+	Vertices []LatLonPair `json:"vertices,omitempty"`
+}
+
+// LatLonPair is a single (lat, lon) vertex in degrees.
+type LatLonPair struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
+// TextureStar is the self-luminous star-surface kind. Granulation is
+// the granulation amplitude (0..1); Seed seeds the noise. Carried in
+// the schema from PR1; the engine consumes it starting PR3.
+type TextureStar struct {
+	Granulation float64 `json:"granulation,omitempty"`
+	Seed        int64   `json:"seed,omitempty"`
+}
+
+// Validate reports the first structural problem in a texture spec, or
+// nil when it is renderable. It is intentionally lenient: an empty
+// block is valid (flat disk), and absent colors fall back at render
+// time. It flags only the cases that would otherwise render as silent
+// garbage — malformed hex colors, non-positive ellipse radii, and
+// inverted band ranges. Used by the loader to fail-soft on user-overlay
+// systems (warn + drop the texture → flat disk) rather than hard-error.
+func (t *Texture) Validate() error {
+	if t == nil {
+		return nil
+	}
+	if !validHexColor(t.Base) {
+		return fmt.Errorf("texture: invalid base color %q", t.Base)
+	}
+	if !validHexColor(t.LimbTint) {
+		return fmt.Errorf("texture: invalid limbTint color %q", t.LimbTint)
+	}
+	for i, b := range t.Bands {
+		if !validHexColor(b.Color) || b.Color == "" {
+			return fmt.Errorf("texture: band %d has invalid color %q", i, b.Color)
+		}
+		if b.LatMin >= b.LatMax {
+			return fmt.Errorf("texture: band %d has latMin %g >= latMax %g", i, b.LatMin, b.LatMax)
+		}
+	}
+	for kind, set := range map[string][]TextureEllipse{
+		"continent": t.Continents,
+		"crater":    t.Craters,
+		"spot":      t.Spots,
+	} {
+		for i, e := range set {
+			if e.LatR <= 0 || e.LonR <= 0 {
+				return fmt.Errorf("texture: %s %d has non-positive radius (latR %g, lonR %g)", kind, i, e.LatR, e.LonR)
+			}
+			if !validHexColor(e.Color) || !validHexColor(e.Rim) {
+				return fmt.Errorf("texture: %s %d has invalid color %q / rim %q", kind, i, e.Color, e.Rim)
+			}
+		}
+	}
+	if t.Mask != nil {
+		for kind, c := range t.Mask.Biomes {
+			if !validHexColor(c) || c == "" {
+				return fmt.Errorf("texture: mask biome %q has invalid color %q", kind, c)
+			}
+		}
+	}
+	if t.Star != nil && (t.Star.Granulation < 0 || t.Star.Granulation > 1) {
+		return fmt.Errorf("texture: star granulation %g out of [0,1]", t.Star.Granulation)
+	}
+	return nil
+}
+
+// validHexColor reports whether s is empty (allowed — falls back) or a
+// "#rgb" / "#rrggbb" hex color. ANSI names/indices are intentionally
+// not accepted in the texture schema; textures speak hex.
+func validHexColor(s string) bool {
+	if s == "" {
+		return true
+	}
+	if s[0] != '#' || (len(s) != 4 && len(s) != 7) {
+		return false
+	}
+	for _, c := range s[1:] {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/bodies/texture_test.go
+++ b/internal/bodies/texture_test.go
@@ -1,0 +1,73 @@
+package bodies
+
+import "testing"
+
+func TestTextureValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		tex     *Texture
+		wantErr bool
+	}{
+		{"nil is valid", nil, false},
+		{"empty block is valid", &Texture{}, false},
+		{"good full block", &Texture{
+			Base:       "#6E5F50",
+			Bands:      []TextureBand{{LatMin: -30, LatMax: 30, Color: "#abc"}},
+			Continents: []TextureEllipse{{Lat: 15, Lon: 70, LatR: 14, LonR: 18, Color: "#3E7A35"}},
+			Craters:    []TextureEllipse{{Lat: -21, Lon: 129, LatR: 3, LonR: 4, Rim: "#fff", Rays: true}},
+			Spots:      []TextureEllipse{{Lat: -22, LatR: 8, LonR: 16, Color: "#A03A28"}},
+			LimbTint:   "#9DC8FF",
+		}, false},
+		{"empty color falls back, ok", &Texture{Continents: []TextureEllipse{{LatR: 1, LonR: 1}}}, false},
+		{"bad base hex", &Texture{Base: "6E5F50"}, true},
+		{"bad base length", &Texture{Base: "#12345"}, true},
+		{"bad limb tint", &Texture{LimbTint: "#xyz"}, true},
+		{"band empty color", &Texture{Bands: []TextureBand{{LatMin: 0, LatMax: 10}}}, true},
+		{"band inverted range", &Texture{Bands: []TextureBand{{LatMin: 30, LatMax: 10, Color: "#fff"}}}, true},
+		{"continent zero radius", &Texture{Continents: []TextureEllipse{{Lat: 0, Lon: 0, LatR: 0, LonR: 5, Color: "#fff"}}}, true},
+		{"crater bad rim", &Texture{Craters: []TextureEllipse{{LatR: 1, LonR: 1, Rim: "nope"}}}, true},
+		{"mask biome bad color", &Texture{Mask: &TextureMask{Biomes: map[string]string{"land": "green"}}}, true},
+		{"star granulation out of range", &Texture{Star: &TextureStar{Granulation: 2}}, true},
+		{"star granulation ok", &Texture{Star: &TextureStar{Granulation: 0.12, Seed: 42}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.tex.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidHexColor(t *testing.T) {
+	for _, c := range []string{"", "#fff", "#FFFFFF", "#1a2B3c", "#abc"} {
+		if !validHexColor(c) {
+			t.Errorf("validHexColor(%q) = false, want true", c)
+		}
+	}
+	for _, c := range []string{"fff", "#ff", "#fffff", "#gggggg", "red", "#12 456"} {
+		if validHexColor(c) {
+			t.Errorf("validHexColor(%q) = true, want false", c)
+		}
+	}
+}
+
+// TestEmbeddedTexturesValidate guards against authoring typos in the
+// built-in catalog: every embedded body's texture (once any are
+// authored, PR2+) must pass Validate, since the loader only fail-softs
+// user overlays — a broken embedded texture should fail CI, not render
+// silently flat.
+func TestEmbeddedTexturesValidate(t *testing.T) {
+	systems, err := loadEmbedded()
+	if err != nil {
+		t.Fatalf("loadEmbedded: %v", err)
+	}
+	for _, s := range systems {
+		for _, b := range s.Bodies {
+			if err := b.Texture.Validate(); err != nil {
+				t.Errorf("%s/%s: invalid embedded texture: %v", s.Name, b.ID, err)
+			}
+		}
+	}
+}

--- a/internal/render/earth.go
+++ b/internal/render/earth.go
@@ -228,6 +228,16 @@ func TextureFor(b bodies.CelestialBody, pxRadius int, subLatDeg, subLonDeg, scre
 // body, or nil if the body has no texture. Split out of TextureFor so
 // the v0.9.6 lighting wrapper has a single base closure to darken.
 func bodyTextureBase(b bodies.CelestialBody, subLatDeg, subLonDeg, screenUpX, screenUpY float64) BodyTexture {
+	// Data-driven path (ADR 0024): a body carrying a Texture spec is
+	// rendered by the generic engine. Sol's bodies have no Texture
+	// block yet (migrated in a later PR), so they fall through to the
+	// hand-written shaders below untouched.
+	if b.Texture != nil {
+		ct := compileTexture(b.Texture, b.Color)
+		return func(dx, dy, r int) lipgloss.Color {
+			return ct.colorAt(dx, dy, r, subLatDeg, subLonDeg, screenUpX, screenUpY)
+		}
+	}
 	switch b.ID {
 	case "sun":
 		return func(dx, dy, r int) lipgloss.Color {

--- a/internal/render/texture_engine.go
+++ b/internal/render/texture_engine.go
@@ -1,0 +1,166 @@
+package render
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// Data-driven body-texture engine (ADR 0024). A single generic shader
+// consumes a bodies.Texture spec, replacing the per-body Go functions
+// dispatched by `switch b.ID` in bodyTextureBase. PR1 renders the
+// ellipse kinds (continents / craters / spots) and bands over a base
+// color; mask / limb-tint / star kinds are carried in the schema but
+// not yet drawn (ADR 0024 rollout PR3).
+//
+// The spec is compiled once per body per frame (hex → lipgloss.Color,
+// ellipses → the render-package continentEllipse type) so the per-pixel
+// closure does no parsing.
+
+// craterDefaultBright is the floor/rim color a crater falls back to
+// when its spec carries neither color nor rim — keeps a rayed crater
+// visible against any base rather than rendering invisibly.
+const craterDefaultBright = lipgloss.Color("#EFEAE0")
+
+// craterRimInner is the normalized elliptical radius (0=center, 1=edge)
+// above which a crater paints its rim color instead of its floor. Only
+// applies when the crater carries a rim.
+const craterRimInner = 0.55
+
+type compiledBand struct {
+	latMin, latMax float64
+	color          lipgloss.Color
+}
+
+type compiledCrater struct {
+	c      continentEllipse // center + semi-axes; color is the floor
+	rim    lipgloss.Color
+	hasRim bool
+}
+
+type compiledTexture struct {
+	base       lipgloss.Color
+	bands      []compiledBand
+	continents []continentEllipse
+	spots      []continentEllipse
+	craters    []compiledCrater
+}
+
+// compileTexture turns a JSON texture spec into a per-pixel-ready form.
+// fallbackBase is used when the spec's base color is empty (the body's
+// display Color); if both are empty the engine still renders, defaulting
+// to a neutral disk. Zero-radius ellipses are dropped (defensive — the
+// loader validates user overlays, but embedded data or future kinds
+// shouldn't be able to divide by zero).
+func compileTexture(t *bodies.Texture, fallbackBase string) *compiledTexture {
+	ct := &compiledTexture{base: parseColor(t.Base, parseColor(fallbackBase, ColorMoonHighland))}
+	for _, b := range t.Bands {
+		ct.bands = append(ct.bands, compiledBand{
+			latMin: b.LatMin, latMax: b.LatMax,
+			color: parseColor(b.Color, ct.base),
+		})
+	}
+	for _, e := range t.Continents {
+		if e.LatR <= 0 || e.LonR <= 0 {
+			continue
+		}
+		ct.continents = append(ct.continents, toEllipse(e, ct.base))
+	}
+	for _, e := range t.Spots {
+		if e.LatR <= 0 || e.LonR <= 0 {
+			continue
+		}
+		ct.spots = append(ct.spots, toEllipse(e, ct.base))
+	}
+	for _, e := range t.Craters {
+		if e.LatR <= 0 || e.LonR <= 0 {
+			continue
+		}
+		floor := e.Color
+		if floor == "" && e.Rim == "" {
+			cr := compiledCrater{c: toEllipseColor(e, craterDefaultBright)}
+			ct.craters = append(ct.craters, cr)
+			continue
+		}
+		cr := compiledCrater{c: toEllipseColor(e, parseColor(floor, craterDefaultBright))}
+		if e.Rim != "" {
+			cr.rim = parseColor(e.Rim, cr.c.color)
+			cr.hasRim = true
+		}
+		ct.craters = append(ct.craters, cr)
+	}
+	return ct
+}
+
+func toEllipse(e bodies.TextureEllipse, fallback lipgloss.Color) continentEllipse {
+	return toEllipseColor(e, parseColor(e.Color, fallback))
+}
+
+func toEllipseColor(e bodies.TextureEllipse, color lipgloss.Color) continentEllipse {
+	return continentEllipse{lat: e.Lat, lon: e.Lon, aLat: e.LatR, aLon: e.LonR, color: color}
+}
+
+// parseColor returns the hex string as a lipgloss.Color, or fallback
+// when empty. The loader validates user-overlay hex; embedded data is
+// covered by tests, so no per-pixel validation is needed here.
+func parseColor(hex string, fallback lipgloss.Color) lipgloss.Color {
+	if hex == "" {
+		return fallback
+	}
+	return lipgloss.Color(hex)
+}
+
+// colorAt is the per-pixel shader. Mirrors the resolution order of the
+// hand-written shaders: base → band (by latitude) → continents (last
+// wins) → spots (last wins) → craters (top). Bands are applied off the
+// latitude alone (valid even at a pole-on view, matching JupiterPixel-
+// Color); the ellipse kinds are gated on a valid longitude.
+func (ct *compiledTexture) colorAt(dx, dy, pxRadius int, subLatDeg, subLonDeg, screenUpX, screenUpY float64) lipgloss.Color {
+	lat, lon, ok := projectPixelToLatLon(dx, dy, pxRadius, subLatDeg, subLonDeg, screenUpX, screenUpY)
+	color := ct.base
+	for _, b := range ct.bands {
+		if lat >= b.latMin && lat < b.latMax {
+			color = b.color
+			break
+		}
+	}
+	if !ok {
+		return color
+	}
+	for _, c := range ct.continents {
+		if inEllipse(lat, lon, c) {
+			color = c.color
+		}
+	}
+	for _, s := range ct.spots {
+		if inEllipse(lat, lon, s) {
+			color = s.color
+		}
+	}
+	for _, cr := range ct.craters {
+		if rr := ellipseNorm(lat, lon, cr.c); rr < 1.0 {
+			if cr.hasRim && rr > craterRimInner {
+				color = cr.rim
+			} else {
+				color = cr.c.color
+			}
+		}
+	}
+	return color
+}
+
+// ellipseNorm returns the squared normalized elliptical radius of
+// (lat, lon) relative to ellipse c: < 1 inside, == 1 on the edge. Same
+// metric inEllipse thresholds at 1.0, exposed so craters can shade an
+// inner floor vs. outer rim.
+func ellipseNorm(lat, lon float64, c continentEllipse) float64 {
+	dlat := lat - c.lat
+	dlon := lon - c.lon
+	for dlon > 180 {
+		dlon -= 360
+	}
+	for dlon < -180 {
+		dlon += 360
+	}
+	return (dlat/c.aLat)*(dlat/c.aLat) + (dlon/c.aLon)*(dlon/c.aLon)
+}

--- a/internal/render/texture_engine_test.go
+++ b/internal/render/texture_engine_test.go
@@ -1,0 +1,137 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// center renders the disk-center pixel (dx=dy=0), which maps to the
+// sub-observer point (subLat=subLon=0 → body lat/lon 0,0).
+func centerColor(ct *compiledTexture) lipgloss.Color {
+	return ct.colorAt(0, 0, 30, 0, 0, 0, 1)
+}
+
+func TestCompileTextureBaseFallback(t *testing.T) {
+	// Empty base → falls back to the body Color passed to compile.
+	ct := compileTexture(&bodies.Texture{}, "#445566")
+	if got := centerColor(ct); got != lipgloss.Color("#445566") {
+		t.Errorf("empty base: got %v, want body color #445566", got)
+	}
+	// Explicit base wins over body color.
+	ct = compileTexture(&bodies.Texture{Base: "#112233"}, "#445566")
+	if got := centerColor(ct); got != lipgloss.Color("#112233") {
+		t.Errorf("explicit base: got %v, want #112233", got)
+	}
+}
+
+func TestColorAtContinentFill(t *testing.T) {
+	// A continent ellipse centered on the sub-observer point colors the
+	// center pixel; a pixel well outside it keeps the base.
+	ct := compileTexture(&bodies.Texture{
+		Base:       "#101010",
+		Continents: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 20, LonR: 20, Color: "#20A020"}},
+	}, "")
+	if got := centerColor(ct); got != lipgloss.Color("#20A020") {
+		t.Errorf("center inside continent: got %v, want #20A020", got)
+	}
+	// Pixel near the limb (far from lat/lon 0) should be base.
+	if got := ct.colorAt(28, 0, 30, 0, 0, 0, 1); got != lipgloss.Color("#101010") {
+		t.Errorf("limb pixel: got %v, want base #101010", got)
+	}
+}
+
+func TestColorAtBandLookup(t *testing.T) {
+	ct := compileTexture(&bodies.Texture{
+		Base:  "#000000",
+		Bands: []bodies.TextureBand{{LatMin: -10, LatMax: 10, Color: "#D7B98C"}},
+	}, "")
+	// Center is lat 0 → inside the equatorial band.
+	if got := centerColor(ct); got != lipgloss.Color("#D7B98C") {
+		t.Errorf("equatorial band: got %v, want #D7B98C", got)
+	}
+}
+
+func TestColorAtCraterRim(t *testing.T) {
+	// A crater with a rim: center pixel is the floor, a pixel in the
+	// outer ring is the rim.
+	ct := compileTexture(&bodies.Texture{
+		Base:    "#202020",
+		Craters: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 30, LonR: 30, Color: "#404040", Rim: "#F0F0F0"}},
+	}, "")
+	if got := centerColor(ct); got != lipgloss.Color("#404040") {
+		t.Errorf("crater floor: got %v, want #404040", got)
+	}
+	// A pixel offset toward the rim: dx chosen so the projected lat/lon
+	// lands in the rim band (rr > craterRimInner) but still inside.
+	got := ct.colorAt(0, 12, 30, 0, 0, 0, 1)
+	if got != lipgloss.Color("#F0F0F0") {
+		t.Errorf("crater rim: got %v, want rim #F0F0F0", got)
+	}
+}
+
+func TestColorAtCraterDefaultBright(t *testing.T) {
+	// Crater with neither color nor rim falls back to the bright default
+	// so it stays visible.
+	ct := compileTexture(&bodies.Texture{
+		Base:    "#202020",
+		Craters: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 10, LonR: 10, Rays: true}},
+	}, "")
+	if got := centerColor(ct); got != craterDefaultBright {
+		t.Errorf("rayed crater default: got %v, want %v", got, craterDefaultBright)
+	}
+}
+
+// TestColorAtResolutionOrder confirms craters paint over continents,
+// which paint over bands, which paint over base — all at the center.
+func TestColorAtResolutionOrder(t *testing.T) {
+	ct := compileTexture(&bodies.Texture{
+		Base:       "#000000",
+		Bands:      []bodies.TextureBand{{LatMin: -90, LatMax: 90, Color: "#111111"}},
+		Continents: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 50, LonR: 50, Color: "#222222"}},
+		Craters:    []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 50, LonR: 50, Color: "#333333"}},
+	}, "")
+	if got := centerColor(ct); got != lipgloss.Color("#333333") {
+		t.Errorf("resolution order: got %v, want crater #333333 on top", got)
+	}
+}
+
+func TestCompileTextureDropsZeroRadius(t *testing.T) {
+	ct := compileTexture(&bodies.Texture{
+		Continents: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 0, LonR: 5, Color: "#fff"}},
+		Spots:      []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 5, LonR: 0, Color: "#fff"}},
+	}, "#202020")
+	if len(ct.continents) != 0 {
+		t.Errorf("zero-latR continent not dropped: %d", len(ct.continents))
+	}
+	if len(ct.spots) != 0 {
+		t.Errorf("zero-lonR spot not dropped: %d", len(ct.spots))
+	}
+}
+
+// TestBodyTextureBaseUsesEngine confirms the bodyTextureBase fallthrough
+// routes a body carrying a Texture spec through the generic engine
+// (a non-Sol ID that would otherwise return nil).
+func TestBodyTextureBaseUsesEngine(t *testing.T) {
+	b := bodies.CelestialBody{
+		ID:    "kern",
+		Color: "#5C8C4A",
+		Texture: &bodies.Texture{
+			Base:       "#1F5F94",
+			Continents: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 30, LonR: 30, Color: "#5C8C4A"}},
+		},
+	}
+	tex := bodyTextureBase(b, 0, 0, 0, 1)
+	if tex == nil {
+		t.Fatal("bodyTextureBase returned nil for a body with a Texture spec")
+	}
+	if got := tex(0, 0, 30); got != lipgloss.Color("#5C8C4A") {
+		t.Errorf("engine center: got %v, want continent #5C8C4A", got)
+	}
+	// A body without a texture and an unknown ID still returns nil.
+	if bodyTextureBase(bodies.CelestialBody{ID: "kern"}, 0, 0, 0, 1) != nil {
+		t.Error("untextured unknown body should return nil")
+	}
+}


### PR DESCRIPTION
## ADR 0024 PR1 — data-driven body-texture engine

First slice of [ADR 0024](https://github.com/jasonfen/terminal-space-program) (data-driven body textures in system JSON). Engine-first / Lumen-before-Sol: stand up the schema + generic engine and prove it on the fallthrough path, **without touching Sol's tested shaders**.

### What this does
- Adds an optional `texture` block to `bodies.CelestialBody` with typed Feature Kinds (ADR §B): `base`, `bands`, `continents`, `craters`, `spots`, plus `mask` / `limbTint` / `star` carried in the schema (round-trip + hash-excluded) but **not yet rendered** (PR3).
- Builds a generic per-pixel engine (`internal/render/texture_engine.go`) that compiles a spec once per body/frame and shades in order base → band → continents → spots → craters. Reuses `projectPixelToLatLon` / `inEllipse`; craters get an inner-floor / outer-rim split via a new `ellipseNorm`.
- `bodyTextureBase` gains a `b.Texture != nil` fallthrough **before** the `switch b.ID`. No Sol JSON carries a block yet, so **Sol renders exactly as before**.

### Save compatibility
`texture` is cosmetic, not semantic, so it's excluded from `CatalogHash` via a `hashView` that zeroes the field before marshalling. Verified the catalog hash is **byte-identical to `main`** (`a6d8fba9…abdec`) — **no save break, no release-note caveat**.

### Open decision pinned (per handoff)
Fail-soft on **user-overlay** textures: the loader runs `Texture.Validate()` per body, emits a `LoadWarning`, and drops the bad texture (→ flat disk) — never hard-errors. Embedded textures are *not* fail-softed (guarded by `TestEmbeddedTexturesValidate`) so authoring typos fail CI instead of rendering silently flat.

### Tests
- `texture_test.go` — schema validation + hex validator.
- `catalog_texture_test.go` — hash exclusion is identical with/without texture, and `hashView` doesn't mutate the live catalog.
- `texture_engine_test.go` — base fallback, continent fill, band lookup, crater rim/default, resolution order, zero-radius drop, fallthrough routing.

Full suite: `go vet ./...` clean, 1191 tests pass across 16 packages.

### Not in this PR (ADR 0024 rollout)
- PR2 — author all 17 Lumen bodies on the ellipse/band tier.
- PR3 — mask/biome + limb-tint + `star` kinds; Kern/Shell/Ember masks + Lumen star.
- PR4 — migrate the 12 Sol bodies into `sol.json`, re-baseline golden tests, delete per-body Go functions, visual-diff Sol.
