### PR TITLE
Cycle 2: CommNet — crew-typed connectivity (ADR 0027) [6/7 slices]

### DIFF
--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -86,6 +86,14 @@ func main() {
 	for _, w := range spacecraft.LoadCatalogOverlay() {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: skipping loadout %s: %v\n", w.Path, w.Err)
 	}
+	// CommNet ground-station overlay (ADR 0027). Surfaces malformed user
+	// ground_stations/*.json before bubbletea takes the screen; NewWorld
+	// loads the merged ring into World.GroundStations.
+	if _, warnings := sim.LoadGroundStationsWithWarnings(); len(warnings) > 0 {
+		for _, w := range warnings {
+			fmt.Fprintf(os.Stderr, "terminal-space-program: skipping ground station %s: %v\n", w.Path, w.Err)
+		}
+	}
 
 	if listSystems || listBodies || listLoadout || listSites {
 		printLists(systems, raw.system, listSystems, listBodies, listLoadout, listSites)

--- a/internal/missions/coverage_test.go
+++ b/internal/missions/coverage_test.go
@@ -1,0 +1,49 @@
+package missions
+
+import "testing"
+
+// TestRelayCoverageObjective (C2-6, ADR 0027): passes once at least
+// MinRelays relay craft are connected; pass-and-stick; inert at MinRelays 0.
+func TestRelayCoverageObjective(t *testing.T) {
+	o := Objective{Kind: KindRelayCoverage, Params: Params{MinRelays: 3}, Status: InProgress}
+	if got := o.Evaluate(EvalContext{ConnectedRelayCount: 2}); got != InProgress {
+		t.Errorf("2 of 3 relays connected: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{ConnectedRelayCount: 3}); got != Passed {
+		t.Errorf("3 of 3 relays connected: got %v, want Passed", got)
+	}
+	if got := o.Evaluate(EvalContext{ConnectedRelayCount: 5}); got != Passed {
+		t.Errorf("more than enough relays: got %v, want Passed", got)
+	}
+	inert := Objective{Kind: KindRelayCoverage, Status: InProgress} // MinRelays 0
+	if got := inert.Evaluate(EvalContext{ConnectedRelayCount: 5}); got != InProgress {
+		t.Errorf("MinRelays 0 must be inert, got %v", got)
+	}
+}
+
+// TestEstablishContactObjective (C2-6): passes when the active craft has a
+// connection; pass-and-stick.
+func TestEstablishContactObjective(t *testing.T) {
+	o := Objective{Kind: KindEstablishContact, Status: InProgress}
+	if got := o.Evaluate(EvalContext{ActiveConnected: false}); got != InProgress {
+		t.Errorf("no connection: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{ActiveConnected: true}); got != Passed {
+		t.Errorf("connected: got %v, want Passed", got)
+	}
+}
+
+// TestDeployActionInVocabulary (C2-6): the deploy semantic action exists
+// and an event objective matches it (cycle 3 emits it).
+func TestDeployActionInVocabulary(t *testing.T) {
+	if ActionDeploy != "deploy" {
+		t.Errorf("ActionDeploy = %q, want deploy", ActionDeploy)
+	}
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionDeploy}, Status: InProgress}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionDeploy}}); got != Passed {
+		t.Errorf("deploy event: got %v, want Passed", got)
+	}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionStage}}); got != InProgress {
+		t.Errorf("unrelated action: got %v, want InProgress", got)
+	}
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -87,6 +87,15 @@ const (
 	// objective was active, rather than a world-state predicate. Used by
 	// control-teaching tutorial steps that leave no world trace.
 	KindEvent Kind = "event"
+
+	// Coverage objectives (v0.23 / ADR 0027): instantaneous + pass-and-stick
+	// CommNet predicates (no accumulator, no save bump). KindRelayCoverage
+	// passes when at least Params.MinRelays relay-antenna craft currently
+	// reach a ground station — "deploy a connected constellation of N
+	// relays". KindEstablishContact passes when the ACTIVE craft currently
+	// has a network connection — "get this probe in contact".
+	KindRelayCoverage    Kind = "relay_coverage"
+	KindEstablishContact Kind = "establish_contact"
 )
 
 // Action is a semantic gameplay verb the player triggers, recorded downward
@@ -120,6 +129,7 @@ const (
 	ActionSpawnCraft      Action = "spawn_craft"
 	ActionUndock          Action = "undock"
 	ActionTranspose       Action = "transpose"
+	ActionDeploy          Action = "deploy" // v0.23 / ADR 0028 (cycle 3 emits it; added with the comms cycle's vocab pass)
 )
 
 // FailCondition is an opt-in trigger that transitions an InProgress
@@ -210,6 +220,10 @@ type Params struct {
 	// Action is the semantic gameplay verb an Event objective matches
 	// (ADR 0025 §6/§7). KindEvent only. v0.21+.
 	Action Action `json:"action,omitempty"`
+
+	// MinRelays is the number of connected relay-antenna craft
+	// KindRelayCoverage requires (ADR 0027). v0.23+.
+	MinRelays int `json:"min_relays,omitempty"`
 }
 
 // Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
@@ -297,6 +311,14 @@ type EvalContext struct {
 	// evaluated while active), gives the "fired while InProgress" semantics
 	// without any per-objective watermark. Read by KindEvent.
 	RecentActions []Action
+
+	// CommNet connectivity snapshot (v0.23 / ADR 0027), projected down from
+	// World.CommGraph so the missions package stays free of any sim import.
+	// ActiveConnected is whether the active craft currently reaches a ground
+	// station; ConnectedRelayCount is how many relay-antenna craft in the
+	// slate currently do. Read by the coverage objectives.
+	ActiveConnected     bool
+	ConnectedRelayCount int
 }
 
 // Evaluate steps the objective one tick and returns the new status.
@@ -346,6 +368,33 @@ func (o Objective) evalKind(ctx EvalContext) Status {
 		return evalDock(o.Params, ctx)
 	case KindEvent:
 		return evalEvent(o.Params, ctx)
+	case KindRelayCoverage:
+		return evalRelayCoverage(o.Params, ctx)
+	case KindEstablishContact:
+		return evalEstablishContact(o.Params, ctx)
+	}
+	return InProgress
+}
+
+// evalRelayCoverage: pass when at least MinRelays relay-antenna craft
+// currently reach a ground station (ADR 0027). Instantaneous + sticky
+// (the Mission latches the Passed status). A non-positive MinRelays is
+// inert so a malformed entry can't pass for free.
+func evalRelayCoverage(p Params, ctx EvalContext) Status {
+	if p.MinRelays <= 0 {
+		return InProgress
+	}
+	if ctx.ConnectedRelayCount >= p.MinRelays {
+		return Passed
+	}
+	return InProgress
+}
+
+// evalEstablishContact: pass when the active craft currently has a network
+// connection (ADR 0027). Instantaneous + sticky.
+func evalEstablishContact(p Params, ctx EvalContext) Status {
+	if ctx.ActiveConnected {
+		return Passed
 	}
 	return InProgress
 }

--- a/internal/physics/occlusion.go
+++ b/internal/physics/occlusion.go
@@ -1,0 +1,68 @@
+package physics
+
+import "github.com/jasonfen/terminal-space-program/internal/orbital"
+
+// Line-of-sight occlusion (v0.23 / ADR 0027, CommNet cycle 2). The one
+// net-new physics primitive the comms subsystem needs: does a straight
+// segment between two antennas pass through a body? Pure geometry,
+// stateless, frame-agnostic — the caller supplies segment endpoints and
+// body centres in one consistent frame (the active system's world frame).
+// No atmosphere refraction and no minimum-elevation margin (ADR 0027 §6).
+
+// OccluderBody is a body that can block a sightline: a sphere with a
+// world-frame centre and radius. The caller builds these per tick from
+// each body's current position + mean radius.
+type OccluderBody struct {
+	Center orbital.Vec3
+	Radius float64
+}
+
+// RaySphereIntersect reports whether the segment [p, q] passes through the
+// INTERIOR of the sphere centred at centre with radius r — i.e. the body
+// blocks the sightline between p and q.
+//
+// "Interior" is deliberate (strict): an endpoint sitting exactly on the
+// surface (a ground station at body radius) does NOT count as blocked, so
+// a station with a target above its horizon keeps line of sight. The body
+// blocks only when the segment actually dips inside it: an endpoint is
+// strictly inside, or the perpendicular foot falls between the endpoints
+// at a distance strictly less than r. A grazing tangent (foot distance
+// exactly r) is treated as clear.
+func RaySphereIntersect(p, q, centre orbital.Vec3, r float64) bool {
+	if r <= 0 {
+		return false
+	}
+	r2 := r * r
+	// Either endpoint strictly inside the sphere → blocked (buried antenna).
+	if pc := p.Sub(centre); pc.Dot(pc) < r2 {
+		return true
+	}
+	if qc := q.Sub(centre); qc.Dot(qc) < r2 {
+		return true
+	}
+	d := q.Sub(p)
+	len2 := d.Dot(d)
+	if len2 == 0 {
+		return false // degenerate segment, both endpoints outside
+	}
+	// Project the centre onto the segment line; t is the foot parameter.
+	t := centre.Sub(p).Dot(d) / len2
+	if t <= 0 || t >= 1 {
+		return false // closest approach is at an endpoint (both outside) → body is behind it
+	}
+	foot := p.Add(d.Scale(t))
+	fc := foot.Sub(centre)
+	return fc.Dot(fc) < r2
+}
+
+// SegmentOccludedByBody reports whether the segment [a, b] is blocked by
+// any body in occluders (using each body's current position + radius). A
+// link is occluded as soon as one body crosses it.
+func SegmentOccludedByBody(a, b orbital.Vec3, occluders []OccluderBody) bool {
+	for _, o := range occluders {
+		if RaySphereIntersect(a, b, o.Center, o.Radius) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/physics/occlusion_test.go
+++ b/internal/physics/occlusion_test.go
@@ -1,0 +1,72 @@
+package physics
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// A unit-ish sphere at the origin, radius 100, for the geometry cases.
+func TestRaySphereIntersect(t *testing.T) {
+	c := orbital.Vec3{}
+	const r = 100
+	cases := []struct {
+		name string
+		p, q orbital.Vec3
+		want bool
+	}{
+		// Horizontal line at y=150, well above the radius-100 sphere — the
+		// perpendicular foot is interior to the segment but 150 > r.
+		{"clear above", orbital.Vec3{X: -200, Y: 150}, orbital.Vec3{X: 200, Y: 150}, false},
+		// Straight through the centre.
+		{"through centre", orbital.Vec3{X: -200}, orbital.Vec3{X: 200}, true},
+		// Station on the surface, target directly overhead (radial) — the
+		// foot is the station endpoint, so NOT occluded by its own body.
+		{"radial overhead from surface", orbital.Vec3{X: 100}, orbital.Vec3{X: 300}, false},
+		// Two antipodal surface points — the chord dips through the body.
+		{"antipodal surface points", orbital.Vec3{X: 100}, orbital.Vec3{X: -100}, true},
+		// Grazing tangent: perpendicular distance exactly r → NOT occluded
+		// (strict interior test; no elevation margin per ADR 0027 §6).
+		{"grazing tangent", orbital.Vec3{X: -200, Y: 100}, orbital.Vec3{X: 200, Y: 100}, false},
+		// An endpoint buried inside the sphere.
+		{"endpoint inside", orbital.Vec3{X: 50}, orbital.Vec3{X: 300}, true},
+		// Both endpoints outside and on the same side — body is behind them.
+		{"both outside same side", orbital.Vec3{X: 200}, orbital.Vec3{X: 200, Y: 200}, false},
+		// Degenerate (zero-length) segment outside the sphere.
+		{"degenerate outside", orbital.Vec3{X: 200}, orbital.Vec3{X: 200}, false},
+	}
+	for _, tc := range cases {
+		if got := RaySphereIntersect(tc.p, tc.q, c, r); got != tc.want {
+			t.Errorf("%s: RaySphereIntersect = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// A zero / negative radius never occludes.
+func TestRaySphereIntersectZeroRadius(t *testing.T) {
+	if RaySphereIntersect(orbital.Vec3{X: -1}, orbital.Vec3{X: 1}, orbital.Vec3{}, 0) {
+		t.Error("zero-radius sphere should never intersect")
+	}
+}
+
+func TestSegmentOccludedByBody(t *testing.T) {
+	a := orbital.Vec3{X: -500}
+	b := orbital.Vec3{X: 500}
+	// No body in the way.
+	far := []OccluderBody{{Center: orbital.Vec3{Y: 1000}, Radius: 100}}
+	if SegmentOccludedByBody(a, b, far) {
+		t.Error("a body far off the segment should not occlude")
+	}
+	// One of several bodies sits across the segment.
+	mixed := []OccluderBody{
+		{Center: orbital.Vec3{Y: 1000}, Radius: 100}, // off to the side
+		{Center: orbital.Vec3{}, Radius: 100},        // on the segment → blocks
+	}
+	if !SegmentOccludedByBody(a, b, mixed) {
+		t.Error("a body across the segment should occlude")
+	}
+	// Empty occluder set never occludes.
+	if SegmentOccludedByBody(a, b, nil) {
+		t.Error("no occluders should never occlude")
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -139,7 +139,7 @@ type Vec3 struct {
 // v5 reader (none in production, but possible for tooling) would
 // still see a coherent craft.
 type Craft struct {
-	ID               uint64  `json:"id,omitempty"` // v0.14.x / schema v7: stable Spacecraft.ID (ADR 0012). Pre-v7 saves omit it; migrateV6PayloadToV7 assigns one per slate position.
+	ID               uint64  `json:"id,omitempty"`         // v0.14.x / schema v7: stable Spacecraft.ID (ADR 0012). Pre-v7 saves omit it; migrateV6PayloadToV7 assigns one per slate position.
 	SystemIdx        int     `json:"system_idx,omitempty"` // v0.16 / schema v8: per-Vessel System binding (ADR 0015). Index into the name-sorted-Sol-first systems. Sol=0 omitted. Pre-v8 saves derive it from PrimaryID via migrateV7PayloadToV8. Distinct from Payload.SystemIdx (the world-level viewed system).
 	Name             string  `json:"name"`
 	DryMass          float64 `json:"dry_mass"`
@@ -279,6 +279,16 @@ type Stage struct {
 	// Spacecraft.HasParachute mirror. Pre-Slice-3 saves load with the
 	// field absent → default-false, matching every pre-Slice-3 stage.
 	HasParachute bool `json:"has_parachute,omitempty"`
+
+	// CommandSource / Antenna (v0.23 / ADR 0027, schema v9 additive — NO
+	// bump): per-Stage comms attributes, round-tripped so a saved probe
+	// or relay sat reloads with its connectivity role intact. Pre-comms
+	// saves load with these absent → empty, and the load-time
+	// EnsureCommandSource backfill stamps a default command source on the
+	// surviving core so old vessels stay controllable.
+	CommandSource string  `json:"command_source,omitempty"`
+	AntennaKind   string  `json:"antenna_kind,omitempty"`
+	AntennaPowerW float64 `json:"antenna_power_w,omitempty"`
 }
 
 // Node mirrors sim.ManeuverNode. Event (v0.6.0+, schema v2) is
@@ -773,6 +783,12 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				c.Color = l.Color
 			}
 		}
+		// v0.23 / ADR 0027: backfill a default command source on pre-comms
+		// craft (no per-stage CommandSource) so old saves stay controllable;
+		// the Role resolved above decides crewed vs probe. No-op for
+		// post-comms saves whose stages already carry the attribute.
+		spacecraft.EnsureCommandSource(c)
+		c.SyncFields()
 		for _, dc := range wc.DockedComponents {
 			c.DockedComponents = append(c.DockedComponents, spacecraft.DockedComponent{
 				Name:             dc.Name,

--- a/internal/save/save_migrate_v5_to_v6.go
+++ b/internal/save/save_migrate_v5_to_v6.go
@@ -35,6 +35,9 @@ func wireStagesToSim(wire []Stage) []spacecraft.Stage {
 			BallisticCoefficient: s.BallisticCoefficient,
 			CanSoftLand:          s.CanSoftLand,
 			HasParachute:         s.HasParachute,
+			CommandSource:        s.CommandSource,
+			AntennaKind:          s.AntennaKind,
+			AntennaPowerW:        s.AntennaPowerW,
 		}
 	}
 	return out
@@ -68,6 +71,9 @@ func simStagesToWire(stages []spacecraft.Stage) []Stage {
 			BallisticCoefficient: s.BallisticCoefficient,
 			CanSoftLand:          s.CanSoftLand,
 			HasParachute:         s.HasParachute,
+			CommandSource:        s.CommandSource,
+			AntennaKind:          s.AntennaKind,
+			AntennaPowerW:        s.AntennaPowerW,
 		}
 	}
 	return out

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -1383,3 +1383,59 @@ func TestRoundtripPreservesMoonPhase(t *testing.T) {
 			d, before, after)
 	}
 }
+
+// TestCommsAttributesRoundtrip (C2-1, ADR 0027): per-stage command_source
+// + antenna survive a save/load round-trip, and a pre-comms craft (stages
+// with no command source) is backfilled to controllable on load.
+func TestCommsAttributesRoundtrip(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// A relay probe (ntr-tug): probe command source + relay antenna.
+	tug := spacecraft.NewFromLoadout("Relay-Tug")
+	tug.Primary = w.Crafts[0].Primary
+	tug.State = w.Crafts[0].State
+	w.Crafts[0] = tug
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	c := got.Crafts[0]
+	if c.Stages[0].CommandSource != spacecraft.CommandProbe {
+		t.Errorf("command source = %q, want probe after round-trip", c.Stages[0].CommandSource)
+	}
+	if c.Stages[0].AntennaKind != spacecraft.AntennaRelay || c.Stages[0].AntennaPowerW != 4000 {
+		t.Errorf("antenna = %q/%g, want relay/4000 after round-trip", c.Stages[0].AntennaKind, c.Stages[0].AntennaPowerW)
+	}
+	if !c.Controllable || c.Crewed {
+		t.Errorf("probe vessel: Controllable=%v Crewed=%v, want true/false", c.Controllable, c.Crewed)
+	}
+
+	// Pre-comms craft: strip the command source from every stage (an old
+	// save shape), confirm the load-time backfill restores controllability.
+	w2, _ := sim.NewWorld()
+	for i := range w2.Crafts[0].Stages {
+		w2.Crafts[0].Stages[i].CommandSource = ""
+	}
+	w2.Crafts[0].SyncFields()
+	if w2.Crafts[0].Controllable {
+		t.Fatal("precondition: stripped craft should be uncontrollable before save")
+	}
+	path2 := filepath.Join(t.TempDir(), "old.json")
+	if err := save.Save(w2, path2); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got2, err := save.Load(path2)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !got2.Crafts[0].Controllable {
+		t.Error("pre-comms craft should be backfilled to controllable on load")
+	}
+}

--- a/internal/sim/burn_pause_resume_test.go
+++ b/internal/sim/burn_pause_resume_test.go
@@ -22,6 +22,7 @@ func twoStageBurner(t *testing.T, w *World, dvRemaining float64) *spacecraft.Spa
 		{Name: "lower", DryMass: 500, FuelMass: 20, FuelCapacity: 20, Thrust: 200000, Isp: 250},
 		{Name: "upper", DryMass: 800, FuelMass: 4000, FuelCapacity: 4000, Thrust: 200000, Isp: 300},
 	}
+	crewTend(c) // synthetic stages carry no command source; crew-tend so commands aren't comms-gated
 	c.SyncFields()
 	c.State.M = c.TotalMass()
 	c.ActiveBurn = &spacecraft.ActiveBurn{

--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -2,6 +2,7 @@ package sim
 
 import (
 	"math"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -186,4 +187,31 @@ func (w *World) CanCommandCraft(c *spacecraft.Spacecraft) bool {
 		w.RecomputeCommGraph()
 	}
 	return w.CommGraph.HasConnection(c.ID)
+}
+
+// noSignalFlashWindow is how long the "NO SIGNAL" transient stays up after
+// a command is blocked (wall-clock, so it expires even while paused).
+const noSignalFlashWindow = 2 * time.Second
+
+// canCommand gates a player command on craft c (which must be non-nil).
+// Returns true if the command may proceed; otherwise flags the NO SIGNAL
+// transient and returns false. Used by the command methods (throttle,
+// attitude, node plant/delete, staging, nav mode) to block new commands to
+// an out-of-contact unmanned probe while letting its onboard plan run.
+func (w *World) canCommand(c *spacecraft.Spacecraft) bool {
+	if w.CanCommandCraft(c) {
+		return true
+	}
+	w.commBlockedUntil = time.Now().Add(noSignalFlashWindow)
+	return false
+}
+
+// CommBlockedFlash returns ("NO SIGNAL", true) while a just-blocked command
+// is within its flash window, else ("", false). The HUD reads this each
+// frame (the comms chip / status flash, C2-7).
+func (w *World) CommBlockedFlash() (string, bool) {
+	if time.Now().Before(w.commBlockedUntil) {
+		return "NO SIGNAL", true
+	}
+	return "", false
 }

--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -1,0 +1,189 @@
+package sim
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// CommNet connectivity graph (v0.23 / ADR 0027, cycle 2 C2-4). Each tick
+// the world builds a graph over {comms-capable crafts, ground stations} in
+// the active craft's system and computes, for every unmanned probe,
+// whether an unoccluded + in-range relay chain reaches any ground station.
+// The result gates command of unmanned vessels (CanCommandCraft) and feeds
+// coverage objectives + the comms HUD (later slices). Transient — never
+// persisted; rebuilt each tick.
+
+// CommRangePerWatt is the placeholder link-range scale: the max link
+// distance (m) is this constant times the WEAKER endpoint's antenna power
+// (W). The two-endpoint range-combination formula is deferred tuning
+// (ADR 0027 §2 floats ∝ √(Pₐ·P_b)); this conservative min-power form ships
+// until playtest decides the real curve.
+const CommRangePerWatt = 5000.0
+
+// commLinkRangeM is the max distance at which two antennas can link, from
+// the weaker of the two powers (placeholder — see CommRangePerWatt).
+func commLinkRangeM(pa, pb float64) float64 {
+	return math.Min(pa, pb) * CommRangePerWatt
+}
+
+// CommGraph is the cached per-tick connectivity result: the set of
+// unmanned craft (by stable ID) that currently have a connection to a
+// ground station.
+type CommGraph struct {
+	Connected map[uint64]bool
+}
+
+// HasConnection reports whether the craft with the given ID has a network
+// connection this tick. nil-safe (a not-yet-computed graph → false).
+func (g *CommGraph) HasConnection(id uint64) bool {
+	return g != nil && g.Connected[id]
+}
+
+// commNode is one node in the connectivity graph — a craft antenna or a
+// ground station, with the world-frame position the LOS + range tests use.
+type commNode struct {
+	pos      orbital.Vec3
+	powerW   float64
+	forwards bool   // can relay traffic onward: a relay antenna + Controllable, or a ground station
+	station  bool   // a ground station (a connection sink)
+	probe    bool   // an unmanned controllable craft — a BFS source that needs a connection
+	craftID  uint64 // 0 for stations
+}
+
+// connectivity builds the adjacency graph over nodes (a link needs both
+// LOS — unoccluded by any body — and range) and returns, for each probe
+// node, whether a relay chain reaches a station. Forwarding is allowed
+// only through forwarder nodes (relays / stations); a direct-only craft is
+// a dead end you cannot relay through. Pure (no world state) so it is
+// unit-tested with synthetic nodes.
+func connectivity(nodes []commNode, occ []physics.OccluderBody) map[uint64]bool {
+	n := len(nodes)
+	adj := make([][]int, n)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			if commLinked(nodes[i], nodes[j], occ) {
+				adj[i] = append(adj[i], j)
+				adj[j] = append(adj[j], i)
+			}
+		}
+	}
+	out := map[uint64]bool{}
+	for i := 0; i < n; i++ {
+		if nodes[i].probe && bfsReachesStation(i, nodes, adj) {
+			out[nodes[i].craftID] = true
+		}
+	}
+	return out
+}
+
+func commLinked(a, b commNode, occ []physics.OccluderBody) bool {
+	if a.powerW <= 0 || b.powerW <= 0 {
+		return false
+	}
+	if a.pos.Sub(b.pos).Norm() > commLinkRangeM(a.powerW, b.powerW) {
+		return false
+	}
+	return !physics.SegmentOccludedByBody(a.pos, b.pos, occ)
+}
+
+// bfsReachesStation returns whether a relay chain from the start node
+// reaches any ground station. The start expands unconditionally (it is
+// transmitting); an intermediate node expands only if it can forward.
+func bfsReachesStation(start int, nodes []commNode, adj [][]int) bool {
+	visited := make([]bool, len(nodes))
+	visited[start] = true
+	queue := []int{start}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur != start && !nodes[cur].forwards {
+			continue // a non-forwarder (direct-only craft) cannot relay through
+		}
+		for _, nb := range adj[cur] {
+			if nodes[nb].station {
+				return true
+			}
+			if !visited[nb] {
+				visited[nb] = true
+				queue = append(queue, nb)
+			}
+		}
+	}
+	return false
+}
+
+// RecomputeCommGraph rebuilds w.CommGraph for the active craft's system:
+// gathers ground-station + craft nodes with their current world positions
+// and the body occluders, then runs connectivity. Called each Tick after
+// physics; also lazily by CanCommandCraft if the cache is nil.
+func (w *World) RecomputeCommGraph() {
+	sys := w.System()
+	sysIdx := w.SystemIdx
+
+	occ := make([]physics.OccluderBody, 0, len(sys.Bodies))
+	for i := range sys.Bodies {
+		b := sys.Bodies[i]
+		occ = append(occ, physics.OccluderBody{Center: w.BodyPosition(b), Radius: b.RadiusMeters()})
+	}
+
+	var nodes []commNode
+	for _, st := range w.GroundStations {
+		body := sys.FindBody(st.BodyID)
+		if body == nil {
+			continue // station's body is not in this system
+		}
+		nodes = append(nodes, commNode{
+			pos:      w.groundStationWorldPos(st, *body),
+			powerW:   st.AntennaPowerW,
+			forwards: true,
+			station:  true,
+		})
+	}
+	for _, c := range w.Crafts {
+		if c == nil || c.SystemIdx != sysIdx || c.AntennaKind == spacecraft.AntennaNone {
+			continue
+		}
+		nodes = append(nodes, commNode{
+			pos:      w.BodyPosition(c.Primary).Add(c.State.R),
+			powerW:   c.AntennaPowerW,
+			forwards: c.AntennaKind == spacecraft.AntennaRelay && c.Controllable,
+			probe:    c.Controllable && !c.Crewed,
+			craftID:  c.ID,
+		})
+	}
+
+	w.CommGraph = &CommGraph{Connected: connectivity(nodes, occ)}
+}
+
+// groundStationWorldPos is a station's current world-frame position: its
+// body's position plus the body-fixed surface point (co-rotating with the
+// body) at sim time.
+func (w *World) groundStationWorldPos(st GroundStationPreset, body bodies.CelestialBody) orbital.Vec3 {
+	r := body.RadiusMeters()
+	dir := render.BodyFixedToWorld(body, st.LatDeg, st.LonEastDeg, w.Clock.SimTime)
+	return w.BodyPosition(body).Add(orbital.Vec3{X: r * dir.X, Y: r * dir.Y, Z: r * dir.Z})
+}
+
+// CanCommandCraft reports whether the player may issue NEW commands to a
+// craft (ADR 0027 §4 — command, not flight). A crewed vessel is never
+// gated; an unmanned probe needs a network connection; passive debris (no
+// command source) is never commandable. The onboard flight plan still
+// executes regardless — only committing new commands is gated by the
+// caller.
+func (w *World) CanCommandCraft(c *spacecraft.Spacecraft) bool {
+	if c == nil || !c.Controllable {
+		return false
+	}
+	if c.Crewed {
+		return true
+	}
+	if w.CommGraph == nil {
+		w.RecomputeCommGraph()
+	}
+	return w.CommGraph.HasConnection(c.ID)
+}

--- a/internal/sim/commnet_test.go
+++ b/internal/sim/commnet_test.go
@@ -1,0 +1,154 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// station / probe / relay node builders for the synthetic-graph tests.
+// Positions are in meters along the X axis; powers chosen so the default
+// CommRangePerWatt makes "near" links close and "far" links break.
+func station(id uint64, x, p float64) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, powerW: p, forwards: true, station: true}
+}
+func probeNode(id uint64, x, p float64, relay bool) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, powerW: p, probe: true, craftID: id, forwards: relay}
+}
+func relayNode(x, p float64) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, powerW: p, forwards: true}
+}
+
+func TestConnectivityDirectLink(t *testing.T) {
+	// Probe (1 km from a 100kW station, direct antenna 3kW): well in range,
+	// clear LOS → connected.
+	nodes := []commNode{
+		station(0, 0, 100000),
+		probeNode(1, 1000, 3000, false),
+	}
+	got := connectivity(nodes, nil)
+	if !got[1] {
+		t.Error("a probe in range with clear LOS should be connected")
+	}
+}
+
+func TestConnectivityOutOfRange(t *testing.T) {
+	// min(power) = 3000 → range = 3000 * CommRangePerWatt. Place the probe
+	// just past it.
+	rng := commLinkRangeM(100000, 3000)
+	nodes := []commNode{
+		station(0, 0, 100000),
+		probeNode(1, rng*1.1, 3000, false),
+	}
+	if connectivity(nodes, nil)[1] {
+		t.Error("a probe beyond link range should not be connected")
+	}
+}
+
+func TestConnectivityOccludedNeedsRelay(t *testing.T) {
+	// A body sits between station (x=-1000) and probe (x=+1000); the direct
+	// link is blocked. A relay parked off-axis with LOS to both bridges it.
+	occ := []physics.OccluderBody{{Center: orbital.Vec3{}, Radius: 100}}
+	st := station(0, -1000, 100000)
+	pr := probeNode(1, 1000, 3000, false)
+
+	// Without a relay: blocked.
+	if connectivity([]commNode{st, pr}, occ)[1] {
+		t.Error("a probe occluded by a body with no relay should be disconnected")
+	}
+	// With an off-axis relay (y=2000) that clears the radius-100 body: linked.
+	relay := commNode{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: true}
+	if !connectivity([]commNode{st, pr, relay}, occ)[1] {
+		t.Error("an off-axis relay with LOS to both should bridge the occluded probe")
+	}
+}
+
+func TestConnectivityCannotRelayThroughDirectCraft(t *testing.T) {
+	// station --- directCraft --- probe, collinear, each hop in range but
+	// the body blocks the direct station↔probe link. The middle craft has a
+	// DIRECT antenna (not a relay), so it cannot forward → probe stays
+	// disconnected.
+	occ := []physics.OccluderBody{{Center: orbital.Vec3{}, Radius: 100}}
+	nodes := []commNode{
+		station(0, -1000, 100000),
+		probeNode(2, 1000, 100000, false), // the probe we test (id 2)
+		// a direct-only craft sitting off-axis with LOS to both, but a
+		// non-forwarder (forwards=false):
+		{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: false, craftID: 9},
+	}
+	if connectivity(nodes, occ)[2] {
+		t.Error("a direct-only craft must not relay traffic through itself")
+	}
+}
+
+// TestCanCommandCraftSemantics (C2-4): crewed → always; debris → never;
+// unmanned probe → gated on the connectivity graph.
+func TestCanCommandCraftSemantics(t *testing.T) {
+	w := &World{}
+
+	crewed := &spacecraft.Spacecraft{Controllable: true, Crewed: true}
+	if !w.CanCommandCraft(crewed) {
+		t.Error("a crewed vessel must always be commandable")
+	}
+
+	debris := &spacecraft.Spacecraft{Controllable: false}
+	if w.CanCommandCraft(debris) {
+		t.Error("passive debris must never be commandable")
+	}
+	if w.CanCommandCraft(nil) {
+		t.Error("nil craft must not be commandable")
+	}
+
+	probe := &spacecraft.Spacecraft{ID: 7, Controllable: true, Crewed: false}
+	// Inject a graph: probe 7 disconnected → not commandable.
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}}
+	if w.CanCommandCraft(probe) {
+		t.Error("a disconnected unmanned probe must not be commandable")
+	}
+	// Now connected → commandable.
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{7: true}}
+	if !w.CanCommandCraft(probe) {
+		t.Error("a connected unmanned probe must be commandable")
+	}
+}
+
+// TestRecomputeCommGraphIntegration (C2-4): a probe spawned near the home
+// DSN ring in LEO comes out connected through the real position pipeline.
+func TestRecomputeCommGraphIntegration(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// A relay probe (graph node + BFS source) placed 200 km directly above
+	// the first DSN station — guaranteed clear radial LOS + in range,
+	// independent of the J2000 rotation phase.
+	tug := spacecraft.NewFromLoadout("Relay-Tug")
+	tug.SystemIdx = 0
+	gs := w.GroundStations[0]
+	sys := w.System()
+	body := *sys.FindBody(gs.BodyID)
+	offset := w.groundStationWorldPos(gs, body).Sub(w.BodyPosition(body)) // surface point, body-relative
+	tug.Primary = body
+	tug.State.R = offset.Add(offset.Unit().Scale(200000)) // 200 km above the station
+	w.Crafts[0] = tug
+	w.EnsureCraftIDs()
+
+	w.RecomputeCommGraph()
+	if !w.CommGraph.HasConnection(tug.ID) {
+		t.Error("a relay probe directly above a DSN station should be connected")
+	}
+	if !w.CanCommandCraft(tug) {
+		t.Error("a connected probe should be commandable")
+	}
+
+	// Sanity: the same probe with NO antenna (strip it) is not a node and
+	// has no connection.
+	tug.Stages[len(tug.Stages)-1].AntennaKind = spacecraft.AntennaNone
+	tug.SyncFields()
+	w.RecomputeCommGraph()
+	if w.CommGraph.HasConnection(tug.ID) {
+		t.Error("a probe with no antenna cannot have a connection")
+	}
+}

--- a/internal/sim/commnet_test.go
+++ b/internal/sim/commnet_test.go
@@ -1,12 +1,73 @@
 package sim
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
+
+// TestCommandGateBlocksDisconnectedProbe (C2-5, ADR 0027): the command
+// methods refuse to mutate an out-of-contact unmanned probe and raise the
+// NO SIGNAL flash; the onboard plan is untouched.
+func TestCommandGateBlocksDisconnectedProbe(t *testing.T) {
+	w := mustWorld(t)
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}} // force "no connection"
+
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(time.Hour), DV: 10, Mode: spacecraft.BurnPrograde})
+	if len(probe.Nodes) != 0 {
+		t.Error("PlanNode must be blocked for a disconnected probe")
+	}
+	if _, ok := w.CommBlockedFlash(); !ok {
+		t.Error("a blocked command must raise the NO SIGNAL flash")
+	}
+	probe.Throttle = 0.5
+	w.SetThrottle(1.0)
+	if probe.Throttle != 0.5 {
+		t.Error("SetThrottle must be blocked for a disconnected probe")
+	}
+	if _, _, err := w.StageActive(0); !errors.Is(err, ErrNoSignal) {
+		t.Errorf("StageActive on a disconnected probe: got %v, want ErrNoSignal", err)
+	}
+}
+
+// TestCommandGateAllowsConnectedAndCrewed (C2-5): a connected probe and a
+// crewed vessel both accept commands.
+func TestCommandGateAllowsConnectedAndCrewed(t *testing.T) {
+	w := mustWorld(t)
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{probe.ID: true}}
+	w.PlanNode(ManeuverNode{TriggerTime: w.Clock.SimTime.Add(time.Hour), DV: 10, Mode: spacecraft.BurnPrograde})
+	if len(probe.Nodes) != 1 {
+		t.Error("a connected probe must accept a node")
+	}
+
+	crew := spacecraft.NewFromLoadout(spacecraft.LoadoutCapsuleID)
+	crew.Primary = w.Crafts[0].Primary
+	crew.State = w.Crafts[0].State
+	w.Crafts = append(w.Crafts, crew)
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(1)
+	w.CommGraph = nil // even with no graph, a crewed craft bypasses connectivity
+	w.SetThrottle(0.7)
+	if crew.Throttle != 0.7 {
+		t.Error("a crewed craft must accept commands regardless of connectivity")
+	}
+}
 
 // station / probe / relay node builders for the synthetic-graph tests.
 // Positions are in meters along the X axis; powers chosen so the default

--- a/internal/sim/craft_identity_test.go
+++ b/internal/sim/craft_identity_test.go
@@ -9,6 +9,24 @@ import (
 // threeCraftSlate spawns two siblings so the slate is [A, B, C] with
 // distinct stable IDs, and returns the three craft pointers. Active is
 // left at idx 0 (A).
+// crewTend marks a craft crew-tended (never comms-gated, ADR 0027) for
+// tests that exercise non-comms logic on a craft that would otherwise
+// default to an out-of-contact probe and trip the command gate. v0.23.
+func crewTend(c *spacecraft.Spacecraft) {
+	if c == nil || len(c.Stages) == 0 {
+		return
+	}
+	c.Stages[len(c.Stages)-1].CommandSource = spacecraft.CommandCrewed
+	c.SyncFields()
+}
+
+// crewTendActive crew-tends the active craft (nil-safe). Used by tests
+// that build a probe stack and exercise a gated command (stage / throttle)
+// without testing comms.
+func crewTendActive(w *World) {
+	crewTend(w.ActiveCraft())
+}
+
 func threeCraftSlate(t *testing.T) (*World, *spacecraft.Spacecraft, *spacecraft.Spacecraft, *spacecraft.Spacecraft) {
 	t.Helper()
 	w := mustWorld(t)
@@ -20,6 +38,12 @@ func threeCraftSlate(t *testing.T) (*World, *spacecraft.Spacecraft, *spacecraft.
 	}
 	if len(w.Crafts) != 3 {
 		t.Fatalf("want 3 crafts, got %d", len(w.Crafts))
+	}
+	// v0.23 / ADR 0027: these helper craft exercise slate/targeting/warp
+	// logic, not comms — keep them crew-tended so the command gate never
+	// interferes (comms gating has its own dedicated tests).
+	for _, c := range w.Crafts {
+		crewTend(c)
 	}
 	a, b, c := w.Crafts[0], w.Crafts[1], w.Crafts[2]
 	// Distinct, nonzero IDs.

--- a/internal/sim/data/ground_stations.json
+++ b/internal/sim/data/ground_stations.json
@@ -1,0 +1,28 @@
+{
+  "stations": [
+    {
+      "key": "goldstone",
+      "name": "Goldstone DSN",
+      "body_id": "earth",
+      "lat_deg": 35.43,
+      "lon_east_deg": -116.89,
+      "antenna_power_w": 100000
+    },
+    {
+      "key": "madrid",
+      "name": "Madrid DSN",
+      "body_id": "earth",
+      "lat_deg": 40.43,
+      "lon_east_deg": -4.25,
+      "antenna_power_w": 100000
+    },
+    {
+      "key": "canberra",
+      "name": "Canberra DSN",
+      "body_id": "earth",
+      "lat_deg": -35.4,
+      "lon_east_deg": 148.98,
+      "antenna_power_w": 100000
+    }
+  ]
+}

--- a/internal/sim/ground_stations.go
+++ b/internal/sim/ground_stations.go
@@ -1,0 +1,143 @@
+package sim
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CommNet ground-station catalog (v0.23 / ADR 0027). The home network is
+// a static DSN ring on the home body; relays extend coverage to the far
+// side of other bodies + deep space. Mirrors the LaunchSitePreset shape
+// but is DATA-driven (embedded JSON + user overlay) so a hard-mode single
+// station, extra stations, or stations on other bodies are just data
+// (ADR 0027 §5). Each station co-rotates with its body — its world
+// position is computed on demand by the connectivity graph (a later
+// cycle-2 slice), from BodyFixedToWorld at sim time.
+
+//go:embed data/ground_stations.json
+var groundStationsFS embed.FS
+
+// GroundStationPreset is one fixed-surface comms anchor. Distinct from a
+// LaunchSitePreset (a launchpad): a ground station is a network node. Key
+// is the short token, BodyID the body it sits on (its surface co-rotates),
+// LatDeg / LonEastDeg the body-fixed position (east-positive, pseudo-
+// Greenwich at simTime=0 — same convention as launch sites), AntennaPowerW
+// the relay power (ground stations are high-power; the two-endpoint range
+// formula is deferred tuning, ADR 0027 §2).
+type GroundStationPreset struct {
+	Key           string  `json:"key"`
+	Name          string  `json:"name"`
+	BodyID        string  `json:"body_id"`
+	LatDeg        float64 `json:"lat_deg"`
+	LonEastDeg    float64 `json:"lon_east_deg"`
+	AntennaPowerW float64 `json:"antenna_power_w"`
+
+	// Source is a runtime annotation ("embedded" / "user"); excluded from
+	// JSON so it never affects round-trips.
+	Source string `json:"-"`
+}
+
+// groundStationCatalog is the on-disk envelope (embedded + user overlay).
+type groundStationCatalog struct {
+	Stations []GroundStationPreset `json:"stations"`
+}
+
+// GroundStationWarning records a user overlay file that failed to load —
+// the bodies-pattern skip-bad-with-warning (ADR 0027 §5 inherits ADR 0026 §3).
+type GroundStationWarning struct {
+	Path string
+	Err  error
+}
+
+func (w GroundStationWarning) Error() string { return fmt.Sprintf("%s: %v", w.Path, w.Err) }
+
+// LoadGroundStations reads the embedded DSN ring merged with any user
+// overlay, dropping warnings. Call LoadGroundStationsWithWarnings to
+// inspect them.
+func LoadGroundStations() ([]GroundStationPreset, []GroundStationWarning) {
+	return LoadGroundStationsWithWarnings()
+}
+
+// LoadGroundStationsWithWarnings loads the embedded catalog merged with the
+// user overlay ($XDG_CONFIG_HOME/terminal-space-program/ground_stations/*.json),
+// user winning on Key. A malformed embedded file panics (build error); a
+// malformed user file is skipped with a warning.
+func LoadGroundStationsWithWarnings() ([]GroundStationPreset, []GroundStationWarning) {
+	stations := loadEmbeddedGroundStations()
+	return mergeUserGroundStations(stations, userGroundStationsDir())
+}
+
+func loadEmbeddedGroundStations() []GroundStationPreset {
+	data, err := groundStationsFS.ReadFile("data/ground_stations.json")
+	if err != nil {
+		panic("sim: embedded ground_stations.json missing: " + err.Error())
+	}
+	var cat groundStationCatalog
+	if err := json.Unmarshal(data, &cat); err != nil {
+		panic("sim: embedded ground_stations.json parse: " + err.Error())
+	}
+	for i := range cat.Stations {
+		cat.Stations[i].Source = "embedded"
+	}
+	return cat.Stations
+}
+
+func mergeUserGroundStations(stations []GroundStationPreset, dir string) ([]GroundStationPreset, []GroundStationWarning) {
+	if dir == "" {
+		return stations, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return stations, nil
+		}
+		return stations, []GroundStationWarning{{Path: dir, Err: err}}
+	}
+	var warnings []GroundStationWarning
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, GroundStationWarning{Path: path, Err: err})
+			continue
+		}
+		var cat groundStationCatalog
+		if err := json.Unmarshal(raw, &cat); err != nil {
+			warnings = append(warnings, GroundStationWarning{Path: path, Err: err})
+			continue
+		}
+		for _, s := range cat.Stations {
+			s.Source = "user"
+			replaced := false
+			for i := range stations {
+				if stations[i].Key == s.Key {
+					stations[i] = s
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				stations = append(stations, s)
+			}
+		}
+	}
+	return stations, warnings
+}
+
+func userGroundStationsDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "ground_stations")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "terminal-space-program", "ground_stations")
+}

--- a/internal/sim/ground_stations_test.go
+++ b/internal/sim/ground_stations_test.go
@@ -1,0 +1,100 @@
+package sim
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestGroundStationsDSNRing (C2-3, ADR 0027): the embedded catalog is a
+// 3-station DSN ring on the home body, spread around the globe (~120°
+// apart) and high-power.
+func TestGroundStationsDSNRing(t *testing.T) {
+	stations, warnings := LoadGroundStations()
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %d, want 0", len(warnings))
+	}
+	if len(stations) != 3 {
+		t.Fatalf("DSN ring = %d stations, want 3", len(stations))
+	}
+	lons := make([]float64, 0, 3)
+	for _, s := range stations {
+		if s.BodyID != "earth" {
+			t.Errorf("station %q BodyID = %q, want earth (home body)", s.Key, s.BodyID)
+		}
+		if s.AntennaPowerW <= 0 {
+			t.Errorf("station %q has no antenna power", s.Key)
+		}
+		if s.Source != "embedded" {
+			t.Errorf("station %q Source = %q, want embedded", s.Key, s.Source)
+		}
+		// normalize longitude to [0, 360) for gap analysis
+		lon := math.Mod(s.LonEastDeg+360, 360)
+		lons = append(lons, lon)
+	}
+	// Each consecutive longitude gap should be wide (well past 60°), the
+	// "~120° apart" DSN spread that gives near-continuous home coverage.
+	sort.Float64s(lons)
+	for i := range lons {
+		next := lons[(i+1)%3]
+		gap := next - lons[i]
+		if i == 2 {
+			gap = lons[0] + 360 - lons[2]
+		}
+		if gap < 60 {
+			t.Errorf("longitude gap %d = %.1f°, want > 60° (stations clustered, not a ring)", i, gap)
+		}
+	}
+}
+
+// TestNewWorldLoadsGroundStations (C2-3): NewWorld populates
+// World.GroundStations from the catalog.
+func TestNewWorldLoadsGroundStations(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if len(w.GroundStations) != 3 {
+		t.Errorf("World.GroundStations = %d, want 3 (DSN ring)", len(w.GroundStations))
+	}
+}
+
+// TestGroundStationUserOverlay (C2-3): a user overlay adds/replaces by
+// Key; a malformed file is skipped with a warning.
+func TestGroundStationUserOverlay(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "terminal-space-program", "ground_stations")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	// Add a new station + override Goldstone's power.
+	good := `{"stations":[
+		{"key":"luna-farside","name":"Luna Farside","body_id":"moon","lat_deg":0,"lon_east_deg":180,"antenna_power_w":50000},
+		{"key":"goldstone","name":"Goldstone (modded)","body_id":"earth","lat_deg":35.43,"lon_east_deg":-116.89,"antenna_power_w":250000}
+	]}`
+	if err := os.WriteFile(filepath.Join(dir, "mine.json"), []byte(good), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stations, warnings := LoadGroundStations()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1 (the malformed file)", len(warnings))
+	}
+	byKey := map[string]GroundStationPreset{}
+	for _, s := range stations {
+		byKey[s.Key] = s
+	}
+	if g, ok := byKey["luna-farside"]; !ok || g.BodyID != "moon" || g.Source != "user" {
+		t.Errorf("user station luna-farside not merged correctly: %+v", g)
+	}
+	if g := byKey["goldstone"]; g.AntennaPowerW != 250000 || g.Source != "user" {
+		t.Errorf("user override of goldstone failed: %+v", g)
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -115,6 +115,9 @@ func (w *World) SetThrottle(t float64) {
 	if c == nil {
 		return
 	}
+	if !w.canCommand(c) { // ADR 0027: no new throttle command without a connection
+		return
+	}
 	if t < 0 {
 		t = 0
 	} else if t > 1 {
@@ -146,9 +149,14 @@ func (w *World) AdjustThrottle(delta float64) {
 // manual burn is already in flight on that craft, the engine
 // direction takes effect on the next tick. v0.8.1+: per-active-craft.
 func (w *World) SetAttitudeMode(mode spacecraft.BurnMode) {
-	if c := w.ActiveCraft(); c != nil {
-		c.AttitudeMode = mode
+	c := w.ActiveCraft()
+	if c == nil {
+		return
 	}
+	if !w.canCommand(c) { // ADR 0027: attitude is a command, gated without a connection
+		return
+	}
+	c.AttitudeMode = mode
 }
 
 // PlanNode inserts a node into the active craft's Nodes slice,
@@ -159,6 +167,9 @@ func (w *World) SetAttitudeMode(mode spacecraft.BurnMode) {
 func (w *World) PlanNode(n ManeuverNode) {
 	c := w.ActiveCraft()
 	if c == nil {
+		return
+	}
+	if !w.canCommand(c) { // ADR 0027: committing a node is a command (covers transfer/plan commits too)
 		return
 	}
 	c.Nodes = append(c.Nodes, n)
@@ -1229,7 +1240,9 @@ func (w *World) PorkchopGrid(targetIdx int, depDays, tofDays []float64, opts Tra
 // component of the integrated Δv is Δv_ideal × sin(α)/α (perpendicular
 // components sum to zero by symmetry). To deliver Δv_target we request
 // Δv such that Δv × sin(α(Δv))/α(Δv) = Δv_target, where
-//   α(Δv) = (Δv·m / F) × n_craft / 2 = k · Δv,  k = m·n/(2F)
+//
+//	α(Δv) = (Δv·m / F) × n_craft / 2 = k · Δv,  k = m·n/(2F)
+//
 // Substituting: sin(k·Δv) = k·Δv_target → Δv = asin(k·Δv_target)/k.
 //
 // Returns the ideal Δv unchanged if k·Δv_target ≥ 1 (geometrically
@@ -2349,6 +2362,9 @@ func (w *World) DeleteNode(idx int) {
 		return
 	}
 	if idx < 0 || idx >= len(c.Nodes) {
+		return
+	}
+	if !w.canCommand(c) { // ADR 0027: editing the flight plan is a command
 		return
 	}
 	c.Nodes = append(c.Nodes[:idx], c.Nodes[idx+1:]...)

--- a/internal/sim/nav.go
+++ b/internal/sim/nav.go
@@ -7,16 +7,16 @@ import "github.com/jasonfen/terminal-space-program/internal/spacecraft"
 // KSP-style: the player cycles a single mode and the same six axis
 // keys reinterpret accordingly.
 //
-//   NavOrbit   — prograde ≡ +v̂ in the active craft's primary-relative
-//                frame (the v0.7.3+ default).
-//   NavSurface — prograde ≡ +(v − ω×r), velocity relative to the
-//                rotating atmosphere; useful for ascent. Only prograde
-//                / retrograde rebind in this mode (KSP shows orbital
-//                normal/radial on the surface navball too).
-//   NavTarget  — prograde ≡ unit(v_active − v_target), retrograde its
-//                flip; radial± rebinds to BurnTarget / BurnAntiTarget
-//                (toward / away from target). Only valid when
-//                World.Target.Kind == TargetCraft. v0.9.3+.
+//	NavOrbit   — prograde ≡ +v̂ in the active craft's primary-relative
+//	             frame (the v0.7.3+ default).
+//	NavSurface — prograde ≡ +(v − ω×r), velocity relative to the
+//	             rotating atmosphere; useful for ascent. Only prograde
+//	             / retrograde rebind in this mode (KSP shows orbital
+//	             normal/radial on the surface navball too).
+//	NavTarget  — prograde ≡ unit(v_active − v_target), retrograde its
+//	             flip; radial± rebinds to BurnTarget / BurnAntiTarget
+//	             (toward / away from target). Only valid when
+//	             World.Target.Kind == TargetCraft. v0.9.3+.
 type NavMode int
 
 const (
@@ -101,6 +101,9 @@ func (w *World) ResolveAttitudeIntent(intent AttitudeIntent) spacecraft.BurnMode
 // player never lands on a mode that silently degrades back to orbit.
 // Returns the new mode for the caller's HUD flash.
 func (w *World) CycleNavMode() NavMode {
+	// Not comms-gated (ADR 0027): NavMode is the navball reference frame —
+	// a display / SAS-reference toggle (like the camera), not a new command
+	// to the vessel. The gated attitude command is SetAttitudeMode.
 	hasCraftTarget := w.Target.Kind == TargetCraft
 	for i := 0; i < 3; i++ {
 		w.NavMode = (w.NavMode + 1) % 3

--- a/internal/sim/spawn_custom_test.go
+++ b/internal/sim/spawn_custom_test.go
@@ -83,6 +83,7 @@ func TestSpawnCustomLanderSplitStages(t *testing.T) {
 	if c.Stages[0].Name != "Descent" || c.Stages[1].Name != "Ascent" {
 		t.Fatalf("stack order wrong: bottom=%q top=%q", c.Stages[0].Name, c.Stages[1].Name)
 	}
+	crewTend(c) // testing the staging split, not comms
 
 	// Stage once: drops the Descent as its own craft, leaving the Ascent.
 	_, jidx, err := w.StageActive(w.ActiveCraftIdx)

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -27,6 +27,10 @@ var (
 	// one stage entry. Real spawn paths always populate Stages via
 	// NewFromLoadout, so this is a defensive check.
 	ErrStageEmpty = errors.New("stage: craft has no stages")
+	// ErrNoSignal — the craft is an unmanned probe out of network contact
+	// (ADR 0027); staging is a command and is blocked. canCommand also
+	// raises the NO SIGNAL flash.
+	ErrNoSignal = errors.New("stage: no signal (unmanned craft out of contact)")
 	// ErrStageOnlyOne — craft has only one stage left. Dropping
 	// the only stage would leave the player with nothing to
 	// control, which is the wrong default. Status-flash + no-op.
@@ -66,6 +70,9 @@ func (w *World) StageActive(craftIdx int) (newActiveIdx, jettisonedIdx int, err 
 	}
 	if len(c.Stages) == 0 {
 		return 0, 0, ErrStageEmpty
+	}
+	if !w.canCommand(c) { // ADR 0027: staging is a command, blocked without a connection
+		return 0, 0, ErrNoSignal
 	}
 
 	// v0.12 Slice 2 / ADR 0007: a Decouple Plan lets a press release

--- a/internal/sim/staging_can_soft_land_test.go
+++ b/internal/sim/staging_can_soft_land_test.go
@@ -36,6 +36,7 @@ func TestApolloStackLanderDecoupleCarriesCanSoftLand(t *testing.T) {
 	apollo.State = w.Crafts[0].State
 	w.Crafts[0] = apollo
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	// Stage 0 = S-IC bottom. Composite's CanSoftLand = false
 	// (S-IC doesn't land).
@@ -124,6 +125,7 @@ func TestFalcon9FirstStageDecoupleCarriesCanSoftLand(t *testing.T) {
 	f9.State = w.Crafts[0].State
 	w.Crafts[0] = f9
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	if !f9.CanSoftLand {
 		t.Errorf("F9 at spawn: CanSoftLand=false, want true (F9-S1 bottom carries flag)")

--- a/internal/sim/staging_surface_test.go
+++ b/internal/sim/staging_surface_test.go
@@ -31,6 +31,7 @@ func landMoonLander(t *testing.T) (*World, *spacecraft.Spacecraft) {
 	c.LandedLatDeg, c.LandedLonDeg = 10.0, 45.0
 	w.Crafts = []*spacecraft.Spacecraft{c}
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 	// Seed R/V from the landed coords so the pre-stage state is realistic.
 	integrateLanded(w, c, time.Second)
 	return w, c
@@ -175,6 +176,7 @@ func TestExtractedLMSurfaceStagesDescentAlone(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	// Drop S-IC, S-II, S-IVB (the [1,1,1] plan), then transpose + undock
 	// to release the LM as its own 2-stage craft.
@@ -209,6 +211,7 @@ func TestExtractedLMSurfaceStagesDescentAlone(t *testing.T) {
 	lm.Landed = true
 	lm.LandedLatDeg, lm.LandedLonDeg = -5.0, 120.0
 	w.SetActiveCraftIdx(lmIdx)
+	crewTend(lm) // testing surface staging, not comms
 	integrateLanded(w, lm, time.Second)
 
 	_, descentIdx, err := w.StageActive(lmIdx)
@@ -247,6 +250,7 @@ func TestDecouplePlanAdvancesOnEachPress(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	wantRemaining := [][]int{
 		{1, 1, 2}, // after S-IC

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -34,6 +34,7 @@ func TestStageActiveOnSaturnVPopsBottomStage(t *testing.T) {
 	saturn.State = w.Crafts[0].State
 	w.Crafts[0] = saturn
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	beforeStageCount := len(saturn.Stages)
 	beforeBottomFuel := saturn.Stages[0].FuelMass
@@ -144,6 +145,7 @@ func TestStageActiveDoesNotImmediatelyReDock(t *testing.T) {
 	saturn.State = w.Crafts[0].State
 	w.Crafts[0] = saturn
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	if _, _, err := w.StageActive(0); err != nil {
 		t.Fatalf("StageActive: %v", err)
@@ -174,6 +176,7 @@ func TestStageActiveAdvancesEngineToNextStage(t *testing.T) {
 	saturn.State = w.Crafts[0].State
 	w.Crafts[0] = saturn
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	// S-IC bottom stage thrust pre-stage.
 	if saturn.Thrust != 35100000 {
@@ -209,6 +212,7 @@ func TestApolloStackManualFlipDropsLMAsOneCraft(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	// Drop the three Saturn stages → pre-transposition [Descent, Ascent, SM, CM].
 	for i := 0; i < 3; i++ {
@@ -255,6 +259,7 @@ func TestTransposeClearsDecouplePlan(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	for i := 0; i < 3; i++ {
 		if _, _, err := w.StageActive(0); err != nil {
@@ -295,6 +300,7 @@ func TestTransposeRejectsWrongShape(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	if err := w.Transpose(0); !errors.Is(err, ErrTransposeNotReady) {
 		t.Errorf("Transpose on full stack: err = %v, want ErrTransposeNotReady", err)
@@ -323,6 +329,7 @@ func TestApolloStackDecoupleChainThenTranspose(t *testing.T) {
 	stack.State = w.Crafts[0].State
 	w.Crafts[0] = stack
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	if len(stack.Stages) != 7 {
 		t.Fatalf("Apollo-Stack should start 7-stage, got %d", len(stack.Stages))
@@ -421,6 +428,7 @@ func TestStageActivePreservesAttitudeOnDroppedStage(t *testing.T) {
 	saturn.CurrentAttitudeDir = orbital.Vec3{X: 0.5, Y: 0, Z: 0.5}
 	w.Crafts[0] = saturn
 	w.ActiveCraftIdx = 0
+	crewTendActive(w)
 
 	parentCmd := saturn.CurrentAttitudeDir
 	_, jettIdx, err := w.StageActive(0)

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -224,6 +224,12 @@ type World struct {
 	missionFailMsg   string
 	missionFailUntil time.Time
 
+	// commBlockedUntil drives the "NO SIGNAL" transient (v0.23 / ADR 0027):
+	// set when a player command is gated on an unmanned vessel that has no
+	// network connection. Wall-clock deadline like missionFailUntil; the
+	// HUD reads CommBlockedFlash. Session scoped, not persisted.
+	commBlockedUntil time.Time
+
 	// enabledMissionPrograms gates which mission programs (ADR 0025 §2 Program
 	// tag) the evaluator and player surface treat as active (v0.21 Slice 7).
 	// A nil map means "all programs enabled" — the back-compat default for

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -194,6 +194,12 @@ type World struct {
 	// Not persisted (rebuilt from the catalog on load).
 	GroundStations []GroundStationPreset
 
+	// CommGraph is the cached per-tick CommNet connectivity result (v0.23 /
+	// ADR 0027): which unmanned probes currently reach a ground station.
+	// Rebuilt each Tick by RecomputeCommGraph after physics; read by
+	// CanCommandCraft + coverage objectives + the comms HUD. Transient.
+	CommGraph *CommGraph
+
 	// stagedThisSession latches once the player decouples a stage; it
 	// feeds the mission evaluator's outcome context (ADR 0025). Session
 	// scoped (not persisted) — outcome objectives that need it land in a
@@ -661,6 +667,12 @@ func (w *World) Tick() {
 	// early-returns when there's no active craft after draining, so actions
 	// recorded during an empty-slate window can't survive to latch a
 	// freshly-active event objective on the first post-spawn tick.
+	//
+	// v0.23 / ADR 0027: rebuild the CommNet connectivity graph after
+	// physics (positions are final) and before mission eval (coverage
+	// objectives read it). Gates command of unmanned vessels via
+	// CanCommandCraft. Cheap at the typical few-vessels + 3-stations scale.
+	w.RecomputeCommGraph()
 	w.evaluateMissions()
 	// v0.11.0+: per-tick ViewLaunch route/release state machine.
 	// Runs after integration so the post-tick Landed state is

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -186,6 +186,14 @@ type World struct {
 	// time; Status fields progress as the player flies. v0.6.5+.
 	Missions []missions.Mission
 
+	// GroundStations is the CommNet ground-station catalog (v0.23 / ADR
+	// 0027): the home-body DSN ring plus any user overlay, loaded at
+	// NewWorld. Each station co-rotates with its body; its world position
+	// is computed on demand (the connectivity graph slice). Data-driven —
+	// extra stations or stations on other bodies are just catalog entries.
+	// Not persisted (rebuilt from the catalog on load).
+	GroundStations []GroundStationPreset
+
 	// stagedThisSession latches once the player decouples a stage; it
 	// feeds the mission evaluator's outcome context (ADR 0025). Session
 	// scoped (not persisted) — outcome objectives that need it land in a
@@ -309,6 +317,13 @@ func NewWorld() (*World, error) {
 	if cat, err := missions.LoadAll(); err == nil {
 		w.Missions = missions.Clone(cat.Missions)
 	}
+
+	// v0.23 / ADR 0027: load the CommNet ground-station catalog (embedded
+	// DSN ring + user overlay). Non-fatal — a bad overlay file is skipped
+	// with a warning and the embedded ring still loads; comms is additive
+	// and must not block worldgen. Warnings are surfaced at startup
+	// (cmd/main.go) like the other overlay catalogs.
+	w.GroundStations, _ = LoadGroundStations()
 
 	// Spawn spacecraft in LEO. v0.1: craft is always in Sol.
 	// v0.8.1+: spawned into the multi-craft slate; subsequent craft

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -841,6 +841,16 @@ func (w *World) missionEvalContext() missions.EvalContext {
 		Staged:         w.stagedThisSession,
 		RecentActions:  w.recentActions,
 	}
+	// v0.23 / ADR 0027: project the CommNet graph down for coverage
+	// objectives (the missions package never imports sim).
+	if w.CommGraph != nil {
+		ctx.ActiveConnected = w.CommGraph.HasConnection(c.ID)
+		for _, oc := range w.Crafts {
+			if oc != nil && oc.AntennaKind == spacecraft.AntennaRelay && w.CommGraph.HasConnection(oc.ID) {
+				ctx.ConnectedRelayCount++
+			}
+		}
+	}
 	// Target-craft relative state (rendezvous), against the player's
 	// current target slot in the active craft's frame. Only when a craft
 	// (not a body) is targeted, so non-rendezvous play skips the solve.

--- a/internal/spacecraft/burn_direction.go
+++ b/internal/spacecraft/burn_direction.go
@@ -113,9 +113,10 @@ func (s *Spacecraft) BurnDirectionForBurn(mode BurnMode, rT, vT orbital.Vec3, pl
 // direction. Public so tests can exercise the rotation math directly.
 //
 // Frame:
-//   up    = r̂                          (local vertical)
-//   east  = unit(spinAxis × up)         (local east on the body)
-//   north = up × east                   (right-handed local frame)
+//
+//	up    = r̂                          (local vertical)
+//	east  = unit(spinAxis × up)         (local east on the body)
+//	north = up × east                   (right-handed local frame)
 //
 // Rotation about north tilts the thrust vector east (+pitch) or west
 // (-pitch) without changing the heading component. At the poles

--- a/internal/spacecraft/burn_direction_test.go
+++ b/internal/spacecraft/burn_direction_test.go
@@ -14,9 +14,9 @@ import (
 func testEarth() bodies.CelestialBody {
 	return bodies.CelestialBody{
 		ID:              "earth",
-		MeanRadius:      6371,                                                // km
-		Mass:            bodies.Mass{Value: 5.972, Exponent: 24},             // kg
-		SideralRotation: 23.9345,                                             // hours (sidereal day)
+		MeanRadius:      6371,                                    // km
+		Mass:            bodies.Mass{Value: 5.972, Exponent: 24}, // kg
+		SideralRotation: 23.9345,                                 // hours (sidereal day)
 	}
 }
 

--- a/internal/spacecraft/catalog.go
+++ b/internal/spacecraft/catalog.go
@@ -154,10 +154,11 @@ func (w CatalogWarning) Error() string {
 // The part's own identity fields ride along (Name / Glyph / Color); the
 // loadout-level LoadoutID is stamped by the loadout-assembly path
 // (C1-3 NewFromLoadout), not here, since a part doesn't know which
-// loadout references it. Tier and the forward-compatible comms attributes
-// have no Stage counterpart yet and are intentionally dropped.
+// loadout references it. Tier (configurator metadata) has no Stage
+// counterpart and is dropped. The comms attributes (command_source /
+// antenna, ADR 0027) DO ride onto the Stage now (cycle 2 / C2-1).
 func (p Part) ToStage() Stage {
-	return Stage{
+	st := Stage{
 		DryMass:              p.DryMassKg,
 		FuelMass:             p.FuelMassKg,
 		FuelCapacity:         p.FuelCapacityKg,
@@ -178,7 +179,13 @@ func (p Part) ToStage() Stage {
 		LaunchSpriteHasLegs:  p.LaunchSpriteHasLegs,
 		CanSoftLand:          p.CanSoftLand,
 		HasParachute:         p.HasParachute,
+		CommandSource:        p.CommandSource,
 	}
+	if p.Antenna != nil {
+		st.AntennaKind = p.Antenna.Kind
+		st.AntennaPowerW = p.Antenna.PowerW
+	}
+	return st
 }
 
 // LoadCatalogOverlay re-resolves the runtime catalogs (Loadouts,

--- a/internal/spacecraft/comms_test.go
+++ b/internal/spacecraft/comms_test.go
@@ -42,9 +42,16 @@ func TestAntennaDerivation(t *testing.T) {
 	if probe.AntennaKind != AntennaDirect || probe.AntennaPowerW != 1500 {
 		t.Errorf("Station-Keeper antenna = %q/%g, want direct/1500", probe.AntennaKind, probe.AntennaPowerW)
 	}
-	sat := NewFromLoadout(LoadoutSaturnVID) // no antenna anywhere
-	if sat.AntennaKind != AntennaNone || sat.AntennaPowerW != 0 {
-		t.Errorf("Saturn-V antenna = %q/%g, want none/0", sat.AntennaKind, sat.AntennaPowerW)
+	// Saturn-V has no authored antenna, but as a defaulted probe it gets a
+	// basic telemetry antenna so it can be reached (else uncommandable).
+	sat := NewFromLoadout(LoadoutSaturnVID)
+	if sat.AntennaKind != AntennaDirect || sat.AntennaPowerW != DefaultProbeAntennaPowerW {
+		t.Errorf("Saturn-V antenna = %q/%g, want direct/%g (defaulted probe telemetry)", sat.AntennaKind, sat.AntennaPowerW, DefaultProbeAntennaPowerW)
+	}
+	// A crewed vessel needs no antenna (crew are never comms-gated).
+	apollo := NewFromLoadout(LoadoutCapsuleID)
+	if apollo.AntennaKind != AntennaNone {
+		t.Errorf("crewed Capsule should not get a defaulted antenna, got %q", apollo.AntennaKind)
 	}
 }
 

--- a/internal/spacecraft/comms_test.go
+++ b/internal/spacecraft/comms_test.go
@@ -1,0 +1,101 @@
+package spacecraft
+
+import "testing"
+
+// TestCommandSourceDerivation (C2-1, ADR 0027): SyncFields derives the
+// vessel-level Crewed / Controllable mirrors from the per-stage command
+// sources, and construction defaults a command-less vessel so it stays
+// controllable.
+func TestCommandSourceDerivation(t *testing.T) {
+	cases := []struct {
+		loadout         string
+		wantCrewed      bool
+		wantControllabe bool
+	}{
+		{LoadoutApolloStackID, true, true}, // CM is a crewed command source
+		{LoadoutCapsuleID, true, true},     // crewed re-entry capsule
+		{LoadoutKernStackID, true, true},   // crewed Pod core
+		{LoadoutSaturnVID, false, true},    // no crew part → defaulted probe core
+		{LoadoutSIVB1ID, false, true},      // single transfer stage → defaulted probe
+		{"Relay-Tug", false, true},         // explicit probe (data-only loadout)
+		{"Station-Keeper", false, true},    // explicit probe
+	}
+	for _, c := range cases {
+		v := NewFromLoadout(c.loadout)
+		if v.Crewed != c.wantCrewed {
+			t.Errorf("%s Crewed = %v, want %v", c.loadout, v.Crewed, c.wantCrewed)
+		}
+		if v.Controllable != c.wantControllabe {
+			t.Errorf("%s Controllable = %v, want %v", c.loadout, v.Controllable, c.wantControllabe)
+		}
+	}
+}
+
+// TestAntennaDerivation (C2-1): the vessel antenna mirror is the
+// highest-power antenna across the stack; a vessel with none reads none.
+func TestAntennaDerivation(t *testing.T) {
+	tug := NewFromLoadout("Relay-Tug") // ntr-tug carries a relay antenna @ 4000 W
+	if tug.AntennaKind != AntennaRelay || tug.AntennaPowerW != 4000 {
+		t.Errorf("Relay-Tug antenna = %q/%g, want relay/4000", tug.AntennaKind, tug.AntennaPowerW)
+	}
+	probe := NewFromLoadout("Station-Keeper") // ion-keeper: direct @ 1500 W
+	if probe.AntennaKind != AntennaDirect || probe.AntennaPowerW != 1500 {
+		t.Errorf("Station-Keeper antenna = %q/%g, want direct/1500", probe.AntennaKind, probe.AntennaPowerW)
+	}
+	sat := NewFromLoadout(LoadoutSaturnVID) // no antenna anywhere
+	if sat.AntennaKind != AntennaNone || sat.AntennaPowerW != 0 {
+		t.Errorf("Saturn-V antenna = %q/%g, want none/0", sat.AntennaKind, sat.AntennaPowerW)
+	}
+}
+
+// TestEnsureCommandSourceDefaulting (C2-1): EnsureCommandSource stamps the
+// surviving core of a command-less vessel — crewed for a crewed-pod role,
+// else probe — and is a no-op once any stage is a command source.
+func TestEnsureCommandSourceDefaulting(t *testing.T) {
+	// Command-less stack, generic role → top stage defaults to probe.
+	c := &Spacecraft{Role: "launch-vehicle", Stages: []Stage{
+		{Name: "booster", DryMass: 1000},
+		{Name: "core", DryMass: 500},
+	}}
+	EnsureCommandSource(c)
+	if c.Stages[1].CommandSource != CommandProbe {
+		t.Errorf("top stage command source = %q, want probe", c.Stages[1].CommandSource)
+	}
+	if c.Stages[0].CommandSource != CommandNone {
+		t.Errorf("bottom stage should stay none, got %q", c.Stages[0].CommandSource)
+	}
+
+	// Crewed-pod role → defaults to crewed.
+	crew := &Spacecraft{Role: "capsule", Stages: []Stage{{Name: "pod", DryMass: 500}}}
+	EnsureCommandSource(crew)
+	if crew.Stages[0].CommandSource != CommandCrewed {
+		t.Errorf("crewed-pod default = %q, want crewed", crew.Stages[0].CommandSource)
+	}
+
+	// Already has a command source → no-op (does not overwrite or add).
+	existing := &Spacecraft{Role: "custom", Stages: []Stage{
+		{Name: "probe", DryMass: 100, CommandSource: CommandProbe},
+		{Name: "tank", DryMass: 200},
+	}}
+	EnsureCommandSource(existing)
+	if existing.Stages[1].CommandSource != CommandNone {
+		t.Errorf("no-op expected, but top stage got %q", existing.Stages[1].CommandSource)
+	}
+}
+
+// TestJettisonedStageIsDebris (C2-1): a craft built directly from
+// command-less stages WITHOUT the construction defaulting (the
+// buildJettisonedCraft path) derives Controllable=false — a spent booster
+// is passive debris, not a vessel.
+func TestJettisonedStageIsDebris(t *testing.T) {
+	debris := &Spacecraft{Role: "launch-vehicle", Stages: []Stage{
+		{Name: "S-IC", DryMass: 130000},
+	}}
+	debris.SyncFields() // no EnsureCommandSource — mirrors buildJettisonedCraft
+	if debris.Controllable {
+		t.Error("a jettisoned command-less booster should be debris (Controllable=false)")
+	}
+	if debris.Crewed {
+		t.Error("debris should not read as crewed")
+	}
+}

--- a/internal/spacecraft/data/parts.json
+++ b/internal/spacecraft/data/parts.json
@@ -190,6 +190,7 @@
     {
       "id": "csm",
       "name": "CSM",
+      "command_source": "crewed",
       "glyph": "➤",
       "color": "#C0C0FF",
       "tier": "payload",
@@ -223,6 +224,7 @@
     {
       "id": "command-module",
       "name": "CM",
+      "command_source": "crewed",
       "glyph": "➤",
       "color": "#B8C8E0",
       "tier": "payload",
@@ -251,6 +253,7 @@
     {
       "id": "capsule",
       "name": "Capsule",
+      "command_source": "crewed",
       "glyph": "➤",
       "color": "#B8C8E0",
       "tier": "payload",
@@ -417,6 +420,7 @@
     {
       "id": "kern-pod",
       "name": "Pod",
+      "command_source": "crewed",
       "glyph": "➤",
       "color": "#B8C8E0",
       "dry_mass_kg": 1000,

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -361,15 +361,25 @@ func roleIsCrewedPod(role string) bool {
 	return role == "capsule" || role == "mission-stack"
 }
 
+// DefaultProbeAntennaPowerW is the basic telemetry antenna a defaulted
+// probe core gets (ADR 0027): a bare launch vehicle / un-annotated custom
+// stack has a guidance + telemetry antenna in reality, so without one it
+// could never establish a connection and would be permanently
+// uncommandable once command-gating lands. Weaker than the dedicated
+// comsat / relay parts; the absolute value is deferred tuning.
+const DefaultProbeAntennaPowerW = 2000.0
+
 // EnsureCommandSource stamps a default command source on a command-less
 // *vessel* so it stays controllable (ADR 0027 defaulting rule): if no
 // stage is already a command source, the surviving core (top stage) gets
 // CommandCrewed when the vessel's role is a crewed pod, else CommandProbe.
-// Applied at vessel construction (NewFromLoadout / NewFromStages) and at
-// save-load — NOT to jettisoned stages, so a spent booster with no core
-// stays passive debris. No-op once any stage declares a command source
-// (the catalog-authored crewed pods / probes, or an already-defaulted
-// vessel), so it is idempotent.
+// A defaulted PROBE (not crewed — crew fly without contact) also gets a
+// basic direct antenna if the vessel carries none, so it can actually
+// reach the network. Applied at vessel construction (NewFromLoadout /
+// NewFromStages) and at save-load — NOT to jettisoned stages, so a spent
+// booster with no core stays passive debris. No-op once any stage declares
+// a command source (the catalog-authored crewed pods / probes, or an
+// already-defaulted vessel), so it is idempotent.
 func EnsureCommandSource(c *Spacecraft) {
 	if len(c.Stages) == 0 {
 		return
@@ -379,11 +389,25 @@ func EnsureCommandSource(c *Spacecraft) {
 			return
 		}
 	}
-	src := CommandProbe
+	top := len(c.Stages) - 1
 	if roleIsCrewedPod(c.Role) {
-		src = CommandCrewed
+		c.Stages[top].CommandSource = CommandCrewed
+		return
 	}
-	c.Stages[len(c.Stages)-1].CommandSource = src
+	c.Stages[top].CommandSource = CommandProbe
+	// A defaulted probe needs an antenna to be reachable; add a basic one
+	// only if the whole vessel carries no antenna already.
+	hasAntenna := false
+	for _, st := range c.Stages {
+		if st.AntennaKind != AntennaNone {
+			hasAntenna = true
+			break
+		}
+	}
+	if !hasAntenna {
+		c.Stages[top].AntennaKind = AntennaDirect
+		c.Stages[top].AntennaPowerW = DefaultProbeAntennaPowerW
+	}
 }
 
 // NewFromStages constructs a Spacecraft from a player-assembled

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -348,8 +348,42 @@ func NewFromLoadout(loadoutID string) *Spacecraft {
 		DecouplePlan:         plan,
 		SlewRateDegPerSec:    l.SlewRateDegPerSec,
 	}
+	EnsureCommandSource(c)
 	c.SyncFields()
 	return c
+}
+
+// roleIsCrewedPod reports whether a loadout/vessel Role denotes a crewed
+// command pod, used by the command-source defaulting (ADR 0027): a
+// command-less vessel whose role is a crewed pod defaults to a crewed
+// command source, otherwise to an uncrewed probe core.
+func roleIsCrewedPod(role string) bool {
+	return role == "capsule" || role == "mission-stack"
+}
+
+// EnsureCommandSource stamps a default command source on a command-less
+// *vessel* so it stays controllable (ADR 0027 defaulting rule): if no
+// stage is already a command source, the surviving core (top stage) gets
+// CommandCrewed when the vessel's role is a crewed pod, else CommandProbe.
+// Applied at vessel construction (NewFromLoadout / NewFromStages) and at
+// save-load — NOT to jettisoned stages, so a spent booster with no core
+// stays passive debris. No-op once any stage declares a command source
+// (the catalog-authored crewed pods / probes, or an already-defaulted
+// vessel), so it is idempotent.
+func EnsureCommandSource(c *Spacecraft) {
+	if len(c.Stages) == 0 {
+		return
+	}
+	for _, st := range c.Stages {
+		if IsCommandSource(st.CommandSource) {
+			return
+		}
+	}
+	src := CommandProbe
+	if roleIsCrewedPod(c.Role) {
+		src = CommandCrewed
+	}
+	c.Stages[len(c.Stages)-1].CommandSource = src
 }
 
 // NewFromStages constructs a Spacecraft from a player-assembled
@@ -398,6 +432,7 @@ func NewFromStages(stages []Stage) *Spacecraft {
 		BallisticCoefficient: DefaultBallisticCoefficient,
 		Stages:               cp,
 	}
+	EnsureCommandSource(c)
 	c.SyncFields()
 	return c
 }

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -523,6 +523,15 @@ func NewInLEO(earth bodies.CelestialBody) *Spacecraft {
 	v := math.Sqrt(mu / r)
 	c := NewFromLoadout(LoadoutSIVB1ID)
 	c.Name = "S-IVB-1" // first vessel of the slate keeps the historical instance name.
+	// v0.23 / ADR 0027: the player's starting vessel is crew-tended, so it
+	// is never comms-gated — the player learns to fly without a connectivity
+	// constraint on their first ship; the probes they later launch ARE gated.
+	// Overrides the probe core EnsureCommandSource stamped at construction.
+	if len(c.Stages) > 0 {
+		top := len(c.Stages) - 1
+		c.Stages[top].CommandSource = CommandCrewed
+		c.SyncFields()
+	}
 	c.Primary = earth
 	// v0.8.6+: rotate the body-frame circular state into world coords
 	// so the orbit physically lies in Earth's equatorial plane (passes

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -218,6 +218,25 @@ type Spacecraft struct {
 	// auto-deploy check. `omitempty`-default-false.
 	HasParachute bool
 
+	// Crewed / Controllable (v0.23 / ADR 0027): vessel-level mirrors of
+	// the per-stage CommandSource, re-derived by SyncFields across the
+	// whole stack on every staging / dock / load. Controllable is true
+	// when the vessel has any command source (crewed pod or probe core);
+	// Crewed is true when any is a crewed pod (crewed vessels are never
+	// comms-gated). A vessel with neither is passive debris. Construction
+	// (NewFromLoadout / NewFromStages) and save-load stamp a default
+	// command source on a command-less *vessel* so it stays controllable;
+	// jettisoned stages get no default, so a spent booster is debris.
+	Crewed       bool
+	Controllable bool
+
+	// AntennaKind / AntennaPowerW (v0.23 / ADR 0027): the vessel's
+	// effective comms antenna — the highest-power one across its stages,
+	// re-derived by SyncFields. Read by the connectivity graph (later
+	// cycle-2 slices). AntennaNone / zero means no antenna.
+	AntennaKind   string
+	AntennaPowerW float64
+
 	// ChuteState (v0.12 Slice 3, ADR 0008): the runtime parachute
 	// deploy state — STOWED → ARMED → DEPLOYED, one-way, DEPLOYED
 	// terminal. Lives alongside Landed / Crashed (the other surface-

--- a/internal/spacecraft/stage.go
+++ b/internal/spacecraft/stage.go
@@ -10,6 +10,34 @@ const (
 	FuelTypeSolid      = "solid"      // APCP (SLS SRB) — orange-red
 )
 
+// Command-source constants (v0.23 / ADR 0027). A stage's CommandSource
+// declares whether it is a control point and, if so, whether crewed.
+// Empty ("") means none (the stage is not a command source). A vessel is
+// Controllable iff ≥1 stage is a command source; Crewed iff any is crewed
+// (else it is an unmanned probe, comms-gated in the connectivity slices).
+const (
+	CommandNone   = ""       // not a command source (tank / engine / spent booster)
+	CommandCrewed = "crewed" // a crewed pod — flown by its crew, never comms-gated
+	CommandProbe  = "probe"  // an uncrewed probe core — needs a connection to be commanded
+)
+
+// IsCommandSource reports whether a CommandSource value makes a stage a
+// control point (crewed or probe — not none/empty/unknown).
+func IsCommandSource(src string) bool {
+	return src == CommandCrewed || src == CommandProbe
+}
+
+// Antenna-kind constants (v0.23 / ADR 0027). A stage's AntennaKind
+// declares its comms hardware: a direct antenna can use the network
+// (reach a ground station, possibly via relays) but cannot forward
+// traffic; a relay antenna can also forward for other vessels. Empty
+// ("") means no antenna.
+const (
+	AntennaNone   = ""       // no antenna
+	AntennaDirect = "direct" // can use the network, cannot forward for others
+	AntennaRelay  = "relay"  // can use AND forward (a comm-sat / ground-station relay)
+)
+
 // Stage describes one decouplable propulsion module on a spacecraft.
 // v0.9.1+. The Stages slice on Spacecraft is the source of truth for
 // dry mass / fuel / engine numbers; the historical flat fields
@@ -186,6 +214,20 @@ type Stage struct {
 	// every staging / dock / load so the capability rides the hardware
 	// across a decouple. `omitempty`.
 	HasParachute bool `json:",omitempty"`
+
+	// CommandSource (v0.23 / ADR 0027) declares whether this stage is a
+	// control point: CommandCrewed / CommandProbe / CommandNone (empty).
+	// Authored on the Part (ADR 0026 catalog) and carried here so it
+	// rides the hardware across staging/dock/save; SyncFields derives the
+	// vessel-level Crewed / Controllable mirrors from the whole stack.
+	CommandSource string `json:",omitempty"`
+
+	// AntennaKind / AntennaPowerW (v0.23 / ADR 0027) declare this stage's
+	// comms hardware (AntennaNone / AntennaDirect / AntennaRelay + power).
+	// Authored on the Part; SyncFields derives the vessel-level antenna
+	// (the highest-power one in the stack) for the connectivity graph.
+	AntennaKind   string  `json:",omitempty"`
+	AntennaPowerW float64 `json:",omitempty"`
 }
 
 // SumDryMass returns the total dry mass across every stage in kg.
@@ -272,6 +314,27 @@ func (s *Spacecraft) SyncFields() {
 	// bottom stage too — the chute becomes "active" only once the
 	// chute-bearing stage is the surviving core (Stages[0]).
 	s.HasParachute = bottom.HasParachute
+	// v0.23 / ADR 0027: comms mirrors derived across the WHOLE stack
+	// (not just the bottom) — a probe core or relay antenna anywhere on
+	// the vessel makes the vessel controllable / relay-capable. Crewed
+	// wins over probe (a crewed pod is never comms-gated); the antenna is
+	// the highest-power one carried.
+	s.Crewed = false
+	s.Controllable = false
+	s.AntennaKind = AntennaNone
+	s.AntennaPowerW = 0
+	for _, st := range s.Stages {
+		if IsCommandSource(st.CommandSource) {
+			s.Controllable = true
+			if st.CommandSource == CommandCrewed {
+				s.Crewed = true
+			}
+		}
+		if st.AntennaKind != AntennaNone && st.AntennaPowerW > s.AntennaPowerW {
+			s.AntennaKind = st.AntennaKind
+			s.AntennaPowerW = st.AntennaPowerW
+		}
+	}
 }
 
 // ActiveStageFuel returns the bottom (currently-firing) stage's

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -82,6 +82,13 @@ type StageModule struct {
 	// and capsule (the standalone re-entry test vehicle). Disjoint from
 	// canSoftLand — a capsule has no engine landing route, only the chute.
 	hasParachute bool
+	// commandSource / antenna (v0.23 / ADR 0027): comms part attributes,
+	// carried onto the built Stage by BuildStage so a configurator-picked
+	// part contributes its connectivity role to a custom stack, exactly as
+	// a loadout-referenced part does via Part.ToStage.
+	commandSource string
+	antennaKind   string
+	antennaPowerW float64
 }
 
 // Catalog stage IDs.
@@ -194,7 +201,25 @@ func (p Part) toStageModule() StageModule {
 		launchSpriteHasLegs: p.LaunchSpriteHasLegs,
 		canSoftLand:         p.CanSoftLand,
 		hasParachute:        p.HasParachute,
+		commandSource:       p.CommandSource,
+		antennaKind:         antennaKindOf(p),
+		antennaPowerW:       antennaPowerOf(p),
 	}
+}
+
+// antennaKindOf / antennaPowerOf read a Part's optional antenna safely.
+func antennaKindOf(p Part) string {
+	if p.Antenna == nil {
+		return AntennaNone
+	}
+	return p.Antenna.Kind
+}
+
+func antennaPowerOf(p Part) float64 {
+	if p.Antenna == nil {
+		return 0
+	}
+	return p.Antenna.PowerW
 }
 
 // StageCatalogOrder is the configurator's canonical cycle order —
@@ -260,6 +285,9 @@ func BuildStage(id string) (Stage, bool) {
 		LaunchSpriteHasLegs:  m.launchSpriteHasLegs,
 		CanSoftLand:          m.canSoftLand,
 		HasParachute:         m.hasParachute,
+		CommandSource:        m.commandSource,
+		AntennaKind:          m.antennaKind,
+		AntennaPowerW:        m.antennaPowerW,
 	}, true
 }
 

--- a/internal/spacecraft/stages_catalog_test.go
+++ b/internal/spacecraft/stages_catalog_test.go
@@ -53,6 +53,7 @@ func TestBuildStageGoldenByteIdentical(t *testing.T) {
 		LaunchSpriteWidthPx: 3,
 		LaunchSpriteColor:   "#C8C8D0",
 		HasParachute:        true,
+		CommandSource:       CommandCrewed, // v0.23/ADR 0027: the capsule is a crewed pod
 	}
 	if got, ok := BuildStage(StageModuleCapsuleID); !ok || !reflect.DeepEqual(got, wantCapsule) {
 		t.Errorf("BuildStage(capsule) byte-identity drift:\n want %+v\n  got %+v (ok=%v)", wantCapsule, got, ok)

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -96,10 +96,10 @@ type BurnMode int
 const (
 	BurnPrograde BurnMode = iota
 	BurnRetrograde
-	BurnNormalPlus    // orbit normal (+h direction)
-	BurnNormalMinus   // orbit normal (-h direction)
-	BurnRadialOut     // away from primary
-	BurnRadialIn      // toward primary
+	BurnNormalPlus  // orbit normal (+h direction)
+	BurnNormalMinus // orbit normal (-h direction)
+	BurnRadialOut   // away from primary
+	BurnRadialIn    // toward primary
 
 	// Surface-relative modes (v0.9.2+) — live SAS only, not planted-
 	// node modes. Direction = ±(v_surface).Unit() where v_surface =

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -288,6 +288,13 @@ func TestDroppedStageVisibleAfterDecouple(t *testing.T) {
 		t.Skipf("Saturn V loadout has %d stages, need >= 2 to decouple", len(active.Stages))
 	}
 	active.Landed = false
+	// v0.23 / ADR 0027: this test exercises the decouple/render path, not
+	// comms — crew-tend the stack so staging isn't comms-gated (a probe on
+	// the KSC pad has no DSN line-of-sight).
+	if len(active.Stages) > 0 {
+		active.Stages[len(active.Stages)-1].CommandSource = spacecraft.CommandCrewed
+		active.SyncFields()
+	}
 	rNorm := active.State.R.Norm()
 	active.State.R = active.State.R.Scale((rNorm + 1000) / rNorm)
 


### PR DESCRIPTION
**Cycle 2** of the Axis B vehicle-expansion program (v0.23): a crew-typed
communications subsystem. Frozen design: ADR 0027; plan: `v0.23-plan.md`
§"Cycle 2". Stacked on cycle 1 (#178, now merged).

**Scope note:** ships **6 of 7 slices** — the comms HUD (C2-7: comms chip +
drawn relay path) is deferred to a follow-up. The gating + connectivity work
all functions; what's missing is the *visual* surfacing of `NO SIGNAL` /
connection state (`CommBlockedFlash` is implemented and ready for the chip).

## Slices
- **C2-1** — crew model: per-stage `command_source` / `antenna` part
  attributes → `Crewed` / `Controllable` derived; construction-time probe
  defaulting (a command-less vessel stays controllable; jettisoned stages are
  debris). No save bump.
- **C2-2** — `physics.SegmentOccludedByBody` / `RaySphereIntersect`: the LOS
  primitive (strict-interior, so a surface station isn't blocked by its own
  body when the target's above the horizon).
- **C2-3** — ground-station catalog: the 3-station DSN ring, data-driven
  (embedded `ground_stations.json` + XDG overlay), `World.GroundStations`.
- **C2-4** — per-tick `CommGraph` + `CanCommandCraft`: LOS + range + relay-BFS
  (forwarding only through relays/stations). Range is a `min(P)·scale`
  placeholder — ADR 0027 §2 deferred tuning.
- **C2-5** — command gating: `canCommand` on throttle / attitude / node
  plant+delete / staging; `NO SIGNAL` transient. NavMode stays ungated (a
  display toggle). Starting vessel is crew-tended (first-flight UX).
- **C2-6** — coverage objectives: `relay_coverage` + `establish_contact`
  mission Kinds (projected from `CommGraph` via EvalContext, preserving the
  `missions`-never-imports-`sim` boundary) + the `deploy` action.

## Testing
`go vet ./...` clean; `go test ./... -race -count=1` green (1282); binary
builds. Every slice TDD.

## Follow-ups
- **C2-7** (comms HUD) — the remaining cycle-2 slice.
- Range-combination formula tuning (placeholder ships).
- No DSN station near KSC → a probe on the pad has no contact (content gap;
  crewed launches unaffected).