### PR TITLE
v0.24 — In-game VAB: composable parts + custom designs (ADR 0029)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,9 @@ and a list of Stages. The catalog (`internal/spacecraft/loadouts.go`) of
 designs the player picks from at spawn time; `NewFromLoadout` instantiates
 a Vessel from one. Loadouts also carry per-vehicle tuning like
 `SlewRateDegPerSec`.
-_Avoid_: Template, Blueprint, Design.
+_Avoid_: Template, Blueprint. (**Design** is now a *distinct* noun — a
+player-saved VAB vehicle, v0.24 / ADR 0029 — so don't call a built-in Loadout
+a Design.)
 
 **Stage**:
 One decoupleable propulsion module on a Vessel. Convention: `Stages[0]` is
@@ -104,6 +106,79 @@ pick drops the four Apollo Stages `[SM, CM, Descent, Ascent]` with the
 seam set between `CM` and `Descent`, so the spawned Composite fires the
 SM and carries the LM as an Undockable payload.
 _Avoid_: Payload boundary, Split point, Stack divider.
+
+**Part**:
+The normalized, data-authored catalog stage (`internal/spacecraft/catalog.go`,
+ADR 0026): one **Part** materializes into one runtime **Stage** via `ToStage`
+at spawn, and a **Loadout** references Parts by ID rather than inlining Stage
+literals. A Part is **atomic** when its scalar stats (dry mass, fuel, thrust,
+Isp, …) are authored inline, or **composed** when it instead declares a
+`components` list and its stats are **derived by Aggregation** at load time
+(v0.24 / ADR 0029). The two are indistinguishable downstream — both become one
+flat Stage — so the runtime never knows which it was; today's whole catalog is
+atomic, so the migration to composability cost zero changes. Embedded + user
+overlay catalog files supply Parts (user wins on ID).
+_Avoid_: Stage (a Part *becomes* a Stage, but a Part is catalog data, a Stage
+is runtime state), Component (the finer noun below), Module.
+
+**Component** (v0.24 / ADR 0029):
+The finest catalog noun — one level below a **Part**. A composed Part lists
+Components by ID; **Aggregation** collapses them into the Part's flat scalars.
+Five **Component Kinds** ship: **engine** (thrust / Isp / fuel type), **tank**
+(fuel capacity / fuel type), **command-core** (a control point — crewed or
+probe — plus optional soft-land / parachute), **antenna** (direct / relay +
+range), and **structure** (inert dry mass: adapters, fairings, ballast). The
+**VAB** composes vehicles from Components. **NB:** this is a *different* noun
+from a **Docked Component** (an element of a **Composite**) — see Flagged
+ambiguities.
+_Avoid_: Part (a Component is finer — many compose one Part), Docked Component
+(unrelated — that's a composite element), Module.
+
+**Aggregation** (v0.24 / ADR 0029):
+The load-time pass that derives a composed **Part**'s flat **Stage** scalars
+from its **Components**: dry mass and tank capacity are **additive** (Σ);
+multiple engines combine honestly — thrust adds (`Thrust = ΣF_i`) and the
+effective Isp is the **thrust-weighted** parallel-engine blend `Isp_eff = ΣF_i
+/ Σ(F_i / Isp_i)` (exact for a single fuel pool); command-source and antenna
+attributes ride up. A stage holds **one fuel chemistry** — a mixed-chemistry
+Part is a catalog warning and the VAB rejects it in the editor — which keeps
+the single-`FuelMass`-pool runtime and the burn integrator untouched.
+_Avoid_: Composition (the act, not the math), Summing (only mass/capacity sum —
+Isp is thrust-weighted, not summed).
+
+**Vehicle Assembly (VAB)**:
+The in-game builder screen (`internal/tui/screens/vab.go`, v0.24 / ADR 0029),
+reached from the pause menu (`Esc → [Build (VAB)]`). The player composes
+**Components** into stages, stacks stages into a vehicle, marks **Dock Seams**
+(N **Nose Payloads**) and fused decouple groups, and reads a live **Δv / TWR /
+mass** panel — then saves the result as a **Design**. Like every screen it
+reads shared state and routes mutations elsewhere; here it owns the **Designs
+Store** I/O directly (designs are app-managed catalog data, not World state).
+_Avoid_: Editor, Configurator (that name belongs to the spawn-form quick stack
+builder — coarser, whole-modules-only, not persistent), Workshop.
+
+**Design** (v0.24 / ADR 0029):
+A saved custom vehicle built in the **VAB**: a **Loadout** plus the **composed
+Parts** it references, serialized as a self-contained catalog fragment. A
+Design is **catalog data, not save state** — global across games, no
+save-schema bump — and lives in the **Designs Store**. At spawn it resolves
+against the live catalog into a flyable Loadout (composed Parts aggregated,
+atomic refs resolved, plans carried), so a Design flies identically to a
+built-in Loadout, and the spawn form lists Designs alongside the built-ins
+(design once, launch many). A first-class noun, distinct from a built-in
+**Loadout**.
+_Avoid_: Loadout (a Design is a *player-saved* vehicle that resolves to its own
+Loadout, outside the built-in catalog namespace), Blueprint, Craft file.
+
+**Designs Store** (v0.24 / ADR 0029):
+The app-managed directory of saved **Designs**
+(`$XDG_CONFIG_HOME/terminal-space-program/designs/`), kept distinct from the
+hand-authored modder overlay (`loadouts/`) so app-written files never override
+a built-in by ID collision. The **VAB** owns its writes and deletes. A Design
+file is a portable catalog fragment — copy it into the sibling `loadouts/`
+overlay to publish it as a mod.
+_Avoid_: Save dir (that is the game-save location, `save.json`), Catalog (the
+embedded / built-in set).
 
 **Service Module (SM)**:
 The propulsive half of the Apollo command-and-service module: carries the
@@ -2179,7 +2254,8 @@ in code review means the opposite of "high BC" in an aerospace paper.
 Always confirm which convention the speaker is using before discussing
 specific values.
 
-**"Component"** collides with **Stage** as a word for "part of a Vessel":
+**"Component"** is a three-way collision — two runtime senses plus, from
+v0.24, a catalog one:
 
 - **Stage** — one element of a Vessel's decoupleable propulsion stack
   (`Stages[i]`). Carries dry mass, fuel, thrust, Isp, ballistic
@@ -2190,20 +2266,28 @@ specific values.
   dry mass, capacities, engine numbers) but **not** state, Maneuver
   Nodes, or Burns. Used by **Undocking** to restore the pre-Dock
   Vessels. Player concept: *the original ship I docked in*.
+- **Component** (catalog, v0.24 / ADR 0029) — the finest *catalog* noun:
+  an engine / tank / command-core / antenna / structure that **composes
+  into a Part** via **Aggregation**. It is build-time catalog data, not a
+  runtime element of a Vessel at all. Player concept: *a part I bolt onto
+  a stage in the VAB*.
 
-Both are "parts of a Vessel" but at different abstraction levels. A
-Composite has both: its **Stages** are the concatenated propulsion
-stack (lead's + partner's, appended on top), its **Docked Components**
-are the original Vessel identities it can decompose back into. Docking
-does **not** add one Component per Stage — it adds *one Component per
-pre-Dock Vessel*, even if that Vessel had multiple stages.
+The first two are "parts of a Vessel" at different abstraction levels; the
+third is catalog data one level *below* a Stage (Components → a composed
+**Part** → one **Stage**). A Composite has both runtime senses: its
+**Stages** are the concatenated propulsion stack (lead's + partner's,
+appended on top), its **Docked Components** are the original Vessel
+identities it can decompose back into. Docking does **not** add one Docked
+Component per Stage — it adds *one per pre-Dock Vessel*, even if that Vessel
+had multiple stages.
 
-**Resolution:** "Stage" is the unambiguous term for the propulsion unit.
-Bare "component" in code-review prose should be qualified as "Docked
-Component" when ambiguity threatens. A diagnostic: if you see
-`len(c.Stages) == 3 && len(c.DockedComponents) == 2`, that's a Composite
-of two pre-Dock Vessels whose stage counts sum to 3 (probably 1+2 or
-2+1).
+**Resolution:** "Stage" is the unambiguous term for the runtime propulsion
+unit. Qualify bare "component" as **Docked Component** (a composite element)
+or **catalog Component** (a VAB build-part) when ambiguity threatens — they
+never appear in the same breath, since one is runtime and the other is
+build-time. A diagnostic: if you see `len(c.Stages) == 3 &&
+len(c.DockedComponents) == 2`, that's a Composite of two pre-Dock Vessels
+whose stage counts sum to 3 (probably 1+2 or 2+1).
 
 **"Encounter"** has two distinct meanings split across domains:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Each vessel is bound for its lifetime to the system it spawns in — the simulat
 
 When your live trajectory is heading into a body's sphere of influence, the orbit map draws the full encounter arc ahead of arrival — entry, perilune, and exit — with a Perilune `⊕` marker and an always-on **SOI PASS** chip showing the altitude and time to closest approach. No need to target the body first. Every orbital marker (apoapsis, periapsis, nodes, closest approach, maneuver nodes) is now a single colored glyph: shape is type, color is type, brightness is state (nominal / counterfactual / alarm). To read an encounter up close, press `f` to focus the body it passes — the camera fits to the body's sphere of influence so the capture curve fills the canvas, and from there the view is yours: `+`/`-` zoom holds until you change focus, view, or system.
 
+Recently introduced: an in-game **Vehicle Assembly Building (VAB)**. From the
+main view press `Esc → [Build (VAB)]` to design your own rocket from fine
+parts — compose engines, fuel tanks, command cores, antennas, and structure
+into stages, stack the stages, mark dock seams for nose payloads, and watch a
+live **Δv / TWR / mass** readout as you build. Save a design and it shows up in
+the spawn form (`n`) alongside the built-in craft, so you design once and
+launch many. Designs are portable files under
+`~/.config/terminal-space-program/designs/` (KSP `.craft`-style); drop one into
+the sibling `loadouts/` overlay dir to share it as a mod. Multiple engines in a
+stage combine honestly (thrust adds, Isp is the thrust-weighted blend) and a
+stage holds a single fuel chemistry, so everything you build flies on the same
+honest physics as the shipped fleet.
+
 The visual foundation was lifted (with MIT attribution) from
 [furan917/go-solar-system](https://github.com/furan917/go-solar-system). See
 [NOTICE.md](NOTICE.md) for the full acknowledgments list.

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -91,7 +91,7 @@ readout shows you why before you watch it fall back.
 
 | Key | Action |
 |---|---|
-| `Esc` | Back, or open the save / load / settings / controls / quit menu on the main view |
+| `Esc` | Back, or open the save / load / build / settings / controls / quit menu on the main view |
 | `Ctrl+C` | Quit immediately |
 | `F1` | Toggle the help overlay (scroll it with `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End`) |
 | `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
@@ -125,7 +125,7 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
 | `shift+←` / `shift+→` | Yaw the 3D view left / right in 5° steps, wrapping all the way around (only in the tilted view) |
 | `F2` | Declutter — hide all overlays (the corner chips and the navball) for a clean look at the orbit. Press again to bring them back. Your core telemetry column stays put |
-| `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build your own rocket stack: on the stack field, `←` / `→` browse parts, `a` adds one on top, `x` removes the top one |
+| `n` | Open the spawn form (craft, where to start, which body, altitude, direction). Pick **Custom…** to build a quick stack from whole modules, or pick one of your **saved designs** (listed after Custom…) built in the VAB (`Esc → [Build (VAB)]`) |
 | `H` | Plan a transfer to your target. To a moon of the planet you're at, it works out two ways to get there and plans the cheaper one, showing you both fuel costs. To another planet, it plans a standard Hohmann transfer. To a moon's parent planet, it plans an escape |
 | `I` | Plan a burn to match your target's orbital tilt (or to level out to the equator when nothing is targeted) |
 | `C` | Plan a circularising burn at the top of your orbit — pairs with the ORBIT READY cue on launch. Won't work if the top of your orbit is still inside the atmosphere or you're on an escape trajectory |
@@ -223,3 +223,38 @@ turn it on for low-thrust craft or big burns where the loss is noticeable.
 
 The cursor opens on the cheapest cell. A `·` marks cells where no transfer was
 found — `Enter` does nothing there.
+
+### Vehicle Assembly (VAB) (`Esc → [Build (VAB)]`)
+
+The VAB is where you design a custom vehicle from fine parts and save it to
+launch later. You compose **components** — engines, fuel tanks, command cores,
+antennas, and structure — into stages, stack the stages into a vehicle, and
+read a live **Δv / TWR / mass** panel as you go. Saved designs are global (they
+survive across games) and show up in the spawn form (`n`) alongside the
+built-in craft, so you design once and launch many.
+
+| Key | Action |
+|---|---|
+| `Tab` | Switch the active pane (palette ↔ stack) |
+| `←` / `→` | Move the palette cursor (browse components by kind, then catalog parts) |
+| `↑` / `↓` | Move the cursor in the active pane |
+| `a` | Add the selected component to the current stage — or, for a catalog part, add it as a new whole stage |
+| `n` | Start a new empty stage on top |
+| `x` | Remove the last component from the stage (or the whole stage when it's empty / a catalog part) |
+| `d` | Toggle a **dock seam** below the stage — everything above the seam becomes a nose payload you release with Undock (`U`) instead of staging. Mark several seams for several payloads |
+| `c` | Toggle a **fused decouple** — the stage drops together with the group below it on one staging press |
+| `s` | Name and save the design |
+| `o` | Open a saved design to edit (`x` deletes the highlighted one) |
+| `Esc` | Back to the map |
+
+A stage can hold only **one fuel chemistry** — the VAB won't let you mix, say,
+a kerolox engine with a hydrolox tank in the same stage. Multiple engines in
+one stage are fine and combine honestly (thrust adds; the effective Isp is the
+thrust-weighted blend). Soft warnings flag the usual snags — no engine, no
+command source (it defaults to a probe core on spawn), or a lift-off TWR below
+1 — but never block you from saving.
+
+Designs are stored as portable files under
+`$XDG_CONFIG_HOME/terminal-space-program/designs/` (typically
+`~/.config/terminal-space-program/designs/`); copy one into the
+`loadouts/` overlay dir next to it to share it as a mod.

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -4,6 +4,8 @@ Newest first. Per-version detail: [state-of-game.md](../designdocs/terminal-spac
 
 ---
 
+**v0.24.0** — In-game Vehicle Assembly Building (ADR 0029). A new `Esc → [Build (VAB)]` screen lets you compose fine **components** (engine / tank / command-core / antenna / structure) into stages, stack stages into a vehicle, mark N dock seams for nose payloads and fused decouple groups, and read a live Δv / TWR / mass panel as you build. Cashes in ADR 0026's forward-compat note: a catalog `Part` gains an optional `components` list whose stats are derived by aggregation (thrust adds; Isp is the thrust-weighted blend; one fuel chemistry per stage), so existing atomic parts stay byte-identical. Designs save as portable catalog fragments under `~/.config/terminal-space-program/designs/` and appear in the spawn form (`n`) alongside the built-ins — design once, launch many. Closes ADR 0028's deferred configurator N-seam. No save break.
+
 **v0.23.0** — Deployable payloads (ADR 0028, PR #186). A new `Y` Deploy verb releases the top carried payload as its own craft while keeping the carrier active — distinct from Undock, which switches you to the released piece. `NosePayloadPlan` supports N stacked payloads so one launch can deploy a full constellation; five starter loadouts ship (Relay Comsat, Ground-Station Lander, Science Probe, Comsat Carrier ×3, Survey Pack). Soft-landing a relay-antenna craft auto-joins the CommNet graph as a player-deployed ground station with no extra step. No save break.
 
 **v0.22.3** — CommNet relay-path rendering fix (PR #185). Long relay hops weren't drawn all the way to the destination. A new canvas primitive draws the beam without the too-long-chord guard, so the full relay chain renders at any zoom. No save break.

--- a/internal/sim/spawn.go
+++ b/internal/sim/spawn.go
@@ -85,6 +85,14 @@ type SpawnSpec struct {
 	Inclination float64
 	Alongside   bool
 
+	// DesignID (v0.24 / ADR 0029) names a saved VAB design to spawn. When
+	// set it takes precedence over LoadoutID / CustomStages: SpawnCraft loads
+	// the design from the app-managed store, resolves it against the live
+	// catalog (composed parts aggregated, atomic refs resolved, decouple +
+	// nose-payload plans carried), and builds the craft — so a design flies
+	// identically to an equivalent catalog loadout. Placement is orthogonal.
+	DesignID string
+
 	// CustomStages (v0.10.1+) is a player-assembled stage list from
 	// the spawn-form stack configurator, bottom-first (same
 	// convention as Loadout.Stages). When non-empty it builds the
@@ -162,7 +170,20 @@ func (w *World) SpawnCraft(spec SpawnSpec) (*spacecraft.Spacecraft, error) {
 	active := w.ActiveCraft()
 
 	var c *spacecraft.Spacecraft
-	if len(spec.CustomStages) > 0 {
+	if spec.DesignID != "" {
+		// v0.24 / ADR 0029: spawn a saved VAB design. Resolve it against the
+		// live catalog; an unknown or unresolvable design is a surfaced error
+		// rather than a silent fallback.
+		d, ok, _ := spacecraft.LoadDesign(spec.DesignID)
+		if !ok {
+			return nil, fmt.Errorf("spawn: design %q not found", spec.DesignID)
+		}
+		l, warns := d.Resolve()
+		if len(l.Stages) == 0 {
+			return nil, fmt.Errorf("spawn: design %q failed to resolve (%d warnings)", spec.DesignID, len(warns))
+		}
+		c = newDesignCraft(l)
+	} else if len(spec.CustomStages) > 0 {
 		// v0.10.1+: player-assembled stack from the configurator.
 		// Ignores LoadoutID — a custom craft is not a catalog
 		// archetype. NewFromStages returns nil only on an empty
@@ -463,6 +484,23 @@ func splitNosePayloads(c *spacecraft.Spacecraft, nosePayloadPlan []int) bool {
 	}
 	c.DockedComponents = comps
 	return true
+}
+
+// newDesignCraft builds a craft from a saved design's resolved Loadout
+// (v0.24 / ADR 0029). Mirrors newCatalogCraft — a baked NosePayloadPlan
+// assembles a deployable docked composite, an ordinary design stays linear —
+// but builds from a Loadout value (designs live outside the global Loadouts
+// map). The design keeps its authored identity (name / glyph / colour) just
+// like a catalog carrier.
+func newDesignCraft(l spacecraft.Loadout) *spacecraft.Spacecraft {
+	c := spacecraft.NewFromLoadoutValue(l)
+	if c == nil {
+		return c
+	}
+	if len(l.NosePayloadPlan) > 0 {
+		splitNosePayloads(c, l.NosePayloadPlan) // no-op on a malformed plan → linear
+	}
+	return c
 }
 
 // newCatalogCraft builds a catalog craft, assembling it into a deployable

--- a/internal/sim/spawn_design_test.go
+++ b/internal/sim/spawn_design_test.go
@@ -1,0 +1,85 @@
+package sim
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestSpawnDesignBuildsFromStore — v0.24 / ADR 0029 S4: a saved VAB design
+// spawns a craft resolved against the live catalog (composed parts
+// aggregated, decouple plan carried). The design references the embedded
+// starter components, so it resolves from the shipped catalog alone.
+func TestSpawnDesignBuildsFromStore(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// A two-stage design: a composed booster under the composed probe sat.
+	design := spacecraft.Design{
+		Loadout: spacecraft.LoadoutDef{
+			ID:    "test-orbiter",
+			Name:  "Test Orbiter",
+			Role:  "custom",
+			Glyph: spacecraft.VesselGlyph,
+			Color: "#5BB3FF",
+			Parts: []spacecraft.PartRef{
+				{PartID: "_test-orbiter_s0"},
+				{PartID: "probe-sat-stage"}, // an embedded composed catalog part
+			},
+			DecouplePlan: []int{1},
+		},
+		Parts: []spacecraft.Part{
+			{ID: "_test-orbiter_s0", Name: "Booster", Glyph: spacecraft.VesselGlyph, Color: "#FFD93D",
+				Components: []string{"probe-engine", "probe-tank-1k"}},
+		},
+	}
+	if err := spacecraft.SaveDesign(design); err != nil {
+		t.Fatalf("SaveDesign: %v", err)
+	}
+
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(SpawnSpec{
+		DesignID:     "test-orbiter",
+		ParentBodyID: "earth",
+		AltitudeM:    400e3,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(design): %v", err)
+	}
+	if w.ActiveCraft() != c {
+		t.Fatal("design craft not active after spawn")
+	}
+	if len(c.Stages) != 2 {
+		t.Fatalf("design craft stages = %d, want 2", len(c.Stages))
+	}
+	// Bottom stage is the composed booster (engine + tank → 50 kN, dry 300).
+	if c.Stages[0].Thrust != 50000 || c.Stages[0].DryMass != 300 {
+		t.Errorf("booster stage = %g N / %g kg dry, want 50000/300", c.Stages[0].Thrust, c.Stages[0].DryMass)
+	}
+	// Top stage is the embedded composed probe sat (dry 400).
+	if c.Stages[1].DryMass != 400 {
+		t.Errorf("probe-sat stage dry = %g, want 400", c.Stages[1].DryMass)
+	}
+	if !strings.HasPrefix(c.Name, "Test Orbiter") {
+		t.Errorf("craft name = %q, want the design name (+ spawn suffix)", c.Name)
+	}
+	if c.Primary.ID != "earth" {
+		t.Errorf("primary = %q, want earth", c.Primary.ID)
+	}
+}
+
+// TestSpawnDesignMissingErrors — an unknown design ID surfaces an error
+// rather than silently falling back to a default loadout.
+func TestSpawnDesignMissingErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(SpawnSpec{DesignID: "no-such-design"}); err == nil {
+		t.Error("spawning an unknown design should error, not fall back")
+	}
+}

--- a/internal/spacecraft/catalog.go
+++ b/internal/spacecraft/catalog.go
@@ -27,7 +27,7 @@ import (
 // and need the catalog only at spawn time, so the loadout catalog is not
 // wired into BodyCatalogHash.
 
-//go:embed data/parts.json data/loadouts.json
+//go:embed data/components.json data/parts.json data/loadouts.json
 var catalogFS embed.FS
 
 // Part is a normalized, data-authored atomic stage — engine + tank +
@@ -77,6 +77,15 @@ type Part struct {
 	// Antenna declares the part's antenna {kind, power}.
 	CommandSource string   `json:"command_source,omitempty"`
 	Antenna       *Antenna `json:"antenna,omitempty"`
+
+	// Components (v0.24 / ADR 0029 §1, the VAB cycle) optionally declares
+	// this Part a composition of finer Components by ID. Absent ⇒ the Part
+	// is atomic and its inline scalar fields above are authoritative
+	// (unchanged, byte-identical). Present ⇒ the scalar fields are DERIVED
+	// by aggregateComponents at load time (thrust-weighted Isp, additive
+	// mass / capacity, single fuel type per stage). Zero migration: today's
+	// catalog declares no components, so every existing Part stays atomic.
+	Components []string `json:"components,omitempty"`
 }
 
 // Antenna is the forward-compatible (ADR 0027) per-part antenna attribute:
@@ -132,11 +141,14 @@ type LoadoutDef struct {
 }
 
 // Catalog is the on-disk envelope shared by the embedded data files and
-// user overlay files: a list of parts and/or loadouts. Both lists are
-// optional, so a user file may add just parts, just loadouts, or both.
+// user overlay files: a list of components, parts and/or loadouts. All
+// lists are optional, so a user file may add just components, just parts,
+// just loadouts, or any mix (the modding path; v0.24 / ADR 0029 added the
+// components list one level below parts).
 type Catalog struct {
-	Parts    []Part       `json:"parts,omitempty"`
-	Loadouts []LoadoutDef `json:"loadouts,omitempty"`
+	Components []Component  `json:"components,omitempty"`
+	Parts      []Part       `json:"parts,omitempty"`
+	Loadouts   []LoadoutDef `json:"loadouts,omitempty"`
 }
 
 // CatalogWarning records a user overlay file that failed to load. Mirrors
@@ -203,7 +215,7 @@ func (p Part) ToStage() Stage {
 // last. Embedded parse failures already panicked at init, so the error
 // from LoadCatalogWithWarnings is not re-surfaced here.
 func LoadCatalogOverlay() []CatalogWarning {
-	parts, defs, warnings, _ := LoadCatalogWithWarnings()
+	comps, parts, defs, warnings, _ := loadMergedCatalog()
 	sc := make(map[string]StageModule, len(parts))
 	for id, p := range parts {
 		sc[id] = p.toStageModule()
@@ -217,6 +229,7 @@ func LoadCatalogOverlay() []CatalogWarning {
 	StageCatalog = sc
 	Loadouts = lo
 	LoadoutOrder = order
+	Components = comps
 	return warnings
 }
 
@@ -230,31 +243,52 @@ func LoadCatalog() (map[string]Part, []LoadoutDef, error) {
 
 // LoadCatalogWithWarnings is the warning-aware variant. The returned
 // warnings slice holds a CatalogWarning per user overlay file that failed
-// to parse; embedded-catalog parse failures surface as a hard error (the
-// embedded set must always load). This is the ADR 0026 "LoadAllWithWarnings
-// style" entrypoint, mirroring bodies.LoadAllWithWarnings.
+// to parse (and per composed Part that failed aggregation); embedded-catalog
+// parse failures surface as a hard error (the embedded set must always
+// load). This is the ADR 0026 "LoadAllWithWarnings style" entrypoint,
+// mirroring bodies.LoadAllWithWarnings. The returned parts are aggregated:
+// a composed Part (ADR 0029) carries its derived scalar stats, so every
+// downstream reader (resolveLoadout / ToStage) sees flat fields exactly as
+// for an atomic part.
 func LoadCatalogWithWarnings() (map[string]Part, []LoadoutDef, []CatalogWarning, error) {
-	parts, loadouts, err := loadEmbeddedCatalog()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	parts, loadouts, warnings := mergeUserCatalog(parts, loadouts, userCatalogDir())
-	return parts, loadouts, warnings, nil
+	_, parts, loadouts, warnings, err := loadMergedCatalog()
+	return parts, loadouts, warnings, err
 }
 
-func loadEmbeddedCatalog() (map[string]Part, []LoadoutDef, error) {
+// loadMergedCatalog is the single internal entrypoint that loads the
+// embedded catalog, merges the user overlay (skip-bad-with-warning), and
+// aggregates composed parts (ADR 0029 §2). Shared by the public
+// LoadCatalog* wrappers and LoadCatalogOverlay so components, parts and
+// loadouts are always resolved through one consistent path. Aggregation
+// warnings (unknown component / mixed fuel) join the overlay warnings.
+func loadMergedCatalog() (map[string]Component, map[string]Part, []LoadoutDef, []CatalogWarning, error) {
+	comps, parts, loadouts, err := loadEmbeddedCatalog()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	comps, parts, loadouts, warnings := mergeUserCatalog(comps, parts, loadouts, userCatalogDir())
+	parts, aggWarnings := aggregateComponents(parts, comps)
+	warnings = append(warnings, aggWarnings...)
+	return comps, parts, loadouts, warnings, nil
+}
+
+func loadEmbeddedCatalog() (map[string]Component, map[string]Part, []LoadoutDef, error) {
+	comps := map[string]Component{}
 	parts := map[string]Part{}
 	var loadouts []LoadoutDef
-	// Two embedded files (parts + loadouts) folded into one merged catalog;
-	// either may hold either list (the shared envelope).
-	for _, name := range []string{"data/parts.json", "data/loadouts.json"} {
+	// Three embedded files (components + parts + loadouts) folded into one
+	// merged catalog; any may hold any list (the shared envelope).
+	for _, name := range []string{"data/components.json", "data/parts.json", "data/loadouts.json"} {
 		data, err := catalogFS.ReadFile(name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("read embedded %s: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("read embedded %s: %w", name, err)
 		}
 		var cat Catalog
 		if err := json.Unmarshal(data, &cat); err != nil {
-			return nil, nil, fmt.Errorf("parse %s: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("parse %s: %w", name, err)
+		}
+		for _, c := range cat.Components {
+			comps[c.ID] = c
 		}
 		for _, p := range cat.Parts {
 			parts[p.ID] = p
@@ -264,24 +298,26 @@ func loadEmbeddedCatalog() (map[string]Part, []LoadoutDef, error) {
 			loadouts = append(loadouts, cat.Loadouts[i])
 		}
 	}
-	return parts, loadouts, nil
+	return comps, parts, loadouts, nil
 }
 
 // mergeUserCatalog overlays every *.json file in dir onto the embedded
-// catalog. A user part wins on ID (replaces the embedded entry); a user
-// loadout replaces on ID, else appends. A missing dir is fine (overlay is
-// optional); a malformed file is skipped with a warning. Factored out (and
-// taking dir) so it can be unit-tested against a temp dir.
-func mergeUserCatalog(parts map[string]Part, loadouts []LoadoutDef, dir string) (map[string]Part, []LoadoutDef, []CatalogWarning) {
+// catalog. A user component / part wins on ID (replaces the embedded
+// entry); a user loadout replaces on ID, else appends. A missing dir is
+// fine (overlay is optional); a malformed file is skipped with a warning.
+// Factored out (and taking dir) so it can be unit-tested against a temp
+// dir. Aggregation of composed parts runs AFTER the merge (loadMergedCatalog)
+// so a composed part may reference an overlay component.
+func mergeUserCatalog(comps map[string]Component, parts map[string]Part, loadouts []LoadoutDef, dir string) (map[string]Component, map[string]Part, []LoadoutDef, []CatalogWarning) {
 	if dir == "" {
-		return parts, loadouts, nil
+		return comps, parts, loadouts, nil
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return parts, loadouts, nil
+			return comps, parts, loadouts, nil
 		}
-		return parts, loadouts, []CatalogWarning{{Path: dir, Err: err}}
+		return comps, parts, loadouts, []CatalogWarning{{Path: dir, Err: err}}
 	}
 	var warnings []CatalogWarning
 	for _, e := range entries {
@@ -298,6 +334,9 @@ func mergeUserCatalog(parts map[string]Part, loadouts []LoadoutDef, dir string) 
 		if err := json.Unmarshal(data, &cat); err != nil {
 			warnings = append(warnings, CatalogWarning{Path: path, Err: err})
 			continue
+		}
+		for _, c := range cat.Components {
+			comps[c.ID] = c // user wins on ID
 		}
 		for _, p := range cat.Parts {
 			parts[p.ID] = p // user wins on ID
@@ -317,7 +356,7 @@ func mergeUserCatalog(parts map[string]Part, loadouts []LoadoutDef, dir string) 
 			}
 		}
 	}
-	return parts, loadouts, warnings
+	return comps, parts, loadouts, warnings
 }
 
 // userCatalogDir resolves the user loadout-overlay directory:

--- a/internal/spacecraft/catalog_test.go
+++ b/internal/spacecraft/catalog_test.go
@@ -217,10 +217,11 @@ func TestMergeUserCatalogWinsOnID(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Seed an "embedded" catalog the user file should override on ID.
+	comps := map[string]Component{}
 	parts := map[string]Part{"shared": {ID: "shared", Name: "Embedded Version", DryMassKg: 1}}
 	loadouts := []LoadoutDef{{ID: "rocket", Name: "Embedded Rocket", Source: "embedded"}}
 
-	parts, loadouts, warnings := mergeUserCatalog(parts, loadouts, dir)
+	_, parts, loadouts, warnings := mergeUserCatalog(comps, parts, loadouts, dir)
 	if len(warnings) != 0 {
 		t.Errorf("warnings = %d, want 0", len(warnings))
 	}

--- a/internal/spacecraft/components.go
+++ b/internal/spacecraft/components.go
@@ -1,0 +1,217 @@
+package spacecraft
+
+import "fmt"
+
+// Component is the finest catalog noun (ADR 0029 §1, the VAB cycle / Axis B
+// cycle 4) — one level below the atomic Part. A Part may declare an
+// optional list of component IDs; when present the Part's flat scalar stats
+// are DERIVED by aggregation (aggregateComponents) instead of authored
+// inline. This cashes in the forward-compat note ADR 0026 left on Part
+// ("a Part can later declare itself a composition of finer components") with
+// ZERO migration: an atomic Part (no Components) is untouched.
+//
+// One Component contributes only to the Stage scalars its Kind owns
+// (ADR 0029 §2):
+//
+//	engine        → ThrustN, IspS, FuelType, dry mass
+//	tank          → FuelCapacityKg, FuelType, dry mass
+//	command-core  → CommandSource, dry mass, optional soft-land / parachute
+//	antenna       → AntennaKind, RangeM, dry mass
+//	structure     → dry mass only (adapters, fairings, ballast)
+//
+// Components are loaded through the existing ADR 0026 catalog loader (one
+// more embedded file + user overlay, skip-bad-with-warning) — the modding
+// path one level deeper. Visual fields (Glyph / Color) are cosmetic and
+// carry no save-hash weight (there is no parts-catalog hash; ADR 0026 §4).
+type Component struct {
+	ID    string `json:"id"`
+	Name  string `json:"name,omitempty"`
+	Glyph string `json:"glyph,omitempty"`
+	Color string `json:"color,omitempty"`
+
+	// Kind is one of the ComponentKind* constants; it selects which Stage
+	// scalars this component contributes during aggregation.
+	Kind string `json:"kind"`
+
+	// DryMassKg is the component's empty mass in kg — additive across the
+	// whole stage for every kind.
+	DryMassKg float64 `json:"dry_mass_kg"`
+
+	// Engine fields.
+	ThrustN float64 `json:"thrust_n,omitempty"`
+	IspS    float64 `json:"isp_s,omitempty"`
+
+	// FuelType is shared by engine + tank: every fuelled component in a
+	// stage must agree on chemistry (ADR 0029 §3, the single-fuel-pool
+	// invariant). Empty contributes nothing to the chemistry check.
+	FuelType string `json:"fuel_type,omitempty"`
+
+	// Tank field.
+	FuelCapacityKg float64 `json:"fuel_capacity_kg,omitempty"`
+
+	// Command-core fields. CommandSource is CommandCrewed / CommandProbe
+	// (ADR 0027); CanSoftLand / HasParachute are the optional recovery
+	// capabilities a command core may carry.
+	CommandSource string `json:"command_source,omitempty"`
+	CanSoftLand   bool   `json:"can_soft_land,omitempty"`
+	HasParachute  bool   `json:"has_parachute,omitempty"`
+
+	// Antenna fields (ADR 0027): kind (AntennaDirect / AntennaRelay) and the
+	// rated range in metres.
+	AntennaKind string  `json:"antenna_kind,omitempty"`
+	RangeM      float64 `json:"range_m,omitempty"`
+}
+
+// Component-kind constants (ADR 0029 §2). The five kinds that ship this
+// cycle; cargo-hold is deferred to the inert-cargo cycle (ADR 0029 §6).
+const (
+	ComponentEngine      = "engine"       // thrust + Isp + fuel chemistry
+	ComponentTank        = "tank"         // fuel capacity + fuel chemistry
+	ComponentCommandCore = "command-core" // control point (crewed/probe) + recovery
+	ComponentAntenna     = "antenna"      // comms hardware (direct/relay)
+	ComponentStructure   = "structure"    // inert dry mass (adapter / fairing / ballast)
+)
+
+// Components indexes the embedded component catalog by ID — the palette the
+// VAB composes from (ADR 0029 §5). Resolved at package-var init from the
+// embedded data/components.json (mirroring Loadouts / StageCatalog), and
+// refreshed with the user overlay by LoadCatalogOverlay at startup. Empty
+// in S1's stub; starter content lands in S4.
+var Components = buildComponents()
+
+// buildComponents loads the embedded component catalog at init. Panics on a
+// malformed embedded file (a build/programmer error, like buildLoadouts).
+func buildComponents() map[string]Component {
+	comps, _, _, err := loadEmbeddedCatalog()
+	if err != nil {
+		panic("spacecraft: embedded component catalog failed to load: " + err.Error())
+	}
+	return comps
+}
+
+// aggregateComponents resolves every composed Part (one with a non-empty
+// Components list) into its flat scalar stats and returns the resolved
+// parts map plus a CatalogWarning per Part that fails validation. Atomic
+// Parts (no Components) pass through byte-identical — the zero-migration
+// property (ADR 0029 §1). Never mutates the input map.
+//
+// Aggregation (ADR 0029 §2): dry mass + tank capacity are additive;
+// engines combine to Thrust = ΣF_i with the thrust-weighted parallel
+// formula Isp_eff = ΣF_i / Σ(F_i/Isp_i) (exact for the single fuel pool);
+// command-source / antenna / recovery attributes ride up. Tanks fill full
+// (FuelMass == FuelCapacity) so a loadout-level fuel-fill override still
+// scales from a full base, exactly as atomic parts do.
+//
+// A Part that references an unknown component, or mixes fuel chemistries in
+// one stage (ADR 0029 §3), yields a warning and is left UNAGGREGATED in the
+// map (so loadout resolution does not panic on a missing ID); the VAB
+// rejects such a stage before it can be saved (S3).
+func aggregateComponents(parts map[string]Part, comps map[string]Component) (map[string]Part, []CatalogWarning) {
+	out := make(map[string]Part, len(parts))
+	var warnings []CatalogWarning
+	for id, p := range parts {
+		if len(p.Components) == 0 {
+			out[id] = p // atomic — untouched
+			continue
+		}
+		agg, err := composePart(p, comps)
+		if err != nil {
+			warnings = append(warnings, CatalogWarning{Path: "part:" + id, Err: err})
+			out[id] = p // keep raw so a referencing loadout still resolves
+			continue
+		}
+		out[id] = agg
+	}
+	return out, warnings
+}
+
+// composePart derives a composed Part's flat scalar stats from its
+// components. Identity (ID / Name / Glyph / Color / Tier), sprite styling,
+// and any non-component fields (RCS pool, ballistic coefficient) are
+// preserved from the Part; every component-derived scalar is assigned
+// explicitly (to zero when no component supplies it) so a composed part
+// cannot smuggle inline engine numbers past aggregation.
+func composePart(p Part, comps map[string]Component) (Part, error) {
+	out := p // preserves identity, sprite, RCS, BC; Components list retained
+	var dryMass, fuelCap, totalThrust, sumThrustOverIsp float64
+	var fuelType, commandSource, antennaKind string
+	var antennaRange float64
+	var canSoftLand, hasParachute bool
+
+	setFuel := func(ft string) error {
+		if ft == "" {
+			return nil
+		}
+		if fuelType == "" {
+			fuelType = ft
+			return nil
+		}
+		if fuelType != ft {
+			return fmt.Errorf("mixes fuel chemistries %q and %q in one stage (single fuel type per stage)", fuelType, ft)
+		}
+		return nil
+	}
+
+	for _, cid := range p.Components {
+		c, ok := comps[cid]
+		if !ok {
+			return Part{}, fmt.Errorf("references unknown component %q", cid)
+		}
+		dryMass += c.DryMassKg
+		switch c.Kind {
+		case ComponentEngine:
+			if c.ThrustN > 0 && c.IspS > 0 {
+				totalThrust += c.ThrustN
+				sumThrustOverIsp += c.ThrustN / c.IspS
+			}
+			if err := setFuel(c.FuelType); err != nil {
+				return Part{}, err
+			}
+		case ComponentTank:
+			fuelCap += c.FuelCapacityKg
+			if err := setFuel(c.FuelType); err != nil {
+				return Part{}, err
+			}
+		case ComponentCommandCore:
+			// Crewed wins over probe (a crewed pod is never comms-gated),
+			// mirroring SyncFields' vessel-level rule.
+			if c.CommandSource == CommandCrewed {
+				commandSource = CommandCrewed
+			} else if c.CommandSource == CommandProbe && commandSource != CommandCrewed {
+				commandSource = CommandProbe
+			}
+			canSoftLand = canSoftLand || c.CanSoftLand
+			hasParachute = hasParachute || c.HasParachute
+		case ComponentAntenna:
+			// Keep the longest-ranged antenna (SyncFields' vessel rule).
+			if c.AntennaKind != AntennaNone && c.RangeM > antennaRange {
+				antennaKind = c.AntennaKind
+				antennaRange = c.RangeM
+			}
+		case ComponentStructure:
+			// Dry mass only — already added above.
+		default:
+			return Part{}, fmt.Errorf("component %q has unknown kind %q", cid, c.Kind)
+		}
+	}
+
+	out.DryMassKg = dryMass
+	out.FuelCapacityKg = fuelCap
+	out.FuelMassKg = fuelCap // full tanks by default
+	out.ThrustN = totalThrust
+	if sumThrustOverIsp > 0 {
+		out.IspS = totalThrust / sumThrustOverIsp
+	} else {
+		out.IspS = 0
+	}
+	out.FuelType = fuelType
+	out.CommandSource = commandSource
+	out.CanSoftLand = canSoftLand
+	out.HasParachute = hasParachute
+	if antennaKind != AntennaNone {
+		out.Antenna = &Antenna{Kind: antennaKind, RangeM: antennaRange}
+	} else {
+		out.Antenna = nil
+	}
+	return out, nil
+}

--- a/internal/spacecraft/components.go
+++ b/internal/spacecraft/components.go
@@ -89,6 +89,25 @@ func buildComponents() map[string]Component {
 	return comps
 }
 
+// ComposeStage aggregates a list of component IDs into a runtime Stage,
+// deriving the RCS pool from dry mass exactly as the loadout-resolve path
+// does (DefaultRCSLoadout) so a VAB preview matches the eventually-spawned
+// craft. Returns a non-empty warning string when the components don't form
+// a valid stage (an unknown component, or mixed fuel chemistry — ADR 0029
+// §3); the returned Stage is then the zero value. Used by the VAB screen
+// (internal/tui/screens/vab.go), which can't reach the unexported
+// aggregation internals.
+func ComposeStage(componentIDs []string, comps map[string]Component) (Stage, string) {
+	agg, err := composePart(Part{Components: componentIDs}, comps)
+	if err != nil {
+		return Stage{}, err.Error()
+	}
+	st := agg.ToStage()
+	mp, monoCap, rcsThrust, rcsIsp := DefaultRCSLoadout(st.DryMass)
+	st.MonopropMass, st.MonopropCap, st.RCSThrust, st.RCSIsp = mp, monoCap, rcsThrust, rcsIsp
+	return st, ""
+}
+
 // aggregateComponents resolves every composed Part (one with a non-empty
 // Components list) into its flat scalar stats and returns the resolved
 // parts map plus a CatalogWarning per Part that fails validation. Atomic

--- a/internal/spacecraft/components.go
+++ b/internal/spacecraft/components.go
@@ -29,6 +29,13 @@ type Component struct {
 	Glyph string `json:"glyph,omitempty"`
 	Color string `json:"color,omitempty"`
 
+	// Description is an optional one-line blurb surfaced by the VAB part
+	// inspector (ADR 0030 §7). Purely cosmetic catalog data — like Glyph /
+	// Color it carries no save-hash weight (there is no parts-catalog hash;
+	// ADR 0026 §4) and is omitempty so existing catalogs round-trip
+	// byte-identical.
+	Description string `json:"description,omitempty"`
+
 	// Kind is one of the ComponentKind* constants; it selects which Stage
 	// scalars this component contributes during aggregation.
 	Kind string `json:"kind"`

--- a/internal/spacecraft/components_test.go
+++ b/internal/spacecraft/components_test.go
@@ -1,0 +1,259 @@
+package spacecraft
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// S1 / ADR 0029 — the component catalog + aggregation spine. A Part may
+// declare an optional `components` list; when present its flat scalar
+// stats are DERIVED by aggregation (dry mass + tank capacity additive;
+// engines combined with thrust-weighted Isp; command-source / antenna
+// attributes carried up). Atomic parts (no components) pass through
+// byte-identical so the existing fleet flies unchanged.
+
+// testComps builds an in-memory component catalog for the aggregation unit
+// tests: two same-chemistry engines of differing Isp, a tank, a structure
+// adapter, a probe core, and a relay antenna.
+func testComps() map[string]Component {
+	return map[string]Component{
+		"eng-a": {ID: "eng-a", Kind: ComponentEngine, DryMassKg: 500, ThrustN: 1_000_000, IspS: 300, FuelType: FuelTypeKerolox},
+		"eng-b": {ID: "eng-b", Kind: ComponentEngine, DryMassKg: 500, ThrustN: 1_000_000, IspS: 350, FuelType: FuelTypeKerolox},
+		"tank":  {ID: "tank", Kind: ComponentTank, DryMassKg: 100, FuelCapacityKg: 2000, FuelType: FuelTypeKerolox},
+		"adapt": {ID: "adapt", Kind: ComponentStructure, DryMassKg: 50},
+		"probe": {ID: "probe", Kind: ComponentCommandCore, DryMassKg: 80, CommandSource: CommandProbe},
+		"crew":  {ID: "crew", Kind: ComponentCommandCore, DryMassKg: 200, CommandSource: CommandCrewed, HasParachute: true},
+		"relay": {ID: "relay", Kind: ComponentAntenna, DryMassKg: 30, AntennaKind: AntennaRelay, RangeM: 1e9},
+		"dish":  {ID: "dish", Kind: ComponentAntenna, DryMassKg: 10, AntennaKind: AntennaDirect, RangeM: 1e7},
+		"hydro": {ID: "hydro", Kind: ComponentTank, DryMassKg: 100, FuelCapacityKg: 2000, FuelType: FuelTypeHydrolox},
+	}
+}
+
+// TestAggregateComposedPart — a composed part with two same-chemistry
+// engines of differing Isp, three tanks, and a structure adapter
+// aggregates to the thrust-weighted Isp_eff, summed thrust, summed dry
+// mass and summed tank capacity (full tanks by default).
+func TestAggregateComposedPart(t *testing.T) {
+	parts := map[string]Part{
+		"s1": {ID: "s1", Name: "Custom S1", Components: []string{"eng-a", "eng-b", "tank", "tank", "tank", "adapt"}},
+	}
+	got, warnings := aggregateComponents(parts, testComps())
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	p := got["s1"]
+	if p.DryMassKg != 500+500+100*3+50 {
+		t.Errorf("DryMassKg = %g, want 1350", p.DryMassKg)
+	}
+	if p.ThrustN != 2_000_000 {
+		t.Errorf("ThrustN = %g, want 2e6", p.ThrustN)
+	}
+	wantIsp := 2_000_000.0 / (1_000_000.0/300 + 1_000_000.0/350) // ≈ 323.077
+	if math.Abs(p.IspS-wantIsp) > 1e-6 {
+		t.Errorf("Isp_eff = %g, want %g (thrust-weighted)", p.IspS, wantIsp)
+	}
+	if p.FuelCapacityKg != 6000 || p.FuelMassKg != 6000 {
+		t.Errorf("fuel = %g/%g, want 6000/6000 (full tanks)", p.FuelMassKg, p.FuelCapacityKg)
+	}
+	if p.FuelType != FuelTypeKerolox {
+		t.Errorf("FuelType = %q, want kerolox", p.FuelType)
+	}
+	// Identity is preserved from the Part, not derived.
+	if p.Name != "Custom S1" {
+		t.Errorf("Name = %q, want preserved", p.Name)
+	}
+	// The components list is retained so the design store can re-serialize it.
+	if len(p.Components) != 6 {
+		t.Errorf("Components list dropped: %v", p.Components)
+	}
+}
+
+// TestAggregateSingleEnginePassthrough — one engine ⇒ Isp_eff == Isp
+// exactly (the degenerate case of the thrust-weighted formula).
+func TestAggregateSingleEnginePassthrough(t *testing.T) {
+	parts := map[string]Part{"s": {ID: "s", Components: []string{"eng-a", "tank"}}}
+	got, warnings := aggregateComponents(parts, testComps())
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if got["s"].IspS != 300 {
+		t.Errorf("single-engine Isp_eff = %g, want 300 (passthrough)", got["s"].IspS)
+	}
+	if got["s"].ThrustN != 1_000_000 {
+		t.Errorf("ThrustN = %g, want 1e6", got["s"].ThrustN)
+	}
+}
+
+// TestAggregateCommandAndAntenna — a command-core lifts CommandSource (and
+// its parachute flag) onto the part; multiple antennas resolve to the
+// longest-ranged one; a crewed core wins over a probe core.
+func TestAggregateCommandAndAntenna(t *testing.T) {
+	parts := map[string]Part{
+		"pod": {ID: "pod", Components: []string{"probe", "crew", "dish", "relay"}},
+	}
+	got, _ := aggregateComponents(parts, testComps())
+	p := got["pod"]
+	if p.CommandSource != CommandCrewed {
+		t.Errorf("CommandSource = %q, want crewed (crewed wins over probe)", p.CommandSource)
+	}
+	if !p.HasParachute {
+		t.Error("HasParachute not carried up from the crew core")
+	}
+	if p.Antenna == nil || p.Antenna.Kind != AntennaRelay || p.Antenna.RangeM != 1e9 {
+		t.Errorf("Antenna = %+v, want relay@1e9 (longest range)", p.Antenna)
+	}
+}
+
+// TestAggregateMixedFuelError — engines/tanks of differing chemistry in one
+// stage is rejected (a catalog warning); single fuel type per stage is the
+// invariant that keeps the single-pool runtime exact.
+func TestAggregateMixedFuelError(t *testing.T) {
+	parts := map[string]Part{
+		"bad": {ID: "bad", Components: []string{"eng-a", "hydro"}}, // kerolox engine + hydrolox tank
+	}
+	_, warnings := aggregateComponents(parts, testComps())
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1 (mixed chemistry)", len(warnings))
+	}
+}
+
+// TestAggregateUnknownComponent — a composed part referencing a missing
+// component is a catalog warning, not a panic (skip-bad-with-warning).
+func TestAggregateUnknownComponent(t *testing.T) {
+	parts := map[string]Part{"x": {ID: "x", Components: []string{"eng-a", "nope"}}}
+	_, warnings := aggregateComponents(parts, testComps())
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1 (unknown component)", len(warnings))
+	}
+}
+
+// TestAggregateAtomicPartsUnchanged — the byte-identical golden: every
+// embedded atomic part (none declare components this cycle) passes through
+// aggregation unchanged, so the existing fleet flies identically.
+func TestAggregateAtomicPartsUnchanged(t *testing.T) {
+	comps, parts, _, err := loadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("loadEmbeddedCatalog: %v", err)
+	}
+	got, warnings := aggregateComponents(parts, comps)
+	if len(warnings) != 0 {
+		t.Fatalf("embedded aggregation warnings = %v, want none", warnings)
+	}
+	for id, p := range parts {
+		if len(p.Components) != 0 {
+			continue // composed — expected to change
+		}
+		if !reflect.DeepEqual(p, got[id]) {
+			t.Errorf("atomic part %q changed under aggregation:\n raw %+v\n got %+v", id, p, got[id])
+		}
+	}
+}
+
+// TestComponentRoundTrip — a Component (every kind's fields) and a Catalog
+// carrying components round-trip through JSON byte-for-byte.
+func TestComponentRoundTrip(t *testing.T) {
+	want := Catalog{
+		Components: []Component{
+			{ID: "m-eng", Name: "Merlin", Glyph: "v", Color: "#FF8C42", Kind: ComponentEngine, DryMassKg: 470, ThrustN: 845_000, IspS: 282, FuelType: FuelTypeKerolox},
+			{ID: "t-2k", Name: "2t tank", Kind: ComponentTank, DryMassKg: 200, FuelCapacityKg: 2000, FuelType: FuelTypeKerolox},
+			{ID: "core", Name: "Probe core", Kind: ComponentCommandCore, DryMassKg: 80, CommandSource: CommandProbe, CanSoftLand: true},
+			{ID: "ant", Name: "Relay", Kind: ComponentAntenna, DryMassKg: 30, AntennaKind: AntennaRelay, RangeM: 1e9},
+			{ID: "ada", Name: "Adapter", Kind: ComponentStructure, DryMassKg: 40},
+		},
+		Parts: []Part{{ID: "composed", Name: "Composed", Components: []string{"m-eng", "t-2k", "core"}}},
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Catalog
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("round-trip mismatch:\n want %+v\n  got %+v", want, got)
+	}
+}
+
+// TestComposedPartViaOverlay — the full modding path one level deeper: a
+// user overlay file adds components AND a composed part referencing them,
+// then a loadout referencing that composed part. Through LoadCatalogWithWarnings
+// (which aggregates) the composed part resolves to flyable stats and
+// NewFromStages-equivalent thrust, and its probe core + antenna ride up.
+func TestComposedPartViaOverlay(t *testing.T) {
+	dir := withUserCatalog(t)
+	overlay := `{
+		"components": [
+			{"id":"c-eng","kind":"engine","dry_mass_kg":500,"thrust_n":1000000,"isp_s":320,"fuel_type":"kerolox"},
+			{"id":"c-tank","kind":"tank","dry_mass_kg":100,"fuel_capacity_kg":4000,"fuel_type":"kerolox"},
+			{"id":"c-core","kind":"command-core","dry_mass_kg":90,"command_source":"probe"},
+			{"id":"c-ant","kind":"antenna","dry_mass_kg":20,"antenna_kind":"direct","range_m":10000000}
+		],
+		"parts": [
+			{"id":"c-stage","name":"Composed Stage","glyph":"➤","color":"#AABBCC","components":["c-eng","c-tank","c-core","c-ant"]}
+		],
+		"loadouts": [
+			{"id":"Composed-Rocket","name":"Composed Rocket","role":"custom","glyph":"➤","color":"#AABBCC","parts":[{"part_id":"c-stage"}]}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "composed.json"), []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parts, defs, warnings, err := LoadCatalogWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadCatalogWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	cs, ok := parts["c-stage"]
+	if !ok {
+		t.Fatal("composed part not in merged catalog")
+	}
+	if cs.ThrustN != 1_000_000 || cs.IspS != 320 {
+		t.Errorf("composed part engine = %g N / %g s, want 1e6/320", cs.ThrustN, cs.IspS)
+	}
+	if cs.DryMassKg != 500+100+90+20 {
+		t.Errorf("composed dry = %g, want 710", cs.DryMassKg)
+	}
+	if cs.FuelCapacityKg != 4000 || cs.FuelMassKg != 4000 {
+		t.Errorf("composed fuel = %g/%g, want 4000/4000", cs.FuelMassKg, cs.FuelCapacityKg)
+	}
+	if cs.CommandSource != CommandProbe {
+		t.Errorf("composed CommandSource = %q, want probe", cs.CommandSource)
+	}
+	if cs.Antenna == nil || cs.Antenna.Kind != AntennaDirect {
+		t.Errorf("composed antenna = %+v, want direct", cs.Antenna)
+	}
+	// The composed part resolves into a flyable loadout (one stage,
+	// thrust carried through ToStage exactly like an atomic part).
+	var def *LoadoutDef
+	for i := range defs {
+		if defs[i].ID == "Composed-Rocket" {
+			def = &defs[i]
+		}
+	}
+	if def == nil {
+		t.Fatal("composed loadout not merged")
+	}
+	l := resolveLoadout(*def, parts)
+	if len(l.Stages) != 1 || l.Stages[0].Thrust != 1_000_000 || l.Stages[0].Isp != 320 {
+		t.Errorf("resolved stage = %+v, want one stage 1e6 N / 320 s", l.Stages)
+	}
+	if l.Stages[0].CommandSource != CommandProbe {
+		t.Errorf("resolved stage CommandSource = %q, want probe", l.Stages[0].CommandSource)
+	}
+}
+
+// TestComponentsGlobalLoadsEmbedded — the package Components global resolves
+// from the embedded components.json at init (mirrors Loadouts / StageCatalog),
+// and the embedded stub loads cleanly.
+func TestComponentsGlobalLoadsEmbedded(t *testing.T) {
+	if Components == nil {
+		t.Fatal("Components global is nil, want non-nil map")
+	}
+}

--- a/internal/spacecraft/data/components.json
+++ b/internal/spacecraft/data/components.json
@@ -1,0 +1,3 @@
+{
+  "components": []
+}

--- a/internal/spacecraft/data/components.json
+++ b/internal/spacecraft/data/components.json
@@ -12,6 +12,61 @@
       "fuel_type": "kerolox"
     },
     {
+      "id": "rd180-booster",
+      "name": "RD-180 Booster",
+      "kind": "engine",
+      "dry_mass_kg": 5500,
+      "thrust_n": 3830000,
+      "isp_s": 311,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "merlin-sustainer",
+      "name": "Merlin 1D",
+      "kind": "engine",
+      "dry_mass_kg": 470,
+      "thrust_n": 845000,
+      "isp_s": 282,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "j2-upper",
+      "name": "J-2 Upper",
+      "kind": "engine",
+      "dry_mass_kg": 1500,
+      "thrust_n": 1033000,
+      "isp_s": 421,
+      "fuel_type": "hydrolox"
+    },
+    {
+      "id": "rl10-vac",
+      "name": "RL-10 Vacuum",
+      "kind": "engine",
+      "dry_mass_kg": 280,
+      "thrust_n": 110000,
+      "isp_s": 451,
+      "fuel_type": "hydrolox"
+    },
+    {
+      "id": "sps-transfer",
+      "name": "SPS Transfer Engine",
+      "kind": "engine",
+      "dry_mass_kg": 300,
+      "thrust_n": 91000,
+      "isp_s": 314,
+      "fuel_type": "hypergolic"
+    },
+    {
+      "id": "lmde-descent",
+      "name": "LMDE Descent Engine",
+      "kind": "engine",
+      "dry_mass_kg": 200,
+      "thrust_n": 45000,
+      "isp_s": 311,
+      "fuel_type": "hypergolic"
+    },
+
+    {
       "id": "probe-tank-1k",
       "name": "FT-1000 Tank",
       "kind": "tank",
@@ -20,6 +75,47 @@
       "fuel_type": "kerolox"
     },
     {
+      "id": "kero-tank-500",
+      "name": "FT-500 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 60,
+      "fuel_capacity_kg": 500,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "kero-tank-4k",
+      "name": "FT-4000 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 350,
+      "fuel_capacity_kg": 4000,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "hydro-tank-2k",
+      "name": "HT-2000 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 260,
+      "fuel_capacity_kg": 2000,
+      "fuel_type": "hydrolox"
+    },
+    {
+      "id": "hydro-tank-8k",
+      "name": "HT-8000 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 950,
+      "fuel_capacity_kg": 8000,
+      "fuel_type": "hydrolox"
+    },
+    {
+      "id": "hyper-tank-15",
+      "name": "PT-1500 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 140,
+      "fuel_capacity_kg": 1500,
+      "fuel_type": "hypergolic"
+    },
+
+    {
       "id": "probe-core",
       "name": "OKTO Probe Core",
       "kind": "command-core",
@@ -27,12 +123,64 @@
       "command_source": "probe"
     },
     {
+      "id": "crew-capsule",
+      "name": "Mk1 Capsule",
+      "kind": "command-core",
+      "dry_mass_kg": 800,
+      "command_source": "crewed",
+      "has_parachute": true
+    },
+    {
+      "id": "lander-can",
+      "name": "Lander Can",
+      "kind": "command-core",
+      "dry_mass_kg": 600,
+      "command_source": "crewed",
+      "can_soft_land": true
+    },
+
+    {
       "id": "probe-antenna",
       "name": "DA-5 Direct Antenna",
       "kind": "antenna",
       "dry_mass_kg": 20,
       "antenna_kind": "direct",
       "range_m": 10000000
+    },
+    {
+      "id": "relay-15",
+      "name": "RA-15 Relay",
+      "kind": "antenna",
+      "dry_mass_kg": 100,
+      "antenna_kind": "relay",
+      "range_m": 1000000000
+    },
+    {
+      "id": "dsn-dish",
+      "name": "DSN-88 Deep-Space Dish",
+      "kind": "antenna",
+      "dry_mass_kg": 200,
+      "antenna_kind": "direct",
+      "range_m": 600000000000
+    },
+
+    {
+      "id": "adapter-tr2",
+      "name": "TR-2 Stack Adapter",
+      "kind": "structure",
+      "dry_mass_kg": 40
+    },
+    {
+      "id": "aero-fairing",
+      "name": "Aero Fairing",
+      "kind": "structure",
+      "dry_mass_kg": 60
+    },
+    {
+      "id": "ballast-plate",
+      "name": "Ballast Plate",
+      "kind": "structure",
+      "dry_mass_kg": 200
     }
   ]
 }

--- a/internal/spacecraft/data/components.json
+++ b/internal/spacecraft/data/components.json
@@ -9,7 +9,8 @@
       "dry_mass_kg": 200,
       "thrust_n": 50000,
       "isp_s": 320,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "A light kerolox kick motor for probes and upper stages."
     },
     {
       "id": "rd180-booster",
@@ -18,7 +19,8 @@
       "dry_mass_kg": 5500,
       "thrust_n": 3830000,
       "isp_s": 311,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "High-thrust kerolox first-stage engine; cluster for heavy lift."
     },
     {
       "id": "merlin-sustainer",
@@ -27,7 +29,8 @@
       "dry_mass_kg": 470,
       "thrust_n": 845000,
       "isp_s": 282,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "Compact kerolox engine — clusters cleanly for a sustainer stage."
     },
     {
       "id": "j2-upper",
@@ -36,7 +39,8 @@
       "dry_mass_kg": 1500,
       "thrust_n": 1033000,
       "isp_s": 421,
-      "fuel_type": "hydrolox"
+      "fuel_type": "hydrolox",
+      "description": "Hydrolox upper-stage engine with strong vacuum Isp."
     },
     {
       "id": "rl10-vac",
@@ -45,7 +49,8 @@
       "dry_mass_kg": 280,
       "thrust_n": 110000,
       "isp_s": 451,
-      "fuel_type": "hydrolox"
+      "fuel_type": "hydrolox",
+      "description": "Efficient hydrolox vacuum engine for transfer and injection burns."
     },
     {
       "id": "sps-transfer",
@@ -54,7 +59,8 @@
       "dry_mass_kg": 300,
       "thrust_n": 91000,
       "isp_s": 314,
-      "fuel_type": "hypergolic"
+      "fuel_type": "hypergolic",
+      "description": "Storable hypergolic engine — restartable for long coasts and capture."
     },
     {
       "id": "lmde-descent",
@@ -63,7 +69,38 @@
       "dry_mass_kg": 200,
       "thrust_n": 45000,
       "isp_s": 311,
-      "fuel_type": "hypergolic"
+      "fuel_type": "hypergolic",
+      "description": "Throttleable hypergolic descent engine for landers."
+    },
+    {
+      "id": "f1-booster",
+      "name": "F-1 Booster",
+      "kind": "engine",
+      "dry_mass_kg": 8400,
+      "thrust_n": 6770000,
+      "isp_s": 263,
+      "fuel_type": "kerolox",
+      "description": "Enormous kerolox first-stage engine — the heavy-lift workhorse."
+    },
+    {
+      "id": "nerva-ntr",
+      "name": "NERVA NTR",
+      "kind": "engine",
+      "dry_mass_kg": 6800,
+      "thrust_n": 246000,
+      "isp_s": 850,
+      "fuel_type": "hydrolox",
+      "description": "Nuclear-thermal engine: very high Isp on liquid-hydrogen (hydrolox tanks)."
+    },
+    {
+      "id": "srb-solid",
+      "name": "S-25 Solid Booster",
+      "kind": "engine",
+      "dry_mass_kg": 3000,
+      "thrust_n": 4000000,
+      "isp_s": 240,
+      "fuel_type": "solid",
+      "description": "Strap-on solid motor — huge liftoff thrust, pair with a solid casing."
     },
 
     {
@@ -72,7 +109,8 @@
       "kind": "tank",
       "dry_mass_kg": 100,
       "fuel_capacity_kg": 1000,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "Small kerolox tank."
     },
     {
       "id": "kero-tank-500",
@@ -80,7 +118,8 @@
       "kind": "tank",
       "dry_mass_kg": 60,
       "fuel_capacity_kg": 500,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "Tiny kerolox tank for trim and probes."
     },
     {
       "id": "kero-tank-4k",
@@ -88,7 +127,17 @@
       "kind": "tank",
       "dry_mass_kg": 350,
       "fuel_capacity_kg": 4000,
-      "fuel_type": "kerolox"
+      "fuel_type": "kerolox",
+      "description": "Mid kerolox tank — the staple booster propellant unit."
+    },
+    {
+      "id": "kero-tank-9k",
+      "name": "FT-9000 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 720,
+      "fuel_capacity_kg": 9000,
+      "fuel_type": "kerolox",
+      "description": "Large kerolox tank for heavy first stages."
     },
     {
       "id": "hydro-tank-2k",
@@ -96,7 +145,8 @@
       "kind": "tank",
       "dry_mass_kg": 260,
       "fuel_capacity_kg": 2000,
-      "fuel_type": "hydrolox"
+      "fuel_type": "hydrolox",
+      "description": "Mid hydrolox tank for upper stages."
     },
     {
       "id": "hydro-tank-8k",
@@ -104,7 +154,8 @@
       "kind": "tank",
       "dry_mass_kg": 950,
       "fuel_capacity_kg": 8000,
-      "fuel_type": "hydrolox"
+      "fuel_type": "hydrolox",
+      "description": "Large hydrolox tank for NTR and high-energy stages."
     },
     {
       "id": "hyper-tank-15",
@@ -112,7 +163,17 @@
       "kind": "tank",
       "dry_mass_kg": 140,
       "fuel_capacity_kg": 1500,
-      "fuel_type": "hypergolic"
+      "fuel_type": "hypergolic",
+      "description": "Storable hypergolic propellant tank for service and landing stages."
+    },
+    {
+      "id": "solid-casing",
+      "name": "Solid Casing",
+      "kind": "tank",
+      "dry_mass_kg": 4000,
+      "fuel_capacity_kg": 40000,
+      "fuel_type": "solid",
+      "description": "Cast solid-propellant casing — feeds a solid booster, cannot be drained early."
     },
 
     {
@@ -120,7 +181,8 @@
       "name": "OKTO Probe Core",
       "kind": "command-core",
       "dry_mass_kg": 80,
-      "command_source": "probe"
+      "command_source": "probe",
+      "description": "Uncrewed guidance core — commandable only with a comms link."
     },
     {
       "id": "crew-capsule",
@@ -128,7 +190,8 @@
       "kind": "command-core",
       "dry_mass_kg": 800,
       "command_source": "crewed",
-      "has_parachute": true
+      "has_parachute": true,
+      "description": "One-seat crew capsule with a recovery parachute."
     },
     {
       "id": "lander-can",
@@ -136,7 +199,8 @@
       "kind": "command-core",
       "dry_mass_kg": 600,
       "command_source": "crewed",
-      "can_soft_land": true
+      "can_soft_land": true,
+      "description": "Crewed lander cabin rated for powered soft landings."
     },
 
     {
@@ -145,7 +209,8 @@
       "kind": "antenna",
       "dry_mass_kg": 20,
       "antenna_kind": "direct",
-      "range_m": 10000000
+      "range_m": 10000000,
+      "description": "Short-range direct antenna — reaches the network but cannot relay."
     },
     {
       "id": "relay-15",
@@ -153,7 +218,8 @@
       "kind": "antenna",
       "dry_mass_kg": 100,
       "antenna_kind": "relay",
-      "range_m": 1000000000
+      "range_m": 1000000000,
+      "description": "Relay antenna — uses the network and forwards for other vessels."
     },
     {
       "id": "dsn-dish",
@@ -161,26 +227,30 @@
       "kind": "antenna",
       "dry_mass_kg": 200,
       "antenna_kind": "direct",
-      "range_m": 600000000000
+      "range_m": 600000000000,
+      "description": "Deep-space direct dish for interplanetary range."
     },
 
     {
       "id": "adapter-tr2",
       "name": "TR-2 Stack Adapter",
       "kind": "structure",
-      "dry_mass_kg": 40
+      "dry_mass_kg": 40,
+      "description": "Inert adapter joining stages of different diameters."
     },
     {
       "id": "aero-fairing",
       "name": "Aero Fairing",
       "kind": "structure",
-      "dry_mass_kg": 60
+      "dry_mass_kg": 60,
+      "description": "Protective payload fairing (inert mass)."
     },
     {
       "id": "ballast-plate",
       "name": "Ballast Plate",
       "kind": "structure",
-      "dry_mass_kg": 200
+      "dry_mass_kg": 200,
+      "description": "Dead-weight ballast for trimming a stack's balance."
     }
   ]
 }

--- a/internal/spacecraft/data/components.json
+++ b/internal/spacecraft/data/components.json
@@ -1,3 +1,38 @@
 {
-  "components": []
+  "components": [
+    {
+      "id": "probe-engine",
+      "name": "LT-50 Probe Engine",
+      "glyph": "➤",
+      "color": "#FFD93D",
+      "kind": "engine",
+      "dry_mass_kg": 200,
+      "thrust_n": 50000,
+      "isp_s": 320,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "probe-tank-1k",
+      "name": "FT-1000 Tank",
+      "kind": "tank",
+      "dry_mass_kg": 100,
+      "fuel_capacity_kg": 1000,
+      "fuel_type": "kerolox"
+    },
+    {
+      "id": "probe-core",
+      "name": "OKTO Probe Core",
+      "kind": "command-core",
+      "dry_mass_kg": 80,
+      "command_source": "probe"
+    },
+    {
+      "id": "probe-antenna",
+      "name": "DA-5 Direct Antenna",
+      "kind": "antenna",
+      "dry_mass_kg": 20,
+      "antenna_kind": "direct",
+      "range_m": 10000000
+    }
+  ]
 }

--- a/internal/spacecraft/data/loadouts.json
+++ b/internal/spacecraft/data/loadouts.json
@@ -296,6 +296,18 @@
         1,
         1
       ]
+    },
+    {
+      "id": "Probe-Sat",
+      "name": "Probe Sat",
+      "role": "probe",
+      "glyph": "➤",
+      "color": "#5BB3FF",
+      "parts": [
+        {
+          "part_id": "probe-sat-stage"
+        }
+      ]
     }
   ]
 }

--- a/internal/spacecraft/data/parts.json
+++ b/internal/spacecraft/data/parts.json
@@ -548,6 +548,22 @@
         "kind": "relay",
         "range_m": 5000000000
       }
+    },
+    {
+      "id": "probe-sat-stage",
+      "name": "Probe Sat",
+      "glyph": "➤",
+      "color": "#5BB3FF",
+      "tier": "payload",
+      "launch_sprite_rows_px": 6,
+      "launch_sprite_width_px": 2,
+      "launch_sprite_color": "#5BB3FF",
+      "components": [
+        "probe-engine",
+        "probe-tank-1k",
+        "probe-core",
+        "probe-antenna"
+      ]
     }
   ]
 }

--- a/internal/spacecraft/designs.go
+++ b/internal/spacecraft/designs.go
@@ -76,6 +76,16 @@ func (d Design) Resolve() (Loadout, []CatalogWarning) {
 	}
 	designParts, aggWarn := aggregateComponents(designParts, comps)
 	warnings = append(warnings, aggWarn...)
+	// A composed part that fails to aggregate (unknown component, mixed fuel)
+	// is left UNAGGREGATED with zero scalars — resolving it would build a
+	// flyable-but-dead ghost stage (0 thrust / 0 mass), and the spawn path
+	// only errors on an EMPTY loadout, never a degenerate one. Reject the
+	// whole design instead so the caller surfaces the failure rather than
+	// spawning dead weight (e.g. a design referencing a since-removed overlay
+	// component, or a hand-edited mixed-fuel stage).
+	if len(aggWarn) > 0 {
+		return Loadout{}, warnings
+	}
 	// Merge the global catalog parts with the design's design-scoped parts.
 	merged := make(map[string]Part, len(globalParts)+len(designParts))
 	for id, p := range globalParts {

--- a/internal/spacecraft/designs.go
+++ b/internal/spacecraft/designs.go
@@ -1,0 +1,215 @@
+package spacecraft
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Design persistence (ADR 0029 §4, the VAB cycle). A custom vehicle the
+// player builds in the VAB is CATALOG DATA, not save state: it lives in an
+// app-managed designs store (its own directory, written and deleted by the
+// VAB), serialized in the SAME catalog-fragment format as the ADR 0026
+// modder overlays. Consequences:
+//
+//   - No save-schema bump — a spawned craft still persists its full
+//     Stages[] inline, so loading a save never needs the design (ADR 0029 §4).
+//   - Global across saves (KSP .craft-like).
+//   - Portable: a design file IS a catalog fragment, so copying it into the
+//     modder overlay dir publishes it as a mod (see TestDesignPortability).
+//
+// The store is deliberately SEPARATE from the hand-authored modder overlay
+// (loadouts/) so app-written files never pollute that channel and a design
+// can never silently override a built-in by ID collision: designs live in
+// their own namespace and are NEVER merged into the global Loadouts map.
+// The spawn form (S4) lists them ALONGSIDE catalog loadouts; Design.Resolve
+// produces a flyable Loadout on demand.
+
+// Design is one saved custom vehicle: a Loadout plus the design-local
+// composed Parts it references (each carrying a Components list; ADR 0029
+// §1). The on-disk form is a Catalog fragment {parts, loadouts:[one]}.
+type Design struct {
+	Loadout LoadoutDef
+	Parts   []Part
+}
+
+// ID / Name read the design's identity off its loadout. ID is the stable
+// key (and file stem); Name is the display label.
+func (d Design) ID() string   { return d.Loadout.ID }
+func (d Design) Name() string { return d.Loadout.Name }
+
+// marshal serializes the design as an indented catalog fragment — the
+// portable on-disk format (also valid as a modder overlay file).
+func (d Design) marshal() ([]byte, error) {
+	cat := Catalog{Parts: d.Parts, Loadouts: []LoadoutDef{d.Loadout}}
+	return json.MarshalIndent(cat, "", "  ")
+}
+
+// designFromCatalog reads a Design out of a parsed catalog fragment. A
+// design file must carry exactly one loadout (its own); the parts are its
+// composed stages.
+func designFromCatalog(cat Catalog) (Design, bool) {
+	if len(cat.Loadouts) == 0 {
+		return Design{}, false
+	}
+	return Design{Loadout: cat.Loadouts[0], Parts: cat.Parts}, true
+}
+
+// Resolve turns a design into a flyable Loadout, resolved against the LIVE
+// catalog (embedded + modder overlay) so its references — both design-local
+// composed parts and existing atomic catalog parts — resolve correctly. The
+// design's own composed parts are aggregated against the live component
+// catalog (ADR 0029 §2). A dangling part reference is skip-bad (a warning +
+// an empty Loadout), never a panic, so a hand-edited design file can't crash
+// the app.
+func (d Design) Resolve() (Loadout, []CatalogWarning) {
+	comps, globalParts, _, warnings, err := loadMergedCatalog()
+	if err != nil {
+		return Loadout{}, append(warnings, CatalogWarning{Path: "designs", Err: err})
+	}
+	// Aggregate the design's own composed parts against the live components.
+	designParts := make(map[string]Part, len(d.Parts))
+	for _, p := range d.Parts {
+		designParts[p.ID] = p
+	}
+	designParts, aggWarn := aggregateComponents(designParts, comps)
+	warnings = append(warnings, aggWarn...)
+	// Merge the global catalog parts with the design's design-scoped parts.
+	merged := make(map[string]Part, len(globalParts)+len(designParts))
+	for id, p := range globalParts {
+		merged[id] = p
+	}
+	for id, p := range designParts {
+		merged[id] = p
+	}
+	// Every loadout ref must resolve; a dangling ref is skip-bad, not a panic
+	// (resolveLoadout panics on unknown IDs — fine for the embedded catalog,
+	// not for user designs).
+	for _, ref := range d.Loadout.Parts {
+		if _, ok := merged[ref.PartID]; !ok {
+			warnings = append(warnings, CatalogWarning{Path: "design:" + d.ID(), Err: fmt.Errorf("references unknown part %q", ref.PartID)})
+			return Loadout{}, warnings
+		}
+	}
+	return resolveLoadout(d.Loadout, merged), warnings
+}
+
+// DesignsDir resolves the app-managed designs directory:
+// $XDG_CONFIG_HOME/terminal-space-program/designs (or
+// ~/.config/terminal-space-program/designs when XDG is unset). A sibling of
+// the modder overlay's loadouts/ dir but a DISTINCT namespace (ADR 0029 §4)
+// so app-written designs never collide with hand-authored mods.
+func DesignsDir() string {
+	if x := os.Getenv("XDG_CONFIG_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "designs")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "terminal-space-program", "designs")
+}
+
+// designFileName maps a design ID to its file name, replacing path-unsafe
+// runes so a free-form name can never escape the designs dir.
+func designFileName(id string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ':', ' ', '.':
+			return '-'
+		}
+		return r
+	}, id)
+	if safe == "" {
+		safe = "design"
+	}
+	return safe + ".json"
+}
+
+// SaveDesign writes a design to the store, creating the dir on first use.
+// Overwrites any existing design with the same ID (the VAB's save-over-name).
+func SaveDesign(d Design) error {
+	dir := DesignsDir()
+	if dir == "" {
+		return fmt.Errorf("cannot resolve designs directory")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create designs dir: %w", err)
+	}
+	data, err := d.marshal()
+	if err != nil {
+		return fmt.Errorf("serialize design %q: %w", d.ID(), err)
+	}
+	return os.WriteFile(filepath.Join(dir, designFileName(d.ID())), data, 0o644)
+}
+
+// ListDesigns reads every design in the store, skipping malformed files with
+// a warning (the ADR 0026 skip-bad-with-warning convention). A missing
+// store dir yields no designs and no warnings.
+func ListDesigns() ([]Design, []CatalogWarning) {
+	dir := DesignsDir()
+	if dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, []CatalogWarning{{Path: dir, Err: err}}
+	}
+	var designs []Design
+	var warnings []CatalogWarning
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			warnings = append(warnings, CatalogWarning{Path: path, Err: err})
+			continue
+		}
+		var cat Catalog
+		if err := json.Unmarshal(data, &cat); err != nil {
+			warnings = append(warnings, CatalogWarning{Path: path, Err: err})
+			continue
+		}
+		d, ok := designFromCatalog(cat)
+		if !ok {
+			warnings = append(warnings, CatalogWarning{Path: path, Err: fmt.Errorf("design file has no loadout")})
+			continue
+		}
+		designs = append(designs, d)
+	}
+	return designs, warnings
+}
+
+// LoadDesign returns the stored design with the given ID, or ok=false if
+// none matches. Warnings from other malformed files in the store are
+// surfaced so the caller can report them.
+func LoadDesign(id string) (Design, bool, []CatalogWarning) {
+	designs, warnings := ListDesigns()
+	for _, d := range designs {
+		if d.ID() == id {
+			return d, true, warnings
+		}
+	}
+	return Design{}, false, warnings
+}
+
+// DeleteDesign removes a design file from the store. Returns an error if no
+// design with that ID exists (so the VAB can report a stale delete).
+func DeleteDesign(id string) error {
+	dir := DesignsDir()
+	if dir == "" {
+		return fmt.Errorf("cannot resolve designs directory")
+	}
+	path := filepath.Join(dir, designFileName(id))
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("design %q not found", id)
+	}
+	return os.Remove(path)
+}

--- a/internal/spacecraft/designs_test.go
+++ b/internal/spacecraft/designs_test.go
@@ -1,0 +1,242 @@
+package spacecraft
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// S2 / ADR 0029 §4 — the app-managed designs store. A Design is a saved
+// custom vehicle: a Loadout plus the composed Parts it references,
+// serialized as a self-contained catalog fragment in its own designs/ dir
+// (distinct from the modder overlay so an app-written file can never
+// override a built-in by ID collision). Designs are global across saves and
+// portable (drop one into the modder overlay dir to publish it as a mod).
+
+// withDesignsAndOverlay points XDG_CONFIG_HOME at a temp root and returns
+// the app-managed designs dir plus the modder overlay (loadouts) dir under
+// it. Both empty.
+func withDesignsAndOverlay(t *testing.T) (designsDir, overlayDir string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	designsDir = filepath.Join(root, "terminal-space-program", "designs")
+	overlayDir = filepath.Join(root, "terminal-space-program", "loadouts")
+	for _, d := range []string{designsDir, overlayDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	return designsDir, overlayDir
+}
+
+// writeOverlayComponents drops a components-only overlay file so a design's
+// composed parts have components to aggregate against (the embedded
+// components.json is an empty stub until S4).
+func writeOverlayComponents(t *testing.T, overlayDir string) {
+	t.Helper()
+	comps := `{"components":[
+		{"id":"c-eng","kind":"engine","dry_mass_kg":500,"thrust_n":1000000,"isp_s":320,"fuel_type":"kerolox"},
+		{"id":"c-tank","kind":"tank","dry_mass_kg":100,"fuel_capacity_kg":4000,"fuel_type":"kerolox"},
+		{"id":"c-core","kind":"command-core","dry_mass_kg":90,"command_source":"probe"}
+	]}`
+	if err := os.WriteFile(filepath.Join(overlayDir, "comps.json"), []byte(comps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// sampleDesign is a Mun-hopper-style design: one composed stage (engine +
+// tank + probe core) under an existing atomic catalog part (s-ivb), with a
+// decouple plan. Exercises mixing composed + catalog parts in one design.
+func sampleDesign() Design {
+	return Design{
+		Loadout: LoadoutDef{
+			ID:    "my-hopper",
+			Name:  "My Hopper",
+			Role:  "custom",
+			Glyph: VesselGlyph,
+			Color: "#AABBCC",
+			Parts: []PartRef{
+				{PartID: "_my-hopper_s0"}, // composed stage
+				{PartID: "s-ivb"},         // atomic catalog part
+			},
+			DecouplePlan: []int{1},
+		},
+		Parts: []Part{
+			{ID: "_my-hopper_s0", Name: "Hopper Core", Glyph: VesselGlyph, Color: "#AABBCC",
+				Components: []string{"c-eng", "c-tank", "c-core"}},
+		},
+	}
+}
+
+// TestDesignRoundTrip — serialize a design to the store, reload it, and
+// confirm it resolves to an identical flyable Loadout (the composed stage
+// aggregates the same, the atomic catalog part is referenced the same).
+func TestDesignRoundTrip(t *testing.T) {
+	_, overlayDir := withDesignsAndOverlay(t)
+	writeOverlayComponents(t, overlayDir)
+
+	d := sampleDesign()
+	want, warnings := d.Resolve()
+	if len(warnings) != 0 {
+		t.Fatalf("Resolve warnings = %v, want none", warnings)
+	}
+	if len(want.Stages) != 2 {
+		t.Fatalf("resolved stages = %d, want 2", len(want.Stages))
+	}
+
+	if err := SaveDesign(d); err != nil {
+		t.Fatalf("SaveDesign: %v", err)
+	}
+	got, ok, warnings := LoadDesign("my-hopper")
+	if !ok {
+		t.Fatal("LoadDesign(my-hopper) not found after save")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("LoadDesign warnings = %v, want none", warnings)
+	}
+	reLoadout, warnings := got.Resolve()
+	if len(warnings) != 0 {
+		t.Fatalf("reloaded Resolve warnings = %v, want none", warnings)
+	}
+	if !reflect.DeepEqual(want, reLoadout) {
+		t.Errorf("round-trip drift:\n want %+v\n  got %+v", want, reLoadout)
+	}
+	// Concretely: the composed stage aggregated and the atomic ref came through.
+	if reLoadout.Stages[0].Thrust != 1_000_000 || reLoadout.Stages[0].Isp != 320 {
+		t.Errorf("composed stage = %g N / %g s, want 1e6/320", reLoadout.Stages[0].Thrust, reLoadout.Stages[0].Isp)
+	}
+	if reLoadout.Stages[1].Name != "S-IVB" {
+		t.Errorf("atomic stage name = %q, want S-IVB", reLoadout.Stages[1].Name)
+	}
+}
+
+// TestDesignPortabilityAsOverlay — the same design file dropped into the
+// modder overlay dir loads as a normal catalog entry (the publish-as-mod
+// path). A design is a plain catalog fragment, so the existing overlay
+// loader resolves it with no special case.
+func TestDesignPortabilityAsOverlay(t *testing.T) {
+	_, overlayDir := withDesignsAndOverlay(t)
+	writeOverlayComponents(t, overlayDir)
+
+	d := sampleDesign()
+	data, err := d.marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayDir, "my-hopper.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parts, defs, warnings, err := LoadCatalogWithWarnings()
+	if err != nil {
+		t.Fatalf("LoadCatalogWithWarnings: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	// The composed part is in the merged catalog with aggregated stats.
+	cp, ok := parts["_my-hopper_s0"]
+	if !ok || cp.ThrustN != 1_000_000 {
+		t.Errorf("composed part not aggregated in overlay path: %+v", cp)
+	}
+	// The loadout resolves as a normal catalog loadout.
+	var def *LoadoutDef
+	for i := range defs {
+		if defs[i].ID == "my-hopper" {
+			def = &defs[i]
+		}
+	}
+	if def == nil {
+		t.Fatal("design loadout not loaded via the overlay path")
+	}
+	l := resolveLoadout(*def, parts)
+	if len(l.Stages) != 2 {
+		t.Errorf("resolved overlay loadout stages = %d, want 2", len(l.Stages))
+	}
+}
+
+// TestDesignMalformedSkipped — a malformed design file is skipped with a
+// warning; the other designs in the store still list.
+func TestDesignMalformedSkipped(t *testing.T) {
+	designsDir, overlayDir := withDesignsAndOverlay(t)
+	writeOverlayComponents(t, overlayDir)
+	if err := SaveDesign(sampleDesign()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(designsDir, "broken.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	designs, warnings := ListDesigns()
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1 (malformed skipped)", len(warnings))
+	}
+	if len(designs) != 1 || designs[0].ID() != "my-hopper" {
+		t.Errorf("designs = %v, want just my-hopper", designs)
+	}
+}
+
+// TestDesignIDCollisionIsolation — a design whose loadout ID equals a
+// built-in does NOT override the built-in: designs live in their own
+// namespace and never merge into the global Loadouts map.
+func TestDesignIDCollisionIsolation(t *testing.T) {
+	withDesignsAndOverlay(t)
+	clash := sampleDesign()
+	clash.Loadout.ID = LoadoutSaturnVID
+	clash.Loadout.Name = "Not Really Saturn"
+	clash.Loadout.Parts = []PartRef{{PartID: "s-ivb"}} // atomic only, no components needed
+	clash.Parts = nil
+	if err := SaveDesign(clash); err != nil {
+		t.Fatal(err)
+	}
+	// The built-in Saturn-V is untouched in the global catalog.
+	if l := Loadouts[LoadoutSaturnVID]; l.Name == "Not Really Saturn" {
+		t.Error("a saved design overrode the built-in Saturn-V in Loadouts")
+	}
+	if len(Loadouts[LoadoutSaturnVID].Stages) != 3 {
+		t.Errorf("built-in Saturn-V stages = %d, want 3 (design must not clobber it)", len(Loadouts[LoadoutSaturnVID].Stages))
+	}
+	// The design IS stored, separately.
+	designs, _ := ListDesigns()
+	if len(designs) != 1 || designs[0].Name() != "Not Really Saturn" {
+		t.Errorf("design not stored in its own namespace: %v", designs)
+	}
+}
+
+// TestDeleteDesign — delete removes the design from the store and its file.
+func TestDeleteDesign(t *testing.T) {
+	designsDir, overlayDir := withDesignsAndOverlay(t)
+	writeOverlayComponents(t, overlayDir)
+	if err := SaveDesign(sampleDesign()); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteDesign("my-hopper"); err != nil {
+		t.Fatalf("DeleteDesign: %v", err)
+	}
+	designs, _ := ListDesigns()
+	if len(designs) != 0 {
+		t.Errorf("designs after delete = %d, want 0", len(designs))
+	}
+	if _, err := os.Stat(filepath.Join(designsDir, "my-hopper.json")); !os.IsNotExist(err) {
+		t.Errorf("design file still present after delete (err=%v)", err)
+	}
+	// Deleting a missing design is a no-op error the caller can ignore.
+	if err := DeleteDesign("nope"); err == nil {
+		t.Error("DeleteDesign(missing) should report not-found")
+	}
+}
+
+// TestDesignResolveSkipsBadRef — a design whose loadout references a part
+// that exists nowhere resolves to a warning, not a panic (hand-edited
+// design files must not crash the app).
+func TestDesignResolveSkipsBadRef(t *testing.T) {
+	withDesignsAndOverlay(t)
+	d := Design{Loadout: LoadoutDef{ID: "broken", Name: "Broken", Parts: []PartRef{{PartID: "ghost-part"}}}}
+	l, warnings := d.Resolve()
+	if len(warnings) == 0 {
+		t.Error("Resolve of a dangling ref should warn")
+	}
+	if len(l.Stages) != 0 {
+		t.Errorf("broken design resolved %d stages, want 0", len(l.Stages))
+	}
+}

--- a/internal/spacecraft/designs_test.go
+++ b/internal/spacecraft/designs_test.go
@@ -226,6 +226,32 @@ func TestDeleteDesign(t *testing.T) {
 	}
 }
 
+// TestDesignResolveRejectsBrokenComposedPart — a design whose composed part
+// fails aggregation (mixed fuel chemistry) resolves to an EMPTY loadout +
+// warnings, not a flyable-but-dead ghost stage. The spawn path keys off the
+// empty loadout to surface the failure instead of spawning dead weight.
+func TestDesignResolveRejectsBrokenComposedPart(t *testing.T) {
+	_, overlayDir := withDesignsAndOverlay(t)
+	comps := `{"components":[
+		{"id":"x-eng","kind":"engine","dry_mass_kg":500,"thrust_n":1000000,"isp_s":300,"fuel_type":"kerolox"},
+		{"id":"x-hydro","kind":"tank","dry_mass_kg":100,"fuel_capacity_kg":2000,"fuel_type":"hydrolox"}
+	]}`
+	if err := os.WriteFile(filepath.Join(overlayDir, "c.json"), []byte(comps), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := Design{
+		Loadout: LoadoutDef{ID: "broken", Name: "Broken", Parts: []PartRef{{PartID: "_broken_s0"}}},
+		Parts:   []Part{{ID: "_broken_s0", Components: []string{"x-eng", "x-hydro"}}},
+	}
+	l, warnings := d.Resolve()
+	if len(l.Stages) != 0 {
+		t.Errorf("mixed-fuel design resolved %d stages, want 0 (rejected)", len(l.Stages))
+	}
+	if len(warnings) == 0 {
+		t.Error("expected an aggregation warning for the mixed-fuel composed stage")
+	}
+}
+
 // TestDesignResolveSkipsBadRef — a design whose loadout references a part
 // that exists nowhere resolves to a warning, not a panic (hand-edited
 // design files must not crash the app).

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -346,7 +346,17 @@ func LookupLoadout(id string) Loadout {
 // from Stages so pre-v0.9.1 readers keep working without per-site
 // changes.
 func NewFromLoadout(loadoutID string) *Spacecraft {
-	l := LookupLoadout(loadoutID)
+	return NewFromLoadoutValue(LookupLoadout(loadoutID))
+}
+
+// NewFromLoadoutValue constructs a Spacecraft from a resolved Loadout VALUE
+// (not a catalog ID). The spawn path for saved VAB designs uses this: a
+// design resolves to a Loadout that lives OUTSIDE the global Loadouts map
+// (ADR 0029 §4 — designs are a separate namespace), so it can't go through
+// the ID-keyed NewFromLoadout. Identical otherwise — copies Stages +
+// DecouplePlan, defaults the command source, and syncs — so a design-spawned
+// craft is byte-identical to the equivalent catalog craft.
+func NewFromLoadoutValue(l Loadout) *Spacecraft {
 	stages := make([]Stage, len(l.Stages))
 	copy(stages, l.Stages)
 	// Copy the decouple plan (own backing array) so StageActive's

--- a/internal/spacecraft/loadouts.go
+++ b/internal/spacecraft/loadouts.go
@@ -217,9 +217,17 @@ func stageRCS(dryMass float64) (mp, monoCap, rcsThrust, rcsIsp float64) {
 // layer (C1-4); this init path reads embedded data only, so it stays
 // deterministic.
 func buildLoadouts() (map[string]Loadout, []string) {
-	parts, defs, err := loadEmbeddedCatalog()
+	comps, parts, defs, err := loadEmbeddedCatalog()
 	if err != nil {
 		panic("spacecraft: embedded loadout catalog failed to load: " + err.Error())
+	}
+	// Resolve any composed parts (ADR 0029) before loadout assembly. The
+	// embedded catalog declares no components this cycle, so this is a
+	// pass-through for the shipped fleet; an aggregation warning on the
+	// embedded set is a build error (like the unknown-part-ID panic below).
+	parts, aggWarnings := aggregateComponents(parts, comps)
+	if len(aggWarnings) > 0 {
+		panic("spacecraft: embedded composed part failed aggregation: " + aggWarnings[0].Error())
 	}
 	out := make(map[string]Loadout, len(defs))
 	order := make([]string, 0, len(defs))

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -388,29 +388,12 @@ func TestLanderStageDeltaVBudgets(t *testing.T) {
 }
 
 // stackDeltaV returns the ideal (rocket-equation) Δv of a bottom-first
-// stage list flown as a single drop-stage chain: each stage fires hauling
-// itself plus everything above it, then is jettisoned. Mirrors the mass
-// convention of TestLanderStageDeltaVBudgets (dry + main fuel only; RCS
-// monoprop is ignored). Engineless / fuelless stages (the parachute Pod)
-// contribute mass but no Δv.
+// stage list flown as a single drop-stage chain. Delegates to the
+// production StackStats so the loadout-budget tests and the VAB readout
+// can never drift apart on the Δv convention (dry + main fuel only; RCS
+// monoprop ignored; engineless / fuelless stages contribute mass but no Δv).
 func stackDeltaV(stages []Stage) float64 {
-	massAtOrAbove := func(i int) float64 {
-		m := 0.0
-		for j := i; j < len(stages); j++ {
-			m += stages[j].DryMass + stages[j].FuelMass
-		}
-		return m
-	}
-	total := 0.0
-	for i, s := range stages {
-		if s.FuelMass <= 0 || s.Isp <= 0 {
-			continue
-		}
-		m0 := massAtOrAbove(i)
-		m1 := m0 - s.FuelMass
-		total += s.Isp * g0 * math.Log(m0/m1)
-	}
-	return total
+	return StackStats(stages).TotalDV
 }
 
 // TestKernStackShape — ADR 0014 Slice C/D. The Kern Stack is the one

--- a/internal/spacecraft/stages_catalog.go
+++ b/internal/spacecraft/stages_catalog.go
@@ -167,9 +167,16 @@ var StageCatalog = buildStageCatalog()
 // as StageModules. Runs once at package-var init. Panics if the embedded
 // data fails to load (it must always load — see StageCatalog).
 func buildStageCatalog() map[string]StageModule {
-	parts, _, err := loadEmbeddedCatalog()
+	comps, parts, _, err := loadEmbeddedCatalog()
 	if err != nil {
 		panic("spacecraft: embedded parts catalog failed to load: " + err.Error())
+	}
+	// Aggregate composed parts (ADR 0029) so a composed catalog part would
+	// project its derived stats. The embedded catalog is all-atomic this
+	// cycle (pass-through); a bad embedded composition is a build error.
+	parts, aggWarnings := aggregateComponents(parts, comps)
+	if len(aggWarnings) > 0 {
+		panic("spacecraft: embedded composed part failed aggregation: " + aggWarnings[0].Error())
 	}
 	out := make(map[string]StageModule, len(parts))
 	for id, p := range parts {

--- a/internal/spacecraft/starter_components_test.go
+++ b/internal/spacecraft/starter_components_test.go
@@ -1,9 +1,85 @@
 package spacecraft
 
 import (
+	"math"
 	"reflect"
 	"testing"
 )
+
+// TestStarterComponentsAggregateCleanly — every embedded component is
+// individually valid (composes into a one-component stage with no warning),
+// carries the fields its kind needs, and each of the five kinds ships a
+// selection (engines/tanks have several so clustering + tank-sizing are real
+// choices). Guards the v0.24 starter content against a malformed addition.
+func TestStarterComponentsAggregateCleanly(t *testing.T) {
+	comps, _, _, err := loadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("loadEmbeddedCatalog: %v", err)
+	}
+	byKind := map[string]int{}
+	for id, c := range comps {
+		byKind[c.Kind]++
+		if _, warn := ComposeStage([]string{id}, comps); warn != "" {
+			t.Errorf("component %q does not aggregate cleanly: %s", id, warn)
+		}
+		if c.DryMassKg <= 0 {
+			t.Errorf("component %q has non-positive dry mass", id)
+		}
+		switch c.Kind {
+		case ComponentEngine:
+			if c.ThrustN <= 0 || c.IspS <= 0 || c.FuelType == "" {
+				t.Errorf("engine %q missing thrust/Isp/fuel: %+v", id, c)
+			}
+		case ComponentTank:
+			if c.FuelCapacityKg <= 0 || c.FuelType == "" {
+				t.Errorf("tank %q missing capacity/fuel: %+v", id, c)
+			}
+		case ComponentCommandCore:
+			if !IsCommandSource(c.CommandSource) {
+				t.Errorf("command-core %q has no command source: %+v", id, c)
+			}
+		case ComponentAntenna:
+			if c.AntennaKind == AntennaNone || c.RangeM <= 0 {
+				t.Errorf("antenna %q missing kind/range: %+v", id, c)
+			}
+		case ComponentStructure:
+			// dry mass only — already checked above.
+		default:
+			t.Errorf("component %q has unknown kind %q", id, c.Kind)
+		}
+	}
+	for _, k := range []string{ComponentEngine, ComponentTank, ComponentCommandCore, ComponentAntenna, ComponentStructure} {
+		if byKind[k] == 0 {
+			t.Errorf("no components of kind %q ship", k)
+		}
+	}
+	if byKind[ComponentEngine] < 3 || byKind[ComponentTank] < 3 {
+		t.Errorf("want a real selection, got %d engines / %d tanks", byKind[ComponentEngine], byKind[ComponentTank])
+	}
+}
+
+// TestStarterEngineClusterThrustWeighted — two different same-chemistry
+// engines from the catalog cluster honestly: thrust adds and the effective
+// Isp is the thrust-weighted blend (the property the spread of engines makes
+// meaningful).
+func TestStarterEngineClusterThrustWeighted(t *testing.T) {
+	comps, _, _, err := loadEmbeddedCatalog()
+	if err != nil {
+		t.Fatalf("loadEmbeddedCatalog: %v", err)
+	}
+	a, b := comps["rd180-booster"], comps["merlin-sustainer"] // both kerolox, different Isp
+	st, warn := ComposeStage([]string{"rd180-booster", "merlin-sustainer"}, comps)
+	if warn != "" {
+		t.Fatalf("kerolox cluster should aggregate: %s", warn)
+	}
+	if st.Thrust != a.ThrustN+b.ThrustN {
+		t.Errorf("cluster thrust = %g, want %g", st.Thrust, a.ThrustN+b.ThrustN)
+	}
+	wantIsp := (a.ThrustN + b.ThrustN) / (a.ThrustN/a.IspS + b.ThrustN/b.IspS)
+	if math.Abs(st.Isp-wantIsp) > 1e-6 {
+		t.Errorf("cluster Isp_eff = %g, want %g (thrust-weighted)", st.Isp, wantIsp)
+	}
+}
 
 // TestProbeSatComposedFromComponents — the v0.24 starter dogfood (ADR 0029
 // S4): the embedded "Probe-Sat" loadout is built from a composed part

--- a/internal/spacecraft/starter_components_test.go
+++ b/internal/spacecraft/starter_components_test.go
@@ -1,0 +1,71 @@
+package spacecraft
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestProbeSatComposedFromComponents — the v0.24 starter dogfood (ADR 0029
+// S4): the embedded "Probe-Sat" loadout is built from a composed part
+// (probe-sat-stage → probe-engine + probe-tank-1k + probe-core +
+// probe-antenna) and must fly INDISTINGUISHABLY from an equivalent atomic
+// part with the same summed stats. Proves the components→part→loadout→spawn
+// chain end-to-end, one level below the ADR 0026 modding proof.
+func TestProbeSatComposedFromComponents(t *testing.T) {
+	c := NewFromLoadout("Probe-Sat")
+	if c == nil || len(c.Stages) != 1 {
+		t.Fatalf("Probe-Sat is not a flyable single-stage craft: %+v", c)
+	}
+	got := c.Stages[0]
+
+	// Hand-summed aggregate of the four starter components:
+	//   dry  = 200 + 100 + 80 + 20 = 400
+	//   fuel = 1000 (the one tank, full)
+	//   thrust 50 kN, Isp 320 (single engine → passthrough)
+	//   probe command source + a basic direct antenna (1e7 m).
+	if got.DryMass != 400 {
+		t.Errorf("dry mass = %g, want 400 (Σ component dry)", got.DryMass)
+	}
+	if got.FuelMass != 1000 || got.FuelCapacity != 1000 {
+		t.Errorf("fuel = %g/%g, want 1000/1000 (full tank)", got.FuelMass, got.FuelCapacity)
+	}
+	if got.Thrust != 50000 || got.Isp != 320 {
+		t.Errorf("engine = %g N / %g s, want 50000/320", got.Thrust, got.Isp)
+	}
+	if got.CommandSource != CommandProbe {
+		t.Errorf("command source = %q, want probe", got.CommandSource)
+	}
+	if got.AntennaKind != AntennaDirect || got.AntennaRangeM != 1e7 {
+		t.Errorf("antenna = %q @ %g, want direct @ 1e7", got.AntennaKind, got.AntennaRangeM)
+	}
+
+	// Build the atomic equivalent and compare the resolved runtime Stage —
+	// they must be byte-identical (RCS derived from the same dry mass).
+	atomic := Part{
+		ID:             "probe-sat-atomic",
+		Name:           "Probe Sat",
+		Glyph:          VesselGlyph,
+		Color:          "#5BB3FF",
+		DryMassKg:      400,
+		FuelMassKg:     1000,
+		FuelCapacityKg: 1000,
+		ThrustN:        50000,
+		IspS:           320,
+		FuelType:       FuelTypeKerolox, // derived up from the engine/tank chemistry
+		CommandSource:  CommandProbe,
+		Antenna:        &Antenna{Kind: AntennaDirect, RangeM: 1e7},
+		// Visual fields the composed part also carries.
+		LaunchSpriteRowsPx:  6,
+		LaunchSpriteWidthPx: 2,
+		LaunchSpriteColor:   "#5BB3FF",
+	}
+	def := LoadoutDef{ID: "Probe-Sat-Atomic", Name: "Probe Sat", Role: "probe", Glyph: VesselGlyph, Color: "#5BB3FF", Parts: []PartRef{{PartID: "probe-sat-atomic"}}}
+	atomicL := resolveLoadout(def, map[string]Part{"probe-sat-atomic": atomic})
+
+	// Compare the physics-relevant fields (LoadoutID differs by construction).
+	want := atomicL.Stages[0]
+	want.LoadoutID = got.LoadoutID
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("composed stage differs from atomic equivalent:\n composed %+v\n  atomic  %+v", got, want)
+	}
+}

--- a/internal/spacecraft/stats.go
+++ b/internal/spacecraft/stats.go
@@ -1,0 +1,53 @@
+package spacecraft
+
+import "math"
+
+// VehicleStats summarizes a bottom-first stage stack for the VAB readout
+// (ADR 0029 §5). It is a pure function of the resolved Stages, recomputed
+// on every edit so the builder always shows live numbers.
+//
+//   - StageDV is the per-stage ideal Δv (m/s), bottom→top: stage i fires
+//     hauling itself plus everything above it (the drop-stage chain), then
+//     is jettisoned. Mirrors the convention of the existing loadout Δv
+//     tests (RCS monoprop excluded — this is main-engine ideal Δv).
+//   - TotalDV is the sum of StageDV.
+//   - TotalMass is the wet mass on the pad (dry + main fuel + RCS monoprop),
+//     across every stage, kg.
+//   - LiftoffTWR is the bottom stage's thrust over the full stack weight at
+//     g0 (the reference launch gravity — the VAB designs a template, not a
+//     spawn on a specific body; the Apollo / Kern liftoff-TWR tests use the
+//     same g0 reference).
+type VehicleStats struct {
+	StageDV    []float64
+	TotalDV    float64
+	TotalMass  float64
+	LiftoffTWR float64
+}
+
+// StackStats computes the VAB readout for a bottom-first stage stack.
+func StackStats(stages []Stage) VehicleStats {
+	massAtOrAbove := func(i int) float64 {
+		m := 0.0
+		for j := i; j < len(stages); j++ {
+			m += stages[j].DryMass + stages[j].FuelMass
+		}
+		return m
+	}
+	vs := VehicleStats{StageDV: make([]float64, len(stages))}
+	for i, s := range stages {
+		if s.FuelMass > 0 && s.Isp > 0 {
+			m0 := massAtOrAbove(i)
+			m1 := m0 - s.FuelMass
+			if m1 > 0 {
+				dv := s.Isp * g0 * math.Log(m0/m1)
+				vs.StageDV[i] = dv
+				vs.TotalDV += dv
+			}
+		}
+		vs.TotalMass += s.DryMass + s.FuelMass + s.MonopropMass
+	}
+	if len(stages) > 0 && vs.TotalMass > 0 {
+		vs.LiftoffTWR = stages[0].Thrust / (vs.TotalMass * g0)
+	}
+	return vs
+}

--- a/internal/spacecraft/stats_test.go
+++ b/internal/spacecraft/stats_test.go
@@ -1,0 +1,59 @@
+package spacecraft
+
+import (
+	"math"
+	"testing"
+)
+
+// TestStackStatsHandWorked — a two-stage stack with hand-computed Δv and
+// liftoff TWR. Stage 0: dry 1000, fuel 9000, thrust 200 kN, Isp 300.
+// Stage 1: dry 500, fuel 4500, thrust 50 kN, Isp 320. Monoprop 0 so the
+// mass convention is unambiguous.
+func TestStackStatsHandWorked(t *testing.T) {
+	stages := []Stage{
+		{DryMass: 1000, FuelMass: 9000, Thrust: 200_000, Isp: 300},
+		{DryMass: 500, FuelMass: 4500, Thrust: 50_000, Isp: 320},
+	}
+	vs := StackStats(stages)
+
+	// Stage 0 hauls the whole stack (m0 = 1000+9000+500+4500 = 15000),
+	// burns 9000 → m1 = 6000. Δv0 = 300·g0·ln(15000/6000).
+	wantDV0 := 300 * g0 * math.Log(15000.0/6000.0)
+	// Stage 1 alone: m0 = 5000, m1 = 500. Δv1 = 320·g0·ln(5000/500).
+	wantDV1 := 320 * g0 * math.Log(5000.0/500.0)
+	if math.Abs(vs.StageDV[0]-wantDV0) > 1e-6 {
+		t.Errorf("StageDV[0] = %g, want %g", vs.StageDV[0], wantDV0)
+	}
+	if math.Abs(vs.StageDV[1]-wantDV1) > 1e-6 {
+		t.Errorf("StageDV[1] = %g, want %g", vs.StageDV[1], wantDV1)
+	}
+	if math.Abs(vs.TotalDV-(wantDV0+wantDV1)) > 1e-6 {
+		t.Errorf("TotalDV = %g, want %g", vs.TotalDV, wantDV0+wantDV1)
+	}
+	if vs.TotalMass != 15000 {
+		t.Errorf("TotalMass = %g, want 15000", vs.TotalMass)
+	}
+	// Liftoff TWR = 200000 / (15000·g0).
+	wantTWR := 200_000.0 / (15000 * g0)
+	if math.Abs(vs.LiftoffTWR-wantTWR) > 1e-9 {
+		t.Errorf("LiftoffTWR = %g, want %g", vs.LiftoffTWR, wantTWR)
+	}
+}
+
+// TestStackStatsEnginelessStage — a fuelless / engineless top stage (a
+// parachute pod) contributes mass but no Δv, and an empty stack is zero.
+func TestStackStatsEnginelessStage(t *testing.T) {
+	vs := StackStats([]Stage{
+		{DryMass: 2000, FuelMass: 8000, Thrust: 100_000, Isp: 300, MonopropMass: 100},
+		{DryMass: 500}, // engineless pod
+	})
+	if vs.StageDV[1] != 0 {
+		t.Errorf("engineless stage Δv = %g, want 0", vs.StageDV[1])
+	}
+	if vs.TotalMass != 2000+8000+100+500 {
+		t.Errorf("TotalMass = %g, want 10600 (incl monoprop)", vs.TotalMass)
+	}
+	if StackStats(nil).TotalDV != 0 || StackStats(nil).LiftoffTWR != 0 {
+		t.Error("empty stack should be all-zero stats")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -33,6 +33,7 @@ const (
 	screenSpawn    // v0.8.2+: craft-type pick form on `n`.
 	screenSettings // v0.13 slice 3: per-Chip visibility toggles, reached from the menu.
 	screenControls // ADR 0022: keyboard-layout selector, reached from the menu.
+	screenVAB      // v0.24 / ADR 0029: Vehicle Assembly (VAB) builder, reached from the menu.
 	screenBoss     // boss key: full-screen fake developer shell (backtick from any screen).
 )
 
@@ -70,6 +71,12 @@ type App struct {
 	// binding-matching and inverted for the F1 help labels.
 	controls *screens.ControlsScreen
 	layout   keylayout.Layout
+
+	// vab is the Vehicle Assembly builder (v0.24 / ADR 0029), reached from
+	// the pause menu. It owns the designs-store interaction (save / load /
+	// delete) directly — designs are app-managed catalog data, not world
+	// state — so opening it from the menu is the only wiring the App needs.
+	vab *screens.VAB
 
 	// boss is the backtick "boss key" fake shell. bossReturnScreen records
 	// the screen that was active when it opened, and bossPrevPaused records
@@ -154,6 +161,7 @@ func New(scenario *sim.StartScenario) (*App, error) {
 
 		settingsScreen: screens.NewSettingsScreen(sth),
 		controls:       screens.NewControlsScreen(sth),
+		vab:            screens.NewVAB(sth),
 		boss:           screens.NewBossShell(sth),
 	}, nil
 }
@@ -575,6 +583,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case screens.ControlsActionCycleLayout:
 				a.cycleLayout()
 			case screens.ControlsActionCancel:
+				a.active = screenOrbit
+			}
+			return a, nil
+		}
+		// VAB (v0.24 / ADR 0029): the Vehicle Assembly builder owns its own
+		// keymap (palette / stack / save / load); esc backs out to orbit.
+		// Handled here so its keys don't fall through to the orbit flight
+		// controls.
+		if a.active == screenVAB {
+			if a.vab.HandleKey(m.String()) == screens.VABActionCancel {
 				a.active = screenOrbit
 			}
 			return a, nil
@@ -1273,6 +1291,12 @@ func (a *App) applyMenuAction(action screens.MenuAction) (tea.Model, tea.Cmd) {
 		a.controls.Reset()
 		a.active = screenControls
 		return a, nil
+	case screens.MenuActionVAB:
+		// Open the Vehicle Assembly builder with the live component catalog
+		// (embedded + user overlay). Reversible, so no confirm gate.
+		a.vab.Reset(spacecraft.Components)
+		a.active = screenVAB
+		return a, nil
 	case screens.MenuActionQuit:
 		a.autosave()
 		return a, tea.Quit
@@ -1405,6 +1429,8 @@ func (a *App) View() string {
 		base = a.settingsScreen.Render(a.orbitView.Settings(), a.width)
 	case screenControls:
 		base = a.controls.Render(a.layout, a.width)
+	case screenVAB:
+		base = a.vab.Render(a.width)
 	case screenBoss:
 		base = a.boss.Render(a.width, a.height)
 	default:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -531,6 +531,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				spec := sim.SpawnSpec{
 					LoadoutID:       a.spawn.SelectedLoadoutID(),
+					DesignID:        a.spawn.SelectedDesignID(),
 					CustomStages:    a.spawn.SelectedCustomStages(),
 					NosePayloadPlan: a.spawn.SelectedNosePayloadPlan(),
 					ParentBodyID:    a.spawn.SelectedParentID(),
@@ -760,7 +761,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if c := a.world.ActiveCraft(); c != nil {
 				defaultParentID = c.Primary.ID
 			}
-			a.spawn.Reset(a.world.System().Bodies, defaultParentID)
+			// v0.24 / ADR 0029: offer saved VAB designs alongside catalog
+			// loadouts. ListDesigns is read here (not in the form) so the
+			// form stays filesystem-free and testable.
+			designs, _ := spacecraft.ListDesigns()
+			a.spawn.Reset(a.world.System().Bodies, defaultParentID, designs)
 			a.active = screenSpawn
 			a.world.RecordAction(missions.ActionSpawnCraft) // ADR 0025 §7
 			return a, nil

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -183,6 +183,32 @@ func TestSettingsScreenRoundTripPersists(t *testing.T) {
 	}
 }
 
+// TestVABOpensFromMenuAndCloses — the pause menu `b` key opens the Vehicle
+// Assembly screen (v0.24 / ADR 0029), its keys are consumed by the screen,
+// and Esc returns to orbit.
+func TestVABOpensFromMenuAndCloses(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.menu.Reset()
+	a.active = screenMenu
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	if a.active != screenVAB {
+		t.Fatalf("after menu `b`, active = %v, want screenVAB", a.active)
+	}
+	// A build key is consumed by the screen (does not fall through / crash).
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}) // new stage
+	if a.active != screenVAB {
+		t.Errorf("VAB build key leaked screen change: active = %v", a.active)
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if a.active != screenOrbit {
+		t.Errorf("after esc, active = %v, want screenOrbit", a.active)
+	}
+}
+
 // Clicking the target ± buttons holds BurnTarget / BurnAntiTarget.
 func TestDispatchNavballControlTarget(t *testing.T) {
 	a, err := New(nil)

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -37,7 +37,7 @@ type helpSection struct {
 var helpSections = []helpSection{
 	{"GENERAL", [][2]string{
 		{"F1", "toggle this help"},
-		{"esc", "back / close (or save/load/settings/controls/quit menu on home)"},
+		{"esc", "back / close (or save/load/build/settings/controls/quit menu on home)"},
 		{"F5 / F9", "quicksave / quickload"},
 		{"q", "quit (confirm + autosave)"},
 		{"ctrl+c", "quit immediately"},
@@ -103,6 +103,16 @@ var helpSections = []helpSection{
 		{"D", "transpose: SM → firing core, LM → releasable nose payload"},
 		{"t / T", "cycle / clear the target"},
 		{"space", "decouple bottom stage (bare chute capsule: arm the chute)"},
+	}},
+	{"VEHICLE ASSEMBLY (VAB)", [][2]string{
+		{"esc → b", "open the VAB from the pause menu (Build)"},
+		{"tab", "switch pane (palette ↔ stack)"},
+		{"←/→ ↑/↓", "move the palette / stack cursor"},
+		{"a", "add the selected component to the stage (or part as a new stage)"},
+		{"n / x", "new empty stage on top / remove component or stage"},
+		{"d", "toggle dock seam below the stage (nose payload, [U]ndock-released)"},
+		{"c", "toggle fused decouple (stage drops with the group below)"},
+		{"s / o", "save the design (name it) / open a saved design"},
 	}},
 	{"MOUSE", [][2]string{
 		{"click body", "focus that body"},

--- a/internal/tui/screens/menu.go
+++ b/internal/tui/screens/menu.go
@@ -25,6 +25,7 @@ type Menu struct {
 	backBtn     buttonRange
 	saveBtn     buttonRange
 	loadBtn     buttonRange
+	vabBtn      buttonRange
 	settingsBtn buttonRange
 	controlsBtn buttonRange
 	quitBtn     buttonRange
@@ -64,6 +65,7 @@ func (m *Menu) Reset() {
 	m.mode = menuModeList
 	m.saveBtn.set = false
 	m.loadBtn.set = false
+	m.vabBtn.set = false
 	m.settingsBtn.set = false
 	m.controlsBtn.set = false
 	m.quitBtn.set = false
@@ -82,6 +84,7 @@ const (
 	MenuActionCancel                   // esc / [Back] — return to orbit
 	MenuActionSave
 	MenuActionLoad
+	MenuActionVAB      // v0.24 / ADR 0029: open the Vehicle Assembly (VAB) screen
 	MenuActionSettings // v0.13: open the per-Chip visibility screen
 	MenuActionControls // ADR 0022: open the keyboard-layout / controls screen
 	MenuActionQuit
@@ -100,6 +103,8 @@ func (m *Menu) HandleKey(s string) MenuAction {
 			return MenuActionSave
 		case "l", "L":
 			return MenuActionLoad
+		case "b", "B":
+			return MenuActionVAB
 		case "t", "T":
 			return MenuActionSettings
 		case "c", "C":
@@ -142,6 +147,10 @@ func (m *Menu) HandleClick(col, row int) MenuAction {
 	switch m.mode {
 	case menuModeList:
 		switch {
+		case m.vabBtn.Hit(col, row):
+			// Opening a screen is reversible, so the VAB skips the
+			// click-confirm gate save/load/quit go through.
+			return MenuActionVAB
 		case m.settingsBtn.Hit(col, row):
 			// Opening a screen is reversible, so settings skips the
 			// click-confirm gate save/load/quit go through.
@@ -210,6 +219,7 @@ func (m *Menu) Render(width int) string {
 	// Reset confirm-button visibility — only the active mode sets them.
 	m.saveBtn.set = false
 	m.loadBtn.set = false
+	m.vabBtn.set = false
 	m.settingsBtn.set = false
 	m.controlsBtn.set = false
 	m.quitBtn.set = false
@@ -251,6 +261,7 @@ func (m *Menu) renderList(rowOffset int) []string {
 	rows := []entry{
 		{"s", "[Save Game]", &m.saveBtn},
 		{"l", "[Load Game]", &m.loadBtn},
+		{"b", "[Build (VAB)]", &m.vabBtn},
 		{"t", "[Settings]", &m.settingsBtn},
 		{"c", "[Controls]", &m.controlsBtn},
 		{"q", "[Quit]", &m.quitBtn},
@@ -276,7 +287,7 @@ func (m *Menu) renderList(rowOffset int) []string {
 	}
 
 	lines = append(lines, "")
-	lines = append(lines, m.theme.Footer.Render("[esc] back to orbit · keyboard: s/l/t/c/q"))
+	lines = append(lines, m.theme.Footer.Render("[esc] back to orbit · keyboard: s/l/b/t/c/q"))
 	return lines
 }
 

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -43,6 +43,13 @@ type SpawnCraft struct {
 	// cycles it; adding the composite "CSM+LM" pick pre-sets it to the
 	// LM's stage count. Clamped to [0, len-1] so the core keeps ≥1 stage.
 	nosePayloadCount int
+
+	// designs (v0.24 / ADR 0029) are the saved VAB designs offered as CRAFT
+	// TYPE rows AFTER the synthetic "Custom…" entry — the "design once,
+	// launch many" split (the VAB is the design surface, the spawn form the
+	// launch surface). Injected at Reset by the App (spacecraft.ListDesigns)
+	// so the form has no filesystem side effects and tests stay isolated.
+	designs []spacecraft.Design
 }
 
 // stackFieldIdx is the form-field index of the STACK editor — only
@@ -77,12 +84,13 @@ func NewSpawnCraft(th Theme) *SpawnCraft { return &SpawnCraft{theme: th} }
 // the parent-field cursor lands on initially (typically the active
 // craft's current primary). v0.8.2+: replaces the v0.8.2-pre
 // no-arg Reset.
-func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string) {
+func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string, designs []spacecraft.Design) {
 	s.fieldIdx = 0
 	s.loadoutIdx = 0
 	s.customStages = nil
 	s.partIdx = 0
 	s.nosePayloadCount = 0
+	s.designs = designs
 	s.posMode = posOrbit
 	s.altIdx = 1 // 500 km — matches the v0.8.1 sister-spawn default
 	s.latIdx = 1 // 28.6° KSC — matches the v0.9.2 launchpad default
@@ -106,21 +114,39 @@ const (
 	SpawnActionConfirm             // enter — caller reads accessors
 )
 
-// loadoutChoiceCount is the number of CRAFT TYPE rows — every
-// catalog loadout plus the synthetic "Custom…" entry at the end.
-func loadoutChoiceCount() int { return len(spacecraft.LoadoutOrder) + 1 }
+// loadoutChoiceCount is the number of CRAFT TYPE rows — every catalog
+// loadout, the synthetic "Custom…" entry, then every saved design (v0.24).
+func (s *SpawnCraft) loadoutChoiceCount() int {
+	return len(spacecraft.LoadoutOrder) + 1 + len(s.designs)
+}
 
 // IsCustomSelected reports whether the cursor is on the synthetic
-// "Custom…" CRAFT TYPE entry (the last row). v0.10.1+.
+// "Custom…" CRAFT TYPE entry. v0.10.1+.
 func (s *SpawnCraft) IsCustomSelected() bool {
 	return s.loadoutIdx == len(spacecraft.LoadoutOrder)
 }
 
-// SelectedLoadoutID returns the loadout ID for the current cursor,
-// or "" when the synthetic Custom entry is selected (the caller
-// then reads SelectedCustomStages instead). v0.10.1+.
+// IsDesignSelected reports whether the cursor is on a saved-design row (the
+// rows after "Custom…"). v0.24 / ADR 0029.
+func (s *SpawnCraft) IsDesignSelected() bool {
+	return s.loadoutIdx > len(spacecraft.LoadoutOrder) &&
+		s.loadoutIdx <= len(spacecraft.LoadoutOrder)+len(s.designs)
+}
+
+// SelectedDesignID returns the saved design's ID under the cursor, or "" when
+// a design row is not selected. v0.24 / ADR 0029.
+func (s *SpawnCraft) SelectedDesignID() string {
+	if !s.IsDesignSelected() {
+		return ""
+	}
+	return s.designs[s.loadoutIdx-len(spacecraft.LoadoutOrder)-1].ID()
+}
+
+// SelectedLoadoutID returns the loadout ID for the current cursor, or "" when
+// the synthetic Custom entry or a saved design is selected (the caller then
+// reads SelectedCustomStages / SelectedDesignID instead). v0.10.1+.
 func (s *SpawnCraft) SelectedLoadoutID() string {
-	if s.IsCustomSelected() {
+	if s.IsCustomSelected() || s.IsDesignSelected() {
 		return ""
 	}
 	if s.loadoutIdx < 0 || s.loadoutIdx >= len(spacecraft.LoadoutOrder) {
@@ -327,8 +353,8 @@ func (s *SpawnCraft) pickedPartID() string {
 func (s *SpawnCraft) cycleField(step int) {
 	switch s.fieldIdx {
 	case 0:
-		// +1 row for the synthetic "Custom…" entry. v0.10.1+.
-		s.loadoutIdx = wrapIdx(s.loadoutIdx+step, loadoutChoiceCount())
+		// +1 row for "Custom…", + the saved designs (v0.24). v0.10.1+.
+		s.loadoutIdx = wrapIdx(s.loadoutIdx+step, s.loadoutChoiceCount())
 	case stackFieldIdx:
 		// STACK field: ←/→ moves the catalog part-picker cursor.
 		s.partIdx = wrapIdx(s.partIdx+step, len(spacecraft.StageCatalogOrder))
@@ -402,6 +428,23 @@ func (s *SpawnCraft) Render(width int) string {
 			customRow = s.theme.Dim.Render(customRow)
 		}
 		lines = append(lines, "  "+marker+customRow)
+	}
+	// v0.24 / ADR 0029: saved VAB designs, listed after "Custom…".
+	for di, d := range s.designs {
+		idx := len(spacecraft.LoadoutOrder) + 1 + di
+		row := fmt.Sprintf("✎ %s  saved design  — %d stages", d.Name(), len(d.Loadout.Parts))
+		marker := "  "
+		if s.loadoutIdx == idx {
+			marker = s.theme.Warning.Render("→ ")
+			if s.fieldIdx == 0 {
+				row = s.theme.Warning.Render(row)
+			} else {
+				row = s.theme.Primary.Render(row)
+			}
+		} else {
+			row = s.theme.Dim.Render(row)
+		}
+		lines = append(lines, "  "+marker+row)
 	}
 
 	// v0.10.1+ STACK editor — only when Custom is selected. Shows the

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -50,7 +50,7 @@ func selectCustom(s *SpawnCraft) {
 // branch.
 func TestSpawnCustomEntryReachableAndEmpty(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 	selectCustom(s)
 
 	if !s.IsCustomSelected() {
@@ -81,7 +81,7 @@ func TestSpawnCustomEntryReachableAndEmpty(t *testing.T) {
 // only once Custom is selected.
 func TestSpawnStackFieldReachableOnlyInCustom(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 
 	// Non-custom: Tab through a full cycle never lands on stackFieldIdx.
 	for i := 0; i < 12; i++ {
@@ -119,7 +119,7 @@ func TestSpawnStackFieldReachableOnlyInCustom(t *testing.T) {
 // CRAFT TYPE, and Tab onward from STACK continues to POSITION (field 1).
 func TestSpawnTabFromCustomReachesStackFirst(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 	selectCustom(s)
 
 	if s.fieldIdx != 0 {
@@ -146,7 +146,7 @@ func TestSpawnTabFromCustomReachesStackFirst(t *testing.T) {
 // picker, [a] appends the picked part on top, [x] removes the top.
 func TestSpawnStackAddRemove(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -184,6 +184,35 @@ func TestSpawnStackAddRemove(t *testing.T) {
 	}
 }
 
+// TestSpawnListsSavedDesigns — v0.24 / ADR 0029: saved designs appear as
+// CRAFT TYPE rows after "Custom…"; cycling onto one reports it via
+// SelectedDesignID (and clears SelectedLoadoutID), and the row renders.
+func TestSpawnListsSavedDesigns(t *testing.T) {
+	designs := []spacecraft.Design{
+		{Loadout: spacecraft.LoadoutDef{ID: "mun-hopper", Name: "Mun Hopper", Parts: []spacecraft.PartRef{{PartID: "x"}}}},
+	}
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "", designs)
+
+	steps := 0
+	for !s.IsDesignSelected() && steps < len(spacecraft.LoadoutOrder)+5 {
+		s.HandleKey("right")
+		steps++
+	}
+	if !s.IsDesignSelected() {
+		t.Fatal("could not reach a saved-design row by cycling CRAFT TYPE")
+	}
+	if s.SelectedDesignID() != "mun-hopper" {
+		t.Errorf("SelectedDesignID = %q, want mun-hopper", s.SelectedDesignID())
+	}
+	if s.SelectedLoadoutID() != "" {
+		t.Errorf("a design row must blank SelectedLoadoutID, got %q", s.SelectedLoadoutID())
+	}
+	if !strings.Contains(s.Render(80), "Mun Hopper") {
+		t.Error("rendered CRAFT TYPE list does not show the saved design")
+	}
+}
+
 // pickPart cycles the part-picker to the given catalog id (STACK field
 // must be focused). Bounded so a missing id can't loop forever.
 func pickPart(s *SpawnCraft, id string) {
@@ -201,7 +230,7 @@ func pickPart(s *SpawnCraft, id string) {
 // payload without the player marking it by hand.
 func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -225,7 +254,7 @@ func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
 // at least one stage. v0.14 / ADR 0011.
 func TestSpawnDockSeamCycleAndClamp(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -264,7 +293,7 @@ func TestSpawnDockSeamCycleAndClamp(t *testing.T) {
 // for Custom and reflects added parts.
 func TestSpawnRenderShowsStackEditor(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "")
+	s.Reset(nil, "", nil)
 
 	if strings.Contains(s.Render(80), "STACK (bottom → top)") {
 		t.Error("STACK editor rendered for a non-custom loadout")

--- a/internal/tui/screens/vab.go
+++ b/internal/tui/screens/vab.go
@@ -1,0 +1,507 @@
+package screens
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// VAB is the Vehicle Assembly screen (ADR 0029 §5, the Axis B cycle-4
+// endgame). The player composes finer Components (engine / tank /
+// command-core / antenna / structure) into stages, stacks stages into a
+// vehicle, marks N dock seams (nose payloads) and decouple groups, and reads
+// live Δv / TWR / mass — then saves the result as a portable Design
+// (internal/spacecraft designs store). Reached from the pause menu.
+//
+// Architecture: a screen sub-model like SpawnCraft / SettingsScreen. It
+// reads the live component catalog (injected at Reset) and owns the designs
+// store interaction (save / load / delete) — the store is app-managed
+// catalog data, not world state, so this does not violate the
+// screens-don't-mutate-the-world rule (ADR 0029 §4).
+type VAB struct {
+	theme Theme
+
+	// comps is the live component catalog (spacecraft.Components), injected
+	// at Reset so the model is testable without touching package globals.
+	comps map[string]spacecraft.Component
+
+	palette    []vabPaletteItem
+	paletteIdx int
+
+	stages   []vabStage
+	stageIdx int
+
+	focus vabFocus
+	mode  vabMode
+
+	name string
+
+	// load-mode picker state.
+	designs []spacecraft.Design
+	loadIdx int
+
+	// flash is a transient one-line notice (validation reject / save result).
+	flash string
+}
+
+// VABAction enumerates the screen's outcomes the App acts on. The screen
+// owns save / load / delete against the designs store directly; the App only
+// needs to know when to leave.
+type VABAction int
+
+const (
+	VABActionNone   VABAction = iota
+	VABActionCancel           // esc from build mode — back to the menu/orbit
+)
+
+// vabFocus selects which pane the up/down keys drive.
+type vabFocus int
+
+const (
+	focusPalette vabFocus = iota
+	focusStack
+)
+
+// vabMode is the screen's interaction mode.
+type vabMode int
+
+const (
+	vabModeBuild  vabMode = iota
+	vabModeNaming         // typing a name to save
+	vabModeLoad           // picking a saved design to load / delete
+)
+
+// vabStage is one stage under assembly: either a composition of component
+// IDs (the fine-parts path) or a reference to an existing atomic catalog
+// Part reused whole. The boundary flags describe the boundary BELOW this
+// stage (between it and the stage beneath), so they ride along on add /
+// remove without a parallel slice to keep in sync.
+type vabStage struct {
+	components    []string
+	catalogPartID string
+	dockSeamBelow bool // a dock seam here → this stage starts a nose-payload group (Undock release)
+	decoupleFused bool // this stage decouples together with the group below (one staging press)
+}
+
+func (vs vabStage) isCatalog() bool { return vs.catalogPartID != "" }
+
+// vabPaletteItem is one entry in the component/part palette.
+type vabPaletteItem struct {
+	isComponent bool
+	id          string
+}
+
+// vabKindOrder is the palette grouping order for components.
+var vabKindOrder = []string{
+	spacecraft.ComponentEngine,
+	spacecraft.ComponentTank,
+	spacecraft.ComponentCommandCore,
+	spacecraft.ComponentAntenna,
+	spacecraft.ComponentStructure,
+}
+
+// NewVAB constructs the screen.
+func NewVAB(th Theme) *VAB { return &VAB{theme: th} }
+
+// Reset opens the VAB fresh with the given live component catalog (typically
+// spacecraft.Components). Starts with an empty stack in build mode.
+func (v *VAB) Reset(comps map[string]spacecraft.Component) {
+	v.comps = comps
+	v.stages = nil
+	v.stageIdx = 0
+	v.paletteIdx = 0
+	v.focus = focusPalette
+	v.mode = vabModeBuild
+	v.name = ""
+	v.flash = ""
+	v.buildPalette()
+}
+
+// buildPalette assembles the flat palette: components grouped by kind (in
+// vabKindOrder, then by ID), followed by single-stage atomic catalog parts
+// (reusable opaque blocks; multi-stage modules are spawn-form conveniences,
+// not VAB parts — ADR 0029 §7).
+func (v *VAB) buildPalette() {
+	v.palette = nil
+	byKind := map[string][]string{}
+	for id, c := range v.comps {
+		byKind[c.Kind] = append(byKind[c.Kind], id)
+	}
+	for _, k := range vabKindOrder {
+		ids := byKind[k]
+		sort.Strings(ids)
+		for _, id := range ids {
+			v.palette = append(v.palette, vabPaletteItem{isComponent: true, id: id})
+		}
+	}
+	for _, id := range spacecraft.StageCatalogOrder {
+		if stages, ok := spacecraft.BuildModule(id); ok && len(stages) == 1 {
+			v.palette = append(v.palette, vabPaletteItem{isComponent: false, id: id})
+		}
+	}
+	if v.paletteIdx >= len(v.palette) {
+		v.paletteIdx = 0
+	}
+}
+
+// --- model operations (key-handling maps onto these; tested directly) ---
+
+// addSelected adds the palette item under the cursor: a component to the
+// current stage (creating one if needed), or a catalog part as a new atomic
+// stage on top.
+func (v *VAB) addSelected() {
+	if v.paletteIdx < 0 || v.paletteIdx >= len(v.palette) {
+		return
+	}
+	it := v.palette[v.paletteIdx]
+	if !it.isComponent {
+		v.stages = append(v.stages, vabStage{catalogPartID: it.id})
+		v.stageIdx = len(v.stages) - 1
+		v.focus = focusStack
+		return
+	}
+	v.addComponentToCurrent(it.id)
+}
+
+// addComponentToCurrent appends a component to the current stage, enforcing
+// single-fuel-per-stage (ADR 0029 §3): a chemistry conflict is rejected with
+// a flash, not applied. Adding to an atomic catalog stage starts a fresh
+// composed stage instead (you can't crack open an opaque block).
+func (v *VAB) addComponentToCurrent(id string) {
+	if len(v.stages) == 0 {
+		v.stages = append(v.stages, vabStage{})
+		v.stageIdx = 0
+	}
+	if v.stageIdx < 0 || v.stageIdx >= len(v.stages) {
+		v.stageIdx = len(v.stages) - 1
+	}
+	if v.stages[v.stageIdx].isCatalog() {
+		v.stages = append(v.stages, vabStage{components: []string{id}})
+		v.stageIdx = len(v.stages) - 1
+		v.focus = focusStack
+		return
+	}
+	if warn := v.fuelConflict(v.stages[v.stageIdx].components, id); warn != "" {
+		v.flash = warn
+		return
+	}
+	v.stages[v.stageIdx].components = append(v.stages[v.stageIdx].components, id)
+	v.focus = focusStack
+	v.flash = ""
+}
+
+// fuelConflict reports a chemistry clash between a stage's existing fuelled
+// components and a new one (empty == matches anything).
+func (v *VAB) fuelConflict(existing []string, newID string) string {
+	nc, ok := v.comps[newID]
+	if !ok || nc.FuelType == "" {
+		return ""
+	}
+	cur := v.stageFuelType(existing)
+	if cur != "" && cur != nc.FuelType {
+		return fmt.Sprintf("can't mix %s with %s in one stage", cur, nc.FuelType)
+	}
+	return ""
+}
+
+// stageFuelType returns the (assumed-consistent) fuel chemistry of a stage's
+// components, or empty if none are fuelled.
+func (v *VAB) stageFuelType(comps []string) string {
+	for _, id := range comps {
+		if c, ok := v.comps[id]; ok && c.FuelType != "" {
+			return c.FuelType
+		}
+	}
+	return ""
+}
+
+// newStage appends an empty composed stage on top and selects it.
+func (v *VAB) newStage() {
+	v.stages = append(v.stages, vabStage{})
+	v.stageIdx = len(v.stages) - 1
+	v.focus = focusStack
+}
+
+// removeFromCurrent pops the last component off the current composed stage,
+// or removes the whole stage when it is empty or an atomic catalog block.
+func (v *VAB) removeFromCurrent() {
+	if len(v.stages) == 0 {
+		return
+	}
+	if v.stageIdx < 0 || v.stageIdx >= len(v.stages) {
+		v.stageIdx = len(v.stages) - 1
+	}
+	st := &v.stages[v.stageIdx]
+	if !st.isCatalog() && len(st.components) > 0 {
+		st.components = st.components[:len(st.components)-1]
+		return
+	}
+	v.stages = append(v.stages[:v.stageIdx], v.stages[v.stageIdx+1:]...)
+	if v.stageIdx >= len(v.stages) {
+		v.stageIdx = len(v.stages) - 1
+	}
+	if v.stageIdx < 0 {
+		v.stageIdx = 0
+	}
+}
+
+// toggleDockSeam flips the dock seam below the current stage (the N-seam
+// generalization of the spawn `d`-key; closes ADR 0028 §8). A seam below the
+// bottom stage is meaningless, so stage 0 is a no-op.
+func (v *VAB) toggleDockSeam() {
+	if v.stageIdx >= 1 && v.stageIdx < len(v.stages) {
+		v.stages[v.stageIdx].dockSeamBelow = !v.stages[v.stageIdx].dockSeamBelow
+	}
+}
+
+// toggleDecoupleFuse flips whether the current stage decouples together with
+// the group below it (one staging press releases both).
+func (v *VAB) toggleDecoupleFuse() {
+	if v.stageIdx >= 1 && v.stageIdx < len(v.stages) {
+		v.stages[v.stageIdx].decoupleFused = !v.stages[v.stageIdx].decoupleFused
+	}
+}
+
+// nosePayloadPlan derives the top-down nose-payload group sizes from the
+// dock-seam flags (the ADR 0028 / catalog.go convention: each entry is a
+// count of contiguous TOP stages forming one docked payload, ordered
+// top-down). Nil when no seams are set.
+func (v *VAB) nosePayloadPlan() []int {
+	var seams []int
+	for i := 1; i < len(v.stages); i++ {
+		if v.stages[i].dockSeamBelow {
+			seams = append(seams, i)
+		}
+	}
+	if len(seams) == 0 {
+		return nil
+	}
+	// Group sizes bottom-up between consecutive seams; the last runs to the top.
+	var bottomUp []int
+	for j := 0; j < len(seams); j++ {
+		end := len(v.stages)
+		if j+1 < len(seams) {
+			end = seams[j+1]
+		}
+		bottomUp = append(bottomUp, end-seams[j])
+	}
+	plan := make([]int, len(bottomUp))
+	for i := range bottomUp {
+		plan[i] = bottomUp[len(bottomUp)-1-i] // reverse → top-down
+	}
+	return plan
+}
+
+// decouplePlan derives the bottom-up staging group sizes from the
+// decouple-fuse flags (catalog.go convention: how many contiguous bottom
+// stages each staging press releases; the surviving top core is excluded).
+// Nil when every stage decouples singly (the all-ones default).
+func (v *VAB) decouplePlan() []int {
+	n := len(v.stages)
+	if n <= 1 {
+		return nil
+	}
+	fused := false
+	var groups []int
+	cur := 1
+	for i := 1; i < n; i++ {
+		if v.stages[i].decoupleFused {
+			cur++
+			fused = true
+		} else {
+			groups = append(groups, cur)
+			cur = 1
+		}
+	}
+	groups = append(groups, cur) // top group = surviving core (excluded)
+	if !fused {
+		return nil // all-ones default
+	}
+	return groups[:len(groups)-1]
+}
+
+// applyNosePayloadPlan sets the dock-seam flags from a top-down plan (the
+// inverse of nosePayloadPlan), used when loading a design.
+func (v *VAB) applyNosePayloadPlan(plan []int) {
+	for i := range v.stages {
+		v.stages[i].dockSeamBelow = false
+	}
+	cum := 0
+	for _, g := range plan {
+		cum += g
+		idx := len(v.stages) - cum
+		if idx >= 1 && idx < len(v.stages) {
+			v.stages[idx].dockSeamBelow = true
+		}
+	}
+}
+
+// applyDecouplePlan sets the decouple-fuse flags from a bottom-up plan (the
+// inverse of decouplePlan), used when loading a design.
+func (v *VAB) applyDecouplePlan(plan []int) {
+	for i := range v.stages {
+		v.stages[i].decoupleFused = false
+	}
+	if len(plan) == 0 {
+		return
+	}
+	idx := 0
+	for _, g := range plan {
+		for k := 0; k < g && idx < len(v.stages); k++ {
+			v.stages[idx].decoupleFused = k > 0
+			idx++
+		}
+	}
+	for k := idx; k < len(v.stages); k++ {
+		v.stages[k].decoupleFused = k > idx // surviving core fuses together
+	}
+}
+
+// --- resolution + stats ---
+
+// resolveStage materializes one working stage into a runtime Stage: an
+// atomic catalog block via BuildStage, or a composition via ComposeStage
+// (RCS derived from dry mass, matching the spawn path).
+func (v *VAB) resolveStage(vs vabStage) spacecraft.Stage {
+	if vs.isCatalog() {
+		if st, ok := spacecraft.BuildStage(vs.catalogPartID); ok {
+			return st
+		}
+		return spacecraft.Stage{}
+	}
+	st, _ := spacecraft.ComposeStage(vs.components, v.comps)
+	return st
+}
+
+// resolvedStages is the whole stack as runtime Stages, bottom→top.
+func (v *VAB) resolvedStages() []spacecraft.Stage {
+	out := make([]spacecraft.Stage, 0, len(v.stages))
+	for _, vs := range v.stages {
+		out = append(out, v.resolveStage(vs))
+	}
+	return out
+}
+
+// Stats is the live Δv / TWR / mass readout for the current stack.
+func (v *VAB) Stats() spacecraft.VehicleStats {
+	return spacecraft.StackStats(v.resolvedStages())
+}
+
+// Warnings returns the soft (non-blocking) validation notes (ADR 0029 §5):
+// empty stack, no engine, no command source (defaults to a probe core on
+// spawn per EnsureCommandSource), liftoff TWR < 1.
+func (v *VAB) Warnings() []string {
+	if len(v.stages) == 0 {
+		return []string{"empty stack — add a component or part with [a]"}
+	}
+	stages := v.resolvedStages()
+	var w []string
+	hasEngine, hasCommand := false, false
+	for _, st := range stages {
+		if st.Thrust > 0 {
+			hasEngine = true
+		}
+		if spacecraft.IsCommandSource(st.CommandSource) {
+			hasCommand = true
+		}
+	}
+	if !hasEngine {
+		w = append(w, "no engine — vehicle can't maneuver")
+	}
+	if !hasCommand {
+		w = append(w, "no command source — will default to a probe core on spawn")
+	}
+	if vs := spacecraft.StackStats(stages); vs.LiftoffTWR > 0 && vs.LiftoffTWR < 1 {
+		w = append(w, fmt.Sprintf("liftoff TWR %.2f < 1 — won't lift off under g₀", vs.LiftoffTWR))
+	}
+	return w
+}
+
+// --- design (de)serialization ---
+
+// toDesign builds the portable Design for the current stack: a composed
+// Part per composed stage (design-scoped auto IDs _<slug>_s<n>), an atomic
+// reference per catalog stage, plus the decouple + nose-payload plans.
+func (v *VAB) toDesign() spacecraft.Design {
+	id := slugifyDesign(v.name)
+	var parts []spacecraft.Part
+	refs := make([]spacecraft.PartRef, 0, len(v.stages))
+	for i, vs := range v.stages {
+		if vs.isCatalog() {
+			refs = append(refs, spacecraft.PartRef{PartID: vs.catalogPartID})
+			continue
+		}
+		pid := fmt.Sprintf("_%s_s%d", id, i)
+		parts = append(parts, spacecraft.Part{
+			ID:         pid,
+			Name:       fmt.Sprintf("%s S%d", v.name, i+1),
+			Glyph:      spacecraft.VesselGlyph,
+			Color:      "#FFD93D",
+			Components: append([]string(nil), vs.components...),
+		})
+		refs = append(refs, spacecraft.PartRef{PartID: pid})
+	}
+	return spacecraft.Design{
+		Loadout: spacecraft.LoadoutDef{
+			ID:              id,
+			Name:            v.name,
+			Role:            "custom",
+			Glyph:           spacecraft.VesselGlyph,
+			Color:           "#FFD93D",
+			Parts:           refs,
+			DecouplePlan:    v.decouplePlan(),
+			NosePayloadPlan: v.nosePayloadPlan(),
+		},
+		Parts: parts,
+	}
+}
+
+// loadDesign rebuilds the working stack from a saved Design — composed
+// stages keep their component lists; non-composed refs become atomic catalog
+// stages — then restores the seam / decouple flags.
+func (v *VAB) loadDesign(d spacecraft.Design) {
+	v.name = d.Name()
+	byID := map[string]spacecraft.Part{}
+	for _, p := range d.Parts {
+		byID[p.ID] = p
+	}
+	v.stages = nil
+	for _, ref := range d.Loadout.Parts {
+		if p, ok := byID[ref.PartID]; ok && len(p.Components) > 0 {
+			v.stages = append(v.stages, vabStage{components: append([]string(nil), p.Components...)})
+		} else {
+			v.stages = append(v.stages, vabStage{catalogPartID: ref.PartID})
+		}
+	}
+	v.applyNosePayloadPlan(d.Loadout.NosePayloadPlan)
+	v.applyDecouplePlan(d.Loadout.DecouplePlan)
+	v.stageIdx = 0
+	v.focus = focusStack
+	v.mode = vabModeBuild
+}
+
+// slugifyDesign turns a free-form design name into a filesystem- and
+// ID-safe slug.
+func slugifyDesign(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			return r
+		case r == ' ' || r == '-' || r == '_':
+			return '-'
+		default:
+			return -1
+		}
+	}, s)
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "design"
+	}
+	return s
+}

--- a/internal/tui/screens/vab.go
+++ b/internal/tui/screens/vab.go
@@ -398,6 +398,18 @@ func (v *VAB) Warnings() []string {
 	}
 	stages := v.resolvedStages()
 	var w []string
+	// An invalid composed stage (a component missing from the live catalog,
+	// e.g. a design loaded after a mod was removed, or a mixed-fuel stage)
+	// resolves to a silent zero Stage — surface why instead of showing a
+	// blank "no engine / dry 0kg" row with no explanation.
+	for i, vs := range v.stages {
+		if vs.isCatalog() {
+			continue
+		}
+		if _, warn := spacecraft.ComposeStage(vs.components, v.comps); warn != "" {
+			w = append(w, fmt.Sprintf("stage %d invalid: %s", i+1, warn))
+		}
+	}
 	hasEngine, hasCommand := false, false
 	for _, st := range stages {
 		if st.Thrust > 0 {
@@ -469,7 +481,12 @@ func (v *VAB) loadDesign(d spacecraft.Design) {
 	}
 	v.stages = nil
 	for _, ref := range d.Loadout.Parts {
-		if p, ok := byID[ref.PartID]; ok && len(p.Components) > 0 {
+		// A part present in the design's own Parts list is a composed stage
+		// (toDesign only emits design-local composed Parts); anything else is
+		// a reference to an atomic catalog part. Discriminate on PRESENCE, not
+		// component count — an empty composed stage (0 components) is still a
+		// composed stage and must not round-trip into a bogus catalog ref.
+		if p, ok := byID[ref.PartID]; ok {
 			v.stages = append(v.stages, vabStage{components: append([]string(nil), p.Components...)})
 		} else {
 			v.stages = append(v.stages, vabStage{catalogPartID: ref.PartID})

--- a/internal/tui/screens/vab.go
+++ b/internal/tui/screens/vab.go
@@ -33,6 +33,13 @@ type VAB struct {
 	stages   []vabStage
 	stageIdx int
 
+	// stackCursor is the single linear cursor over the vehicle column's
+	// flattened rows (ADR 0030 §3): stage-header rows and their component
+	// groups interleaved in display order, so ↑/↓ walk stages AND their
+	// components with no separate horizontal axis. stageIdx is kept synced
+	// to the cursor's stage so the existing model ops act on the right stage.
+	stackCursor int
+
 	focus vabFocus
 	mode  vabMode
 
@@ -111,6 +118,7 @@ func (v *VAB) Reset(comps map[string]spacecraft.Component) {
 	v.comps = comps
 	v.stages = nil
 	v.stageIdx = 0
+	v.stackCursor = 0
 	v.paletteIdx = 0
 	v.focus = focusPalette
 	v.mode = vabModeBuild
@@ -159,7 +167,7 @@ func (v *VAB) addSelected() {
 	if !it.isComponent {
 		v.stages = append(v.stages, vabStage{catalogPartID: it.id})
 		v.stageIdx = len(v.stages) - 1
-		v.focus = focusStack
+		v.focusStageInStack(v.stageIdx)
 		return
 	}
 	v.addComponentToCurrent(it.id)
@@ -180,7 +188,7 @@ func (v *VAB) addComponentToCurrent(id string) {
 	if v.stages[v.stageIdx].isCatalog() {
 		v.stages = append(v.stages, vabStage{components: []string{id}})
 		v.stageIdx = len(v.stages) - 1
-		v.focus = focusStack
+		v.focusStageInStack(v.stageIdx)
 		return
 	}
 	if warn := v.fuelConflict(v.stages[v.stageIdx].components, id); warn != "" {
@@ -188,7 +196,7 @@ func (v *VAB) addComponentToCurrent(id string) {
 		return
 	}
 	v.stages[v.stageIdx].components = append(v.stages[v.stageIdx].components, id)
-	v.focus = focusStack
+	v.focusStageInStack(v.stageIdx)
 	v.flash = ""
 }
 
@@ -221,7 +229,7 @@ func (v *VAB) stageFuelType(comps []string) string {
 func (v *VAB) newStage() {
 	v.stages = append(v.stages, vabStage{})
 	v.stageIdx = len(v.stages) - 1
-	v.focus = focusStack
+	v.focusStageInStack(v.stageIdx)
 }
 
 // removeFromCurrent pops the last component off the current composed stage,
@@ -495,7 +503,8 @@ func (v *VAB) loadDesign(d spacecraft.Design) {
 	v.applyNosePayloadPlan(d.Loadout.NosePayloadPlan)
 	v.applyDecouplePlan(d.Loadout.DecouplePlan)
 	v.stageIdx = 0
-	v.focus = focusStack
+	v.focus = focusStack // a loaded vehicle becomes the active column
+	v.focusStageInStack(v.stageIdx)
 	v.mode = vabModeBuild
 }
 
@@ -521,4 +530,282 @@ func slugifyDesign(name string) string {
 		s = "design"
 	}
 	return s
+}
+
+// --- linear stack cursor, canonical fold, and editing ops (ADR 0030) ---
+
+// vabGroup is a kind-folded run of identical components within a stage
+// (canonical fold-all, ADR 0030 §4): every instance of one component ID,
+// counted. Groups display ordered by kind (vabKindOrder) then ID.
+type vabGroup struct {
+	compID string
+	kind   string
+	count  int
+}
+
+// vabRow is one navigable row in the vehicle column's flattened display list
+// (ADR 0030 §3): a stage header, or a component group under it. group == -1
+// marks the stage-header row; group >= 0 indexes that stage's groups.
+type vabRow struct {
+	stageIdx int
+	group    int
+}
+
+func (r vabRow) isHeader() bool { return r.group < 0 }
+
+// componentGroups folds a composed stage's flat component list into canonical
+// kind-ordered ×N groups (ADR 0030 §4). Nil for an atomic catalog stage — an
+// opaque block has no addressable components. Order is physically free to
+// canonicalize because aggregation sums regardless of order (ADR 0029 §2).
+func (v *VAB) componentGroups(i int) []vabGroup {
+	if i < 0 || i >= len(v.stages) || v.stages[i].isCatalog() {
+		return nil
+	}
+	counts := map[string]int{}
+	var firstSeen []string
+	for _, id := range v.stages[i].components {
+		if counts[id] == 0 {
+			firstSeen = append(firstSeen, id)
+		}
+		counts[id]++
+	}
+	groups := make([]vabGroup, 0, len(firstSeen))
+	for _, id := range firstSeen {
+		groups = append(groups, vabGroup{compID: id, kind: v.comps[id].Kind, count: counts[id]})
+	}
+	sort.SliceStable(groups, func(a, b int) bool {
+		if ra, rb := kindRank(groups[a].kind), kindRank(groups[b].kind); ra != rb {
+			return ra < rb
+		}
+		return groups[a].compID < groups[b].compID
+	})
+	return groups
+}
+
+// stackRows builds the vehicle column's navigable rows in DISPLAY order (top
+// stage first): each stage header followed by its component groups. The
+// linear stack cursor (stackCursor) indexes this slice.
+func (v *VAB) stackRows() []vabRow {
+	var rows []vabRow
+	for i := len(v.stages) - 1; i >= 0; i-- {
+		rows = append(rows, vabRow{stageIdx: i, group: -1})
+		for g := range v.componentGroups(i) {
+			rows = append(rows, vabRow{stageIdx: i, group: g})
+		}
+	}
+	return rows
+}
+
+// currentRow returns the flattened row under the stack cursor (clamped); false
+// when the stack is empty.
+func (v *VAB) currentRow() (vabRow, bool) {
+	rows := v.stackRows()
+	if len(rows) == 0 {
+		return vabRow{}, false
+	}
+	v.stackCursor = clampI(v.stackCursor, 0, len(rows)-1)
+	return rows[v.stackCursor], true
+}
+
+// syncStageIdx keeps the legacy active-stage index aligned with the cursor so
+// the existing model ops act on the stage the cursor is in.
+func (v *VAB) syncStageIdx() {
+	if r, ok := v.currentRow(); ok {
+		v.stageIdx = r.stageIdx
+	}
+}
+
+// headerRowIndex finds the flattened-row index of stage i's header row.
+func (v *VAB) headerRowIndex(i int) int {
+	for idx, r := range v.stackRows() {
+		if r.stageIdx == i && r.isHeader() {
+			return idx
+		}
+	}
+	return 0
+}
+
+// focusStageInStack moves the stack cursor onto stage i's header (after add /
+// new / structural edits so the vehicle view follows the change). It does NOT
+// change which column has focus — building stays in the palette.
+func (v *VAB) focusStageInStack(i int) {
+	v.stageIdx = i
+	v.stackCursor = v.headerRowIndex(i)
+}
+
+// moveStackCursor moves the linear cursor by step (clamped, no wrap — a
+// vehicle has a top and a bottom) and re-syncs the active stage.
+func (v *VAB) moveStackCursor(step int) {
+	rows := v.stackRows()
+	if len(rows) == 0 {
+		return
+	}
+	v.stackCursor = clampI(v.stackCursor+step, 0, len(rows)-1)
+	v.syncStageIdx()
+}
+
+// removeStageAt splices out stage i.
+func (v *VAB) removeStageAt(i int) {
+	if i < 0 || i >= len(v.stages) {
+		return
+	}
+	v.stages = append(v.stages[:i], v.stages[i+1:]...)
+}
+
+// removeOneComponent removes the first occurrence of compID from stage i.
+func (v *VAB) removeOneComponent(i int, compID string) {
+	if i < 0 || i >= len(v.stages) {
+		return
+	}
+	cs := v.stages[i].components
+	for k, id := range cs {
+		if id == compID {
+			v.stages[i].components = append(cs[:k], cs[k+1:]...)
+			return
+		}
+	}
+}
+
+// removeUnderCursor deletes what the cursor is on: one instance of a component
+// group, or the whole stage when the cursor is on a stage header (ADR 0030
+// §3) — replacing the baseline's pop-last-only remove.
+func (v *VAB) removeUnderCursor() {
+	r, ok := v.currentRow()
+	if !ok {
+		return
+	}
+	if r.isHeader() {
+		v.removeStageAt(r.stageIdx)
+	} else {
+		groups := v.componentGroups(r.stageIdx)
+		if r.group < len(groups) {
+			v.removeOneComponent(r.stageIdx, groups[r.group].compID)
+		}
+	}
+	v.clampCursor()
+	v.syncStageIdx()
+	v.flash = ""
+}
+
+// quantityDelta bumps the count of the component group under the cursor up or
+// down (ADR 0030 §5) — the cluster ergonomics that pair with the ×N fold.
+// Adding one more of the SAME component never conflicts on fuel chemistry.
+func (v *VAB) quantityDelta(d int) {
+	r, ok := v.currentRow()
+	if !ok || r.isHeader() {
+		v.flash = "select a component (↑/↓) to change its count"
+		return
+	}
+	groups := v.componentGroups(r.stageIdx)
+	if r.group >= len(groups) {
+		return
+	}
+	id := groups[r.group].compID
+	if d > 0 {
+		v.stages[r.stageIdx].components = append(v.stages[r.stageIdx].components, id)
+	} else {
+		v.removeOneComponent(r.stageIdx, id)
+	}
+	v.clampCursor()
+	v.syncStageIdx()
+	v.flash = ""
+}
+
+// reorderStage moves the cursor's stage one position toward the top (dir +1)
+// or the bottom (dir -1) of the stack (ADR 0030 §5). The whole vabStage rides
+// along with its seam / decouple flags, so a seam stays attached to the stage
+// it was set on.
+func (v *VAB) reorderStage(dir int) {
+	r, ok := v.currentRow()
+	if !ok {
+		return
+	}
+	i := r.stageIdx
+	j := i + dir
+	if j < 0 || j >= len(v.stages) {
+		return
+	}
+	v.stages[i], v.stages[j] = v.stages[j], v.stages[i]
+	v.focus = focusStack
+	v.focusStageInStack(j)
+	v.flash = ""
+}
+
+// duplicateStage clones the cursor's stage and inserts the copy directly above
+// it (ADR 0030 §5). The clone starts with fresh boundary flags so it doesn't
+// inherit surprising staging.
+func (v *VAB) duplicateStage() {
+	r, ok := v.currentRow()
+	if !ok {
+		return
+	}
+	i := r.stageIdx
+	src := v.stages[i]
+	clone := vabStage{
+		components:    append([]string(nil), src.components...),
+		catalogPartID: src.catalogPartID,
+	}
+	ns := make([]vabStage, 0, len(v.stages)+1)
+	ns = append(ns, v.stages[:i+1]...)
+	ns = append(ns, clone)
+	ns = append(ns, v.stages[i+1:]...)
+	v.stages = ns
+	v.focus = focusStack
+	v.focusStageInStack(i + 1)
+	v.flash = ""
+}
+
+// clampCursor re-clamps the stack cursor after a structural edit.
+func (v *VAB) clampCursor() {
+	rows := v.stackRows()
+	v.stackCursor = clampI(v.stackCursor, 0, maxInt(0, len(rows)-1))
+}
+
+// jumpSection jumps by a whole section (ADR 0030 §7, PgUp/PgDn): between stage
+// headers in the vehicle column, or between kind groups in the palette.
+func (v *VAB) jumpSection(dir int) {
+	if v.focus == focusStack {
+		v.jumpStage(dir)
+		return
+	}
+	v.jumpKind(dir)
+}
+
+// jumpStage moves the stack cursor to the previous / next stage header.
+func (v *VAB) jumpStage(dir int) {
+	rows := v.stackRows()
+	if len(rows) == 0 {
+		return
+	}
+	v.stackCursor = clampI(v.stackCursor, 0, len(rows)-1)
+	for i := v.stackCursor + dir; i >= 0 && i < len(rows); i += dir {
+		if rows[i].isHeader() {
+			v.stackCursor = i
+			v.syncStageIdx()
+			return
+		}
+	}
+}
+
+// jumpKind moves the palette cursor to the first item of the previous / next
+// kind section.
+func (v *VAB) jumpKind(dir int) {
+	if len(v.palette) == 0 {
+		return
+	}
+	var starts []int
+	lastKind := "\x00"
+	for i, it := range v.palette {
+		if k, _ := v.paletteItemLabel(it); k != lastKind {
+			starts = append(starts, i)
+			lastKind = k
+		}
+	}
+	cur := 0
+	for s, idx := range starts {
+		if idx <= v.paletteIdx {
+			cur = s
+		}
+	}
+	v.paletteIdx = starts[clampI(cur+dir, 0, len(starts)-1)]
 }

--- a/internal/tui/screens/vab_ops_test.go
+++ b/internal/tui/screens/vab_ops_test.go
@@ -1,0 +1,204 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// S6 / S7 — ADR 0030 — the linear-cursor model, canonical fold, and the new
+// build operations (remove-under-cursor, quantity ±, reorder, duplicate, the
+// column switch and section jump). These drive the model methods directly.
+
+func countComp(st vabStage, id string) int {
+	n := 0
+	for _, c := range st.components {
+		if c == id {
+			n++
+		}
+	}
+	return n
+}
+
+// TestVABCanonicalFold — components added in any order fold into kind-ordered
+// ×N groups: engines before tanks, identical components counted (ADR 0030 §4).
+func TestVABCanonicalFold(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("tank") // tank added FIRST
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("eng") // a 2-engine cluster
+	groups := v.componentGroups(0)
+	if len(groups) != 2 {
+		t.Fatalf("groups = %d, want 2 (one engine group, one tank group)", len(groups))
+	}
+	if groups[0].kind != spacecraft.ComponentEngine {
+		t.Errorf("first group kind = %q, want engine (kind-ordered, not insertion-ordered)", groups[0].kind)
+	}
+	if groups[0].compID != "eng" || groups[0].count != 2 {
+		t.Errorf("engine group = %s ×%d, want eng ×2", groups[0].compID, groups[0].count)
+	}
+	if groups[1].kind != spacecraft.ComponentTank || groups[1].count != 1 {
+		t.Errorf("tank group = %s ×%d (%s), want tank ×1", groups[1].compID, groups[1].count, groups[1].kind)
+	}
+}
+
+// TestVABStackRowsInterleaved — the flattened cursor list is stage headers and
+// their groups interleaved, top stage first (ADR 0030 §3).
+func TestVABStackRowsInterleaved(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.newStage()
+	v.addComponentToCurrent("core")
+	rows := v.stackRows()
+	// top stage (1: core) header + 1 group, then bottom stage (0) header + 2 groups
+	if len(rows) != 5 {
+		t.Fatalf("rows = %d, want 5 (2 headers + 3 groups)", len(rows))
+	}
+	if !rows[0].isHeader() || rows[0].stageIdx != 1 {
+		t.Errorf("row0 = %+v, want header of top stage 1", rows[0])
+	}
+	if rows[1].isHeader() || rows[1].stageIdx != 1 {
+		t.Errorf("row1 = %+v, want a group of stage 1", rows[1])
+	}
+	if !rows[2].isHeader() || rows[2].stageIdx != 0 {
+		t.Errorf("row2 = %+v, want header of bottom stage 0", rows[2])
+	}
+}
+
+// TestVABRemoveUnderCursorGroup — with the cursor on a component group, [x]
+// removes ONE instance of that group, not the whole stage (ADR 0030 §3).
+func TestVABRemoveUnderCursorGroup(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("eng") // eng ×2
+	v.addComponentToCurrent("tank")
+	// rows: [header, engGroup, tankGroup]; put cursor on the engine group.
+	v.stackCursor = 1
+	v.removeUnderCursor()
+	if got := countComp(v.stages[0], "eng"); got != 1 {
+		t.Errorf("engine count = %d, want 1 (one instance removed)", got)
+	}
+	if len(v.stages) != 1 {
+		t.Errorf("stage was removed (%d left), want the stage kept", len(v.stages))
+	}
+}
+
+// TestVABRemoveUnderCursorHeader — with the cursor on a stage header, [x]
+// removes the whole stage.
+func TestVABRemoveUnderCursorHeader(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.newStage()
+	v.addComponentToCurrent("core")
+	// Top stage (1) header is row 0.
+	v.stackCursor = 0
+	v.removeUnderCursor()
+	if len(v.stages) != 1 {
+		t.Fatalf("stages = %d, want 1 after removing the top stage", len(v.stages))
+	}
+	if countComp(v.stages[0], "eng") != 1 {
+		t.Error("wrong stage removed — expected the engine stage to survive")
+	}
+}
+
+// TestVABQuantityDelta — +/- on a component group changes its count and the
+// stage's Δv (ADR 0030 §5).
+func TestVABQuantityDelta(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.stackCursor = v.headerRowIndex(0) + 2 // the tank group (after engine group)
+	if r, _ := v.currentRow(); r.isHeader() {
+		t.Fatal("cursor landed on a header, expected a component group")
+	}
+	dv0 := v.Stats().StageDV[0]
+	v.quantityDelta(+1) // a second tank
+	if countComp(v.stages[0], "tank") != 2 {
+		t.Fatalf("tank count = %d, want 2 after +1", countComp(v.stages[0], "tank"))
+	}
+	if v.Stats().StageDV[0] <= dv0 {
+		t.Error("+1 tank did not raise Δv")
+	}
+	v.quantityDelta(-1)
+	if countComp(v.stages[0], "tank") != 1 {
+		t.Errorf("tank count = %d, want 1 after -1", countComp(v.stages[0], "tank"))
+	}
+}
+
+// TestVABReorderStage — moving a stage swaps its position in the stack
+// (ADR 0030 §5).
+func TestVABReorderStage(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng") // stage 0
+	v.newStage()
+	v.addComponentToCurrent("core") // stage 1
+	v.focusStageInStack(1)
+	v.reorderStage(-1) // move the top stage down to index 0
+	if countComp(v.stages[0], "core") != 1 {
+		t.Errorf("stage 0 = %v, want the core stage after reorder", v.stages[0].components)
+	}
+	if countComp(v.stages[1], "eng") != 1 {
+		t.Errorf("stage 1 = %v, want the engine stage after reorder", v.stages[1].components)
+	}
+}
+
+// TestVABDuplicateStage — duplicating clones a stage's components into a new
+// adjacent stage (ADR 0030 §5).
+func TestVABDuplicateStage(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.focusStageInStack(0)
+	v.duplicateStage()
+	if len(v.stages) != 2 {
+		t.Fatalf("stages = %d, want 2 after duplicate", len(v.stages))
+	}
+	if countComp(v.stages[0], "eng") != 1 || countComp(v.stages[1], "eng") != 1 ||
+		countComp(v.stages[0], "tank") != 1 || countComp(v.stages[1], "tank") != 1 {
+		t.Errorf("clone mismatch: s0=%v s1=%v", v.stages[0].components, v.stages[1].components)
+	}
+	// Mutating the clone must not touch the original (deep copy).
+	v.removeOneComponent(1, "tank")
+	if countComp(v.stages[0], "tank") != 1 {
+		t.Error("editing the clone mutated the original stage (shared slice)")
+	}
+}
+
+// TestVABColumnSwitchKeys — ←/→ switch the active column and never steal a
+// cursor (ADR 0030 §3); the cumbersome focus-stealing behavior is gone.
+func TestVABColumnSwitchKeys(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.HandleKey("right")
+	if v.focus != focusStack {
+		t.Errorf("→ focus = %v, want focusStack", v.focus)
+	}
+	v.HandleKey("left")
+	if v.focus != focusPalette {
+		t.Errorf("← focus = %v, want focusPalette", v.focus)
+	}
+}
+
+// TestVABKindJump — PgUp/PgDn jumps the palette cursor between kind sections
+// (ADR 0030 §7).
+func TestVABKindJump(t *testing.T) {
+	v := NewVAB(Theme{}) // real component catalog via the package global
+	v.Reset(spacecraft.Components)
+	if len(v.palette) == 0 {
+		t.Skip("no components in catalog")
+	}
+	startKind, _ := v.paletteItemLabel(v.palette[v.paletteIdx])
+	v.jumpKind(+1)
+	nextKind, _ := v.paletteItemLabel(v.palette[v.paletteIdx])
+	if startKind == nextKind {
+		t.Errorf("jumpKind stayed in the same section %q", startKind)
+	}
+}

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -1,0 +1,380 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// HandleKey routes a raw key to the active mode. The VAB owns its own keymap
+// (handled here, like SpawnCraft) so its keys never fall through to the
+// orbit flight controls.
+func (v *VAB) HandleKey(key string) VABAction {
+	switch v.mode {
+	case vabModeNaming:
+		return v.handleNamingKey(key)
+	case vabModeLoad:
+		return v.handleLoadKey(key)
+	default:
+		return v.handleBuildKey(key)
+	}
+}
+
+func (v *VAB) handleBuildKey(key string) VABAction {
+	switch key {
+	case "esc":
+		return VABActionCancel
+	case "tab":
+		if v.focus == focusPalette {
+			v.focus = focusStack
+		} else {
+			v.focus = focusPalette
+		}
+	case "up":
+		v.moveCursor(-1)
+	case "down":
+		v.moveCursor(+1)
+	case "left":
+		v.focus = focusPalette
+		v.paletteIdx = wrapIdx(v.paletteIdx-1, len(v.palette))
+	case "right":
+		v.focus = focusPalette
+		v.paletteIdx = wrapIdx(v.paletteIdx+1, len(v.palette))
+	case "a":
+		v.addSelected()
+	case "n":
+		v.newStage()
+	case "x":
+		v.removeFromCurrent()
+	case "d":
+		v.toggleDockSeam()
+	case "c":
+		v.toggleDecoupleFuse()
+	case "s":
+		v.flash = ""
+		v.mode = vabModeNaming
+	case "o":
+		v.enterLoadMode()
+	}
+	return VABActionNone
+}
+
+func (v *VAB) moveCursor(step int) {
+	if v.focus == focusStack {
+		if len(v.stages) > 0 {
+			v.stageIdx = wrapIdx(v.stageIdx+step, len(v.stages))
+		}
+		return
+	}
+	if len(v.palette) > 0 {
+		v.paletteIdx = wrapIdx(v.paletteIdx+step, len(v.palette))
+	}
+}
+
+func (v *VAB) handleNamingKey(key string) VABAction {
+	switch key {
+	case "esc":
+		v.mode = vabModeBuild
+	case "enter":
+		if strings.TrimSpace(v.name) == "" {
+			v.flash = "name can't be empty"
+			return VABActionNone
+		}
+		if err := spacecraft.SaveDesign(v.toDesign()); err != nil {
+			v.flash = "save failed: " + err.Error()
+		} else {
+			v.flash = fmt.Sprintf("saved design %q", v.name)
+		}
+		v.mode = vabModeBuild
+	case "backspace":
+		if r := []rune(v.name); len(r) > 0 {
+			v.name = string(r[:len(r)-1])
+		}
+	case "space":
+		v.name += " "
+	default:
+		if len([]rune(key)) == 1 {
+			v.name += key
+		}
+	}
+	return VABActionNone
+}
+
+func (v *VAB) handleLoadKey(key string) VABAction {
+	switch key {
+	case "esc":
+		v.mode = vabModeBuild
+	case "up":
+		if len(v.designs) > 0 {
+			v.loadIdx = wrapIdx(v.loadIdx-1, len(v.designs))
+		}
+	case "down":
+		if len(v.designs) > 0 {
+			v.loadIdx = wrapIdx(v.loadIdx+1, len(v.designs))
+		}
+	case "enter":
+		if v.loadIdx >= 0 && v.loadIdx < len(v.designs) {
+			v.loadDesign(v.designs[v.loadIdx])
+			v.flash = fmt.Sprintf("loaded %q", v.name)
+		}
+	case "x":
+		if v.loadIdx >= 0 && v.loadIdx < len(v.designs) {
+			id := v.designs[v.loadIdx].ID()
+			if err := spacecraft.DeleteDesign(id); err == nil {
+				v.refreshDesigns()
+				v.flash = fmt.Sprintf("deleted %q", id)
+			} else {
+				v.flash = "delete failed: " + err.Error()
+			}
+		}
+	}
+	return VABActionNone
+}
+
+func (v *VAB) enterLoadMode() {
+	v.refreshDesigns()
+	v.loadIdx = 0
+	v.mode = vabModeLoad
+	v.flash = ""
+}
+
+func (v *VAB) refreshDesigns() {
+	designs, _ := spacecraft.ListDesigns()
+	v.designs = designs
+	if v.loadIdx >= len(v.designs) {
+		v.loadIdx = 0
+	}
+}
+
+// Render returns the VAB screen for the current mode. width is the terminal
+// width.
+func (v *VAB) Render(width int) string {
+	switch v.mode {
+	case vabModeNaming:
+		return v.renderNaming(width)
+	case vabModeLoad:
+		return v.renderLoad(width)
+	default:
+		return v.renderBuild(width)
+	}
+}
+
+func (v *VAB) renderBuild(width int) string {
+	var lines []string
+	lines = append(lines, v.theme.Title.Render("terminal-space-program — Vehicle Assembly (VAB)"))
+	name := v.name
+	if name == "" {
+		name = "(unsaved)"
+	}
+	lines = append(lines, v.theme.Dim.Render("design: ")+v.theme.Primary.Render(name))
+	lines = append(lines, "")
+
+	// STACK pane (bottom→top), per-stage Δv, seam + decouple markers.
+	stackHdr := "STACK (bottom → top)"
+	if v.focus == focusStack {
+		lines = append(lines, v.theme.Warning.Render("▶ "+stackHdr))
+	} else {
+		lines = append(lines, v.theme.Primary.Render("  "+stackHdr))
+	}
+	stages := v.resolvedStages()
+	stats := spacecraft.StackStats(stages)
+	if len(v.stages) == 0 {
+		lines = append(lines, "  "+v.theme.Dim.Render("(empty — pick a part below and press [a] to add)"))
+	} else {
+		for i := len(v.stages) - 1; i >= 0; i-- {
+			vs := v.stages[i]
+			st := stages[i]
+			if i >= 1 && vs.dockSeamBelow {
+				lines = append(lines, "  "+v.theme.Warning.Render("── dock seam ──  (above = nose payload, [U]ndock to release)"))
+			}
+			cursor := "  "
+			if i == v.stageIdx {
+				cursor = v.theme.Warning.Render("→ ")
+			}
+			label := v.stageLabel(vs)
+			eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
+			if st.Thrust == 0 {
+				eng = "no engine"
+			}
+			tags := ""
+			if vs.decoupleFused && i >= 1 {
+				tags = v.theme.Dim.Render("  ⛓ fused-decouple")
+			}
+			row := fmt.Sprintf("S%d %-18s dry %.0fkg fuel %.0fkg  %s  Δv %.0f m/s",
+				i+1, label, st.DryMass, st.FuelMass, eng, stats.StageDV[i])
+			if i == v.stageIdx && v.focus == focusStack {
+				row = v.theme.Warning.Render(row)
+			} else {
+				row = v.theme.Primary.Render(row)
+			}
+			lines = append(lines, "  "+cursor+row+tags)
+		}
+	}
+
+	// STATS summary.
+	lines = append(lines, "")
+	lines = append(lines, "  "+v.theme.Primary.Render(fmt.Sprintf(
+		"Σ  total Δv %.0f m/s   mass %.0f kg   liftoff TWR %.2f (g₀)",
+		stats.TotalDV, stats.TotalMass, stats.LiftoffTWR)))
+
+	// Soft-validation warnings.
+	for _, w := range v.Warnings() {
+		lines = append(lines, "  "+v.theme.Dim.Render("⚠ "+w))
+	}
+
+	// PALETTE pane.
+	lines = append(lines, "")
+	palHdr := "PALETTE (components by kind · catalog parts)"
+	if v.focus == focusPalette {
+		lines = append(lines, v.theme.Warning.Render("▶ "+palHdr))
+	} else {
+		lines = append(lines, v.theme.Primary.Render("  "+palHdr))
+	}
+	lines = append(lines, v.renderPalette()...)
+
+	// Flash + footer.
+	lines = append(lines, "")
+	if v.flash != "" {
+		lines = append(lines, "  "+v.theme.Warning.Render(v.flash))
+	}
+	lines = append(lines, v.theme.Dim.Render(strings.Repeat("─", 64)))
+	lines = append(lines, v.theme.Footer.Render(
+		"[tab] pane  [←/→ ↑/↓] move  [a] add  [n] new stage  [x] remove"))
+	lines = append(lines, v.theme.Footer.Render(
+		"[d] dock seam  [c] fuse decouple  [s] save  [o] open  [esc] back"))
+	return strings.Join(lines, "\n")
+}
+
+// renderPalette lists the palette around the cursor with kind grouping
+// headers, windowed so a long catalog doesn't overflow the screen.
+func (v *VAB) renderPalette() []string {
+	if len(v.palette) == 0 {
+		return []string{"  " + v.theme.Dim.Render("(no components yet — catalog parts only)")}
+	}
+	const window = 8
+	start := v.paletteIdx - window/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + window
+	if end > len(v.palette) {
+		end = len(v.palette)
+		start = end - window
+		if start < 0 {
+			start = 0
+		}
+	}
+	var lines []string
+	lastKind := "?"
+	for i := start; i < end; i++ {
+		it := v.palette[i]
+		kind, label := v.paletteItemLabel(it)
+		if kind != lastKind {
+			lines = append(lines, "  "+v.theme.Dim.Render("· "+kind+" ·"))
+			lastKind = kind
+		}
+		marker := "  "
+		row := label
+		if i == v.paletteIdx {
+			marker = v.theme.Warning.Render("→ ")
+			if v.focus == focusPalette {
+				row = v.theme.Warning.Render(row)
+			} else {
+				row = v.theme.Primary.Render(row)
+			}
+		} else {
+			row = v.theme.Dim.Render(row)
+		}
+		lines = append(lines, "    "+marker+row)
+	}
+	return lines
+}
+
+// paletteItemLabel returns the group label and one-line description for a
+// palette entry.
+func (v *VAB) paletteItemLabel(it vabPaletteItem) (kind, label string) {
+	if !it.isComponent {
+		m, ok := spacecraft.StageCatalog[it.id]
+		if !ok {
+			return "catalog part", it.id
+		}
+		return "catalog part", fmt.Sprintf("%s %s [%s]", m.Glyph, m.Name, m.Tier)
+	}
+	c := v.comps[it.id]
+	switch c.Kind {
+	case spacecraft.ComponentEngine:
+		return "engine", fmt.Sprintf("%s  %.0fkN @ %.0fs  %s  dry %.0fkg", v.compName(c), c.ThrustN/1000, c.IspS, c.FuelType, c.DryMassKg)
+	case spacecraft.ComponentTank:
+		return "tank", fmt.Sprintf("%s  %.0fkg %s  dry %.0fkg", v.compName(c), c.FuelCapacityKg, c.FuelType, c.DryMassKg)
+	case spacecraft.ComponentCommandCore:
+		return "command-core", fmt.Sprintf("%s  %s  dry %.0fkg", v.compName(c), c.CommandSource, c.DryMassKg)
+	case spacecraft.ComponentAntenna:
+		return "antenna", fmt.Sprintf("%s  %s  dry %.0fkg", v.compName(c), c.AntennaKind, c.DryMassKg)
+	default:
+		return "structure", fmt.Sprintf("%s  dry %.0fkg", v.compName(c), c.DryMassKg)
+	}
+}
+
+func (v *VAB) compName(c spacecraft.Component) string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.ID
+}
+
+// stageLabel summarizes a working stage for the stack list.
+func (v *VAB) stageLabel(vs vabStage) string {
+	if vs.isCatalog() {
+		if m, ok := spacecraft.StageCatalog[vs.catalogPartID]; ok {
+			return m.Name + " (catalog)"
+		}
+		return vs.catalogPartID
+	}
+	if len(vs.components) == 0 {
+		return "(empty)"
+	}
+	return fmt.Sprintf("%d components", len(vs.components))
+}
+
+func (v *VAB) renderNaming(width int) string {
+	var lines []string
+	lines = append(lines, v.theme.Title.Render("terminal-space-program — save design"))
+	lines = append(lines, "")
+	lines = append(lines, "  "+v.theme.Primary.Render("name: ")+v.theme.Warning.Render(v.name+"▏"))
+	lines = append(lines, "")
+	if v.flash != "" {
+		lines = append(lines, "  "+v.theme.Warning.Render(v.flash))
+		lines = append(lines, "")
+	}
+	lines = append(lines, v.theme.Footer.Render("[enter] save  [esc] cancel"))
+	return strings.Join(lines, "\n")
+}
+
+func (v *VAB) renderLoad(width int) string {
+	var lines []string
+	lines = append(lines, v.theme.Title.Render("terminal-space-program — load design"))
+	lines = append(lines, "")
+	if len(v.designs) == 0 {
+		lines = append(lines, "  "+v.theme.Dim.Render("(no saved designs yet)"))
+	} else {
+		for i, d := range v.designs {
+			marker := "  "
+			row := fmt.Sprintf("%s  (%d stages)", d.Name(), len(d.Loadout.Parts))
+			if i == v.loadIdx {
+				marker = v.theme.Warning.Render("→ ")
+				row = v.theme.Warning.Render(row)
+			} else {
+				row = v.theme.Dim.Render(row)
+			}
+			lines = append(lines, "  "+marker+row)
+		}
+	}
+	lines = append(lines, "")
+	if v.flash != "" {
+		lines = append(lines, "  "+v.theme.Warning.Render(v.flash))
+		lines = append(lines, "")
+	}
+	lines = append(lines, v.theme.Footer.Render("[↑/↓] pick  [enter] load  [x] delete  [esc] back"))
+	return strings.Join(lines, "\n")
+}

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -91,9 +91,10 @@ func (v *VAB) handleNamingKey(key string) VABAction {
 		if r := []rune(v.name); len(r) > 0 {
 			v.name = string(r[:len(r)-1])
 		}
-	case "space":
-		v.name += " "
 	default:
+		// Bubble Tea reports the spacebar as " " (a single rune), not "space",
+		// so the single-rune default covers it along with every printable
+		// character; multi-rune keys (arrows, "tab", …) are ignored.
 		if len([]rune(key)) == 1 {
 			v.name += key
 		}

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -25,28 +27,42 @@ func (v *VAB) handleBuildKey(key string) VABAction {
 	switch key {
 	case "esc":
 		return VABActionCancel
+	// ←/→ switch columns spatially (palette on the left, vehicle on the
+	// right) — they never steal focus or move a cursor anymore (ADR 0030 §3).
+	case "left", "h":
+		v.focus = focusPalette
+	case "right", "l":
+		v.focus = focusStack
 	case "tab":
 		if v.focus == focusPalette {
 			v.focus = focusStack
 		} else {
 			v.focus = focusPalette
 		}
-	case "up":
+	case "up", "k":
 		v.moveCursor(-1)
-	case "down":
+	case "down", "j":
 		v.moveCursor(+1)
-	case "left":
-		v.focus = focusPalette
-		v.paletteIdx = wrapIdx(v.paletteIdx-1, len(v.palette))
-	case "right":
-		v.focus = focusPalette
-		v.paletteIdx = wrapIdx(v.paletteIdx+1, len(v.palette))
+	case "pgup":
+		v.jumpSection(-1)
+	case "pgdown":
+		v.jumpSection(+1)
 	case "a":
 		v.addSelected()
 	case "n":
 		v.newStage()
 	case "x":
-		v.removeFromCurrent()
+		v.removeUnderCursor()
+	case "+", "=":
+		v.quantityDelta(+1)
+	case "-", "_":
+		v.quantityDelta(-1)
+	case "]":
+		v.reorderStage(+1)
+	case "[":
+		v.reorderStage(-1)
+	case "y":
+		v.duplicateStage()
 	case "d":
 		v.toggleDockSeam()
 	case "c":
@@ -60,11 +76,12 @@ func (v *VAB) handleBuildKey(key string) VABAction {
 	return VABActionNone
 }
 
+// moveCursor drives the single linear cursor in the active column: the
+// flattened stage/group cursor in the vehicle column (clamped, no wrap), or
+// the palette list (wraps).
 func (v *VAB) moveCursor(step int) {
 	if v.focus == focusStack {
-		if len(v.stages) > 0 {
-			v.stageIdx = wrapIdx(v.stageIdx+step, len(v.stages))
-		}
+		v.moveStackCursor(step)
 		return
 	}
 	if len(v.palette) > 0 {
@@ -161,99 +178,99 @@ func (v *VAB) Render(width int) string {
 	}
 }
 
+// renderBuild lays out the VAB as two side-by-side columns — the component
+// palette on the left, the vehicle (glyph view) on the right — with a live
+// stats strip and a full-width footer (ADR 0030 §2). The columns are joined
+// per-line so a single linear cursor reads naturally down whichever column
+// has focus.
 func (v *VAB) renderBuild(width int) string {
-	var lines []string
-	lines = append(lines, v.theme.Title.Render("terminal-space-program — Vehicle Assembly (VAB)"))
+	if width < 64 {
+		width = 64 // floor: keep both columns usable on a narrow terminal
+	}
+	palW := clampI(width*42/100, 30, 48)
+	vehW := width - palW - 3 // 3 = " │ " separator
+	if vehW < 28 {
+		vehW = 28
+	}
+
+	var head []string
+	head = append(head, v.theme.Title.Render("terminal-space-program — Vehicle Assembly (VAB)"))
 	name := v.name
 	if name == "" {
 		name = "(unsaved)"
 	}
-	lines = append(lines, v.theme.Dim.Render("design: ")+v.theme.Primary.Render(name))
-	lines = append(lines, "")
+	head = append(head, v.theme.Dim.Render("design: ")+v.theme.Primary.Render(name))
 
-	// STACK pane (bottom→top), per-stage Δv, seam + decouple markers.
-	stackHdr := "STACK (bottom → top)"
-	if v.focus == focusStack {
-		lines = append(lines, v.theme.Warning.Render("▶ "+stackHdr))
-	} else {
-		lines = append(lines, v.theme.Primary.Render("  "+stackHdr))
-	}
-	stages := v.resolvedStages()
-	stats := spacecraft.StackStats(stages)
-	if len(v.stages) == 0 {
-		lines = append(lines, "  "+v.theme.Dim.Render("(empty — pick a part below and press [a] to add)"))
-	} else {
-		for i := len(v.stages) - 1; i >= 0; i-- {
-			vs := v.stages[i]
-			st := stages[i]
-			if i >= 1 && vs.dockSeamBelow {
-				lines = append(lines, "  "+v.theme.Warning.Render("── dock seam ──  (above = nose payload, [U]ndock to release)"))
-			}
-			cursor := "  "
-			if i == v.stageIdx {
-				cursor = v.theme.Warning.Render("→ ")
-			}
-			label := v.stageLabel(vs)
-			eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
-			if st.Thrust == 0 {
-				eng = "no engine"
-			}
-			tags := ""
-			if vs.decoupleFused && i >= 1 {
-				tags = v.theme.Dim.Render("  ⛓ fused-decouple")
-			}
-			row := fmt.Sprintf("S%d %-18s dry %.0fkg fuel %.0fkg  %s  Δv %.0f m/s",
-				i+1, label, st.DryMass, st.FuelMass, eng, stats.StageDV[i])
-			if i == v.stageIdx && v.focus == focusStack {
-				row = v.theme.Warning.Render(row)
-			} else {
-				row = v.theme.Primary.Render(row)
-			}
-			lines = append(lines, "  "+cursor+row+tags)
-		}
-	}
+	body := v.joinColumns(v.renderPaletteColumn(palW), v.renderVehicleColumn(vehW), palW)
 
-	// STATS summary.
-	lines = append(lines, "")
-	lines = append(lines, "  "+v.theme.Primary.Render(fmt.Sprintf(
-		"Σ  total Δv %.0f m/s   mass %.0f kg   liftoff TWR %.2f (g₀)",
-		stats.TotalDV, stats.TotalMass, stats.LiftoffTWR)))
-
-	// Soft-validation warnings.
-	for _, w := range v.Warnings() {
-		lines = append(lines, "  "+v.theme.Dim.Render("⚠ "+w))
-	}
-
-	// PALETTE pane.
-	lines = append(lines, "")
-	palHdr := "PALETTE (components by kind · catalog parts)"
-	if v.focus == focusPalette {
-		lines = append(lines, v.theme.Warning.Render("▶ "+palHdr))
-	} else {
-		lines = append(lines, v.theme.Primary.Render("  "+palHdr))
-	}
-	lines = append(lines, v.renderPalette()...)
-
-	// Flash + footer.
-	lines = append(lines, "")
+	var foot []string
 	if v.flash != "" {
-		lines = append(lines, "  "+v.theme.Warning.Render(v.flash))
+		foot = append(foot, "", v.theme.Warning.Render(v.flash))
 	}
-	lines = append(lines, v.theme.Dim.Render(strings.Repeat("─", 64)))
-	lines = append(lines, v.theme.Footer.Render(
-		"[tab] pane  [←/→ ↑/↓] move  [a] add  [n] new stage  [x] remove"))
-	lines = append(lines, v.theme.Footer.Render(
-		"[d] dock seam  [c] fuse decouple  [s] save  [o] open  [esc] back"))
-	return strings.Join(lines, "\n")
+	foot = append(foot, v.theme.Dim.Render(strings.Repeat("─", clampI(width, 40, 100))))
+	foot = append(foot, v.theme.Footer.Render(
+		"[←/→] column  [↑/↓] move  [PgUp/Dn] section  [a] add  [n] new stage  [x] remove"))
+	foot = append(foot, v.theme.Footer.Render(
+		"[+/−] qty  ['['/']'] reorder  [y] duplicate  [d] dock seam  [c] fuse  [s] save  [o] open  [esc] back"))
+
+	return strings.Join(head, "\n") + "\n\n" + body + "\n" + strings.Join(foot, "\n")
 }
 
-// renderPalette lists the palette around the cursor with kind grouping
-// headers, windowed so a long catalog doesn't overflow the screen.
-func (v *VAB) renderPalette() []string {
-	if len(v.palette) == 0 {
-		return []string{"  " + v.theme.Dim.Render("(no components yet — catalog parts only)")}
+// joinColumns stitches the left and right column line-lists side by side,
+// padding the left to leftW (display width) and inserting a dim divider, so
+// the divider stays vertically aligned regardless of ANSI styling or wide
+// runes.
+func (v *VAB) joinColumns(left, right []string, leftW int) string {
+	sep := v.theme.Dim.Render(" │ ")
+	n := maxInt(len(left), len(right))
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		l, r := "", ""
+		if i < len(left) {
+			l = left[i]
+		}
+		if i < len(right) {
+			r = right[i]
+		}
+		pad := leftW - lipgloss.Width(l)
+		if pad < 0 {
+			pad = 0
+		}
+		b.WriteString(l)
+		b.WriteString(strings.Repeat(" ", pad))
+		b.WriteString(sep)
+		b.WriteString(r)
+		if i < n-1 {
+			b.WriteString("\n")
+		}
 	}
-	const window = 8
+	return b.String()
+}
+
+// renderPaletteColumn is the left column: a kind-grouped, windowed component
+// palette plus a live inspector for the item under the cursor (ADR 0030 §7).
+func (v *VAB) renderPaletteColumn(w int) []string {
+	hdr := "PALETTE  components · parts"
+	var lines []string
+	if v.focus == focusPalette {
+		lines = append(lines, v.theme.Warning.Render("▶ "+hdr))
+	} else {
+		lines = append(lines, v.theme.Dim.Render("  "+hdr))
+	}
+	lines = append(lines, v.renderPalette(w)...)
+	lines = append(lines, "")
+	lines = append(lines, v.renderInspector(w)...)
+	return lines
+}
+
+// renderPalette windows the palette around the cursor with kind-section
+// headers; the glyph is colored by kind (the shared legend, ADR 0030 §6) and
+// the label is just the name — full stats live in the inspector.
+func (v *VAB) renderPalette(w int) []string {
+	if len(v.palette) == 0 {
+		return []string{v.theme.Dim.Render("  (catalog parts only)")}
+	}
+	const window = 9
 	start := v.paletteIdx - window/2
 	if start < 0 {
 		start = 0
@@ -261,60 +278,252 @@ func (v *VAB) renderPalette() []string {
 	end := start + window
 	if end > len(v.palette) {
 		end = len(v.palette)
-		start = end - window
-		if start < 0 {
-			start = 0
-		}
+		start = maxInt(0, end-window)
 	}
 	var lines []string
-	lastKind := "?"
+	lastKind := "\x00"
 	for i := start; i < end; i++ {
 		it := v.palette[i]
 		kind, label := v.paletteItemLabel(it)
 		if kind != lastKind {
-			lines = append(lines, "  "+v.theme.Dim.Render("· "+kind+" ·"))
+			lines = append(lines, v.theme.Dim.Render("· "+kind+" ·"))
 			lastKind = kind
 		}
-		marker := "  "
-		row := label
-		if i == v.paletteIdx {
-			marker = v.theme.Warning.Render("→ ")
-			if v.focus == focusPalette {
-				row = v.theme.Warning.Render(row)
-			} else {
-				row = v.theme.Primary.Render(row)
-			}
-		} else {
-			row = v.theme.Dim.Render(row)
+		glyph := "  "
+		if it.isComponent {
+			glyph = v.componentStyle(it.id).Render(v.componentGlyph(it.id)) + " "
 		}
-		lines = append(lines, "    "+marker+row)
+		label = truncWidth(label, w-5)
+		marker := "  "
+		var styled string
+		switch {
+		case i == v.paletteIdx && v.focus == focusPalette:
+			marker = v.theme.Warning.Render("→ ")
+			styled = v.theme.Warning.Render(label)
+		case i == v.paletteIdx:
+			marker = v.theme.Primary.Render("→ ")
+			styled = v.theme.Primary.Render(label)
+		default:
+			styled = v.theme.Dim.Render(label)
+		}
+		lines = append(lines, marker+glyph+styled)
 	}
 	return lines
 }
 
-// paletteItemLabel returns the group label and one-line description for a
-// palette entry.
+// renderInspector shows the full stats of the palette item under the cursor,
+// its description, and what it would add to the active stage (ADR 0030 §7).
+func (v *VAB) renderInspector(w int) []string {
+	if v.paletteIdx < 0 || v.paletteIdx >= len(v.palette) {
+		return nil
+	}
+	it := v.palette[v.paletteIdx]
+	lines := []string{v.theme.Dim.Render("┌ inspect")}
+	add := func(s string) { lines = append(lines, v.theme.Dim.Render("│ ")+s) }
+	if it.isComponent {
+		c := v.comps[it.id]
+		add(v.componentStyle(it.id).Render(v.componentGlyph(it.id)) + " " + v.theme.Primary.Render(v.compName(c)))
+		switch c.Kind {
+		case spacecraft.ComponentEngine:
+			add(v.theme.Dim.Render(fmt.Sprintf("engine · %s", c.FuelType)))
+			add(v.theme.Dim.Render(fmt.Sprintf("%.0f kN · Isp %.0f s · dry %.0f kg", c.ThrustN/1000, c.IspS, c.DryMassKg)))
+		case spacecraft.ComponentTank:
+			add(v.theme.Dim.Render(fmt.Sprintf("tank · %s", c.FuelType)))
+			add(v.theme.Dim.Render(fmt.Sprintf("%.0f kg fuel · dry %.0f kg", c.FuelCapacityKg, c.DryMassKg)))
+		case spacecraft.ComponentCommandCore:
+			add(v.theme.Dim.Render(fmt.Sprintf("command-core · %s · dry %.0f kg", c.CommandSource, c.DryMassKg)))
+		case spacecraft.ComponentAntenna:
+			add(v.theme.Dim.Render(fmt.Sprintf("antenna · %s · dry %.0f kg", c.AntennaKind, c.DryMassKg)))
+		default:
+			add(v.theme.Dim.Render(fmt.Sprintf("structure · dry %.0f kg", c.DryMassKg)))
+		}
+		for _, ln := range wrapText(c.Description, w-2) {
+			add(v.theme.Dim.Render(ln))
+		}
+		add(v.inspectAddLine(w - 2))
+	} else if m, ok := spacecraft.StageCatalog[it.id]; ok {
+		add(v.theme.Primary.Render(m.Glyph + " " + m.Name))
+		add(v.theme.Dim.Render("catalog part · " + m.Tier))
+		add(v.theme.Dim.Render("→ adds as a new opaque stage"))
+	} else {
+		add(v.theme.Primary.Render(it.id))
+	}
+	return lines
+}
+
+// inspectAddLine previews where the selected palette item would land and
+// whether it is fuel-compatible with the active stage.
+func (v *VAB) inspectAddLine(w int) string {
+	it := v.palette[v.paletteIdx]
+	if len(v.stages) == 0 {
+		return v.theme.Dim.Render(truncWidth("→ adds to a new stage", w))
+	}
+	i := clampI(v.stageIdx, 0, len(v.stages)-1)
+	if v.stages[i].isCatalog() {
+		return v.theme.Dim.Render(truncWidth("→ starts a new stage (block is opaque)", w))
+	}
+	if warn := v.fuelConflict(v.stages[i].components, it.id); warn != "" {
+		return v.theme.Warning.Render(truncWidth("✗ "+warn, w))
+	}
+	return v.theme.Dim.Render(truncWidth(fmt.Sprintf("→ adds to S%d", i+1), w))
+}
+
+// paletteItemLabel returns the kind (section header / jump key) and the short
+// display name for a palette entry. Full stats are in the inspector.
 func (v *VAB) paletteItemLabel(it vabPaletteItem) (kind, label string) {
 	if !it.isComponent {
 		m, ok := spacecraft.StageCatalog[it.id]
 		if !ok {
 			return "catalog part", it.id
 		}
-		return "catalog part", fmt.Sprintf("%s %s [%s]", m.Glyph, m.Name, m.Tier)
+		return "catalog part", fmt.Sprintf("%s [%s]", m.Name, m.Tier)
 	}
 	c := v.comps[it.id]
-	switch c.Kind {
-	case spacecraft.ComponentEngine:
-		return "engine", fmt.Sprintf("%s  %.0fkN @ %.0fs  %s  dry %.0fkg", v.compName(c), c.ThrustN/1000, c.IspS, c.FuelType, c.DryMassKg)
-	case spacecraft.ComponentTank:
-		return "tank", fmt.Sprintf("%s  %.0fkg %s  dry %.0fkg", v.compName(c), c.FuelCapacityKg, c.FuelType, c.DryMassKg)
-	case spacecraft.ComponentCommandCore:
-		return "command-core", fmt.Sprintf("%s  %s  dry %.0fkg", v.compName(c), c.CommandSource, c.DryMassKg)
-	case spacecraft.ComponentAntenna:
-		return "antenna", fmt.Sprintf("%s  %s  dry %.0fkg", v.compName(c), c.AntennaKind, c.DryMassKg)
-	default:
-		return "structure", fmt.Sprintf("%s  dry %.0fkg", v.compName(c), c.DryMassKg)
+	return c.Kind, v.compName(c)
+}
+
+// renderVehicleColumn is the right column: the stats strip and the glyph
+// vehicle view — stage headers with their kind-folded component groups, seam
+// and decouple markers, and soft-validation warnings (ADR 0030 §1-§4).
+func (v *VAB) renderVehicleColumn(w int) []string {
+	hdr := "VEHICLE  top → bottom"
+	var lines []string
+	if v.focus == focusStack {
+		lines = append(lines, v.theme.Warning.Render("▶ "+hdr))
+	} else {
+		lines = append(lines, v.theme.Dim.Render("  "+hdr))
 	}
+	stages := v.resolvedStages()
+	stats := spacecraft.StackStats(stages)
+	lines = append(lines, v.theme.Primary.Render(truncWidth(fmt.Sprintf(
+		"Σ Δv %.0f m/s · %.1f t · TWR %.2f", stats.TotalDV, stats.TotalMass/1000, stats.LiftoffTWR), w)))
+	lines = append(lines, "")
+	if len(v.stages) == 0 {
+		lines = append(lines, v.theme.Dim.Render("(empty — pick a part and press [a])"))
+		return lines
+	}
+	rows := v.stackRows()
+	for idx, r := range rows {
+		cursorOn := idx == v.stackCursor
+		sel := cursorOn && v.focus == focusStack
+		if r.isHeader() {
+			// A dock seam below the stage above (i+1) sits between it and this
+			// stage — render the divider just before this header (top-down).
+			if up := r.stageIdx + 1; up < len(v.stages) && v.stages[up].dockSeamBelow {
+				lines = append(lines, v.theme.Warning.Render(truncWidth("── dock seam (Undock to release) ──", w)))
+			}
+			lines = append(lines, v.stageHeaderLine(r.stageIdx, stats, sel, cursorOn, w))
+		} else {
+			groups := v.componentGroups(r.stageIdx)
+			if r.group < len(groups) {
+				lines = append(lines, v.groupLine(groups[r.group], sel, cursorOn, w))
+			}
+		}
+	}
+	for _, warn := range v.Warnings() {
+		lines = append(lines, v.theme.Dim.Render(truncWidth("⚠ "+warn, w)))
+	}
+	return lines
+}
+
+// stageHeaderLine renders one stage header: its number, fuel chemistry (or
+// catalog name), engine summary, per-stage Δv, and a fused-decouple marker.
+func (v *VAB) stageHeaderLine(i int, stats spacecraft.VehicleStats, sel, cursorOn bool, w int) string {
+	st := v.resolveStage(v.stages[i])
+	eng := "no engine"
+	if st.Thrust > 0 {
+		eng = fmt.Sprintf("%.0fkN@%.0fs", st.Thrust/1000, st.Isp)
+	}
+	chem := "—"
+	if v.stages[i].isCatalog() {
+		chem = "catalog"
+		if m, ok := spacecraft.StageCatalog[v.stages[i].catalogPartID]; ok {
+			chem = m.Name
+		}
+	} else if ft := v.stageFuelType(v.stages[i].components); ft != "" {
+		chem = ft
+	}
+	tag := ""
+	if v.stages[i].decoupleFused && i >= 1 {
+		tag = " ⛓"
+	}
+	text := truncWidth(fmt.Sprintf("S%d  %s · %s · Δv %.0f%s", i+1, chem, eng, stats.StageDV[i], tag), w-2)
+	marker := "  "
+	switch {
+	case sel:
+		marker = v.theme.Warning.Render("→ ")
+		text = v.theme.Warning.Render(text)
+	case cursorOn:
+		text = v.theme.Primary.Render(text)
+	default:
+		text = v.theme.Primary.Render(text)
+	}
+	return marker + text
+}
+
+// groupLine renders one kind-folded component group: a kind-colored glyph, the
+// component name, and a ×N count when clustered (ADR 0030 §4).
+func (v *VAB) groupLine(g vabGroup, sel, cursorOn bool, w int) string {
+	glyph := v.componentStyle(g.compID).Render(v.componentGlyph(g.compID))
+	name := v.compName(v.comps[g.compID])
+	if g.count > 1 {
+		name += fmt.Sprintf(" ×%d", g.count)
+	}
+	name = truncWidth(name, w-6)
+	marker := "    "
+	if cursorOn {
+		if sel {
+			marker = v.theme.Warning.Render("  → ")
+			name = v.theme.Warning.Render(name)
+		} else {
+			marker = "  → "
+			name = v.theme.Primary.Render(name)
+		}
+	} else {
+		name = v.theme.Dim.Render(name)
+	}
+	return marker + glyph + " " + name
+}
+
+// truncWidth truncates plain (un-styled) text to a display width, appending an
+// ellipsis. Apply BEFORE styling so ANSI codes aren't counted or cut.
+func truncWidth(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= w {
+		return s
+	}
+	r := []rune(s)
+	for len(r) > 0 && lipgloss.Width(string(r))+1 > w {
+		r = r[:len(r)-1]
+	}
+	return string(r) + "…"
+}
+
+// wrapText word-wraps plain text to a column width, returning the lines (empty
+// for an empty string). Used by the inspector for descriptions.
+func wrapText(s string, w int) []string {
+	if strings.TrimSpace(s) == "" || w <= 0 {
+		return nil
+	}
+	var lines []string
+	var cur string
+	for _, word := range strings.Fields(s) {
+		switch {
+		case cur == "":
+			cur = word
+		case lipgloss.Width(cur)+1+lipgloss.Width(word) <= w:
+			cur += " " + word
+		default:
+			lines = append(lines, cur)
+			cur = word
+		}
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
 }
 
 func (v *VAB) compName(c spacecraft.Component) string {

--- a/internal/tui/screens/vab_test.go
+++ b/internal/tui/screens/vab_test.go
@@ -271,7 +271,7 @@ func TestVABRenderSmoke(t *testing.T) {
 	v.addComponentToCurrent("tank")
 	v.addComponentToCurrent("core")
 	build := v.Render(100)
-	for _, want := range []string{"Vehicle Assembly", "STACK", "total Δv", "PALETTE", "[a] add"} {
+	for _, want := range []string{"Vehicle Assembly", "VEHICLE", "Σ Δv", "PALETTE", "inspect", "[a] add"} {
 		if !contains(build, want) {
 			t.Errorf("build render missing %q", want)
 		}

--- a/internal/tui/screens/vab_test.go
+++ b/internal/tui/screens/vab_test.go
@@ -1,0 +1,269 @@
+package screens
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// S3 / ADR 0029 §5 — the VAB screen model. These drive the model operations
+// directly (what HandleKey maps onto) so the editor logic is tested without
+// the render or the App.
+
+func testVABComps() map[string]spacecraft.Component {
+	return map[string]spacecraft.Component{
+		"eng":   {ID: "eng", Name: "Big Engine", Kind: spacecraft.ComponentEngine, DryMassKg: 500, ThrustN: 200_000, IspS: 300, FuelType: spacecraft.FuelTypeKerolox},
+		"eng2":  {ID: "eng2", Name: "Vac Engine", Kind: spacecraft.ComponentEngine, DryMassKg: 400, ThrustN: 50_000, IspS: 320, FuelType: spacecraft.FuelTypeKerolox},
+		"tank":  {ID: "tank", Name: "Big Tank", Kind: spacecraft.ComponentTank, DryMassKg: 100, FuelCapacityKg: 9000, FuelType: spacecraft.FuelTypeKerolox},
+		"tank2": {ID: "tank2", Name: "Vac Tank", Kind: spacecraft.ComponentTank, DryMassKg: 50, FuelCapacityKg: 4500, FuelType: spacecraft.FuelTypeKerolox},
+		"core":  {ID: "core", Name: "Crew Pod", Kind: spacecraft.ComponentCommandCore, DryMassKg: 400, CommandSource: spacecraft.CommandCrewed},
+		"hydro": {ID: "hydro", Name: "H2 Tank", Kind: spacecraft.ComponentTank, DryMassKg: 100, FuelCapacityKg: 2000, FuelType: spacecraft.FuelTypeHydrolox},
+	}
+}
+
+// TestVABAddRemoveComponentUpdatesStats — adding a tank to a stage raises its
+// Δv (more propellant); removing it restores the prior value.
+func TestVABAddRemoveComponentUpdatesStats(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	dv1 := v.Stats().StageDV[0]
+	if dv1 <= 0 {
+		t.Fatalf("StageDV[0] = %g, want > 0 after engine+tank", dv1)
+	}
+	v.addComponentToCurrent("tank2") // second same-chemistry tank
+	dv2 := v.Stats().StageDV[0]
+	if dv2 <= dv1 {
+		t.Errorf("adding a tank did not raise Δv: %g → %g", dv1, dv2)
+	}
+	v.removeFromCurrent() // pop the second tank
+	if dv := v.Stats().StageDV[0]; math.Abs(dv-dv1) > 1e-6 {
+		t.Errorf("remove did not restore Δv: %g, want %g", dv, dv1)
+	}
+}
+
+// TestVABAddRemoveStageUpdatesTotals — a second stage raises total Δv and
+// mass; removing it restores them.
+func TestVABAddRemoveStageUpdatesTotals(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	one := v.Stats()
+	v.newStage()
+	v.addComponentToCurrent("eng2")
+	v.addComponentToCurrent("tank2")
+	two := v.Stats()
+	if two.TotalDV <= one.TotalDV {
+		t.Errorf("second stage did not raise total Δv: %g → %g", one.TotalDV, two.TotalDV)
+	}
+	if two.TotalMass <= one.TotalMass {
+		t.Errorf("second stage did not raise total mass: %g → %g", one.TotalMass, two.TotalMass)
+	}
+	v.stageIdx = 1
+	v.removeFromCurrent() // removes tank2
+	v.removeFromCurrent() // removes eng2
+	v.removeFromCurrent() // removes the now-empty stage
+	if got := v.Stats(); math.Abs(got.TotalDV-one.TotalDV) > 1e-6 || len(v.stages) != 1 {
+		t.Errorf("removing the second stage did not restore totals: %+v (stages=%d)", got, len(v.stages))
+	}
+}
+
+// TestVABDeltaVHandWorked — the per-stage Δv from the aggregated stack
+// matches the rocket equation, and TWR is consistent with total mass.
+func TestVABDeltaVHandWorked(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")  // 500 dry, 200 kN, Isp 300
+	v.addComponentToCurrent("tank") // +100 dry, +9000 fuel
+	st := v.resolvedStages()[0]
+	// Aggregated: dry 600, fuel 9000, thrust 200 kN, Isp 300.
+	m0 := st.DryMass + st.FuelMass // 9600
+	m1 := st.DryMass               // 600
+	wantDV := 300 * 9.80665 * math.Log(m0/m1)
+	if got := v.Stats().StageDV[0]; math.Abs(got-wantDV) > 1e-3 {
+		t.Errorf("StageDV[0] = %g, want %g (rocket eq over the aggregated stage)", got, wantDV)
+	}
+	stats := v.Stats()
+	wantTWR := st.Thrust / (stats.TotalMass * 9.80665)
+	if math.Abs(stats.LiftoffTWR-wantTWR) > 1e-9 {
+		t.Errorf("LiftoffTWR = %g, want %g (consistent with total mass)", stats.LiftoffTWR, wantTWR)
+	}
+}
+
+// TestVABSeamCyclingPlan — toggling dock seams produces the expected
+// top-down NosePayloadPlan (the N-seam generalization that closes ADR 0028
+// §8).
+func TestVABSeamCyclingPlan(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	for i := 0; i < 3; i++ { // three single-component stages
+		v.newStage()
+		v.addComponentToCurrent("tank")
+	}
+	if len(v.stages) != 3 {
+		t.Fatalf("stages = %d, want 3", len(v.stages))
+	}
+	if v.nosePayloadPlan() != nil {
+		t.Errorf("no seams ⇒ plan should be nil, got %v", v.nosePayloadPlan())
+	}
+	v.stageIdx = 2
+	v.toggleDockSeam() // seam below the top stage → top 1 stage is a payload
+	if got := v.nosePayloadPlan(); !reflect.DeepEqual(got, []int{1}) {
+		t.Errorf("one top seam ⇒ plan %v, want [1]", got)
+	}
+	v.stageIdx = 1
+	v.toggleDockSeam() // second seam → two single-stage payloads
+	if got := v.nosePayloadPlan(); !reflect.DeepEqual(got, []int{1, 1}) {
+		t.Errorf("two seams ⇒ plan %v, want [1 1]", got)
+	}
+}
+
+// TestVABMixedChemistryRejected — adding a second fuel chemistry to a stage
+// is rejected in the model (not just the view); the component is not added
+// and a flash explains why.
+func TestVABMixedChemistryRejected(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")   // kerolox
+	v.addComponentToCurrent("hydro") // hydrolox — must be rejected
+	if n := len(v.stages[0].components); n != 1 {
+		t.Errorf("mixed-chemistry component was added: stage has %d components, want 1", n)
+	}
+	if v.flash == "" {
+		t.Error("mixed-chemistry add should set a flash explaining the reject")
+	}
+}
+
+// TestVABCatalogPartAsStage — adding a catalog-part palette item appends an
+// opaque atomic stage that resolves to the catalog part's stats.
+func TestVABCatalogPartAsStage(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(map[string]spacecraft.Component{}) // empty comps ⇒ palette is catalog parts only
+	if len(v.palette) == 0 {
+		t.Fatal("palette empty — expected single-stage catalog parts")
+	}
+	// Cursor starts at 0 (a catalog part); add it.
+	v.addSelected()
+	if len(v.stages) != 1 || !v.stages[0].isCatalog() {
+		t.Fatalf("expected one atomic catalog stage, got %d stages (catalog=%v)", len(v.stages), len(v.stages) == 1 && v.stages[0].isCatalog())
+	}
+	if v.resolvedStages()[0].DryMass <= 0 {
+		t.Error("catalog stage resolved to zero dry mass")
+	}
+}
+
+// TestVABSaveLoadRoundTrip — saving a design through the store and loading it
+// back reconstructs an equivalent design (the screen's serialization ↔
+// rebuild fidelity).
+func TestVABSaveLoadRoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.addComponentToCurrent("core")
+	v.newStage()
+	v.addComponentToCurrent("eng2")
+	v.addComponentToCurrent("tank2")
+	v.stageIdx = 1
+	v.toggleDockSeam() // a nose-payload seam to exercise plan round-trip
+	v.name = "Test Hopper"
+
+	before := v.toDesign()
+	if err := spacecraft.SaveDesign(before); err != nil {
+		t.Fatalf("SaveDesign: %v", err)
+	}
+
+	// Wipe and reload through the screen's load path.
+	v.Reset(testVABComps())
+	v.refreshDesigns()
+	if len(v.designs) != 1 {
+		t.Fatalf("designs after save = %d, want 1", len(v.designs))
+	}
+	v.loadDesign(v.designs[0])
+	after := v.toDesign()
+
+	if !reflect.DeepEqual(before, after) {
+		t.Errorf("save/load round-trip drift:\n before %+v\n  after %+v", before, after)
+	}
+	if v.nosePayloadPlan() == nil {
+		t.Error("dock seam lost across save/load")
+	}
+}
+
+// TestVABDecouplePlanRoundTrip — the decouple-fuse flags survive a
+// derive→apply round-trip.
+func TestVABDecouplePlanRoundTrip(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	for i := 0; i < 4; i++ {
+		v.newStage()
+		v.addComponentToCurrent("tank")
+	}
+	v.stageIdx = 1
+	v.toggleDecoupleFuse() // stages 0+1 drop together
+	plan := v.decouplePlan()
+	if plan == nil {
+		t.Fatal("decouplePlan nil after fusing a boundary")
+	}
+	v.applyDecouplePlan(plan)
+	if got := v.decouplePlan(); !reflect.DeepEqual(got, plan) {
+		t.Errorf("decouple plan round-trip: %v → %v", plan, got)
+	}
+}
+
+// TestVABWarnings — soft validation flags the common pitfalls.
+func TestVABWarnings(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	if w := v.Warnings(); len(w) != 1 {
+		t.Errorf("empty stack warnings = %v, want one (empty)", w)
+	}
+	v.addComponentToCurrent("tank") // tank only: no engine, no command
+	w := v.Warnings()
+	joined := ""
+	for _, s := range w {
+		joined += s + "\n"
+	}
+	if !contains(joined, "no engine") || !contains(joined, "no command source") {
+		t.Errorf("warnings = %v, want no-engine + no-command", w)
+	}
+}
+
+// TestVABRenderSmoke — every mode renders without panicking and surfaces the
+// expected anchors (stats line, palette, footer).
+func TestVABRenderSmoke(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.addComponentToCurrent("core")
+	build := v.Render(100)
+	for _, want := range []string{"Vehicle Assembly", "STACK", "total Δv", "PALETTE", "[a] add"} {
+		if !contains(build, want) {
+			t.Errorf("build render missing %q", want)
+		}
+	}
+	v.mode = vabModeNaming
+	if !contains(v.Render(100), "save design") {
+		t.Error("naming render missing title")
+	}
+	v.mode = vabModeLoad
+	if !contains(v.Render(100), "load design") {
+		t.Error("load render missing title")
+	}
+}
+
+func contains(s, sub string) bool { return len(s) >= len(sub) && (indexOf(s, sub) >= 0) }
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/tui/screens/vab_test.go
+++ b/internal/tui/screens/vab_test.go
@@ -195,6 +195,34 @@ func TestVABSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestVABEmptyStageRoundTrip — an empty composed stage (added with [n], no
+// components) survives save/load as a composed stage, not a bogus catalog
+// reference (the discriminator is design-local presence, not component count).
+func TestVABEmptyStageRoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	v.addComponentToCurrent("eng")
+	v.addComponentToCurrent("tank")
+	v.newStage() // an empty composed stage on top
+	v.name = "Has Empty"
+	if err := spacecraft.SaveDesign(v.toDesign()); err != nil {
+		t.Fatalf("SaveDesign: %v", err)
+	}
+	v.Reset(testVABComps())
+	v.refreshDesigns()
+	if len(v.designs) != 1 {
+		t.Fatalf("designs = %d, want 1", len(v.designs))
+	}
+	v.loadDesign(v.designs[0])
+	if len(v.stages) != 2 {
+		t.Fatalf("reloaded stages = %d, want 2", len(v.stages))
+	}
+	if v.stages[1].isCatalog() {
+		t.Error("empty composed stage round-tripped into a catalog reference")
+	}
+}
+
 // TestVABDecouplePlanRoundTrip — the decouple-fuse flags survive a
 // derive→apply round-trip.
 func TestVABDecouplePlanRoundTrip(t *testing.T) {

--- a/internal/tui/screens/vab_visual.go
+++ b/internal/tui/screens/vab_visual.go
@@ -1,0 +1,93 @@
+package screens
+
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// VAB visual legend (ADR 0030 §6). Glyph AND color both encode the component
+// kind, identical in the palette and the vehicle column, so the player learns
+// exactly one legend. A component may override either via its catalog
+// Glyph / Color fields. Glyphs are deliberately SINGLE-WIDTH Unicode — a
+// double-width emoji would desync the two-column lipgloss.Width math the
+// layout depends on, so none are used here.
+var kindGlyph = map[string]string{
+	spacecraft.ComponentEngine:      "➤",
+	spacecraft.ComponentTank:        "▮",
+	spacecraft.ComponentCommandCore: "◈",
+	spacecraft.ComponentAntenna:     "Ψ",
+	spacecraft.ComponentStructure:   "▭",
+}
+
+var kindColor = map[string]string{
+	spacecraft.ComponentEngine:      "#FFAF00", // amber
+	spacecraft.ComponentTank:        "#5FD7FF", // cyan
+	spacecraft.ComponentCommandCore: "#5FD75F", // green
+	spacecraft.ComponentAntenna:     "#AF87FF", // violet
+	spacecraft.ComponentStructure:   "#9E9E9E", // gray
+}
+
+// catalogColor tints an opaque atomic catalog block in the vehicle column
+// (matches the yellow of spacecraft.VesselGlyph) so it reads distinctly from
+// the kind-colored composed components.
+const catalogColor = "#FFD93D"
+
+func glyphForKind(kind string) string {
+	if g, ok := kindGlyph[kind]; ok {
+		return g
+	}
+	return "•"
+}
+
+func styleForKind(kind string) lipgloss.Style {
+	if c, ok := kindColor[kind]; ok {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(c))
+	}
+	return lipgloss.NewStyle()
+}
+
+// componentGlyph resolves a component's display glyph, honoring a
+// per-component override (ADR 0030 §6) and falling back to the kind default.
+func (v *VAB) componentGlyph(id string) string {
+	if c, ok := v.comps[id]; ok {
+		if c.Glyph != "" {
+			return c.Glyph
+		}
+		return glyphForKind(c.Kind)
+	}
+	return "?"
+}
+
+// componentStyle resolves a component's display color the same way.
+func (v *VAB) componentStyle(id string) lipgloss.Style {
+	if c, ok := v.comps[id]; ok {
+		if c.Color != "" {
+			return lipgloss.NewStyle().Foreground(lipgloss.Color(c.Color))
+		}
+		return styleForKind(c.Kind)
+	}
+	return lipgloss.NewStyle()
+}
+
+// kindRank orders a kind by vabKindOrder for canonical fold-all display
+// (ADR 0030 §4); unknown kinds sort last.
+func kindRank(kind string) int {
+	for i, k := range vabKindOrder {
+		if k == kind {
+			return i
+		}
+	}
+	return len(vabKindOrder)
+}
+
+// clampI clamps i into [lo, hi].
+func clampI(i, lo, hi int) int {
+	if i < lo {
+		return lo
+	}
+	if i > hi {
+		return hi
+	}
+	return i
+}


### PR DESCRIPTION
The deliberately-last Axis B cycle (ADR 0029): an in-game **Vehicle Assembly Building**. The whole vehicle-expansion arc (ADR 0026–0029) completes with this.

Four TDD slices, one PR per the batch-review convention. **Zero migration, no save bump, runtime untouched** — an extension of the ADR 0026 normalized catalog, not a re-normalization.

## Slices
- **S1 — component catalog + aggregation** (`aa39c7a`): a new finest catalog noun `Component` (engine / tank / command-core / antenna / structure) + `data/components.json` through the existing ADR 0026 overlay loader; a `Part` gains an optional `components` list whose flat stats are derived by `aggregateComponents` at load time — additive mass/capacity, multi-engine `Thrust=ΣF` / `Isp_eff=ΣF/Σ(F/Isp)` (exact for one fuel pool), single fuel chemistry per stage. Existing atomic parts stay byte-identical (golden green).
- **S2 — designs store** (`75227c6`): an app-managed `designs/` dir (distinct from the modder `loadouts/` overlay so a design can't override a built-in by ID), serializing a design as a portable catalog fragment; `Design.Resolve()` + Save/List/Load/Delete; portability + ID-collision-isolation tests.
- **S3 — VAB screen + stats** (`39f396b`): `internal/tui/screens/vab.go`, reached from the pause menu (`[Build (VAB)]`) — palette / stack / live Δv·TWR·mass (`spacecraft.StackStats`). N nose-payload dock seams (**closes ADR 0028 §8**) + fused decouple groups; design save/name/load/delete; soft-validation; single-fuel rejected in the model. F1 help updated.
- **S4 — spawn integration + starter content + docs** (`847c6f9`, `16dfbeb`): the spawn form lists saved designs (`SpawnSpec.DesignID` → `NewFromLoadoutValue`, plans carried, flies identically to a catalog loadout); four starter components + a composed `Probe-Sat` loadout dogfood the components→part→loadout→spawn chain (a test pins the composed stage byte-identical to its atomic equivalent); docs (controls / README / `CONTEXT.md` nouns / version-history).

## Batch /code-review (`b2b115b`)
Run once over the whole diff. Fixed a real ghost-stage bug (a design referencing a since-removed/modded component spawned a silent 0-mass craft → now rejected with a clean error + surfaced in the VAB), an empty-stage round-trip bug, and minor cleanups. Regression tests added.

## Verification
`go vet ./...` clean · `go test ./... -race -count=1` → **1348 pass** · binary builds · `--list-loadouts` shows the composed `Probe-Sat`.

Planning docs (vault): ADR 0029 accepted; `state-of-game.md` cycle entry pending this PR's merge metadata. Target tag **v0.24.0**.