### PR TITLE
CommNet hardening: command-gate completeness + undock/debris command-source fixes (ADR 0027)

### DIFF
--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -305,6 +305,59 @@ func TestRoundtripTopLevelStageFields(t *testing.T) {
 	}
 }
 
+// TestJettisonedDebrisStaysDebrisAcrossSave (hardening, ADR 0027): a saved
+// spent booster (Role jettisoned-stage, no command source) must reload as
+// passive debris. The load-time EnsureCommandSource backfill is meant only
+// for pre-comms saves and must not resurrect debris into a commandable probe
+// (and a CommNet node).
+func TestJettisonedDebrisStaysDebrisAcrossSave(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Swap in a multi-stage, crew-tended Saturn V so StageActive can pop a
+	// spent booster as real debris.
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	stack.Stages[len(stack.Stages)-1].CommandSource = spacecraft.CommandCrewed
+	stack.SyncFields()
+	w.Crafts[0] = stack
+	w.EnsureCraftIDs()
+	w.ActiveCraftIdx = 0
+
+	_, jettIdx, err := w.StageActive(0)
+	if err != nil {
+		t.Fatalf("StageActive: %v", err)
+	}
+	if w.Crafts[jettIdx].Controllable {
+		t.Fatal("setup: a freshly jettisoned booster should be passive debris")
+	}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	var debris *spacecraft.Spacecraft
+	for _, c := range got.Crafts {
+		if c != nil && c.Role == spacecraft.RoleJettisonedStage {
+			debris = c
+			break
+		}
+	}
+	if debris == nil {
+		t.Fatal("jettisoned debris not found after reload")
+	}
+	if debris.Controllable {
+		t.Error("a saved spent booster must stay debris, not reload as a commandable probe")
+	}
+}
+
 // TestLoadOldSaveDockedComponentFallsBackSingleStage — a v6 save written
 // before ADR 0009 has DockedComponents with no "stages" array. Loading
 // it and undocking must fall back to the legacy single-stage rebuild

--- a/internal/sim/commnet_test.go
+++ b/internal/sim/commnet_test.go
@@ -40,6 +40,79 @@ func TestCommandGateBlocksDisconnectedProbe(t *testing.T) {
 	}
 }
 
+// TestCommandGateBlocksManualBurnAndRCS (hardening, ADR 0027): the gate must
+// also cover engine ignition (StartManualBurn, the `b` key) and RCS pulses —
+// the two direct-thrust commands the original C2-5 slice missed. A
+// disconnected probe is refused on both; a connection lets ignition through,
+// proving the craft can burn and the gate was the only blocker.
+func TestCommandGateBlocksManualBurnAndRCS(t *testing.T) {
+	w := mustWorld(t)
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}} // disconnected
+
+	w.StartManualBurn()
+	if probe.ManualBurn != nil {
+		t.Error("StartManualBurn must be blocked for a disconnected probe")
+	}
+	if _, ok := w.CommBlockedFlash(); !ok {
+		t.Error("a blocked ignition must raise the NO SIGNAL flash")
+	}
+
+	probe.EngineMode = spacecraft.EngineRCS
+	if w.FireRCSPulse(spacecraft.BurnPrograde) {
+		t.Error("FireRCSPulse must be blocked for a disconnected probe")
+	}
+
+	// Reconnect → ignition proceeds.
+	probe.EngineMode = spacecraft.EngineMain
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{probe.ID: true}}
+	w.StartManualBurn()
+	if probe.ManualBurn == nil {
+		t.Error("a connected probe with fuel+thrust must ignite")
+	}
+}
+
+// TestCommandGateBlocksClearNodesAndTranspose (hardening, ADR 0027): the
+// wipe-all ClearNodes (sibling of the gated DeleteNode) and Transpose
+// (sibling of the gated StageActive) must also refuse a disconnected probe.
+func TestCommandGateBlocksClearNodesAndTranspose(t *testing.T) {
+	w := mustWorld(t)
+	probe := spacecraft.NewFromLoadout("Relay-Tug")
+	probe.Primary = w.Crafts[0].Primary
+	probe.State = w.Crafts[0].State
+	probe.Nodes = []ManeuverNode{{TriggerTime: w.Clock.SimTime.Add(time.Hour), DV: 10, Mode: spacecraft.BurnPrograde}}
+	w.Crafts[0] = probe
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}} // disconnected
+
+	w.ClearNodes()
+	if len(probe.Nodes) != 1 {
+		t.Error("ClearNodes must be blocked for a disconnected probe (node should remain)")
+	}
+
+	// A TransposeReady but unmanned, disconnected probe is refused with ErrNoSignal.
+	tp := &spacecraft.Spacecraft{
+		Controllable: true,
+		Crewed:       false,
+		Stages: []spacecraft.Stage{
+			{Name: "Descent"}, {Name: "Ascent"}, {Name: "SM"}, {Name: "CM"},
+		},
+	}
+	w.Crafts[0] = tp
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}}
+	if err := w.Transpose(0); !errors.Is(err, ErrNoSignal) {
+		t.Errorf("Transpose on a disconnected probe: got %v, want ErrNoSignal", err)
+	}
+}
+
 // TestCommandGateAllowsConnectedAndCrewed (C2-5): a connected probe and a
 // crewed vessel both accept commands.
 func TestCommandGateAllowsConnectedAndCrewed(t *testing.T) {

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -145,6 +145,15 @@ func (w *World) Undock(idx int) bool {
 				V: c.State.V.Add(radialOut.Scale(offset * pushVMS)),
 			},
 		}
+		// ADR 0027: every other vessel-construction path (NewFromLoadout /
+		// NewFromStages / save-load) backfills a command source on a
+		// command-less stack so it stays controllable. Undock must too —
+		// otherwise a released component whose own stages carry no command
+		// source (e.g. an uncrewed custom payload, or a legacy single-stage
+		// rebuild) derives Controllable=false and becomes unflyable debris.
+		// No-op when the component already carries one (the crewed LM cabin,
+		// the CSM's CM), so it doesn't override authored roles.
+		spacecraft.EnsureCommandSource(s)
 		s.SyncFields()
 		s.State.M = s.TotalMass()
 		restored = append(restored, s)

--- a/internal/sim/landed_test.go
+++ b/internal/sim/landed_test.go
@@ -157,6 +157,7 @@ func TestEngineIgnitionClearsLanded(t *testing.T) {
 	}
 	c.Throttle = 1.0
 	c.AttitudeMode = spacecraft.BurnRadialOut
+	crewTend(c) // command gate (ADR 0027): this test exercises landed/ignition logic, not comms
 	w.StartManualBurn()
 	if c.Landed {
 		t.Error("StartManualBurn should clear Landed; got Landed=true")
@@ -214,6 +215,7 @@ func TestLandedNoseTracksLocalUpThroughWarp(t *testing.T) {
 
 	// Liftoff: with the nose correct the craft must actually rise.
 	alt0 := c.Altitude()
+	crewTend(c) // command gate (ADR 0027): this test exercises landed/ignition logic, not comms
 	w.StartManualBurn()
 	for i := 0; i < 60; i++ { // ~3 s at 1× / 50 ms base step
 		w.Tick()
@@ -258,6 +260,7 @@ func TestLandedCraftStaysAtPadAfterLiftoff(t *testing.T) {
 
 	c.Throttle = 1.0
 	c.AttitudeMode = spacecraft.BurnRadialOut
+	crewTend(c) // command gate (ADR 0027): this test exercises landed/ignition logic, not comms
 	w.StartManualBurn()
 	if c.Landed {
 		t.Fatal("setup: StartManualBurn should clear Landed")

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -53,6 +53,9 @@ func (w *World) StartManualBurn() {
 	if c == nil {
 		return
 	}
+	if !w.canCommand(c) { // ADR 0027: igniting the engine is a command, gated without a connection
+		return
+	}
 	if c.ActiveBurn != nil || c.ManualBurn != nil {
 		return
 	}
@@ -2346,9 +2349,14 @@ func (e transferError) Error() string { return string(e) }
 // ClearNodes wipes every pending node from the active craft. v0.8.1+:
 // per-active-craft (was global pre-v0.8.1).
 func (w *World) ClearNodes() {
-	if c := w.ActiveCraft(); c != nil {
-		c.Nodes = nil
+	c := w.ActiveCraft()
+	if c == nil {
+		return
 	}
+	if !w.canCommand(c) { // ADR 0027: editing the flight plan is a command (matches DeleteNode)
+		return
+	}
+	c.Nodes = nil
 }
 
 // DeleteNode removes the node at idx from the active craft's plan.

--- a/internal/sim/onpad_test.go
+++ b/internal/sim/onpad_test.go
@@ -69,6 +69,7 @@ func TestLiftoffClearsOnPad(t *testing.T) {
 	}
 	c.AttitudeMode = spacecraft.BurnRadialOut
 	c.Throttle = 1.0
+	crewTend(c) // command gate (ADR 0027): this test exercises onpad/liftoff logic, not comms
 	w.StartManualBurn()
 	if c.OnPad {
 		t.Errorf("after StartManualBurn: OnPad=true, want false")

--- a/internal/sim/rcs.go
+++ b/internal/sim/rcs.go
@@ -50,6 +50,9 @@ func (w *World) FireRCSPulse(mode spacecraft.BurnMode) bool {
 	if w.ActiveCraft() == nil || w.ActiveCraft().EngineMode != spacecraft.EngineRCS {
 		return false
 	}
+	if !w.canCommand(w.ActiveCraft()) { // ADR 0027: an RCS pulse delivers Δv — a command
+		return false
+	}
 	if w.ActiveCraft().ActiveBurn != nil {
 		return false
 	}

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -303,6 +303,9 @@ func (w *World) Transpose(craftIdx int) error {
 	if c == nil {
 		return fmt.Errorf("%w: %d (nil)", ErrStageNoCraft, craftIdx)
 	}
+	if !w.canCommand(c) { // ADR 0027: transposition restructures the stack — a command
+		return ErrNoSignal
+	}
 	if !TransposeReady(c) {
 		return ErrTransposeNotReady
 	}

--- a/internal/sim/staging.go
+++ b/internal/sim/staging.go
@@ -200,7 +200,7 @@ func buildJettisonedCraft(stages []spacecraft.Stage, parent *spacecraft.Spacecra
 	c := &spacecraft.Spacecraft{
 		Name:                 name,
 		LoadoutID:            bottom.LoadoutID,
-		Role:                 "jettisoned-stage",
+		Role:                 spacecraft.RoleJettisonedStage,
 		Glyph:                glyph,
 		Color:                color,
 		Throttle:             0, // passive — player isn't flying it.

--- a/internal/sim/staging_test.go
+++ b/internal/sim/staging_test.go
@@ -244,6 +244,55 @@ func TestApolloStackManualFlipDropsLMAsOneCraft(t *testing.T) {
 	}
 }
 
+// TestUndockedApolloLMIsControllable (hardening, ADR 0027): after the Apollo
+// transpose + undock, the released LM must stay flyable. Its Descent/Ascent
+// stages carried no catalog command source, and Undock — unlike every other
+// craft-construction path — skipped the EnsureCommandSource backfill, so the
+// LM derived Controllable=false and could not be commanded to the surface.
+// The LM is crewed (astronauts aboard the ascent cabin), so it must not be
+// reduced to a relay-gated probe either.
+func TestUndockedApolloLMIsControllable(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	stack := spacecraft.NewFromLoadout(spacecraft.LoadoutApolloStackID)
+	stack.Primary = w.Crafts[0].Primary
+	stack.State = w.Crafts[0].State
+	w.Crafts[0] = stack
+	w.ActiveCraftIdx = 0
+	crewTendActive(w)
+
+	for i := 0; i < 3; i++ { // drop the three Saturn stages → [Descent,Ascent,SM,CM]
+		if _, _, err := w.StageActive(0); err != nil {
+			t.Fatalf("Saturn drop #%d: %v", i, err)
+		}
+	}
+	if err := w.Transpose(0); err != nil {
+		t.Fatalf("Transpose: %v", err)
+	}
+	if !w.Undock(0) { // releases the LM (Descent+Ascent) and the CSM core (SM+CM)
+		t.Fatal("Undock returned false")
+	}
+
+	var lm *spacecraft.Spacecraft
+	for _, c := range w.Crafts {
+		if c != nil && len(c.Stages) == 2 && c.Stages[0].Name == "Descent" && c.Stages[1].Name == "Ascent" {
+			lm = c
+			break
+		}
+	}
+	if lm == nil {
+		t.Fatal("could not find the undocked LM in the slate")
+	}
+	if !lm.Controllable {
+		t.Error("the undocked LM must be controllable (flyable to the surface)")
+	}
+	if !lm.Crewed {
+		t.Error("the Apollo LM is crewed — it must not depend on a CommNet relay to command")
+	}
+}
+
 // TestTransposeClearsDecouplePlan — after a one-shot transpose (D), the
 // leftover loadout plan (the trailing LM "2" group, unconsumed because
 // the player transposed instead of staging the LM off) must be cleared.

--- a/internal/spacecraft/data/parts.json
+++ b/internal/spacecraft/data/parts.json
@@ -339,6 +339,7 @@
     {
       "id": "apollo-ascent",
       "name": "Ascent",
+      "command_source": "crewed",
       "glyph": "➤",
       "color": "#7BFFA0",
       "dry_mass_kg": 1200,

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -353,6 +353,14 @@ func NewFromLoadout(loadoutID string) *Spacecraft {
 	return c
 }
 
+// RoleJettisonedStage is the Role stamped on a spent stage popped into its
+// own passive craft by staging (World.StageActive → buildJettisonedCraft). It
+// marks debris: EnsureCommandSource never backfills it, so a spent booster
+// stays uncommandable across construction and save-load (ADR 0027). Lives
+// here so the sim staging code and the save-load backfill agree on one value
+// rather than two magic strings.
+const RoleJettisonedStage = "jettisoned-stage"
+
 // roleIsCrewedPod reports whether a loadout/vessel Role denotes a crewed
 // command pod, used by the command-source defaulting (ADR 0027): a
 // command-less vessel whose role is a crewed pod defaults to a crewed
@@ -382,6 +390,13 @@ const DefaultProbeAntennaPowerW = 2000.0
 // already-defaulted vessel), so it is idempotent.
 func EnsureCommandSource(c *Spacecraft) {
 	if len(c.Stages) == 0 {
+		return
+	}
+	// Jettisoned debris is never backfilled — a spent booster legitimately
+	// carries no command source and must stay passive. Guarding here (not just
+	// at the construction call sites) keeps the save-load backfill from
+	// resurrecting a saved spent stage into a commandable probe (ADR 0027).
+	if c.Role == RoleJettisonedStage {
 		return
 	}
 	for _, st := range c.Stages {

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -51,6 +51,11 @@ func spawnSaturnVOnPad(t *testing.T) (*sim.World, *spacecraft.Spacecraft) {
 	if !c.Landed {
 		t.Fatal("launchpad spawn should set Landed=true")
 	}
+	// A crewed Saturn V: these launch-view tests exercise rendering and
+	// flight physics, not the comms command gate (ADR 0027). Without a
+	// command source the unmanned-default stack would refuse ignition / RCS.
+	c.Stages[len(c.Stages)-1].CommandSource = spacecraft.CommandCrewed
+	c.SyncFields()
 	return w, c
 }
 


### PR DESCRIPTION
Fixes three correctness bugs in **already-merged cycle-2 code** (#179), surfaced
by the batched cycle-2 `/code-review`. Each fix is test-first.

## 1. Complete the command gate (`e6f3c0d`)
The C2-5 gate guarded SetThrottle/SetAttitudeMode/PlanNode/DeleteNode/StageActive
but missed sibling commands that mutate the active craft. A disconnected unmanned
probe could still **ignite its main engine** (`StartManualBurn`, the `b` key —
reachable immediately since craft default Throttle=1.0), **apply Δv** (`FireRCSPulse`),
**wipe its plan** (`ClearNodes`), and **restructure its stack** (`Transpose`). All
four now gated. Crewed craft bypass as before.

## 2. Undocked Apollo LM stays controllable (`557be25`)
The LM's ascent cabin (`apollo-ascent`) carried no `command_source`, and `Undock`
— unlike every other construction path — skipped the `EnsureCommandSource` backfill.
So after the CSM/LM split the LM derived `Controllable=false` and **couldn't be flown
to the surface**. Fix: annotate the crewed ascent cabin `command_source: crewed`
(the LM is crewed — it must not be a relay-gated probe near the Moon), and add the
backfill to `Undock` so any command-less released component becomes a controllable
probe instead of dead debris.

## 3. Don't resurrect jettisoned debris on load (`41e76cd`)
The load-time `EnsureCommandSource` backfill ran on every craft, so a saved spent
booster (no command source) was stamped a probe core on reload → became a commandable
probe + CommNet node. Guard inside `EnsureCommandSource` itself (its doc already says
"NOT to jettisoned stages"); add a shared `spacecraft.RoleJettisonedStage` const.

## Tests
New: `TestCommandGateBlocksManualBurnAndRCS`, `TestCommandGateBlocksClearNodesAndTranspose`,
`TestUndockedApolloLMIsControllable`, `TestJettisonedDebrisStaysDebrisAcrossSave`. Test
friction from the new gates resolved by crew-tending launchpad craft in landed/onpad/launch
tests (they exercise flight logic, not comms). `go vet ./...` + `go test ./... -race -count=1`
green (15 packages).

## Relationship to #180
#180 is the clean C2-7 HUD slice. This PR fixes the pre-existing cycle-2 bugs the same
review surfaced, kept separate to preserve slice boundaries. Independent files — both
merge cleanly in either order.