### PR TITLE
feat(missions): tutorial + challenge ladder catalog + real requires gating (ADR 0025 Slice 6)

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -96,6 +96,7 @@ readout shows you why before you watch it fall back.
 | `F1` | Toggle the help overlay (scroll it with `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End`) |
 | `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
 | `i` | Body info screen |
+| `M` | Mission ladder — your program / objective progress, with the active mission's checklist and locked rungs shown with what unlocks them (same screen as the `[Missions]` button) |
 | `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
 | `0` | Pause / resume |
 | `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn) |
@@ -172,7 +173,7 @@ Click only — no dragging, no scroll-to-zoom.
 |---|---|
 | `[»Burn]` (top-right) | Toggle auto-warp to the next burn (same as `G`). Shows `[■Burn]` while running, dimmed when no burn is planned |
 | `[Menu]` (top-right) | Save / load / settings / controls / quit menu |
-| `[Missions]` (top-right) | Mission list with pass / fail marks |
+| `[Missions]` (top-right) | Mission ladder — active mission checklist on top, the rest of the program below with locked rungs and pass / fail marks (same as `M`) |
 | A body | Follow it with the camera (same as cursoring onto it) |
 | A craft | Follow it with the camera |
 | A planned burn | Open the planner for that burn (its fire time is kept) |

--- a/internal/missions/catalog_integrity_test.go
+++ b/internal/missions/catalog_integrity_test.go
@@ -1,0 +1,86 @@
+package missions
+
+import "testing"
+
+// TestEmbeddedCatalogIntegrity guards the hand-authored embedded ladder
+// (v0.21 Slice 6) against the silent-failure modes the typed-kind schema is
+// prone to: a typo'd kind or event action sits inert (never passes), and a
+// requires edge to a missing mission — or a cycle — leaves a rung
+// permanently locked. Pinning these in a test catches an authoring slip the
+// compiler can't.
+func TestEmbeddedCatalogIntegrity(t *testing.T) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+
+	validKinds := map[Kind]bool{
+		KindCircularize: true, KindOrbitInsertion: true, KindSOIFlyby: true,
+		KindCircularizeFromPad: true, KindReachAltitude: true, KindLandAtBody: true,
+		KindRendezvous: true, KindDock: true, KindReturnToBody: true, KindEvent: true,
+	}
+	validActions := map[Action]bool{
+		ActionThrottleFull: true, ActionThrottleCut: true, ActionThrottleUp: true,
+		ActionThrottleDown: true, ActionOpenManeuver: true, ActionPlanTransfer: true,
+		ActionPlanCircularize: true, ActionPlanIncl: true, ActionPlanRendezvous: true,
+		ActionRefinePlan: true, ActionClearNodes: true, ActionToggleBurn: true,
+		ActionStage: true, ActionCycleTarget: true, ActionClearTarget: true,
+		ActionCycleView: true, ActionCycleNavMode: true, ActionAutoWarp: true,
+		ActionSpawnCraft: true, ActionUndock: true, ActionTranspose: true,
+	}
+
+	ids := make(map[string]bool, len(cat.Missions))
+	for _, m := range cat.Missions {
+		if ids[m.ID] {
+			t.Errorf("duplicate mission id %q", m.ID)
+		}
+		ids[m.ID] = true
+	}
+
+	for _, m := range cat.Missions {
+		for _, req := range m.Requires {
+			if !ids[req] {
+				t.Errorf("mission %q requires unknown mission %q", m.ID, req)
+			}
+		}
+		for j, o := range m.Objectives {
+			if !validKinds[o.Kind] {
+				t.Errorf("mission %q objective %d has unknown kind %q", m.ID, j, o.Kind)
+			}
+			// An event objective with an unknown (or empty) action can never
+			// fire — the player would be stuck on a step that nothing matches.
+			if o.Kind == KindEvent && !validActions[o.Params.Action] {
+				t.Errorf("mission %q objective %d (event) has unknown action %q", m.ID, j, o.Params.Action)
+			}
+		}
+	}
+
+	// Every mission must be reachable: resolve requires by Kahn's algorithm
+	// (repeatedly mark missions whose prerequisites are all marked). Anything
+	// left unmarked is in a cycle or depends on a dangling prerequisite.
+	resolved := make(map[string]bool, len(cat.Missions))
+	for progress := true; progress; {
+		progress = false
+		for _, m := range cat.Missions {
+			if resolved[m.ID] {
+				continue
+			}
+			ok := true
+			for _, req := range m.Requires {
+				if !resolved[req] {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				resolved[m.ID] = true
+				progress = true
+			}
+		}
+	}
+	for _, m := range cat.Missions {
+		if !resolved[m.ID] {
+			t.Errorf("mission %q is unreachable (requires cycle or dangling prerequisite)", m.ID)
+		}
+	}
+}

--- a/internal/missions/event_test.go
+++ b/internal/missions/event_test.go
@@ -1,0 +1,99 @@
+package missions
+
+import "testing"
+
+// v0.21 Slice 4 (ADR 0025 §6/§7) — the event objective family. An event
+// objective matches a semantic gameplay Action that fired *while it was
+// active*. The sink (ctx.RecentActions) holds actions recorded since the last
+// tick and is drained each tick by the sim, so an action fired before the
+// objective became active was already drained and cannot latch it.
+
+// TestEventObjectivePassesOnMatchingAction — the matching action in the
+// since-last-tick sink passes the objective.
+func TestEventObjectivePassesOnMatchingAction(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionStage}}
+	ctx := EvalContext{RecentActions: []Action{ActionThrottleFull, ActionStage}}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("stage in sink: got %v, want Passed", got)
+	}
+}
+
+// TestEventObjectiveInProgressWithoutAction — no action, or only non-matching
+// actions, leaves it InProgress.
+func TestEventObjectiveInProgressWithoutAction(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionStage}}
+	if got := o.Evaluate(EvalContext{}); got != InProgress {
+		t.Fatalf("empty sink: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionThrottleFull, ActionCycleView}}); got != InProgress {
+		t.Fatalf("non-matching actions: got %v, want InProgress", got)
+	}
+}
+
+// TestEventObjectiveEmptyActionInert — an event objective with no Action param
+// never passes (a misconfigured catalog entry sits inert, never matching the
+// empty string against recorded actions).
+func TestEventObjectiveEmptyActionInert(t *testing.T) {
+	o := Objective{Kind: KindEvent}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{"", ActionStage}}); got != InProgress {
+		t.Fatalf("empty Action param: got %v, want InProgress", got)
+	}
+}
+
+// TestEventMissionSinceActiveWindow — the defining contract: an event
+// objective passes ONLY when its action fires during its active window. A
+// two-step event mission (stage -> open_maneuver) must not let an
+// open_maneuver fired BEFORE step 1 passed satisfy step 2; step 2 needs its
+// own open_maneuver after it becomes active. This mirrors the per-tick drain
+// the sim performs (each Evaluate call here gets a fresh "tick" of actions).
+func TestEventMissionSinceActiveWindow(t *testing.T) {
+	m := Mission{
+		ID: "stage-then-maneuver",
+		Objectives: []Objective{
+			{Kind: KindEvent, Params: Params{Action: ActionStage}},
+			{Kind: KindEvent, Params: Params{Action: ActionOpenManeuver}},
+		},
+	}
+	// Tick 1: player opens the maneuver planner before staging. Step 1
+	// (stage) doesn't match; step 2 is locked and never sees this action.
+	if got := m.Evaluate(EvalContext{RecentActions: []Action{ActionOpenManeuver}}); got != InProgress {
+		t.Fatalf("tick 1 (open before stage): got %v, want InProgress", got)
+	}
+	if m.Objectives[1].Status == Passed {
+		t.Fatal("step 2 latched on an open_maneuver fired before it was active")
+	}
+	// Tick 2: player stages. Step 1 passes. Step 2 becomes active this tick,
+	// but the only action present is stage (open_maneuver was drained with
+	// tick 1), so step 2 must stay InProgress.
+	if got := m.Evaluate(EvalContext{RecentActions: []Action{ActionStage}}); got != InProgress {
+		t.Fatalf("tick 2 (stage): got %v, want InProgress", got)
+	}
+	if m.Objectives[0].Status != Passed {
+		t.Fatalf("step 1 after stage: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != InProgress {
+		t.Fatalf("step 2 after stage: got %v, want InProgress (needs its own open_maneuver)", m.Objectives[1].Status)
+	}
+	// Tick 3: player opens the maneuver planner again, now while step 2 is
+	// active. Step 2 passes, completing the mission.
+	if got := m.Evaluate(EvalContext{RecentActions: []Action{ActionOpenManeuver}}); got != Passed {
+		t.Fatalf("tick 3 (open while step 2 active): got %v, want Passed", got)
+	}
+}
+
+// TestEventObjectiveSameTickPassThrough — when step 1's action and step 2's
+// action both fire in the same tick, the ordered pass-through still lets both
+// pass that tick (step 1 passes, step 2 is evaluated the same tick against the
+// same action set). Pins the same-tick behaviour explicitly.
+func TestEventObjectiveSameTickPassThrough(t *testing.T) {
+	m := Mission{
+		ID: "two-events",
+		Objectives: []Objective{
+			{Kind: KindEvent, Params: Params{Action: ActionStage}},
+			{Kind: KindEvent, Params: Params{Action: ActionToggleBurn}},
+		},
+	}
+	if got := m.Evaluate(EvalContext{RecentActions: []Action{ActionStage, ActionToggleBurn}}); got != Passed {
+		t.Fatalf("both actions same tick: got %v, want Passed", got)
+	}
+}

--- a/internal/missions/failure_test.go
+++ b/internal/missions/failure_test.go
@@ -1,0 +1,224 @@
+package missions
+
+import "testing"
+
+// v0.21 Slice 3 (ADR 0025 §5) — opt-in failure semantics. An Objective may
+// declare fail_on conditions (crashed, out_of_fuel); declaring nothing means
+// it never fails (retry forever). This is the first code path that produces
+// Failed. Evaluation is against the Active Vessel (per-craft binding deferred
+// to v0.22), so these predicates read the same ctx the live evaluator builds.
+
+// TestObjectiveNoFailOnNeverFails — the default contract: an objective with
+// no fail_on never transitions to Failed, even when both crash and
+// out-of-fuel conditions are present in the context. (Half of the slice's
+// "done when".)
+func TestObjectiveNoFailOnNeverFails(t *testing.T) {
+	o := Objective{Kind: KindReachAltitude, Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9}}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 100e3), // nowhere near 1e9 floor
+		Crashed:        true,
+		TotalFuelKg:    0,
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("no fail_on with crash + empty tanks: got %v, want InProgress", got)
+	}
+}
+
+// TestObjectiveFailOnCrashed — a fail_on: [crashed] objective Fails the
+// moment the active craft is Crashed, and stays InProgress otherwise.
+// (The other half of the slice's "done when".)
+func TestObjectiveFailOnCrashed(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9},
+		FailOn: []FailCondition{FailCrashed},
+	}
+	base := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 100e3),
+	}
+	notCrashed := base
+	if got := o.Evaluate(notCrashed); got != InProgress {
+		t.Fatalf("intact craft below floor: got %v, want InProgress", got)
+	}
+	crashed := base
+	crashed.Crashed = true
+	if got := o.Evaluate(crashed); got != Failed {
+		t.Fatalf("crashed craft: got %v, want Failed", got)
+	}
+}
+
+// TestObjectiveOnlyDeclaredConditionsFire — fail conditions are opt-in per
+// condition: a craft that is Crashed does NOT fail an objective whose fail_on
+// only lists out_of_fuel.
+func TestObjectiveOnlyDeclaredConditionsFire(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9},
+		FailOn: []FailCondition{FailOutOfFuel},
+	}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 100e3),
+		Crashed:        true, // undeclared for this objective
+		TotalFuelKg:    500,  // still has propellant
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("crash with only out_of_fuel declared: got %v, want InProgress", got)
+	}
+}
+
+// TestObjectiveFailOnOutOfFuel — a fail_on: [out_of_fuel] objective Fails when
+// the craft has no propellant left, and stays InProgress while it has fuel.
+func TestObjectiveFailOnOutOfFuel(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9},
+		FailOn: []FailCondition{FailOutOfFuel},
+	}
+	base := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 100e3),
+	}
+	withFuel := base
+	withFuel.TotalFuelKg = 1200
+	if got := o.Evaluate(withFuel); got != InProgress {
+		t.Fatalf("with fuel below floor: got %v, want InProgress", got)
+	}
+	dry := base
+	dry.TotalFuelKg = 0
+	if got := o.Evaluate(dry); got != Failed {
+		t.Fatalf("dry tanks: got %v, want Failed", got)
+	}
+}
+
+// TestObjectiveOutOfFuelUsesTotalNotActiveStage — the multi-stage footgun:
+// out_of_fuel must read TOTAL propellant across all stages, not the active
+// (bottom) stage. A Saturn-V-style craft whose bottom stage is spent
+// (FuelKg == 0) but with full upper stages (TotalFuelKg > 0) is NOT out of
+// fuel — staging would continue the flight.
+func TestObjectiveOutOfFuelUsesTotalNotActiveStage(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9},
+		FailOn: []FailCondition{FailOutOfFuel},
+	}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 100e3),
+		FuelKg:         0,       // bottom stage spent...
+		TotalFuelKg:    549_000, // ...but upper stages full
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("bottom stage dry, upper stages full: got %v, want InProgress", got)
+	}
+}
+
+// TestObjectivePassBeatsFailSameTick — pass takes precedence over fail on the
+// same tick: achieving the goal wins even when a fail condition is also met.
+// A craft that lands on the target body with empty tanks PASSES land_at_body
+// (it accomplished the landing) rather than failing out_of_fuel.
+func TestObjectivePassBeatsFailSameTick(t *testing.T) {
+	o := Objective{
+		Kind:   KindLandAtBody,
+		Params: Params{PrimaryID: "earth"},
+		FailOn: []FailCondition{FailOutOfFuel},
+	}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		Landed:         true,
+		TotalFuelKg:    0, // out of fuel, but already landed
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("landed with empty tanks: got %v, want Passed (pass beats fail)", got)
+	}
+}
+
+// TestObjectiveFailOnStickyTerminal — once Failed, an objective stays Failed
+// regardless of later context (mirrors Passed idempotency), so the per-tick
+// caller can blindly re-evaluate.
+func TestObjectiveFailOnStickyTerminal(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 1e9},
+		FailOn: []FailCondition{FailCrashed},
+		Status: Failed,
+	}
+	// Context with no crash and even a satisfied goal must not un-fail it.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 2e9), // above the floor
+	}
+	if got := o.Evaluate(ctx); got != Failed {
+		t.Fatalf("Failed objective should stay Failed, got %v", got)
+	}
+}
+
+// TestCloneDeepCopiesFailOn — Clone must give each cloned objective its own
+// FailOn backing array, so mutating a seeded mission's fail conditions can't
+// bleed back into the shared embedded catalog (Clone's deep-copy contract).
+func TestCloneDeepCopiesFailOn(t *testing.T) {
+	src := []Mission{{
+		ID: "m",
+		Objectives: []Objective{{
+			Kind:   KindReachAltitude,
+			FailOn: []FailCondition{FailCrashed},
+		}},
+	}}
+	dup := Clone(src)
+	if len(dup[0].Objectives[0].FailOn) == 0 {
+		t.Fatal("test setup: cloned objective lost its FailOn")
+	}
+	dup[0].Objectives[0].FailOn[0] = FailOutOfFuel
+	if src[0].Objectives[0].FailOn[0] != FailCrashed {
+		t.Fatal("Clone shares FailOn backing memory with source")
+	}
+}
+
+// TestMissionFailsWhenActiveObjectiveFailsOn — the rollup: a fail_on condition
+// on the in-progress objective fails the whole Mission (the existing terminal
+// rollup), and the failure is sticky.
+func TestMissionFailsWhenActiveObjectiveFailsOn(t *testing.T) {
+	m := Mission{
+		ID: "crash-fails",
+		Objectives: []Objective{
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: "moon"}}, // step 1
+			{ // step 2 — fails on crash
+				Kind:   KindReachAltitude,
+				Params: Params{PrimaryID: "moon", MinAltitudeM: 1e9},
+				FailOn: []FailCondition{FailCrashed},
+			},
+		},
+	}
+	// Tick 1 at the Moon, intact: step 1 passes, step 2 is now active but
+	// below its floor — mission still in progress.
+	if got := m.Evaluate(EvalContext{PrimaryID: "moon", PrimaryRadiusM: moonRadius, PrimaryMu: moonMu, State: circularState(moonRadius, moonMu, 100e3)}); got != InProgress {
+		t.Fatalf("after moon flyby, intact: got %v, want InProgress", got)
+	}
+	if m.Objectives[0].Status != Passed {
+		t.Fatalf("step 1: got %v, want Passed", m.Objectives[0].Status)
+	}
+	// Tick 2: crash while step 2 is active — the mission fails.
+	crash := EvalContext{PrimaryID: "moon", PrimaryRadiusM: moonRadius, PrimaryMu: moonMu, State: circularState(moonRadius, moonMu, 100e3), Crashed: true}
+	if got := m.Evaluate(crash); got != Failed {
+		t.Fatalf("crash on active fail_on objective: got %v, want Failed", got)
+	}
+	// Sticky: a later clean tick keeps the mission Failed.
+	if got := m.Evaluate(EvalContext{PrimaryID: "moon"}); got != Failed {
+		t.Fatalf("mission should stay Failed, got %v", got)
+	}
+}

--- a/internal/missions/loader.go
+++ b/internal/missions/loader.go
@@ -1,0 +1,126 @@
+package missions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadWarning reports a user-overlay file that couldn't be loaded. The
+// embedded starter catalog must always load — a parse failure there is a
+// hard error, not a warning. Mirrors bodies.LoadWarning.
+type LoadWarning struct {
+	Path string
+	Err  error
+}
+
+func (w LoadWarning) Error() string {
+	return fmt.Sprintf("%s: %v", w.Path, w.Err)
+}
+
+// LoadAll returns the embedded starter catalog merged with any user
+// overlay files from $XDG_CONFIG_HOME/terminal-space-program/missions/*.json
+// (or ~/.config/... if XDG is unset). Warnings from malformed user files
+// are dropped — call LoadAllWithWarnings to inspect them. A malformed
+// overlay file still leaves a Failed-status placeholder mission in the
+// catalog so the player sees it in-game. Mirrors bodies.LoadAll.
+func LoadAll() (Catalog, error) {
+	cat, _, err := LoadAllWithWarnings()
+	return cat, err
+}
+
+// LoadAllWithWarnings is the warning-aware variant of LoadAll. The
+// returned warnings slice contains a LoadWarning for any user overlay
+// file that failed to read or parse; a malformed embedded catalog surfaces
+// as a hard error (the err value) since the embedded set must always load.
+//
+// A bad user file never fails the whole catalog (ADR 0025): it is appended
+// as a single Failed-status mission whose description carries the parse
+// error, fixing the archived "stderr line you didn't see" gap. User
+// missions whose ID matches an embedded mission win on the match;
+// otherwise they're appended.
+func LoadAllWithWarnings() (Catalog, []LoadWarning, error) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		return Catalog{}, nil, err
+	}
+	merged, warnings := mergeUserOverlay(cat.Missions, userMissionsDir())
+	cat.Missions = merged
+	return cat, warnings, nil
+}
+
+func mergeUserOverlay(base []Mission, dir string) ([]Mission, []LoadWarning) {
+	if dir == "" {
+		return base, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Missing dir is fine — the overlay is optional. Other I/O errors
+		// (permissions, etc.) surface as a warning on the dir path; we
+		// can't enumerate files, so there's no per-file placeholder.
+		if os.IsNotExist(err) {
+			return base, nil
+		}
+		return base, []LoadWarning{{Path: dir, Err: err}}
+	}
+	var warnings []LoadWarning
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		uc, err := LoadCatalog(data)
+		if err != nil {
+			warnings = append(warnings, LoadWarning{Path: path, Err: err})
+			base = append(base, failedMissionFromFile(path, err))
+			continue
+		}
+		for _, m := range uc.Missions {
+			base = upsertMission(base, m)
+		}
+	}
+	return base, warnings
+}
+
+// failedMissionFromFile turns an unloadable overlay file into a single
+// Failed-status placeholder mission so the problem is visible in-game
+// rather than dropped to stderr.
+func failedMissionFromFile(path string, err error) Mission {
+	base := filepath.Base(path)
+	return Mission{
+		ID:          "invalid:" + base,
+		Name:        "Invalid mission file: " + base,
+		Description: err.Error(),
+		Status:      Failed,
+	}
+}
+
+// upsertMission appends m, or replaces an existing mission with the same
+// ID (user files win on ID match).
+func upsertMission(base []Mission, m Mission) []Mission {
+	for i := range base {
+		if base[i].ID == m.ID {
+			base[i] = m
+			return base
+		}
+	}
+	return append(base, m)
+}
+
+func userMissionsDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "missions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "terminal-space-program", "missions")
+}

--- a/internal/missions/loader_test.go
+++ b/internal/missions/loader_test.go
@@ -47,8 +47,9 @@ func TestLoadAllNoOverlay(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %v", warnings)
 	}
-	if len(cat.Missions) != 4 {
-		t.Errorf("expected 4 embedded missions, got %d", len(cat.Missions))
+	base, _ := DefaultCatalog()
+	if len(cat.Missions) != len(base.Missions) {
+		t.Errorf("expected %d embedded missions, got %d", len(base.Missions), len(cat.Missions))
 	}
 }
 
@@ -74,7 +75,7 @@ func TestLoadAllMergesUserOverlay(t *testing.T) {
 		t.Errorf("user mission objectives not parsed: %+v", m.Objectives)
 	}
 	// Embedded missions survive alongside the overlay.
-	if _, ok := missionByID(cat, "mars-soi-flyby"); !ok {
+	if _, ok := missionByID(cat, "chal-mars-flyby"); !ok {
 		t.Error("embedded mission dropped after overlay merge")
 	}
 }
@@ -84,17 +85,18 @@ func TestLoadAllMergesUserOverlay(t *testing.T) {
 // count doesn't grow.
 func TestLoadAllUserOverrideByID(t *testing.T) {
 	writeOverlay(t, map[string]string{
-		"override.json": `{"missions":[{"id":"mars-soi-flyby","name":"Mars flyby (custom)",
+		"override.json": `{"missions":[{"id":"chal-mars-flyby","name":"Mars flyby (custom)",
 			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"mars"}}]}]}`,
 	})
 	cat, _, err := LoadAllWithWarnings()
 	if err != nil {
 		t.Fatalf("LoadAllWithWarnings: %v", err)
 	}
-	if len(cat.Missions) != 4 {
-		t.Errorf("override grew the catalog: got %d missions, want 4", len(cat.Missions))
+	base, _ := DefaultCatalog()
+	if len(cat.Missions) != len(base.Missions) {
+		t.Errorf("override grew the catalog: got %d missions, want %d", len(cat.Missions), len(base.Missions))
 	}
-	m, ok := missionByID(cat, "mars-soi-flyby")
+	m, ok := missionByID(cat, "chal-mars-flyby")
 	if !ok {
 		t.Fatal("overridden mission missing")
 	}
@@ -119,8 +121,8 @@ func TestLoadAllBadFileBecomesFailedMission(t *testing.T) {
 	if len(warnings) == 0 {
 		t.Error("expected a warning for the malformed overlay file")
 	}
-	// All four embedded missions still present.
-	for _, id := range []string{"leo-circularize-1000", "luna-orbit-insertion", "mars-soi-flyby", "saturn-v-pad-to-leo"} {
+	// A representative spread of embedded missions still present.
+	for _, id := range []string{"tut-orient", "chal-high-orbit", "chal-mars-flyby", "chal-pad-to-leo"} {
 		if _, ok := missionByID(cat, id); !ok {
 			t.Errorf("embedded mission %q dropped by a bad overlay file", id)
 		}
@@ -154,7 +156,8 @@ func TestLoadAllDropsWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadAll: %v", err)
 	}
-	if len(cat.Missions) != 5 { // 4 embedded + 1 Failed placeholder
-		t.Errorf("got %d missions, want 5 (4 embedded + 1 failed placeholder)", len(cat.Missions))
+	base, _ := DefaultCatalog()
+	if len(cat.Missions) != len(base.Missions)+1 { // embedded + 1 Failed placeholder
+		t.Errorf("got %d missions, want %d (embedded + 1 failed placeholder)", len(cat.Missions), len(base.Missions)+1)
 	}
 }

--- a/internal/missions/loader_test.go
+++ b/internal/missions/loader_test.go
@@ -1,0 +1,160 @@
+package missions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeOverlay points XDG_CONFIG_HOME at a temp dir and writes name→json
+// files into its terminal-space-program/missions overlay dir, returning
+// the overlay dir path. Mirrors the bodies overlay convention.
+func writeOverlay(t *testing.T, files map[string]string) string {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "terminal-space-program", "missions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir overlay: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func missionByID(cat Catalog, id string) (Mission, bool) {
+	for _, m := range cat.Missions {
+		if m.ID == id {
+			return m, true
+		}
+	}
+	return Mission{}, false
+}
+
+// TestLoadAllNoOverlay — with no user overlay dir, LoadAll returns just
+// the embedded starter catalog and no warnings.
+func TestLoadAllNoOverlay(t *testing.T) {
+	// Point XDG at an empty temp dir so the overlay dir is absent.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("expected 4 embedded missions, got %d", len(cat.Missions))
+	}
+}
+
+// TestLoadAllMergesUserOverlay — a valid user mission file is appended to
+// the embedded catalog.
+func TestLoadAllMergesUserOverlay(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"custom.json": `{"missions":[{"id":"user-venus-flyby","name":"Venus flyby",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"venus"}}]}]}`,
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	m, ok := missionByID(cat, "user-venus-flyby")
+	if !ok {
+		t.Fatalf("user mission not merged; got %d missions", len(cat.Missions))
+	}
+	if len(m.Objectives) != 1 || m.Objectives[0].Kind != KindSOIFlyby {
+		t.Errorf("user mission objectives not parsed: %+v", m.Objectives)
+	}
+	// Embedded missions survive alongside the overlay.
+	if _, ok := missionByID(cat, "mars-soi-flyby"); !ok {
+		t.Error("embedded mission dropped after overlay merge")
+	}
+}
+
+// TestLoadAllUserOverrideByID — a user mission whose ID matches an
+// embedded one replaces it (user files win on ID match), and the total
+// count doesn't grow.
+func TestLoadAllUserOverrideByID(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"override.json": `{"missions":[{"id":"mars-soi-flyby","name":"Mars flyby (custom)",
+			"objectives":[{"kind":"soi_flyby","params":{"primary_id":"mars"}}]}]}`,
+	})
+	cat, _, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings: %v", err)
+	}
+	if len(cat.Missions) != 4 {
+		t.Errorf("override grew the catalog: got %d missions, want 4", len(cat.Missions))
+	}
+	m, ok := missionByID(cat, "mars-soi-flyby")
+	if !ok {
+		t.Fatal("overridden mission missing")
+	}
+	if m.Name != "Mars flyby (custom)" {
+		t.Errorf("user override didn't win: name = %q", m.Name)
+	}
+}
+
+// TestLoadAllBadFileBecomesFailedMission — a malformed user file never
+// fails the whole catalog: it surfaces as one Failed-status mission whose
+// description carries the parse error, plus a warning, while the embedded
+// missions all load. (ADR 0025 — fixes the "stderr line you didn't see"
+// gap.)
+func TestLoadAllBadFileBecomesFailedMission(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `{"missions":[{"id":"oops",`, // truncated JSON
+	})
+	cat, warnings, err := LoadAllWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadAllWithWarnings should not hard-fail on a bad overlay: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected a warning for the malformed overlay file")
+	}
+	// All four embedded missions still present.
+	for _, id := range []string{"leo-circularize-1000", "luna-orbit-insertion", "mars-soi-flyby", "saturn-v-pad-to-leo"} {
+		if _, ok := missionByID(cat, id); !ok {
+			t.Errorf("embedded mission %q dropped by a bad overlay file", id)
+		}
+	}
+	// The bad file is represented by exactly one Failed-status mission.
+	var failed []Mission
+	for _, m := range cat.Missions {
+		if m.Status == Failed {
+			failed = append(failed, m)
+		}
+	}
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 Failed placeholder mission, got %d", len(failed))
+	}
+	if !strings.Contains(failed[0].Name, "broken.json") {
+		t.Errorf("Failed mission name should name the file: %q", failed[0].Name)
+	}
+	if failed[0].Description == "" {
+		t.Error("Failed mission should carry the parse error in its description")
+	}
+}
+
+// TestLoadAllDropsWarnings — the convenience LoadAll wraps
+// LoadAllWithWarnings and swallows warnings but still returns the merged
+// catalog (including any Failed placeholder).
+func TestLoadAllDropsWarnings(t *testing.T) {
+	writeOverlay(t, map[string]string{
+		"broken.json": `not json at all`,
+	})
+	cat, err := LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(cat.Missions) != 5 { // 4 embedded + 1 Failed placeholder
+		t.Errorf("got %d missions, want 5 (4 embedded + 1 failed placeholder)", len(cat.Missions))
+	}
+}

--- a/internal/missions/loader_test.go
+++ b/internal/missions/loader_test.go
@@ -122,7 +122,7 @@ func TestLoadAllBadFileBecomesFailedMission(t *testing.T) {
 		t.Error("expected a warning for the malformed overlay file")
 	}
 	// A representative spread of embedded missions still present.
-	for _, id := range []string{"tut-orient", "chal-high-orbit", "chal-mars-flyby", "chal-pad-to-leo"} {
+	for _, id := range []string{"tut-orient", "chal-high-orbit", "chal-mars-flyby", "chal-dock"} {
 		if _, ok := missionByID(cat, id); !ok {
 			t.Errorf("embedded mission %q dropped by a bad overlay file", id)
 		}

--- a/internal/missions/mission_eval_test.go
+++ b/internal/missions/mission_eval_test.go
@@ -1,0 +1,96 @@
+package missions
+
+import "testing"
+
+// Mission.Evaluate is the v0.21 container behaviour: it rolls an ordered
+// list of Objectives up into a single Mission status. These tests pin the
+// sequencing contract (ADR 0025 §2) using soi_flyby objectives, whose
+// pass condition is just "current primary == target" — so a single
+// EvalContext can satisfy or withhold each step deterministically.
+
+// flybyMission returns a fresh two-step mission: flyby A, then flyby B.
+func flybyMission(a, b string) Mission {
+	return Mission{
+		ID: "test-flyby",
+		Objectives: []Objective{
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: a}},
+			{Kind: KindSOIFlyby, Params: Params{PrimaryID: b}},
+		},
+	}
+}
+
+// TestMissionOrderedSecondDoesNotLatchEarly — the defining ordered
+// behaviour: even when the SECOND objective's condition is already
+// satisfied, it must not pass while the FIRST is still in progress.
+func TestMissionOrderedSecondDoesNotLatchEarly(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	// At Mars: objective 2 (mars) would pass on its own, but objective 1
+	// (moon) hasn't, so ordering must hold both back.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("mission status: got %v, want InProgress", got)
+	}
+	if m.Objectives[1].Status == Passed {
+		t.Fatal("second objective latched before the first passed")
+	}
+}
+
+// TestMissionPassesAfterObjectivesPassInOrder — the mission passes only
+// once every objective has passed, in sequence across ticks.
+func TestMissionPassesAfterObjectivesPassInOrder(t *testing.T) {
+	m := flybyMission("moon", "mars")
+
+	// Tick 1 at the Moon: objective 1 passes; objective 2 is evaluated the
+	// same tick (its predecessor passed) but the craft isn't at Mars yet.
+	if got := m.Evaluate(EvalContext{PrimaryID: "moon"}); got != InProgress {
+		t.Fatalf("after moon flyby: got %v, want InProgress", got)
+	}
+	if m.Objectives[0].Status != Passed {
+		t.Fatalf("objective 1 after moon flyby: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != InProgress {
+		t.Fatalf("objective 2 after moon flyby: got %v, want InProgress", m.Objectives[1].Status)
+	}
+
+	// Tick 2 at Mars: objective 2 passes, completing the mission.
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("after mars flyby: got %v, want Passed", got)
+	}
+	if m.Objectives[1].Status != Passed {
+		t.Fatalf("objective 2 after mars flyby: got %v, want Passed", m.Objectives[1].Status)
+	}
+}
+
+// TestMissionStickyOnTerminal — a Passed mission stays Passed regardless
+// of later context (mirrors Objective idempotency).
+func TestMissionStickyOnTerminal(t *testing.T) {
+	m := flybyMission("moon", "mars")
+	m.Status = Passed
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != Passed {
+		t.Fatalf("sticky terminal: got %v, want Passed", got)
+	}
+}
+
+// TestMissionEmptyNeverPasses — a mission with no objectives is never
+// complete; it can't accidentally roll up to Passed on an empty loop.
+func TestMissionEmptyNeverPasses(t *testing.T) {
+	m := Mission{ID: "empty"}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != InProgress {
+		t.Fatalf("empty mission: got %v, want InProgress", got)
+	}
+}
+
+// TestMissionSingleObjectiveBehavesLikePredicate — the embedded starter
+// catalog wraps each legacy predicate in a one-objective mission; that
+// shape must behave exactly like the old single predicate.
+func TestMissionSingleObjectiveBehavesLikePredicate(t *testing.T) {
+	m := Mission{
+		ID:         "single",
+		Objectives: []Objective{{Kind: KindSOIFlyby, Params: Params{PrimaryID: "mars"}}},
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "earth"}); got != InProgress {
+		t.Fatalf("not at mars: got %v, want InProgress", got)
+	}
+	if got := m.Evaluate(EvalContext{PrimaryID: "mars"}); got != Passed {
+		t.Fatalf("at mars: got %v, want Passed", got)
+	}
+}

--- a/internal/missions/mission_helpers_test.go
+++ b/internal/missions/mission_helpers_test.go
@@ -115,6 +115,18 @@ func TestMissionFailedObjective(t *testing.T) {
 	}
 }
 
+func TestObjectiveLabel(t *testing.T) {
+	if got := (Objective{Name: "n", Description: "d", Kind: KindDock}).Label(); got != "n" {
+		t.Errorf("name-priority label = %q, want n", got)
+	}
+	if got := (Objective{Description: "d", Kind: KindDock}).Label(); got != "d" {
+		t.Errorf("description-fallback label = %q, want d", got)
+	}
+	if got := (Objective{Kind: KindDock}).Label(); got != "dock" {
+		t.Errorf("kind-fallback label = %q, want dock", got)
+	}
+}
+
 func TestFailConditionLabel(t *testing.T) {
 	if got := FailCrashed.Label(); got != "crashed" {
 		t.Errorf("FailCrashed label = %q, want crashed", got)

--- a/internal/missions/mission_helpers_test.go
+++ b/internal/missions/mission_helpers_test.go
@@ -1,0 +1,125 @@
+package missions
+
+import "testing"
+
+// These cover the v0.21 Slice 5 player-surface helpers: the pure
+// progress / current-objective / requirement-gating / fail-reason
+// accessors the ladder screen and checklist chip read. They never touch
+// the tui or sim — same dependency boundary as the rest of the package.
+
+func threeStep() Mission {
+	return Mission{
+		ID: "three",
+		Objectives: []Objective{
+			{Kind: KindSOIFlyby, Name: "step 1", Params: Params{PrimaryID: "a"}},
+			{Kind: KindSOIFlyby, Name: "step 2", Params: Params{PrimaryID: "b"}},
+			{Kind: KindSOIFlyby, Name: "step 3", Params: Params{PrimaryID: "c"}},
+		},
+	}
+}
+
+func TestMissionProgress(t *testing.T) {
+	m := threeStep()
+	if p, total := m.Progress(); p != 0 || total != 3 {
+		t.Fatalf("fresh mission progress = %d/%d, want 0/3", p, total)
+	}
+	m.Objectives[0].Status = Passed
+	if p, total := m.Progress(); p != 1 || total != 3 {
+		t.Fatalf("one-passed progress = %d/%d, want 1/3", p, total)
+	}
+	m.Objectives[1].Status = Passed
+	m.Objectives[2].Status = Passed
+	if p, total := m.Progress(); p != 3 || total != 3 {
+		t.Fatalf("all-passed progress = %d/%d, want 3/3", p, total)
+	}
+	// A Failed objective is not Passed, so it does not count toward progress.
+	m.Objectives[2].Status = Failed
+	if p, total := m.Progress(); p != 2 || total != 3 {
+		t.Fatalf("with-failed progress = %d/%d, want 2/3", p, total)
+	}
+}
+
+func TestMissionCurrentObjective(t *testing.T) {
+	m := threeStep()
+	// Fresh: the first objective is current.
+	if o, ok := m.CurrentObjective(); !ok || o.Name != "step 1" {
+		t.Fatalf("fresh current = %q ok=%v, want step 1 true", o.Name, ok)
+	}
+	// Pass the first: the second becomes current.
+	m.Objectives[0].Status = Passed
+	if o, ok := m.CurrentObjective(); !ok || o.Name != "step 2" {
+		t.Fatalf("after one passed, current = %q ok=%v, want step 2 true", o.Name, ok)
+	}
+	// All passed: no current objective.
+	m.Objectives[1].Status = Passed
+	m.Objectives[2].Status = Passed
+	if o, ok := m.CurrentObjective(); ok {
+		t.Fatalf("all passed current = %q ok=%v, want !ok", o.Name, ok)
+	}
+	// Empty mission: no current objective.
+	if _, ok := (Mission{ID: "empty"}).CurrentObjective(); ok {
+		t.Fatal("empty mission reported a current objective")
+	}
+}
+
+func TestMissionRequirementsMet(t *testing.T) {
+	// No requirements → always met (ungated rung).
+	if !(Mission{ID: "free"}).RequirementsMet(nil) {
+		t.Fatal("no-requirements mission should be unlocked")
+	}
+	m := Mission{ID: "gated", Requires: []string{"a", "b"}}
+	if m.RequirementsMet(map[string]bool{"a": true}) {
+		t.Fatal("missing requirement b should keep the rung locked")
+	}
+	if !m.RequirementsMet(map[string]bool{"a": true, "b": true}) {
+		t.Fatal("all requirements present should unlock the rung")
+	}
+	// A required ID present-but-false (shouldn't happen — the set holds only
+	// Passed IDs — but be defensive) counts as unmet.
+	if m.RequirementsMet(map[string]bool{"a": true, "b": false}) {
+		t.Fatal("present-but-false requirement should not unlock")
+	}
+}
+
+func TestObjectiveFailReason(t *testing.T) {
+	crash := Objective{Kind: KindCircularize, FailOn: []FailCondition{FailCrashed}}
+	if fc, ok := crash.FailReason(EvalContext{Crashed: true}); !ok || fc != FailCrashed {
+		t.Fatalf("crashed reason = %q ok=%v, want crashed true", fc, ok)
+	}
+	if _, ok := crash.FailReason(EvalContext{Crashed: false}); ok {
+		t.Fatal("not crashed should report no fail reason")
+	}
+	fuel := Objective{Kind: KindCircularize, FailOn: []FailCondition{FailOutOfFuel}}
+	if fc, ok := fuel.FailReason(EvalContext{TotalFuelKg: 0}); !ok || fc != FailOutOfFuel {
+		t.Fatalf("dry reason = %q ok=%v, want out_of_fuel true", fc, ok)
+	}
+	if _, ok := fuel.FailReason(EvalContext{TotalFuelKg: 10}); ok {
+		t.Fatal("fuel remaining should report no fail reason")
+	}
+	// No opt-in conditions → never a reason, even when crashed and dry.
+	none := Objective{Kind: KindCircularize}
+	if _, ok := none.FailReason(EvalContext{Crashed: true, TotalFuelKg: 0}); ok {
+		t.Fatal("no fail_on objective should never report a fail reason")
+	}
+}
+
+func TestMissionFailedObjective(t *testing.T) {
+	m := threeStep()
+	if _, ok := m.FailedObjective(); ok {
+		t.Fatal("no objective failed yet")
+	}
+	m.Objectives[1].Status = Failed
+	o, ok := m.FailedObjective()
+	if !ok || o.Name != "step 2" {
+		t.Fatalf("failed objective = %q ok=%v, want step 2 true", o.Name, ok)
+	}
+}
+
+func TestFailConditionLabel(t *testing.T) {
+	if got := FailCrashed.Label(); got != "crashed" {
+		t.Errorf("FailCrashed label = %q, want crashed", got)
+	}
+	if got := FailOutOfFuel.Label(); got != "out of fuel" {
+		t.Errorf("FailOutOfFuel label = %q, want 'out of fuel'", got)
+	}
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -64,6 +64,14 @@ const (
 	KindOrbitInsertion     Kind = "orbit_insertion"
 	KindSOIFlyby           Kind = "soi_flyby"
 	KindCircularizeFromPad Kind = "circularize_from_pad" // v0.9.2+
+
+	// v0.21 (ADR 0025 §3) — the new state-objective vocabulary. All are
+	// instantaneous current-state checks; dwell is deferred to v0.22.
+	KindReachAltitude Kind = "reach_altitude"
+	KindLandAtBody    Kind = "land_at_body"
+	KindRendezvous    Kind = "rendezvous"
+	KindDock          Kind = "dock"
+	KindReturnToBody  Kind = "return_to_body"
 )
 
 // Params is the union of parameters across all objective kinds. Each
@@ -94,6 +102,25 @@ type Params struct {
 	// LEO counts the same as a 200 × 200 km circular one.
 	// v0.9.2+.
 	MinPeriapsisAltM float64 `json:"min_periapsis_alt_m,omitempty"`
+
+	// MinAltitudeM is the minimum altitude above the primary's mean
+	// radius (m) for ReachAltitude to pass. v0.21+.
+	MinAltitudeM float64 `json:"min_altitude_m,omitempty"`
+
+	// SiteLatDeg / SiteLonDeg / SiteRadiusM constrain LandAtBody to a
+	// target landing zone: the touchdown must lie within SiteRadiusM
+	// (great-circle metres) of (SiteLatDeg, SiteLonDeg). Coordinates are
+	// north-positive, east-positive. When SiteRadiusM is zero the kind
+	// accepts a landing anywhere on the body. v0.21+.
+	SiteLatDeg  float64 `json:"site_lat_deg,omitempty"`
+	SiteLonDeg  float64 `json:"site_lon_deg,omitempty"`
+	SiteRadiusM float64 `json:"site_radius_m,omitempty"`
+
+	// RangeM / RelSpeedMs are the Rendezvous gates: the active craft must
+	// be within RangeM metres of the targeted craft AND closing slower
+	// than RelSpeedMs metres/second. v0.21+.
+	RangeM     float64 `json:"range_m,omitempty"`
+	RelSpeedMs float64 `json:"rel_speed_ms,omitempty"`
 }
 
 // Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
@@ -116,6 +143,39 @@ type EvalContext struct {
 	PrimaryMu      float64             // craft primary's GM
 	State          physics.StateVector // craft state in primary frame
 	SimTime        time.Time           // current sim time
+
+	// v0.21 (ADR 0025) surface/landing state. Landed is the ADR 0004
+	// surface-contact flag; SurfaceLatDeg/LonDeg are the craft's
+	// body-fixed touchdown coordinates (north-positive, east-positive),
+	// valid when Landed. Read by land_at_body and return_to_body.
+	Landed        bool
+	SurfaceLatDeg float64
+	SurfaceLonDeg float64
+
+	// v0.21 (ADR 0025) target-craft relative state, against the player's
+	// current target slot. HasTargetCraft is false when no craft is
+	// targeted; TargetRangeM / TargetRelSpeedMs are the instantaneous
+	// separation and closing speed. Read by rendezvous.
+	HasTargetCraft   bool
+	TargetRangeM     float64
+	TargetRelSpeedMs float64
+
+	// Docked is true when the active craft is a docked composite (it has
+	// fused with at least one other vessel). Read by dock. v0.21+.
+	Docked bool
+
+	// v0.21 (ADR 0025) resource + outcome snapshot. These are wired now so
+	// the slice-3 failure semantics (out_of_fuel / crashed) and slice-4
+	// outcome steps read a complete context; no v0.21 state-objective kind
+	// consumes them yet. FuelKg is the active stage's propellant; DvBudget
+	// is the active stage's remaining Δv (m/s).
+	FuelKg     float64
+	MonopropKg float64
+	DvBudget   float64
+	Crashed    bool
+	HasNode    bool // active craft has at least one planted maneuver node
+	HasTarget  bool // a body or craft is selected in the world target slot
+	Staged     bool // the player has decoupled a stage this session
 }
 
 // Evaluate steps the objective one tick and returns the new status.
@@ -134,6 +194,115 @@ func (o Objective) Evaluate(ctx EvalContext) Status {
 		return evalSOIFlyby(o.Params, ctx)
 	case KindCircularizeFromPad:
 		return evalCircularizeFromPad(o.Params, ctx)
+	case KindReachAltitude:
+		return evalReachAltitude(o.Params, ctx)
+	case KindReturnToBody:
+		return evalReturnToBody(o.Params, ctx)
+	case KindLandAtBody:
+		return evalLandAtBody(o.Params, ctx)
+	case KindRendezvous:
+		return evalRendezvous(o.Params, ctx)
+	case KindDock:
+		return evalDock(o.Params, ctx)
+	}
+	return InProgress
+}
+
+// evalDock: pass when the active craft is a docked composite. Grounded in
+// the durable composite state (DockedComponents) rather than the ephemeral
+// dock event, keeping the check instantaneous. The optional target_craft
+// param (ADR 0025 §3) is deferred — any dock satisfies the kind. v0.21+.
+func evalDock(_ Params, ctx EvalContext) Status {
+	if ctx.Docked {
+		return Passed
+	}
+	return InProgress
+}
+
+// evalRendezvous: pass when a craft is targeted and the active craft is
+// within RangeM metres of it AND closing slower than RelSpeedMs. Evaluated
+// against the player's current target slot rather than a catalog-named
+// craft, since runtime craft IDs aren't authorable in a static catalog.
+// v0.21+.
+func evalRendezvous(p Params, ctx EvalContext) Status {
+	if !ctx.HasTargetCraft {
+		return InProgress
+	}
+	if ctx.TargetRangeM <= p.RangeM && ctx.TargetRelSpeedMs <= p.RelSpeedMs {
+		return Passed
+	}
+	return InProgress
+}
+
+// evalLandAtBody: pass when the craft is Landed on the named primary. An
+// optional site (SiteRadiusM > 0) further requires the touchdown to lie
+// within SiteRadiusM great-circle metres of (SiteLatDeg, SiteLonDeg);
+// without a site, landing anywhere on the body passes. v0.21+.
+func evalLandAtBody(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if !ctx.Landed {
+		return InProgress
+	}
+	if p.SiteRadiusM <= 0 {
+		return Passed
+	}
+	d := greatCircleDistanceM(ctx.SurfaceLatDeg, ctx.SurfaceLonDeg, p.SiteLatDeg, p.SiteLonDeg, ctx.PrimaryRadiusM)
+	if d <= p.SiteRadiusM {
+		return Passed
+	}
+	return InProgress
+}
+
+// greatCircleDistanceM returns the surface distance (metres) between two
+// lat/lon points (degrees) on a sphere of the given radius, via the
+// haversine formula.
+func greatCircleDistanceM(lat1, lon1, lat2, lon2, radiusM float64) float64 {
+	const deg2rad = math.Pi / 180
+	phi1 := lat1 * deg2rad
+	phi2 := lat2 * deg2rad
+	dPhi := (lat2 - lat1) * deg2rad
+	dLambda := (lon2 - lon1) * deg2rad
+	a := math.Sin(dPhi/2)*math.Sin(dPhi/2) +
+		math.Cos(phi1)*math.Cos(phi2)*math.Sin(dLambda/2)*math.Sin(dLambda/2)
+	return radiusM * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}
+
+// evalReturnToBody: pass when the craft has "come back" to the named body
+// — its current primary matches AND it is either captured (a bound orbit,
+// e < 1) or Landed. A hyperbolic whizz-through of the SOI is not a return.
+// The there-and-back sequencing comes from the Mission's ordering; this
+// predicate just confirms the craft actually stayed. v0.21+.
+func evalReturnToBody(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.Landed {
+		return Passed
+	}
+	if ctx.PrimaryMu == 0 {
+		return InProgress
+	}
+	el := orbital.ElementsFromState(ctx.State.R, ctx.State.V, ctx.PrimaryMu)
+	if el.A <= 0 || math.IsNaN(el.A) || math.IsInf(el.A, 0) {
+		return InProgress
+	}
+	if el.E >= 1 {
+		return InProgress
+	}
+	return Passed
+}
+
+// evalReachAltitude: pass when the craft is in the named primary's frame
+// and its current altitude above the primary's mean radius reaches the
+// floor. A pure radial check — orbit shape is irrelevant. v0.21+.
+func evalReachAltitude(p Params, ctx EvalContext) Status {
+	if ctx.PrimaryID != p.PrimaryID {
+		return InProgress
+	}
+	if ctx.State.R.Norm()-ctx.PrimaryRadiusM >= p.MinAltitudeM {
+		return Passed
 	}
 	return InProgress
 }

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -74,6 +74,27 @@ const (
 	KindReturnToBody  Kind = "return_to_body"
 )
 
+// FailCondition is an opt-in trigger that transitions an InProgress
+// Objective to Failed (ADR 0025 §5, v0.21 — the first code path that
+// produces Failed). An Objective declares zero or more on its FailOn
+// list; declaring none means it never fails (retry forever). Like Kind,
+// the string values are part of the modder-facing schema — renaming one
+// breaks community catalogs. Both conditions read the Active Vessel
+// (per-craft binding is deferred to a v0.22 ADR amendment).
+type FailCondition string
+
+const (
+	// FailCrashed fails when the active craft is Crashed (the ADR 0004
+	// destructive surface-contact signal).
+	FailCrashed FailCondition = "crashed"
+	// FailOutOfFuel fails when the active craft has no main propellant
+	// left in ANY stage (TotalFuelKg <= 0). It reads the summed all-stage
+	// fuel, not the active stage, so a multi-stage craft whose bottom
+	// stage is spent but whose upper stages are full is not "out of fuel"
+	// — staging would continue the flight. RCS monoprop is excluded.
+	FailOutOfFuel FailCondition = "out_of_fuel"
+)
+
 // Params is the union of parameters across all objective kinds. Each
 // kind reads only the fields it cares about; the rest stay zero.
 type Params struct {
@@ -132,6 +153,12 @@ type Objective struct {
 	Kind        Kind   `json:"kind"`
 	Params      Params `json:"params"`
 	Status      Status `json:"status,omitempty"`
+
+	// FailOn is the opt-in set of conditions that fail this objective
+	// while it is InProgress (ADR 0025 §5, v0.21). Empty (the default)
+	// means the objective never fails. Additive to the v9 save shape
+	// (omitempty), so no schema bump. v0.21+.
+	FailOn []FailCondition `json:"fail_on,omitempty"`
 }
 
 // EvalContext is the minimum slice of World state an objective predicate
@@ -164,27 +191,50 @@ type EvalContext struct {
 	// fused with at least one other vessel). Read by dock. v0.21+.
 	Docked bool
 
-	// v0.21 (ADR 0025) resource + outcome snapshot. These are wired now so
-	// the slice-3 failure semantics (out_of_fuel / crashed) and slice-4
-	// outcome steps read a complete context; no v0.21 state-objective kind
-	// consumes them yet. FuelKg is the active stage's propellant; DvBudget
-	// is the active stage's remaining Δv (m/s).
-	FuelKg     float64
-	MonopropKg float64
-	DvBudget   float64
-	Crashed    bool
-	HasNode    bool // active craft has at least one planted maneuver node
-	HasTarget  bool // a body or craft is selected in the world target slot
-	Staged     bool // the player has decoupled a stage this session
+	// v0.21 (ADR 0025) resource + outcome snapshot. FuelKg is the active
+	// (bottom) stage's propellant; DvBudget is the active stage's remaining
+	// Δv (m/s); no v0.21 state-objective kind consumes either yet (slice-4
+	// outcome steps will). TotalFuelKg is the summed main propellant across
+	// ALL stages — the signal the out_of_fuel fail condition reads, since a
+	// spent bottom stage with full upper stages is not stranded (staging
+	// continues the flight). Crashed is the ADR 0004 destructive-contact
+	// flag read by the crashed fail condition.
+	FuelKg      float64
+	MonopropKg  float64
+	DvBudget    float64
+	TotalFuelKg float64
+	Crashed     bool
+	HasNode     bool // active craft has at least one planted maneuver node
+	HasTarget   bool // a body or craft is selected in the world target slot
+	Staged      bool // the player has decoupled a stage this session
 }
 
 // Evaluate steps the objective one tick and returns the new status.
 // Idempotent on terminal states (Passed/Failed return immediately).
 // Does not mutate the receiver — the caller owns the status.
+//
+// Pass takes precedence over fail on the same tick: a terminal status from
+// the kind predicate (today only Passed) wins even when a declared fail
+// condition is also met — achieving the goal beats, say, running the tanks
+// dry on touchdown. Only while the kind reports InProgress do the opt-in
+// fail_on conditions apply (ADR 0025 §5, v0.21).
 func (o Objective) Evaluate(ctx EvalContext) Status {
 	if o.Status != InProgress {
 		return o.Status
 	}
+	if s := o.evalKind(ctx); s != InProgress {
+		return s
+	}
+	if o.failOnTriggered(ctx) {
+		return Failed
+	}
+	return InProgress
+}
+
+// evalKind dispatches to the per-kind state predicate. An unknown kind
+// stays InProgress so an unrecognised catalog entry sits inert rather than
+// spuriously passing.
+func (o Objective) evalKind(ctx EvalContext) Status {
 	switch o.Kind {
 	case KindCircularize:
 		return evalCircularize(o.Params, ctx)
@@ -206,6 +256,25 @@ func (o Objective) Evaluate(ctx EvalContext) Status {
 		return evalDock(o.Params, ctx)
 	}
 	return InProgress
+}
+
+// failOnTriggered reports whether any of the objective's declared fail
+// conditions is currently met. An objective with no FailOn never triggers
+// (ADR 0025 §5: declare nothing → never fails, retry forever).
+func (o Objective) failOnTriggered(ctx EvalContext) bool {
+	for _, fc := range o.FailOn {
+		switch fc {
+		case FailCrashed:
+			if ctx.Crashed {
+				return true
+			}
+		case FailOutOfFuel:
+			if ctx.TotalFuelKg <= 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // evalDock: pass when the active craft is a docked composite. Grounded in
@@ -412,9 +481,9 @@ type Mission struct {
 // a later step can't latch before its predecessor (e.g. you can't
 // "return" before you "land"). An Objective that just Passed this tick
 // lets the next one be evaluated the same tick. The Mission Passes when
-// every Objective has Passed; it Fails the moment any Objective Fails (no
-// Objective produces Failed until the slice-3 failure semantics land). A
-// Mission with no Objectives never passes.
+// every Objective has Passed; it Fails the moment any Objective Fails —
+// which an objective does when one of its opt-in fail_on conditions fires
+// (ADR 0025 §5, v0.21). A Mission with no Objectives never passes.
 func (m *Mission) Evaluate(ctx EvalContext) Status {
 	if m.Status != InProgress {
 		return m.Status
@@ -459,9 +528,9 @@ func LoadCatalog(data []byte) (Catalog, error) {
 // Clone returns a deep copy of the mission slice. Used when seeding
 // World.Missions from a catalog so per-session status progression
 // doesn't mutate the shared template. The per-Mission Objectives /
-// Requires / Unlocks slices are copied too — a shallow copy would let a
-// cloned mission's objective-status mutation bleed back into the
-// embedded catalog.
+// Requires / Unlocks slices are copied too — and each Objective's FailOn
+// slice — because a shallow copy would let a cloned mission's mutation
+// bleed back into the embedded catalog.
 func Clone(ms []Mission) []Mission {
 	if len(ms) == 0 {
 		return nil
@@ -470,6 +539,9 @@ func Clone(ms []Mission) []Mission {
 	for i := range ms {
 		out[i] = ms[i]
 		out[i].Objectives = append([]Objective(nil), ms[i].Objectives...)
+		for j := range out[i].Objectives {
+			out[i].Objectives[j].FailOn = append([]FailCondition(nil), ms[i].Objectives[j].FailOn...)
+		}
 		out[i].Requires = append([]string(nil), ms[i].Requires...)
 		out[i].Unlocks = append([]string(nil), ms[i].Unlocks...)
 	}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -217,6 +217,20 @@ type Objective struct {
 	FailOn []FailCondition `json:"fail_on,omitempty"`
 }
 
+// Label returns the player-facing one-line label for an objective: its Name,
+// falling back to its Description, then to the raw Kind string. The player
+// surface (the checklist chip and the ladder card) shares this so an objective
+// authored with only a Description renders the same on both. v0.21 Slice 6.
+func (o Objective) Label() string {
+	if o.Name != "" {
+		return o.Name
+	}
+	if o.Description != "" {
+		return o.Description
+	}
+	return string(o.Kind)
+}
+
 // EvalContext is the minimum slice of World state an objective predicate
 // needs. Lifted out of sim so the missions package can depend only on
 // orbital/physics and avoid an import cycle. (Slice 2 expands this.)

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -1,21 +1,23 @@
-// Package missions defines pass/fail objectives evaluated against the
-// live sim state each Tick. v0.6.5+.
+// Package missions defines pass/fail Objectives and the Missions that
+// bundle them, evaluated against the live sim state each Tick.
 //
-// A Mission is a typed predicate over the spacecraft's current
-// (primary, state, sim-time) tuple. Three predicate kinds ship in the
-// v0.6.5 starter catalog:
+// Vocabulary (ADR 0025, v0.21 — a deliberate inversion of the pre-v0.21
+// naming, where a single predicate was called a "Mission"):
 //
-//   - Circularize: craft is in the named primary's frame, orbit is
-//     bound, eccentricity ≤ cap, and semimajor axis is within ±tol of
-//     target altitude (radius + altitude_m).
-//   - OrbitInsertion: craft is in the named primary's frame on a
-//     bound orbit (e < 1).
-//   - SOIFlyby: any tick where the craft's current primary ID matches
-//     the named body.
+//   - Objective — the atomic pass/fail predicate over the spacecraft's
+//     current (primary, state, sim-time) tuple. Four instantaneous kinds
+//     ship today (circularize, orbit_insertion, soi_flyby,
+//     circularize_from_pad); the v0.21 vocabulary grows in later slices.
+//   - Mission — an ordered list of Objectives plus campaign metadata
+//     (a `program` tag and `requires`/`unlocks` edges). The player sees a
+//     Mission as a checklist of sub-steps; the Mission carries the
+//     sequencing memory so each Objective stays memoryless. "Luna landing
+//     & return" is one Mission whose ordered Objectives are
+//     [land_at_luna] → [return_to_earth].
 //
-// Status is a three-state machine (InProgress → Passed | Failed).
-// Terminal states are sticky: Evaluate is idempotent on Passed/Failed
-// missions, so the per-tick caller can blindly walk all missions
+// Status is a three-state machine (InProgress → Passed | Failed) at both
+// levels. Terminal states are sticky: Evaluate is idempotent on
+// Passed/Failed, so the per-tick caller can blindly walk everything
 // without filtering.
 package missions
 
@@ -29,7 +31,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
-// Status is the mission state machine.
+// Status is the objective/mission state machine.
 type Status int
 
 const (
@@ -51,18 +53,20 @@ func (s Status) String() string {
 	return "?"
 }
 
-// Type discriminates the predicate kind. Stored in JSON as a string
-// so the catalog stays human-editable without leaking enum integers.
-type Type string
+// Kind discriminates the objective predicate kind. Stored in JSON as a
+// string so the catalog stays human-editable without leaking enum
+// integers. Kind names are part of the modder-facing schema (ADR 0025
+// §7) — renaming one breaks community catalogs.
+type Kind string
 
 const (
-	TypeCircularize         Type = "circularize"
-	TypeOrbitInsertion      Type = "orbit_insertion"
-	TypeSOIFlyby            Type = "soi_flyby"
-	TypeCircularizeFromPad  Type = "circularize_from_pad" // v0.9.2+
+	KindCircularize        Kind = "circularize"
+	KindOrbitInsertion     Kind = "orbit_insertion"
+	KindSOIFlyby           Kind = "soi_flyby"
+	KindCircularizeFromPad Kind = "circularize_from_pad" // v0.9.2+
 )
 
-// Params is the union of parameters across all predicate kinds. Each
+// Params is the union of parameters across all objective kinds. Each
 // kind reads only the fields it cares about; the rest stay zero.
 type Params struct {
 	// PrimaryID is the body whose frame the predicate evaluates in
@@ -92,21 +96,20 @@ type Params struct {
 	MinPeriapsisAltM float64 `json:"min_periapsis_alt_m,omitempty"`
 }
 
-// Mission groups the catalog metadata, the predicate parameters, and
-// the runtime status. JSON-serialisable for both the catalog and the
-// save file.
-type Mission struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
+// Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
+// JSON-serialisable for both the catalog and the save file.
+type Objective struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Type        Type   `json:"type"`
+	Kind        Kind   `json:"kind"`
 	Params      Params `json:"params"`
 	Status      Status `json:"status,omitempty"`
 }
 
-// EvalContext is the minimum slice of World state a mission predicate
+// EvalContext is the minimum slice of World state an objective predicate
 // needs. Lifted out of sim so the missions package can depend only on
-// orbital/physics and avoid an import cycle.
+// orbital/physics and avoid an import cycle. (Slice 2 expands this.)
 type EvalContext struct {
 	PrimaryID      string              // craft's current primary ID
 	PrimaryRadiusM float64             // craft primary's mean radius
@@ -115,21 +118,22 @@ type EvalContext struct {
 	SimTime        time.Time           // current sim time
 }
 
-// Evaluate steps the predicate one tick and returns the new status.
+// Evaluate steps the objective one tick and returns the new status.
 // Idempotent on terminal states (Passed/Failed return immediately).
-func (m Mission) Evaluate(ctx EvalContext) Status {
-	if m.Status != InProgress {
-		return m.Status
+// Does not mutate the receiver — the caller owns the status.
+func (o Objective) Evaluate(ctx EvalContext) Status {
+	if o.Status != InProgress {
+		return o.Status
 	}
-	switch m.Type {
-	case TypeCircularize:
-		return evalCircularize(m.Params, ctx)
-	case TypeOrbitInsertion:
-		return evalOrbitInsertion(m.Params, ctx)
-	case TypeSOIFlyby:
-		return evalSOIFlyby(m.Params, ctx)
-	case TypeCircularizeFromPad:
-		return evalCircularizeFromPad(m.Params, ctx)
+	switch o.Kind {
+	case KindCircularize:
+		return evalCircularize(o.Params, ctx)
+	case KindOrbitInsertion:
+		return evalOrbitInsertion(o.Params, ctx)
+	case KindSOIFlyby:
+		return evalSOIFlyby(o.Params, ctx)
+	case KindCircularizeFromPad:
+		return evalCircularizeFromPad(o.Params, ctx)
 	}
 	return InProgress
 }
@@ -213,9 +217,63 @@ func evalCircularizeFromPad(p Params, ctx EvalContext) Status {
 	return Passed
 }
 
-// Catalog is a list of missions, persisted to JSON. The starter
-// catalog ships embedded in the binary; future config-file work could
-// supply user-authored catalogs through the same shape.
+// Mission bundles an ordered list of Objectives plus campaign metadata.
+// A Program (ADR 0025 §2) is not a separate type — it is a lightweight
+// grouping expressed by the Program tag plus Requires/Unlocks edges
+// between Missions, so a campaign and the tutorial are both gated
+// Mission chains. JSON-serialisable for both the catalog and the save
+// file.
+type Mission struct {
+	ID          string      `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Program     string      `json:"program,omitempty"`  // campaign grouping tag
+	Requires    []string    `json:"requires,omitempty"` // mission IDs that must Pass before this unlocks
+	Unlocks     []string    `json:"unlocks,omitempty"`  // mission IDs this unlocks (informational)
+	Objectives  []Objective `json:"objectives"`
+	Status      Status      `json:"status,omitempty"`
+}
+
+// Evaluate steps the Mission's Objectives in catalog order and returns
+// the rolled-up Mission status, mutating per-Objective and Mission
+// Status in place. Sticky on terminal states.
+//
+// Ordering is the defining behaviour of a Mission-as-sequence: an
+// Objective is evaluated only once every earlier Objective has Passed, so
+// a later step can't latch before its predecessor (e.g. you can't
+// "return" before you "land"). An Objective that just Passed this tick
+// lets the next one be evaluated the same tick. The Mission Passes when
+// every Objective has Passed; it Fails the moment any Objective Fails (no
+// Objective produces Failed until the slice-3 failure semantics land). A
+// Mission with no Objectives never passes.
+func (m *Mission) Evaluate(ctx EvalContext) Status {
+	if m.Status != InProgress {
+		return m.Status
+	}
+	for i := range m.Objectives {
+		if m.Objectives[i].Status == Passed {
+			continue
+		}
+		s := m.Objectives[i].Evaluate(ctx)
+		m.Objectives[i].Status = s
+		if s == Failed {
+			m.Status = Failed
+			return m.Status
+		}
+		if s != Passed {
+			// Ordered: this objective is still in progress, so every
+			// later objective stays locked until it passes.
+			return m.Status
+		}
+	}
+	if len(m.Objectives) > 0 {
+		m.Status = Passed
+	}
+	return m.Status
+}
+
+// Catalog is a list of Missions, persisted to JSON. The starter catalog
+// ships embedded in the binary; user overlays load through LoadAll.
 type Catalog struct {
 	Missions []Mission `json:"missions"`
 }
@@ -230,13 +288,21 @@ func LoadCatalog(data []byte) (Catalog, error) {
 }
 
 // Clone returns a deep copy of the mission slice. Used when seeding
-// World.Missions from the embedded catalog so per-session status
-// progression doesn't mutate the shared template.
-func Clone(missions []Mission) []Mission {
-	if len(missions) == 0 {
+// World.Missions from a catalog so per-session status progression
+// doesn't mutate the shared template. The per-Mission Objectives /
+// Requires / Unlocks slices are copied too — a shallow copy would let a
+// cloned mission's objective-status mutation bleed back into the
+// embedded catalog.
+func Clone(ms []Mission) []Mission {
+	if len(ms) == 0 {
 		return nil
 	}
-	out := make([]Mission, len(missions))
-	copy(out, missions)
+	out := make([]Mission, len(ms))
+	for i := range ms {
+		out[i] = ms[i]
+		out[i].Objectives = append([]Objective(nil), ms[i].Objectives...)
+		out[i].Requires = append([]string(nil), ms[i].Requires...)
+		out[i].Unlocks = append([]string(nil), ms[i].Unlocks...)
+	}
 	return out
 }

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -72,6 +72,45 @@ const (
 	KindRendezvous    Kind = "rendezvous"
 	KindDock          Kind = "dock"
 	KindReturnToBody  Kind = "return_to_body"
+
+	// KindEvent (ADR 0025 §6, v0.21) is the second objective family: it
+	// matches a semantic gameplay Action (Params.Action) that fired while the
+	// objective was active, rather than a world-state predicate. Used by
+	// control-teaching tutorial steps that leave no world trace.
+	KindEvent Kind = "event"
+)
+
+// Action is a semantic gameplay verb the player triggers, recorded downward
+// from the input layer (ADR 0025 §7, v0.21). The input resolves a keybinding
+// to an Action and records the Action — not the raw keystroke — so event
+// objectives survive rebinding (GH #130) and layout presets (ADR 0022). Like
+// Kind, the string values are modder-facing schema. Pure camera / navigation
+// / meta bindings (zoom, tilt, focus, help, quit) are deliberately excluded —
+// no tutorial verifies them.
+type Action string
+
+const (
+	ActionThrottleFull    Action = "throttle_full"
+	ActionThrottleCut     Action = "throttle_cut"
+	ActionThrottleUp      Action = "throttle_up"
+	ActionThrottleDown    Action = "throttle_down"
+	ActionOpenManeuver    Action = "open_maneuver"
+	ActionPlanTransfer    Action = "plan_transfer"
+	ActionPlanCircularize Action = "plan_circularize"
+	ActionPlanIncl        Action = "plan_incl"
+	ActionPlanRendezvous  Action = "plan_rendezvous"
+	ActionRefinePlan      Action = "refine_plan"
+	ActionClearNodes      Action = "clear_nodes"
+	ActionToggleBurn      Action = "toggle_burn"
+	ActionStage           Action = "stage"
+	ActionCycleTarget     Action = "cycle_target"
+	ActionClearTarget     Action = "clear_target"
+	ActionCycleView       Action = "cycle_view"
+	ActionCycleNavMode    Action = "cycle_navmode"
+	ActionAutoWarp        Action = "auto_warp"
+	ActionSpawnCraft      Action = "spawn_craft"
+	ActionUndock          Action = "undock"
+	ActionTranspose       Action = "transpose"
 )
 
 // FailCondition is an opt-in trigger that transitions an InProgress
@@ -142,6 +181,10 @@ type Params struct {
 	// than RelSpeedMs metres/second. v0.21+.
 	RangeM     float64 `json:"range_m,omitempty"`
 	RelSpeedMs float64 `json:"rel_speed_ms,omitempty"`
+
+	// Action is the semantic gameplay verb an Event objective matches
+	// (ADR 0025 §6/§7). KindEvent only. v0.21+.
+	Action Action `json:"action,omitempty"`
 }
 
 // Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
@@ -207,6 +250,14 @@ type EvalContext struct {
 	HasNode     bool // active craft has at least one planted maneuver node
 	HasTarget   bool // a body or craft is selected in the world target slot
 	Staged      bool // the player has decoupled a stage this session
+
+	// RecentActions are the semantic gameplay actions recorded since the last
+	// mission-eval tick (ADR 0025 §6, v0.21). The sim drains this each tick,
+	// so the event objective sees only actions fired during the current tick
+	// window — which, combined with Mission ordering (an objective is only
+	// evaluated while active), gives the "fired while InProgress" semantics
+	// without any per-objective watermark. Read by KindEvent.
+	RecentActions []Action
 }
 
 // Evaluate steps the objective one tick and returns the new status.
@@ -254,6 +305,26 @@ func (o Objective) evalKind(ctx EvalContext) Status {
 		return evalRendezvous(o.Params, ctx)
 	case KindDock:
 		return evalDock(o.Params, ctx)
+	case KindEvent:
+		return evalEvent(o.Params, ctx)
+	}
+	return InProgress
+}
+
+// evalEvent: pass when the objective's Action appears in the since-last-tick
+// action sink (ctx.RecentActions) — i.e. the player triggered that semantic
+// gameplay verb during this tick window. Because the sim drains the sink each
+// tick and Mission ordering only evaluates an objective while it is active, a
+// match here means the action fired while the objective was InProgress. A
+// missing Action param is inert (never matches). v0.21+ (ADR 0025 §6).
+func evalEvent(p Params, ctx EvalContext) Status {
+	if p.Action == "" {
+		return InProgress
+	}
+	for _, a := range ctx.RecentActions {
+		if a == p.Action {
+			return Passed
+		}
 	}
 	return InProgress
 }

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -134,6 +134,19 @@ const (
 	FailOutOfFuel FailCondition = "out_of_fuel"
 )
 
+// Label returns the player-facing phrasing of a fail condition, used by the
+// in-flight failure flash (ADR 0025 §5 / Slice 5). Falls back to the raw
+// schema string for any condition without an explicit label.
+func (fc FailCondition) Label() string {
+	switch fc {
+	case FailCrashed:
+		return "crashed"
+	case FailOutOfFuel:
+		return "out of fuel"
+	}
+	return string(fc)
+}
+
 // Params is the union of parameters across all objective kinds. Each
 // kind reads only the fields it cares about; the rest stay zero.
 type Params struct {
@@ -333,19 +346,28 @@ func evalEvent(p Params, ctx EvalContext) Status {
 // conditions is currently met. An objective with no FailOn never triggers
 // (ADR 0025 §5: declare nothing → never fails, retry forever).
 func (o Objective) failOnTriggered(ctx EvalContext) bool {
+	_, ok := o.FailReason(ctx)
+	return ok
+}
+
+// FailReason returns the first declared fail condition currently met and
+// true, or ("", false) when none is — the same predicate failOnTriggered
+// gates Evaluate on, but surfacing *which* condition fired so the player
+// surface can name it ("failed: crashed"). v0.21 Slice 5 (ADR 0025 §5).
+func (o Objective) FailReason(ctx EvalContext) (FailCondition, bool) {
 	for _, fc := range o.FailOn {
 		switch fc {
 		case FailCrashed:
 			if ctx.Crashed {
-				return true
+				return FailCrashed, true
 			}
 		case FailOutOfFuel:
 			if ctx.TotalFuelKg <= 0 {
-				return true
+				return FailOutOfFuel, true
 			}
 		}
 	}
-	return false
+	return "", false
 }
 
 // evalDock: pass when the active craft is a docked composite. Grounded in
@@ -579,6 +601,60 @@ func (m *Mission) Evaluate(ctx EvalContext) Status {
 		m.Status = Passed
 	}
 	return m.Status
+}
+
+// Progress reports how many of the mission's objectives have Passed and
+// the total count — the "N/M" the checklist chip and ladder screen show.
+// Only Passed counts toward N; a Failed objective is not progress. v0.21
+// Slice 5 (ADR 0025).
+func (m Mission) Progress() (passed, total int) {
+	for i := range m.Objectives {
+		if m.Objectives[i].Status == Passed {
+			passed++
+		}
+	}
+	return passed, len(m.Objectives)
+}
+
+// CurrentObjective returns the first objective that has not yet Passed (the
+// one the player is working on) and true, or the zero Objective and false
+// when every objective has Passed or the mission has none. For an active
+// (InProgress) mission this is the first still-InProgress step; for a Failed
+// mission it is the step that failed. v0.21 Slice 5 (ADR 0025).
+func (m Mission) CurrentObjective() (Objective, bool) {
+	for i := range m.Objectives {
+		if m.Objectives[i].Status != Passed {
+			return m.Objectives[i], true
+		}
+	}
+	return Objective{}, false
+}
+
+// FailedObjective returns the first objective in the Failed state and true,
+// or the zero Objective and false when none has failed. The player surface
+// uses it (together with Objective.FailReason) to name why a mission died.
+// v0.21 Slice 5 (ADR 0025).
+func (m Mission) FailedObjective() (Objective, bool) {
+	for i := range m.Objectives {
+		if m.Objectives[i].Status == Failed {
+			return m.Objectives[i], true
+		}
+	}
+	return Objective{}, false
+}
+
+// RequirementsMet reports whether every mission ID in this mission's
+// Requires list is present and true in passed (the set of already-Passed
+// mission IDs). A mission with no Requires is always met (an ungated rung).
+// Drives the ladder screen's locked-vs-available classification (ADR 0025
+// §2 / §"Locked rungs"). v0.21 Slice 5.
+func (m Mission) RequirementsMet(passed map[string]bool) bool {
+	for _, id := range m.Requires {
+		if !passed[id] {
+			return false
+		}
+	}
+	return true
 }
 
 // Catalog is a list of Missions, persisted to JSON. The starter catalog

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -646,8 +646,10 @@ func (m Mission) FailedObjective() (Objective, bool) {
 // RequirementsMet reports whether every mission ID in this mission's
 // Requires list is present and true in passed (the set of already-Passed
 // mission IDs). A mission with no Requires is always met (an ungated rung).
-// Drives the ladder screen's locked-vs-available classification (ADR 0025
-// §2 / §"Locked rungs"). v0.21 Slice 5.
+// Gates both the ladder screen's locked-vs-available classification (ADR
+// 0025 §2 / §"Locked rungs") and — since v0.21 Slice 6 — the evaluator
+// itself: a locked mission is not evaluated, so its objectives can't latch
+// out of order (ADR 0025 §8: "requires gates the next mission"). v0.21.
 func (m Mission) RequirementsMet(passed map[string]bool) bool {
 	for _, id := range m.Requires {
 		if !passed[id] {
@@ -655,6 +657,18 @@ func (m Mission) RequirementsMet(passed map[string]bool) bool {
 		}
 	}
 	return true
+}
+
+// PassedSet returns the set of mission IDs currently in the Passed state —
+// the prerequisite set RequirementsMet is checked against. v0.21 Slice 6.
+func PassedSet(ms []Mission) map[string]bool {
+	out := make(map[string]bool, len(ms))
+	for i := range ms {
+		if ms[i].Status == Passed {
+			out[ms[i].ID] = true
+		}
+	}
+	return out
 }
 
 // Catalog is a list of Missions, persisted to JSON. The starter catalog

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -1,58 +1,180 @@
 {
   "missions": [
     {
-      "id": "leo-circularize-1000",
-      "name": "Circularize at 1000 km LEO",
-      "description": "Reach a circular orbit around Earth at 1000 km altitude (±5%, e ≤ 0.005).",
+      "id": "tut-orient",
+      "name": "Flight School: Orientation",
+      "description": "Get your bearings — the camera and the target slot.",
+      "program": "tutorial",
       "objectives": [
         {
+          "name": "Change your view",
+          "description": "Press [v] to cycle the camera view.",
+          "kind": "event",
+          "params": { "action": "cycle_view" }
+        },
+        {
+          "name": "Target the Moon",
+          "description": "Press [t] to cycle the target slot; stop on the Moon. [T] clears it.",
+          "kind": "event",
+          "params": { "action": "cycle_target" }
+        }
+      ]
+    },
+    {
+      "id": "tut-plan",
+      "name": "Flight School: Plan a Burn",
+      "description": "Open the planner and plant your first maneuver.",
+      "program": "tutorial",
+      "requires": ["tut-orient"],
+      "objectives": [
+        {
+          "name": "Open the planner",
+          "description": "Press [m] to open the maneuver planner.",
+          "kind": "event",
+          "params": { "action": "open_maneuver" }
+        },
+        {
+          "name": "Plant a transfer",
+          "description": "With the Moon targeted, press [H] to plant a transfer burn toward it.",
+          "kind": "event",
+          "params": { "action": "plan_transfer" }
+        }
+      ]
+    },
+    {
+      "id": "tut-fly",
+      "name": "Flight School: Fly It",
+      "description": "Execute a burn and climb away from your starting orbit.",
+      "program": "tutorial",
+      "requires": ["tut-plan"],
+      "objectives": [
+        {
+          "name": "Climb above 700 km",
+          "description": "Warp to your burn ([G]) or fire manually ([b]) and raise your altitude past 700 km.",
+          "kind": "reach_altitude",
+          "params": { "primary_id": "earth", "min_altitude_m": 700000 }
+        }
+      ]
+    },
+    {
+      "id": "chal-high-orbit",
+      "name": "Make a 1000 km Orbit",
+      "description": "Trim a clean, near-circular orbit at 1000 km.",
+      "program": "challenge",
+      "requires": ["tut-fly"],
+      "objectives": [
+        {
+          "name": "Circular orbit at 1000 km",
+          "description": "Raise and round out your orbit to 1000 km altitude (±5%, e ≤ 0.01).",
           "kind": "circularize",
           "params": {
             "primary_id": "earth",
             "altitude_m": 1000000,
             "altitude_tol_pct": 0.05,
-            "eccentricity_cap": 0.005
+            "eccentricity_cap": 0.01
           }
         }
       ]
     },
     {
-      "id": "luna-orbit-insertion",
-      "name": "Luna orbit insertion",
-      "description": "Capture into a bound orbit around Earth's Moon.",
+      "id": "chal-luna-flyby",
+      "name": "Luna Flyby",
+      "description": "Coast into the Moon's sphere of influence.",
+      "program": "challenge",
+      "requires": ["chal-high-orbit"],
       "objectives": [
         {
-          "kind": "orbit_insertion",
-          "params": {
-            "primary_id": "moon"
-          }
-        }
-      ]
-    },
-    {
-      "id": "mars-soi-flyby",
-      "name": "Mars SOI flyby",
-      "description": "Cross into Mars' sphere of influence.",
-      "objectives": [
-        {
+          "name": "Enter Luna's SOI",
+          "description": "Target the Moon, plant a transfer ([H]), and coast until the Moon's gravity takes over.",
           "kind": "soi_flyby",
-          "params": {
-            "primary_id": "mars"
-          }
+          "params": { "primary_id": "moon" }
         }
       ]
     },
     {
-      "id": "saturn-v-pad-to-leo",
-      "name": "Saturn V: pad to LEO",
-      "description": "Spawn a Saturn V on the launchpad (n → POSITION → launchpad → LATITUDE → 28.6° KSC). Manually fly the gravity turn — pitch east, stage as each booster empties — and circularize at periapsis above 200 km.",
+      "id": "chal-luna-capture",
+      "name": "Luna Capture",
+      "description": "Brake into a bound orbit around the Moon.",
+      "program": "challenge",
+      "requires": ["chal-luna-flyby"],
       "objectives": [
         {
+          "name": "Capture at Luna",
+          "description": "Burn retrograde near periapsis to drop into a bound lunar orbit (e < 1).",
+          "kind": "orbit_insertion",
+          "params": { "primary_id": "moon" }
+        }
+      ]
+    },
+    {
+      "id": "chal-luna-return",
+      "name": "Luna Landing & Return",
+      "description": "Land on the Moon, then bring it home.",
+      "program": "challenge",
+      "requires": ["chal-luna-capture"],
+      "objectives": [
+        {
+          "name": "Land on Luna",
+          "description": "Descend and touch down anywhere on the Moon's surface.",
+          "kind": "land_at_body",
+          "params": { "primary_id": "moon" }
+        },
+        {
+          "name": "Return to Earth",
+          "description": "Lift off, transfer back, and settle into a bound Earth orbit (or land).",
+          "kind": "return_to_body",
+          "params": { "primary_id": "earth" }
+        }
+      ]
+    },
+    {
+      "id": "chal-dock",
+      "name": "Rendezvous & Dock",
+      "description": "Bring two craft together and dock them.",
+      "program": "challenge",
+      "requires": ["chal-luna-return"],
+      "objectives": [
+        {
+          "name": "Spawn a partner",
+          "description": "Press [n] to spawn a second craft to rendezvous with.",
+          "kind": "event",
+          "params": { "action": "spawn_craft" }
+        },
+        {
+          "name": "Dock the two craft",
+          "description": "Target the other craft ([t]), close in ([K] plants a rendezvous nudge), and dock.",
+          "kind": "dock",
+          "params": {}
+        }
+      ]
+    },
+    {
+      "id": "chal-mars-flyby",
+      "name": "Mars Flyby",
+      "description": "Leave Earth's neighbourhood — fly past Mars.",
+      "program": "challenge",
+      "requires": ["chal-dock"],
+      "objectives": [
+        {
+          "name": "Enter Mars' SOI",
+          "description": "Plant an interplanetary transfer to Mars ([t] target Mars, [H]) and coast into its sphere of influence.",
+          "kind": "soi_flyby",
+          "params": { "primary_id": "mars" }
+        }
+      ]
+    },
+    {
+      "id": "chal-pad-to-leo",
+      "name": "Saturn V: Pad to LEO",
+      "description": "Do it the hard way — launch a Saturn V from the pad.",
+      "program": "challenge",
+      "requires": ["chal-high-orbit"],
+      "objectives": [
+        {
+          "name": "Reach orbit from the pad",
+          "description": "Spawn a Saturn V on the launchpad ([n] → POSITION → launchpad → 28.6° KSC), fly the gravity turn — pitch east, stage as each booster empties — and circularize with periapsis above 200 km.",
           "kind": "circularize_from_pad",
-          "params": {
-            "primary_id": "earth",
-            "min_periapsis_alt_m": 200000
-          }
+          "params": { "primary_id": "earth", "min_periapsis_alt_m": 200000 }
         }
       ]
     }

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -13,8 +13,8 @@
           "params": { "action": "cycle_view" }
         },
         {
-          "name": "Target the Moon",
-          "description": "Press [t] to cycle the target slot; stop on the Moon. [T] clears it.",
+          "name": "Pick a target",
+          "description": "Press [t] to cycle the target slot — aim for the Moon. [T] clears it.",
           "kind": "event",
           "params": { "action": "cycle_target" }
         }
@@ -160,21 +160,6 @@
           "description": "Plant an interplanetary transfer to Mars ([t] target Mars, [H]) and coast into its sphere of influence.",
           "kind": "soi_flyby",
           "params": { "primary_id": "mars" }
-        }
-      ]
-    },
-    {
-      "id": "chal-pad-to-leo",
-      "name": "Saturn V: Pad to LEO",
-      "description": "Do it the hard way — launch a Saturn V from the pad.",
-      "program": "challenge",
-      "requires": ["chal-high-orbit"],
-      "objectives": [
-        {
-          "name": "Reach orbit from the pad",
-          "description": "Spawn a Saturn V on the launchpad ([n] → POSITION → launchpad → 28.6° KSC), fly the gravity turn — pitch east, stage as each booster empties — and circularize with periapsis above 200 km.",
-          "kind": "circularize_from_pad",
-          "params": { "primary_id": "earth", "min_periapsis_alt_m": 200000 }
         }
       ]
     }

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -4,41 +4,57 @@
       "id": "leo-circularize-1000",
       "name": "Circularize at 1000 km LEO",
       "description": "Reach a circular orbit around Earth at 1000 km altitude (±5%, e ≤ 0.005).",
-      "type": "circularize",
-      "params": {
-        "primary_id": "earth",
-        "altitude_m": 1000000,
-        "altitude_tol_pct": 0.05,
-        "eccentricity_cap": 0.005
-      }
+      "objectives": [
+        {
+          "kind": "circularize",
+          "params": {
+            "primary_id": "earth",
+            "altitude_m": 1000000,
+            "altitude_tol_pct": 0.05,
+            "eccentricity_cap": 0.005
+          }
+        }
+      ]
     },
     {
       "id": "luna-orbit-insertion",
       "name": "Luna orbit insertion",
       "description": "Capture into a bound orbit around Earth's Moon.",
-      "type": "orbit_insertion",
-      "params": {
-        "primary_id": "moon"
-      }
+      "objectives": [
+        {
+          "kind": "orbit_insertion",
+          "params": {
+            "primary_id": "moon"
+          }
+        }
+      ]
     },
     {
       "id": "mars-soi-flyby",
       "name": "Mars SOI flyby",
       "description": "Cross into Mars' sphere of influence.",
-      "type": "soi_flyby",
-      "params": {
-        "primary_id": "mars"
-      }
+      "objectives": [
+        {
+          "kind": "soi_flyby",
+          "params": {
+            "primary_id": "mars"
+          }
+        }
+      ]
     },
     {
       "id": "saturn-v-pad-to-leo",
       "name": "Saturn V: pad to LEO",
       "description": "Spawn a Saturn V on the launchpad (n → POSITION → launchpad → LATITUDE → 28.6° KSC). Manually fly the gravity turn — pitch east, stage as each booster empties — and circularize at periapsis above 200 km.",
-      "type": "circularize_from_pad",
-      "params": {
-        "primary_id": "earth",
-        "min_periapsis_alt_m": 200000
-      }
+      "objectives": [
+        {
+          "kind": "circularize_from_pad",
+          "params": {
+            "primary_id": "earth",
+            "min_periapsis_alt_m": 200000
+          }
+        }
+      ]
     }
   ]
 }

--- a/internal/missions/missions_test.go
+++ b/internal/missions/missions_test.go
@@ -31,8 +31,8 @@ func circularState(r, mu, alt float64) physics.StateVector {
 }
 
 func TestCircularizeStartsInProgress(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -47,14 +47,14 @@ func TestCircularizeStartsInProgress(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 500e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("at 500 km, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizePassesAtTarget(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -68,14 +68,14 @@ func TestCircularizePassesAtTarget(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("at 1000 km circular, expected Passed, got %v", got)
 	}
 }
 
 func TestCircularizeTolerance(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -92,20 +92,20 @@ func TestCircularizeTolerance(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, insideAlt),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("inside tolerance, expected Passed, got %v", got)
 	}
 	// Outside tolerance: 10% under.
 	outsideAlt := 1_000_000 - 0.10*target
 	ctx.State = circularState(earthRadius, earthMu, outsideAlt)
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("outside tolerance, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeEccentricityCap(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -131,14 +131,14 @@ func TestCircularizeEccentricityCap(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("e=0.05 over cap=0.005, expected InProgress, got %v", got)
 	}
 }
 
 func TestCircularizeWrongPrimary(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularize,
+	o := Objective{
+		Kind: KindCircularize,
 		Params: Params{
 			PrimaryID:       "earth",
 			AltitudeM:       1_000_000,
@@ -154,14 +154,14 @@ func TestCircularizeWrongPrimary(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 1_000_000),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("primary mismatch, expected InProgress, got %v", got)
 	}
 }
 
 func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	ctx := EvalContext{
@@ -170,14 +170,14 @@ func TestOrbitInsertionPassesOnBoundOrbit(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          circularState(moonRadius, moonMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("bound moon orbit, expected Passed, got %v", got)
 	}
 }
 
 func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
-	m := Mission{
-		Type:   TypeOrbitInsertion,
+	o := Objective{
+		Kind:   KindOrbitInsertion,
 		Params: Params{PrimaryID: "moon"},
 	}
 	// Velocity well above escape — hyperbolic.
@@ -194,43 +194,43 @@ func TestOrbitInsertionInProgressOnHyperbolic(t *testing.T) {
 		PrimaryMu:      moonMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("hyperbolic, expected InProgress, got %v", got)
 	}
 }
 
 func TestSOIFlybyPassesOnPrimaryMatch(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "mars"}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Fatalf("inside Mars SOI, expected Passed, got %v", got)
 	}
 }
 
 func TestSOIFlybyInProgressOtherwise(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Fatalf("not in Mars SOI, expected InProgress, got %v", got)
 	}
 }
 
 func TestEvaluateIdempotentOnTerminal(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 		Status: Passed,
 	}
-	// Even though we're back at Earth, a Passed mission stays Passed.
+	// Even though we're back at Earth, a Passed objective stays Passed.
 	ctx := EvalContext{PrimaryID: "earth"}
-	if got := m.Evaluate(ctx); got != Passed {
-		t.Fatalf("Passed mission should stay Passed, got %v", got)
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("Passed objective should stay Passed, got %v", got)
 	}
 }
 
@@ -243,10 +243,10 @@ func TestDefaultCatalogLoads(t *testing.T) {
 		t.Fatalf("expected 4 starter missions, got %d", len(cat.Missions))
 	}
 	wantIDs := map[string]bool{
-		"leo-circularize-1000":  false,
-		"luna-orbit-insertion":  false,
-		"mars-soi-flyby":        false,
-		"saturn-v-pad-to-leo":   false, // v0.9.2+
+		"leo-circularize-1000": false,
+		"luna-orbit-insertion": false,
+		"mars-soi-flyby":       false,
+		"saturn-v-pad-to-leo":  false, // v0.9.2+
 	}
 	for _, m := range cat.Missions {
 		if _, ok := wantIDs[m.ID]; !ok {
@@ -254,6 +254,14 @@ func TestDefaultCatalogLoads(t *testing.T) {
 			continue
 		}
 		wantIDs[m.ID] = true
+		// Each starter mission wraps exactly one objective with a kind.
+		if len(m.Objectives) != 1 {
+			t.Errorf("mission %q: got %d objectives, want 1", m.ID, len(m.Objectives))
+			continue
+		}
+		if m.Objectives[0].Kind == "" {
+			t.Errorf("mission %q: objective has empty kind", m.ID)
+		}
 	}
 	for id, found := range wantIDs {
 		if !found {
@@ -286,33 +294,43 @@ func TestCloneIsIndependent(t *testing.T) {
 	dup := Clone(cat.Missions)
 	dup[0].Status = Passed
 	if cat.Missions[0].Status == Passed {
-		t.Fatal("Clone shares backing memory with source")
+		t.Fatal("Clone shares mission-level backing memory with source")
+	}
+	// Deep copy: mutating a cloned mission's nested objective status must
+	// not bleed back into the source catalog. A shallow copy would alias
+	// the Objectives slice and corrupt the embedded template.
+	if len(dup[0].Objectives) == 0 {
+		t.Fatal("test setup: cloned mission has no objectives")
+	}
+	dup[0].Objectives[0].Status = Passed
+	if cat.Missions[0].Objectives[0].Status == Passed {
+		t.Fatal("Clone shares objective backing memory with source")
 	}
 }
 
 // Sanity check that EvalContext's SimTime field is wired but not
 // currently consumed — guards against accidentally tying behaviour
-// to wall-clock during the v0.6.5 scaffold.
+// to wall-clock during the pre-dwell scaffold.
 func TestEvalIgnoresSimTime(t *testing.T) {
-	m := Mission{
-		Type:   TypeSOIFlyby,
+	o := Objective{
+		Kind:   KindSOIFlyby,
 		Params: Params{PrimaryID: "mars"},
 	}
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
 	ctx1 := EvalContext{PrimaryID: "earth", SimTime: t1}
 	ctx2 := EvalContext{PrimaryID: "earth", SimTime: t2}
-	if m.Evaluate(ctx1) != m.Evaluate(ctx2) {
-		t.Fatal("SimTime should not affect predicate outcome in v0.6.5")
+	if o.Evaluate(ctx1) != o.Evaluate(ctx2) {
+		t.Fatal("SimTime should not affect predicate outcome before dwell objectives")
 	}
 }
 
 // TestCircularizeFromPadInProgressBelowFloor — a low orbit
-// (periapsis below the configured floor) keeps the mission in
+// (periapsis below the configured floor) keeps the objective in
 // progress. v0.9.2+.
 func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -325,7 +343,7 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 100e3),
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("100 km LEO with 200 km floor: got %v, want InProgress", got)
 	}
 }
@@ -334,8 +352,8 @@ func TestCircularizeFromPadInProgressBelowFloor(t *testing.T) {
 // periapsis above the floor passes, regardless of eccentricity.
 // v0.9.2+.
 func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -348,17 +366,17 @@ func TestCircularizeFromPadPassesAboveFloor(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          circularState(earthRadius, earthMu, 250e3),
 	}
-	if got := m.Evaluate(ctx); got != Passed {
+	if got := o.Evaluate(ctx); got != Passed {
 		t.Errorf("250 km LEO with 200 km floor: got %v, want Passed", got)
 	}
 }
 
 // TestCircularizeFromPadRejectsHyperbolic — an unbound (e ≥ 1)
-// trajectory keeps the mission in progress even if the
+// trajectory keeps the objective in progress even if the
 // instantaneous radius is above the floor. v0.9.2+.
 func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
-	m := Mission{
-		Type: TypeCircularizeFromPad,
+	o := Objective{
+		Kind: KindCircularizeFromPad,
 		Params: Params{
 			PrimaryID:        "earth",
 			MinPeriapsisAltM: 200_000,
@@ -379,7 +397,7 @@ func TestCircularizeFromPadRejectsHyperbolic(t *testing.T) {
 		PrimaryMu:      earthMu,
 		State:          state,
 	}
-	if got := m.Evaluate(ctx); got != InProgress {
+	if got := o.Evaluate(ctx); got != InProgress {
 		t.Errorf("hyperbolic with floor: got %v, want InProgress", got)
 	}
 }

--- a/internal/missions/missions_test.go
+++ b/internal/missions/missions_test.go
@@ -239,33 +239,28 @@ func TestDefaultCatalogLoads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DefaultCatalog: %v", err)
 	}
-	if len(cat.Missions) != 4 {
-		t.Fatalf("expected 4 starter missions, got %d", len(cat.Missions))
+	if len(cat.Missions) == 0 {
+		t.Fatal("embedded catalog is empty")
 	}
-	wantIDs := map[string]bool{
-		"leo-circularize-1000": false,
-		"luna-orbit-insertion": false,
-		"mars-soi-flyby":       false,
-		"saturn-v-pad-to-leo":  false, // v0.9.2+
+	// Key rungs of the v0.21 tutorial→challenge ladder are present.
+	for _, id := range []string{"tut-orient", "tut-fly", "chal-high-orbit", "chal-luna-return", "chal-mars-flyby"} {
+		if _, ok := missionByID(cat, id); !ok {
+			t.Errorf("expected ladder mission %q in the embedded catalog", id)
+		}
 	}
+	// Every mission is well-formed: a non-empty id and at least one objective,
+	// each objective carrying a non-empty kind (an empty kind sits inert).
 	for _, m := range cat.Missions {
-		if _, ok := wantIDs[m.ID]; !ok {
-			t.Errorf("unexpected mission id %q", m.ID)
-			continue
+		if m.ID == "" {
+			t.Errorf("mission %q has an empty id", m.Name)
 		}
-		wantIDs[m.ID] = true
-		// Each starter mission wraps exactly one objective with a kind.
-		if len(m.Objectives) != 1 {
-			t.Errorf("mission %q: got %d objectives, want 1", m.ID, len(m.Objectives))
-			continue
+		if len(m.Objectives) == 0 {
+			t.Errorf("mission %q has no objectives", m.ID)
 		}
-		if m.Objectives[0].Kind == "" {
-			t.Errorf("mission %q: objective has empty kind", m.ID)
-		}
-	}
-	for id, found := range wantIDs {
-		if !found {
-			t.Errorf("missing mission id %q", id)
+		for j, o := range m.Objectives {
+			if o.Kind == "" {
+				t.Errorf("mission %q objective %d has an empty kind", m.ID, j)
+			}
 		}
 	}
 }

--- a/internal/missions/state_kinds_test.go
+++ b/internal/missions/state_kinds_test.go
@@ -1,0 +1,256 @@
+package missions
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// v0.21 Slice 2 (ADR 0025 §3) — the five new instantaneous state-objective
+// kinds. Each test exercises pass / not-yet / frame-mismatch per the
+// cycle-plan done-criteria. Reuses circularState + the earth/moon
+// constants from missions_test.go (same package).
+
+// --- reach_altitude {primary, min_altitude_m} ---
+
+func TestReachAltitudePassesAtOrAboveTarget(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// 1000 km altitude — comfortably above the 500 km floor.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 1000e3),
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("1000 km vs 500 km floor: got %v, want Passed", got)
+	}
+}
+
+func TestReachAltitudeInProgressBelowTarget(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// 300 km — short of the 500 km floor.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 300e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("300 km vs 500 km floor: got %v, want InProgress", got)
+	}
+}
+
+func TestReachAltitudeFrameMismatch(t *testing.T) {
+	o := Objective{
+		Kind:   KindReachAltitude,
+		Params: Params{PrimaryID: "earth", MinAltitudeM: 500e3},
+	}
+	// Plenty high, but around the Moon — wrong primary, predicate dormant.
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 1000e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("right altitude wrong primary: got %v, want InProgress", got)
+	}
+}
+
+// --- return_to_body {primary} : captured-or-landed ---
+
+func TestReturnToBodyPassesOnBoundOrbit(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State:          circularState(earthRadius, earthMu, 300e3),
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("bound earth orbit: got %v, want Passed", got)
+	}
+}
+
+func TestReturnToBodyPassesWhenLanded(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// Landed back on Earth — passes even though the (pinned, surface) state
+	// vector isn't a bound orbit.
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		Landed:         true,
+		State:          physics.StateVector{R: orbital.Vec3{X: earthRadius}, M: 1000},
+	}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("landed on earth: got %v, want Passed", got)
+	}
+}
+
+func TestReturnToBodyInProgressOnHyperbolicPassthrough(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// In Earth's SOI but on a hyperbolic flyby (not captured, not landed) —
+	// a whizz-through is not a return.
+	radius := earthRadius + 500e3
+	vEsc := math.Sqrt(2 * earthMu / radius)
+	ctx := EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		State: physics.StateVector{
+			R: orbital.Vec3{X: radius},
+			V: orbital.Vec3{Y: vEsc * 1.5},
+			M: 1000,
+		},
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("hyperbolic passthrough: got %v, want InProgress", got)
+	}
+}
+
+func TestReturnToBodyFrameMismatch(t *testing.T) {
+	o := Objective{Kind: KindReturnToBody, Params: Params{PrimaryID: "earth"}}
+	// Bound around the Moon — right shape, wrong body.
+	ctx := EvalContext{
+		PrimaryID:      "moon",
+		PrimaryRadiusM: moonRadius,
+		PrimaryMu:      moonMu,
+		State:          circularState(moonRadius, moonMu, 100e3),
+	}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("bound around moon, want earth: got %v, want InProgress", got)
+	}
+}
+
+// --- land_at_body {primary, optional site lat/lon + radius_m} ---
+
+// landedCtx builds a landed-on-earth EvalContext at the given surface
+// coordinates.
+func landedCtx(latDeg, lonDeg float64) EvalContext {
+	return EvalContext{
+		PrimaryID:      "earth",
+		PrimaryRadiusM: earthRadius,
+		PrimaryMu:      earthMu,
+		Landed:         true,
+		SurfaceLatDeg:  latDeg,
+		SurfaceLonDeg:  lonDeg,
+		State:          physics.StateVector{R: orbital.Vec3{X: earthRadius}, M: 1000},
+	}
+}
+
+func TestLandAtBodyPassesLandedAnywhereWithoutSite(t *testing.T) {
+	// No site constraint (SiteRadiusM == 0): landing anywhere on Earth passes.
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "earth"}}
+	if got := o.Evaluate(landedCtx(12, 34)); got != Passed {
+		t.Fatalf("landed anywhere, no site: got %v, want Passed", got)
+	}
+}
+
+func TestLandAtBodyPassesInsideSite(t *testing.T) {
+	// KSC site, 100 km radius; craft set down essentially on the pad.
+	o := Objective{Kind: KindLandAtBody, Params: Params{
+		PrimaryID: "earth", SiteLatDeg: 28.6, SiteLonDeg: -80.6, SiteRadiusM: 100e3,
+	}}
+	if got := o.Evaluate(landedCtx(28.61, -80.59)); got != Passed {
+		t.Fatalf("landed inside site radius: got %v, want Passed", got)
+	}
+}
+
+func TestLandAtBodyInProgressNotLanded(t *testing.T) {
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "earth"}}
+	ctx := landedCtx(12, 34)
+	ctx.Landed = false
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("not landed: got %v, want InProgress", got)
+	}
+}
+
+func TestLandAtBodyInProgressOutsideSite(t *testing.T) {
+	// KSC site, 100 km radius; craft set down at the equator/prime-meridian
+	// — thousands of km away.
+	o := Objective{Kind: KindLandAtBody, Params: Params{
+		PrimaryID: "earth", SiteLatDeg: 28.6, SiteLonDeg: -80.6, SiteRadiusM: 100e3,
+	}}
+	if got := o.Evaluate(landedCtx(0, 0)); got != InProgress {
+		t.Fatalf("landed outside site radius: got %v, want InProgress", got)
+	}
+}
+
+func TestLandAtBodyFrameMismatch(t *testing.T) {
+	// Landed, but the objective is for the Moon while the craft is on Earth.
+	o := Objective{Kind: KindLandAtBody, Params: Params{PrimaryID: "moon"}}
+	if got := o.Evaluate(landedCtx(0, 0)); got != InProgress {
+		t.Fatalf("landed on earth, objective moon: got %v, want InProgress", got)
+	}
+}
+
+// TestGreatCircleDistance — sanity-check the haversine helper against the
+// classic ~111 km per degree of latitude on Earth.
+func TestGreatCircleDistance(t *testing.T) {
+	d := greatCircleDistanceM(0, 0, 1, 0, earthRadius)
+	want := earthRadius * math.Pi / 180 // 1° in radians × R
+	if math.Abs(d-want) > 1 {
+		t.Fatalf("1° of latitude: got %.1f m, want ~%.1f m", d, want)
+	}
+}
+
+// --- rendezvous {range_m, rel_speed_ms} : vs the targeted craft ---
+
+func TestRendezvousPassesWithinRangeAndSpeed(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 80, TargetRelSpeedMs: 0.3}
+	if got := o.Evaluate(ctx); got != Passed {
+		t.Fatalf("80 m / 0.3 m/s vs 100 m / 0.5 m/s: got %v, want Passed", got)
+	}
+}
+
+func TestRendezvousInProgressTooFar(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 200, TargetRelSpeedMs: 0.1}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("200 m (too far): got %v, want InProgress", got)
+	}
+}
+
+func TestRendezvousInProgressTooFast(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	ctx := EvalContext{HasTargetCraft: true, TargetRangeM: 50, TargetRelSpeedMs: 2.0}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("2.0 m/s (too fast): got %v, want InProgress", got)
+	}
+}
+
+func TestRendezvousInProgressNoTarget(t *testing.T) {
+	o := Objective{Kind: KindRendezvous, Params: Params{RangeM: 100, RelSpeedMs: 0.5}}
+	// No craft targeted — nothing to rendezvous with (frame-mismatch analogue).
+	ctx := EvalContext{HasTargetCraft: false, TargetRangeM: 0, TargetRelSpeedMs: 0}
+	if got := o.Evaluate(ctx); got != InProgress {
+		t.Fatalf("no target craft: got %v, want InProgress", got)
+	}
+}
+
+// --- dock {} : active craft is a docked composite ---
+
+func TestDockPassesWhenDocked(t *testing.T) {
+	o := Objective{Kind: KindDock}
+	if got := o.Evaluate(EvalContext{Docked: true}); got != Passed {
+		t.Fatalf("docked composite: got %v, want Passed", got)
+	}
+}
+
+func TestDockInProgressWhenUndocked(t *testing.T) {
+	o := Objective{Kind: KindDock}
+	if got := o.Evaluate(EvalContext{Docked: false}); got != InProgress {
+		t.Fatalf("not docked: got %v, want InProgress", got)
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -48,8 +48,12 @@ import (
 // binding. The v7→v8 migration derives each craft's SystemIdx from which
 // loaded System contains its PrimaryID (Sol/0 fallback), so existing Sol
 // craft and any craft spawned by the buggy interim Lumen build both
-// migrate correctly; see migrateV7PayloadToV8.
-const SchemaVersion = 8
+// migrate correctly; see migrateV7PayloadToV8. v0.21 bumps to v9
+// (ADR 0025) — the mission shape inverts from a single typed predicate to
+// a Mission of ordered Objectives + campaign metadata. The v8→v9 migration
+// re-seeds: it drops the old single-predicate progress so the load path
+// reseeds the new ladder from the catalog; see migrateV8PayloadToV9.
+const SchemaVersion = 9
 
 // File is the on-disk envelope.
 type File struct {
@@ -467,6 +471,13 @@ func Load(path string) (*sim.World, error) {
 	// alone. v8+ saves already carry SystemIdx and skip this.
 	if f.Version < 8 {
 		migrateV7PayloadToV8(&f.Payload, systems)
+	}
+	// v0.21 / schema v9 (ADR 0025): the mission shape inverted (single
+	// predicate → Mission of ordered Objectives). Drop the old
+	// single-predicate progress so worldFromPayload reseeds the new ladder
+	// from the catalog. Payload-only, so it runs here on the wire payload.
+	if f.Version < 9 {
+		migrateV8PayloadToV9(&f.Payload)
 	}
 	return worldFromPayload(f.Payload, systems)
 }
@@ -906,14 +917,15 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 	// prime NextNodeID past every ID in play, so a post-load plant can't
 	// mint a colliding node ID. Mirrors EnsureCraftIDs above.
 	w.EnsureNodeIDs()
-	// v0.6.5: missions persist with status. v3+ saves carry an explicit
-	// (possibly-empty) Missions slice; v1/v2 saves wire-out as nil and
-	// get the embedded starter catalog seeded fresh so older saves
-	// gain the new feature without a manual edit. A failed catalog
-	// load is non-fatal — missions are additive.
+	// v0.6.5: missions persist with status. v9+ saves carry an explicit
+	// (possibly-empty) Missions slice in the nested shape; pre-v9 saves are
+	// re-seeded — migrateV8PayloadToV9 nils Missions so this branch loads
+	// the current ladder fresh (embedded + user overlay, via LoadAll,
+	// matching NewWorld). A failed catalog load is non-fatal — missions are
+	// additive.
 	if p.Missions != nil {
 		w.Missions = missions.Clone(p.Missions)
-	} else if cat, err := missions.DefaultCatalog(); err == nil {
+	} else if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 	return w, nil

--- a/internal/save/save_migrate_v8_to_v9.go
+++ b/internal/save/save_migrate_v8_to_v9.go
@@ -1,0 +1,24 @@
+// v0.21: schema v8 → v9 migration (ADR 0025). Pre-v9 saves model a
+// mission as a single typed predicate (the old missions.Mission shape:
+// type + params + a flat status). v0.21 inverts the vocabulary — a Mission
+// is now an ordered list of Objectives plus campaign metadata (program tag,
+// requires/unlocks edges, per-objective status) — so the on-disk shape
+// changes fundamentally.
+//
+// Field-migrating the old single-predicate progress into the new nested
+// shape would carry little value (the old catalog was four standalone
+// predicates with no ladder), so this is a re-seed migration: drop the old
+// mission state entirely. With Payload.Missions left nil, worldFromPayload
+// reseeds from the current catalog (embedded + user overlay), so the player
+// picks up the new tutorial→challenge ladder fresh. Ladder progression and
+// per-objective status persist going forward under v9.
+
+package save
+
+// migrateV8PayloadToV9 drops the pre-v0.21 single-predicate mission
+// progress so the load path reseeds the new Mission/Objective ladder from
+// the catalog. Operates on the payload alone, so it runs before
+// rehydration like the positional v6→v7 pass.
+func migrateV8PayloadToV9(p *Payload) {
+	p.Missions = nil
+}

--- a/internal/save/save_migrate_v8_to_v9_test.go
+++ b/internal/save/save_migrate_v8_to_v9_test.go
@@ -1,0 +1,25 @@
+package save
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// TestMigrateV8PayloadToV9DropsOldMissions — ADR 0025. A pre-v9 payload's
+// Missions are the old single-predicate shape (no nested objectives). The
+// Mission shape changed fundamentally, so the migration drops the
+// low-value old progress, leaving Missions nil so worldFromPayload
+// reseeds from the new catalog rather than rehydrating empty husks.
+func TestMigrateV8PayloadToV9DropsOldMissions(t *testing.T) {
+	p := &Payload{
+		Missions: []missions.Mission{
+			{ID: "old-circ", Name: "Old circularize", Status: missions.Passed},
+			{ID: "old-flyby", Name: "Old flyby", Status: missions.InProgress},
+		},
+	}
+	migrateV8PayloadToV9(p)
+	if p.Missions != nil {
+		t.Fatalf("expected Missions dropped to nil, got %d", len(p.Missions))
+	}
+}

--- a/internal/save/save_mission_v9_test.go
+++ b/internal/save/save_mission_v9_test.go
@@ -68,8 +68,9 @@ func TestLoadV8SaveReseedsMissions(t *testing.T) {
 
 	// Reseeded to the new nested catalog: every starter mission present,
 	// each with objectives, none carrying the dropped Passed progress.
-	if len(got.Missions) != 4 {
-		t.Fatalf("reseed: got %d missions, want 4 embedded starter missions", len(got.Missions))
+	base, _ := missions.DefaultCatalog()
+	if len(got.Missions) != len(base.Missions) {
+		t.Fatalf("reseed: got %d missions, want %d embedded starter missions", len(got.Missions), len(base.Missions))
 	}
 	for _, m := range got.Missions {
 		if len(m.Objectives) == 0 {

--- a/internal/save/save_mission_v9_test.go
+++ b/internal/save/save_mission_v9_test.go
@@ -1,0 +1,136 @@
+package save_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestLoadV8SaveReseedsMissions — ADR 0025 soft save break. A pre-v0.21
+// (v8) save carries old single-predicate mission progress; loading it
+// under v9 drops that progress and reseeds the new ladder from the
+// catalog, so a previously "passed" mission comes back fresh in the new
+// nested shape.
+func TestLoadV8SaveReseedsMissions(t *testing.T) {
+	// Isolate from any real user overlay so the reseed is exactly the
+	// embedded starter catalog.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Rewrite the freshly-saved (v9) file to look like a pre-v0.21 v8
+	// save: downgrade the version and replace the mission array with the
+	// old single-predicate shape (type/params/status, no objectives), with
+	// the mission already Passed.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	doc["version"] = 8
+	payload := doc["payload"].(map[string]any)
+	payload["missions"] = []any{
+		map[string]any{
+			"id":     "leo-circularize-1000",
+			"name":   "Old circularize",
+			"type":   "circularize",
+			"status": 1, // Passed, in the old shape
+			"params": map[string]any{"primary_id": "earth", "altitude_m": 1000000},
+		},
+	}
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load v8 save: %v", err)
+	}
+
+	// Reseeded to the new nested catalog: every starter mission present,
+	// each with objectives, none carrying the dropped Passed progress.
+	if len(got.Missions) != 4 {
+		t.Fatalf("reseed: got %d missions, want 4 embedded starter missions", len(got.Missions))
+	}
+	for _, m := range got.Missions {
+		if len(m.Objectives) == 0 {
+			t.Errorf("reseeded mission %q has no objectives (old husk leaked through)", m.ID)
+		}
+		if m.Status != missions.InProgress {
+			t.Errorf("reseeded mission %q status = %v, want InProgress (old progress not dropped)", m.ID, m.Status)
+		}
+	}
+}
+
+// TestRoundtripV9MissionShape — a v9 save preserves the full nested
+// mission shape: program tag, requires edges, ordered objectives, and
+// per-objective status all survive Save→Load.
+func TestRoundtripV9MissionShape(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:          "rt-multi",
+		Name:        "Round trip",
+		Description: "two ordered steps",
+		Program:     "test-prog",
+		Requires:    []string{"leo-circularize-1000"},
+		Objectives: []missions.Objective{
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "moon"}, Status: missions.Passed},
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "mars"}, Status: missions.InProgress},
+		},
+		Status: missions.InProgress,
+	}}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(got.Missions) != 1 {
+		t.Fatalf("got %d missions, want 1", len(got.Missions))
+	}
+	m := got.Missions[0]
+	if m.ID != "rt-multi" || m.Program != "test-prog" {
+		t.Errorf("metadata lost: id=%q program=%q", m.ID, m.Program)
+	}
+	if len(m.Requires) != 1 || m.Requires[0] != "leo-circularize-1000" {
+		t.Errorf("requires lost: %v", m.Requires)
+	}
+	if len(m.Objectives) != 2 {
+		t.Fatalf("got %d objectives, want 2", len(m.Objectives))
+	}
+	if m.Objectives[0].Kind != missions.KindSOIFlyby || m.Objectives[0].Params.PrimaryID != "moon" {
+		t.Errorf("objective 0 lost: %+v", m.Objectives[0])
+	}
+	if m.Objectives[0].Status != missions.Passed {
+		t.Errorf("objective 0 status: got %v, want Passed", m.Objectives[0].Status)
+	}
+	if m.Objectives[1].Status != missions.InProgress {
+		t.Errorf("objective 1 status: got %v, want InProgress", m.Objectives[1].Status)
+	}
+}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -35,6 +35,7 @@ const (
 	ChipAttitude        Chip = "attitude"
 	ChipProjectedOrbit  Chip = "projectedOrbit"
 	ChipSOIPass         Chip = "soiPass"
+	ChipMissions        Chip = "missions" // v0.21 (ADR 0025): in-flight mission checklist
 )
 
 // Note: the Orbit-metrics readout and the active-burn (BURNS) readout are
@@ -61,6 +62,7 @@ var AllChips = []Chip{
 	ChipAttitude,
 	ChipProjectedOrbit,
 	ChipSOIPass,
+	ChipMissions,
 }
 
 // chipLabels maps each Chip to the human-readable name the Settings
@@ -78,6 +80,7 @@ var chipLabels = map[Chip]string{
 	ChipAttitude:        "Attitude",
 	ChipProjectedOrbit:  "Projected orbit",
 	ChipSOIPass:         "SOI pass",
+	ChipMissions:        "Mission checklist",
 }
 
 // Label returns the display name for c, falling back to the raw key for

--- a/internal/sim/landed.go
+++ b/internal/sim/landed.go
@@ -47,13 +47,10 @@ func integrateLanded(w *World, c *spacecraft.Spacecraft, simDelta time.Duration)
 	// v0.11.4 shipped LandedLatDeg/LonDeg (soft-touchdown coords) but
 	// never wired them in here — a soft-landed craft was re-pinned to
 	// its launch site projected onto the arrival body (or (0,0) for an
-	// orbit-spawned craft). Prefer the touchdown coords when set; fall
-	// back to the launchpad-spawn coords otherwise. Matches the field's
-	// documented "when non-zero, read these instead" contract.
-	lat, lon := c.LaunchLatDeg, c.LaunchLonDeg
-	if c.LandedLatDeg != 0 || c.LandedLonDeg != 0 {
-		lat, lon = c.LandedLatDeg, c.LandedLonDeg
-	}
+	// orbit-spawned craft). SurfaceLatLon prefers the touchdown coords
+	// when set, else the launchpad-spawn coords (v0.21: shared with the
+	// mission evaluator so both pin to the same point).
+	lat, lon := c.SurfaceLatLon()
 	dirRender := render.BodyFixedToWorld(c.Primary, lat, lon, w.Clock.SimTime)
 	c.State.R = orbital.Vec3{
 		X: radius * dirRender.X,

--- a/internal/sim/mission_catalog_progression_test.go
+++ b/internal/sim/mission_catalog_progression_test.go
@@ -1,0 +1,83 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// TestEmbeddedTutorialProgression is the automated proxy for playtesting the
+// v0.21 Slice 6 catalog: it drives the seeded tutorial through its intended
+// semantic actions + the requires gating and asserts each rung advances in
+// order, ending with the first challenge surfaced as active. This pins the
+// Slice-6 done-criterion ("a new player can complete the tutorial") so a
+// future catalog edit that strands a rung fails loudly.
+func TestEmbeddedTutorialProgression(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	statusByID := func(id string) missions.Status {
+		for i := range w.Missions {
+			if w.Missions[i].ID == id {
+				return w.Missions[i].Status
+			}
+		}
+		t.Fatalf("mission %q not in seeded catalog", id)
+		return missions.InProgress
+	}
+	// step records a semantic action and runs one mission-eval tick — the
+	// downward tui→sim→missions path the input handler drives in flight.
+	step := func(a missions.Action) {
+		w.RecordAction(a)
+		w.evaluateMissions()
+	}
+
+	// The opening active rung is the first tutorial step.
+	if am := w.ActiveMission(); am == nil || am.ID != "tut-orient" {
+		t.Fatalf("opening active mission = %v, want tut-orient", am)
+	}
+
+	// tut-orient: change view, then target.
+	step(missions.ActionCycleView)
+	step(missions.ActionCycleTarget)
+	if got := statusByID("tut-orient"); got != missions.Passed {
+		t.Fatalf("tut-orient = %v after view+target, want Passed", got)
+	}
+
+	// tut-plan unlocks: open the planner, then plant a transfer.
+	step(missions.ActionOpenManeuver)
+	step(missions.ActionPlanTransfer)
+	if got := statusByID("tut-plan"); got != missions.Passed {
+		t.Fatalf("tut-plan = %v after open+transfer, want Passed", got)
+	}
+
+	// tut-fly unlocks: a state objective — climb above 700 km. Pin the craft
+	// above the floor and evaluate (no physics tick needed).
+	c := w.ActiveCraft()
+	r := c.Primary.RadiusMeters() + 800_000 // comfortably above the 700 km floor
+	mu := c.Primary.GravitationalParameter()
+	c.State = physics.StateVector{
+		R: orbital.Vec3{X: r},
+		V: orbital.Vec3{Y: math.Sqrt(mu / r)},
+		M: c.TotalMass(),
+	}
+	w.evaluateMissions()
+	if got := statusByID("tut-fly"); got != missions.Passed {
+		t.Fatalf("tut-fly = %v after climbing above 700 km, want Passed", got)
+	}
+
+	// With the tutorial done, the first challenge is the active rung — and it
+	// stays InProgress (the craft is at 800 km, not a 1000 km circular), so
+	// the gating didn't let a later rung latch out of order.
+	if am := w.ActiveMission(); am == nil || am.ID != "chal-high-orbit" {
+		t.Fatalf("post-tutorial active mission = %v, want chal-high-orbit", am)
+	}
+	if got := statusByID("chal-high-orbit"); got != missions.InProgress {
+		t.Fatalf("chal-high-orbit = %v, want InProgress (not yet flown)", got)
+	}
+}

--- a/internal/sim/mission_context_test.go
+++ b/internal/sim/mission_context_test.go
@@ -1,0 +1,149 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// v0.21 Slice 2 (ADR 0025) — the sim→missions seam. missionEvalContext
+// snapshots Active-Vessel + world state into the read-only EvalContext the
+// evaluator consumes. These tests prove every field is wired from real
+// World state (including the resource/outcome fields no kind reads yet).
+
+func TestMissionEvalContextSnapshotsActiveCraft(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// Arrange a distinctive landed + noded + targeted + staged state.
+	c.Landed = true
+	c.LandedLatDeg, c.LandedLonDeg = 28.6, -80.6
+	c.Crashed = false
+	c.Nodes = append(c.Nodes, ManeuverNode{PrimaryID: c.Primary.ID})
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: 1}
+	w.stagedThisSession = true
+
+	ctx := w.missionEvalContext()
+
+	if ctx.PrimaryID != c.Primary.ID {
+		t.Errorf("PrimaryID: got %q want %q", ctx.PrimaryID, c.Primary.ID)
+	}
+	if !ctx.Landed {
+		t.Error("Landed not propagated")
+	}
+	if ctx.SurfaceLatDeg != 28.6 || ctx.SurfaceLonDeg != -80.6 {
+		t.Errorf("surface coords: got (%v,%v) want (28.6,-80.6)", ctx.SurfaceLatDeg, ctx.SurfaceLonDeg)
+	}
+	if ctx.FuelKg != c.ActiveStageFuel() {
+		t.Errorf("FuelKg: got %v want %v", ctx.FuelKg, c.ActiveStageFuel())
+	}
+	if ctx.MonopropKg != c.Monoprop {
+		t.Errorf("MonopropKg: got %v want %v", ctx.MonopropKg, c.Monoprop)
+	}
+	if ctx.DvBudget != c.RemainingDeltaV() {
+		t.Errorf("DvBudget: got %v want %v", ctx.DvBudget, c.RemainingDeltaV())
+	}
+	if !ctx.HasNode {
+		t.Error("HasNode not set with a planted node")
+	}
+	if !ctx.HasTarget {
+		t.Error("HasTarget not set with a body target")
+	}
+	if !ctx.Staged {
+		t.Error("Staged not propagated")
+	}
+}
+
+// TestMissionEvalContextSurfaceFallsBackToLaunchSite — with no soft-touchdown
+// coords, the surface position falls back to the launchpad-spawn site
+// (mirrors integrateLanded).
+func TestMissionEvalContextSurfaceFallsBackToLaunchSite(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.LaunchLatDeg, c.LaunchLonDeg = 45, 10
+	c.LandedLatDeg, c.LandedLonDeg = 0, 0 // no touchdown coords
+
+	ctx := w.missionEvalContext()
+	if ctx.SurfaceLatDeg != 45 || ctx.SurfaceLonDeg != 10 {
+		t.Errorf("fallback to launch site: got (%v,%v) want (45,10)", ctx.SurfaceLatDeg, ctx.SurfaceLonDeg)
+	}
+}
+
+// TestMissionEvalContextRendezvousRelativeState — a craft target feeds the
+// instantaneous range / closing speed used by the rendezvous kind. A
+// co-located twin yields ~0 separation and ~0 relative speed.
+func TestMissionEvalContextRendezvousRelativeState(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	twin := *active // co-located second vessel, same primary/state
+	twin.ID = active.ID + 1000
+	w.Crafts = append(w.Crafts, &twin)
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: twin.ID}
+
+	ctx := w.missionEvalContext()
+	if !ctx.HasTargetCraft {
+		t.Fatal("HasTargetCraft not set with a craft target")
+	}
+	if ctx.TargetRangeM > 1 {
+		t.Errorf("co-located range: got %v m, want ~0", ctx.TargetRangeM)
+	}
+	if ctx.TargetRelSpeedMs > 0.001 {
+		t.Errorf("co-located rel speed: got %v m/s, want ~0", ctx.TargetRelSpeedMs)
+	}
+}
+
+// TestTickPassesLandAtBody — the integration path: a land_at_body mission
+// passes through Tick→evaluateMissions once the active craft is Landed on
+// the named primary.
+func TestTickPassesLandAtBody(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.Missions = []missions.Mission{{
+		ID: "land-anywhere",
+		Objectives: []missions.Objective{
+			{Kind: missions.KindLandAtBody, Params: missions.Params{PrimaryID: c.Primary.ID}},
+		},
+	}}
+	c.Landed = true
+	w.Tick()
+	if w.Missions[0].Status != missions.Passed {
+		t.Fatalf("land_at_body after landing: got %v, want Passed", w.Missions[0].Status)
+	}
+}
+
+// TestStageActiveLatchesStagedFlag — decoupling a stage latches the
+// session staged flag the outcome context reads.
+func TestStageActiveLatchesStagedFlag(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.stagedThisSession {
+		t.Fatal("stagedThisSession should start false")
+	}
+	c := w.ActiveCraft()
+	if len(c.Stages) < 2 {
+		// Give the active craft a second stage so StageActive has something
+		// to drop (the default loadout may be single-stage).
+		c.Stages = append([]spacecraft.Stage{c.Stages[0]}, c.Stages...)
+		c.SyncFields()
+	}
+	if _, _, err := w.StageActive(w.ActiveCraftIdx); err != nil {
+		t.Fatalf("StageActive: %v", err)
+	}
+	if !w.stagedThisSession {
+		t.Error("stagedThisSession not latched after StageActive")
+	}
+}

--- a/internal/sim/mission_event_test.go
+++ b/internal/sim/mission_event_test.go
@@ -1,0 +1,106 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// v0.21 Slice 4 (ADR 0025 §6/§7) — the sim event sink. World.RecordAction is
+// the downward seam the TUI input layer calls (tui -> sim -> missions); the
+// evaluator drains the sink each tick so events only match during the tick
+// they fired.
+
+// TestRecordActionWiresRecentActions — RecordAction feeds the EvalContext sink
+// the event objective reads.
+func TestRecordActionWiresRecentActions(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.RecordAction(missions.ActionStage)
+	w.RecordAction(missions.ActionOpenManeuver)
+	ctx := w.missionEvalContext()
+	if len(ctx.RecentActions) != 2 || ctx.RecentActions[0] != missions.ActionStage || ctx.RecentActions[1] != missions.ActionOpenManeuver {
+		t.Fatalf("RecentActions: got %v, want [stage open_maneuver]", ctx.RecentActions)
+	}
+}
+
+// TestTickDrainsActionSink — evaluateMissions drains the sink each tick, so a
+// recorded action does not linger to latch a later-active objective.
+func TestTickDrainsActionSink(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.RecordAction(missions.ActionStage)
+	w.Tick()
+	if len(w.recentActions) != 0 {
+		t.Fatalf("sink after tick: got %d actions, want 0 (drained)", len(w.recentActions))
+	}
+}
+
+// TestActionSinkDrainsWithNoMissions — the sink drains even when no mission is
+// loaded, so actions can't accumulate unbounded across a missionless session.
+func TestActionSinkDrainsWithNoMissions(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = nil
+	w.RecordAction(missions.ActionStage)
+	w.Tick()
+	if len(w.recentActions) != 0 {
+		t.Fatalf("sink after missionless tick: got %d, want 0", len(w.recentActions))
+	}
+}
+
+// TestActionSinkDrainsWithEmptySlate — the sink drains every tick even with
+// NO crafts (empty slate after EndFlight). spawn_craft / auto_warp / cycle_view
+// aren't craft-gated, so without an unconditional drain the sink would grow
+// unbounded AND stale actions would survive to latch a freshly-active event
+// objective on the first post-spawn tick (ADR 0025 §6 since-active guarantee).
+func TestActionSinkDrainsWithEmptySlate(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Crafts = nil // empty slate — last craft ended
+	w.RecordAction(missions.ActionSpawnCraft)
+	w.Tick()
+	if len(w.recentActions) != 0 {
+		t.Fatalf("sink after empty-slate tick: got %d, want 0 (drained regardless of crafts)", len(w.recentActions))
+	}
+}
+
+// TestEventObjectivePassesThroughTick — the integration path: an event
+// objective passes when its action is recorded before the tick, and a fresh
+// one stays InProgress when no action is recorded (proves the drain).
+func TestEventObjectivePassesThroughTick(t *testing.T) {
+	mk := func() *World {
+		w, err := NewWorld()
+		if err != nil {
+			t.Fatalf("NewWorld: %v", err)
+		}
+		w.Missions = []missions.Mission{{
+			ID:         "event-stage",
+			Objectives: []missions.Objective{{Kind: missions.KindEvent, Params: missions.Params{Action: missions.ActionStage}}},
+		}}
+		return w
+	}
+
+	// Recorded before the tick -> passes.
+	w := mk()
+	w.RecordAction(missions.ActionStage)
+	w.Tick()
+	if w.Missions[0].Status != missions.Passed {
+		t.Fatalf("with stage recorded: got %v, want Passed", w.Missions[0].Status)
+	}
+
+	// Not recorded -> stays InProgress (the sink was drained, nothing matches).
+	w2 := mk()
+	w2.Tick()
+	if w2.Missions[0].Status != missions.InProgress {
+		t.Fatalf("without action: got %v, want InProgress", w2.Missions[0].Status)
+	}
+}

--- a/internal/sim/mission_fail_flash_test.go
+++ b/internal/sim/mission_fail_flash_test.go
@@ -1,0 +1,90 @@
+package sim
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// The checklist chip flashes a just-failed mission for a few wall-clock
+// seconds before advancing (ADR 0025 §5 / Slice 5). These pin the window
+// helper and the InProgress→Failed transition detection in evaluateMissions.
+
+func TestMissionFailFlashActiveWindow(t *testing.T) {
+	now := time.Unix(1000, 0)
+	if _, ok := missionFailFlashActive("", now.Add(time.Second), now); ok {
+		t.Error("empty message should never be active")
+	}
+	if msg, ok := missionFailFlashActive("Apollo failed: crashed", now.Add(time.Second), now); !ok || msg != "Apollo failed: crashed" {
+		t.Errorf("within window: got %q ok=%v, want the message + true", msg, ok)
+	}
+	if _, ok := missionFailFlashActive("Apollo failed", now.Add(-time.Second), now); ok {
+		t.Error("past the deadline should be inactive")
+	}
+}
+
+// failOnCrashMission is a one-objective mission that can only end by failing
+// on crash: the SOIFlyby names a body the craft is never the primary of, so
+// the kind predicate stays InProgress and the opt-in fail_on drives it Failed.
+func failOnCrashMission() missions.Mission {
+	return missions.Mission{
+		ID:   "t",
+		Name: "Test Mission",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindSOIFlyby,
+			Params: missions.Params{PrimaryID: "no-such-body"},
+			FailOn: []missions.FailCondition{missions.FailCrashed},
+		}},
+	}
+}
+
+func TestEvaluateMissionsFlagsFailure(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+	c.Crashed = true
+	w.Missions = []missions.Mission{failOnCrashMission()}
+
+	w.evaluateMissions()
+
+	if w.Missions[0].Status != missions.Failed {
+		t.Fatalf("mission status = %v, want Failed", w.Missions[0].Status)
+	}
+	msg, ok := w.MissionFailFlash()
+	if !ok {
+		t.Fatal("expected an active failure flash after the crash")
+	}
+	if !strings.Contains(msg, "Test Mission") || !strings.Contains(msg, "crashed") {
+		t.Errorf("flash = %q, want it to name the mission and the reason", msg)
+	}
+}
+
+func TestEvaluateMissionsNoFlashWithoutFailure(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Crashed, but the mission opts into no fail condition — it must not flash.
+	w.ActiveCraft().Crashed = true
+	w.Missions = []missions.Mission{{
+		ID:   "safe",
+		Name: "Safe",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindSOIFlyby,
+			Params: missions.Params{PrimaryID: "no-such-body"},
+		}},
+	}}
+
+	w.evaluateMissions()
+
+	if _, ok := w.MissionFailFlash(); ok {
+		t.Error("a no-fail_on mission should not raise a failure flash")
+	}
+}

--- a/internal/sim/mission_failure_test.go
+++ b/internal/sim/mission_failure_test.go
@@ -1,0 +1,75 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// v0.21 Slice 3 (ADR 0025 §5) — the sim→missions seam for failure. These
+// prove the fail-condition inputs are wired from real World state (the
+// Active Vessel) and that a fail_on objective fails through the Tick path.
+
+// TestMissionEvalContextWiresTotalFuel — out_of_fuel reads TotalFuelKg, the
+// summed propellant across every stage (c.Fuel), NOT the active-stage fuel.
+func TestMissionEvalContextWiresTotalFuel(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	ctx := w.missionEvalContext()
+	if ctx.TotalFuelKg != c.Fuel {
+		t.Errorf("TotalFuelKg: got %v want %v (summed all-stage fuel)", ctx.TotalFuelKg, c.Fuel)
+	}
+}
+
+// TestTickFailsOnCrash — the integration path: a fail_on: [crashed] mission
+// transitions to Failed through Tick→evaluateMissions once the active craft
+// is Crashed.
+func TestTickFailsOnCrash(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.Missions = []missions.Mission{{
+		ID: "dont-crash",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindReachAltitude,
+			Params: missions.Params{PrimaryID: c.Primary.ID, MinAltitudeM: 1e9},
+			FailOn: []missions.FailCondition{missions.FailCrashed},
+		}},
+	}}
+	w.Tick()
+	if w.Missions[0].Status != missions.InProgress {
+		t.Fatalf("intact craft below floor: got %v, want InProgress", w.Missions[0].Status)
+	}
+	c.Crashed = true
+	w.Tick()
+	if w.Missions[0].Status != missions.Failed {
+		t.Fatalf("after crash: got %v, want Failed", w.Missions[0].Status)
+	}
+}
+
+// TestTickNoFailOnSurvivesCrash — a mission with no fail_on never fails, even
+// when the active craft is Crashed (the no-fail default flown end to end).
+func TestTickNoFailOnSurvivesCrash(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.Missions = []missions.Mission{{
+		ID: "no-fail",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindReachAltitude,
+			Params: missions.Params{PrimaryID: c.Primary.ID, MinAltitudeM: 1e9},
+		}},
+	}}
+	c.Crashed = true
+	w.Tick()
+	if w.Missions[0].Status != missions.InProgress {
+		t.Fatalf("no fail_on after crash: got %v, want InProgress", w.Missions[0].Status)
+	}
+}

--- a/internal/sim/mission_requires_test.go
+++ b/internal/sim/mission_requires_test.go
@@ -45,3 +45,24 @@ func TestEvaluateMissionsGatesOnRequires(t *testing.T) {
 		t.Fatalf("B status = %v, want Passed once A passed", w.Missions[1].Status)
 	}
 }
+
+// ActiveMission (the chip's source) must skip a requires-locked rung even when
+// it is the first InProgress mission — otherwise the chip would surface a
+// frozen mission the evaluator never advances, disagreeing with the ladder
+// screen, which classifies the same rung as locked. v0.21 Slice 6.
+func TestActiveMissionSkipsLockedRungs(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "locked", Name: "Locked", Requires: []string{"prereq"},
+			Objectives: []missions.Objective{{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "x"}}}},
+		{ID: "prereq", Name: "Prereq",
+			Objectives: []missions.Objective{{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "y"}}}},
+	}
+	am := w.ActiveMission()
+	if am == nil || am.ID != "prereq" {
+		t.Fatalf("ActiveMission = %v, want the unlocked 'prereq', not the locked rung ordered before it", am)
+	}
+}

--- a/internal/sim/mission_requires_test.go
+++ b/internal/sim/mission_requires_test.go
@@ -1,0 +1,47 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// requires gates the evaluator, not just the ladder display (ADR 0025 §8,
+// v0.21 Slice 6): a mission whose prerequisites haven't Passed must not have
+// its objectives latch — even when the objective condition is already true.
+
+func TestEvaluateMissionsGatesOnRequires(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	primary := w.ActiveCraft().Primary.ID // the craft's real primary (earth)
+
+	// B is gated behind A. B's soi_flyby of the craft's own primary would
+	// pass on tick 1; A's names a body the craft is never the primary of, so
+	// A stays InProgress and B must stay locked.
+	w.Missions = []missions.Mission{
+		{ID: "A", Name: "A", Objectives: []missions.Objective{
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "no-such-body"}},
+		}},
+		{ID: "B", Name: "B", Requires: []string{"A"}, Objectives: []missions.Objective{
+			{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: primary}},
+		}},
+	}
+
+	w.evaluateMissions()
+	if w.Missions[1].Status == missions.Passed {
+		t.Fatal("gated mission B passed before requirement A — requires must gate evaluation, not just display")
+	}
+
+	// Unblock A, then B should be free to pass on a subsequent tick.
+	w.Missions[0].Objectives[0].Params.PrimaryID = primary
+	w.evaluateMissions() // A passes (B still gated against the pre-tick snapshot)
+	w.evaluateMissions() // A now in the passed set → B evaluated → passes
+	if w.Missions[0].Status != missions.Passed {
+		t.Fatalf("A status = %v, want Passed", w.Missions[0].Status)
+	}
+	if w.Missions[1].Status != missions.Passed {
+		t.Fatalf("B status = %v, want Passed once A passed", w.Missions[1].Status)
+	}
+}

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -128,6 +128,7 @@ func (w *World) StageActive(craftIdx int) (newActiveIdx, jettisonedIdx int, err 
 	// upper chain). Slate ordering: active idx is unchanged; the
 	// jettisoned stage sits at the end.
 	newActiveIdx = craftIdx
+	w.stagedThisSession = true // mission outcome context (ADR 0025)
 	return newActiveIdx, jettisonedIdx, nil
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -668,7 +668,16 @@ func (w *World) evaluateMissions() {
 		return
 	}
 	ctx := w.missionEvalContext()
+	// requires gates the evaluator, not just the ladder display (ADR 0025 §8,
+	// v0.21 Slice 6): skip any mission whose prerequisites haven't Passed so
+	// its objectives can't latch out of order. The passed set is snapshotted
+	// before the loop, so a prerequisite that passes this tick only unlocks
+	// its dependents on the next tick (one 50 ms step — imperceptible).
+	passed := missions.PassedSet(w.Missions)
 	for i := range w.Missions {
+		if !w.Missions[i].RequirementsMet(passed) {
+			continue
+		}
 		prev := w.Missions[i].Status
 		w.Missions[i].Evaluate(ctx)
 		// A fresh InProgress→Failed transition arms the chip's failure flash

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -186,6 +186,12 @@ type World struct {
 	// time; Status fields progress as the player flies. v0.6.5+.
 	Missions []missions.Mission
 
+	// stagedThisSession latches once the player decouples a stage; it
+	// feeds the mission evaluator's outcome context (ADR 0025). Session
+	// scoped (not persisted) — outcome objectives that need it land in a
+	// later slice. v0.21+.
+	stagedThisSession bool
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -633,16 +639,56 @@ func (w *World) evaluateMissions() {
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
 	}
-	ctx := missions.EvalContext{
-		PrimaryID:      w.ActiveCraft().Primary.ID,
-		PrimaryRadiusM: w.ActiveCraft().Primary.RadiusMeters(),
-		PrimaryMu:      w.ActiveCraft().Primary.GravitationalParameter(),
-		State:          w.ActiveCraft().State,
-		SimTime:        w.Clock.SimTime,
-	}
+	ctx := w.missionEvalContext()
 	for i := range w.Missions {
 		w.Missions[i].Evaluate(ctx)
 	}
+}
+
+// missionEvalContext snapshots the read-only slice of World state the
+// mission evaluator needs, all relative to the Active Vessel. Returns the
+// zero EvalContext when there's no active craft. The resource/outcome
+// fields (fuel, monoprop, Δv, crashed, node/target/staged flags) are
+// populated even though no v0.21 state-objective kind reads them yet — the
+// slice-3 failure semantics and slice-4 outcome steps depend on a complete
+// context. v0.21 (ADR 0025).
+func (w *World) missionEvalContext() missions.EvalContext {
+	c := w.ActiveCraft()
+	if c == nil {
+		return missions.EvalContext{}
+	}
+	// Surface coordinates: same source of truth integrateLanded pins to,
+	// so the mission evaluates against the craft's actual landed position.
+	lat, lon := c.SurfaceLatLon()
+	ctx := missions.EvalContext{
+		PrimaryID:      c.Primary.ID,
+		PrimaryRadiusM: c.Primary.RadiusMeters(),
+		PrimaryMu:      c.Primary.GravitationalParameter(),
+		State:          c.State,
+		SimTime:        w.Clock.SimTime,
+		Landed:         c.Landed,
+		SurfaceLatDeg:  lat,
+		SurfaceLonDeg:  lon,
+		Crashed:        c.Crashed,
+		FuelKg:         c.ActiveStageFuel(),
+		MonopropKg:     c.Monoprop,
+		DvBudget:       c.RemainingDeltaV(),
+		Docked:         len(c.DockedComponents) > 0,
+		HasNode:        len(c.Nodes) > 0,
+		HasTarget:      w.Target.Kind != spacecraft.TargetNone,
+		Staged:         w.stagedThisSession,
+	}
+	// Target-craft relative state (rendezvous), against the player's
+	// current target slot in the active craft's frame. Only when a craft
+	// (not a body) is targeted, so non-rendezvous play skips the solve.
+	if w.Target.Kind == spacecraft.TargetCraft {
+		if rT, vT, ok := w.TargetStateRelativeToActivePrimary(); ok {
+			ctx.HasTargetCraft = true
+			ctx.TargetRangeM = c.State.R.Sub(rT).Norm()
+			ctx.TargetRelSpeedMs = c.State.V.Sub(vT).Norm()
+		}
+	}
+	return ctx
 }
 
 // ActiveMission returns the first in-progress mission, or nil if all

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -267,10 +267,12 @@ func NewWorld() (*World, error) {
 	}
 	w.Calculator = orbital.ForSystem(w.System())
 
-	// v0.6.5: seed missions from the embedded starter catalog. A failure
-	// to load the catalog is non-fatal — missions are an additive
-	// feature and shouldn't block worldgen if the JSON is malformed.
-	if cat, err := missions.DefaultCatalog(); err == nil {
+	// v0.6.5: seed missions from the starter catalog. v0.21 (ADR 0025):
+	// LoadAll merges the embedded catalog with any user overlay and never
+	// hard-fails on a bad overlay file (it surfaces as a Failed
+	// placeholder mission), so this stays non-fatal — missions are an
+	// additive feature and shouldn't block worldgen.
+	if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
 
@@ -622,9 +624,11 @@ type DockEvent struct {
 	CompositeName string // name of the resulting composite craft
 }
 
-// evaluateMissions steps each mission's predicate against the live
-// craft state. Terminal-state missions are evaluated too, but their
-// status is sticky in missions.Mission.Evaluate. v0.6.5+.
+// evaluateMissions steps each mission against the live craft state.
+// Mission.Evaluate walks the mission's ordered objectives, mutating
+// per-objective and per-mission Status in place; terminal states are
+// sticky, so missions already Passed/Failed are cheap no-ops. v0.6.5+;
+// v0.21 (ADR 0025) the unit is a Mission of ordered Objectives.
 func (w *World) evaluateMissions() {
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
@@ -637,7 +641,7 @@ func (w *World) evaluateMissions() {
 		SimTime:        w.Clock.SimTime,
 	}
 	for i := range w.Missions {
-		w.Missions[i].Status = w.Missions[i].Evaluate(ctx)
+		w.Missions[i].Evaluate(ctx)
 	}
 }
 

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -673,6 +673,7 @@ func (w *World) missionEvalContext() missions.EvalContext {
 		FuelKg:         c.ActiveStageFuel(),
 		MonopropKg:     c.Monoprop,
 		DvBudget:       c.RemainingDeltaV(),
+		TotalFuelKg:    c.Fuel, // summed all-stage propellant (out_of_fuel)
 		Docked:         len(c.DockedComponents) > 0,
 		HasNode:        len(c.Nodes) > 0,
 		HasTarget:      w.Target.Kind != spacecraft.TargetNone,

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -199,6 +199,17 @@ type World struct {
 	// persisted.
 	recentActions []missions.Action
 
+	// missionFailMsg / missionFailUntil drive the checklist chip's
+	// transient failure flash (ADR 0025 §5 / Slice 5, v0.21). When a mission
+	// transitions InProgress→Failed, evaluateMissions records a player-facing
+	// message ("<name> failed: <reason>") and a wall-clock deadline
+	// missionFailFlashWindow out; MissionFailFlash reports it active until the
+	// deadline passes, after which the chip advances to the next mission. The
+	// deadline is wall-clock, not sim-time, so it expires even if the player
+	// pauses the instant they fail. Session scoped, not persisted.
+	missionFailMsg   string
+	missionFailUntil time.Time
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -658,8 +669,56 @@ func (w *World) evaluateMissions() {
 	}
 	ctx := w.missionEvalContext()
 	for i := range w.Missions {
+		prev := w.Missions[i].Status
 		w.Missions[i].Evaluate(ctx)
+		// A fresh InProgress→Failed transition arms the chip's failure flash
+		// (ADR 0025 §5). Naming the reason needs the failed objective: scan
+		// for it and ask which opt-in fail_on condition fired.
+		if prev == missions.InProgress && w.Missions[i].Status == missions.Failed {
+			var reason missions.FailCondition
+			if o, ok := w.Missions[i].FailedObjective(); ok {
+				if r, ok := o.FailReason(ctx); ok {
+					reason = r
+				}
+			}
+			w.flagMissionFailure(w.Missions[i].Name, reason)
+		}
 	}
+}
+
+// missionFailFlashWindow is how long (wall-clock) the checklist chip flashes
+// a just-failed mission before advancing to the next active one. Wall-clock,
+// not sim-time, so it still expires if the player pauses on failure.
+const missionFailFlashWindow = 4 * time.Second
+
+// flagMissionFailure records that mission `name` just died for `reason`, so
+// the checklist chip can flash it for missionFailFlashWindow. The newest
+// failure overwrites any prior flash. A blank reason yields a bare
+// "<name> failed" (no opt-in condition matched the failed objective).
+func (w *World) flagMissionFailure(name string, reason missions.FailCondition) {
+	if reason != "" {
+		w.missionFailMsg = name + " failed: " + reason.Label()
+	} else {
+		w.missionFailMsg = name + " failed"
+	}
+	w.missionFailUntil = time.Now().Add(missionFailFlashWindow)
+}
+
+// MissionFailFlash returns the active failure-flash text and true while a
+// just-failed mission is still within its flash window, or ("", false)
+// once the window has elapsed (or none has failed). The player surface (the
+// checklist chip) reads this each frame. v0.21 Slice 5 (ADR 0025 §5).
+func (w *World) MissionFailFlash() (string, bool) {
+	return missionFailFlashActive(w.missionFailMsg, w.missionFailUntil, time.Now())
+}
+
+// missionFailFlashActive is the pure window predicate behind MissionFailFlash,
+// split out so the time-window logic is testable without wall-clock.
+func missionFailFlashActive(msg string, until, now time.Time) (string, bool) {
+	if msg == "" || !now.Before(until) {
+		return "", false
+	}
+	return msg, true
 }
 
 // RecordAction appends a semantic gameplay action to the per-tick event sink

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -787,13 +787,19 @@ func (w *World) missionEvalContext() missions.EvalContext {
 	return ctx
 }
 
-// ActiveMission returns the first in-progress mission, or nil if all
-// missions are passed/failed (or none are loaded). v0.6.5+. Used by
-// the HUD to surface a single-line status — multi-mission UX is a
-// follow-up.
+// ActiveMission returns the first in-progress mission whose requirements are
+// met — the rung the player is actually working on — or nil if none qualifies
+// (all passed/failed/locked, or none loaded). v0.6.5+. The requires gate (ADR
+// 0025 §8, v0.21 Slice 6) matters because the evaluator now skips locked
+// missions, so a locked mission stays InProgress forever: without this gate
+// the in-flight chip (the only caller) could surface a locked mission with
+// frozen progress while the ladder screen — which classifies the same mission
+// as locked — shows a different active card. Both surfaces now share one
+// definition of "active". Used by the HUD to surface a single-line status.
 func (w *World) ActiveMission() *missions.Mission {
+	passed := missions.PassedSet(w.Missions)
 	for i := range w.Missions {
-		if w.Missions[i].Status == missions.InProgress {
+		if w.Missions[i].Status == missions.InProgress && w.Missions[i].RequirementsMet(passed) {
 			return &w.Missions[i]
 		}
 	}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -192,6 +192,13 @@ type World struct {
 	// later slice. v0.21+.
 	stagedThisSession bool
 
+	// recentActions is the event-objective sink (ADR 0025 §6, v0.21): the
+	// semantic gameplay actions the TUI input layer recorded since the last
+	// mission-eval tick. Appended by RecordAction (downward from tui),
+	// consumed + drained by evaluateMissions each tick. Session scoped, not
+	// persisted.
+	recentActions []missions.Action
+
 	// soiCheckCounter throttles primary-reevaluation — we only need to
 	// check every few ticks, not every Verlet sub-step.
 	soiCheckCounter int
@@ -612,8 +619,13 @@ func (w *World) Tick() {
 				CompositeName: w.ActiveCraft().Name,
 			}
 		}
-		w.evaluateMissions()
 	}
+	// Mission eval runs every tick — even with an empty slate — so the event
+	// sink is drained each tick regardless of crafts (ADR 0025 §6). It
+	// early-returns when there's no active craft after draining, so actions
+	// recorded during an empty-slate window can't survive to latch a
+	// freshly-active event objective on the first post-spawn tick.
+	w.evaluateMissions()
 	// v0.11.0+: per-tick ViewLaunch route/release state machine.
 	// Runs after integration so the post-tick Landed state is
 	// authoritative (engine ignition clears Landed inside
@@ -636,6 +648,11 @@ type DockEvent struct {
 // sticky, so missions already Passed/Failed are cheap no-ops. v0.6.5+;
 // v0.21 (ADR 0025) the unit is a Mission of ordered Objectives.
 func (w *World) evaluateMissions() {
+	// Drain the event-action sink every tick regardless of mission state:
+	// actions recorded while no objective was active must not pile up and
+	// later latch a freshly-active event objective (ADR 0025 §6), and the
+	// slice must not grow unbounded. Reslice to [:0] keeps the backing array.
+	defer func() { w.recentActions = w.recentActions[:0] }()
 	if len(w.Missions) == 0 || w.ActiveCraft() == nil {
 		return
 	}
@@ -643,6 +660,15 @@ func (w *World) evaluateMissions() {
 	for i := range w.Missions {
 		w.Missions[i].Evaluate(ctx)
 	}
+}
+
+// RecordAction appends a semantic gameplay action to the per-tick event sink
+// the mission evaluator drains (ADR 0025 §6/§7, v0.21). Called downward by the
+// TUI input layer after it resolves a keybinding to an action — so events are
+// rebinding-proof and `missions` never imports `tui`. No-op-safe to call when
+// no mission is loaded (the sink is drained each tick anyway).
+func (w *World) RecordAction(a missions.Action) {
+	w.recentActions = append(w.recentActions, a)
 }
 
 // missionEvalContext snapshots the read-only slice of World state the
@@ -678,6 +704,7 @@ func (w *World) missionEvalContext() missions.EvalContext {
 		HasNode:        len(c.Nodes) > 0,
 		HasTarget:      w.Target.Kind != spacecraft.TargetNone,
 		Staged:         w.stagedThisSession,
+		RecentActions:  w.recentActions,
 	}
 	// Target-craft relative state (rendezvous), against the player's
 	// current target slot in the active craft's frame. Only when a craft

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -81,8 +81,8 @@ type bodies_CelestialBody = bodies.CelestialBody
 // render as 384k km from the Sun — closer than Mercury.
 func TestBodyPositionRecursesThroughHierarchy(t *testing.T) {
 	w, _ := NewWorld()
-	moonPtr := findBody(w,"Moon")
-	earthPtr := findBody(w,"Earth")
+	moonPtr := findBody(w, "Moon")
+	earthPtr := findBody(w, "Earth")
 	if moonPtr == nil || earthPtr == nil {
 		t.Skip("Moon or Earth missing from Sol")
 	}
@@ -112,7 +112,7 @@ func TestBodyPositionRecursesThroughHierarchy(t *testing.T) {
 func TestFindPrimaryNestedSOIWalk(t *testing.T) {
 	w, _ := NewWorld()
 	sys := w.System()
-	moon := findBody(w,"Moon")
+	moon := findBody(w, "Moon")
 	if moon == nil {
 		t.Skip("Moon missing from Sol")
 	}
@@ -141,7 +141,7 @@ func TestFindPrimaryGalileanMultiMoon(t *testing.T) {
 	w, _ := NewWorld()
 	sys := w.System()
 	for _, name := range []string{"Io", "Europa", "Ganymede", "Callisto"} {
-		moon := findBody(w,name)
+		moon := findBody(w, name)
 		if moon == nil {
 			t.Errorf("%s missing from Sol", name)
 			continue
@@ -344,25 +344,29 @@ func TestTickPassesCircularizeAtTarget(t *testing.T) {
 		V: orbital.Vec3{Y: v},
 		M: w.ActiveCraft().TotalMass(),
 	}
+
+	// Inject a single un-gated circularize mission so this exercises the
+	// Tick → evaluateMissions → circularize-passes path directly. (The seeded
+	// catalog's circularize rung is now requires-gated behind the tutorial —
+	// ADR 0025 Slice 6 — so it deliberately won't latch out of order.)
+	w.Missions = []missions.Mission{{
+		ID:   "test-circ",
+		Name: "Circularize",
+		Objectives: []missions.Objective{{
+			Kind: missions.KindCircularize,
+			Params: missions.Params{
+				PrimaryID:       w.ActiveCraft().Primary.ID,
+				AltitudeM:       1_000_000,
+				AltitudeTolPct:  0.05,
+				EccentricityCap: 0.01,
+			},
+		}},
+	}}
+
 	w.Tick()
 
-	var found *missions.Mission
-	for i := range w.Missions {
-		for j := range w.Missions[i].Objectives {
-			if w.Missions[i].Objectives[j].Kind == missions.KindCircularize {
-				found = &w.Missions[i]
-				break
-			}
-		}
-		if found != nil {
-			break
-		}
-	}
-	if found == nil {
-		t.Fatal("circularize mission not present in default catalog")
-	}
-	if found.Status != missions.Passed {
-		t.Errorf("circularize at 1000 km: got %v, want Passed", found.Status)
+	if got := w.Missions[0].Status; got != missions.Passed {
+		t.Errorf("circularize at 1000 km: got %v, want Passed", got)
 	}
 }
 

--- a/internal/sim/world_test.go
+++ b/internal/sim/world_test.go
@@ -348,8 +348,13 @@ func TestTickPassesCircularizeAtTarget(t *testing.T) {
 
 	var found *missions.Mission
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularize {
-			found = &w.Missions[i]
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularize {
+				found = &w.Missions[i]
+				break
+			}
+		}
+		if found != nil {
 			break
 		}
 	}

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -400,6 +400,20 @@ func (s *Spacecraft) EffectiveThrottle() float64 {
 // TotalMass returns dry + fuel + monoprop.
 func (s *Spacecraft) TotalMass() float64 { return s.DryMass + s.Fuel + s.Monoprop }
 
+// SurfaceLatLon returns the craft's body-fixed surface coordinates in
+// degrees (north-positive, east-positive): the soft-touchdown coords when
+// set, else the launchpad-spawn coords ("when non-zero, read these
+// instead"). Meaningful when the craft is Landed. Single source of truth
+// for both the landed-integration pin (sim.integrateLanded) and the
+// mission evaluator's surface position (sim.missionEvalContext). v0.21+.
+func (s *Spacecraft) SurfaceLatLon() (lat, lon float64) {
+	lat, lon = s.LaunchLatDeg, s.LaunchLonDeg
+	if s.LandedLatDeg != 0 || s.LandedLonDeg != 0 {
+		lat, lon = s.LandedLatDeg, s.LandedLonDeg
+	}
+	return lat, lon
+}
+
 // DefaultBallisticCoefficient is the v0.8.4 baseline (C_D · A / m)
 // for an S-IVB-1-class craft in m²/kg. Used as the fallback when
 // Spacecraft.BallisticCoefficient is zero — legacy saves and any

--- a/internal/spacecraft/spacecraft_test.go
+++ b/internal/spacecraft/spacecraft_test.go
@@ -30,3 +30,19 @@ func TestNewInLEO(t *testing.T) {
 		t.Errorf("orbital speed = %.1f m/s, want ~7613 m/s", v)
 	}
 }
+
+// TestSurfaceLatLon — touchdown coords win when set; otherwise the
+// launchpad-spawn coords are used (the "when non-zero, read these instead"
+// fallback shared by integrateLanded and the mission evaluator).
+func TestSurfaceLatLon(t *testing.T) {
+	s := &Spacecraft{LaunchLatDeg: 28.6, LaunchLonDeg: -80.6}
+	// No touchdown coords → falls back to the launch site.
+	if lat, lon := s.SurfaceLatLon(); lat != 28.6 || lon != -80.6 {
+		t.Errorf("fallback: got (%v,%v), want (28.6,-80.6)", lat, lon)
+	}
+	// Touchdown coords set → they win.
+	s.LandedLatDeg, s.LandedLonDeg = -5, 120
+	if lat, lon := s.SurfaceLatLon(); lat != -5 || lon != 120 {
+		t.Errorf("touchdown: got (%v,%v), want (-5,120)", lat, lon)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/keylayout"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/settings"
@@ -298,6 +299,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// v0.8.6+: clear-all from the maneuver form. Replaces the
 		// retired N global keybinding.
 		a.world.ClearNodes()
+		a.world.RecordAction(missions.ActionClearNodes) // ADR 0025 §7
 		a.maneuver.ResetEditing()
 		a.world.Clock.Paused = false
 		a.active = screenOrbit
@@ -642,6 +644,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.bindManeuverTarget()
 				a.active = screenManeuver
 				a.world.Clock.Paused = true
+				a.world.RecordAction(missions.ActionOpenManeuver) // ADR 0025 §7
 			}
 			return a, nil
 		case key.Matches(m, a.keys.WarpUp):
@@ -659,6 +662,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Toggle Auto-Warp to the globally-soonest burn. A no-op when
 			// no burn is eligible (engage returns false silently).
 			a.world.ToggleAutoWarp()
+			a.world.RecordAction(missions.ActionAutoWarp) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.CancelWarp):
 			// Drop straight to 1× from any warp state: cancel Auto-Warp
@@ -721,6 +725,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.spawn.Reset(a.world.System().Bodies, defaultParentID)
 			a.active = screenSpawn
+			a.world.RecordAction(missions.ActionSpawnCraft) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.PlanTransfer):
 			// v0.9.0+: H consumes World.Target instead of the implicit
@@ -732,6 +737,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				switch a.world.Target.Kind {
 				case sim.TargetBody:
 					_, _ = a.world.PlanTransfer(a.world.Target.BodyIdx)
+					a.world.RecordAction(missions.ActionPlanTransfer) // ADR 0025 §7
 					// v0.12.x (ADR 0005): the intra-primary auto-plant is
 					// now a plane-aware dual-strategy solver (combined
 					// fused-Lambert vs split raise + apoapsis plane change)
@@ -784,6 +790,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						plan.DV, nodeLabel)
 				}
 				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.world.RecordAction(missions.ActionPlanIncl) // ADR 0025 §7
 			}
 			return a, nil
 		case key.Matches(m, a.keys.PlanCircularize):
@@ -802,6 +809,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						plan.ApoAltM/1000, plan.DV)
 				}
 				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.world.RecordAction(missions.ActionPlanCircularize) // ADR 0025 §7
 			}
 			return a, nil
 		case key.Matches(m, a.keys.PlanRendezvous):
@@ -821,6 +829,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival)
 				}
 				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.world.RecordAction(missions.ActionPlanRendezvous) // ADR 0025 §7
 			}
 			return a, nil
 		case key.Matches(m, a.keys.Porkchop):
@@ -839,6 +848,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.CycleView):
 			a.world.CycleViewMode()
+			a.world.RecordAction(missions.ActionCycleView) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.Declutter):
 			// v0.13+ (ADR 0010): toggle the momentary "hide all overlays"
@@ -878,6 +888,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.statusMsg = fmt.Sprintf("refined — correction %.1f m/s, arrival %.1f m/s", corr, arr)
 				}
 				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.world.RecordAction(missions.ActionRefinePlan) // ADR 0025 §7
 			}
 			return a, nil
 
@@ -888,15 +899,19 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// was easy to trigger by accident.
 		case key.Matches(m, a.keys.ThrottleFull):
 			a.world.SetThrottle(1.0)
+			a.world.RecordAction(missions.ActionThrottleFull) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.ThrottleCut):
 			a.world.SetThrottle(0)
+			a.world.RecordAction(missions.ActionThrottleCut) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.ThrottleUp):
 			a.world.AdjustThrottle(0.1)
+			a.world.RecordAction(missions.ActionThrottleUp) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.ThrottleDown):
 			a.world.AdjustThrottle(-0.1)
+			a.world.RecordAction(missions.ActionThrottleDown) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.AttitudePrograde):
 			a.handleAttitudeIntent(sim.IntentPrograde)
@@ -918,6 +933,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.ToggleBurn):
 			a.world.ToggleManualBurn()
+			a.world.RecordAction(missions.ActionToggleBurn) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.CycleEngine):
 			a.world.CycleEngineMode()
@@ -939,6 +955,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.world.Undock(a.world.ActiveCraftIdx) {
 				a.statusMsg = fmt.Sprintf("undocked into %d components", len(a.world.Crafts))
 				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.world.RecordAction(missions.ActionUndock) // ADR 0025 §7
 			}
 			return a, nil
 		case key.Matches(m, a.keys.Transpose):
@@ -947,6 +964,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// TEI) with the LM as a docked nose payload released via U.
 			switch err := a.world.Transpose(a.world.ActiveCraftIdx); {
 			case err == nil:
+				a.world.RecordAction(missions.ActionTranspose) // ADR 0025 §7
 				a.statusMsg = "transposed: SM is firing core — press U to release the LM"
 			case errors.Is(err, sim.ErrTransposeNotReady):
 				a.statusMsg = "transpose: drop the launch vehicle first (stack must be Descent/Ascent/SM/CM)"
@@ -957,12 +975,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		case key.Matches(m, a.keys.CycleTarget):
 			a.world.CycleTarget(true)
+			a.world.RecordAction(missions.ActionCycleTarget) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.ClearTarget):
 			a.world.ClearTarget()
+			a.world.RecordAction(missions.ActionClearTarget) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.CycleNavMode):
 			nav := a.world.CycleNavMode()
+			a.world.RecordAction(missions.ActionCycleNavMode) // ADR 0025 §7
 			a.statusMsg = fmt.Sprintf("nav: %s", nav)
 			a.statusExpires = time.Now().Add(2 * time.Second)
 			return a, nil
@@ -1000,6 +1021,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_, jettIdx, err := a.world.StageActive(a.world.ActiveCraftIdx)
 			switch {
 			case err == nil:
+				a.world.RecordAction(missions.ActionStage) // ADR 0025 §7
 				name := a.world.Crafts[jettIdx].Name
 				a.statusMsg = fmt.Sprintf("staged: %s jettisoned", name)
 				// v0.12 / ADR 0009: surface the transposition hint the

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -647,6 +647,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.world.RecordAction(missions.ActionOpenManeuver) // ADR 0025 §7
 			}
 			return a, nil
+		case key.Matches(m, a.keys.Missions):
+			// `M` opens the mission ladder (ADR 0025 Slice 5) — the same
+			// screen as the title-bar [Missions] button. No RecordAction: the
+			// curated event vocabulary excludes pure-navigation bindings.
+			if a.active == screenOrbit {
+				a.active = screenMissions
+			}
+			return a, nil
 		case key.Matches(m, a.keys.WarpUp):
 			// Manual warp cancels Auto-Warp, then applies (ADR 0016) —
 			// Disengage leaves Selected Warp untouched so the step lands

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -44,6 +44,7 @@ type Keymap struct {
 	Help       key.Binding
 	BodyInfo   key.Binding
 	Maneuver   key.Binding
+	Missions   key.Binding
 	NextBody   key.Binding
 	PrevBody   key.Binding
 	NextSystem key.Binding
@@ -252,6 +253,7 @@ func DefaultKeymap() Keymap {
 		Help:     key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "help")),
 		BodyInfo: key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
 		Maneuver: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
+		Missions: key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "missions (ladder)")),
 		NextBody: key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
 		PrevBody: key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
 		// v0.7.3: NextSystem moved s → tab to free `s` for AttitudeRetrograde.

--- a/internal/tui/mission_event_wiring_test.go
+++ b/internal/tui/mission_event_wiring_test.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// v0.21 Slice 4 (ADR 0025 §6/§7) — the full tui→sim→missions path. Pressing a
+// bound key records its semantic action downward, and an event objective
+// waiting on that action passes on the next mission-eval tick. Proves the
+// input layer is actually wired to World.RecordAction (not just that the sink
+// works in isolation).
+func TestKeypressRecordsActionForEventObjective(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenOrbit
+	a.world.Clock.Paused = false
+	a.world.Missions = []missions.Mission{{
+		ID:         "press-cycle-view",
+		Objectives: []missions.Objective{{Kind: missions.KindEvent, Params: missions.Params{Action: missions.ActionCycleView}}},
+	}}
+
+	// Press 'v' (CycleView) — the handler must record cycle_view downward.
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	// Next tick drains the sink into the evaluator; the event objective passes.
+	a.world.Tick()
+	if a.world.Missions[0].Status != missions.Passed {
+		t.Fatalf("event objective after 'v' keypress: got %v, want Passed", a.world.Missions[0].Status)
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -56,6 +56,7 @@ var helpSections = []helpSection{
 		{"← / h", "move the body cursor previous"},
 		{"tab", "switch star system"},
 		{"i", "body info screen"},
+		{"M", "missions ladder (program / objective progress)"},
 	}},
 	{"TIME & WARP", [][2]string{
 		{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/missions.go
+++ b/internal/tui/screens/missions.go
@@ -161,7 +161,7 @@ func (m *Missions) Render(w *sim.World, width int) string {
 	// current step's hint, framed in the HUD box so it reads as "what now".
 	for _, r := range rows {
 		if r.Category == ladderActive {
-			b.WriteString(m.activeCard(r))
+			b.WriteString(m.activeCard(r, width))
 			b.WriteString("\n\n")
 			break
 		}
@@ -187,9 +187,15 @@ func (m *Missions) Render(w *sim.World, width int) string {
 // marker, and the current objective's hint text indented beneath it (the
 // hint that, by Jason's Slice-5 call, lives on the screen rather than the
 // in-flight chip).
-func (m *Missions) activeCard(r ladderRow) string {
-	var c strings.Builder
-	c.WriteString(m.theme.Primary.Render("ACTIVE: " + r.Name))
+func (m *Missions) activeCard(r ladderRow, width int) string {
+	// Clamp each content line to the terminal width less the box chrome
+	// (rounded border = 2 cols + Padding(0,1) = 2 cols) so a long objective
+	// hint can't push the box border off a narrow screen.
+	max := width - 4
+	if max < 8 {
+		max = 8
+	}
+	lines := []string{clipLine(m.theme.Primary.Render("ACTIVE: "+r.Name), max)}
 	currentSeen := false
 	for _, o := range r.Objectives {
 		marker, isCurrent := "  · ", false
@@ -206,15 +212,13 @@ func (m *Missions) activeCard(r ladderRow) string {
 		if label == "" {
 			label = string(o.Kind)
 		}
-		c.WriteByte('\n')
-		c.WriteString(marker + label)
+		lines = append(lines, clipLine(marker+label, max))
 		// The current step's hint surfaces here (no hint in the chip).
 		if isCurrent && o.Description != "" {
-			c.WriteByte('\n')
-			c.WriteString(m.theme.Dim.Render("      " + o.Description))
+			lines = append(lines, clipLine(m.theme.Dim.Render("      "+o.Description), max))
 		}
 	}
-	return m.theme.HUDBox.Render(c.String())
+	return m.theme.HUDBox.Render(strings.Join(lines, "\n"))
 }
 
 // ladderRowLine renders one non-active rung in the list below the card:

--- a/internal/tui/screens/missions.go
+++ b/internal/tui/screens/missions.go
@@ -8,11 +8,13 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
-// Missions is the v0.7.4+ dedicated mission-list screen. Reachable
-// from the orbit-screen title bar's `[Missions]` button (or the
-// keyboard via app.go's MissionsKey). Lists every loaded mission with
-// its current status; the orbit HUD's MISSION block was removed in
-// v0.7.4 to give the right-hand pane back to flight state.
+// Missions is the v0.7.4+ dedicated mission screen, rebuilt in v0.21
+// (ADR 0025 Slice 5) into a gated ladder/program view: the active mission
+// shows as a highlighted card on top (its name + live objective checklist
+// with the current step's hint), and the rest of the ladder lists below —
+// completed rungs checked, locked rungs shown-locked with a requirement
+// hint, failed rungs marked. Reachable from the orbit-screen title bar's
+// `[Missions]` button or the `M` keybinding (ADR 0025 Slice 5).
 type Missions struct {
 	theme Theme
 
@@ -24,10 +26,94 @@ type Missions struct {
 
 func NewMissions(th Theme) *Missions { return &Missions{theme: th} }
 
-// Render returns the mission list with status indicators and a
-// progress summary. Empty-catalog worlds show a placeholder so the
-// player isn't faced with a blank screen. width is the terminal
-// width — used to right-align the [Back] button on row 0.
+// ladderCategory is the render bucket each mission falls into on the ladder
+// screen (ADR 0025 Slice 5). Drives the marker, styling, and whether the
+// rung gets the active card.
+type ladderCategory int
+
+const (
+	ladderCompleted ladderCategory = iota // Passed
+	ladderActive                          // first unlocked InProgress — gets the card
+	ladderAvailable                       // unlocked InProgress, but not the active one
+	ladderLocked                          // InProgress with unmet requires
+	ladderFailed                          // Failed
+)
+
+// ladderRow is one classified rung in the render-model. Objectives is
+// populated only for the active row (the card needs the full checklist);
+// Hint carries the "needs: …" requirement text for a locked rung.
+type ladderRow struct {
+	Name       string
+	Category   ladderCategory
+	Hint       string
+	Objectives []missions.Objective
+}
+
+// classifyLadder is the pure render-model for the ladder screen: it buckets
+// each mission and computes locked-rung hints, given the catalog's current
+// per-mission Status. The active rung is the FIRST unlocked InProgress
+// mission — every later unlocked InProgress one is merely available. A
+// mission is locked when any mission ID in its Requires is not yet Passed;
+// its hint names the unmet prerequisites. v0.21 Slice 5 (ADR 0025 §2/§"Locked
+// rungs").
+func classifyLadder(ms []missions.Mission) []ladderRow {
+	passed := make(map[string]bool, len(ms))
+	nameByID := make(map[string]string, len(ms))
+	for i := range ms {
+		nameByID[ms[i].ID] = ms[i].Name
+		if ms[i].Status == missions.Passed {
+			passed[ms[i].ID] = true
+		}
+	}
+	activeAssigned := false
+	rows := make([]ladderRow, 0, len(ms))
+	for i := range ms {
+		m := ms[i]
+		row := ladderRow{Name: m.Name}
+		switch {
+		case m.Status == missions.Passed:
+			row.Category = ladderCompleted
+		case m.Status == missions.Failed:
+			row.Category = ladderFailed
+		case !m.RequirementsMet(passed):
+			row.Category = ladderLocked
+			row.Hint = lockedHint(m, nameByID, passed)
+		case !activeAssigned:
+			row.Category = ladderActive
+			row.Objectives = m.Objectives
+			activeAssigned = true
+		default:
+			row.Category = ladderAvailable
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// lockedHint builds the "needs: A, B" requirement text for a locked rung,
+// naming the prerequisite missions that have not yet Passed (falling back to
+// the raw ID when a requirement names an unknown mission).
+func lockedHint(m missions.Mission, nameByID map[string]string, passed map[string]bool) string {
+	var need []string
+	for _, id := range m.Requires {
+		if passed[id] {
+			continue
+		}
+		n := nameByID[id]
+		if n == "" {
+			n = id
+		}
+		need = append(need, n)
+	}
+	if len(need) == 0 {
+		return ""
+	}
+	return "needs: " + strings.Join(need, ", ")
+}
+
+// Render returns the ladder/program screen. width is the terminal width —
+// used to right-align the [Back] button on row 0. Empty-catalog worlds show
+// a placeholder so the player isn't faced with a blank screen.
 func (m *Missions) Render(w *sim.World, width int) string {
 	const titleText = "missions"
 	const backLabel = "[Back]"
@@ -68,32 +154,87 @@ func (m *Missions) Render(w *sim.World, width int) string {
 	b.WriteString("  " + m.theme.Primary.Render(summary))
 	b.WriteString("\n\n")
 
-	for i, ms := range w.Missions {
-		marker := m.theme.Dim.Render("  · ")
-		switch ms.Status {
-		case missions.Passed:
-			marker = m.theme.Primary.Render("  ✓ ")
-		case missions.Failed:
-			marker = m.theme.Alert.Render("  ✗ ")
+	rows := classifyLadder(w.Missions)
+
+	// Active card on top (ADR 0025 Slice 5 — Jason's "active card" layout):
+	// the current mission, expanded to its objective checklist with the
+	// current step's hint, framed in the HUD box so it reads as "what now".
+	for _, r := range rows {
+		if r.Category == ladderActive {
+			b.WriteString(m.activeCard(r))
+			b.WriteString("\n\n")
+			break
 		}
-		b.WriteString(marker)
-		b.WriteString(ms.Name)
+	}
+
+	// The rest of the ladder lists below the card. The active rung is omitted
+	// here — it already owns the card — so each remaining rung shows once.
+	for _, r := range rows {
+		if r.Category == ladderActive {
+			continue
+		}
+		b.WriteString(m.ladderRowLine(r))
 		b.WriteByte('\n')
-		statusLine := m.theme.Dim.Render("      " + ms.Status.String())
-		b.WriteString(statusLine)
-		b.WriteByte('\n')
-		if ms.Description != "" {
-			b.WriteString(m.theme.Dim.Render("      " + ms.Description))
-			b.WriteByte('\n')
-		}
-		if i < len(w.Missions)-1 {
-			b.WriteByte('\n')
-		}
 	}
 
 	b.WriteString("\n")
 	b.WriteString(m.theme.Footer.Render("[esc] back to orbit"))
 	return b.String()
+}
+
+// activeCard renders the highlighted active-mission card: an "ACTIVE: <name>"
+// header, each objective with a ✓ (passed) / ▸ (current) / · (upcoming)
+// marker, and the current objective's hint text indented beneath it (the
+// hint that, by Jason's Slice-5 call, lives on the screen rather than the
+// in-flight chip).
+func (m *Missions) activeCard(r ladderRow) string {
+	var c strings.Builder
+	c.WriteString(m.theme.Primary.Render("ACTIVE: " + r.Name))
+	currentSeen := false
+	for _, o := range r.Objectives {
+		marker, isCurrent := "  · ", false
+		switch {
+		case o.Status == missions.Passed:
+			marker = "  ✓ "
+		case o.Status == missions.Failed:
+			marker = "  ✗ "
+		case !currentSeen:
+			marker, isCurrent = "  ▸ ", true
+			currentSeen = true
+		}
+		label := o.Name
+		if label == "" {
+			label = string(o.Kind)
+		}
+		c.WriteByte('\n')
+		c.WriteString(marker + label)
+		// The current step's hint surfaces here (no hint in the chip).
+		if isCurrent && o.Description != "" {
+			c.WriteByte('\n')
+			c.WriteString(m.theme.Dim.Render("      " + o.Description))
+		}
+	}
+	return m.theme.HUDBox.Render(c.String())
+}
+
+// ladderRowLine renders one non-active rung in the list below the card:
+// completed rungs checked, available rungs as a pending dot, locked rungs
+// dimmed with their requirement hint, failed rungs marked.
+func (m *Missions) ladderRowLine(r ladderRow) string {
+	switch r.Category {
+	case ladderCompleted:
+		return m.theme.Primary.Render("  ✓ " + r.Name)
+	case ladderFailed:
+		return m.theme.Alert.Render("  ✗ " + r.Name + "  (failed)")
+	case ladderLocked:
+		line := "  · " + r.Name
+		if r.Hint != "" {
+			line += "   " + r.Hint
+		}
+		return m.theme.Dim.Render(line)
+	default: // ladderAvailable
+		return "  · " + r.Name
+	}
 }
 
 // HitBackButton reports whether a click at (col, row) lands on the

--- a/internal/tui/screens/missions.go
+++ b/internal/tui/screens/missions.go
@@ -57,13 +57,10 @@ type ladderRow struct {
 // its hint names the unmet prerequisites. v0.21 Slice 5 (ADR 0025 §2/§"Locked
 // rungs").
 func classifyLadder(ms []missions.Mission) []ladderRow {
-	passed := make(map[string]bool, len(ms))
+	passed := missions.PassedSet(ms)
 	nameByID := make(map[string]string, len(ms))
 	for i := range ms {
 		nameByID[ms[i].ID] = ms[i].Name
-		if ms[i].Status == missions.Passed {
-			passed[ms[i].ID] = true
-		}
 	}
 	activeAssigned := false
 	rows := make([]ladderRow, 0, len(ms))
@@ -208,11 +205,7 @@ func (m *Missions) activeCard(r ladderRow, width int) string {
 			marker, isCurrent = "  ▸ ", true
 			currentSeen = true
 		}
-		label := o.Name
-		if label == "" {
-			label = string(o.Kind)
-		}
-		lines = append(lines, clipLine(marker+label, max))
+		lines = append(lines, clipLine(marker+o.Label(), max))
 		// The current step's hint surfaces here (no hint in the chip).
 		if isCurrent && o.Description != "" {
 			lines = append(lines, clipLine(m.theme.Dim.Render("      "+o.Description), max))

--- a/internal/tui/screens/missions_screen_test.go
+++ b/internal/tui/screens/missions_screen_test.go
@@ -1,0 +1,118 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// classifyLadder is the pure render-model behind the missions/ladder screen
+// (ADR 0025 / Slice 5): it sorts each mission into completed / active /
+// available / locked / failed and computes the locked-rung "needs:" hint.
+// These pin that classification independent of the layout/box rendering.
+
+func TestClassifyLadder(t *testing.T) {
+	ms := []missions.Mission{
+		{ID: "a", Name: "First", Status: missions.Passed},
+		{ID: "b", Name: "Second", Objectives: []missions.Objective{{Name: "o1"}}},
+		{ID: "c", Name: "Third"},
+		{ID: "d", Name: "Fourth", Requires: []string{"c"}},
+		{ID: "e", Name: "Fifth", Status: missions.Failed},
+	}
+	rows := classifyLadder(ms)
+	if len(rows) != 5 {
+		t.Fatalf("rows = %d, want 5", len(rows))
+	}
+	if rows[0].Category != ladderCompleted {
+		t.Errorf("row 0 (Passed) = %v, want completed", rows[0].Category)
+	}
+	if rows[1].Category != ladderActive {
+		t.Errorf("row 1 (first unlocked InProgress) = %v, want active", rows[1].Category)
+	}
+	if len(rows[1].Objectives) != 1 {
+		t.Errorf("active row should carry its objective checklist, got %d", len(rows[1].Objectives))
+	}
+	if rows[2].Category != ladderAvailable {
+		t.Errorf("row 2 (second unlocked InProgress) = %v, want available", rows[2].Category)
+	}
+	if rows[3].Category != ladderLocked {
+		t.Errorf("row 3 (unmet requires) = %v, want locked", rows[3].Category)
+	}
+	if !strings.Contains(rows[3].Hint, "Third") {
+		t.Errorf("locked hint = %q, want it to name the unmet requirement 'Third'", rows[3].Hint)
+	}
+	if rows[4].Category != ladderFailed {
+		t.Errorf("row 4 (Failed) = %v, want failed", rows[4].Category)
+	}
+}
+
+func TestClassifyLadderExactlyOneActive(t *testing.T) {
+	// Several unlocked InProgress missions, but only the first is the active
+	// one (it gets the card); the rest are available.
+	ms := []missions.Mission{
+		{ID: "a", Name: "A"},
+		{ID: "b", Name: "B"},
+		{ID: "c", Name: "C"},
+	}
+	rows := classifyLadder(ms)
+	active := 0
+	for _, r := range rows {
+		if r.Category == ladderActive {
+			active++
+		}
+	}
+	if active != 1 {
+		t.Fatalf("active rows = %d, want exactly 1", active)
+	}
+}
+
+func TestClassifyLadderUnlockedAfterRequirementPassed(t *testing.T) {
+	// Once the prerequisite passes, the gated rung becomes available, not locked.
+	ms := []missions.Mission{
+		{ID: "c", Name: "Third", Status: missions.Passed},
+		{ID: "d", Name: "Fourth", Requires: []string{"c"}},
+	}
+	rows := classifyLadder(ms)
+	if rows[1].Category == ladderLocked {
+		t.Errorf("row with a now-passed requirement should not be locked")
+	}
+}
+
+// TestMissionsRenderSmoke checks the screen produces the active-card header,
+// the live objective status, and a locked rung's hint without panicking.
+func TestMissionsRenderSmoke(t *testing.T) {
+	scr := NewMissions(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "a", Name: "Reach Orbit", Status: missions.Passed},
+		{ID: "b", Name: "Circularize", Objectives: []missions.Objective{
+			{Name: "reach 100 km", Status: missions.Passed},
+			{Name: "circular orbit", Description: "burn at apoapsis"},
+		}},
+		{ID: "c", Name: "Luna Flyby", Requires: []string{"b"}},
+	}
+	out := scr.Render(w, 60)
+	for _, want := range []string{"ACTIVE", "Circularize", "circular orbit", "Luna Flyby", "needs:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered screen missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMissionsRenderEmpty(t *testing.T) {
+	scr := NewMissions(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = nil
+	out := scr.Render(w, 60)
+	if !strings.Contains(out, "no missions") {
+		t.Errorf("empty catalog should show a placeholder, got:\n%s", out)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2213,21 +2213,26 @@ func formatDurationShort(sec float64) string {
 // string when no such mission is in flight. v0.9.4+.
 func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
 	for _, m := range w.Missions {
-		if m.Type != missions.TypeCircularizeFromPad {
-			continue
-		}
 		if m.Status == missions.Passed {
 			continue
 		}
-		if m.Params.PrimaryID != c.Primary.ID {
-			continue
+		for _, o := range m.Objectives {
+			if o.Kind != missions.KindCircularizeFromPad {
+				continue
+			}
+			if o.Status == missions.Passed {
+				continue
+			}
+			if o.Params.PrimaryID != c.Primary.ID {
+				continue
+			}
+			target := o.Params.MinPeriapsisAltM
+			if target <= 0 {
+				target = launchMissionFloorM
+			}
+			return fmt.Sprintf("mission:    pe %s / %s target",
+				formatAltKm(periAltM), formatAltKm(target))
 		}
-		target := m.Params.MinPeriapsisAltM
-		if target <= 0 {
-			target = launchMissionFloorM
-		}
-		return fmt.Sprintf("mission:    pe %s / %s target",
-			formatAltKm(periAltM), formatAltKm(target))
 	}
 	return ""
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2213,7 +2213,10 @@ func formatDurationShort(sec float64) string {
 // string when no such mission is in flight. v0.9.4+.
 func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM float64) string {
 	for _, m := range w.Missions {
-		if m.Status == missions.Passed {
+		// Only a still-active mission shows a live progress row; skip both
+		// Passed and (v0.21 ADR 0025 §5) Failed — a failed mission must not
+		// keep rendering as if in flight.
+		if m.Status != missions.InProgress {
 			continue
 		}
 		for _, o := range m.Objectives {

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -144,17 +144,10 @@ func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mi
 		// defend against an empty/all-passed mission slipping through anyway.
 		return []string{header}
 	}
-	label := obj.Name
-	if label == "" {
-		label = obj.Description
-	}
-	if label == "" {
-		label = string(obj.Kind)
-	}
 	passed, total := m.Progress()
 	return []string{
 		header,
-		fmt.Sprintf("  %s %s  %d/%d", hudNodeMarker, label, passed, total),
+		fmt.Sprintf("  %s %s  %d/%d", hudNodeMarker, obj.Label(), passed, total),
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
@@ -47,6 +48,9 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 		}
 		chips = append(chips, builtChip{id: id, corner: corner, lines: lines})
 	}
+	// The current goal sits directly under the pinned VESSEL chip — "who I am"
+	// then "what I'm doing" in the top-left status corner (ADR 0025 / Slice 5).
+	add(settings.ChipMissions, cornerTopLeft, v.buildMissionsChip(w))
 	// Top-left transient stack (stacking order = listed order, downward).
 	// The in-flight ● BURNS readout used to live here; v0.16 folds it into
 	// the bottom-right NODES chip (a live burn is the firing head of the
@@ -102,6 +106,56 @@ func (v *OrbitView) anyActiveBurn(w *sim.World) bool {
 		}
 	}
 	return false
+}
+
+// buildMissionsChip is the in-flight mission checklist chip (ADR 0025
+// §"Player surface" / Slice 5). A one-liner: the active mission's name plus
+// its current objective and N/M progress, so the player always sees "what
+// now" without opening the missions screen (which carries the full ladder +
+// hint text). On a mission failure it flashes "✗ <name> failed: <reason>" for
+// a few wall-clock seconds (World.MissionFailFlash) before advancing to the
+// next mission. Returns nil when no mission is active and nothing is flashing.
+// Honours the Settings toggle + F2 declutter like any chip (no force-show —
+// a failed mission isn't safety-critical the way a live burn is).
+func (v *OrbitView) buildMissionsChip(w *sim.World) []string {
+	flash, flashing := w.MissionFailFlash()
+	return v.missionChipLines(flash, flashing, w.ActiveMission())
+}
+
+// missionChipLines is the pure content selector behind buildMissionsChip,
+// split out so both the (World-armed) failure flash and the active-mission
+// forms are unit-testable without a live World. A live flash takes precedence
+// over the active mission — the mission that just failed is more urgent to
+// surface than the next one in the ladder.
+func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mission) []string {
+	if flashing {
+		return []string{
+			v.theme.Alert.Render("MISSION"),
+			v.theme.Alert.Render("  ✗ " + flash),
+		}
+	}
+	if m == nil {
+		return nil
+	}
+	header := v.theme.Primary.Render("MISSION") + "  " + m.Name
+	obj, ok := m.CurrentObjective()
+	if !ok {
+		// An InProgress mission always has a current (non-Passed) objective;
+		// defend against an empty/all-passed mission slipping through anyway.
+		return []string{header}
+	}
+	label := obj.Name
+	if label == "" {
+		label = obj.Description
+	}
+	if label == "" {
+		label = string(obj.Kind)
+	}
+	passed, total := m.Progress()
+	return []string{
+		header,
+		fmt.Sprintf("  %s %s  %d/%d", hudNodeMarker, label, passed, total),
+	}
 }
 
 // buildAttitudeChip surfaces the held attitude / nav mode / engine mode /

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -78,6 +78,16 @@ func TestLaunchMissionProgressMatchesCircularizeFromPad(t *testing.T) {
 	if c == nil {
 		t.Fatal("expected active craft from NewWorld")
 	}
+	// Inject an in-flight circularize_from_pad mission for the craft's primary
+	// (the embedded ladder no longer ships one — it can't verify a pad launch
+	// — so this exercises the launch-HUD path directly).
+	w.Missions = []missions.Mission{{
+		ID: "pad",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindCircularizeFromPad,
+			Params: missions.Params{PrimaryID: c.Primary.ID, MinPeriapsisAltM: 200_000},
+		}},
+	}}
 	got := launchMissionProgress(w, c, 130_000)
 	if got == "" {
 		t.Fatal("expected non-empty progress for active circularize_from_pad mission")
@@ -102,13 +112,15 @@ func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 	if c == nil {
 		t.Fatal("expected active craft from NewWorld")
 	}
-	for i := range w.Missions {
-		for j := range w.Missions[i].Objectives {
-			if w.Missions[i].Objectives[j].Kind == missions.KindCircularizeFromPad {
-				w.Missions[i].Status = missions.Passed
-			}
-		}
-	}
+	// A Passed circularize_from_pad mission yields no launch-HUD row.
+	w.Missions = []missions.Mission{{
+		ID:     "pad",
+		Status: missions.Passed,
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindCircularizeFromPad,
+			Params: missions.Params{PrimaryID: c.Primary.ID, MinPeriapsisAltM: 200_000},
+		}},
+	}}
 	if got := launchMissionProgress(w, c, 130_000); got != "" {
 		t.Errorf("progress with no in-flight mission = %q, want \"\"", got)
 	}

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -103,8 +103,10 @@ func TestLaunchMissionProgressEmptyWithoutMission(t *testing.T) {
 		t.Fatal("expected active craft from NewWorld")
 	}
 	for i := range w.Missions {
-		if w.Missions[i].Type == missions.TypeCircularizeFromPad {
-			w.Missions[i].Status = missions.Passed
+		for j := range w.Missions[i].Objectives {
+			if w.Missions[i].Objectives[j].Kind == missions.KindCircularizeFromPad {
+				w.Missions[i].Status = missions.Passed
+			}
 		}
 	}
 	if got := launchMissionProgress(w, c, 130_000); got != "" {

--- a/internal/tui/screens/orbit_mission_chip_test.go
+++ b/internal/tui/screens/orbit_mission_chip_test.go
@@ -1,0 +1,96 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// The mission checklist chip (ADR 0025 / Slice 5) is a one-liner: the active
+// mission name, its current objective, and N/M progress — with a transient
+// failure flash when a mission dies. missionChipLines is the pure content
+// selector, exercised here without needing a live World to arm the flash.
+
+func TestMissionChipLinesActive(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	m := &missions.Mission{
+		ID:   "m1",
+		Name: "Circularize",
+		Objectives: []missions.Objective{
+			{Kind: missions.KindReachAltitude, Name: "reach 100 km", Status: missions.Passed},
+			{Kind: missions.KindCircularize, Name: "circular orbit"},
+		},
+	}
+	lines := v.missionChipLines("", false, m)
+	if lines == nil {
+		t.Fatal("active mission chip = nil, want content")
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "MISSION") {
+		t.Errorf("chip missing MISSION header:\n%s", joined)
+	}
+	if !strings.Contains(joined, "Circularize") {
+		t.Errorf("chip missing mission name:\n%s", joined)
+	}
+	if !strings.Contains(joined, "circular orbit") {
+		t.Errorf("chip missing current objective:\n%s", joined)
+	}
+	if !strings.Contains(joined, "1/2") {
+		t.Errorf("chip missing 1/2 progress:\n%s", joined)
+	}
+	// The chip is a one-liner: header line + a single objective line.
+	if len(lines) != 2 {
+		t.Errorf("active chip = %d lines, want 2 (one-liner):\n%s", len(lines), joined)
+	}
+}
+
+func TestMissionChipLinesFailureFlash(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	// The flash wins even with an active mission present (it just failed).
+	m := &missions.Mission{ID: "next", Name: "Luna Flyby"}
+	lines := v.missionChipLines("Land Test failed: crashed", true, m)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "✗") {
+		t.Errorf("failure flash missing ✗ marker:\n%s", joined)
+	}
+	if !strings.Contains(joined, "Land Test failed: crashed") {
+		t.Errorf("failure flash missing the message:\n%s", joined)
+	}
+	if strings.Contains(joined, "Luna Flyby") {
+		t.Errorf("failure flash should not show the next mission yet:\n%s", joined)
+	}
+}
+
+func TestMissionChipLinesNilWhenIdle(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	if got := v.missionChipLines("", false, nil); got != nil {
+		t.Errorf("no mission + no flash chip = %v, want nil", got)
+	}
+}
+
+// TestBuildMissionsChipReadsWorld confirms the builder pulls the active
+// mission out of the World (the no-flash path) — the wiring missionChipLines
+// can't cover on its own.
+func TestBuildMissionsChipReadsWorld(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:   "m1",
+		Name: "Reach Orbit",
+		Objectives: []missions.Objective{
+			{Kind: missions.KindOrbitInsertion, Name: "make orbit"},
+		},
+	}}
+	chip := v.buildMissionsChip(w)
+	if chip == nil {
+		t.Fatal("buildMissionsChip = nil with an active mission")
+	}
+	if !strings.Contains(strings.Join(chip, "\n"), "Reach Orbit") {
+		t.Errorf("chip did not read the active mission name:\n%s", strings.Join(chip, "\n"))
+	}
+}


### PR DESCRIPTION
Stacked on #175 (Slice 5). Base = `feat/adr0025-mission-model-slice5`. The headline value of the v0.21 cycle — the actual reason to fly.

## What

### The catalog (`internal/missions/missions.json`)
Replaces the 4 placeholders with the v0.21 **tutorial → challenge ladder**, a single gated continuum (ADR 0025 §4):

- **Tutorial** (program `tutorial`, 3 rungs): `orient` → `plan` → `fly`. Taught with **event objectives** (press `v`, `t`, `m`, `H`) plus a gentle `reach_altitude` state objective, each with **hint text**.
- **Challenge ladder** (program `challenge`, 7 rungs, `requires`-gated): 1000 km orbit → Luna flyby → Luna capture → Luna landing & return → dock → Mars flyby, plus a `pad-to-LEO` side challenge (keeps the `circularize_from_pad` launch-HUD path exercised). Targets sit **above the 500 km Earth spawn** so nothing auto-passes at tick 1.

### `requires` now gates evaluation, not just display
Discovered while authoring: `evaluateMissions` evaluated **every** mission each tick regardless of `requires` (the gating was UI-only after Slice 5). That let a gated objective latch out of order — dock-in-LEO would satisfy a Luna-gated dock; tutorial event steps could latch early. Now `evaluateMissions` skips a mission whose prerequisites haven't Passed (`missions.PassedSet` + the existing `RequirementsMet`), so the ladder gates for real (ADR 0025 §8). Snapshot is taken before the loop, so a prerequisite that passes this tick unlocks dependents next tick (one 50 ms step).

## Tests
- **`TestEmbeddedTutorialProgression`** — drives the *seeded* tutorial through its semantic actions + gating end-to-end and asserts each rung advances in order, ending with the first challenge surfaced as active. The automated proxy for the Slice-6 done-criterion ("a new player can complete the tutorial").
- **`TestEmbeddedCatalogIntegrity`** — every kind + event action is valid, every `requires` resolves, no cycles, no duplicate IDs.
- **`TestEvaluateMissionsGatesOnRequires`** — a gated mission stays InProgress until its prereq passes, even when its objective condition is already true.
- Updated the catalog-coupled tests (loader / default-catalog / save-reseed / tick-circularize) to the new ladder, keyed off the embedded count rather than a magic literal.

## Polish
Active card width-clamps each line to the terminal width less the box chrome, so a long objective hint can't push the rounded border off a narrow terminal.

## Save
**No bump** — catalog content rides the unreleased v9 re-seed migration from Slice 1.

`go vet ./...` clean · `go test ./... -race -count=1` green (1236) · gofmt-clean.

> Remaining: a **live** in-app playtest pass to tune targets/tolerances (the tutorial flow is verified by the progression test; the challenge difficulty curve wants real flying). The batched `/code-review` over Slices 5+6 runs next.