### PR TITLE
CommNet range model: combinability + antenna tiers — Relay-Tug reaches Earth/Moon (closes #182)

### DIFF
--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -286,9 +286,15 @@ type Stage struct {
 	// saves load with these absent → empty, and the load-time
 	// EnsureCommandSource backfill stamps a default command source on the
 	// surviving core so old vessels stay controllable.
+	//
+	// AntennaRangeM is a rated range in metres (v0.22.x combinability model,
+	// ADR 0027 §2 amendment), renamed from the original antenna_power_w. A
+	// pre-amendment save carries antenna_power_w (now an ignored key) → this
+	// field loads as 0; wireStagesToSim backfills the rated range from the
+	// antenna kind so those saves keep working without a schema bump.
 	CommandSource string  `json:"command_source,omitempty"`
 	AntennaKind   string  `json:"antenna_kind,omitempty"`
-	AntennaPowerW float64 `json:"antenna_power_w,omitempty"`
+	AntennaRangeM float64 `json:"antenna_range_m,omitempty"`
 }
 
 // Node mirrors sim.ManeuverNode. Event (v0.6.0+, schema v2) is

--- a/internal/save/save_migrate_v5_to_v6.go
+++ b/internal/save/save_migrate_v5_to_v6.go
@@ -37,7 +37,15 @@ func wireStagesToSim(wire []Stage) []spacecraft.Stage {
 			HasParachute:         s.HasParachute,
 			CommandSource:        s.CommandSource,
 			AntennaKind:          s.AntennaKind,
-			AntennaPowerW:        s.AntennaPowerW,
+			AntennaRangeM:        s.AntennaRangeM,
+		}
+		// Save-compat (ADR 0027 §2 amendment): a pre-amendment save stored the
+		// antenna's legacy power in antenna_power_w (now an ignored key), so
+		// AntennaRangeM loads as 0 even though the antenna kind survives. A real
+		// antenna always has a positive range, so kind!=none with range 0
+		// uniquely marks an old save — re-range it from its kind's tier.
+		if out[i].AntennaKind != spacecraft.AntennaNone && out[i].AntennaRangeM == 0 {
+			out[i].AntennaRangeM = spacecraft.DefaultAntennaRangeForKind(out[i].AntennaKind)
 		}
 	}
 	return out
@@ -73,7 +81,7 @@ func simStagesToWire(stages []spacecraft.Stage) []Stage {
 			HasParachute:         s.HasParachute,
 			CommandSource:        s.CommandSource,
 			AntennaKind:          s.AntennaKind,
-			AntennaPowerW:        s.AntennaPowerW,
+			AntennaRangeM:        s.AntennaRangeM,
 		}
 	}
 	return out

--- a/internal/save/save_test.go
+++ b/internal/save/save_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1437,6 +1438,46 @@ func TestRoundtripPreservesMoonPhase(t *testing.T) {
 	}
 }
 
+// TestPreAmendmentAntennaReRanged (#182, ADR 0027 §2 amendment): a save
+// written before the rated-range amendment stored the antenna's legacy power
+// in antenna_power_w. On load the new antenna_range_m is absent (0), so the
+// loader re-ranges the surviving antenna kind to its tier — a relay antenna
+// comes back at the cislunar range, not dead. Simulated by renaming the new
+// save's antenna_range_m key back to the legacy antenna_power_w.
+func TestPreAmendmentAntennaReRanged(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	tug := spacecraft.NewFromLoadout("Relay-Tug")
+	tug.Primary = w.Crafts[0].Primary
+	tug.State = w.Crafts[0].State
+	w.Crafts[0] = tug
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	old := strings.ReplaceAll(string(raw), "antenna_range_m", "antenna_power_w")
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	s := got.Crafts[0].Stages[0]
+	if s.AntennaKind != spacecraft.AntennaRelay || s.AntennaRangeM != spacecraft.AntennaRangeRelayCislunar {
+		t.Errorf("pre-amendment antenna = %q/%g, want relay/%g (re-ranged from kind on load)",
+			s.AntennaKind, s.AntennaRangeM, spacecraft.AntennaRangeRelayCislunar)
+	}
+}
+
 // TestCommsAttributesRoundtrip (C2-1, ADR 0027): per-stage command_source
 // + antenna survive a save/load round-trip, and a pre-comms craft (stages
 // with no command source) is backfilled to controllable on load.
@@ -1463,8 +1504,8 @@ func TestCommsAttributesRoundtrip(t *testing.T) {
 	if c.Stages[0].CommandSource != spacecraft.CommandProbe {
 		t.Errorf("command source = %q, want probe after round-trip", c.Stages[0].CommandSource)
 	}
-	if c.Stages[0].AntennaKind != spacecraft.AntennaRelay || c.Stages[0].AntennaPowerW != 4000 {
-		t.Errorf("antenna = %q/%g, want relay/4000 after round-trip", c.Stages[0].AntennaKind, c.Stages[0].AntennaPowerW)
+	if c.Stages[0].AntennaKind != spacecraft.AntennaRelay || c.Stages[0].AntennaRangeM != spacecraft.AntennaRangeRelayCislunar {
+		t.Errorf("antenna = %q/%g, want relay/%g after round-trip", c.Stages[0].AntennaKind, c.Stages[0].AntennaRangeM, spacecraft.AntennaRangeRelayCislunar)
 	}
 	if !c.Controllable || c.Crewed {
 		t.Errorf("probe vessel: Controllable=%v Crewed=%v, want true/false", c.Controllable, c.Crewed)

--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -19,17 +19,16 @@ import (
 // coverage objectives + the comms HUD (later slices). Transient — never
 // persisted; rebuilt each tick.
 
-// CommRangePerWatt is the placeholder link-range scale: the max link
-// distance (m) is this constant times the WEAKER endpoint's antenna power
-// (W). The two-endpoint range-combination formula is deferred tuning
-// (ADR 0027 §2 floats ∝ √(Pₐ·P_b)); this conservative min-power form ships
-// until playtest decides the real curve.
-const CommRangePerWatt = 5000.0
-
-// commLinkRangeM is the max distance at which two antennas can link, from
-// the weaker of the two powers (placeholder — see CommRangePerWatt).
-func commLinkRangeM(pa, pb float64) float64 {
-	return math.Min(pa, pb) * CommRangePerWatt
+// commLinkRangeM is the max distance at which two antennas can link, under
+// the KSP-style combinability model (ADR 0027 §2 amendment, v0.22.x): each
+// antenna carries a RATED RANGE (m) — the distance at which it reaches an
+// identical antenna — and the link range between two is the geometric mean of
+// their rated ranges. This lets a powerful ground station extend a weak
+// craft's reach (√ of a big and a small range lands usefully far), instead of
+// the old min-power form that capped every link at the weaker antenna. The
+// rated ranges themselves are the antenna tier values authored in the catalog.
+func commLinkRangeM(ra, rb float64) float64 {
+	return math.Sqrt(ra * rb)
 }
 
 // CommGraph is the cached per-tick connectivity result: the set of
@@ -67,11 +66,11 @@ func (g *CommGraph) Path(id uint64) []orbital.Vec3 {
 // ground station, with the world-frame position the LOS + range tests use.
 type commNode struct {
 	pos      orbital.Vec3
-	powerW   float64
-	forwards bool   // can relay traffic onward: a relay antenna + Controllable, or a ground station
-	station  bool   // a ground station (a connection sink)
-	probe    bool   // an unmanned controllable craft — a BFS source that needs a connection
-	craftID  uint64 // 0 for stations
+	rangeM   float64 // antenna rated range (m) — see commLinkRangeM
+	forwards bool    // can relay traffic onward: a relay antenna + Controllable, or a ground station
+	station  bool    // a ground station (a connection sink)
+	probe    bool    // an unmanned controllable craft — a BFS source that needs a connection
+	craftID  uint64  // 0 for stations
 }
 
 // connectivityResult is the full output of the connectivity solve: which
@@ -123,10 +122,10 @@ func connectivityFull(nodes []commNode, occ []physics.OccluderBody) connectivity
 }
 
 func commLinked(a, b commNode, occ []physics.OccluderBody) bool {
-	if a.powerW <= 0 || b.powerW <= 0 {
+	if a.rangeM <= 0 || b.rangeM <= 0 {
 		return false
 	}
-	if a.pos.Sub(b.pos).Norm() > commLinkRangeM(a.powerW, b.powerW) {
+	if a.pos.Sub(b.pos).Norm() > commLinkRangeM(a.rangeM, b.rangeM) {
 		return false
 	}
 	return !physics.SegmentOccludedByBody(a.pos, b.pos, occ)
@@ -207,7 +206,7 @@ func (w *World) RecomputeCommGraph() {
 		}
 		nodes = append(nodes, commNode{
 			pos:      w.groundStationWorldPos(st, *body),
-			powerW:   st.AntennaPowerW,
+			rangeM:   st.AntennaRangeM,
 			forwards: true,
 			station:  true,
 		})
@@ -218,7 +217,7 @@ func (w *World) RecomputeCommGraph() {
 		}
 		nodes = append(nodes, commNode{
 			pos:      w.BodyPosition(c.Primary).Add(c.State.R),
-			powerW:   c.AntennaPowerW,
+			rangeM:   c.AntennaRangeM,
 			forwards: c.AntennaKind == spacecraft.AntennaRelay && c.Controllable,
 			probe:    c.Controllable && !c.Crewed,
 			craftID:  c.ID,

--- a/internal/sim/commnet_test.go
+++ b/internal/sim/commnet_test.go
@@ -143,16 +143,17 @@ func TestCommandGateAllowsConnectedAndCrewed(t *testing.T) {
 }
 
 // station / probe / relay node builders for the synthetic-graph tests.
-// Positions are in meters along the X axis; powers chosen so the default
-// CommRangePerWatt makes "near" links close and "far" links break.
-func station(id uint64, x, p float64) commNode {
-	return commNode{pos: orbital.Vec3{X: x}, powerW: p, forwards: true, station: true}
+// Positions are in meters along the X axis; rated ranges chosen so the
+// combinability link range (√(rₐ·r_b)) makes "near" links close and "far"
+// links break.
+func station(id uint64, x, r float64) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, rangeM: r, forwards: true, station: true}
 }
-func probeNode(id uint64, x, p float64, relay bool) commNode {
-	return commNode{pos: orbital.Vec3{X: x}, powerW: p, probe: true, craftID: id, forwards: relay}
+func probeNode(id uint64, x, r float64, relay bool) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, rangeM: r, probe: true, craftID: id, forwards: relay}
 }
-func relayNode(x, p float64) commNode {
-	return commNode{pos: orbital.Vec3{X: x}, powerW: p, forwards: true}
+func relayNode(x, r float64) commNode {
+	return commNode{pos: orbital.Vec3{X: x}, rangeM: r, forwards: true}
 }
 
 func TestConnectivityDirectLink(t *testing.T) {
@@ -169,8 +170,7 @@ func TestConnectivityDirectLink(t *testing.T) {
 }
 
 func TestConnectivityOutOfRange(t *testing.T) {
-	// min(power) = 3000 → range = 3000 * CommRangePerWatt. Place the probe
-	// just past it.
+	// rng = √(100000·3000); place the probe just past it.
 	rng := commLinkRangeM(100000, 3000)
 	nodes := []commNode{
 		station(0, 0, 100000),
@@ -193,7 +193,7 @@ func TestConnectivityOccludedNeedsRelay(t *testing.T) {
 		t.Error("a probe occluded by a body with no relay should be disconnected")
 	}
 	// With an off-axis relay (y=2000) that clears the radius-100 body: linked.
-	relay := commNode{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: true}
+	relay := commNode{pos: orbital.Vec3{Y: 2000}, rangeM: 100000, forwards: true}
 	if !connectivity([]commNode{st, pr, relay}, occ)[1] {
 		t.Error("an off-axis relay with LOS to both should bridge the occluded probe")
 	}
@@ -210,7 +210,7 @@ func TestConnectivityCannotRelayThroughDirectCraft(t *testing.T) {
 		probeNode(2, 1000, 100000, false), // the probe we test (id 2)
 		// a direct-only craft sitting off-axis with LOS to both, but a
 		// non-forwarder (forwards=false):
-		{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: false, craftID: 9},
+		{pos: orbital.Vec3{Y: 2000}, rangeM: 100000, forwards: false, craftID: 9},
 	}
 	if connectivity(nodes, occ)[2] {
 		t.Error("a direct-only craft must not relay traffic through itself")
@@ -241,7 +241,7 @@ func TestConnectivityPathViaRelay(t *testing.T) {
 	nodes := []commNode{
 		station(0, -1000, 100000),       // index 0
 		probeNode(1, 1000, 3000, false), // index 1 (direct link occluded)
-		{pos: orbital.Vec3{Y: 2000}, powerW: 100000, forwards: true}, // index 2 relay
+		{pos: orbital.Vec3{Y: 2000}, rangeM: 100000, forwards: true}, // index 2 relay
 	}
 	res := connectivityFull(nodes, occ)
 	if !res.connected[1] {
@@ -307,6 +307,105 @@ func TestActiveCommPathDisconnected(t *testing.T) {
 	w.CommGraph = &CommGraph{Connected: map[uint64]bool{}} // disconnected
 	if _, _, connected := w.ActiveCommPath(); connected {
 		t.Error("a disconnected probe must report no path")
+	}
+}
+
+// radialAboveStation0 places craft c at distM straight up from DSN station 0
+// (clear radial line of sight, home system), so connectivity is gated by range
+// alone. craft-to-station distance == distM.
+func radialAboveStation0(t *testing.T, w *World, c *spacecraft.Spacecraft, distM float64) {
+	t.Helper()
+	gs := w.GroundStations[0]
+	sys := w.System()
+	body := *sys.FindBody(gs.BodyID)
+	up := w.groundStationWorldPos(gs, body).Sub(w.BodyPosition(body)).Unit()
+	c.SystemIdx = 0
+	c.Primary = body
+	c.State.R = up.Scale(body.RadiusMeters() + distM)
+}
+
+// connectedAt spawns the given loadout distM straight up from DSN station 0
+// (clear LOS) and reports whether it reaches the network — the integration
+// seam for the combinability/tier reach (#182, ADR 0027 §2 amendment).
+func connectedAt(t *testing.T, w *World, loadout string, distM float64) bool {
+	t.Helper()
+	c := spacecraft.NewFromLoadout(loadout)
+	radialAboveStation0(t, w, c, distM)
+	w.Crafts = []*spacecraft.Spacecraft{c}
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.RecomputeCommGraph()
+	return w.CommGraph.HasConnection(c.ID)
+}
+
+// TestCommReachTiers (#182): the combinability model + antenna tiers give each
+// tier its intended reach against the home DSN. The Relay-Tug fulfils
+// Earth/Moon; a basic antenna stops at geostationary; deep-space reaches
+// Mars-class; and the range limit is still real.
+func TestCommReachTiers(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	const (
+		geo     = 35_786e3   // geostationary
+		moon    = 384_400e3  // Earth–Moon
+		marsish = 40e9       // 40M km — within deep-space reach, beyond the relay tug
+		beyond  = 100e9      // 100M km — past even deep-space reach
+	)
+	// Relay-Tug: reaches geostationary AND the Moon (the headline fix).
+	if !connectedAt(t, w, "Relay-Tug", geo) {
+		t.Error("Relay-Tug must reach geostationary")
+	}
+	if !connectedAt(t, w, "Relay-Tug", moon) {
+		t.Error("Relay-Tug must reach the Moon (Earth/Moon workhorse)")
+	}
+	// Basic telemetry (Station-Keeper / direct-basic): geostationary yes, Moon no.
+	if !connectedAt(t, w, "Station-Keeper", geo) {
+		t.Error("a basic direct antenna must reach geostationary")
+	}
+	if connectedAt(t, w, "Station-Keeper", moon) {
+		t.Error("a basic direct antenna must NOT reach the Moon — that's the relay tug's job")
+	}
+	// Deep-space: reaches Mars-class where the relay tug cannot.
+	if !connectedAt(t, w, "Deep-Space-Relay", marsish) {
+		t.Error("the deep-space antenna must reach Mars-class distance")
+	}
+	if connectedAt(t, w, "Relay-Tug", marsish) {
+		t.Error("a relay tug must NOT reach Mars-class distance (needs a deep-space antenna)")
+	}
+	// The limit is still real — even deep-space drops out eventually.
+	if connectedAt(t, w, "Deep-Space-Relay", beyond) {
+		t.Error("even the deep-space antenna must read NO SIGNAL past its reach")
+	}
+}
+
+// TestCommRelayChainBridgesCislunar (#182): two Relay-Tugs link to each other
+// across cislunar distances, so a tug beyond direct DSN reach still reaches the
+// network through a forwarding tug — and is NO SIGNAL without it.
+func TestCommRelayChainBridgesCislunar(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	a := spacecraft.NewFromLoadout("Relay-Tug")
+	radialAboveStation0(t, w, a, 2_200_000_000) // 2.2M km — within DSN reach (~2.24M km)
+	b := spacecraft.NewFromLoadout("Relay-Tug")
+	radialAboveStation0(t, w, b, 3_000_000_000) // 3.0M km — beyond direct DSN reach
+	w.Crafts = []*spacecraft.Spacecraft{a, b}
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(1)
+	w.RecomputeCommGraph()
+	if !w.CommGraph.HasConnection(b.ID) {
+		t.Error("tug B should reach the network through tug A (cislunar relay chain)")
+	}
+	// Drop the forwarding tug → B is beyond direct DSN reach → NO SIGNAL.
+	w.Crafts = []*spacecraft.Spacecraft{b}
+	w.EnsureCraftIDs()
+	w.SetActiveCraftIdx(0)
+	w.RecomputeCommGraph()
+	if w.CommGraph.HasConnection(b.ID) {
+		t.Error("without the relay, tug B (beyond direct DSN reach) must read NO SIGNAL")
 	}
 }
 

--- a/internal/sim/data/ground_stations.json
+++ b/internal/sim/data/ground_stations.json
@@ -6,7 +6,7 @@
       "body_id": "earth",
       "lat_deg": 35.43,
       "lon_east_deg": -116.89,
-      "antenna_power_w": 100000
+      "antenna_range_m": 5000000000
     },
     {
       "key": "madrid",
@@ -14,7 +14,7 @@
       "body_id": "earth",
       "lat_deg": 40.43,
       "lon_east_deg": -4.25,
-      "antenna_power_w": 100000
+      "antenna_range_m": 5000000000
     },
     {
       "key": "canberra",
@@ -22,7 +22,7 @@
       "body_id": "earth",
       "lat_deg": -35.4,
       "lon_east_deg": 148.98,
-      "antenna_power_w": 100000
+      "antenna_range_m": 5000000000
     }
   ]
 }

--- a/internal/sim/ground_stations.go
+++ b/internal/sim/ground_stations.go
@@ -63,13 +63,27 @@ func LoadGroundStations() ([]GroundStationPreset, []GroundStationWarning) {
 	return LoadGroundStationsWithWarnings()
 }
 
+// DefaultGroundStationRangeM is the rated range a station falls back to when
+// its entry carries no positive range — e.g. a user overlay authored before
+// the power_w→range_m rename (ADR 0027 §2 amendment), whose old key now
+// unmarshals to 0. Keeps a mis-keyed / un-ranged station functional at the DSN
+// tier instead of silently dead (commLinked rejects range<=0). The embedded
+// ring always carries explicit ranges, so this only ever rescues overlays.
+const DefaultGroundStationRangeM = 5.0e9
+
 // LoadGroundStationsWithWarnings loads the embedded catalog merged with the
 // user overlay ($XDG_CONFIG_HOME/terminal-space-program/ground_stations/*.json),
 // user winning on Key. A malformed embedded file panics (build error); a
-// malformed user file is skipped with a warning.
+// malformed user file is skipped with a warning. A station with no positive
+// range falls back to DefaultGroundStationRangeM.
 func LoadGroundStationsWithWarnings() ([]GroundStationPreset, []GroundStationWarning) {
-	stations := loadEmbeddedGroundStations()
-	return mergeUserGroundStations(stations, userGroundStationsDir())
+	stations, warnings := mergeUserGroundStations(loadEmbeddedGroundStations(), userGroundStationsDir())
+	for i := range stations {
+		if stations[i].AntennaRangeM <= 0 {
+			stations[i].AntennaRangeM = DefaultGroundStationRangeM
+		}
+	}
+	return stations, warnings
 }
 
 func loadEmbeddedGroundStations() []GroundStationPreset {

--- a/internal/sim/ground_stations.go
+++ b/internal/sim/ground_stations.go
@@ -25,16 +25,17 @@ var groundStationsFS embed.FS
 // LaunchSitePreset (a launchpad): a ground station is a network node. Key
 // is the short token, BodyID the body it sits on (its surface co-rotates),
 // LatDeg / LonEastDeg the body-fixed position (east-positive, pseudo-
-// Greenwich at simTime=0 — same convention as launch sites), AntennaPowerW
-// the relay power (ground stations are high-power; the two-endpoint range
-// formula is deferred tuning, ADR 0027 §2).
+// Greenwich at simTime=0 — same convention as launch sites), AntennaRangeM
+// the antenna's rated range in metres (the network anchor: ground stations
+// are long-ranged, so via combinability they extend a weak craft's reach —
+// ADR 0027 §2 amendment).
 type GroundStationPreset struct {
 	Key           string  `json:"key"`
 	Name          string  `json:"name"`
 	BodyID        string  `json:"body_id"`
 	LatDeg        float64 `json:"lat_deg"`
 	LonEastDeg    float64 `json:"lon_east_deg"`
-	AntennaPowerW float64 `json:"antenna_power_w"`
+	AntennaRangeM float64 `json:"antenna_range_m"`
 
 	// Source is a runtime annotation ("embedded" / "user"); excluded from
 	// JSON so it never affects round-trips.

--- a/internal/sim/ground_stations_test.go
+++ b/internal/sim/ground_stations_test.go
@@ -98,3 +98,35 @@ func TestGroundStationUserOverlay(t *testing.T) {
 		t.Errorf("user override of goldstone failed: %+v", g)
 	}
 }
+
+// TestGroundStationLegacyKeyFallsBackToDefaultRange (#182): a user overlay
+// authored before the power_w→range_m rename uses the old key, which now
+// unmarshals to range 0. The loader must rescue it to the DSN-tier default so
+// the station stays functional rather than silently dead (commLinked rejects
+// range<=0).
+func TestGroundStationLegacyKeyFallsBackToDefaultRange(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "terminal-space-program", "ground_stations")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", root)
+
+	// Pre-amendment overlay: the legacy antenna_power_w key, no antenna_range_m.
+	legacy := `{"stations":[
+		{"key":"legacy","name":"Legacy Dish","body_id":"earth","lat_deg":0,"lon_east_deg":0,"antenna_power_w":250000}
+	]}`
+	if err := os.WriteFile(filepath.Join(dir, "legacy.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stations, _ := LoadGroundStations()
+	for _, s := range stations {
+		if s.Key == "legacy" {
+			if s.AntennaRangeM != DefaultGroundStationRangeM {
+				t.Errorf("legacy-key station range = %g, want default %g (rescued, not dead)", s.AntennaRangeM, DefaultGroundStationRangeM)
+			}
+			return
+		}
+	}
+	t.Error("legacy-key station was not loaded")
+}

--- a/internal/sim/ground_stations_test.go
+++ b/internal/sim/ground_stations_test.go
@@ -24,8 +24,8 @@ func TestGroundStationsDSNRing(t *testing.T) {
 		if s.BodyID != "earth" {
 			t.Errorf("station %q BodyID = %q, want earth (home body)", s.Key, s.BodyID)
 		}
-		if s.AntennaPowerW <= 0 {
-			t.Errorf("station %q has no antenna power", s.Key)
+		if s.AntennaRangeM <= 0 {
+			t.Errorf("station %q has no antenna range", s.Key)
 		}
 		if s.Source != "embedded" {
 			t.Errorf("station %q Source = %q, want embedded", s.Key, s.Source)
@@ -71,10 +71,10 @@ func TestGroundStationUserOverlay(t *testing.T) {
 	}
 	t.Setenv("XDG_CONFIG_HOME", root)
 
-	// Add a new station + override Goldstone's power.
+	// Add a new station + override Goldstone's range.
 	good := `{"stations":[
-		{"key":"luna-farside","name":"Luna Farside","body_id":"moon","lat_deg":0,"lon_east_deg":180,"antenna_power_w":50000},
-		{"key":"goldstone","name":"Goldstone (modded)","body_id":"earth","lat_deg":35.43,"lon_east_deg":-116.89,"antenna_power_w":250000}
+		{"key":"luna-farside","name":"Luna Farside","body_id":"moon","lat_deg":0,"lon_east_deg":180,"antenna_range_m":50000},
+		{"key":"goldstone","name":"Goldstone (modded)","body_id":"earth","lat_deg":35.43,"lon_east_deg":-116.89,"antenna_range_m":250000}
 	]}`
 	if err := os.WriteFile(filepath.Join(dir, "mine.json"), []byte(good), 0o644); err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func TestGroundStationUserOverlay(t *testing.T) {
 	if g, ok := byKey["luna-farside"]; !ok || g.BodyID != "moon" || g.Source != "user" {
 		t.Errorf("user station luna-farside not merged correctly: %+v", g)
 	}
-	if g := byKey["goldstone"]; g.AntennaPowerW != 250000 || g.Source != "user" {
+	if g := byKey["goldstone"]; g.AntennaRangeM != 250000 || g.Source != "user" {
 		t.Errorf("user override of goldstone failed: %+v", g)
 	}
 }

--- a/internal/spacecraft/catalog.go
+++ b/internal/spacecraft/catalog.go
@@ -81,11 +81,13 @@ type Part struct {
 
 // Antenna is the forward-compatible (ADR 0027) per-part antenna attribute:
 // kind is "none" | "direct" | "relay"; a direct antenna can use the
-// network, a relay antenna can also forward for others. Declared in the
+// network, a relay antenna can also forward for others. range_m is the
+// antenna's rated range in metres — the distance at which it reaches an
+// identical antenna (the CommNet combinability model). Declared in the
 // cycle-1 schema; cycle 2 reads it.
 type Antenna struct {
 	Kind   string  `json:"kind"`
-	PowerW float64 `json:"power_w,omitempty"`
+	RangeM float64 `json:"range_m,omitempty"`
 }
 
 // PartOverride carries the only per-instance knobs a loadout may apply to
@@ -183,7 +185,7 @@ func (p Part) ToStage() Stage {
 	}
 	if p.Antenna != nil {
 		st.AntennaKind = p.Antenna.Kind
-		st.AntennaPowerW = p.Antenna.PowerW
+		st.AntennaRangeM = p.Antenna.RangeM
 	}
 	return st
 }

--- a/internal/spacecraft/catalog_test.go
+++ b/internal/spacecraft/catalog_test.go
@@ -89,7 +89,7 @@ func TestCatalogRoundTrip(t *testing.T) {
 				HasParachute:         false,
 				// Forward-compatible (cycle 2 / ADR 0027) — declared now.
 				CommandSource: "none",
-				Antenna:       &Antenna{Kind: "relay", PowerW: 5000},
+				Antenna:       &Antenna{Kind: "relay", RangeM: 5000},
 			},
 			{
 				ID:            "test-capsule",

--- a/internal/spacecraft/comms_test.go
+++ b/internal/spacecraft/comms_test.go
@@ -32,21 +32,21 @@ func TestCommandSourceDerivation(t *testing.T) {
 }
 
 // TestAntennaDerivation (C2-1): the vessel antenna mirror is the
-// highest-power antenna across the stack; a vessel with none reads none.
+// longest-ranged antenna across the stack; a vessel with none reads none.
 func TestAntennaDerivation(t *testing.T) {
-	tug := NewFromLoadout("Relay-Tug") // ntr-tug carries a relay antenna @ 4000 W
-	if tug.AntennaKind != AntennaRelay || tug.AntennaPowerW != 4000 {
-		t.Errorf("Relay-Tug antenna = %q/%g, want relay/4000", tug.AntennaKind, tug.AntennaPowerW)
+	tug := NewFromLoadout("Relay-Tug") // ntr-tug carries the relay-cislunar antenna
+	if tug.AntennaKind != AntennaRelay || tug.AntennaRangeM != AntennaRangeRelayCislunar {
+		t.Errorf("Relay-Tug antenna = %q/%g, want relay/%g", tug.AntennaKind, tug.AntennaRangeM, AntennaRangeRelayCislunar)
 	}
-	probe := NewFromLoadout("Station-Keeper") // ion-keeper: direct @ 1500 W
-	if probe.AntennaKind != AntennaDirect || probe.AntennaPowerW != 1500 {
-		t.Errorf("Station-Keeper antenna = %q/%g, want direct/1500", probe.AntennaKind, probe.AntennaPowerW)
+	probe := NewFromLoadout("Station-Keeper") // ion-keeper: direct-basic
+	if probe.AntennaKind != AntennaDirect || probe.AntennaRangeM != AntennaRangeDirectBasic {
+		t.Errorf("Station-Keeper antenna = %q/%g, want direct/%g", probe.AntennaKind, probe.AntennaRangeM, AntennaRangeDirectBasic)
 	}
 	// Saturn-V has no authored antenna, but as a defaulted probe it gets a
 	// basic telemetry antenna so it can be reached (else uncommandable).
 	sat := NewFromLoadout(LoadoutSaturnVID)
-	if sat.AntennaKind != AntennaDirect || sat.AntennaPowerW != DefaultProbeAntennaPowerW {
-		t.Errorf("Saturn-V antenna = %q/%g, want direct/%g (defaulted probe telemetry)", sat.AntennaKind, sat.AntennaPowerW, DefaultProbeAntennaPowerW)
+	if sat.AntennaKind != AntennaDirect || sat.AntennaRangeM != DefaultProbeAntennaRangeM {
+		t.Errorf("Saturn-V antenna = %q/%g, want direct/%g (defaulted probe telemetry)", sat.AntennaKind, sat.AntennaRangeM, DefaultProbeAntennaRangeM)
 	}
 	// A crewed vessel needs no antenna (crew are never comms-gated).
 	apollo := NewFromLoadout(LoadoutCapsuleID)

--- a/internal/spacecraft/data/loadouts.json
+++ b/internal/spacecraft/data/loadouts.json
@@ -200,6 +200,18 @@
           "part_id": "ion-keeper"
         }
       ]
+    },
+    {
+      "id": "Deep-Space-Relay",
+      "name": "Deep-Space Relay",
+      "role": "tug",
+      "glyph": "➤",
+      "color": "#FFD27F",
+      "parts": [
+        {
+          "part_id": "deep-space-relay"
+        }
+      ]
     }
   ]
 }

--- a/internal/spacecraft/data/parts.json
+++ b/internal/spacecraft/data/parts.json
@@ -449,7 +449,7 @@
       "command_source": "probe",
       "antenna": {
         "kind": "relay",
-        "power_w": 4000
+        "range_m": 1000000000
       }
     },
     {
@@ -470,7 +470,28 @@
       "command_source": "probe",
       "antenna": {
         "kind": "direct",
-        "power_w": 1500
+        "range_m": 10000000
+      }
+    },
+    {
+      "id": "deep-space-relay",
+      "name": "Deep-Space Relay",
+      "glyph": "➤",
+      "color": "#FFD27F",
+      "tier": "tug",
+      "dry_mass_kg": 4200,
+      "fuel_mass_kg": 9000,
+      "fuel_capacity_kg": 9000,
+      "thrust_n": 12000,
+      "isp_s": 4000,
+      "launch_sprite_rows_px": 7,
+      "launch_sprite_width_px": 3,
+      "launch_sprite_color": "#FFD27F",
+      "fuel_type": "hydrolox",
+      "command_source": "probe",
+      "antenna": {
+        "kind": "relay",
+        "range_m": 600000000000
       }
     }
   ]

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -380,7 +380,7 @@ func roleIsCrewedPod(role string) bool {
 const (
 	AntennaRangeDirectBasic   = 1.0e7  // near-Earth (LEO → geostationary), no forwarding
 	AntennaRangeRelayCislunar = 1.0e9  // Earth/Moon workhorse, forwards
-	AntennaRangeDeepSpace     = 6.0e11 // interplanetary
+	AntennaRangeDeepSpace     = 6.0e11 // Mars-class near opposition (far-interplanetary tuning deferred, #182)
 )
 
 // DefaultProbeAntennaRangeM is the basic telemetry antenna a defaulted probe

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -369,13 +369,42 @@ func roleIsCrewedPod(role string) bool {
 	return role == "capsule" || role == "mission-stack"
 }
 
-// DefaultProbeAntennaPowerW is the basic telemetry antenna a defaulted
-// probe core gets (ADR 0027): a bare launch vehicle / un-annotated custom
-// stack has a guidance + telemetry antenna in reality, so without one it
-// could never establish a connection and would be permanently
-// uncommandable once command-gating lands. Weaker than the dedicated
-// comsat / relay parts; the absolute value is deferred tuning.
-const DefaultProbeAntennaPowerW = 2000.0
+// Antenna tier rated ranges in metres (ADR 0027 §2 amendment, v0.22.x): the
+// reference tiers of the CommNet combinability model, where a link reaches
+// √(rangeₐ · range_b). These mirror the values authored in the catalog
+// (parts.json / ground_stations.json); kept here as named constants for the
+// default-probe backfill (EnsureCommandSource) and the save-compat re-ranging
+// of a pre-amendment save's antenna. Tier behaviour (vs the home DSN ≈ 5e9 m):
+// direct-basic reaches LEO→geostationary; relay-cislunar reaches the Moon and
+// forwards (the Relay-Tug); deep-space reaches Mars-class distances.
+const (
+	AntennaRangeDirectBasic   = 1.0e7  // near-Earth (LEO → geostationary), no forwarding
+	AntennaRangeRelayCislunar = 1.0e9  // Earth/Moon workhorse, forwards
+	AntennaRangeDeepSpace     = 6.0e11 // interplanetary
+)
+
+// DefaultProbeAntennaRangeM is the basic telemetry antenna a defaulted probe
+// core gets (ADR 0027): a bare launch vehicle / un-annotated custom stack has
+// a guidance + telemetry antenna in reality, so without one it could never
+// establish a connection and would be permanently uncommandable under the
+// command gate. The direct-basic tier.
+const DefaultProbeAntennaRangeM = AntennaRangeDirectBasic
+
+// DefaultAntennaRangeForKind returns the reference rated range for an antenna
+// kind. Used to re-range a pre-amendment save's antenna: those saves stored
+// the legacy antenna_power_w (now an ignored key), so the loaded range is 0 —
+// the save loader maps the surviving kind back to its tier. relay → cislunar,
+// direct → basic, none → 0.
+func DefaultAntennaRangeForKind(kind string) float64 {
+	switch kind {
+	case AntennaRelay:
+		return AntennaRangeRelayCislunar
+	case AntennaDirect:
+		return AntennaRangeDirectBasic
+	default:
+		return 0
+	}
+}
 
 // EnsureCommandSource stamps a default command source on a command-less
 // *vessel* so it stays controllable (ADR 0027 defaulting rule): if no
@@ -421,7 +450,7 @@ func EnsureCommandSource(c *Spacecraft) {
 	}
 	if !hasAntenna {
 		c.Stages[top].AntennaKind = AntennaDirect
-		c.Stages[top].AntennaPowerW = DefaultProbeAntennaPowerW
+		c.Stages[top].AntennaRangeM = DefaultProbeAntennaRangeM
 	}
 }
 

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -230,12 +230,13 @@ type Spacecraft struct {
 	Crewed       bool
 	Controllable bool
 
-	// AntennaKind / AntennaPowerW (v0.23 / ADR 0027): the vessel's
-	// effective comms antenna — the highest-power one across its stages,
-	// re-derived by SyncFields. Read by the connectivity graph (later
-	// cycle-2 slices). AntennaNone / zero means no antenna.
+	// AntennaKind / AntennaRangeM (v0.23 / ADR 0027): the vessel's
+	// effective comms antenna — the longest-ranged one across its stages,
+	// re-derived by SyncFields. Read by the connectivity graph. AntennaNone /
+	// zero means no antenna. AntennaRangeM is a rated range in metres (the
+	// combinability model; see sim.commLinkRangeM).
 	AntennaKind   string
-	AntennaPowerW float64
+	AntennaRangeM float64
 
 	// ChuteState (v0.12 Slice 3, ADR 0008): the runtime parachute
 	// deploy state — STOWED → ARMED → DEPLOYED, one-way, DEPLOYED

--- a/internal/spacecraft/stage.go
+++ b/internal/spacecraft/stage.go
@@ -222,12 +222,14 @@ type Stage struct {
 	// vessel-level Crewed / Controllable mirrors from the whole stack.
 	CommandSource string `json:",omitempty"`
 
-	// AntennaKind / AntennaPowerW (v0.23 / ADR 0027) declare this stage's
-	// comms hardware (AntennaNone / AntennaDirect / AntennaRelay + power).
-	// Authored on the Part; SyncFields derives the vessel-level antenna
-	// (the highest-power one in the stack) for the connectivity graph.
+	// AntennaKind / AntennaRangeM (v0.23 / ADR 0027) declare this stage's
+	// comms hardware: kind (AntennaNone / AntennaDirect / AntennaRelay) plus a
+	// rated range in metres — the distance at which it reaches an identical
+	// antenna (the CommNet combinability model; see sim.commLinkRangeM).
+	// Authored on the Part; SyncFields derives the vessel-level antenna (the
+	// longest-ranged one in the stack) for the connectivity graph.
 	AntennaKind   string  `json:",omitempty"`
-	AntennaPowerW float64 `json:",omitempty"`
+	AntennaRangeM float64 `json:",omitempty"`
 }
 
 // SumDryMass returns the total dry mass across every stage in kg.
@@ -318,11 +320,11 @@ func (s *Spacecraft) SyncFields() {
 	// (not just the bottom) — a probe core or relay antenna anywhere on
 	// the vessel makes the vessel controllable / relay-capable. Crewed
 	// wins over probe (a crewed pod is never comms-gated); the antenna is
-	// the highest-power one carried.
+	// the longest-ranged one carried.
 	s.Crewed = false
 	s.Controllable = false
 	s.AntennaKind = AntennaNone
-	s.AntennaPowerW = 0
+	s.AntennaRangeM = 0
 	for _, st := range s.Stages {
 		if IsCommandSource(st.CommandSource) {
 			s.Controllable = true
@@ -330,9 +332,9 @@ func (s *Spacecraft) SyncFields() {
 				s.Crewed = true
 			}
 		}
-		if st.AntennaKind != AntennaNone && st.AntennaPowerW > s.AntennaPowerW {
+		if st.AntennaKind != AntennaNone && st.AntennaRangeM > s.AntennaRangeM {
 			s.AntennaKind = st.AntennaKind
-			s.AntennaPowerW = st.AntennaPowerW
+			s.AntennaRangeM = st.AntennaRangeM
 		}
 	}
 }

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -88,7 +88,7 @@ type StageModule struct {
 	// a loadout-referenced part does via Part.ToStage.
 	commandSource string
 	antennaKind   string
-	antennaPowerW float64
+	antennaRangeM float64
 }
 
 // Catalog stage IDs.
@@ -203,11 +203,11 @@ func (p Part) toStageModule() StageModule {
 		hasParachute:        p.HasParachute,
 		commandSource:       p.CommandSource,
 		antennaKind:         antennaKindOf(p),
-		antennaPowerW:       antennaPowerOf(p),
+		antennaRangeM:       antennaRangeOf(p),
 	}
 }
 
-// antennaKindOf / antennaPowerOf read a Part's optional antenna safely.
+// antennaKindOf / antennaRangeOf read a Part's optional antenna safely.
 func antennaKindOf(p Part) string {
 	if p.Antenna == nil {
 		return AntennaNone
@@ -215,11 +215,11 @@ func antennaKindOf(p Part) string {
 	return p.Antenna.Kind
 }
 
-func antennaPowerOf(p Part) float64 {
+func antennaRangeOf(p Part) float64 {
 	if p.Antenna == nil {
 		return 0
 	}
-	return p.Antenna.PowerW
+	return p.Antenna.RangeM
 }
 
 // StageCatalogOrder is the configurator's canonical cycle order —
@@ -287,7 +287,7 @@ func BuildStage(id string) (Stage, bool) {
 		HasParachute:         m.hasParachute,
 		CommandSource:        m.commandSource,
 		AntennaKind:          m.antennaKind,
-		AntennaPowerW:        m.antennaPowerW,
+		AntennaRangeM:        m.antennaRangeM,
 	}, true
 }
 


### PR DESCRIPTION
Implements PRD #182. The placeholder range model bricked every unmanned probe
past ~13,600 km altitude — geostationary, lunar, and interplanetary probes were
permanently NO SIGNAL (the playtest report: "Relay-Tug can't reach Earth at
35,876 km"). Replaces it with KSP-style combinability + antenna tiers.

## Changes
- **Formula:** link range = `√(ratedₐ · rated_b)` — the powerful DSN extends a
  weak craft's reach; `CommRangePerWatt` removed.
- **Antenna attribute renamed** `power_w → range_m` (a rated self-range in
  metres) across `Part` / `Stage` / save wire / ground stations / the
  default-probe const.
- **Tiers** (rated self-range): direct-basic `1e7` (LEO→GEO), relay-cislunar
  `1e9` (Earth/Moon + forwarding — the Relay-Tug), deep-space `6e11` (Mars-class,
  new `deep-space-relay` part + `Deep-Space-Relay` loadout); DSN `5e9`.
- **Save-compat, no schema bump:** a pre-amendment save stored `antenna_power_w`
  (now ignored) → range loads as 0, and `wireStagesToSim` re-ranges from the
  surviving antenna kind (relay→cislunar, direct→basic).

## Reach (verified by tests, vs the DSN)
| antenna | GEO 35,786 km | Moon 384,400 km | Mars ~40M km |
|---|---|---|---|
| direct-basic | ✅ | ❌ | ❌ |
| relay-cislunar (Relay-Tug) | ✅ | ✅ | ❌ |
| deep-space | ✅ | ✅ | ✅ |

Two Relay-Tugs bridge cislunar via forwarding; out-of-range is still NO SIGNAL.

## Tests
Single integration seam (`RecomputeCommGraph` → `HasConnection`/`CanCommandCraft`)
per the PRD: `TestCommReachTiers`, `TestCommRelayChainBridgesCislunar`, plus
`TestPreAmendmentAntennaReRanged` (save-compat) and the existing connectivity /
catalog / save tests retuned. `go vet ./...` + `go test ./... -race -count=1`
green (15 packages). No hard save break.

## Notes
- The LEO occlusion coverage gaps (genuine, minutes-long) are unchanged and
  intended; the v0.22.1 self-occlusion flicker was a separate fix.
- Targets a **v0.22.2** point release.