### PR TITLE
feat(bodies): author all 16 non-star Lumen bodies on the texture engine (ADR 0024 PR2)

### DIFF
--- a/internal/bodies/systems/lumen.json
+++ b/internal/bodies/systems/lumen.json
@@ -23,6 +23,17 @@
     },
     {
       "id": "bit",
+      "texture": {
+        "base": "#6E5F50",
+        "continents": [
+          { "lat": 0, "lon": 20, "latR": 18, "lonR": 24, "color": "#544738" },
+          { "lat": 35, "lon": -70, "latR": 14, "lonR": 20, "color": "#8C7B6B" }
+        ],
+        "craters": [
+          { "lat": -25, "lon": 70, "latR": 4, "lonR": 4, "color": "#A89684", "rays": true },
+          { "lat": 20, "lon": 130, "latR": 3, "lonR": 3, "color": "#A89684" }
+        ]
+      },
       "name": "Bit",
       "englishName": "Bit",
       "bodyType": "Planet",
@@ -43,6 +54,16 @@
     },
     {
       "id": "ember",
+      "texture": {
+        "base": "#5E3A6E",
+        "continents": [
+          { "lat": 0, "lon": 0, "latR": 30, "lonR": 35, "color": "#7A4A8E" },
+          { "lat": 30, "lon": -80, "latR": 20, "lonR": 30, "color": "#9B59B6" },
+          { "lat": -25, "lon": 70, "latR": 22, "lonR": 30, "color": "#452A52" },
+          { "lat": -50, "lon": -40, "latR": 15, "lonR": 35, "color": "#7A4A8E" },
+          { "lat": 55, "lon": 120, "latR": 14, "lonR": 40, "color": "#452A52" }
+        ]
+      },
       "name": "Ember",
       "englishName": "Ember",
       "bodyType": "Planet",
@@ -71,6 +92,26 @@
     },
     {
       "id": "kern",
+      "texture": {
+        "base": "#1F5C82",
+        "continents": [
+          { "lat": 0, "lon": -60, "latR": 18, "lonR": 22, "color": "#4E7A3A" },
+          { "lat": -8, "lon": -44, "latR": 14, "lonR": 16, "color": "#4E7A3A" },
+          { "lat": 10, "lon": -74, "latR": 12, "lonR": 14, "color": "#3E6A2E" },
+          { "lat": 2, "lon": -50, "latR": 8, "lonR": 10, "color": "#C2A35A" },
+          { "lat": 12, "lon": 52, "latR": 20, "lonR": 24, "color": "#4E7A3A" },
+          { "lat": 0, "lon": 66, "latR": 13, "lonR": 16, "color": "#3E6A2E" },
+          { "lat": 22, "lon": 36, "latR": 12, "lonR": 14, "color": "#4E7A3A" },
+          { "lat": 46, "lon": 132, "latR": 18, "lonR": 30, "color": "#6E7A4A" },
+          { "lat": 34, "lon": 150, "latR": 12, "lonR": 18, "color": "#4E7A3A" },
+          { "lat": -36, "lon": -142, "latR": 16, "lonR": 30, "color": "#4E7A3A" },
+          { "lat": -46, "lon": -118, "latR": 12, "lonR": 20, "color": "#6E7A4A" },
+          { "lat": -10, "lon": 122, "latR": 14, "lonR": 20, "color": "#C2A35A" },
+          { "lat": -18, "lon": 136, "latR": 10, "lonR": 14, "color": "#C2A35A" },
+          { "lat": 86, "lon": 0, "latR": 7, "lonR": 180, "color": "#E8F0F6" },
+          { "lat": -86, "lon": 0, "latR": 7, "lonR": 180, "color": "#E8F0F6" }
+        ]
+      },
       "name": "Kern",
       "englishName": "Kern",
       "bodyType": "Planet",
@@ -99,6 +140,17 @@
     },
     {
       "id": "rust",
+      "texture": {
+        "base": "#C0502E",
+        "continents": [
+          { "lat": 10, "lon": 40, "latR": 16, "lonR": 20, "color": "#8A3A22" },
+          { "lat": -20, "lon": -60, "latR": 14, "lonR": 22, "color": "#8A3A22" },
+          { "lat": 25, "lon": -120, "latR": 12, "lonR": 18, "color": "#D98050" },
+          { "lat": -35, "lon": 100, "latR": 12, "lonR": 16, "color": "#8A3A22" },
+          { "lat": 82, "lon": 0, "latR": 10, "lonR": 180, "color": "#F0E8E0" },
+          { "lat": -82, "lon": 0, "latR": 12, "lonR": 180, "color": "#F0E8E0" }
+        ]
+      },
       "name": "Rust",
       "englishName": "Rust",
       "bodyType": "Planet",
@@ -127,6 +179,17 @@
     },
     {
       "id": "dash",
+      "texture": {
+        "base": "#6E6555",
+        "continents": [
+          { "lat": 10, "lon": -40, "latR": 16, "lonR": 22, "color": "#544B3E" }
+        ],
+        "craters": [
+          { "lat": -30, "lon": 30, "latR": 4, "lonR": 4, "color": "#9A8E7A", "rim": "#7E7460", "rays": true },
+          { "lat": 25, "lon": 90, "latR": 3, "lonR": 3, "color": "#9A8E7A" },
+          { "lat": -10, "lon": -100, "latR": 5, "lonR": 5, "color": "#8E8474" }
+        ]
+      },
       "name": "Dash",
       "englishName": "Dash",
       "bodyType": "Planet",
@@ -147,6 +210,21 @@
     },
     {
       "id": "daemon",
+      "texture": {
+        "base": "#5FA84E",
+        "bands": [
+          { "latMin": -90, "latMax": -60, "color": "#4E7A42" },
+          { "latMin": -60, "latMax": -35, "color": "#4E8A40" },
+          { "latMin": -35, "latMax": -12, "color": "#6FB85E" },
+          { "latMin": -12, "latMax": 12, "color": "#7AC468" },
+          { "latMin": 12, "latMax": 35, "color": "#6FB85E" },
+          { "latMin": 35, "latMax": 60, "color": "#4E8A40" },
+          { "latMin": 60, "latMax": 90, "color": "#4E7A42" }
+        ],
+        "spots": [
+          { "lat": -18, "lon": 0, "latR": 6, "lonR": 12, "color": "#3E6A34" }
+        ]
+      },
       "name": "Daemon",
       "englishName": "Daemon",
       "bodyType": "Planet",
@@ -178,6 +256,17 @@
     },
     {
       "id": "cache",
+      "texture": {
+        "base": "#C0D4DA",
+        "continents": [
+          { "lat": 20, "lon": -50, "latR": 14, "lonR": 20, "color": "#A0B8C0" },
+          { "lat": -30, "lon": 40, "latR": 12, "lonR": 18, "color": "#90A8B0" }
+        ],
+        "craters": [
+          { "lat": 0, "lon": 100, "latR": 4, "lonR": 4, "color": "#E8F2F6", "rays": true },
+          { "lat": 40, "lon": -120, "latR": 3, "lonR": 3, "color": "#E8F2F6" }
+        ]
+      },
       "name": "Cache",
       "englishName": "Cache",
       "bodyType": "Planet",
@@ -198,6 +287,20 @@
     },
     {
       "id": "cursor",
+      "texture": {
+        "base": "#9A9A9E",
+        "continents": [
+          { "lat": 10, "lon": -30, "latR": 18, "lonR": 25, "color": "#6A6A70" },
+          { "lat": -20, "lon": 50, "latR": 15, "lonR": 20, "color": "#6A6A70" },
+          { "lat": 30, "lon": 100, "latR": 12, "lonR": 18, "color": "#6A6A70" }
+        ],
+        "craters": [
+          { "lat": -45, "lon": -10, "latR": 5, "lonR": 5, "color": "#E0E0D8", "rim": "#C0C0B8", "rays": true },
+          { "lat": 15, "lon": 40, "latR": 4, "lonR": 4, "color": "#D8D8D0", "rim": "#B8B8B0", "rays": true },
+          { "lat": -10, "lon": -80, "latR": 3, "lonR": 3, "color": "#D8D8D0" },
+          { "lat": 50, "lon": 150, "latR": 4, "lonR": 4, "color": "#D8D8D0", "rays": true }
+        ]
+      },
       "name": "Cursor",
       "englishName": "Cursor",
       "bodyType": "Moon",
@@ -217,6 +320,13 @@
     },
     {
       "id": "glyph",
+      "texture": {
+        "base": "#80C0B8",
+        "craters": [
+          { "lat": 10, "lon": -30, "latR": 6, "lonR": 8, "color": "#A8E0D8" },
+          { "lat": -25, "lon": 60, "latR": 5, "lonR": 6, "color": "#98D0C8" }
+        ]
+      },
       "name": "Glyph",
       "englishName": "Glyph",
       "bodyType": "Moon",
@@ -238,6 +348,13 @@
     },
     {
       "id": "mote",
+      "texture": {
+        "base": "#6E6450",
+        "craters": [
+          { "lat": 20, "lon": 30, "latR": 6, "lonR": 8, "color": "#9A8A6E" },
+          { "lat": -30, "lon": -60, "latR": 5, "lonR": 6, "color": "#857A62" }
+        ]
+      },
       "name": "Mote",
       "englishName": "Mote",
       "bodyType": "Moon",
@@ -259,6 +376,15 @@
     },
     {
       "id": "flag",
+      "texture": {
+        "base": "#585048",
+        "continents": [
+          { "lat": 0, "lon": 40, "latR": 18, "lonR": 24, "color": "#444038" }
+        ],
+        "craters": [
+          { "lat": -30, "lon": -20, "latR": 4, "lonR": 4, "color": "#7A7068", "rays": true }
+        ]
+      },
       "name": "Flag",
       "englishName": "Flag",
       "bodyType": "Moon",
@@ -278,6 +404,16 @@
     },
     {
       "id": "shell",
+      "texture": {
+        "base": "#3A5A78",
+        "continents": [
+          { "lat": 5, "lon": -40, "latR": 12, "lonR": 16, "color": "#4A5848" },
+          { "lat": -15, "lon": 60, "latR": 10, "lonR": 14, "color": "#4A5848" },
+          { "lat": 30, "lon": 120, "latR": 8, "lonR": 12, "color": "#3E382E" },
+          { "lat": 80, "lon": 0, "latR": 10, "lonR": 180, "color": "#D8E4EC" },
+          { "lat": -80, "lon": 0, "latR": 10, "lonR": 180, "color": "#D8E4EC" }
+        ]
+      },
       "name": "Shell",
       "englishName": "Shell",
       "bodyType": "Moon",
@@ -303,6 +439,15 @@
     },
     {
       "id": "pipe",
+      "texture": {
+        "base": "#80A0B0",
+        "continents": [
+          { "lat": 0, "lon": 0, "latR": 20, "lonR": 28, "color": "#6E8C9C" }
+        ],
+        "craters": [
+          { "lat": -30, "lon": 80, "latR": 4, "lonR": 4, "color": "#A8C8D8", "rays": true }
+        ]
+      },
       "name": "Pipe",
       "englishName": "Pipe",
       "bodyType": "Moon",
@@ -322,6 +467,17 @@
     },
     {
       "id": "fork",
+      "texture": {
+        "base": "#B0A488",
+        "continents": [
+          { "lat": 15, "lon": -40, "latR": 20, "lonR": 28, "color": "#988460" },
+          { "lat": -25, "lon": 60, "latR": 16, "lonR": 22, "color": "#988460" }
+        ],
+        "craters": [
+          { "lat": 0, "lon": 120, "latR": 5, "lonR": 5, "color": "#D8CCB0", "rim": "#B8AC90", "rays": true },
+          { "lat": 40, "lon": -100, "latR": 4, "lonR": 4, "color": "#D8CCB0" }
+        ]
+      },
       "name": "Fork",
       "englishName": "Fork",
       "bodyType": "Moon",
@@ -341,6 +497,13 @@
     },
     {
       "id": "byte",
+      "texture": {
+        "base": "#645840",
+        "craters": [
+          { "lat": 0, "lon": 30, "latR": 8, "lonR": 10, "color": "#8A7A5E" },
+          { "lat": -20, "lon": -50, "latR": 5, "lonR": 6, "color": "#7A6C50" }
+        ]
+      },
       "name": "Byte",
       "englishName": "Byte",
       "bodyType": "Moon",
@@ -362,6 +525,13 @@
     },
     {
       "id": "nib",
+      "texture": {
+        "base": "#988850",
+        "continents": [
+          { "lat": 10, "lon": 0, "latR": 18, "lonR": 24, "color": "#C8B86E" },
+          { "lat": -30, "lon": 70, "latR": 8, "lonR": 12, "color": "#7E7042" }
+        ]
+      },
       "name": "Nib",
       "englishName": "Nib",
       "bodyType": "Moon",

--- a/internal/render/lumen_texture_test.go
+++ b/internal/render/lumen_texture_test.go
@@ -1,0 +1,59 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// TestLumenBodiesRenderTextured is the PR2 end-to-end guard (ADR 0024):
+// every Lumen body that ships a texture block must actually paint a
+// multi-color disk through the generic engine — not silently render
+// flat because its features landed off-disk, had degenerate radii, or
+// failed to compile. Samples the disk on a grid and counts distinct
+// colors; a textured body must show at least two.
+func TestLumenBodiesRenderTextured(t *testing.T) {
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	var lumen *bodies.System
+	for i := range systems {
+		if systems[i].Name == "Lumen" {
+			lumen = &systems[i]
+			break
+		}
+	}
+	if lumen == nil {
+		t.Fatal("Lumen system not found")
+	}
+
+	const pxRadius = 24 // comfortably above BodyTextureMinRadius
+	textured := 0
+	for _, b := range lumen.Bodies {
+		if b.Texture == nil {
+			continue // the star carries no texture until PR3
+		}
+		textured++
+		tex := TextureFor(b, pxRadius, 0, 0, 0, 1, nil)
+		if tex == nil {
+			t.Errorf("%s: TextureFor returned nil despite a texture block", b.ID)
+			continue
+		}
+		seen := map[string]bool{}
+		for dy := -pxRadius; dy <= pxRadius; dy++ {
+			for dx := -pxRadius; dx <= pxRadius; dx++ {
+				if dx*dx+dy*dy > pxRadius*pxRadius {
+					continue // outside the disk
+				}
+				seen[string(tex(dx, dy, pxRadius))] = true
+			}
+		}
+		if len(seen) < 2 {
+			t.Errorf("%s: rendered %d distinct color(s), want >= 2 (features not landing on disk?)", b.ID, len(seen))
+		}
+	}
+	if textured != 16 {
+		t.Errorf("expected 16 textured Lumen bodies (all but the star), got %d", textured)
+	}
+}


### PR DESCRIPTION
## ADR 0024 PR2 — author all 16 non-star Lumen bodies on the texture engine

Second slice of ADR 0024. Every Lumen planet and moon now ships a `texture` block on the PR1 ellipse/band tier, tiered per ADR §E and mapped to its KSP stock analog. Builds on #167.

### Coverage (16 bodies — the star waits for PR3)
| Tier | Bodies |
|------|--------|
| **Hero** (rich) | Kern≈Kerbin (ocean + clustered green continents + biomes + ice caps), Cursor≈Mun (grey maria + rayed craters), Daemon≈Jool (banded green gas giant + storm spot), Rust≈Duna (red albedo + white poles) |
| **Mid** (moderate) | Ember≈Eve (mottled purple), Shell≈Laythe (ocean + volcanic islands), Cache≈Eeloo (icy + craters), Dash≈Dres (grey cratered), Bit≈Moho (baked brown cratered) |
| **Long-tail** (archetype default) | Mote, Flag, Glyph, Pipe, Fork, Byte, Nib |

- The **star (Lumen)** stays untextured until PR3 adds the `star` kind + its day/night-shading exemption.
- Terrestrials (Kern/Shell/Ember) use ellipse continents here; **PR3 swaps them for hand-authored polygon masks** per ADR §F — that's where the definitive Kerbin/Laythe/Eve silhouettes land.

### Kern polish
Kern got an extra pass after a "doesn't look enough like Kerbin" review: deeper ocean blue (#1F5C82), continents decomposed into overlapping ellipse clusters (irregular coastlines, not smooth ovals), and biome variation — grassland / tropical jungle / desert / boreal-tundra / ice — instead of flat green. Ellipses can only approximate; the polygon mask in PR3 is the real fidelity jump.

### Save compatibility
`texture` is hash-excluded, so the catalog hash is unchanged (`a6d8fba9…abdec`) — **no save break**.

### Tests
- `TestLumenBodiesRenderTextured` — every one of the 16 textured bodies paints a multi-color disk end-to-end through the engine (catches features that land off-disk, degenerate radii, or fail to compile).
- `TestEmbeddedTexturesValidate` (from PR1) now covers all 16 authored blocks.
- `go vet ./...` clean; full suite 1192 pass across 16 packages.

### Next (ADR 0024 rollout)
- PR3 — mask/biome + limb-tint + `star` kinds; Kern/Shell/Ember polygon masks + Lumen star.
- PR4 — migrate the 12 Sol bodies into `sol.json`, re-baseline golden tests, delete per-body Go functions, visual-diff Sol.
