### PR TITLE
feat(missions): EvalContext + 5 state-objective kinds (ADR 0025 Slice 2)

### DIFF
--- a/internal/missions/loader.go
+++ b/internal/missions/loader.go
@@ -1,0 +1,126 @@
+package missions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadWarning reports a user-overlay file that couldn't be loaded. The
+// embedded starter catalog must always load — a parse failure there is a
+// hard error, not a warning. Mirrors bodies.LoadWarning.
+type LoadWarning struct {
+	Path string
+	Err  error
+}
+
+func (w LoadWarning) Error() string {
+	return fmt.Sprintf("%s: %v", w.Path, w.Err)
+}
+
+// LoadAll returns the embedded starter catalog merged with any user
+// overlay files from $XDG_CONFIG_HOME/terminal-space-program/missions/*.json
+// (or ~/.config/... if XDG is unset). Warnings from malformed user files
+// are dropped — call LoadAllWithWarnings to inspect them. A malformed
+// overlay file still leaves a Failed-status placeholder mission in the
+// catalog so the player sees it in-game. Mirrors bodies.LoadAll.
+func LoadAll() (Catalog, error) {
+	cat, _, err := LoadAllWithWarnings()
+	return cat, err
+}
+
+// LoadAllWithWarnings is the warning-aware variant of LoadAll. The
+// returned warnings slice contains a LoadWarning for any user overlay
+// file that failed to read or parse; a malformed embedded catalog surfaces
+// as a hard error (the err value) since the embedded set must always load.
+//
+// A bad user file never fails the whole catalog (ADR 0025): it is appended
+// as a single Failed-status mission whose description carries the parse
+// error, fixing the archived "stderr line you didn't see" gap. User
+// missions whose ID matches an embedded mission win on the match;
+// otherwise they're appended.
+func LoadAllWithWarnings() (Catalog, []LoadWarning, error) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		return Catalog{}, nil, err
+	}
+	merged, warnings := mergeUserOverlay(cat.Missions, userMissionsDir())
+	cat.Missions = merged
+	return cat, warnings, nil
+}
+
+func mergeUserOverlay(base []Mission, dir string) ([]Mission, []LoadWarning) {
+	if dir == "" {
+		return base, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing dir is fine — the overlay is optional. Other I/O errors
+		// (permissions, etc.) surface as a warning on the dir path; we
+		// can't enumerate files, so there's no per-file placeholder.
+		if os.IsNotExist(err) {
+			return base, nil
+		}
+		return base, []LoadWarning{{Path: dir, Err: err}}
+	}
+	var warnings []LoadWarning
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		uc, err := LoadCatalog(data)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		for _, m := range uc.Missions {
+			base = upsertMission(base, m)
+		}
+	}
+	return base, warnings
+}
+
+// failedMissionFromFile turns an unloadable overlay file into a single
+// Failed-status placeholder mission so the problem is visible in-game
+// rather than dropped to stderr.
+func failedMissionFromFile(path string, err error) Mission {
+	base := filepath.Base(path)
+	return Mission{
+		ID:          "invalid:" + base,
+		Name:        "Invalid mission file: " + base,
+		Description: err.Error(),
+		Status:      Failed,
+	}
+}
+
+// upsertMission appends m, or replaces an existing mission with the same
+// ID (user files win on ID match).
+func upsertMission(base []Mission, m Mission) []Mission {
+	for i := range base {
+		if base[i].ID == m.ID {
+			base[i] = m
+			return base
+		}
+	}
+	return append(base, m)
+}
+
+func userMissionsDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "missions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "terminal-space-program", "missions")
+}

--- a/internal/missions/loader_test.go
+++ b/internal/missions/loader_test.go
@@ -1,0 +1,160 @@
+package missions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeOverlay points XDG_CONFIG_HOME at a temp dir and writes name→json
+// files into its terminal-space-program/missions overlay dir, returning
+// the overlay dir path. Mirrors the bodies overlay convention.
+func writeOverlay(t *testing.T, files map[string]string) string {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "terminal-space-program", "missions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func missionByID(cat Catalog, id string) (Mission, bool) {
+	for _, m := range cat.Missions {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return Mission{}, false
+}
+
+// TestLoadAllNoOverlay — with no user overlay dir, LoadAll returns just
+// the embedded starter catalog and no warnings.
+func TestLoadAllNoOverlay(t *testing.T) {
+	// Point XDG at an empty temp dir so the overlay dir is absent.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("expected 4 embedded missions, got %d", len(cat.Missions))
+	}
+}
+
+// TestLoadAllMergesUserOverlay — a valid user mission file is appended to
+// the embedded catalog.
+func TestLoadAllMergesUserOverlay(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"custom.json": `{"missions":[{"id":"user-venus-flyby","name":"Venus flyby",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"venus"}}]}]}`,
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	m, ok := missionByID(cat, "user-venus-flyby")
+	if !ok {
+		t.Fatalf("user mission not merged; got %d missions", len(cat.Missions))
+	}
+	if len(m.Objectives) != 1 || m.Objectives[0].Kind != KindSOIFlyby {
+		t.Errorf("user mission objectives not parsed: %+v", m.Objectives)
+	}
+	// Embedded missions survive alongside the overlay.
+	if _, ok := missionByID(cat, "mars-soi-flyby"); !ok {
+		t.Error("embedded mission dropped after overlay merge")
+	}
+}
+
+// TestLoadAllUserOverrideByID — a user mission whose ID matches an
+// embedded one replaces it (user files win on ID match), and the total
+// count doesn't grow.
+func TestLoadAllUserOverrideByID(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"override.json": `{"missions":[{"id":"mars-soi-flyby","name":"Mars flyby (custom)",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"mars"}}]}]}`,
+	})
+	cat, _, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("override grew the catalog: got %d missions, want 4", len(cat.Missions))
+	}
+	m, ok := missionByID(cat, "mars-soi-flyby")
+	if !ok {
+		t.Fatal("overridden mission missing")
+	}
+	if m.Name != "Mars flyby (custom)" {
+		t.Errorf("user override didn't win: name = %q", m.Name)
+	}
+}
+
+// TestLoadAllBadFileBecomesFailedMission — a malformed user file never
+// fails the whole catalog: it surfaces as one Failed-status mission whose
+// description carries the parse error, plus a warning, while the embedded
+// missions all load. (ADR 0025 — fixes the "stderr line you didn't see"
+// gap.)
+func TestLoadAllBadFileBecomesFailedMission(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `{"missions":[{"id":"oops",`, // truncated JSON
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings should not hard-fail on a bad overlay: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected a warning for the malformed overlay file")
+	}
+	// All four embedded missions still present.
+	for _, id := range []string{"leo-circularize-1000", "luna-orbit-insertion", "mars-soi-flyby", "saturn-v-pad-to-leo"} {
+		if _, ok := missionByID(cat, id); !ok {
+			t.Errorf("embedded mission %q dropped by a bad overlay file", id)
+		}
+	}
+	// The bad file is represented by exactly one Failed-status mission.
+	var failed []Mission
+	for _, m := range cat.Missions {
+		if m.Status == Failed {
+			failed = append(failed, m)
+		}
+	}
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 Failed placeholder mission, got %d", len(failed))
+	}
+	if !strings.Contains(failed[0].Name, "broken.json") {
+		t.Errorf("Failed mission name should name the file: %q", failed[0].Name)
+	}
+	if failed[0].Description == "" {
+		t.Error("Failed mission should carry the parse error in its description")
+	}
+}
+
+// TestLoadAllDropsWarnings — the convenience LoadAll wraps
+// LoadAllWithWarnings and swallows warnings but still returns the merged
+// catalog (including any Failed placeholder).
+func TestLoadAllDropsWarnings(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `not json at all`,
+	})
+	cat, err := LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(cat.Missions) != 5 { // 4 embedded + 1 Failed placeholder
+		t.Errorf("got %d missions, want 5 (4 embedded + 1 failed placeholder)", len(cat.Missions))
+	}
+}

--- a/internal/missions/mission_eval_test.go
+++ b/internal/missions/mission_eval_test.go
@@ -1,0 +1,96 @@
+package missions
+
+import "testing"
+
+// Mission.Evaluate is the v0.21 container behaviour: it rolls an ordered
+// list of Objectives up into a single Mission status. These tests pin the
+// sequencing contract (ADR 0025 §2) using soi_flyby objectives, whose
+// pass condition is just "current primary == target" — so a single
+// EvalContext can satisfy or withhold each step deterministically.
+
+// flybyMission returns a fresh two-step mission: flyby A, then flyby B.
+func flybyMission(a, b string) Mission {
+	return Mission{
+		ID: "test-flyby",
+		Objectives: []Objective{
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: a}},
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: b}},
+		},
+	}
+}
+
+// TestMissionOrderedSecondDoesNotLatchEarly — the defining ordered
+// behaviour: even when the SECOND objective's condition is already
+// satisfied, it must not pass while the FIRST is still in progress.
+func TestMissionOrderedSecondDoesNotLatchEarly(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	// At Mars: objective 2 (mars) would pass on its own, but objective 1
+	// (moon) hasn't, so ordering must hold both back.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("mission status: got %v, want InProgress", got)
+	}
+	if m.Objectives[1].Status == Passed {
+		t.Fatal("second objective latched before the first passed")
+	}
+}
+
+// TestMissionPassesAfterObjectivesPassInOrder — the mission passes only
+// once every objective has passed, in sequence across ticks.
+func TestMissionPassesAfterObjectivesPassInOrder(t *testing.T) {
+	m := flybyMission("moon", "mars")
+
+	// Tick 1 at the Moon: objective 1 passes; objective 2 is evaluated the
+	// same tick (its predecessor passed) but the craft isn't at Mars yet.
+	if got := m.Evaluate(EvalContext{PrimaryID: "moon"}); got != InProgress {
+		t.Fatalf("after moon flyby: got %v, want InProgress", got)
+	}
+	if m.Objectives[0].Status != Passed {
+		t.Fatalf("objective 1 after moon flyby: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != InProgress {
+		t.Fatalf("objective 2 after moon flyby: got %v, want InProgress", m.Objectives[1].Status)
+	}
+
+	// Tick 2 at Mars: objective 2 passes, completing the mission.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("after mars flyby: got %v, want Passed", got)
+	}
+	if m.Objectives[1].Status != Passed {
+		t.Fatalf("objective 2 after mars flyby: got %v, want Passed", m.Objectives[1].Status)
+	}
+}
+
+// TestMissionStickyOnTerminal — a Passed mission stays Passed regardless
+// of later context (mirrors Objective idempotency).
+func TestMissionStickyOnTerminal(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	m.Status = Passed
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != Passed {
+		t.Fatalf("sticky terminal: got %v, want Passed", got)
+	}
+}
+
+// TestMissionEmptyNeverPasses — a mission with no objectives is never
+// complete; it can't accidentally roll up to Passed on an empty loop.
+func TestMissionEmptyNeverPasses(t *testing.T) {
+	m := Mission{ID: "empty"}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("empty mission: got %v, want InProgress", got)
+	}
+}
+
+// TestMissionSingleObjectiveBehavesLikePredicate — the embedded starter
+// catalog wraps each legacy predicate in a one-objective mission; that
+// shape must behave exactly like the old single predicate.
+func TestMissionSingleObjectiveBehavesLikePredicate(t *testing.T) {
+	m := Mission{
+		ID:         "single",
+		Objectives: []Objective{{Kind: KindSOIFlyby, Params: Params{PrimaryID: "mars"}}},
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != InProgress {
+		t.Fatalf("not at mars: got %v, want InProgress", got)
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("at mars: got %v, want Passed", got)
+	}
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -64,6 +64,14 @@ const (
 	KindOrbitInsertion     Kind = "orbit_insertion"
 	KindSOIFlyby           Kind = "soi_flyby"
 	KindCircularizeFromPad Kind = "circularize_from_pad" // v0.9.2+
+
+	// v0.21 (ADR 0025 §3) — the new state-objective vocabulary. All are
+	// instantaneous current-state checks; dwell is deferred to v0.22.
+	KindReachAltitude Kind = "reach_altitude"
+	KindLandAtBody    Kind = "land_at_body"
+	KindRendezvous    Kind = "rendezvous"
+	KindDock          Kind = "dock"
+	KindReturnToBody  Kind = "return_to_body"
 )
 
 // Params is the union of parameters across all objective kinds. Each
@@ -94,6 +102,25 @@ type Params struct {
 	// LEO counts the same as a 200 × 200 km circular one.
 	// v0.9.2+.
 	MinPeriapsisAltM float64 `json:"min_periapsis_alt_m,omitempty"`
+
+	// MinAltitudeM is the minimum altitude above the primary's mean
+	// radius (m) for ReachAltitude to pass. v0.21+.
+	MinAltitudeM float64 `json:"min_altitude_m,omitempty"`
+
+	// SiteLatDeg / SiteLonDeg / SiteRadiusM constrain LandAtBody to a
+	// target landing zone: the touchdown must lie within SiteRadiusM
+	// (great-circle metres) of (SiteLatDeg, SiteLonDeg). Coordinates are
+	// north-positive, east-positive. When SiteRadiusM is zero the kind
+	// accepts a landing anywhere on the body. v0.21+.
+	SiteLatDeg  float64 `json:"site_lat_deg,omitempty"`
+	SiteLonDeg  float64 `json:"site_lon_deg,omitempty"`
+	SiteRadiusM float64 `json:"site_radius_m,omitempty"`
+
+	// RangeM / RelSpeedMs are the Rendezvous gates: the active craft must
+	// be within RangeM metres of the targeted craft AND closing slower
+	// than RelSpeedMs metres/second. v0.21+.
+	RangeM     float64 `json:"range_m,omitempty"`
+	RelSpeedMs float64 `json:"rel_speed_ms,omitempty"`
 }
 
 // Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
@@ -116,6 +143,39 @@ type EvalContext struct {
 	PrimaryMu      float64             // craft primary's GM
 	State          physics.StateVector // craft state in primary frame
 	SimTime        time.Time           // current sim time
+
+	// v0.21 (ADR 0025) surface/landing state. Landed is the ADR 0004
+	// surface-contact flag; SurfaceLatDeg/LonDeg are the craft's
+	// body-fixed touchdown coordinates (north-positive, east-positive),
+	// valid when Landed. Read by land_at_body and return_to_body.
+	Landed        bool
+	SurfaceLatDeg float64
+	SurfaceLonDeg float64
+
+	// v0.21 (ADR 0025) target-craft relative state, against the player's
+	// current target slot. HasTargetCraft is false when no craft is
+	// targeted; TargetRangeM / TargetRelSpeedMs are the instantaneous
+	// separation and closing speed. Read by rendezvous.
+	HasTargetCraft   bool
+	TargetRangeM     float64
+	TargetRelSpeedMs float64
+
+	// Docked is true when the active craft is a docked composite (it has
+	// fused with at least one other vessel). Read by dock. v0.21+.
+	Docked bool
+
+	// v0.21 (ADR 0025) resource + outcome snapshot. These are wired now so
+	// the slice-3 failure semantics (out_of_fuel / crashed) and slice-4
+	// outcome steps read a complete context; no v0.21 state-objective kind
+	// consumes them yet. FuelKg is the active stage's propellant; DvBudget
+	// is the active stage's remaining Δv (m/s).
+	FuelKg     float64
+	MonopropKg float64
+	DvBudget   float64
+	Crashed    bool
+	HasNode    bool // active craft has at least one planted maneuver node
+	HasTarget  bool // a body or craft is selected in the world target slot
+	Staged     bool // the player has decoupled a stage this session
 }
 
 // Evaluate steps the objective one tick and returns the new status.
@@ -134,6 +194,115 @@ func (o Objective) Evaluate(ctx EvalContext) Status {
 		return evalSOIFlyby(o.Params, ctx)
 	case KindCircularizeFromPad:
 		return evalCircularizeFromPad(o.Params, ctx)
+	case KindReachAltitude:
+		return evalReachAltitude(o.Params, ctx)
+	case KindReturnToBody:
+		return evalReturnToBody(o.Params, ctx)
+	case KindLandAtBody:
+		return evalLandAtBody(o.Params, ctx)
+	case KindRendezvous:
+		return evalRendezvous(o.Params, ctx)
+	case KindDock:
+		return evalDock(o.Params, ctx)
+	}
+	return InProgress
+}
+
+// evalDock: pass when the active craft is a docked composite. Grounded in
+// the durable composite state (DockedComponents) rather than the ephemeral
+// dock event, keeping the check instantaneous. The optional target_craft
+// param (ADR 0025 §3) is deferred — any dock satisfies the kind. v0.21+.
+func evalDock(_ Params, ctx EvalContext) Status {
+	if ctx.Docked {
+		return Passed
+	}
+	return InProgress
+}
+
+// evalRendezvous: pass when a craft is targeted and the active craft is
+// within RangeM metres of it AND closing slower than RelSpeedMs. Evaluated
+// against the player's current target slot rather than a catalog-named
+// craft, since runtime craft IDs aren't authorable in a static catalog.
+// v0.21+.
+func evalRendezvous(p Params, ctx EvalContext) Status {
+	if !ctx.HasTargetCraft {
+		return InProgress
+	}
+	if ctx.TargetRangeM <= p.RangeM && ctx.TargetRelSpeedMs <= p.RelSpeedMs {
+		return Passed
+	}
+	return InProgress
+}
+
+// evalLandAtBody: pass when the craft is Landed on the named primary. An
+// optional site (SiteRadiusM > 0) further requires the touchdown to lie
+// within SiteRadiusM great-circle metres of (SiteLatDeg, SiteLonDeg);
+// without a site, landing anywhere on the body passes. v0.21+.
+func evalLandAtBody(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if !ctx.Landed {
+		return InProgress
+	}
+	if p.SiteRadiusM <= 0 {
+		return Passed
+	}
+	d := greatCircleDistanceM(ctx.SurfaceLatDeg, ctx.SurfaceLonDeg, p.SiteLatDeg, p.SiteLonDeg, ctx.PrimaryRadiusM)
+	if d <= p.SiteRadiusM {
+		return Passed
+	}
+	return InProgress
+}
+
+// greatCircleDistanceM returns the surface distance (metres) between two
+// lat/lon points (degrees) on a sphere of the given radius, via the
+// haversine formula.
+func greatCircleDistanceM(lat1, lon1, lat2, lon2, radiusM float64) float64 {
+	const deg2rad = math.Pi / 180
+	phi1 := lat1 * deg2rad
+	phi2 := lat2 * deg2rad
+	dPhi := (lat2 - lat1) * deg2rad
+	dLambda := (lon2 - lon1) * deg2rad
+	a := math.Sin(dPhi/2)*math.Sin(dPhi/2) +
+		math.Cos(phi1)*math.Cos(phi2)*math.Sin(dLambda/2)*math.Sin(dLambda/2)
+	return radiusM * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}
+
+// evalReturnToBody: pass when the craft has "come back" to the named body
+// — its current primary matches AND it is either captured (a bound orbit,
+// e < 1) or Landed. A hyperbolic whizz-through of the SOI is not a return.
+// The there-and-back sequencing comes from the Mission's ordering; this
+// predicate just confirms the craft actually stayed. v0.21+.
+func evalReturnToBody(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.Landed {
+		return Passed
+	}
+	if ctx.PrimaryMu == 0 {
+		return InProgress
+	}
+	el := orbital.ElementsFromState(ctx.State.R, ctx.State.V, ctx.PrimaryMu)
+	if el.A <= 0 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return InProgress
+	}
+	if el.E >= 1 {
+		return InProgress
+	}
+	return Passed
+}
+
+// evalReachAltitude: pass when the craft is in the named primary's frame
+// and its current altitude above the primary's mean radius reaches the
+// floor. A pure radial check — orbit shape is irrelevant. v0.21+.
+func evalReachAltitude(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.State.R.Norm()-ctx.PrimaryRadiusM >= p.MinAltitudeM {
+		return Passed
 	}
 	return InProgress
 }

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -1,21 +1,23 @@
-// Package missions defines pass/fail objectives evaluated against the
-// live sim state each Tick. v0.6.5+.
+// Package missions defines pass/fail Objectives and the Missions that
+// bundle them, evaluated against the live sim state each Tick.
 //
-// A Mission is a typed predicate over the spacecraft's current
-// (primary, state, sim-time) tuple. Three predicate kinds ship in the
-// v0.6.5 starter catalog:
+// Vocabulary (ADR 0025, v0.21 — a deliberate inversion of the pre-v0.21
+// naming, where a single predicate was called a "Mission"):
 //
-//   - Circularize: craft is in the named primary's frame, orbit is
-//     bound, eccentricity ≤ cap, and semimajor axis is within ±tol of
-//     target altitude (radius + altitude_m).
-//   - OrbitInsertion: craft is in the named primary's frame on a
-//     bound orbit (e < 1).
-//   - SOIFlyby: any tick where the craft's current primary ID matches
-//     the named body.
+//   - Objective — the atomic pass/fail predicate over the spacecraft's
+//     current (primary, state, sim-time) tuple. Four instantaneous kinds
+//     ship today (circularize, orbit_insertion, soi_flyby,
+//     circularize_from_pad); the v0.21 vocabulary grows in later slices.
+//   - Mission — an ordered list of Objectives plus campaign metadata
+//     (a `program` tag and `requires`/`unlocks` edges). The player sees a
+//     Mission as a checklist of sub-steps; the Mission carries the
+//     sequencing memory so each Objective stays memoryless. "Luna landing
+//     & return" is one Mission whose ordered Objectives are
+//     [land_at_luna] → [return_to_earth].
 //
-// Status is a three-state machine (InProgress → Passed | Failed).
-// Terminal states are sticky: Evaluate is idempotent on Passed/Failed
-// missions, so the per-tick caller can blindly walk all missions
+// Status is a three-state machine (InProgress → Passed | Failed) at both
+// levels. Terminal states are sticky: Evaluate is idempotent on
+// Passed/Failed, so the per-tick caller can blindly walk everything
 // without filtering.
 package missions
 
@@ -29,7 +31,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
-// Status is the mission state machine.
+// Status is the objective/mission state machine.
 type Status int
 
 const (
@@ -51,18 +53,20 @@ func (s Status) String() string {
 	return "?"
 }
 
-// Type discriminates the predicate kind. Stored in JSON as a string
-// so the catalog stays human-editable without leaking enum integers.
-type Type string
+// Kind discriminates the objective predicate kind. Stored in JSON as a
+// string so the catalog stays human-editable without leaking enum
+// integers. Kind names are part of the modder-facing schema (ADR 0025
+// §7) — renaming one breaks community catalogs.
+type Kind string
 
 const (
-	TypeCircularize         Type = "circularize"
-	TypeOrbitInsertion      Type = "orbit_insertion"
-	TypeSOIFlyby            Type = "soi_flyby"
-	TypeCircularizeFromPad  Type = "circularize_from_pad" // v0.9.2+
+	KindCircularize        Kind = "circularize"
+	KindOrbitInsertion     Kind = "orbit_insertion"
+	KindSOIFlyby           Kind = "soi_flyby"
+	KindCircularizeFromPad Kind = "circularize_from_pad" // v0.9.2+
 )
 
-// Params is the union of parameters across all predicate kinds. Each
+// Params is the union of parameters across all objective kinds. Each
 // kind reads only the fields it cares about; the rest stay zero.
 type Params struct {
 	// PrimaryID is the body whose frame the predicate evaluates in
@@ -92,21 +96,20 @@ type Params struct {
 	MinPeriapsisAltM float64 `json:"min_periapsis_alt_m,omitempty"`
 }
 
-// Mission groups the catalog metadata, the predicate parameters, and
-// the runtime status. JSON-serialisable for both the catalog and the
-// save file.
-type Mission struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
+// Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
+// JSON-serialisable for both the catalog and the save file.
+type Objective struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Type        Type   `json:"type"`
+	Kind        Kind   `json:"kind"`
 	Params      Params `json:"params"`
 	Status      Status `json:"status,omitempty"`
 }
 
-// EvalContext is the minimum slice of World state a mission predicate
+// EvalContext is the minimum slice of World state an objective predicate
 // needs. Lifted out of sim so the missions package can depend only on
-// orbital/physics and avoid an import cycle.
+// orbital/physics and avoid an import cycle. (Slice 2 expands this.)
 type EvalContext struct {
 	PrimaryID      string              // craft's current primary ID
 	PrimaryRadiusM float64             // craft primary's mean radius
@@ -115,21 +118,22 @@ type EvalContext struct {
 	SimTime        time.Time           // current sim time
 }
 
-// Evaluate steps the predicate one tick and returns the new status.
+// Evaluate steps the objective one tick and returns the new status.
 // Idempotent on terminal states (Passed/Failed return immediately).
-func (m Mission) Evaluate(ctx EvalContext) Status {
-	if m.Status != InProgress {
-		return m.Status
+// Does not mutate the receiver — the caller owns the status.
+func (o Objective) Evaluate(ctx EvalContext) Status {
+	if o.Status != InProgress {
+		return o.Status
 	}
-	switch m.Type {
-	case TypeCircularize:
-		return evalCircularize(m.Params, ctx)
-	case TypeOrbitInsertion:
-		return evalOrbitInsertion(m.Params, ctx)
-	case TypeSOIFlyby:
-		return evalSOIFlyby(m.Params, ctx)
-	case TypeCircularizeFromPad:
-		return evalCircularizeFromPad(m.Params, ctx)
+	switch o.Kind {
+	case KindCircularize:
+		return evalCircularize(o.Params, ctx)
+	case KindOrbitInsertion:
+		return evalOrbitInsertion(o.Params, ctx)
+	case KindSOIFlyby:
+		return evalSOIFlyby(o.Params, ctx)
+	case KindCircularizeFromPad:
+		return evalCircularizeFromPad(o.Params, ctx)
 	}
 	return InProgress
 }
@@ -213,9 +217,63 @@ func evalCircularizeFromPad(p Params, ctx EvalContext) Status {
 	return Passed
 }
 
-// Catalog is a list of missions, persisted to JSON. The starter
-// catalog ships embedded in the binary; future config-file work could
-// supply user-authored catalogs through the same shape.
+// Mission bundles an ordered list of Objectives plus campaign metadata.
+// A Program (ADR 0025 §2) is not a separate type — it is a lightweight
+// grouping expressed by the Program tag plus Requires/Unlocks edges
+// between Missions, so a campaign and the tutorial are both gated
+// Mission chains. JSON-serialisable for both the catalog and the save
+// file.
+type Mission struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Program     string      `json:"program,omitempty"`  // campaign grouping tag
+	Requires    []string    `json:"requires,omitempty"` // mission IDs that must Pass before this unlocks
+	Unlocks     []string    `json:"unlocks,omitempty"`  // mission IDs this unlocks (informational)
+	Objectives  []Objective `json:"objectives"`
+	Status      Status      `json:"status,omitempty"`
+}
+
+// Evaluate steps the Mission's Objectives in catalog order and returns
+// the rolled-up Mission status, mutating per-Objective and Mission
+// Status in place. Sticky on terminal states.
+//
+// Ordering is the defining behaviour of a Mission-as-sequence: an
+// Objective is evaluated only once every earlier Objective has Passed, so
+// a later step can't latch before its predecessor (e.g. you can't
+// "return" before you "land"). An Objective that just Passed this tick
+// lets the next one be evaluated the same tick. The Mission Passes when
+// every Objective has Passed; it Fails the moment any Objective Fails (no
+// Objective produces Failed until the slice-3 failure semantics land). A
+// Mission with no Objectives never passes.
+func (m *Mission) Evaluate(ctx EvalContext) Status {
+	if m.Status != InProgress {
+		return m.Status
+	}
+	for i := range m.Objectives {
+		if m.Objectives[i].Status == Passed {
+			continue
+		}
+		s := m.Objectives[i].Evaluate(ctx)
+		m.Objectives[i].Status = s
+		if s == Failed {
+			m.Status = Failed
+			return m.Status
+		}
+		if s != Passed {
+			// Ordered: this objective is still in progress, so every
+			// later objective stays locked until it passes.
+			return m.Status
+		}
+	}
+	if len(m.Objectives) > 0 {
+		m.Status = Passed
+	}
+	return m.Status
+}
+
+// Catalog is a list of Missions, persisted to JSON. The starter catalog
+// ships embedded in the binary; user overlays load through LoadAll.
 type Catalog struct {
 	Missions []Mission `json:"missions"`
 }
@@ -230,13 +288,21 @@ func LoadCatalog(data []byte) (Catalog, error) {
 }
 
 // Clone returns a deep copy of the mission slice. Used when seeding
-// World.Missions from the embedded catalog so per-session status
-// progression doesn't mutate the shared template.
-func Clone(missions []Mission) []Mission {
-	if len(missions) == 0 {
+// World.Missions from a catalog so per-session status progression
+// doesn't mutate the shared template. The per-Mission Objectives /
+// Requires / Unlocks slices are copied too — a shallow copy would let a
+// cloned mission's objective-status mutation bleed back into the
+// embedded catalog.
+func Clone(ms []Mission) []Mission {
+	if len(ms) == 0 {
 		return nil
 	}
-	out := make([]Mission, len(missions))
-	copy(out, missions)
+	out := make([]Mission, len(ms))
+	for i := range ms {
+		out[i] = ms[i]
+		out[i].Objectives = append([]Objective(nil), ms[i].Objectives...)
+		out[i].Requires = append([]string(nil), ms[i].Requires...)
+		out[i].Unlocks = append([]string(nil), ms[i].Unlocks...)
+	}
 	return out
 }

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -4,41 +4,57 @@
       "id": "leo-circularize-1000",
       "name": "Circularize at 1000 km LEO",
       "description": "Reach a circular orbit around Earth at 1000 km altitude (±5%, e ≤ 0.005).",
-      "type": "circularize",
-      "params": {
-        "primary_id": "earth",
-        "altitude_m": 1000000,
-        "altitude_tol_pct": 0.05,
-        "eccentricity_cap": 0.005
-      }
+      "objectives": [
+        {
+          "kind": "circularize",
+          "params": {
+            "primary_id": "earth",
+            "altitude_m": 1000000,
+            "altitude_tol_pct": 0.05,
+            "eccentricity_cap": 0.005
+          }
+        }
+      ]
     },
     {
       "id": "luna-orbit-insertion",
       "name": "Luna orbit insertion",
       "description": "Capture into a bound orbit around Earth's Moon.",
-      "type": "orbit_insertion",
-      "params": {
-        "primary_id": "moon"
-      }
+      "objectives": [
+        {
+          "kind": "orbit_insertion",
+          "params": {
+            "primary_id": "moon"
+          }
+        }
+      ]
     },
     {
       "id": "mars-soi-flyby",
       "name": "Mars SOI flyby",
       "description": "Cross into Mars' sphere of influence.",
-      "type": "soi_flyby",
-      "params": {
-        "primary_id": "mars"
-      }
+      "objectives": [
+        {
+          "kind": "soi_flyby",
+          "params": {
+            "primary_id": "mars"
+          }
+        }
+      ]
     },
     {
       "id": "saturn-v-pad-to-leo",
       "name": "Saturn V: pad to LEO",
       "description": "Spawn a Saturn V on the launchpad (n → POSITION → launchpad → LATITUDE → 28.6° KSC). Manually fly the gravity turn — pitch east, stage as each booster empties — and circularize at periapsis above 200 km.",
-      "type": "circularize_from_pad",
-      "params": {
-        "primary_id": "earth",
-        "min_periapsis_alt_m": 200000
-      }
+      "objectives": [
+        {
+          "kind": "circularize_from_pad",
+          "params": {
+            "primary_id": "earth",
+            "min_periapsis_alt_m": 200000
+          }
+        }
+      ]
     }
   ]
 }

--- a/internal/missions/missions_test.go
+++ b/internal/missions/missions_test.go
@@ -31,8 +31,8 @@ func circularState(r, mu, alt float64) physics.StateVector {
 }
 
 func TestCircularizeStartsInProgress(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -47,14 +47,14 @@ func TestCircularizeStartsInProgress(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 500e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("at 500 km, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizePassesAtTarget(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -68,14 +68,14 @@ func TestCircularizePassesAtTarget(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("at 1000 km circular, expected Passed, got %v", got)
 	}
 }
 
 func TestCircularizeTolerance(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -92,20 +92,20 @@ func TestCircularizeTolerance(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, insideAlt),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("inside tolerance, expected Passed, got %v", got)
 	}
 	// Outside tolerance: 10% under.
 	outsideAlt := 1_000_000 - 0.10*target
 	ctx.State = circularState(earthRadius, earthMu, outsideAlt)
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("outside tolerance, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeEccentricityCap(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -131,14 +131,14 @@ func TestCircularizeEccentricityCap(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("e=0.05 over cap=0.005, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeWrongPrimary(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -154,14 +154,14 @@ func TestCircularizeWrongPrimary(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("primary mismatch, expected InProgress, got %v", got)
 	}
 }
 
 func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	ctx := EvalContext{
@@ -170,14 +170,14 @@ func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("bound moon orbit, expected Passed, got %v", got)
 	}
 }
 
 func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	// Velocity well above escape — hyperbolic.
@@ -194,43 +194,43 @@ func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("hyperbolic, expected InProgress, got %v", got)
 	}
 }
 
 func TestSOIFlybyPassesOnPrimaryMatch(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "mars"}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("inside Mars SOI, expected Passed, got %v", got)
 	}
 }
 
 func TestSOIFlybyInProgressOtherwise(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("not in Mars SOI, expected InProgress, got %v", got)
 	}
 }
 
 func TestEvaluateIdempotentOnTerminal(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 		Status: Passed,
 	}
-	// Even though we're back at Earth, a Passed mission stays Passed.
+	// Even though we're back at Earth, a Passed objective stays Passed.
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != Passed {
-		t.Fatalf("Passed mission should stay Passed, got %v", got)
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("Passed objective should stay Passed, got %v", got)
 	}
 }
 
@@ -243,10 +243,10 @@ func TestDefaultCatalogLoads(t *testing.T) {
 		t.Fatalf("expected 4 starter missions, got %d", len(cat.Missions))
 	}
 	wantIDs := map[string]bool{
-		"leo-circularize-1000":  false,
-		"luna-orbit-insertion":  false,
-		"mars-soi-flyby":        false,
-		"saturn-v-pad-to-leo":   false, // v0.9.2+
+		"leo-circularize-1000": false,
+		"luna-orbit-insertion": false,
+		"mars-soi-flyby":       false,
+		"saturn-v-pad-to-leo":  false, // v0.9.2+
 	}
 	for _, m := range cat.Missions {
 		if _, ok := wantIDs[m.ID]; !ok {
@@ -254,6 +254,14 @@ func TestDefaultCatalogLoads(t *testing.T) {
 			continue
 		}
 		wantIDs[m.ID] = true
+		// Each starter mission wraps exactly one objective with a kind.
+		if len(m.Objectives) != 1 {
+			t.Errorf("mission %q: got %d objectives, want 1", m.ID, len(m.Objectives))
+			continue
+		}
+		if m.Objectives[0].Kind == "" {
+			t.Errorf("mission %q: objective has empty kind", m.ID)
+		}
 	}
 	for id, found := range wantIDs {
 		if !found {
@@ -286,33 +294,43 @@ func TestCloneIsIndependent(t *testing.T) {
 	dup := Clone(cat.Missions)
 	dup[0].Status = Passed
 	if cat.Missions[0].Status == Passed {
-		t.Fatal("Clone shares backing memory with source")
+		t.Fatal("Clone shares mission-level backing memory with source")
+	}
+	// Deep copy: mutating a cloned mission's nested objective status must
+	// not bleed back into the source catalog. A shallow copy would alias
+	// the Objectives slice and corrupt the embedded template.
+	if len(dup[0].Objectives) == 0 {
+		t.Fatal("test setup: cloned mission has no objectives")
+	}
+	dup[0].Objectives[0].Status = Passed
+	if cat.Missions[0].Objectives[0].Status == Passed {
+		t.Fatal("Clone shares objective backing memory with source")
 	}
 }
 
 // Sanity check that EvalContext's SimTime field is wired but not
 // currently consumed — guards against accidentally tying behaviour
-// to wall-clock during the v0.6.5 scaffold.
+// to wall-clock during the pre-dwell scaffold.
 func TestEvalIgnoresSimTime(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
 	ctx1 := EvalContext{PrimaryID: "earth", SimTime: t1}
 	ctx2 := EvalContext{PrimaryID: "earth", SimTime: t2}
-	if m.Evaluate(ctx1) != m.Evaluate(ctx2) {
-		t.Fatal("SimTime should not affect predicate outcome in v0.6.5")
+	if o.Evaluate(ctx1) != o.Evaluate(ctx2) {
+		t.Fatal("SimTime should not affect predicate outcome before dwell objectives")
 	}
 }
 
 // TestCircularizeFromPadInProgressBelowFloor — a low orbit
-// (periapsis below the configured floor) keeps the mission in
+// (periapsis below the configured floor) keeps the objective in
 // progress. v0.9.2+.
 func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -325,7 +343,7 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("100 km LEO with 200 km floor: got %v, want InProgress", got)
 	}
 }
@@ -334,8 +352,8 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 // periapsis above the floor passes, regardless of eccentricity.
 // v0.9.2+.
 func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -348,17 +366,17 @@ func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 250e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("250 km LEO with 200 km floor: got %v, want Passed", got)
 	}
 }
 
 // TestCircularizeFromPadRejectsHyperbolic — an unbound (e ≥ 1)
-// trajectory keeps the mission in progress even if the
+// trajectory keeps the objective in progress even if the
 // instantaneous radius is above the floor. v0.9.2+.
 func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -379,7 +397,7 @@ func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("hyperbolic with floor: got %v, want InProgress", got)
 	}
 }

--- a/internal/missions/state_kinds_test.go
+++ b/internal/missions/state_kinds_test.go
@@ -1,0 +1,256 @@
+package missions
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// v0.21 Slice 2 (ADR 0025 §3) — the five new instantaneous state-objective
+// kinds. Each test exercises pass / not-yet / frame-mismatch per the
+// cycle-plan done-criteria. Reuses circularState + the earth/moon
+// constants from missions_test.go (same package).
+
+// --- reach_altitude {primary, min_altitude_m} ---
+
+func TestReachAltitudePassesAtOrAboveTarget(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// 1000 km altitude — comfortably above the 500 km floor.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 1000e3),
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("1000 km vs 500 km floor: got %v, want Passed", got)
+	}
+}
+
+func TestReachAltitudeInProgressBelowTarget(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// 300 km — short of the 500 km floor.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 300e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("300 km vs 500 km floor: got %v, want InProgress", got)
+	}
+}
+
+func TestReachAltitudeFrameMismatch(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// Plenty high, but around the Moon — wrong primary, predicate dormant.
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 1000e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("right altitude wrong primary: got %v, want InProgress", got)
+	}
+}
+
+// --- return_to_body {primary} : captured-or-landed ---
+
+func TestReturnToBodyPassesOnBoundOrbit(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 300e3),
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("bound earth orbit: got %v, want Passed", got)
+	}
+}
+
+func TestReturnToBodyPassesWhenLanded(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// Landed back on Earth — passes even though the (pinned, surface) state
+	// vector isn't a bound orbit.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		Landed:         true,
+		State:          physics.StateVector{R: orbital.Vec3{X: earthRadius}, M: 1000},
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("landed on earth: got %v, want Passed", got)
+	}
+}
+
+func TestReturnToBodyInProgressOnHyperbolicPassthrough(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// In Earth's SOI but on a hyperbolic flyby (not captured, not landed) —
+	// a whizz-through is not a return.
+	radius := earthRadius + 500e3
+	vEsc := math.Sqrt(2 * earthMu / radius)
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State: physics.StateVector{
+			R: orbital.Vec3{X: radius},
+			V: orbital.Vec3{Y: vEsc * 1.5},
+			M: 1000,
+		},
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("hyperbolic passthrough: got %v, want InProgress", got)
+	}
+}
+
+func TestReturnToBodyFrameMismatch(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// Bound around the Moon — right shape, wrong body.
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 100e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("bound around moon, want earth: got %v, want InProgress", got)
+	}
+}
+
+// --- land_at_body {primary, optional site lat/lon + radius_m} ---
+
+// landedCtx builds a landed-on-earth EvalContext at the given surface
+// coordinates.
+func landedCtx(latDeg, lonDeg float64) EvalContext {
+	return EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		Landed:         true,
+		SurfaceLatDeg:  latDeg,
+		SurfaceLonDeg:  lonDeg,
+		State:          physics.StateVector{R: orbital.Vec3{X: earthRadius}, M: 1000},
+	}
+}
+
+func TestLandAtBodyPassesLandedAnywhereWithoutSite(t *testing.T) {
+	// No site constraint (SiteRadiusM == 0): landing anywhere on Earth passes.
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "earth"}}
+	if got := o.Evaluate(landedCtx(12, 34)); got != Passed {
+		t.Fatalf("landed anywhere, no site: got %v, want Passed", got)
+	}
+}
+
+func TestLandAtBodyPassesInsideSite(t *testing.T) {
+	// KSC site, 100 km radius; craft set down essentially on the pad.
+	o := Objective{Kind: KindLandAtBody, Params: Params{
+		PrimaryID: "earth", SiteLatDeg: 28.6, SiteLonDeg: -80.6, SiteRadiusM: 100e3,
+	}}
+	if got := o.Evaluate(landedCtx(28.61, -80.59)); got != Passed {
+		t.Fatalf("landed inside site radius: got %v, want Passed", got)
+	}
+}
+
+func TestLandAtBodyInProgressNotLanded(t *testing.T) {
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "earth"}}
+	ctx := landedCtx(12, 34)
+	ctx.Landed = false
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("not landed: got %v, want InProgress", got)
+	}
+}
+
+func TestLandAtBodyInProgressOutsideSite(t *testing.T) {
+	// KSC site, 100 km radius; craft set down at the equator/prime-meridian
+	// — thousands of km away.
+	o := Objective{Kind: KindLandAtBody, Params: Params{
+		PrimaryID: "earth", SiteLatDeg: 28.6, SiteLonDeg: -80.6, SiteRadiusM: 100e3,
+	}}
+	if got := o.Evaluate(landedCtx(0, 0)); got != InProgress {
+		t.Fatalf("landed outside site radius: got %v, want InProgress", got)
+	}
+}
+
+func TestLandAtBodyFrameMismatch(t *testing.T) {
+	// Landed, but the objective is for the Moon while the craft is on Earth.
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "moon"}}
+	if got := o.Evaluate(landedCtx(0, 0)); got != InProgress {
+		t.Fatalf("landed on earth, objective moon: got %v, want InProgress", got)
+	}
+}
+
+// TestGreatCircleDistance — sanity-check the haversine helper against the
+// classic ~111 km per degree of latitude on Earth.
+func TestGreatCircleDistance(t *testing.T) {
+	d := greatCircleDistanceM(0, 0, 1, 0, earthRadius)
+	want := earthRadius * math.Pi / 180 // 1° in radians × R
+	if math.Abs(d-want) > 1 {
+		t.Fatalf("1° of latitude: got %.1f m, want ~%.1f m", d, want)
+	}
+}
+
+// --- rendezvous {range_m, rel_speed_ms} : vs the targeted craft ---
+
+func TestRendezvousPassesWithinRangeAndSpeed(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 80, TargetRelSpeedMs: 0.3}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("80 m / 0.3 m/s vs 100 m / 0.5 m/s: got %v, want Passed", got)
+	}
+}
+
+func TestRendezvousInProgressTooFar(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 200, TargetRelSpeedMs: 0.1}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("200 m (too far): got %v, want InProgress", got)
+	}
+}
+
+func TestRendezvousInProgressTooFast(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 50, TargetRelSpeedMs: 2.0}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("2.0 m/s (too fast): got %v, want InProgress", got)
+	}
+}
+
+func TestRendezvousInProgressNoTarget(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	// No craft targeted — nothing to rendezvous with (frame-mismatch analogue).
+	ctx := EvalContext{HasTargetCraft: false, TargetRangeM: 0, TargetRelSpeedMs: 0}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("no target craft: got %v, want InProgress", got)
+	}
+}
+
+// --- dock {} : active craft is a docked composite ---
+
+func TestDockPassesWhenDocked(t *testing.T) {
+	o := Objective{Kind: KindDock}
+	if got := o.Evaluate(EvalContext{Docked: true}); got != Passed {
+		t.Fatalf("docked composite: got %v, want Passed", got)
+	}
+}
+
+func TestDockInProgressWhenUndocked(t *testing.T) {
+	o := Objective{Kind: KindDock}
+	if got := o.Evaluate(EvalContext{Docked: false}); got != InProgress {
+		t.Fatalf("not docked: got %v, want InProgress", got)
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -48,8 +48,12 @@ import (
 // binding. The v7→v8 migration derives each craft's SystemIdx from which
 // loaded System contains its PrimaryID (Sol/0 fallback), so existing Sol
 // craft and any craft spawned by the buggy interim Lumen build both
-// migrate correctly; see migrateV7PayloadToV8.
-const SchemaVersion = 8
+// migrate correctly; see migrateV7PayloadToV8. v0.21 bumps to v9
+// (ADR 0025) — the mission shape inverts from a single typed predicate to
+// a Mission of ordered Objectives + campaign metadata. The v8→v9 migration
+// re-seeds: it drops the old single-predicate progress so the load path
+// reseeds the new ladder from the catalog; see migrateV8PayloadToV9.
+const SchemaVersion = 9
 
 // File is the on-disk envelope.
 type File struct {
@@ -467,6 +471,13 @@ func Load(path string) (*sim.World, error) {
 	// alone. v8+ saves already carry SystemIdx and skip this.
 	if f.Version < 8 {
 		migrateV7PayloadToV8(&f.Payload, systems)
+	}
+	// v0.21 / schema v9 (ADR 0025): the mission shape inverted (single
+	// predicate → Mission of ordered Objectives). Drop the old
+	// single-predicate progress so worldFromPayload reseeds the new ladder
+	// from the catalog. Payload-only, so it runs here on the wire payload.
+	if f.Version < 9 {
+		migrateV8PayloadToV9(&f.Payload)
 	}
 	return worldFromPayload(f.Payload, systems)
 }
@@ -906,14 +917,15 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	// prime NextNodeID past every ID in play, so a post-load plant can't
 	// mint a colliding node ID. Mirrors EnsureCraftIDs above.
 	w.EnsureNodeIDs()
-	// v0.6.5: missions persist with status. v3+ saves carry an explicit
-	// (possibly-empty) Missions slice; v1/v2 saves wire-out as nil and
-	// get the embedded starter catalog seeded fresh so older saves
-	// gain the new feature without a manual edit. A failed catalog
-	// load is non-fatal — missions are additive.
+	// v0.6.5: missions persist with status. v9+ saves carry an explicit
+	// (possibly-empty) Missions slice in the nested shape; pre-v9 saves are
+	// re-seeded — migrateV8PayloadToV9 nils Missions so this branch loads
+	// the current ladder fresh (embedded + user overlay, via LoadAll,
+	// matching NewWorld). A failed catalog load is non-fatal — missions are
+	// additive.
 	if p.Missions != nil {
 		w.Missions = missions.Clone(p.Missions)
-	} else if cat, err := missions.DefaultCatalog(); err == nil {
+	} else if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 	return w, nil

--- a/internal/save/save_migrate_v8_to_v9.go
+++ b/internal/save/save_migrate_v8_to_v9.go
@@ -1,0 +1,24 @@
+// v0.21: schema v8 → v9 migration (ADR 0025). Pre-v9 saves model a
+// mission as a single typed predicate (the old missions.Mission shape:
+// type + params + a flat status). v0.21 inverts the vocabulary — a Mission
+// is now an ordered list of Objectives plus campaign metadata (program tag,
+// requires/unlocks edges, per-objective status) — so the on-disk shape
+// changes fundamentally.
+//
+// Field-migrating the old single-predicate progress into the new nested
+// shape would carry little value (the old catalog was four standalone
+// predicates with no ladder), so this is a re-seed migration: drop the old
+// mission state entirely. With Payload.Missions left nil, worldFromPayload
+// reseeds from the current catalog (embedded + user overlay), so the player
+// picks up the new tutorial→challenge ladder fresh. Ladder progression and
+// per-objective status persist going forward under v9.
+
+package save
+
+// migrateV8PayloadToV9 drops the pre-v0.21 single-predicate mission
+// progress so the load path reseeds the new Mission/Objective ladder from
+// the catalog. Operates on the payload alone, so it runs before
+// rehydration like the positional v6→v7 pass.
+func migrateV8PayloadToV9(p *Payload) {
+	p.Missions = nil
+}

--- a/internal/save/save_migrate_v8_to_v9_test.go
+++ b/internal/save/save_migrate_v8_to_v9_test.go
@@ -1,0 +1,25 @@
+package save
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// TestMigrateV8PayloadToV9DropsOldMissions — ADR 0025. A pre-v9 payload's
+// Missions are the old single-predicate shape (no nested objectives). The
+// Mission shape changed fundamentally, so the migration drops the
+// low-value old progress, leaving Missions nil so worldFromPayload
+// reseeds from the new catalog rather than rehydrating empty husks.
+func TestMigrateV8PayloadToV9DropsOldMissions(t *testing.T) {
+	p := &Payload{
+		Missions: []missions.Mission{
+			{ID: "old-circ", Name: "Old circularize", Status: missions.Passed},
+			{ID: "old-flyby", Name: "Old flyby", Status: missions.InProgress},
+		},
+	}
+	migrateV8PayloadToV9(p)
+	if p.Missions != nil {
+		t.Fatalf("expected Missions dropped to nil, got %d", len(p.Missions))
+	}
+}

--- a/internal/save/save_mission_v9_test.go
+++ b/internal/save/save_mission_v9_test.go
@@ -1,0 +1,136 @@
+package save_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestLoadV8SaveReseedsMissions — ADR 0025 soft save break. A pre-v0.21
+// (v8) save carries old single-predicate mission progress; loading it
+// under v9 drops that progress and reseeds the new ladder from the
+// catalog, so a previously "passed" mission comes back fresh in the new
+// nested shape.
+func TestLoadV8SaveReseedsMissions(t *testing.T) {
+	// Isolate from any real user overlay so the reseed is exactly the
+	// embedded starter catalog.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Rewrite the freshly-saved (v9) file to look like a pre-v0.21 v8
+	// save: downgrade the version and replace the mission array with the
+	// old single-predicate shape (type/params/status, no objectives), with
+	// the mission already Passed.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	doc["version"] = 8
+	payload := doc["payload"].(map[string]any)
+	payload["missions"] = []any{
+		map[string]any{
+			"id":     "leo-circularize-1000",
+			"name":   "Old circularize",
+			"type":   "circularize",
+			"status": 1, // Passed, in the old shape
+			"params": map[string]any{"primary_id": "earth", "altitude_m": 1000000},
+		},
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load v8 save: %v", err)
+	}
+
+	// Reseeded to the new nested catalog: every starter mission present,
+	// each with objectives, none carrying the dropped Passed progress.
+	if len(got.Missions) != 4 {
+		t.Fatalf("reseed: got %d missions, want 4 embedded starter missions", len(got.Missions))
+	}
+	for _, m := range got.Missions {
+		if len(m.Objectives) == 0 {
+			t.Errorf("reseeded mission %q has no objectives (old husk leaked through)", m.ID)
+		}
+		if m.Status != missions.InProgress {
+			t.Errorf("reseeded mission %q status = %v, want InProgress (old progress not dropped)", m.ID, m.Status)
+		}
+	}
+}
+
+// TestRoundtripV9MissionShape — a v9 save preserves the full nested
+// mission shape: program tag, requires edges, ordered objectives, and
+// per-objective status all survive Save→Load.
+func TestRoundtripV9MissionShape(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:          "rt-multi",
+		Name:        "Round trip",
+		Description: "two ordered steps",
+		Program:     "test-prog",
+		Requires:    []string{"leo-circularize-1000"},
+		Objectives: []missions.Objective{
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "moon"}, Status: missions.Passed},
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "mars"}, Status: missions.InProgress},
+		},
+		Status: missions.InProgress,
+	}}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(got.Missions) != 1 {
+		t.Fatalf("got %d missions, want 1", len(got.Missions))
+	}
+	m := got.Missions[0]
+	if m.ID != "rt-multi" || m.Program != "test-prog" {
+		t.Errorf("metadata lost: id=%q program=%q", m.ID, m.Program)
+	}
+	if len(m.Requires) != 1 || m.Requires[0] != "leo-circularize-1000" {
+		t.Errorf("requires lost: %v", m.Requires)
+	}
+	if len(m.Objectives) != 2 {
+		t.Fatalf("got %d objectives, want 2", len(m.Objectives))
+	}
+	if m.Objectives[0].Kind != missions.KindSOIFlyby || m.Objectives[0].Params.PrimaryID != "moon" {
+		t.Errorf("objective 0 lost: %+v", m.Objectives[0])
+	}
+	if m.Objectives[0].Status != missions.Passed {
+		t.Errorf("objective 0 status: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != missions.InProgress {
+		t.Errorf("objective 1 status: got %v, want InProgress", m.Objectives[1].Status)
+	}
+}

--- a/internal/sim/landed.go
+++ b/internal/sim/landed.go
@@ -47,13 +47,10 @@ func integrateLanded(w *World, c *spacecraft.Spacecraft, simDelta time.Duration)
 	// v0.11.4 shipped LandedLatDeg/LonDeg (soft-touchdown coords) but
 	// never wired them in here — a soft-landed craft was re-pinned to
 	// its launch site projected onto the arrival body (or (0,0) for an
-	// orbit-spawned craft). Prefer the touchdown coords when set; fall
-	// back to the launchpad-spawn coords otherwise. Matches the field's
-	// documented "when non-zero, read these instead" contract.
-	lat, lon := c.LaunchLatDeg, c.LaunchLonDeg
-	if c.LandedLatDeg != 0 || c.LandedLonDeg != 0 {
-		lat, lon = c.LandedLatDeg, c.LandedLonDeg
-	}
+	// orbit-spawned craft). SurfaceLatLon prefers the touchdown coords
+	// when set, else the launchpad-spawn coords (v0.21: shared with the
+	// mission evaluator so both pin to the same point).
+	lat, lon := c.SurfaceLatLon()
 	dirRender := render.BodyFixedToWorld(c.Primary, lat, lon, w.Clock.SimTime)
 	c.State.R = orbital.Vec3{
 		X: radius * dirRender.X,

--- a/internal/sim/mission_context_test.go
+++ b/internal/sim/mission_context_test.go
@@ -1,0 +1,149 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// v0.21 Slice 2 (ADR 0025) — the sim→missions seam. missionEvalContext
+// snapshots Active-Vessel + world state into the read-only EvalContext the
+// evaluator consumes. These tests prove every field is wired from real
+// World state (including the resource/outcome fields no kind reads yet).
+
+func TestMissionEvalContextSnapshotsActiveCraft(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// Arrange a distinctive landed + noded + targeted + staged state.
+	c.Landed = true
+	c.LandedLatDeg, c.LandedLonDeg = 28.6, -80.6
+	c.Crashed = false
+	c.Nodes = append(c.Nodes, ManeuverNode{PrimaryID: c.Primary.ID})
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: 1}
+	w.stagedThisSession = true
+
+	ctx := w.missionEvalContext()
+
+	if ctx.PrimaryID != c.Primary.ID {
+		t.Errorf("PrimaryID: got %q want %q", ctx.PrimaryID, c.Primary.ID)
+	}
+	if !ctx.Landed {
+		t.Error("Landed not propagated")
+	}
+	if ctx.SurfaceLatDeg != 28.6 || ctx.SurfaceLonDeg != -80.6 {
+		t.Errorf("surface coords: got (%v,%v) want (28.6,-80.6)", ctx.SurfaceLatDeg, ctx.SurfaceLonDeg)
+	}
+	if ctx.FuelKg != c.ActiveStageFuel() {
+		t.Errorf("FuelKg: got %v want %v", ctx.FuelKg, c.ActiveStageFuel())
+	}
+	if ctx.MonopropKg != c.Monoprop {
+		t.Errorf("MonopropKg: got %v want %v", ctx.MonopropKg, c.Monoprop)
+	}
+	if ctx.DvBudget != c.RemainingDeltaV() {
+		t.Errorf("DvBudget: got %v want %v", ctx.DvBudget, c.RemainingDeltaV())
+	}
+	if !ctx.HasNode {
+		t.Error("HasNode not set with a planted node")
+	}
+	if !ctx.HasTarget {
+		t.Error("HasTarget not set with a body target")
+	}
+	if !ctx.Staged {
+		t.Error("Staged not propagated")
+	}
+}
+
+// TestMissionEvalContextSurfaceFallsBackToLaunchSite — with no soft-touchdown
+// coords, the surface position falls back to the launchpad-spawn site
+// (mirrors integrateLanded).
+func TestMissionEvalContextSurfaceFallsBackToLaunchSite(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.LaunchLatDeg, c.LaunchLonDeg = 45, 10
+	c.LandedLatDeg, c.LandedLonDeg = 0, 0 // no touchdown coords
+
+	ctx := w.missionEvalContext()
+	if ctx.SurfaceLatDeg != 45 || ctx.SurfaceLonDeg != 10 {
+		t.Errorf("fallback to launch site: got (%v,%v) want (45,10)", ctx.SurfaceLatDeg, ctx.SurfaceLonDeg)
+	}
+}
+
+// TestMissionEvalContextRendezvousRelativeState — a craft target feeds the
+// instantaneous range / closing speed used by the rendezvous kind. A
+// co-located twin yields ~0 separation and ~0 relative speed.
+func TestMissionEvalContextRendezvousRelativeState(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	twin := *active // co-located second vessel, same primary/state
+	twin.ID = active.ID + 1000
+	w.Crafts = append(w.Crafts, &twin)
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: twin.ID}
+
+	ctx := w.missionEvalContext()
+	if !ctx.HasTargetCraft {
+		t.Fatal("HasTargetCraft not set with a craft target")
+	}
+	if ctx.TargetRangeM > 1 {
+		t.Errorf("co-located range: got %v m, want ~0", ctx.TargetRangeM)
+	}
+	if ctx.TargetRelSpeedMs > 0.001 {
+		t.Errorf("co-located rel speed: got %v m/s, want ~0", ctx.TargetRelSpeedMs)
+	}
+}
+
+// TestTickPassesLandAtBody — the integration path: a land_at_body mission
+// passes through Tick→evaluateMissions once the active craft is Landed on
+// the named primary.
+func TestTickPassesLandAtBody(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.Missions = []missions.Mission{{
+		ID: "land-anywhere",
+		Objectives: []missions.Objective{
+			{Kind: missions.KindLandAtBody, Params: missions.Params{PrimaryID: c.Primary.ID}},
+		},
+	}}
+	c.Landed = true
+	w.Tick()
+	if w.Missions[0].Status != missions.Passed {
+		t.Fatalf("land_at_body after landing: got %v, want Passed", w.Missions[0].Status)
+	}
+}
+
+// TestStageActiveLatchesStagedFlag — decoupling a stage latches the
+// session staged flag the outcome context reads.
+func TestStageActiveLatchesStagedFlag(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.stagedThisSession {
+		t.Fatal("stagedThisSession should start false")
+	}
+	c := w.ActiveCraft()
+	if len(c.Stages) < 2 {
+		// Give the active craft a second stage so StageActive has something
+		// to drop (the default loadout may be single-stage).
+		c.Stages = append([]spacecraft.Stage{c.Stages[0]}, c.Stages...)
+		c.SyncFields()
+	}
+	if _, _, err := w.StageActive(w.ActiveCraftIdx); err != nil {
+		t.Fatalf("StageActive: %v", err)
+	}
+	if !w.stagedThisSession {
+		t.Error("stagedThisSession not latched after StageActive")
+	}
+}

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -128,6 +128,7 @@ func (w *World) StageActive(craftIdx int) (newActiveIdx, jettisonedIdx int, err 
 	// upper chain). Slate ordering: active idx is unchanged; the
 	// jettisoned stage sits at the end.
 	newActiveIdx = craftIdx
+	w.stagedThisSession = true // mission outcome context (ADR 0025)
 	return newActiveIdx, jettisonedIdx, nil
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -186,6 +186,12 @@ type World struct {
 	// time; Status fields progress as the player flies. v0.6.5+.
 	Missions []missions.Mission
 
+	// stagedThisSession latches once the player decouples a stage; it
+	// feeds the mission evaluator's outcome context (ADR 0025). Session
+	// scoped (not persisted) — outcome objectives that need it land in a
+	// later slice. v0.21+.
+	stagedThisSession bool
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -633,16 +639,56 @@ func (w *World) evaluateMissions() {
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
 	}
-	ctx := missions.EvalContext{
-		PrimaryID:      w.ActiveCraft().Primary.ID,
-		PrimaryRadiusM: w.ActiveCraft().Primary.RadiusMeters(),
-		PrimaryMu:      w.ActiveCraft().Primary.GravitationalParameter(),
-		State:          w.ActiveCraft().State,
-		SimTime:        w.Clock.SimTime,
-	}
+	ctx := w.missionEvalContext()
 	for i := range w.Missions {
 		w.Missions[i].Evaluate(ctx)
 	}
+}
+
+// missionEvalContext snapshots the read-only slice of World state the
+// mission evaluator needs, all relative to the Active Vessel. Returns the
+// zero EvalContext when there's no active craft. The resource/outcome
+// fields (fuel, monoprop, Δv, crashed, node/target/staged flags) are
+// populated even though no v0.21 state-objective kind reads them yet — the
+// slice-3 failure semantics and slice-4 outcome steps depend on a complete
+// context. v0.21 (ADR 0025).
+func (w *World) missionEvalContext() missions.EvalContext {
+	c := w.ActiveCraft()
+	if c == nil {
+		return missions.EvalContext{}
+	}
+	// Surface coordinates: same source of truth integrateLanded pins to,
+	// so the mission evaluates against the craft's actual landed position.
+	lat, lon := c.SurfaceLatLon()
+	ctx := missions.EvalContext{
+		PrimaryID:      c.Primary.ID,
+		PrimaryRadiusM: c.Primary.RadiusMeters(),
+		PrimaryMu:      c.Primary.GravitationalParameter(),
+		State:          c.State,
+		SimTime:        w.Clock.SimTime,
+		Landed:         c.Landed,
+		SurfaceLatDeg:  lat,
+		SurfaceLonDeg:  lon,
+		Crashed:        c.Crashed,
+		FuelKg:         c.ActiveStageFuel(),
+		MonopropKg:     c.Monoprop,
+		DvBudget:       c.RemainingDeltaV(),
+		Docked:         len(c.DockedComponents) > 0,
+		HasNode:        len(c.Nodes) > 0,
+		HasTarget:      w.Target.Kind != spacecraft.TargetNone,
+		Staged:         w.stagedThisSession,
+	}
+	// Target-craft relative state (rendezvous), against the player's
+	// current target slot in the active craft's frame. Only when a craft
+	// (not a body) is targeted, so non-rendezvous play skips the solve.
+	if w.Target.Kind == spacecraft.TargetCraft {
+		if rT, vT, ok := w.TargetStateRelativeToActivePrimary(); ok {
+			ctx.HasTargetCraft = true
+			ctx.TargetRangeM = c.State.R.Sub(rT).Norm()
+			ctx.TargetRelSpeedMs = c.State.V.Sub(vT).Norm()
+		}
+	}
+	return ctx
 }
 
 // ActiveMission returns the first in-progress mission, or nil if all

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -267,10 +267,12 @@ func NewWorld() (*World, error) {
 	}
 	w.Calculator = orbital.ForSystem(w.System())
 
-	// v0.6.5: seed missions from the embedded starter catalog. A failure
-	// to load the catalog is non-fatal — missions are an additive
-	// feature and shouldn't block worldgen if the JSON is malformed.
-	if cat, err := missions.DefaultCatalog(); err == nil {
+	// v0.6.5: seed missions from the starter catalog. v0.21 (ADR 0025):
+	// LoadAll merges the embedded catalog with any user overlay and never
+	// hard-fails on a bad overlay file (it surfaces as a Failed
+	// placeholder mission), so this stays non-fatal — missions are an
+	// additive feature and shouldn't block worldgen.
+	if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 
@@ -622,9 +624,11 @@ type DockEvent struct {
 	CompositeName string // name of the resulting composite craft
 }
 
-// evaluateMissions steps each mission's predicate against the live
-// craft state. Terminal-state missions are evaluated too, but their
-// status is sticky in missions.Mission.Evaluate. v0.6.5+.
+// evaluateMissions steps each mission against the live craft state.
+// Mission.Evaluate walks the mission's ordered objectives, mutating
+// per-objective and per-mission Status in place; terminal states are
+// sticky, so missions already Passed/Failed are cheap no-ops. v0.6.5+;
+// v0.21 (ADR 0025) the unit is a Mission of ordered Objectives.
 func (w *World) evaluateMissions() {
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
@@ -637,7 +641,7 @@ func (w *World) evaluateMissions() {
 		SimTime:        w.Clock.SimTime,
 	}
 	for i := range w.Missions {
-		w.Missions[i].Status = w.Missions[i].Evaluate(ctx)
+		w.Missions[i].Evaluate(ctx)
 	}
 }
 

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -348,8 +348,13 @@ func TestTickPassesCircularizeAtTarget(t *testing.T) {
 
 	var found *missions.Mission
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularize {
-			found = &w.Missions[i]
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularize {
+				found = &w.Missions[i]
+				break
+			}
+		}
+		if found != nil {
 			break
 		}
 	}

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -400,6 +400,20 @@ func (s *Spacecraft) EffectiveThrottle() float64 {
 // TotalMass returns dry + fuel + monoprop.
 func (s *Spacecraft) TotalMass() float64 { return s.DryMass + s.Fuel + s.Monoprop }
 
+// SurfaceLatLon returns the craft's body-fixed surface coordinates in
+// degrees (north-positive, east-positive): the soft-touchdown coords when
+// set, else the launchpad-spawn coords ("when non-zero, read these
+// instead"). Meaningful when the craft is Landed. Single source of truth
+// for both the landed-integration pin (sim.integrateLanded) and the
+// mission evaluator's surface position (sim.missionEvalContext). v0.21+.
+func (s *Spacecraft) SurfaceLatLon() (lat, lon float64) {
+	lat, lon = s.LaunchLatDeg, s.LaunchLonDeg
+	if s.LandedLatDeg != 0 || s.LandedLonDeg != 0 {
+		lat, lon = s.LandedLatDeg, s.LandedLonDeg
+	}
+	return lat, lon
+}
+
 // DefaultBallisticCoefficient is the v0.8.4 baseline (C_D · A / m)
 // for an S-IVB-1-class craft in m²/kg. Used as the fallback when
 // Spacecraft.BallisticCoefficient is zero — legacy saves and any

--- a/internal/spacecraft/spacecraft_test.go
+++ b/internal/spacecraft/spacecraft_test.go
@@ -30,3 +30,19 @@ func TestNewInLEO(t *testing.T) {
 		t.Errorf("orbital speed = %.1f m/s, want ~7613 m/s", v)
 	}
 }
+
+// TestSurfaceLatLon — touchdown coords win when set; otherwise the
+// launchpad-spawn coords are used (the "when non-zero, read these instead"
+// fallback shared by integrateLanded and the mission evaluator).
+func TestSurfaceLatLon(t *testing.T) {
+	s := &Spacecraft{LaunchLatDeg: 28.6, LaunchLonDeg: -80.6}
+	// No touchdown coords → falls back to the launch site.
+	if lat, lon := s.SurfaceLatLon(); lat != 28.6 || lon != -80.6 {
+		t.Errorf("fallback: got (%v,%v), want (28.6,-80.6)", lat, lon)
+	}
+	// Touchdown coords set → they win.
+	s.LandedLatDeg, s.LandedLonDeg = -5, 120
+	if lat, lon := s.SurfaceLatLon(); lat != -5 || lon != 120 {
+		t.Errorf("touchdown: got (%v,%v), want (-5,120)", lat, lon)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2213,21 +2213,26 @@ func formatDurationShort(sec float64) string {
 // string when no such mission is in flight. v0.9.4+.
 func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
 	for _, m := range w.Missions {
-		if m.Type != missions.TypeCircularizeFromPad {
-			continue
-		}
 		if m.Status == missions.Passed {
 			continue
 		}
-		if m.Params.PrimaryID != c.Primary.ID {
-			continue
+		for _, o := range m.Objectives {
+			if o.Kind != missions.KindCircularizeFromPad {
+				continue
+			}
+			if o.Status == missions.Passed {
+				continue
+			}
+			if o.Params.PrimaryID != c.Primary.ID {
+				continue
+			}
+			target := o.Params.MinPeriapsisAltM
+			if target <= 0 {
+				target = launchMissionFloorM
+			}
+			return fmt.Sprintf("mission:    pe %s / %s target",
+				formatAltKm(periAltM), formatAltKm(target))
 		}
-		target := m.Params.MinPeriapsisAltM
-		if target <= 0 {
-			target = launchMissionFloorM
-		}
-		return fmt.Sprintf("mission:    pe %s / %s target",
-			formatAltKm(periAltM), formatAltKm(target))
 	}
 	return ""
 }

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -103,8 +103,10 @@ func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 		t.Fatal("expected active craft from NewWorld")
 	}
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularizeFromPad {
-			w.Missions[i].Status = missions.Passed
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularizeFromPad {
+				w.Missions[i].Status = missions.Passed
+			}
 		}
 	}
 	if got := launchMissionProgress(w, c, 130_000); got != "" {


### PR DESCRIPTION
## v0.21 Slice 2 — EvalContext + state-objective vocabulary (ADR 0025)

**Stacked on #171 (Slice 1).** Review/merge #171 first; this PR's base is the Slice 1 branch, so its own diff is just the Slice 2 commit.

Implements the locked **9-kind** state-objective vocabulary by adding the five new kinds alongside the existing four. All instantaneous current-state checks (dwell stays deferred to v0.22).

| Kind | Predicate | Params |
|---|---|---|
| `reach_altitude` | primary match & `R−radius ≥ min` | `min_altitude_m` |
| `land_at_body` | primary match & `Landed` & (no site, or within great-circle `site_radius_m`) | `site_lat_deg`,`site_lon_deg`,`site_radius_m` |
| `rendezvous` | `range ≤ range_m` AND `|v_rel| ≤ rel_speed_ms` vs the **targeted** craft | `range_m`,`rel_speed_ms` |
| `dock` | active craft is a docked composite | — |
| `return_to_body` | primary match AND (bound orbit `e<1` OR `Landed`) — captured-or-landed, not a hyperbolic flyby | uses `primary_id` |

### EvalContext + the sim seam
`EvalContext` gains the full plan-listed read-only surface: `Landed` + surface lat/lon, target-craft relative range/speed, `Docked`, plus the resource/outcome fields (`FuelKg`/`MonopropKg`/`DvBudget`, `Crashed`, `HasNode`/`HasTarget`/`Staged`) — wired now so Slice 3 (failure) and Slice 4 (outcome) read a complete context; no v0.21 kind consumes them yet.

The seam is a new testable `World.missionEvalContext()` builder. Landed surface coords now come from a shared `Spacecraft.SurfaceLatLon()` — single source of truth for both `integrateLanded` and the evaluator (replaces a duplicated fallback; review fix). Rel-state is solved only when a craft is targeted. A session `staged` flag latches in `StageActive`.

### Design notes
- **`rendezvous`/`dock` use the current world Target slot**, not a catalog-named craft — runtime craft IDs (monotonic `uint64`) aren't authorable in a static JSON catalog, so ADR §3's `target_craft` param is deferred (additive later).
- **No catalog content** (that's Slice 6); **no save break** (no schema change).

### Tests / gates
Per-kind pass / not-yet / frame-mismatch, haversine sanity, the sim builder (every field), `land_at_body` through `Tick`, and `SurfaceLatLon` precedence. `go vet` clean · `go test ./... -race` → **1192 passed, 16 packages** · multi-agent `/code-review` run; two findings fixed (shared `SurfaceLatLon`, craft-target guard), the rest refuted or pre-existing.

Refs: ADR 0025 §3, `v0.21-plan.md` §"Slice 2".