### PR TITLE
feat(render): mask, limb-tint, and star texture kinds (ADR 0024 PR3)

### DIFF
--- a/internal/bodies/systems/lumen.json
+++ b/internal/bodies/systems/lumen.json
@@ -7,6 +7,21 @@
   "bodies": [
     {
       "id": "lumen",
+      "texture": {
+        "star": {
+          "core": "#FFF0C0",
+          "surface": "#FFD27F",
+          "limb": "#E89030",
+          "spot": "#B86A28",
+          "granulation": 0.14,
+          "seed": 7
+        },
+        "spots": [
+          { "lat": 20, "lon": -48, "latR": 3, "lonR": 4 },
+          { "lat": -16, "lon": 52, "latR": 2, "lonR": 3 },
+          { "lat": 34, "lon": 18, "latR": 2, "lonR": 3 }
+        ]
+      },
       "name": "Lumen",
       "englishName": "Lumen",
       "bodyType": "Star",
@@ -56,13 +71,29 @@
       "id": "ember",
       "texture": {
         "base": "#5E3A6E",
-        "continents": [
-          { "lat": 0, "lon": 0, "latR": 30, "lonR": 35, "color": "#7A4A8E" },
-          { "lat": 30, "lon": -80, "latR": 20, "lonR": 30, "color": "#9B59B6" },
-          { "lat": -25, "lon": 70, "latR": 22, "lonR": 30, "color": "#452A52" },
-          { "lat": -50, "lon": -40, "latR": 15, "lonR": 35, "color": "#7A4A8E" },
-          { "lat": 55, "lon": 120, "latR": 14, "lonR": 40, "color": "#452A52" }
-        ]
+        "limbTint": "#B07FD8",
+        "mask": {
+          "biomes": {
+            "mid": "#7A4A8E",
+            "high": "#9B59B6",
+            "dark": "#452A52"
+          },
+          "polys": [
+            { "kind": "mid", "vertices": [
+              {"lat":10,"lon":-30},{"lat":20,"lon":0},{"lat":14,"lon":30},{"lat":-2,"lon":28},
+              {"lat":-12,"lon":5},{"lat":-8,"lon":-25} ] },
+            { "kind": "high", "vertices": [
+              {"lat":30,"lon":-80},{"lat":40,"lon":-55},{"lat":32,"lon":-40},{"lat":20,"lon":-55},{"lat":24,"lon":-78} ] },
+            { "kind": "dark", "vertices": [
+              {"lat":-20,"lon":60},{"lat":-10,"lon":85},{"lat":-22,"lon":100},{"lat":-36,"lon":90},{"lat":-34,"lon":66} ] },
+            { "kind": "mid", "vertices": [
+              {"lat":-50,"lon":-50},{"lat":-42,"lon":-25},{"lat":-52,"lon":-10},{"lat":-62,"lon":-30},{"lat":-58,"lon":-52} ] },
+            { "kind": "high", "vertices": [
+              {"lat":50,"lon":120},{"lat":60,"lon":150},{"lat":52,"lon":170},{"lat":42,"lon":155},{"lat":44,"lon":128} ] },
+            { "kind": "dark", "vertices": [
+              {"lat":8,"lon":110},{"lat":16,"lon":135},{"lat":4,"lon":150},{"lat":-6,"lon":132},{"lat":-2,"lon":112} ] }
+          ]
+        }
       },
       "name": "Ember",
       "englishName": "Ember",
@@ -94,23 +125,49 @@
       "id": "kern",
       "texture": {
         "base": "#1F5C82",
-        "continents": [
-          { "lat": 0, "lon": -60, "latR": 18, "lonR": 22, "color": "#4E7A3A" },
-          { "lat": -8, "lon": -44, "latR": 14, "lonR": 16, "color": "#4E7A3A" },
-          { "lat": 10, "lon": -74, "latR": 12, "lonR": 14, "color": "#3E6A2E" },
-          { "lat": 2, "lon": -50, "latR": 8, "lonR": 10, "color": "#C2A35A" },
-          { "lat": 12, "lon": 52, "latR": 20, "lonR": 24, "color": "#4E7A3A" },
-          { "lat": 0, "lon": 66, "latR": 13, "lonR": 16, "color": "#3E6A2E" },
-          { "lat": 22, "lon": 36, "latR": 12, "lonR": 14, "color": "#4E7A3A" },
-          { "lat": 46, "lon": 132, "latR": 18, "lonR": 30, "color": "#6E7A4A" },
-          { "lat": 34, "lon": 150, "latR": 12, "lonR": 18, "color": "#4E7A3A" },
-          { "lat": -36, "lon": -142, "latR": 16, "lonR": 30, "color": "#4E7A3A" },
-          { "lat": -46, "lon": -118, "latR": 12, "lonR": 20, "color": "#6E7A4A" },
-          { "lat": -10, "lon": 122, "latR": 14, "lonR": 20, "color": "#C2A35A" },
-          { "lat": -18, "lon": 136, "latR": 10, "lonR": 14, "color": "#C2A35A" },
-          { "lat": 86, "lon": 0, "latR": 7, "lonR": 180, "color": "#E8F0F6" },
-          { "lat": -86, "lon": 0, "latR": 7, "lonR": 180, "color": "#E8F0F6" }
-        ]
+        "limbTint": "#9DC8FF",
+        "mask": {
+          "biomes": {
+            "grass": "#4E7A3A",
+            "tropical": "#3E6A2E",
+            "desert": "#C2A35A",
+            "boreal": "#6E7A4A",
+            "ice": "#E8F0F6"
+          },
+          "polys": [
+            { "kind": "grass", "vertices": [
+              {"lat":-5,"lon":-90},{"lat":8,"lon":-85},{"lat":18,"lon":-70},{"lat":20,"lon":-55},
+              {"lat":12,"lon":-45},{"lat":2,"lon":-42},{"lat":-8,"lon":-48},{"lat":-15,"lon":-60},{"lat":-12,"lon":-78} ] },
+            { "kind": "grass", "vertices": [
+              {"lat":30,"lon":30},{"lat":34,"lon":55},{"lat":28,"lon":72},{"lat":15,"lon":75},
+              {"lat":6,"lon":65},{"lat":8,"lon":45},{"lat":18,"lon":32} ] },
+            { "kind": "grass", "vertices": [
+              {"lat":-28,"lon":-150},{"lat":-22,"lon":-130},{"lat":-26,"lon":-112},{"lat":-38,"lon":-110},
+              {"lat":-46,"lon":-125},{"lat":-44,"lon":-145},{"lat":-34,"lon":-152} ] },
+            { "kind": "boreal", "vertices": [
+              {"lat":38,"lon":118},{"lat":52,"lon":130},{"lat":54,"lon":155},{"lat":44,"lon":165},
+              {"lat":34,"lon":150},{"lat":32,"lon":128} ] },
+            { "kind": "grass", "vertices": [
+              {"lat":34,"lon":135},{"lat":40,"lon":150},{"lat":34,"lon":158},{"lat":30,"lon":142} ] },
+            { "kind": "desert", "vertices": [
+              {"lat":-6,"lon":108},{"lat":-2,"lon":128},{"lat":-10,"lon":142},{"lat":-22,"lon":140},
+              {"lat":-24,"lon":122},{"lat":-16,"lon":108} ] },
+            { "kind": "desert", "vertices": [
+              {"lat":2,"lon":-72},{"lat":8,"lon":-64},{"lat":4,"lon":-54},{"lat":-4,"lon":-52},{"lat":-6,"lon":-64} ] },
+            { "kind": "tropical", "vertices": [
+              {"lat":-12,"lon":-70},{"lat":-6,"lon":-55},{"lat":-14,"lon":-50},{"lat":-16,"lon":-62} ] },
+            { "kind": "tropical", "vertices": [
+              {"lat":6,"lon":55},{"lat":2,"lon":68},{"lat":-4,"lon":62},{"lat":0,"lon":50} ] },
+            { "kind": "boreal", "vertices": [
+              {"lat":-44,"lon":-140},{"lat":-40,"lon":-120},{"lat":-48,"lon":-118},{"lat":-50,"lon":-138} ] },
+            { "kind": "ice", "vertices": [
+              {"lat":80,"lon":-180},{"lat":82,"lon":-90},{"lat":80,"lon":0},{"lat":82,"lon":90},
+              {"lat":80,"lon":180},{"lat":89,"lon":180},{"lat":89,"lon":-180} ] },
+            { "kind": "ice", "vertices": [
+              {"lat":-80,"lon":-180},{"lat":-82,"lon":-90},{"lat":-80,"lon":0},{"lat":-82,"lon":90},
+              {"lat":-80,"lon":180},{"lat":-89,"lon":180},{"lat":-89,"lon":-180} ] }
+          ]
+        }
       },
       "name": "Kern",
       "englishName": "Kern",
@@ -142,6 +199,7 @@
       "id": "rust",
       "texture": {
         "base": "#C0502E",
+        "limbTint": "#E0A060",
         "continents": [
           { "lat": 10, "lon": 40, "latR": 16, "lonR": 20, "color": "#8A3A22" },
           { "lat": -20, "lon": -60, "latR": 14, "lonR": 22, "color": "#8A3A22" },
@@ -406,13 +464,29 @@
       "id": "shell",
       "texture": {
         "base": "#3A5A78",
-        "continents": [
-          { "lat": 5, "lon": -40, "latR": 12, "lonR": 16, "color": "#4A5848" },
-          { "lat": -15, "lon": 60, "latR": 10, "lonR": 14, "color": "#4A5848" },
-          { "lat": 30, "lon": 120, "latR": 8, "lonR": 12, "color": "#3E382E" },
-          { "lat": 80, "lon": 0, "latR": 10, "lonR": 180, "color": "#D8E4EC" },
-          { "lat": -80, "lon": 0, "latR": 10, "lonR": 180, "color": "#D8E4EC" }
-        ]
+        "limbTint": "#7FA8D8",
+        "mask": {
+          "biomes": {
+            "island": "#4A5848",
+            "volcanic": "#3E382E",
+            "ice": "#D8E4EC"
+          },
+          "polys": [
+            { "kind": "island", "vertices": [
+              {"lat":8,"lon":-40},{"lat":14,"lon":-28},{"lat":6,"lon":-20},{"lat":-4,"lon":-26},
+              {"lat":-6,"lon":-38},{"lat":2,"lon":-46} ] },
+            { "kind": "island", "vertices": [
+              {"lat":-12,"lon":55},{"lat":-6,"lon":66},{"lat":-14,"lon":72},{"lat":-22,"lon":64},{"lat":-18,"lon":54} ] },
+            { "kind": "island", "vertices": [
+              {"lat":28,"lon":118},{"lat":34,"lon":128},{"lat":28,"lon":136},{"lat":20,"lon":130},{"lat":22,"lon":118} ] },
+            { "kind": "volcanic", "vertices": [
+              {"lat":0,"lon":-32},{"lat":4,"lon":-26},{"lat":-2,"lon":-24},{"lat":-4,"lon":-30} ] },
+            { "kind": "ice", "vertices": [
+              {"lat":78,"lon":-180},{"lat":80,"lon":0},{"lat":78,"lon":180},{"lat":89,"lon":180},{"lat":89,"lon":-180} ] },
+            { "kind": "ice", "vertices": [
+              {"lat":-78,"lon":-180},{"lat":-80,"lon":0},{"lat":-78,"lon":180},{"lat":-89,"lon":180},{"lat":-89,"lon":-180} ] }
+          ]
+        }
       },
       "name": "Shell",
       "englishName": "Shell",

--- a/internal/bodies/texture.go
+++ b/internal/bodies/texture.go
@@ -99,10 +99,20 @@ type LatLonPair struct {
 	Lon float64 `json:"lon"`
 }
 
-// TextureStar is the self-luminous star-surface kind. Granulation is
-// the granulation amplitude (0..1); Seed seeds the noise. Carried in
-// the schema from PR1; the engine consumes it starting PR3.
+// TextureStar is the self-luminous star-surface kind: concentric
+// limb darkening (bright Core → Surface → darker Limb) with optional
+// granulation jitter and sunspots. A body carrying a Star block is
+// exempt from day/night shading — it is the light source. Core /
+// Surface / Limb are hex colors; empty ones derive from the body's
+// Color. Granulation is the surface mottling amplitude (0..1); Seed
+// makes the (deterministic) granulation pattern reproducible. Spot is
+// the sunspot color; spot *positions* are taken from the texture's
+// Spots ellipses.
 type TextureStar struct {
+	Core        string  `json:"core,omitempty"`
+	Surface     string  `json:"surface,omitempty"`
+	Limb        string  `json:"limb,omitempty"`
+	Spot        string  `json:"spot,omitempty"`
 	Granulation float64 `json:"granulation,omitempty"`
 	Seed        int64   `json:"seed,omitempty"`
 }
@@ -152,9 +162,27 @@ func (t *Texture) Validate() error {
 				return fmt.Errorf("texture: mask biome %q has invalid color %q", kind, c)
 			}
 		}
+		for i, region := range t.Mask.Polys {
+			if region.Kind == "" {
+				return fmt.Errorf("texture: mask poly %d has empty kind", i)
+			}
+			if _, ok := t.Mask.Biomes[region.Kind]; !ok {
+				return fmt.Errorf("texture: mask poly %d kind %q has no biome color", i, region.Kind)
+			}
+			if len(region.Vertices) < 3 {
+				return fmt.Errorf("texture: mask poly %d (%s) has %d vertices, need >= 3", i, region.Kind, len(region.Vertices))
+			}
+		}
 	}
-	if t.Star != nil && (t.Star.Granulation < 0 || t.Star.Granulation > 1) {
-		return fmt.Errorf("texture: star granulation %g out of [0,1]", t.Star.Granulation)
+	if t.Star != nil {
+		if t.Star.Granulation < 0 || t.Star.Granulation > 1 {
+			return fmt.Errorf("texture: star granulation %g out of [0,1]", t.Star.Granulation)
+		}
+		for name, c := range map[string]string{"core": t.Star.Core, "surface": t.Star.Surface, "limb": t.Star.Limb, "spot": t.Star.Spot} {
+			if !validHexColor(c) {
+				return fmt.Errorf("texture: star %s has invalid color %q", name, c)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/bodies/texture_test.go
+++ b/internal/bodies/texture_test.go
@@ -27,8 +27,25 @@ func TestTextureValidate(t *testing.T) {
 		{"continent zero radius", &Texture{Continents: []TextureEllipse{{Lat: 0, Lon: 0, LatR: 0, LonR: 5, Color: "#fff"}}}, true},
 		{"crater bad rim", &Texture{Craters: []TextureEllipse{{LatR: 1, LonR: 1, Rim: "nope"}}}, true},
 		{"mask biome bad color", &Texture{Mask: &TextureMask{Biomes: map[string]string{"land": "green"}}}, true},
+		{"mask good poly", &Texture{Mask: &TextureMask{
+			Biomes: map[string]string{"land": "#4E7A3A"},
+			Polys:  []TextureRegion{{Kind: "land", Vertices: []LatLonPair{{0, 0}, {1, 0}, {1, 1}}}},
+		}}, false},
+		{"mask poly empty kind", &Texture{Mask: &TextureMask{
+			Biomes: map[string]string{"land": "#4E7A3A"},
+			Polys:  []TextureRegion{{Vertices: []LatLonPair{{0, 0}, {1, 0}, {1, 1}}}},
+		}}, true},
+		{"mask poly unknown biome", &Texture{Mask: &TextureMask{
+			Biomes: map[string]string{"land": "#4E7A3A"},
+			Polys:  []TextureRegion{{Kind: "sea", Vertices: []LatLonPair{{0, 0}, {1, 0}, {1, 1}}}},
+		}}, true},
+		{"mask poly too few vertices", &Texture{Mask: &TextureMask{
+			Biomes: map[string]string{"land": "#4E7A3A"},
+			Polys:  []TextureRegion{{Kind: "land", Vertices: []LatLonPair{{0, 0}, {1, 0}}}},
+		}}, true},
 		{"star granulation out of range", &Texture{Star: &TextureStar{Granulation: 2}}, true},
-		{"star granulation ok", &Texture{Star: &TextureStar{Granulation: 0.12, Seed: 42}}, false},
+		{"star bad core color", &Texture{Star: &TextureStar{Core: "nope"}}, true},
+		{"star granulation ok", &Texture{Star: &TextureStar{Core: "#FFF0C0", Granulation: 0.12, Seed: 42}}, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/render/earth.go
+++ b/internal/render/earth.go
@@ -216,7 +216,11 @@ func TextureFor(b bodies.CelestialBody, pxRadius int, subLatDeg, subLonDeg, scre
 		return nil
 	}
 	base := bodyTextureBase(b, subLatDeg, subLonDeg, screenUpX, screenUpY)
-	if base == nil || b.ID == "sun" || light == nil {
+	// Stars are the light source — exempt from day/night shading. The
+	// hardcoded "sun" stays; a data-driven body declaring a star kind
+	// (ADR 0024 PR3, e.g. Lumen) is exempt the same way.
+	isStar := b.ID == "sun" || (b.Texture != nil && b.Texture.Star != nil)
+	if base == nil || isStar || light == nil {
 		return base
 	}
 	return func(dx, dy, r int) lipgloss.Color {

--- a/internal/render/lumen_texture_test.go
+++ b/internal/render/lumen_texture_test.go
@@ -32,7 +32,7 @@ func TestLumenBodiesRenderTextured(t *testing.T) {
 	textured := 0
 	for _, b := range lumen.Bodies {
 		if b.Texture == nil {
-			continue // the star carries no texture until PR3
+			continue
 		}
 		textured++
 		tex := TextureFor(b, pxRadius, 0, 0, 0, 1, nil)
@@ -53,7 +53,7 @@ func TestLumenBodiesRenderTextured(t *testing.T) {
 			t.Errorf("%s: rendered %d distinct color(s), want >= 2 (features not landing on disk?)", b.ID, len(seen))
 		}
 	}
-	if textured != 16 {
-		t.Errorf("expected 16 textured Lumen bodies (all but the star), got %d", textured)
+	if textured != 17 {
+		t.Errorf("expected all 17 Lumen bodies textured (16 surfaces + the star), got %d", textured)
 	}
 }

--- a/internal/render/texture_engine.go
+++ b/internal/render/texture_engine.go
@@ -1,6 +1,8 @@
 package render
 
 import (
+	"math"
+
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
@@ -38,12 +40,33 @@ type compiledCrater struct {
 	hasRim bool
 }
 
+// limbTintThreshold is the squared normalized disk radius beyond which
+// a limb-tint color paints the atmospheric-halo ring (matches Earth's
+// r2 > 0.92 atmosphere band).
+const limbTintThreshold = 0.92
+
+type compiledRegion struct {
+	verts [][2]float64 // (lat, lon) polygon, ray-cast point-in-polygon
+	color lipgloss.Color
+}
+
+type compiledStar struct {
+	core, surface, limb lipgloss.Color
+	spots               []continentEllipse // sunspot positions, color baked in
+	granulation         float64
+	seed                int64
+}
+
 type compiledTexture struct {
-	base       lipgloss.Color
-	bands      []compiledBand
-	continents []continentEllipse
-	spots      []continentEllipse
-	craters    []compiledCrater
+	base        lipgloss.Color
+	bands       []compiledBand
+	mask        []compiledRegion
+	continents  []continentEllipse
+	spots       []continentEllipse
+	craters     []compiledCrater
+	limbTint    lipgloss.Color
+	hasLimbTint bool
+	star        *compiledStar
 }
 
 // compileTexture turns a JSON texture spec into a per-pixel-ready form.
@@ -89,6 +112,43 @@ func compileTexture(t *bodies.Texture, fallbackBase string) *compiledTexture {
 		}
 		ct.craters = append(ct.craters, cr)
 	}
+	if t.Mask != nil {
+		for _, region := range t.Mask.Polys {
+			if len(region.Vertices) < 3 {
+				continue
+			}
+			verts := make([][2]float64, len(region.Vertices))
+			for i, v := range region.Vertices {
+				verts[i] = [2]float64{v.Lat, v.Lon}
+			}
+			ct.mask = append(ct.mask, compiledRegion{
+				verts: verts,
+				color: parseColor(t.Mask.Biomes[region.Kind], ct.base),
+			})
+		}
+	}
+	if t.LimbTint != "" {
+		ct.limbTint = lipgloss.Color(t.LimbTint)
+		ct.hasLimbTint = true
+	}
+	if t.Star != nil {
+		surface := parseColor(t.Star.Surface, ct.base)
+		cs := &compiledStar{
+			core:        parseColor(t.Star.Core, surface),
+			surface:     surface,
+			limb:        parseColor(t.Star.Limb, Shade(surface, 0.7)),
+			granulation: t.Star.Granulation,
+			seed:        t.Star.Seed,
+		}
+		spotColor := parseColor(t.Star.Spot, Shade(surface, 0.55))
+		for _, e := range t.Spots {
+			if e.LatR <= 0 || e.LonR <= 0 {
+				continue
+			}
+			cs.spots = append(cs.spots, toEllipseColor(e, parseColor(e.Color, spotColor)))
+		}
+		ct.star = cs
+	}
 	return ct
 }
 
@@ -116,6 +176,11 @@ func parseColor(hex string, fallback lipgloss.Color) lipgloss.Color {
 // latitude alone (valid even at a pole-on view, matching JupiterPixel-
 // Color); the ellipse kinds are gated on a valid longitude.
 func (ct *compiledTexture) colorAt(dx, dy, pxRadius int, subLatDeg, subLonDeg, screenUpX, screenUpY float64) lipgloss.Color {
+	// A star is self-luminous: it ignores the surface kinds (and the
+	// caller's day/night shading is suppressed in TextureFor).
+	if ct.star != nil {
+		return ct.star.colorAt(dx, dy, pxRadius, subLatDeg, subLonDeg, screenUpX, screenUpY)
+	}
 	lat, lon, ok := projectPixelToLatLon(dx, dy, pxRadius, subLatDeg, subLonDeg, screenUpX, screenUpY)
 	color := ct.base
 	for _, b := range ct.bands {
@@ -126,6 +191,11 @@ func (ct *compiledTexture) colorAt(dx, dy, pxRadius int, subLatDeg, subLonDeg, s
 	}
 	if !ok {
 		return color
+	}
+	for _, region := range ct.mask {
+		if pointInLatLonPolygon(lat, lon, region.verts) {
+			color = region.color
+		}
 	}
 	for _, c := range ct.continents {
 		if inEllipse(lat, lon, c) {
@@ -146,7 +216,57 @@ func (ct *compiledTexture) colorAt(dx, dy, pxRadius int, subLatDeg, subLonDeg, s
 			}
 		}
 	}
+	if ct.hasLimbTint {
+		nx := float64(dx) / float64(pxRadius)
+		ny := float64(dy) / float64(pxRadius)
+		if nx*nx+ny*ny > limbTintThreshold {
+			color = ct.limbTint
+		}
+	}
 	return color
+}
+
+// colorAt shades a star surface: concentric limb darkening (core →
+// surface → limb by disk radius) with optional sunspots and granulation
+// mottling on the mid band. Mirrors SunPixelColor's band structure but
+// is fully data-driven.
+func (cs *compiledStar) colorAt(dx, dy, pxRadius int, subLatDeg, subLonDeg, screenUpX, screenUpY float64) lipgloss.Color {
+	nx := float64(dx) / float64(pxRadius)
+	ny := float64(dy) / float64(pxRadius)
+	r2 := nx*nx + ny*ny
+	switch {
+	case r2 > 0.85:
+		return cs.limb
+	case r2 > 0.45:
+		lat, lon, ok := projectPixelToLatLon(dx, dy, pxRadius, subLatDeg, subLonDeg, screenUpX, screenUpY)
+		if !ok {
+			return cs.surface
+		}
+		for _, s := range cs.spots {
+			if inEllipse(lat, lon, s) {
+				return s.color
+			}
+		}
+		if cs.granulation > 0 {
+			return Shade(cs.surface, 1-cs.granulation*granuleNoise(lat, lon, cs.seed))
+		}
+		return cs.surface
+	default:
+		return cs.core
+	}
+}
+
+// granuleNoise returns a deterministic value in [0,1) for a lat/lon
+// cell, used to mottle a star's surface. Quantizing to ~6° cells gives
+// granule-sized blobs; the integer hash keeps it reproducible (no RNG)
+// and seedable per body.
+func granuleNoise(lat, lon float64, seed int64) float64 {
+	x := uint64(int64(math.Floor(lat / 6.0)))
+	y := uint64(int64(math.Floor(lon / 6.0)))
+	h := x*73856093 ^ y*19349663 ^ uint64(seed)*83492791
+	h = (h ^ (h >> 13)) * 0x5bd1e995
+	h ^= h >> 15
+	return float64(h&0xffff) / 65536.0
 }
 
 // ellipseNorm returns the squared normalized elliptical radius of

--- a/internal/render/texture_engine_test.go
+++ b/internal/render/texture_engine_test.go
@@ -111,6 +111,93 @@ func TestCompileTextureDropsZeroRadius(t *testing.T) {
 	}
 }
 
+func TestColorAtMask(t *testing.T) {
+	// A mask region (a big polygon around lat/lon 0) colors the center;
+	// outside it stays base.
+	ct := compileTexture(&bodies.Texture{
+		Base: "#1F5C82",
+		Mask: &bodies.TextureMask{
+			Biomes: map[string]string{"land": "#4E7A3A"},
+			Polys: []bodies.TextureRegion{{
+				Kind: "land",
+				Vertices: []bodies.LatLonPair{
+					{Lat: -20, Lon: -20}, {Lat: 20, Lon: -20},
+					{Lat: 20, Lon: 20}, {Lat: -20, Lon: 20},
+				},
+			}},
+		},
+	}, "")
+	if got := centerColor(ct); got != lipgloss.Color("#4E7A3A") {
+		t.Errorf("center inside mask poly: got %v, want land #4E7A3A", got)
+	}
+	// Pixel projecting to a far longitude (outside the ±20 poly) → base.
+	if got := ct.colorAt(20, 0, 30, 0, 0, 0, 1); got != lipgloss.Color("#1F5C82") {
+		t.Errorf("pixel outside mask poly: got %v, want base #1F5C82", got)
+	}
+}
+
+func TestColorAtLimbTint(t *testing.T) {
+	ct := compileTexture(&bodies.Texture{Base: "#101010", LimbTint: "#9DC8FF"}, "")
+	// Center is well inside → base.
+	if got := centerColor(ct); got != lipgloss.Color("#101010") {
+		t.Errorf("center: got %v, want base", got)
+	}
+	// A near-limb pixel (r2 = 0.946 > limbTintThreshold) → tint.
+	if got := ct.colorAt(23, 4, 24, 0, 0, 0, 1); got != lipgloss.Color("#9DC8FF") {
+		t.Errorf("limb pixel: got %v, want limb tint #9DC8FF", got)
+	}
+}
+
+func TestStarConcentricBands(t *testing.T) {
+	ct := compileTexture(&bodies.Texture{
+		Star: &bodies.TextureStar{Core: "#FFF0C0", Surface: "#FFD27F", Limb: "#E89030"},
+	}, "")
+	if ct.star == nil {
+		t.Fatal("star not compiled")
+	}
+	// Center → core; mid-disk → surface (no granulation); limb → limb.
+	if got := ct.colorAt(0, 0, 24, 0, 0, 0, 1); got != lipgloss.Color("#FFF0C0") {
+		t.Errorf("core: got %v, want #FFF0C0", got)
+	}
+	if got := ct.colorAt(0, 18, 24, 0, 0, 0, 1); got != lipgloss.Color("#FFD27F") {
+		t.Errorf("surface (r2~0.56): got %v, want #FFD27F", got)
+	}
+	if got := ct.colorAt(0, 23, 24, 0, 0, 0, 1); got != lipgloss.Color("#E89030") {
+		t.Errorf("limb (r2~0.92): got %v, want #E89030", got)
+	}
+}
+
+func TestStarGranulationDeterministic(t *testing.T) {
+	star := &bodies.TextureStar{Surface: "#FFD27F", Granulation: 0.2, Seed: 7}
+	a := compileTexture(&bodies.Texture{Star: star}, "")
+	b := compileTexture(&bodies.Texture{Star: star}, "")
+	// Same seed → identical surface pixel (granulation is reproducible).
+	pa := a.colorAt(2, 17, 24, 0, 0, 0, 1)
+	pb := b.colorAt(2, 17, 24, 0, 0, 0, 1)
+	if pa != pb {
+		t.Errorf("granulation not deterministic: %v vs %v", pa, pb)
+	}
+}
+
+func TestStarExemptFromShading(t *testing.T) {
+	// A body declaring a star kind must not be day/night shaded even
+	// when a light is supplied — it is the light source.
+	b := bodies.CelestialBody{
+		ID:      "lumen",
+		Color:   "#FFD27F",
+		Texture: &bodies.Texture{Star: &bodies.TextureStar{Core: "#FFF0C0", Surface: "#FFD27F", Limb: "#E89030"}},
+	}
+	light := &SolarLight{} // any non-nil light
+	tex := TextureFor(b, 24, 0, 0, 0, 1, light)
+	if tex == nil {
+		t.Fatal("nil texture for star body")
+	}
+	// Core pixel should be the raw core color, not a Shade()-darkened one.
+	if got := tex(0, 0, 24); got != lipgloss.Color("#FFF0C0") {
+		t.Errorf("star core shaded: got %v, want raw #FFF0C0", got)
+	}
+}
+
 // TestBodyTextureBaseUsesEngine confirms the bodyTextureBase fallthrough
 // routes a body carrying a Texture spec through the generic engine
 // (a non-Sol ID that would otherwise return nil).


### PR DESCRIPTION
## ADR 0024 PR3 — mask, limb-tint, and star texture kinds

Third slice of ADR 0024. Adds the three remaining texture kinds to the generic engine and authors them across Lumen, completing the home system's data-driven look. Builds on #167 / #168.

### Engine (`internal/render/texture_engine.go`)
- **`mask`** — per-pixel ray-cast point-in-polygon over a body's `TextureMask` regions; each region's biome kind maps to a color, last match wins. Reuses `pointInLatLonPolygon`. Sharper coastlines than the PR2 ellipse tier.
- **`limbTint`** — paints an atmospheric-halo color over the outer disk ring (r² > 0.92), matching Earth's atmosphere band.
- **`star`** — concentric limb darkening (core → surface → limb by disk radius) with deterministic, seedable granulation mottling and sunspots (positions from the texture's `Spots`). `TextureStar` gains core/surface/limb/spot colors.
- **`TextureFor`** now exempts any star-kind body from day/night shading, not just the hardcoded `"sun"` — Lumen is the light source in its own system.

### Authoring (`lumen.json`)
- **Kern / Shell / Ember** swap their PR2 ellipse continents for hand-authored polygon **masks** — Kerbin continents + biomes (grass/tropical/desert/boreal/ice), Laythe ocean + volcanic islands, Eve mottled purple — per ADR §F. This is the definitive Kerbin silhouette the earlier review asked for.
- Atmospheric **limb tints** on Kern/Shell/Ember/Rust (matching their atmosphere colors).
- **Lumen** (the star) gets a `star` texture block and is now the 17th textured body, shading-exempt.

### Save compatibility
`texture` stays hash-excluded → catalog hash unchanged (`a6d8fba9…abdec`), **no save break**.

### Tests
- New: mask / limb-tint / star rendering, granulation determinism, star shading exemption, and the extended `Validate()` rules (mask poly kind/biome/vertex-count, star colors).
- `TestLumenBodiesRenderTextured` now asserts all **17** Lumen bodies render multi-color.
- `go vet ./...` clean; full suite 1202 pass across 16 packages.

### Next (ADR 0024 rollout)
- **PR4** — migrate the 12 Sol bodies into `sol.json`, re-baseline golden tests, delete the per-body Go texture functions, visual-diff Sol.
