### PR TITLE
feat(hud): seconds on ORBIT + PROJECTED ORBIT period readouts

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2236,6 +2236,29 @@ func formatDurationShort(sec float64) string {
 	return fmt.Sprintf("%dh%02dm", h, m)
 }
 
+// formatPeriod renders an orbital period keeping seconds at every scale —
+// "45s" / "3m45s" / "6h04m21s". It differs from formatDurationShort only in
+// the hour band, where the latter drops seconds to keep live countdowns
+// (t→Ap / t→Pe / TCA) from ticking a noisy seconds digit. The period is a
+// near-static readout the player tunes a resonant / phasing orbit against,
+// and minute rounding there is ±30s — which over m revolutions amplifies to
+// ±360°·m·δ/T of placement error per slot. Seconds make the period the sharp
+// tuning lever the use case needs. v0.24.4+.
+func formatPeriod(sec float64) string {
+	if sec < 60 {
+		return fmt.Sprintf("%.0fs", sec)
+	}
+	if sec < 3600 {
+		m := int(sec) / 60
+		s := int(sec) % 60
+		return fmt.Sprintf("%dm%02ds", m, s)
+	}
+	h := int(sec) / 3600
+	m := (int(sec) % 3600) / 60
+	s := int(sec) % 60
+	return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+}
+
 // launchMissionProgress returns the pe-altitude-vs-mission-floor
 // row for the LAUNCH HUD when the active craft is flying a
 // circularize_from_pad mission for its current primary. Empty

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -659,7 +659,7 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	// synchronous period for steady ground coverage). a > 0 and e < 1 are
 	// guaranteed above, so the period is finite.
 	period := 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
-	lines = append(lines, chipRow("period:", formatDurationShort(period)))
+	lines = append(lines, chipRow("period:", formatPeriod(period)))
 	lines = append(lines, chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)))
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
 	if periAlt < 0 {
@@ -707,7 +707,7 @@ func (v *OrbitView) buildProjectedOrbitChip(w *sim.World) []string {
 		lines = append(lines,
 			fmt.Sprintf("  Ap:        %.1f km alt", (ro.ApoMeters-primaryR)/1000),
 			fmt.Sprintf("  Pe:        %.1f km alt", (ro.PeriMeters-primaryR)/1000),
-			fmt.Sprintf("  period:    %s", formatDurationShort(projPeriod)),
+			fmt.Sprintf("  period:    %s", formatPeriod(projPeriod)),
 			fmt.Sprintf("  inclin.:   %.2f°", ro.Inclination*180/math.Pi),
 			fmt.Sprintf("  direction: %s", v.orbitDirectionLabel(ro.Inclination)),
 		)

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -65,6 +65,35 @@ func TestFormatDurationShortBands(t *testing.T) {
 	}
 }
 
+// TestFormatPeriodKeepsSeconds exercises the period formatter that the
+// ORBIT and PROJECTED ORBIT chips render through. Unlike
+// formatDurationShort, it keeps seconds in the hour band so a resonant /
+// phasing orbit can be tuned to better than the ±30s the minute-rounded
+// readout allowed. The 21861s case is the worked example: a 5h47m target
+// raised by 21/20 to a 6h04m21s phasing period for a 4-sat constellation.
+func TestFormatPeriodKeepsSeconds(t *testing.T) {
+	cases := []struct {
+		sec  float64
+		want string
+	}{
+		{0, "0s"},
+		{12, "12s"},
+		{60, "1m00s"},
+		{225, "3m45s"},
+		{3599, "59m59s"},
+		{3600, "1h00m00s"},
+		{4920, "1h22m00s"},
+		{20820, "5h47m00s"},
+		{21861, "6h04m21s"},
+	}
+	for _, c := range cases {
+		got := formatPeriod(c.sec)
+		if got != c.want {
+			t.Errorf("formatPeriod(%g) = %q, want %q", c.sec, got, c.want)
+		}
+	}
+}
+
 // TestLaunchMissionProgressMatchesCircularizeFromPad — when the world
 // has an in-flight circularize_from_pad mission for the active
 // craft's primary, the progress line shows current pe / target.


### PR DESCRIPTION
## What

The orbital-period readout on the **ORBIT** and **PROJECTED ORBIT** chips now shows seconds (`6h04m21s`) instead of rounding to the nearest minute (`6h04m`).

## Why

`formatDurationShort` drops seconds in the hour band, so any orbit ≥ 1h read to minute granularity. That's ±30s of tuning slack on the period — and when tuning a **phasing orbit** for an evenly-spaced comsat constellation, that error amplifies over `m` revolutions:

```
Δφ ≈ 360° × m × δ / T
```

e.g. spacing 4 sats with a 5-rev phasing orbit (period ~5h47m), ±30s rounding → ~2.6° placement error per slot. Tolerable (the sats' own budget can trim it), but the readout should be the sharp lever, not the coarse one.

## How

- New `formatPeriod` keeps seconds at every scale; the hour band becomes `%dh%02dm%02ds`.
- ORBIT (`orbit_chip_builders.go:662`) and PROJECTED ORBIT (`:710`) period rows point at it.
- `formatDurationShort` is **unchanged** — the live `t→Ap` / `t→Pe` / TCA countdowns keep their quiet minute-scale display rather than ticking a seconds digit at hour scale.
- Test `TestFormatPeriodKeepsSeconds` covers all bands incl. the `21861s → "6h04m21s"` worked example.

See also the new `docs/constellation-deploy.md` guide (separate commit on main) for the phasing math this readout serves.

## Test
`go vet ./...` clean; `go test ./... -race -count=1` → 1389 pass.