### PR TITLE
Force-bridge the relay path so long hops render (C2-7 follow-up)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1700,7 +1700,12 @@ func (v *OrbitView) drawCommPath(w *sim.World) {
 		return
 	}
 	for i := 0; i+1 < len(pts); i++ {
-		v.canvas.PlotDenseLineColored(pts[i], pts[i+1], render.ColorCommLink, 3)
+		// Force-bridge: a relay link is a real straight sightline, so it must
+		// draw all the way toward its (often off-screen) far endpoint — a
+		// Moon→Earth hop spans far more than the canvas. The guarded variant
+		// would dot-only such a hop (the orbit-arc rule); the forced variant
+		// clips to the canvas and draws the visible run (C2-7 follow-up).
+		v.canvas.PlotDenseLineForcedColored(pts[i], pts[i+1], render.ColorCommLink, 3)
 	}
 }
 

--- a/internal/tui/screens/orbit_comms_path_test.go
+++ b/internal/tui/screens/orbit_comms_path_test.go
@@ -43,3 +43,30 @@ func TestDrawCommPath(t *testing.T) {
 		t.Error("a connected probe should draw its relay path on the canvas")
 	}
 }
+
+// TestDrawCommPathBridgesLongHop: a relay hop longer than the canvas (a
+// Moon→Earth-scale leg) must still draw its visible run. The hop here straddles
+// the whole canvas with both endpoints off-screen — the old guarded line
+// primitive would draw nothing (both endpoint dots off-canvas), so a changed
+// canvas proves drawCommPath force-bridges the link instead of dot-only.
+func TestDrawCommPathBridgesLongHop(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.canvas.Resize(60, 30) // 120 × 120 px grid
+	v.canvas.SetScale(1)
+	v.canvas.Center(orbital.Vec3{})
+
+	c := &spacecraft.Spacecraft{ID: 1, Controllable: true}
+	w := &sim.World{Crafts: []*spacecraft.Spacecraft{c}, ActiveCraftIdx: 0}
+	w.CommGraph = &sim.CommGraph{
+		Connected: map[uint64]bool{1: true},
+		// Endpoints project to x=-40 and x=160 — both off-canvas, straddling
+		// the 120px-wide view: the guarded variant draws 0 pixels here.
+		Paths: map[uint64][]orbital.Vec3{1: {{X: -100}, {X: 100}}},
+	}
+	v.canvas.Clear()
+	blank := v.canvas.String()
+	v.drawCommPath(w)
+	if v.canvas.String() == blank {
+		t.Error("drawCommPath must force-bridge a long straddling relay hop (guarded would draw nothing)")
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -679,6 +679,99 @@ func (c *Canvas) PlotDenseLineColored(a, b orbital.Vec3, color lipgloss.Color, s
 	}
 }
 
+// PlotDenseLineForcedColored draws a dotted line between world points a and b
+// like PlotDenseLineColored, but WITHOUT the "too long to bridge" guard: it
+// always connects the two points, clipping the segment to the canvas so a link
+// to a far off-screen endpoint draws its visible run with O(canvas) iteration
+// rather than O(projected distance). Use for a genuine straight sightline — a
+// CommNet relay link (C2-7) — where the chord IS the real path and must draw
+// all the way toward its (possibly off-screen) far endpoint, e.g. a Moon→Earth
+// relay hop. Orbit-arc chords keep the guarded variant, which refuses to bridge
+// a long chord because that chord is NOT a real straight path across the view.
+func (c *Canvas) PlotDenseLineForcedColored(a, b orbital.Vec3, color lipgloss.Color, step int) {
+	if step < 1 {
+		step = 1
+	}
+	ax, ay, _ := c.Project(a)
+	bx, by, _ := c.Project(b)
+	cax, cay, cbx, cby, ok := clipSegmentToCanvas(ax, ay, bx, by, c.pxW, c.pxH)
+	if !ok {
+		return // segment lies wholly off the canvas
+	}
+	if c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	plotPx := func(px, py int) {
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			return
+		}
+		c.dc.Set(px, py)
+		c.pixelTags[[2]int{px, py}] = CellTag{Color: color}
+	}
+	dx, dy := cbx-cax, cby-cay
+	n := dx
+	if n < 0 {
+		n = -n
+	}
+	if ady := dy; ady < 0 {
+		if -ady > n {
+			n = -ady
+		}
+	} else if ady > n {
+		n = ady
+	}
+	if n == 0 {
+		plotPx(cax, cay)
+		return
+	}
+	for i := 0; i <= n; i += step {
+		plotPx(
+			cax+int(math.Round(float64(dx)*float64(i)/float64(n))),
+			cay+int(math.Round(float64(dy)*float64(i)/float64(n))),
+		)
+	}
+}
+
+// clipSegmentToCanvas clips the pixel segment [(ax,ay),(bx,by)] to the canvas
+// rectangle [0,w-1]×[0,h-1] via Liang-Barsky, returning the clipped integer
+// endpoints and ok=false when the segment lies wholly outside. Bounds the
+// forced dense-line iteration so a link to a far off-screen endpoint costs
+// O(canvas), not O(projected distance).
+func clipSegmentToCanvas(ax, ay, bx, by, w, h int) (int, int, int, int, bool) {
+	x0, y0 := float64(ax), float64(ay)
+	dx, dy := float64(bx-ax), float64(by-ay)
+	maxX, maxY := float64(w-1), float64(h-1)
+	p := [4]float64{-dx, dx, -dy, dy}
+	q := [4]float64{x0, maxX - x0, y0, maxY - y0}
+	u0, u1 := 0.0, 1.0
+	for i := 0; i < 4; i++ {
+		if p[i] == 0 {
+			if q[i] < 0 {
+				return 0, 0, 0, 0, false // parallel to an edge and outside it
+			}
+			continue
+		}
+		t := q[i] / p[i]
+		if p[i] < 0 {
+			if t > u1 {
+				return 0, 0, 0, 0, false
+			}
+			if t > u0 {
+				u0 = t
+			}
+		} else {
+			if t < u0 {
+				return 0, 0, 0, 0, false
+			}
+			if t < u1 {
+				u1 = t
+			}
+		}
+	}
+	return int(math.Round(x0 + u0*dx)), int(math.Round(y0 + u0*dy)),
+		int(math.Round(x0 + u1*dx)), int(math.Round(y0 + u1*dy)), true
+}
+
 // Cols / Rows expose the configured terminal cell dimensions.
 func (c *Canvas) Cols() int { return c.cols }
 func (c *Canvas) Rows() int { return c.rows }

--- a/internal/tui/widgets/dense_line_test.go
+++ b/internal/tui/widgets/dense_line_test.go
@@ -125,6 +125,63 @@ func TestPlotDenseLineLongChordNotBridged(t *testing.T) {
 	}
 }
 
+// TestPlotDenseLineForcedBridgesLongChord: the forced variant (for genuine
+// straight sightlines — a CommNet relay link) DOES bridge a chord longer than
+// the canvas, drawing the visible run all the way toward a far off-screen
+// endpoint — the case the guarded variant deliberately refuses (compare
+// TestPlotDenseLineLongChordNotBridged).
+func TestPlotDenseLineForcedBridgesLongChord(t *testing.T) {
+	c := NewCanvas(60, 30) // 120 × 120 px, centre (60,60)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	color := lipgloss.Color("#34E2D0")
+	a := orbital.Vec3{}          // centre, on-canvas
+	b := orbital.Vec3{X: 100000} // far off the right edge
+	c.PlotDenseLineForcedColored(a, b, color, 1)
+
+	px := taggedPixels(c, color)
+	cx, cy, _ := c.Project(a) // (60,60)
+	if len(px) < 50 {
+		t.Fatalf("forced long chord set %d pixels, want the visible run (~%d, centre→right edge)", len(px), 120-cx)
+	}
+	for _, p := range px {
+		if p[1] != cy {
+			t.Errorf("pixel %v off the y=%d line", p, cy)
+		}
+		if p[0] < cx || p[0] >= 120 {
+			t.Errorf("pixel %v outside the visible run [%d,119]", p, cx)
+		}
+	}
+}
+
+// TestPlotDenseLineForcedClipsStraddle: a forced chord with BOTH endpoints
+// off-canvas on opposite sides (the guarded variant draws nothing — both
+// endpoint dots are off-screen) draws its full visible run, clipped to the
+// canvas, with bounded iteration.
+func TestPlotDenseLineForcedClipsStraddle(t *testing.T) {
+	c := NewCanvas(60, 30) // 120 × 120 px, centre (60,60)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	color := lipgloss.Color("#34E2D0")
+	a := orbital.Vec3{X: -100} // → pixel x = -40 (off-left)
+	b := orbital.Vec3{X: 100}  // → pixel x = 160 (off-right)
+	c.PlotDenseLineForcedColored(a, b, color, 1)
+
+	px := taggedPixels(c, color)
+	if len(px) < 100 {
+		t.Errorf("forced straddle set %d pixels, want ~120 (the full visible width)", len(px))
+	}
+	for _, p := range px {
+		if p[0] < 0 || p[0] >= 120 || p[1] < 0 || p[1] >= 120 {
+			t.Errorf("pixel %v outside canvas bounds (clip failed)", p)
+		}
+	}
+}
+
 // TestPlotDenseLineOffCanvasSkipped: a chord lying wholly off one edge sets
 // nothing and returns promptly (the same-off-edge guard), so a zoomed-in
 // leg's off-screen samples cost nothing.


### PR DESCRIPTION
Playtest (v0.22.2): a relay network around the Moon hopping back to GEO/Earth
relays renders the local mesh but **not the long leg home**.

## Cause
`drawCommPath` hands the full multi-hop chain (probe → relays → station) to
`PlotDenseLineColored`, but that primitive deliberately refuses to bridge a chord
longer than the canvas's shorter dimension — the orbit-arc rule (ADR 0023 C),
where a long chord between two orbit samples can shoot a bogus line across the
view. A relay link is the opposite: a real, straight, unoccluded sightline, so
bridging it is *always* correct. At Moon zoom a Moon→Earth hop spans tens of
canvas-widths → it drew only endpoint dots (and an off-screen far relay drew
nothing), so the leg "back to Earth" never rendered.

## Fix
- `PlotDenseLineForcedColored` — the same dotted line **without** the too-long
  guard, with **Liang-Barsky clipping** (`clipSegmentToCanvas`) so a link toward a
  far off-screen endpoint draws its visible run with O(canvas) iteration, not
  O(projected distance).
- `drawCommPath` uses it; orbit-arc chords keep the guarded variant unchanged.

## Tests
- `TestPlotDenseLineForcedBridgesLongChord` — bridges a chord longer than the
  canvas (vs the guarded `TestPlotDenseLineLongChordNotBridged` which dots only).
- `TestPlotDenseLineForcedClipsStraddle` — a both-off-canvas straddle draws its
  full visible run, clipped to bounds.
- `TestDrawCommPathBridgesLongHop` — drawCommPath force-bridges a long straddling
  hop the guarded variant would have drawn nothing for.

`go vet ./...` + `go test ./... -race -count=1` green (15 packages). Pure render
change — no save/sim impact. Ships as a v0.22.x point release.