### PR TITLE
feat(missions): Mission/Objective model + save v8→v9 (ADR 0025 Slice 1)

### DIFF
--- a/internal/missions/loader.go
+++ b/internal/missions/loader.go
@@ -1,0 +1,126 @@
+package missions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadWarning reports a user-overlay file that couldn't be loaded. The
+// embedded starter catalog must always load — a parse failure there is a
+// hard error, not a warning. Mirrors bodies.LoadWarning.
+type LoadWarning struct {
+	Path string
+	Err  error
+}
+
+func (w LoadWarning) Error() string {
+	return fmt.Sprintf("%s: %v", w.Path, w.Err)
+}
+
+// LoadAll returns the embedded starter catalog merged with any user
+// overlay files from $XDG_CONFIG_HOME/terminal-space-program/missions/*.json
+// (or ~/.config/... if XDG is unset). Warnings from malformed user files
+// are dropped — call LoadAllWithWarnings to inspect them. A malformed
+// overlay file still leaves a Failed-status placeholder mission in the
+// catalog so the player sees it in-game. Mirrors bodies.LoadAll.
+func LoadAll() (Catalog, error) {
+	cat, _, err := LoadAllWithWarnings()
+	return cat, err
+}
+
+// LoadAllWithWarnings is the warning-aware variant of LoadAll. The
+// returned warnings slice contains a LoadWarning for any user overlay
+// file that failed to read or parse; a malformed embedded catalog surfaces
+// as a hard error (the err value) since the embedded set must always load.
+//
+// A bad user file never fails the whole catalog (ADR 0025): it is appended
+// as a single Failed-status mission whose description carries the parse
+// error, fixing the archived "stderr line you didn't see" gap. User
+// missions whose ID matches an embedded mission win on the match;
+// otherwise they're appended.
+func LoadAllWithWarnings() (Catalog, []LoadWarning, error) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		return Catalog{}, nil, err
+	}
+	merged, warnings := mergeUserOverlay(cat.Missions, userMissionsDir())
+	cat.Missions = merged
+	return cat, warnings, nil
+}
+
+func mergeUserOverlay(base []Mission, dir string) ([]Mission, []LoadWarning) {
+	if dir == "" {
+		return base, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing dir is fine — the overlay is optional. Other I/O errors
+		// (permissions, etc.) surface as a warning on the dir path; we
+		// can't enumerate files, so there's no per-file placeholder.
+		if os.IsNotExist(err) {
+			return base, nil
+		}
+		return base, []LoadWarning{{Path: dir, Err: err}}
+	}
+	var warnings []LoadWarning
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		uc, err := LoadCatalog(data)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		for _, m := range uc.Missions {
+			base = upsertMission(base, m)
+		}
+	}
+	return base, warnings
+}
+
+// failedMissionFromFile turns an unloadable overlay file into a single
+// Failed-status placeholder mission so the problem is visible in-game
+// rather than dropped to stderr.
+func failedMissionFromFile(path string, err error) Mission {
+	base := filepath.Base(path)
+	return Mission{
+		ID:          "invalid:" + base,
+		Name:        "Invalid mission file: " + base,
+		Description: err.Error(),
+		Status:      Failed,
+	}
+}
+
+// upsertMission appends m, or replaces an existing mission with the same
+// ID (user files win on ID match).
+func upsertMission(base []Mission, m Mission) []Mission {
+	for i := range base {
+		if base[i].ID == m.ID {
+			base[i] = m
+			return base
+		}
+	}
+	return append(base, m)
+}
+
+func userMissionsDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "missions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "terminal-space-program", "missions")
+}

--- a/internal/missions/loader_test.go
+++ b/internal/missions/loader_test.go
@@ -1,0 +1,160 @@
+package missions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeOverlay points XDG_CONFIG_HOME at a temp dir and writes name→json
+// files into its terminal-space-program/missions overlay dir, returning
+// the overlay dir path. Mirrors the bodies overlay convention.
+func writeOverlay(t *testing.T, files map[string]string) string {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "terminal-space-program", "missions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func missionByID(cat Catalog, id string) (Mission, bool) {
+	for _, m := range cat.Missions {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return Mission{}, false
+}
+
+// TestLoadAllNoOverlay — with no user overlay dir, LoadAll returns just
+// the embedded starter catalog and no warnings.
+func TestLoadAllNoOverlay(t *testing.T) {
+	// Point XDG at an empty temp dir so the overlay dir is absent.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("expected 4 embedded missions, got %d", len(cat.Missions))
+	}
+}
+
+// TestLoadAllMergesUserOverlay — a valid user mission file is appended to
+// the embedded catalog.
+func TestLoadAllMergesUserOverlay(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"custom.json": `{"missions":[{"id":"user-venus-flyby","name":"Venus flyby",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"venus"}}]}]}`,
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	m, ok := missionByID(cat, "user-venus-flyby")
+	if !ok {
+		t.Fatalf("user mission not merged; got %d missions", len(cat.Missions))
+	}
+	if len(m.Objectives) != 1 || m.Objectives[0].Kind != KindSOIFlyby {
+		t.Errorf("user mission objectives not parsed: %+v", m.Objectives)
+	}
+	// Embedded missions survive alongside the overlay.
+	if _, ok := missionByID(cat, "mars-soi-flyby"); !ok {
+		t.Error("embedded mission dropped after overlay merge")
+	}
+}
+
+// TestLoadAllUserOverrideByID — a user mission whose ID matches an
+// embedded one replaces it (user files win on ID match), and the total
+// count doesn't grow.
+func TestLoadAllUserOverrideByID(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"override.json": `{"missions":[{"id":"mars-soi-flyby","name":"Mars flyby (custom)",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"mars"}}]}]}`,
+	})
+	cat, _, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("override grew the catalog: got %d missions, want 4", len(cat.Missions))
+	}
+	m, ok := missionByID(cat, "mars-soi-flyby")
+	if !ok {
+		t.Fatal("overridden mission missing")
+	}
+	if m.Name != "Mars flyby (custom)" {
+		t.Errorf("user override didn't win: name = %q", m.Name)
+	}
+}
+
+// TestLoadAllBadFileBecomesFailedMission — a malformed user file never
+// fails the whole catalog: it surfaces as one Failed-status mission whose
+// description carries the parse error, plus a warning, while the embedded
+// missions all load. (ADR 0025 — fixes the "stderr line you didn't see"
+// gap.)
+func TestLoadAllBadFileBecomesFailedMission(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `{"missions":[{"id":"oops",`, // truncated JSON
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings should not hard-fail on a bad overlay: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected a warning for the malformed overlay file")
+	}
+	// All four embedded missions still present.
+	for _, id := range []string{"leo-circularize-1000", "luna-orbit-insertion", "mars-soi-flyby", "saturn-v-pad-to-leo"} {
+		if _, ok := missionByID(cat, id); !ok {
+			t.Errorf("embedded mission %q dropped by a bad overlay file", id)
+		}
+	}
+	// The bad file is represented by exactly one Failed-status mission.
+	var failed []Mission
+	for _, m := range cat.Missions {
+		if m.Status == Failed {
+			failed = append(failed, m)
+		}
+	}
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 Failed placeholder mission, got %d", len(failed))
+	}
+	if !strings.Contains(failed[0].Name, "broken.json") {
+		t.Errorf("Failed mission name should name the file: %q", failed[0].Name)
+	}
+	if failed[0].Description == "" {
+		t.Error("Failed mission should carry the parse error in its description")
+	}
+}
+
+// TestLoadAllDropsWarnings — the convenience LoadAll wraps
+// LoadAllWithWarnings and swallows warnings but still returns the merged
+// catalog (including any Failed placeholder).
+func TestLoadAllDropsWarnings(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `not json at all`,
+	})
+	cat, err := LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(cat.Missions) != 5 { // 4 embedded + 1 Failed placeholder
+		t.Errorf("got %d missions, want 5 (4 embedded + 1 failed placeholder)", len(cat.Missions))
+	}
+}

--- a/internal/missions/mission_eval_test.go
+++ b/internal/missions/mission_eval_test.go
@@ -1,0 +1,96 @@
+package missions
+
+import "testing"
+
+// Mission.Evaluate is the v0.21 container behaviour: it rolls an ordered
+// list of Objectives up into a single Mission status. These tests pin the
+// sequencing contract (ADR 0025 §2) using soi_flyby objectives, whose
+// pass condition is just "current primary == target" — so a single
+// EvalContext can satisfy or withhold each step deterministically.
+
+// flybyMission returns a fresh two-step mission: flyby A, then flyby B.
+func flybyMission(a, b string) Mission {
+	return Mission{
+		ID: "test-flyby",
+		Objectives: []Objective{
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: a}},
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: b}},
+		},
+	}
+}
+
+// TestMissionOrderedSecondDoesNotLatchEarly — the defining ordered
+// behaviour: even when the SECOND objective's condition is already
+// satisfied, it must not pass while the FIRST is still in progress.
+func TestMissionOrderedSecondDoesNotLatchEarly(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	// At Mars: objective 2 (mars) would pass on its own, but objective 1
+	// (moon) hasn't, so ordering must hold both back.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("mission status: got %v, want InProgress", got)
+	}
+	if m.Objectives[1].Status == Passed {
+		t.Fatal("second objective latched before the first passed")
+	}
+}
+
+// TestMissionPassesAfterObjectivesPassInOrder — the mission passes only
+// once every objective has passed, in sequence across ticks.
+func TestMissionPassesAfterObjectivesPassInOrder(t *testing.T) {
+	m := flybyMission("moon", "mars")
+
+	// Tick 1 at the Moon: objective 1 passes; objective 2 is evaluated the
+	// same tick (its predecessor passed) but the craft isn't at Mars yet.
+	if got := m.Evaluate(EvalContext{PrimaryID: "moon"}); got != InProgress {
+		t.Fatalf("after moon flyby: got %v, want InProgress", got)
+	}
+	if m.Objectives[0].Status != Passed {
+		t.Fatalf("objective 1 after moon flyby: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != InProgress {
+		t.Fatalf("objective 2 after moon flyby: got %v, want InProgress", m.Objectives[1].Status)
+	}
+
+	// Tick 2 at Mars: objective 2 passes, completing the mission.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("after mars flyby: got %v, want Passed", got)
+	}
+	if m.Objectives[1].Status != Passed {
+		t.Fatalf("objective 2 after mars flyby: got %v, want Passed", m.Objectives[1].Status)
+	}
+}
+
+// TestMissionStickyOnTerminal — a Passed mission stays Passed regardless
+// of later context (mirrors Objective idempotency).
+func TestMissionStickyOnTerminal(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	m.Status = Passed
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != Passed {
+		t.Fatalf("sticky terminal: got %v, want Passed", got)
+	}
+}
+
+// TestMissionEmptyNeverPasses — a mission with no objectives is never
+// complete; it can't accidentally roll up to Passed on an empty loop.
+func TestMissionEmptyNeverPasses(t *testing.T) {
+	m := Mission{ID: "empty"}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("empty mission: got %v, want InProgress", got)
+	}
+}
+
+// TestMissionSingleObjectiveBehavesLikePredicate — the embedded starter
+// catalog wraps each legacy predicate in a one-objective mission; that
+// shape must behave exactly like the old single predicate.
+func TestMissionSingleObjectiveBehavesLikePredicate(t *testing.T) {
+	m := Mission{
+		ID:         "single",
+		Objectives: []Objective{{Kind: KindSOIFlyby, Params: Params{PrimaryID: "mars"}}},
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != InProgress {
+		t.Fatalf("not at mars: got %v, want InProgress", got)
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("at mars: got %v, want Passed", got)
+	}
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -1,21 +1,23 @@
-// Package missions defines pass/fail objectives evaluated against the
-// live sim state each Tick. v0.6.5+.
+// Package missions defines pass/fail Objectives and the Missions that
+// bundle them, evaluated against the live sim state each Tick.
 //
-// A Mission is a typed predicate over the spacecraft's current
-// (primary, state, sim-time) tuple. Three predicate kinds ship in the
-// v0.6.5 starter catalog:
+// Vocabulary (ADR 0025, v0.21 — a deliberate inversion of the pre-v0.21
+// naming, where a single predicate was called a "Mission"):
 //
-//   - Circularize: craft is in the named primary's frame, orbit is
-//     bound, eccentricity ≤ cap, and semimajor axis is within ±tol of
-//     target altitude (radius + altitude_m).
-//   - OrbitInsertion: craft is in the named primary's frame on a
-//     bound orbit (e < 1).
-//   - SOIFlyby: any tick where the craft's current primary ID matches
-//     the named body.
+//   - Objective — the atomic pass/fail predicate over the spacecraft's
+//     current (primary, state, sim-time) tuple. Four instantaneous kinds
+//     ship today (circularize, orbit_insertion, soi_flyby,
+//     circularize_from_pad); the v0.21 vocabulary grows in later slices.
+//   - Mission — an ordered list of Objectives plus campaign metadata
+//     (a `program` tag and `requires`/`unlocks` edges). The player sees a
+//     Mission as a checklist of sub-steps; the Mission carries the
+//     sequencing memory so each Objective stays memoryless. "Luna landing
+//     & return" is one Mission whose ordered Objectives are
+//     [land_at_luna] → [return_to_earth].
 //
-// Status is a three-state machine (InProgress → Passed | Failed).
-// Terminal states are sticky: Evaluate is idempotent on Passed/Failed
-// missions, so the per-tick caller can blindly walk all missions
+// Status is a three-state machine (InProgress → Passed | Failed) at both
+// levels. Terminal states are sticky: Evaluate is idempotent on
+// Passed/Failed, so the per-tick caller can blindly walk everything
 // without filtering.
 package missions
 
@@ -29,7 +31,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
-// Status is the mission state machine.
+// Status is the objective/mission state machine.
 type Status int
 
 const (
@@ -51,18 +53,20 @@ func (s Status) String() string {
 	return "?"
 }
 
-// Type discriminates the predicate kind. Stored in JSON as a string
-// so the catalog stays human-editable without leaking enum integers.
-type Type string
+// Kind discriminates the objective predicate kind. Stored in JSON as a
+// string so the catalog stays human-editable without leaking enum
+// integers. Kind names are part of the modder-facing schema (ADR 0025
+// §7) — renaming one breaks community catalogs.
+type Kind string
 
 const (
-	TypeCircularize         Type = "circularize"
-	TypeOrbitInsertion      Type = "orbit_insertion"
-	TypeSOIFlyby            Type = "soi_flyby"
-	TypeCircularizeFromPad  Type = "circularize_from_pad" // v0.9.2+
+	KindCircularize        Kind = "circularize"
+	KindOrbitInsertion     Kind = "orbit_insertion"
+	KindSOIFlyby           Kind = "soi_flyby"
+	KindCircularizeFromPad Kind = "circularize_from_pad" // v0.9.2+
 )
 
-// Params is the union of parameters across all predicate kinds. Each
+// Params is the union of parameters across all objective kinds. Each
 // kind reads only the fields it cares about; the rest stay zero.
 type Params struct {
 	// PrimaryID is the body whose frame the predicate evaluates in
@@ -92,21 +96,20 @@ type Params struct {
 	MinPeriapsisAltM float64 `json:"min_periapsis_alt_m,omitempty"`
 }
 
-// Mission groups the catalog metadata, the predicate parameters, and
-// the runtime status. JSON-serialisable for both the catalog and the
-// save file.
-type Mission struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
+// Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
+// JSON-serialisable for both the catalog and the save file.
+type Objective struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Type        Type   `json:"type"`
+	Kind        Kind   `json:"kind"`
 	Params      Params `json:"params"`
 	Status      Status `json:"status,omitempty"`
 }
 
-// EvalContext is the minimum slice of World state a mission predicate
+// EvalContext is the minimum slice of World state an objective predicate
 // needs. Lifted out of sim so the missions package can depend only on
-// orbital/physics and avoid an import cycle.
+// orbital/physics and avoid an import cycle. (Slice 2 expands this.)
 type EvalContext struct {
 	PrimaryID      string              // craft's current primary ID
 	PrimaryRadiusM float64             // craft primary's mean radius
@@ -115,21 +118,22 @@ type EvalContext struct {
 	SimTime        time.Time           // current sim time
 }
 
-// Evaluate steps the predicate one tick and returns the new status.
+// Evaluate steps the objective one tick and returns the new status.
 // Idempotent on terminal states (Passed/Failed return immediately).
-func (m Mission) Evaluate(ctx EvalContext) Status {
-	if m.Status != InProgress {
-		return m.Status
+// Does not mutate the receiver — the caller owns the status.
+func (o Objective) Evaluate(ctx EvalContext) Status {
+	if o.Status != InProgress {
+		return o.Status
 	}
-	switch m.Type {
-	case TypeCircularize:
-		return evalCircularize(m.Params, ctx)
-	case TypeOrbitInsertion:
-		return evalOrbitInsertion(m.Params, ctx)
-	case TypeSOIFlyby:
-		return evalSOIFlyby(m.Params, ctx)
-	case TypeCircularizeFromPad:
-		return evalCircularizeFromPad(m.Params, ctx)
+	switch o.Kind {
+	case KindCircularize:
+		return evalCircularize(o.Params, ctx)
+	case KindOrbitInsertion:
+		return evalOrbitInsertion(o.Params, ctx)
+	case KindSOIFlyby:
+		return evalSOIFlyby(o.Params, ctx)
+	case KindCircularizeFromPad:
+		return evalCircularizeFromPad(o.Params, ctx)
 	}
 	return InProgress
 }
@@ -213,9 +217,63 @@ func evalCircularizeFromPad(p Params, ctx EvalContext) Status {
 	return Passed
 }
 
-// Catalog is a list of missions, persisted to JSON. The starter
-// catalog ships embedded in the binary; future config-file work could
-// supply user-authored catalogs through the same shape.
+// Mission bundles an ordered list of Objectives plus campaign metadata.
+// A Program (ADR 0025 §2) is not a separate type — it is a lightweight
+// grouping expressed by the Program tag plus Requires/Unlocks edges
+// between Missions, so a campaign and the tutorial are both gated
+// Mission chains. JSON-serialisable for both the catalog and the save
+// file.
+type Mission struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Program     string      `json:"program,omitempty"`  // campaign grouping tag
+	Requires    []string    `json:"requires,omitempty"` // mission IDs that must Pass before this unlocks
+	Unlocks     []string    `json:"unlocks,omitempty"`  // mission IDs this unlocks (informational)
+	Objectives  []Objective `json:"objectives"`
+	Status      Status      `json:"status,omitempty"`
+}
+
+// Evaluate steps the Mission's Objectives in catalog order and returns
+// the rolled-up Mission status, mutating per-Objective and Mission
+// Status in place. Sticky on terminal states.
+//
+// Ordering is the defining behaviour of a Mission-as-sequence: an
+// Objective is evaluated only once every earlier Objective has Passed, so
+// a later step can't latch before its predecessor (e.g. you can't
+// "return" before you "land"). An Objective that just Passed this tick
+// lets the next one be evaluated the same tick. The Mission Passes when
+// every Objective has Passed; it Fails the moment any Objective Fails (no
+// Objective produces Failed until the slice-3 failure semantics land). A
+// Mission with no Objectives never passes.
+func (m *Mission) Evaluate(ctx EvalContext) Status {
+	if m.Status != InProgress {
+		return m.Status
+	}
+	for i := range m.Objectives {
+		if m.Objectives[i].Status == Passed {
+			continue
+		}
+		s := m.Objectives[i].Evaluate(ctx)
+		m.Objectives[i].Status = s
+		if s == Failed {
+			m.Status = Failed
+			return m.Status
+		}
+		if s != Passed {
+			// Ordered: this objective is still in progress, so every
+			// later objective stays locked until it passes.
+			return m.Status
+		}
+	}
+	if len(m.Objectives) > 0 {
+		m.Status = Passed
+	}
+	return m.Status
+}
+
+// Catalog is a list of Missions, persisted to JSON. The starter catalog
+// ships embedded in the binary; user overlays load through LoadAll.
 type Catalog struct {
 	Missions []Mission `json:"missions"`
 }
@@ -230,13 +288,21 @@ func LoadCatalog(data []byte) (Catalog, error) {
 }
 
 // Clone returns a deep copy of the mission slice. Used when seeding
-// World.Missions from the embedded catalog so per-session status
-// progression doesn't mutate the shared template.
-func Clone(missions []Mission) []Mission {
-	if len(missions) == 0 {
+// World.Missions from a catalog so per-session status progression
+// doesn't mutate the shared template. The per-Mission Objectives /
+// Requires / Unlocks slices are copied too — a shallow copy would let a
+// cloned mission's objective-status mutation bleed back into the
+// embedded catalog.
+func Clone(ms []Mission) []Mission {
+	if len(ms) == 0 {
 		return nil
 	}
-	out := make([]Mission, len(missions))
-	copy(out, missions)
+	out := make([]Mission, len(ms))
+	for i := range ms {
+		out[i] = ms[i]
+		out[i].Objectives = append([]Objective(nil), ms[i].Objectives...)
+		out[i].Requires = append([]string(nil), ms[i].Requires...)
+		out[i].Unlocks = append([]string(nil), ms[i].Unlocks...)
+	}
 	return out
 }

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -4,41 +4,57 @@
       "id": "leo-circularize-1000",
       "name": "Circularize at 1000 km LEO",
       "description": "Reach a circular orbit around Earth at 1000 km altitude (±5%, e ≤ 0.005).",
-      "type": "circularize",
-      "params": {
-        "primary_id": "earth",
-        "altitude_m": 1000000,
-        "altitude_tol_pct": 0.05,
-        "eccentricity_cap": 0.005
-      }
+      "objectives": [
+        {
+          "kind": "circularize",
+          "params": {
+            "primary_id": "earth",
+            "altitude_m": 1000000,
+            "altitude_tol_pct": 0.05,
+            "eccentricity_cap": 0.005
+          }
+        }
+      ]
     },
     {
       "id": "luna-orbit-insertion",
       "name": "Luna orbit insertion",
       "description": "Capture into a bound orbit around Earth's Moon.",
-      "type": "orbit_insertion",
-      "params": {
-        "primary_id": "moon"
-      }
+      "objectives": [
+        {
+          "kind": "orbit_insertion",
+          "params": {
+            "primary_id": "moon"
+          }
+        }
+      ]
     },
     {
       "id": "mars-soi-flyby",
       "name": "Mars SOI flyby",
       "description": "Cross into Mars' sphere of influence.",
-      "type": "soi_flyby",
-      "params": {
-        "primary_id": "mars"
-      }
+      "objectives": [
+        {
+          "kind": "soi_flyby",
+          "params": {
+            "primary_id": "mars"
+          }
+        }
+      ]
     },
     {
       "id": "saturn-v-pad-to-leo",
       "name": "Saturn V: pad to LEO",
       "description": "Spawn a Saturn V on the launchpad (n → POSITION → launchpad → LATITUDE → 28.6° KSC). Manually fly the gravity turn — pitch east, stage as each booster empties — and circularize at periapsis above 200 km.",
-      "type": "circularize_from_pad",
-      "params": {
-        "primary_id": "earth",
-        "min_periapsis_alt_m": 200000
-      }
+      "objectives": [
+        {
+          "kind": "circularize_from_pad",
+          "params": {
+            "primary_id": "earth",
+            "min_periapsis_alt_m": 200000
+          }
+        }
+      ]
     }
   ]
 }

--- a/internal/missions/missions_test.go
+++ b/internal/missions/missions_test.go
@@ -31,8 +31,8 @@ func circularState(r, mu, alt float64) physics.StateVector {
 }
 
 func TestCircularizeStartsInProgress(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -47,14 +47,14 @@ func TestCircularizeStartsInProgress(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 500e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("at 500 km, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizePassesAtTarget(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -68,14 +68,14 @@ func TestCircularizePassesAtTarget(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("at 1000 km circular, expected Passed, got %v", got)
 	}
 }
 
 func TestCircularizeTolerance(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -92,20 +92,20 @@ func TestCircularizeTolerance(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, insideAlt),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("inside tolerance, expected Passed, got %v", got)
 	}
 	// Outside tolerance: 10% under.
 	outsideAlt := 1_000_000 - 0.10*target
 	ctx.State = circularState(earthRadius, earthMu, outsideAlt)
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("outside tolerance, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeEccentricityCap(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -131,14 +131,14 @@ func TestCircularizeEccentricityCap(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("e=0.05 over cap=0.005, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeWrongPrimary(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -154,14 +154,14 @@ func TestCircularizeWrongPrimary(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("primary mismatch, expected InProgress, got %v", got)
 	}
 }
 
 func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	ctx := EvalContext{
@@ -170,14 +170,14 @@ func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("bound moon orbit, expected Passed, got %v", got)
 	}
 }
 
 func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	// Velocity well above escape — hyperbolic.
@@ -194,43 +194,43 @@ func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("hyperbolic, expected InProgress, got %v", got)
 	}
 }
 
 func TestSOIFlybyPassesOnPrimaryMatch(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "mars"}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("inside Mars SOI, expected Passed, got %v", got)
 	}
 }
 
 func TestSOIFlybyInProgressOtherwise(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("not in Mars SOI, expected InProgress, got %v", got)
 	}
 }
 
 func TestEvaluateIdempotentOnTerminal(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 		Status: Passed,
 	}
-	// Even though we're back at Earth, a Passed mission stays Passed.
+	// Even though we're back at Earth, a Passed objective stays Passed.
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != Passed {
-		t.Fatalf("Passed mission should stay Passed, got %v", got)
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("Passed objective should stay Passed, got %v", got)
 	}
 }
 
@@ -243,10 +243,10 @@ func TestDefaultCatalogLoads(t *testing.T) {
 		t.Fatalf("expected 4 starter missions, got %d", len(cat.Missions))
 	}
 	wantIDs := map[string]bool{
-		"leo-circularize-1000":  false,
-		"luna-orbit-insertion":  false,
-		"mars-soi-flyby":        false,
-		"saturn-v-pad-to-leo":   false, // v0.9.2+
+		"leo-circularize-1000": false,
+		"luna-orbit-insertion": false,
+		"mars-soi-flyby":       false,
+		"saturn-v-pad-to-leo":  false, // v0.9.2+
 	}
 	for _, m := range cat.Missions {
 		if _, ok := wantIDs[m.ID]; !ok {
@@ -254,6 +254,14 @@ func TestDefaultCatalogLoads(t *testing.T) {
 			continue
 		}
 		wantIDs[m.ID] = true
+		// Each starter mission wraps exactly one objective with a kind.
+		if len(m.Objectives) != 1 {
+			t.Errorf("mission %q: got %d objectives, want 1", m.ID, len(m.Objectives))
+			continue
+		}
+		if m.Objectives[0].Kind == "" {
+			t.Errorf("mission %q: objective has empty kind", m.ID)
+		}
 	}
 	for id, found := range wantIDs {
 		if !found {
@@ -286,33 +294,43 @@ func TestCloneIsIndependent(t *testing.T) {
 	dup := Clone(cat.Missions)
 	dup[0].Status = Passed
 	if cat.Missions[0].Status == Passed {
-		t.Fatal("Clone shares backing memory with source")
+		t.Fatal("Clone shares mission-level backing memory with source")
+	}
+	// Deep copy: mutating a cloned mission's nested objective status must
+	// not bleed back into the source catalog. A shallow copy would alias
+	// the Objectives slice and corrupt the embedded template.
+	if len(dup[0].Objectives) == 0 {
+		t.Fatal("test setup: cloned mission has no objectives")
+	}
+	dup[0].Objectives[0].Status = Passed
+	if cat.Missions[0].Objectives[0].Status == Passed {
+		t.Fatal("Clone shares objective backing memory with source")
 	}
 }
 
 // Sanity check that EvalContext's SimTime field is wired but not
 // currently consumed — guards against accidentally tying behaviour
-// to wall-clock during the v0.6.5 scaffold.
+// to wall-clock during the pre-dwell scaffold.
 func TestEvalIgnoresSimTime(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
 	ctx1 := EvalContext{PrimaryID: "earth", SimTime: t1}
 	ctx2 := EvalContext{PrimaryID: "earth", SimTime: t2}
-	if m.Evaluate(ctx1) != m.Evaluate(ctx2) {
-		t.Fatal("SimTime should not affect predicate outcome in v0.6.5")
+	if o.Evaluate(ctx1) != o.Evaluate(ctx2) {
+		t.Fatal("SimTime should not affect predicate outcome before dwell objectives")
 	}
 }
 
 // TestCircularizeFromPadInProgressBelowFloor — a low orbit
-// (periapsis below the configured floor) keeps the mission in
+// (periapsis below the configured floor) keeps the objective in
 // progress. v0.9.2+.
 func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -325,7 +343,7 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("100 km LEO with 200 km floor: got %v, want InProgress", got)
 	}
 }
@@ -334,8 +352,8 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 // periapsis above the floor passes, regardless of eccentricity.
 // v0.9.2+.
 func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -348,17 +366,17 @@ func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 250e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("250 km LEO with 200 km floor: got %v, want Passed", got)
 	}
 }
 
 // TestCircularizeFromPadRejectsHyperbolic — an unbound (e ≥ 1)
-// trajectory keeps the mission in progress even if the
+// trajectory keeps the objective in progress even if the
 // instantaneous radius is above the floor. v0.9.2+.
 func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -379,7 +397,7 @@ func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("hyperbolic with floor: got %v, want InProgress", got)
 	}
 }

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -48,8 +48,12 @@ import (
 // binding. The v7→v8 migration derives each craft's SystemIdx from which
 // loaded System contains its PrimaryID (Sol/0 fallback), so existing Sol
 // craft and any craft spawned by the buggy interim Lumen build both
-// migrate correctly; see migrateV7PayloadToV8.
-const SchemaVersion = 8
+// migrate correctly; see migrateV7PayloadToV8. v0.21 bumps to v9
+// (ADR 0025) — the mission shape inverts from a single typed predicate to
+// a Mission of ordered Objectives + campaign metadata. The v8→v9 migration
+// re-seeds: it drops the old single-predicate progress so the load path
+// reseeds the new ladder from the catalog; see migrateV8PayloadToV9.
+const SchemaVersion = 9
 
 // File is the on-disk envelope.
 type File struct {
@@ -467,6 +471,13 @@ func Load(path string) (*sim.World, error) {
 	// alone. v8+ saves already carry SystemIdx and skip this.
 	if f.Version < 8 {
 		migrateV7PayloadToV8(&f.Payload, systems)
+	}
+	// v0.21 / schema v9 (ADR 0025): the mission shape inverted (single
+	// predicate → Mission of ordered Objectives). Drop the old
+	// single-predicate progress so worldFromPayload reseeds the new ladder
+	// from the catalog. Payload-only, so it runs here on the wire payload.
+	if f.Version < 9 {
+		migrateV8PayloadToV9(&f.Payload)
 	}
 	return worldFromPayload(f.Payload, systems)
 }
@@ -906,14 +917,15 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	// prime NextNodeID past every ID in play, so a post-load plant can't
 	// mint a colliding node ID. Mirrors EnsureCraftIDs above.
 	w.EnsureNodeIDs()
-	// v0.6.5: missions persist with status. v3+ saves carry an explicit
-	// (possibly-empty) Missions slice; v1/v2 saves wire-out as nil and
-	// get the embedded starter catalog seeded fresh so older saves
-	// gain the new feature without a manual edit. A failed catalog
-	// load is non-fatal — missions are additive.
+	// v0.6.5: missions persist with status. v9+ saves carry an explicit
+	// (possibly-empty) Missions slice in the nested shape; pre-v9 saves are
+	// re-seeded — migrateV8PayloadToV9 nils Missions so this branch loads
+	// the current ladder fresh (embedded + user overlay, via LoadAll,
+	// matching NewWorld). A failed catalog load is non-fatal — missions are
+	// additive.
 	if p.Missions != nil {
 		w.Missions = missions.Clone(p.Missions)
-	} else if cat, err := missions.DefaultCatalog(); err == nil {
+	} else if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 	return w, nil

--- a/internal/save/save_migrate_v8_to_v9.go
+++ b/internal/save/save_migrate_v8_to_v9.go
@@ -1,0 +1,24 @@
+// v0.21: schema v8 → v9 migration (ADR 0025). Pre-v9 saves model a
+// mission as a single typed predicate (the old missions.Mission shape:
+// type + params + a flat status). v0.21 inverts the vocabulary — a Mission
+// is now an ordered list of Objectives plus campaign metadata (program tag,
+// requires/unlocks edges, per-objective status) — so the on-disk shape
+// changes fundamentally.
+//
+// Field-migrating the old single-predicate progress into the new nested
+// shape would carry little value (the old catalog was four standalone
+// predicates with no ladder), so this is a re-seed migration: drop the old
+// mission state entirely. With Payload.Missions left nil, worldFromPayload
+// reseeds from the current catalog (embedded + user overlay), so the player
+// picks up the new tutorial→challenge ladder fresh. Ladder progression and
+// per-objective status persist going forward under v9.
+
+package save
+
+// migrateV8PayloadToV9 drops the pre-v0.21 single-predicate mission
+// progress so the load path reseeds the new Mission/Objective ladder from
+// the catalog. Operates on the payload alone, so it runs before
+// rehydration like the positional v6→v7 pass.
+func migrateV8PayloadToV9(p *Payload) {
+	p.Missions = nil
+}

--- a/internal/save/save_migrate_v8_to_v9_test.go
+++ b/internal/save/save_migrate_v8_to_v9_test.go
@@ -1,0 +1,25 @@
+package save
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// TestMigrateV8PayloadToV9DropsOldMissions — ADR 0025. A pre-v9 payload's
+// Missions are the old single-predicate shape (no nested objectives). The
+// Mission shape changed fundamentally, so the migration drops the
+// low-value old progress, leaving Missions nil so worldFromPayload
+// reseeds from the new catalog rather than rehydrating empty husks.
+func TestMigrateV8PayloadToV9DropsOldMissions(t *testing.T) {
+	p := &Payload{
+		Missions: []missions.Mission{
+			{ID: "old-circ", Name: "Old circularize", Status: missions.Passed},
+			{ID: "old-flyby", Name: "Old flyby", Status: missions.InProgress},
+		},
+	}
+	migrateV8PayloadToV9(p)
+	if p.Missions != nil {
+		t.Fatalf("expected Missions dropped to nil, got %d", len(p.Missions))
+	}
+}

--- a/internal/save/save_mission_v9_test.go
+++ b/internal/save/save_mission_v9_test.go
@@ -1,0 +1,136 @@
+package save_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestLoadV8SaveReseedsMissions — ADR 0025 soft save break. A pre-v0.21
+// (v8) save carries old single-predicate mission progress; loading it
+// under v9 drops that progress and reseeds the new ladder from the
+// catalog, so a previously "passed" mission comes back fresh in the new
+// nested shape.
+func TestLoadV8SaveReseedsMissions(t *testing.T) {
+	// Isolate from any real user overlay so the reseed is exactly the
+	// embedded starter catalog.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Rewrite the freshly-saved (v9) file to look like a pre-v0.21 v8
+	// save: downgrade the version and replace the mission array with the
+	// old single-predicate shape (type/params/status, no objectives), with
+	// the mission already Passed.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	doc["version"] = 8
+	payload := doc["payload"].(map[string]any)
+	payload["missions"] = []any{
+		map[string]any{
+			"id":     "leo-circularize-1000",
+			"name":   "Old circularize",
+			"type":   "circularize",
+			"status": 1, // Passed, in the old shape
+			"params": map[string]any{"primary_id": "earth", "altitude_m": 1000000},
+		},
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load v8 save: %v", err)
+	}
+
+	// Reseeded to the new nested catalog: every starter mission present,
+	// each with objectives, none carrying the dropped Passed progress.
+	if len(got.Missions) != 4 {
+		t.Fatalf("reseed: got %d missions, want 4 embedded starter missions", len(got.Missions))
+	}
+	for _, m := range got.Missions {
+		if len(m.Objectives) == 0 {
+			t.Errorf("reseeded mission %q has no objectives (old husk leaked through)", m.ID)
+		}
+		if m.Status != missions.InProgress {
+			t.Errorf("reseeded mission %q status = %v, want InProgress (old progress not dropped)", m.ID, m.Status)
+		}
+	}
+}
+
+// TestRoundtripV9MissionShape — a v9 save preserves the full nested
+// mission shape: program tag, requires edges, ordered objectives, and
+// per-objective status all survive Save→Load.
+func TestRoundtripV9MissionShape(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:          "rt-multi",
+		Name:        "Round trip",
+		Description: "two ordered steps",
+		Program:     "test-prog",
+		Requires:    []string{"leo-circularize-1000"},
+		Objectives: []missions.Objective{
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "moon"}, Status: missions.Passed},
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "mars"}, Status: missions.InProgress},
+		},
+		Status: missions.InProgress,
+	}}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(got.Missions) != 1 {
+		t.Fatalf("got %d missions, want 1", len(got.Missions))
+	}
+	m := got.Missions[0]
+	if m.ID != "rt-multi" || m.Program != "test-prog" {
+		t.Errorf("metadata lost: id=%q program=%q", m.ID, m.Program)
+	}
+	if len(m.Requires) != 1 || m.Requires[0] != "leo-circularize-1000" {
+		t.Errorf("requires lost: %v", m.Requires)
+	}
+	if len(m.Objectives) != 2 {
+		t.Fatalf("got %d objectives, want 2", len(m.Objectives))
+	}
+	if m.Objectives[0].Kind != missions.KindSOIFlyby || m.Objectives[0].Params.PrimaryID != "moon" {
+		t.Errorf("objective 0 lost: %+v", m.Objectives[0])
+	}
+	if m.Objectives[0].Status != missions.Passed {
+		t.Errorf("objective 0 status: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != missions.InProgress {
+		t.Errorf("objective 1 status: got %v, want InProgress", m.Objectives[1].Status)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -267,10 +267,12 @@ func NewWorld() (*World, error) {
 	}
 	w.Calculator = orbital.ForSystem(w.System())
 
-	// v0.6.5: seed missions from the embedded starter catalog. A failure
-	// to load the catalog is non-fatal — missions are an additive
-	// feature and shouldn't block worldgen if the JSON is malformed.
-	if cat, err := missions.DefaultCatalog(); err == nil {
+	// v0.6.5: seed missions from the starter catalog. v0.21 (ADR 0025):
+	// LoadAll merges the embedded catalog with any user overlay and never
+	// hard-fails on a bad overlay file (it surfaces as a Failed
+	// placeholder mission), so this stays non-fatal — missions are an
+	// additive feature and shouldn't block worldgen.
+	if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 
@@ -622,9 +624,11 @@ type DockEvent struct {
 	CompositeName string // name of the resulting composite craft
 }
 
-// evaluateMissions steps each mission's predicate against the live
-// craft state. Terminal-state missions are evaluated too, but their
-// status is sticky in missions.Mission.Evaluate. v0.6.5+.
+// evaluateMissions steps each mission against the live craft state.
+// Mission.Evaluate walks the mission's ordered objectives, mutating
+// per-objective and per-mission Status in place; terminal states are
+// sticky, so missions already Passed/Failed are cheap no-ops. v0.6.5+;
+// v0.21 (ADR 0025) the unit is a Mission of ordered Objectives.
 func (w *World) evaluateMissions() {
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
@@ -637,7 +641,7 @@ func (w *World) evaluateMissions() {
 		SimTime:        w.Clock.SimTime,
 	}
 	for i := range w.Missions {
-		w.Missions[i].Status = w.Missions[i].Evaluate(ctx)
+		w.Missions[i].Evaluate(ctx)
 	}
 }
 

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -348,8 +348,13 @@ func TestTickPassesCircularizeAtTarget(t *testing.T) {
 
 	var found *missions.Mission
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularize {
-			found = &w.Missions[i]
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularize {
+				found = &w.Missions[i]
+				break
+			}
+		}
+		if found != nil {
 			break
 		}
 	}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2213,21 +2213,26 @@ func formatDurationShort(sec float64) string {
 // string when no such mission is in flight. v0.9.4+.
 func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
 	for _, m := range w.Missions {
-		if m.Type != missions.TypeCircularizeFromPad {
-			continue
-		}
 		if m.Status == missions.Passed {
 			continue
 		}
-		if m.Params.PrimaryID != c.Primary.ID {
-			continue
+		for _, o := range m.Objectives {
+			if o.Kind != missions.KindCircularizeFromPad {
+				continue
+			}
+			if o.Status == missions.Passed {
+				continue
+			}
+			if o.Params.PrimaryID != c.Primary.ID {
+				continue
+			}
+			target := o.Params.MinPeriapsisAltM
+			if target <= 0 {
+				target = launchMissionFloorM
+			}
+			return fmt.Sprintf("mission:    pe %s / %s target",
+				formatAltKm(periAltM), formatAltKm(target))
 		}
-		target := m.Params.MinPeriapsisAltM
-		if target <= 0 {
-			target = launchMissionFloorM
-		}
-		return fmt.Sprintf("mission:    pe %s / %s target",
-			formatAltKm(periAltM), formatAltKm(target))
 	}
 	return ""
 }

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -103,8 +103,10 @@ func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 		t.Fatal("expected active craft from NewWorld")
 	}
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularizeFromPad {
-			w.Missions[i].Status = missions.Passed
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularizeFromPad {
+				w.Missions[i].Status = missions.Passed
+			}
 		}
 	}
 	if got := launchMissionProgress(w, c, 130_000); got != "" {


### PR DESCRIPTION
## v0.21 Slice 1 — Model + schema refactor (ADR 0025)

The foundation for the data-authored mission system. **Pure structure + persistence; no new objective kinds** (those land in Slice 2). Built test-first per `/tdd`.

### Vocabulary inversion (ADR 0025 §2)
- Rename single-predicate `missions.Mission` → **`Objective`**; rename its `Type` → **`Kind`** (JSON `kind`; `KindCircularize`/`KindOrbitInsertion`/`KindSOIFlyby`/`KindCircularizeFromPad`). Eval logic unchanged.
- New **`Mission`** container: ordered `[]Objective` + campaign metadata (`Program` tag, `Requires`/`Unlocks` edges) + per-mission & per-objective `Status`. `Mission.Evaluate` is sticky-on-terminal and **ordered** — an objective is evaluated only once every earlier one has Passed, so a later step can't latch before its predecessor (e.g. you can't "return" before you "land").

### Catalog + user overlay
`LoadAll` / `LoadAllWithWarnings` merge the embedded starter catalog with a user overlay (`$XDG_CONFIG_HOME/terminal-space-program/missions/*.json`), mirroring the `internal/bodies` loader. A bad user file becomes **one `Failed`-status placeholder mission** with the parse error in its description and **never fails the whole catalog** (fixes the archived "stderr line you didn't see" gap). User missions win on ID match.

### Persistence
- `save.SchemaVersion 8 → 9` with typed **re-seed** migration `migrateV8PayloadToV9`: drops the low-value old single-predicate progress so `worldFromPayload` reseeds the new ladder from the catalog. Old saves keep flying; their mission progress resets to the new shape.
- World seeding (`NewWorld` + reseed path) now goes through `LoadAll` (overlay-aware).

### Scope / constraints honored
- `CONTEXT.md` **untouched** — docs-maintainer rewrites its Objectives section *after* the slices land (it must keep describing shipped code).
- `internal/missions` imports only `orbital`/`physics` — no upward deps. Event family / `RecordAction` is Slice 4.
- No new objective kinds; that's Slice 2.

### Tests (TDD, red→green)
Ordered rollup (second objective doesn't latch early; passes in order; empty never passes); overlay merge/override/bad-file→Failed; v8→v9 reseed (old save loads + drops progress + reseeds); v9 nested-shape round-trip (program/requires/objectives/statuses survive).

**Gates:** `go vet ./...` clean · `go test ./... -race -count=1` → **1167 passed, 16 packages** · binary builds · multi-agent `/code-review` clean (no findings).

Refs: ADR 0025, `v0.21-plan.md` §"Slice 1".