### PR TITLE
Cycle 2 C2-7: comms HUD chip + drawn relay path (ADR 0027)

### DIFF
--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -47,6 +47,12 @@ var (
 	// which clashed with the new fuel-type flame palette.
 	ColorRCSPuffOrigin = lipgloss.Color("#FFFFFF") // bright white — thruster ignition pixel
 	ColorRCSPuffTip    = ColorDim                  // dim grey — fading trail tip
+	// ColorCommLink is the CommNet relay sightline (ADR 0027 / C2-7) drawn
+	// from the active probe through any relay hops to a ground station —
+	// bright teal, drawn as a sparse dotted beam (step 3) so it reads as a
+	// signal link distinct from the slate live orbit, amber maneuver legs,
+	// and orchid SOI arcs.
+	ColorCommLink = lipgloss.Color("#34E2D0")
 )
 
 // Orbital-marker type colours (ADR 0020). The unified marker convention

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -36,6 +36,7 @@ const (
 	ChipProjectedOrbit  Chip = "projectedOrbit"
 	ChipSOIPass         Chip = "soiPass"
 	ChipMissions        Chip = "missions" // v0.21 (ADR 0025): in-flight mission checklist
+	ChipComms           Chip = "comms"    // v0.23 (ADR 0027): CommNet link status
 )
 
 // Note: the Orbit-metrics readout and the active-burn (BURNS) readout are
@@ -63,6 +64,7 @@ var AllChips = []Chip{
 	ChipProjectedOrbit,
 	ChipSOIPass,
 	ChipMissions,
+	ChipComms,
 }
 
 // chipLabels maps each Chip to the human-readable name the Settings
@@ -81,6 +83,7 @@ var chipLabels = map[Chip]string{
 	ChipProjectedOrbit:  "Projected orbit",
 	ChipSOIPass:         "SOI pass",
 	ChipMissions:        "Mission checklist",
+	ChipComms:           "Comms link",
 }
 
 // Label returns the display name for c, falling back to the raw key for

--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -34,15 +34,33 @@ func commLinkRangeM(pa, pb float64) float64 {
 
 // CommGraph is the cached per-tick connectivity result: the set of
 // unmanned craft (by stable ID) that currently have a connection to a
-// ground station.
+// ground station, plus — for each connected probe — the world-frame relay
+// chain it reaches the network through (probe, relays…, station), which the
+// comms HUD draws and counts hops from (C2-7).
 type CommGraph struct {
 	Connected map[uint64]bool
+	// Paths maps a connected probe's ID to its shortest relay chain as
+	// ordered world-frame points: the probe first, then each relay hop, then
+	// the terminal ground station. Absent for disconnected probes. The
+	// positions are the same absolute world frame the orbit canvas projects
+	// (body position + state), so the HUD draws segments without rebasing.
+	Paths map[uint64][]orbital.Vec3
 }
 
 // HasConnection reports whether the craft with the given ID has a network
 // connection this tick. nil-safe (a not-yet-computed graph → false).
 func (g *CommGraph) HasConnection(id uint64) bool {
 	return g != nil && g.Connected[id]
+}
+
+// Path returns the world-frame relay chain (probe→relays…→station) for the
+// craft with the given ID, or nil if it has no recorded connection this
+// tick. nil-safe.
+func (g *CommGraph) Path(id uint64) []orbital.Vec3 {
+	if g == nil {
+		return nil
+	}
+	return g.Paths[id]
 }
 
 // commNode is one node in the connectivity graph — a craft antenna or a
@@ -56,13 +74,31 @@ type commNode struct {
 	craftID  uint64 // 0 for stations
 }
 
+// connectivityResult is the full output of the connectivity solve: which
+// probes are connected, and the shortest relay path (as node indices,
+// probe→…→station) for each connected probe. RecomputeCommGraph maps the
+// node-index paths to world-frame positions; the bool map alone is enough
+// for the command gate (CanCommandCraft).
+type connectivityResult struct {
+	connected map[uint64]bool
+	paths     map[uint64][]int // probe id → node-index chain probe…station
+}
+
 // connectivity builds the adjacency graph over nodes (a link needs both
 // LOS — unoccluded by any body — and range) and returns, for each probe
 // node, whether a relay chain reaches a station. Forwarding is allowed
 // only through forwarder nodes (relays / stations); a direct-only craft is
-// a dead end you cannot relay through. Pure (no world state) so it is
-// unit-tested with synthetic nodes.
+// a dead end you cannot relay through. Thin bool-map wrapper over
+// connectivityFull for the command-gate callers and their tests.
 func connectivity(nodes []commNode, occ []physics.OccluderBody) map[uint64]bool {
+	return connectivityFull(nodes, occ).connected
+}
+
+// connectivityFull is the connectivity solve: it builds the adjacency graph
+// then, for each probe, runs a hop-shortest BFS to a station, recording both
+// the connected flag and the node-index path. Pure (no world state) so it is
+// unit-tested with synthetic nodes.
+func connectivityFull(nodes []commNode, occ []physics.OccluderBody) connectivityResult {
 	n := len(nodes)
 	adj := make([][]int, n)
 	for i := 0; i < n; i++ {
@@ -73,13 +109,17 @@ func connectivity(nodes []commNode, occ []physics.OccluderBody) map[uint64]bool 
 			}
 		}
 	}
-	out := map[uint64]bool{}
+	res := connectivityResult{connected: map[uint64]bool{}, paths: map[uint64][]int{}}
 	for i := 0; i < n; i++ {
-		if nodes[i].probe && bfsReachesStation(i, nodes, adj) {
-			out[nodes[i].craftID] = true
+		if !nodes[i].probe {
+			continue
+		}
+		if path := bfsPathToStation(i, nodes, adj); path != nil {
+			res.connected[nodes[i].craftID] = true
+			res.paths[nodes[i].craftID] = path
 		}
 	}
-	return out
+	return res
 }
 
 func commLinked(a, b commNode, occ []physics.OccluderBody) bool {
@@ -92,11 +132,18 @@ func commLinked(a, b commNode, occ []physics.OccluderBody) bool {
 	return !physics.SegmentOccludedByBody(a.pos, b.pos, occ)
 }
 
-// bfsReachesStation returns whether a relay chain from the start node
-// reaches any ground station. The start expands unconditionally (it is
-// transmitting); an intermediate node expands only if it can forward.
-func bfsReachesStation(start int, nodes []commNode, adj [][]int) bool {
+// bfsPathToStation returns the hop-shortest relay chain from the start node
+// to any ground station, as node indices [start, …, station], or nil if no
+// chain reaches a station. The start expands unconditionally (it is
+// transmitting); an intermediate node expands only if it can forward. BFS
+// order makes the first station reached the fewest-hops one; the predecessor
+// map reconstructs the chain.
+func bfsPathToStation(start int, nodes []commNode, adj [][]int) []int {
 	visited := make([]bool, len(nodes))
+	pred := make([]int, len(nodes))
+	for i := range pred {
+		pred[i] = -1
+	}
 	visited[start] = true
 	queue := []int{start}
 	for len(queue) > 0 {
@@ -106,16 +153,36 @@ func bfsReachesStation(start int, nodes []commNode, adj [][]int) bool {
 			continue // a non-forwarder (direct-only craft) cannot relay through
 		}
 		for _, nb := range adj[cur] {
+			if visited[nb] {
+				continue
+			}
+			visited[nb] = true
+			pred[nb] = cur
 			if nodes[nb].station {
-				return true
+				return reconstructPath(pred, start, nb)
 			}
-			if !visited[nb] {
-				visited[nb] = true
-				queue = append(queue, nb)
-			}
+			queue = append(queue, nb)
 		}
 	}
-	return false
+	return nil
+}
+
+// reconstructPath walks the predecessor map from end back to start and
+// returns the forward chain [start, …, end].
+func reconstructPath(pred []int, start, end int) []int {
+	var rev []int
+	for at := end; at != -1; at = pred[at] {
+		rev = append(rev, at)
+		if at == start {
+			break
+		}
+	}
+	// rev is end→start; flip to start→end.
+	path := make([]int, len(rev))
+	for i, v := range rev {
+		path[len(rev)-1-i] = v
+	}
+	return path
 }
 
 // RecomputeCommGraph rebuilds w.CommGraph for the active craft's system:
@@ -158,7 +225,38 @@ func (w *World) RecomputeCommGraph() {
 		})
 	}
 
-	w.CommGraph = &CommGraph{Connected: connectivity(nodes, occ)}
+	res := connectivityFull(nodes, occ)
+	paths := make(map[uint64][]orbital.Vec3, len(res.paths))
+	for id, idxPath := range res.paths {
+		pts := make([]orbital.Vec3, len(idxPath))
+		for i, ni := range idxPath {
+			pts[i] = nodes[ni].pos
+		}
+		paths[id] = pts
+	}
+	w.CommGraph = &CommGraph{Connected: res.connected, Paths: paths}
+}
+
+// ActiveCommPath returns the active craft's relay chain as ordered
+// world-frame points (probe, relays…, station), the hop count (number of
+// links = len(points)-1), and whether it is connected. Recomputes the graph
+// lazily if the cache is nil. connected is false for a crewed/non-probe
+// active craft (which has no BFS path) or a disconnected probe — the comms
+// HUD uses that to choose between DIRECT/CONNECTED and NO SIGNAL, and to
+// decide whether to draw the chain. (C2-7)
+func (w *World) ActiveCommPath() (points []orbital.Vec3, hops int, connected bool) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return nil, 0, false
+	}
+	if w.CommGraph == nil {
+		w.RecomputeCommGraph()
+	}
+	pts := w.CommGraph.Path(c.ID)
+	if len(pts) < 2 {
+		return nil, 0, false
+	}
+	return pts, len(pts) - 1, true
 }
 
 // groundStationWorldPos is a station's current world-frame position: its

--- a/internal/sim/commnet_test.go
+++ b/internal/sim/commnet_test.go
@@ -144,6 +144,99 @@ func TestConnectivityCannotRelayThroughDirectCraft(t *testing.T) {
 	}
 }
 
+// TestConnectivityPathDirect (C2-7): a directly-linked probe's recorded path
+// is the two-node chain probe→station (hops = 1).
+func TestConnectivityPathDirect(t *testing.T) {
+	nodes := []commNode{
+		station(0, 0, 100000),           // index 0
+		probeNode(1, 1000, 3000, false), // index 1
+	}
+	res := connectivityFull(nodes, nil)
+	if !res.connected[1] {
+		t.Fatal("a probe in range with clear LOS should be connected")
+	}
+	path := res.paths[1]
+	if len(path) != 2 || path[0] != 1 || path[len(path)-1] != 0 {
+		t.Errorf("direct path: got %v, want [1 0] (probe→station)", path)
+	}
+}
+
+// TestConnectivityPathViaRelay (C2-7): an occluded probe bridged by an
+// off-axis relay records the three-node chain probe→relay→station (hops = 2).
+func TestConnectivityPathViaRelay(t *testing.T) {
+	occ := []physics.OccluderBody{{Center: orbital.Vec3{}, Radius: 100}}
+	nodes := []commNode{
+		station(0, -1000, 100000),       // index 0
+		probeNode(1, 1000, 3000, false), // index 1 (direct link occluded)
+		{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: true}, // index 2 relay
+	}
+	res := connectivityFull(nodes, occ)
+	if !res.connected[1] {
+		t.Fatal("an off-axis relay should bridge the occluded probe")
+	}
+	path := res.paths[1]
+	if len(path) != 3 || path[0] != 1 || path[1] != 2 || path[2] != 0 {
+		t.Errorf("relay path: got %v, want [1 2 0] (probe→relay→station)", path)
+	}
+}
+
+// TestActiveCommPathDirect (C2-7): the active probe's path surfaces through
+// the World as world-frame points anchored on the craft and the station,
+// with hops = 1 for a direct link. Mirrors TestRecomputeCommGraphIntegration.
+func TestActiveCommPathDirect(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	tug := spacecraft.NewFromLoadout("Relay-Tug")
+	tug.SystemIdx = 0
+	gs := w.GroundStations[0]
+	sys := w.System()
+	body := *sys.FindBody(gs.BodyID)
+	offset := w.groundStationWorldPos(gs, body).Sub(w.BodyPosition(body))
+	tug.Primary = body
+	tug.State.R = offset.Add(offset.Unit().Scale(200000)) // 200 km above the station
+	w.Crafts[0] = tug
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.RecomputeCommGraph()
+
+	pts, hops, connected := w.ActiveCommPath()
+	if !connected {
+		t.Fatal("a relay probe directly above a DSN station should be connected")
+	}
+	if hops != 1 {
+		t.Errorf("direct link hops: got %d, want 1", hops)
+	}
+	if len(pts) != 2 {
+		t.Fatalf("path points: got %d, want 2", len(pts))
+	}
+	craftPos := w.BodyPosition(tug.Primary).Add(tug.State.R)
+	if pts[0].Sub(craftPos).Norm() > 1 {
+		t.Errorf("path start should be the craft world position")
+	}
+	stationPos := w.groundStationWorldPos(gs, body)
+	if pts[len(pts)-1].Sub(stationPos).Norm() > 1 {
+		t.Errorf("path end should be the station world position")
+	}
+}
+
+// TestActiveCommPathDisconnected (C2-7): a disconnected probe and a crewed
+// active craft both report no drawable path.
+func TestActiveCommPathDisconnected(t *testing.T) {
+	w := mustWorld(t)
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}} // disconnected
+	if _, _, connected := w.ActiveCommPath(); connected {
+		t.Error("a disconnected probe must report no path")
+	}
+}
+
 // TestCanCommandCraftSemantics (C2-4): crewed → always; debris → never;
 // unmanned probe → gated on the connectivity graph.
 func TestCanCommandCraftSemantics(t *testing.T) {

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -902,6 +902,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// the *unburned* trajectory, drawn ahead of arrival with a Perilune
 		// marker — always-on, independent of the Target slot.
 		v.drawSOIPass(w)
+		// CommNet relay sightline (ADR 0027 / C2-7): the active probe's link
+		// chain to a ground station, when connected. Map-layer content like
+		// the node trajectory — drawn regardless of declutter (only the COMMS
+		// chip declutters); no-op for a manned or disconnected craft.
+		v.drawCommPath(w)
 	}
 
 	// Stamp the active projection in the canvas's bottom-left corner
@@ -1677,6 +1682,25 @@ func (v *OrbitView) plotPredictedLegs(w *sim.World, legs []predictLegDraw) {
 				v.canvas.PlotDenseLineColored(pts[i], pts[i+1], leg.color, 2)
 			}
 		}
+	}
+}
+
+// drawCommPath draws the active probe's CommNet relay sightline — the chain
+// from the probe through any relay hops to a ground station — as a sparse
+// teal dotted beam (step 3) on the canvas (ADR 0027 / C2-7). A no-op unless
+// the active craft is a connected probe (a manned or out-of-contact craft
+// returns no path). The chain points are absolute world positions — the same
+// frame the canvas projects bodies and craft in (body position + state) — so
+// no rebasing is needed. Every link is guaranteed unoccluded by a body in 3D
+// (the comm graph only links nodes with clear line of sight), so a straight
+// chord per segment is physically faithful.
+func (v *OrbitView) drawCommPath(w *sim.World) {
+	pts, _, connected := w.ActiveCommPath()
+	if !connected {
+		return
+	}
+	for i := 0; i+1 < len(pts); i++ {
+		v.canvas.PlotDenseLineColored(pts[i], pts[i+1], render.ColorCommLink, 3)
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -61,6 +61,16 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	add(settings.ChipDescent, cornerTopLeft, v.buildDescentChip(w))
 	add(settings.ChipChute, cornerTopLeft, v.buildChuteChip(w))
 	add(settings.ChipAttitude, cornerTopLeft, v.buildAttitudeChip(w))
+	// COMMS link status for the active probe (ADR 0027 / C2-7), beneath the
+	// vessel-state readouts. Force-shown while a just-blocked command is
+	// flashing (CommBlockedFlash) — bypassing the toggle + declutter — so the
+	// NO SIGNAL reason for a refused command is never hidden; otherwise it
+	// honours the toggle like any chip.
+	if lines := v.buildCommsChip(w); lines != nil {
+		if _, flashing := w.CommBlockedFlash(); flashing || v.chipEnabled(settings.ChipComms) {
+			chips = append(chips, builtChip{id: settings.ChipComms, corner: cornerTopLeft, lines: lines})
+		}
+	}
 	// Top-right stack: Orbit metrics on top, the Target readout beneath it
 	// (append order = top-to-bottom). Orbit metrics is always-on (empty id):
 	// the current orbit (apo/peri/incl) is never user-hideable from the
@@ -178,6 +188,47 @@ func (v *OrbitView) buildAttitudeChip(w *sim.World) []string {
 		fmt.Sprintf("  hold:    %s", c.AttitudeMode.String()),
 		fmt.Sprintf("  engine:  %s", c.EngineMode.String()),
 		fmt.Sprintf("  manual:  %s", manualState),
+	}
+}
+
+// buildCommsChip surfaces the active probe's CommNet link state (ADR 0027 /
+// C2-7): DIRECT (linked straight to a ground station), CONNECTED via N hops
+// (through relays), or NO SIGNAL. Hidden for a crewed vessel — it is never
+// command-gated — and for debris / no visible craft. assembleChips
+// force-shows it while a just-blocked command is flashing (CommBlockedFlash),
+// so the player learns why a command was refused even with the chip toggled
+// off; otherwise it honours the Settings toggle + F2 declutter like any chip.
+func (v *OrbitView) buildCommsChip(w *sim.World) []string {
+	c := w.ActiveCraft()
+	if c == nil || !w.CraftVisibleHere() {
+		return nil
+	}
+	if c.Crewed || !c.Controllable {
+		return nil // crewed craft are never gated; debris has no link to show
+	}
+	_, hops, connected := w.ActiveCommPath()
+	return v.commsChipLines(hops, connected)
+}
+
+// commsChipLines is the pure content selector behind buildCommsChip, split
+// out so the DIRECT / CONNECTED / NO SIGNAL forms are unit-testable without a
+// live World. A connected probe reads DIRECT for a single hop (straight to a
+// station) or "CONNECTED via N hops" through relays; a disconnected probe
+// reads NO SIGNAL in the alert style.
+func (v *OrbitView) commsChipLines(hops int, connected bool) []string {
+	if !connected {
+		return []string{
+			v.theme.Alert.Render("COMMS"),
+			v.theme.Alert.Render("  ⚠ NO SIGNAL"),
+		}
+	}
+	status := fmt.Sprintf("CONNECTED via %d hops", hops)
+	if hops <= 1 {
+		status = "DIRECT"
+	}
+	return []string{
+		v.theme.Primary.Render("COMMS"),
+		"  " + status,
 	}
 }
 

--- a/internal/tui/screens/orbit_comms_chip_test.go
+++ b/internal/tui/screens/orbit_comms_chip_test.go
@@ -1,0 +1,86 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// The comms chip (ADR 0027 / C2-7) surfaces the active probe's CommNet link
+// state: DIRECT (one hop to a ground station), CONNECTED via N hops (through
+// relays), or NO SIGNAL. commsChipLines is the pure content selector,
+// exercised here without a live World.
+
+func TestCommsChipLinesDirect(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	lines := v.commsChipLines(1, true)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "COMMS") {
+		t.Errorf("chip missing COMMS header:\n%s", joined)
+	}
+	if !strings.Contains(joined, "DIRECT") {
+		t.Errorf("a one-hop link should read DIRECT:\n%s", joined)
+	}
+	if strings.Contains(joined, "via") {
+		t.Errorf("a direct link should not mention hops:\n%s", joined)
+	}
+}
+
+func TestCommsChipLinesRelayed(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	joined := strings.Join(v.commsChipLines(3, true), "\n")
+	if !strings.Contains(joined, "CONNECTED via 3 hops") {
+		t.Errorf("a three-hop link should read CONNECTED via 3 hops:\n%s", joined)
+	}
+}
+
+func TestCommsChipLinesNoSignal(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	joined := strings.Join(v.commsChipLines(0, false), "\n")
+	if !strings.Contains(joined, "NO SIGNAL") {
+		t.Errorf("a disconnected probe should read NO SIGNAL:\n%s", joined)
+	}
+}
+
+// TestBuildCommsChipHiddenForCrewed: the default seed craft is crew-tended
+// (C2-5), so it is never command-gated and the comms chip stays hidden.
+func TestBuildCommsChipHiddenForCrewed(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if c := w.ActiveCraft(); c == nil || !c.Crewed {
+		t.Fatalf("expected a crewed seed craft, got crewed=%v", c != nil && c.Crewed)
+	}
+	if chip := v.buildCommsChip(w); chip != nil {
+		t.Errorf("comms chip should be hidden for a crewed craft, got:\n%s", strings.Join(chip, "\n"))
+	}
+}
+
+// TestBuildCommsChipProbeNoSignal: an unmanned probe with no connection
+// surfaces NO SIGNAL through the world-reading builder.
+func TestBuildCommsChipProbeNoSignal(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	probe.SystemIdx = w.Crafts[0].SystemIdx
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &sim.CommGraph{Connected: map[uint64]bool{}} // force disconnected
+	chip := v.buildCommsChip(w)
+	if chip == nil {
+		t.Fatal("comms chip should show for an unmanned probe")
+	}
+	if !strings.Contains(strings.Join(chip, "\n"), "NO SIGNAL") {
+		t.Errorf("disconnected probe chip should read NO SIGNAL:\n%s", strings.Join(chip, "\n"))
+	}
+}

--- a/internal/tui/screens/orbit_comms_path_test.go
+++ b/internal/tui/screens/orbit_comms_path_test.go
@@ -1,0 +1,45 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// drawCommPath (ADR 0027 / C2-7) draws the active probe's relay sightline on
+// the orbit canvas when connected, and nothing otherwise. The projection /
+// dashing math is covered by the canvas dense-line tests; here we assert the
+// wiring: a connected path mutates the canvas, a disconnected one leaves it
+// untouched.
+func TestDrawCommPath(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.canvas.Resize(60, 30) // pixel grid 120 × 120
+	v.canvas.SetScale(1)
+	v.canvas.Center(orbital.Vec3{})
+
+	c := &spacecraft.Spacecraft{ID: 1, Controllable: true}
+	w := &sim.World{Crafts: []*spacecraft.Spacecraft{c}, ActiveCraftIdx: 0}
+
+	// Disconnected probe: no path → canvas unchanged.
+	w.CommGraph = &sim.CommGraph{Connected: map[uint64]bool{}}
+	v.canvas.Clear()
+	before := v.canvas.String()
+	v.drawCommPath(w)
+	if v.canvas.String() != before {
+		t.Error("a disconnected craft must not draw a relay path")
+	}
+
+	// Connected probe with a two-point path spanning the canvas → pixels drawn.
+	w.CommGraph = &sim.CommGraph{
+		Connected: map[uint64]bool{1: true},
+		Paths:     map[uint64][]orbital.Vec3{1: {{X: -40}, {X: 40}}},
+	}
+	v.canvas.Clear()
+	blank := v.canvas.String()
+	v.drawCommPath(w)
+	if v.canvas.String() == blank {
+		t.Error("a connected probe should draw its relay path on the canvas")
+	}
+}


### PR DESCRIPTION
Final CommNet slice (C2-7, ADR 0027). Closes out cycle 2's player-facing layer.

## What landed
- **Sim:** `CommGraph` now records, per connected probe, the world-frame relay
  chain (probe → relays… → station) via a predecessor-tracking BFS — not just a
  connected bool. `World.ActiveCommPath()` surfaces the active craft's chain +
  hop count for the HUD.
- **COMMS chip** (`ChipComms`): `DIRECT` / `CONNECTED via N hops` / `NO SIGNAL`.
  Hidden for crewed craft (never gated); force-shown while a just-blocked command
  flashes (`CommBlockedFlash`) so the NO SIGNAL reason can't be toggled/decluttered
  away; honours the Settings toggle + F2 otherwise.
- **Relay sightline** drawn on the orbit canvas as a sparse teal dotted beam
  (`ColorCommLink`, step 3) — distinct from slate orbit / amber legs / orchid SOI
  arcs. Map-layer content (not declutter-gated); chain points are absolute world
  positions so no rebasing. Drawn only when connected.

## Tests
TDD throughout: connectivity path reconstruction, `ActiveCommPath`, `commsChipLines`
forms, `buildCommsChip` world-read, `drawCommPath` wiring. `go vet ./...` +
`go test ./... -race -count=1` green (1280+).

## Review note
A batched `/code-review` over the whole cycle (`c3b7d19..HEAD`, C2-1..C2-7) found
this slice clean, but surfaced **pre-existing correctness bugs in already-merged
cycle-2 code** (#179): the C2-5 command gate misses `StartManualBurn`/`FireRCSPulse`/
`ClearNodes`/`Transpose`; `Undock` skips the `EnsureCommandSource` backfill (undocked
Apollo LM becomes uncontrollable); save-load resurrects jettisoned debris into
commandable probes. Those are being fixed in a **separate hardening PR** to keep this
slice's boundary clean.