### PR TITLE
feat(flight): dedicated `p` key to step RCS pulse size for fine trim

### DIFF
--- a/docs/constellation-deploy.md
+++ b/docs/constellation-deploy.md
@@ -170,7 +170,9 @@ what a comsat's own trim budget cares about.
   let each comsat trim its own final position with its onboard budget.
 - **Coarse carrier + comsat cleanup** is usually the cheapest overall plan: a
   low-`m` (cheap, fast) carrier phasing that gets each sat *close*, finished off
-  by the sat's own station-keeping delta-v.
+  by the sat's own station-keeping delta-v. Trim a comsat in RCS mode (`r`) and
+  step the pulse down with `p` (0.1 → 0.01 → 0.001 m/s) to null its period to the
+  second without overshooting.
 - **Need finer than a second?** Tune the **projected apoapsis** instead of the
   period — it reads to 0.1 km, and at a typical comsat orbit ~1 km of apoapsis is
   ~1 second of period (`dT/dr_apo = ¾·T/a`), so it's an even sharper lever. You'll

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -156,6 +156,7 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `q` / `e` | Point radial+ / radial- (away from / toward the body) |
 | `b` | Light / cut the main engine (needs throttle above zero) |
 | `r` | Switch between the main engine and RCS thrusters |
+| `p` | RCS pulse step: cycle the per-press Δv (0.1 → 0.01 → 0.001 m/s) for fine trim |
 | `k` | Steering style: smooth turning (the default) or instant snap |
 | `;` | Switch the autopilot's reference: Orbit → Surface → Target (skips Target when none is set) |
 | `W` / `S` | Point along / against your ground speed — matches your velocity relative to the spinning atmosphere. Use this for the launch gravity turn |
@@ -164,8 +165,11 @@ Dvorak, and free per-key remapping aren't supported yet.)
 
 The pointing keys only aim the craft — `b` is what actually fires the engine.
 In RCS mode those same keys also fire one small thruster pulse per press (hold
-a key for a steady stream). The readouts show which engine is armed, how much
-RCS fuel you have, and how much Δv it's worth.
+a key for a steady stream). Each pulse is 0.1 m/s by default; press `p` to step
+it down to 0.01 or 0.001 m/s for fine work like nulling out an orbital period to
+the second (see the [constellation deployment guide](constellation-deploy.md)).
+The readouts show which engine is armed, the current pulse size, how much RCS
+fuel you have, and how much Δv it's worth.
 
 ### Mouse
 

--- a/internal/sim/rcs.go
+++ b/internal/sim/rcs.go
@@ -24,6 +24,20 @@ func (w *World) CycleEngineMode() {
 	w.ActiveCraft().EngineMode = spacecraft.EngineMain
 }
 
+// CycleRCSPulseScale steps the active craft's RCS pulse magnitude to the
+// next fine level, wrapping after the finest: 0.1 → 0.01 → 0.001 → 0.1
+// m/s. The dedicated `p` fine-trim key; mirrors CycleEngineMode. No-op
+// without an active craft. Only RCS pulses read the level, so cycling in
+// main-engine mode is harmless — the new step takes effect once `r`
+// switches to RCS. v0.24.5+.
+func (w *World) CycleRCSPulseScale() {
+	c := w.ActiveCraft()
+	if c == nil {
+		return
+	}
+	c.RCSFineLevel = (c.RCSFineLevel + 1) % spacecraft.RCSFineLevels
+}
+
 // RCSActive reports whether the active craft is currently in RCS
 // engine mode. Nil-safe (no craft → false), mirroring the
 // CycleEngineMode guard. Used by the navball panel to colour the

--- a/internal/sim/rcs_test.go
+++ b/internal/sim/rcs_test.go
@@ -27,6 +27,47 @@ func TestCycleEngineMode(t *testing.T) {
 	}
 }
 
+// TestCycleRCSPulseScaleWrapsAndScalesPulse: cycling steps the level
+// 0→1→2→0, the reported per-pulse Δv tracks it (0.1 / 0.01 / 0.001),
+// and a fired pulse delivers the level's Δv.
+func TestCycleRCSPulseScaleWrapsAndScalesPulse(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.EngineMode = spacecraft.EngineRCS
+
+	if c.RCSFineLevel != 0 || math.Abs(c.RCSPulseDV()-0.1) > 1e-12 {
+		t.Fatalf("default level %d / dv %g, want 0 / 0.1", c.RCSFineLevel, c.RCSPulseDV())
+	}
+
+	want := []struct {
+		level int
+		dv    float64
+	}{{1, 0.01}, {2, 0.001}, {0, 0.1}}
+	for i, wcase := range want {
+		w.CycleRCSPulseScale()
+		if c.RCSFineLevel != wcase.level || math.Abs(c.RCSPulseDV()-wcase.dv) > 1e-12 {
+			t.Errorf("cycle %d: level %d / dv %g, want %d / %g",
+				i+1, c.RCSFineLevel, c.RCSPulseDV(), wcase.level, wcase.dv)
+		}
+		v0 := c.OrbitalSpeed()
+		if !w.FireRCSPulse(spacecraft.BurnPrograde) {
+			t.Fatalf("cycle %d: FireRCSPulse returned false", i+1)
+		}
+		if got := c.OrbitalSpeed() - v0; math.Abs(got-wcase.dv) > 1e-9 {
+			t.Errorf("cycle %d: Δ|v| = %g, want %g", i+1, got, wcase.dv)
+		}
+	}
+}
+
+// TestCycleRCSPulseScaleNilSafe: no active craft → no panic.
+func TestCycleRCSPulseScaleNilSafe(t *testing.T) {
+	w := &World{}
+	w.CycleRCSPulseScale() // must not panic
+}
+
 // TestFireRCSPulseGatesOnEngineMode: in EngineMain mode, FireRCSPulse
 // should be a no-op even with a fully-fueled craft. Switching to
 // EngineRCS and pulsing must change |v|.

--- a/internal/spacecraft/rcs_test.go
+++ b/internal/spacecraft/rcs_test.go
@@ -24,6 +24,39 @@ func TestApplyRCSPulseDeliversQuantumDV(t *testing.T) {
 	}
 }
 
+// TestApplyRCSPulseFineLevelScalesDV: a pulse at fine level N must
+// change |v| by RCSDvQuantum/10^N, and an out-of-range level falls
+// back to the coarse quantum.
+func TestApplyRCSPulseFineLevelScalesDV(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+
+	cases := []struct {
+		level  int
+		wantDV float64
+	}{
+		{0, 0.1},
+		{1, 0.01},
+		{2, 0.001},
+		{RCSFineLevels, 0.1}, // out of range → coarse fallback
+		{-1, 0.1},            // negative → coarse fallback
+	}
+	for _, c := range cases {
+		sc := NewInLEO(*earth)
+		sc.RCSFineLevel = c.level
+		if got := sc.RCSPulseDV(); math.Abs(got-c.wantDV) > 1e-12 {
+			t.Errorf("level %d: RCSPulseDV() = %g, want %g", c.level, got, c.wantDV)
+		}
+		v0 := sc.OrbitalSpeed()
+		if !sc.ApplyRCSPulse(BurnPrograde) {
+			t.Fatalf("level %d: ApplyRCSPulse returned false on a fueled craft", c.level)
+		}
+		if got := sc.OrbitalSpeed(); math.Abs(got-(v0+c.wantDV)) > 1e-9 {
+			t.Errorf("level %d: Δ|v| = %g, want %g", c.level, got-v0, c.wantDV)
+		}
+	}
+}
+
 // TestApplyRCSPulseConsumesMonoprop: every pulse should debit the
 // monoprop pool by some positive amount and never go negative.
 func TestApplyRCSPulseConsumesMonoprop(t *testing.T) {

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -131,6 +131,14 @@ type Spacecraft struct {
 	AttitudeMode BurnMode
 	EngineMode   EngineMode
 
+	// RCSFineLevel selects the per-pulse Δv magnitude for live RCS
+	// trim: level 0 = the coarse RCSDvQuantum (0.1 m/s), each level up
+	// divides by 10 (0.01, 0.001 m/s) for sub-second orbital-period
+	// trim on a low-budget comsat. Transient manual-flight state — not
+	// persisted (resets to coarse on load) and dropped on dock,
+	// alongside AttitudeMode / EngineMode.
+	RCSFineLevel int
+
 	// CurrentAttitudeDir (v0.10.0+) is the craft's *actual* nose
 	// unit vector in the same world/primary frame as State.R/V —
 	// the physical orientation, distinct from the *commanded*

--- a/internal/spacecraft/thrust.go
+++ b/internal/spacecraft/thrust.go
@@ -42,6 +42,22 @@ func (e EngineMode) String() string {
 // a few seconds. v0.8.0+.
 const RCSDvQuantum = 0.1
 
+// RCSFineLevels is how many per-pulse magnitudes the RCS fine-trim
+// cycle steps through before wrapping: the coarse RCSDvQuantum, then
+// ÷10 and ÷100 (0.1 → 0.01 → 0.001 m/s). v0.24.5+.
+const RCSFineLevels = 3
+
+// RCSPulseDV returns the per-pulse Δv for the craft's current RCS fine
+// level: RCSDvQuantum (0.1 m/s) at level 0, divided by 10 each level up
+// (0.01 m/s, 0.001 m/s) for sub-second orbital-period trim. A level
+// outside [0, RCSFineLevels) falls back to the coarse default. v0.24.5+.
+func (s *Spacecraft) RCSPulseDV() float64 {
+	if s.RCSFineLevel <= 0 || s.RCSFineLevel >= RCSFineLevels {
+		return RCSDvQuantum
+	}
+	return RCSDvQuantum / math.Pow(10, float64(s.RCSFineLevel))
+}
+
 // ApplyRCSPulse delivers one RCSDvQuantum of Δv in the given burn
 // direction, debiting monoprop via the rocket equation against the
 // RCSIsp engine. No-op if monoprop is empty or RCSThrust / RCSIsp are
@@ -72,7 +88,7 @@ func (s *Spacecraft) ApplyRCSPulseWithTarget(mode BurnMode, rT, vT orbital.Vec3)
 	if dir.Norm() == 0 {
 		return false
 	}
-	dv := RCSDvQuantum
+	dv := s.RCSPulseDV()
 	// Rocket equation against monoprop pool only — main fuel
 	// untouched. m0 = TotalMass; m1 = m0 · exp(-Δv / (Isp·g0)).
 	m0 := s.TotalMass()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -984,6 +984,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.CycleEngine):
 			a.world.CycleEngineMode()
 			return a, nil
+		case key.Matches(m, a.keys.CycleRCSScale):
+			a.world.CycleRCSPulseScale()
+			if c := a.world.ActiveCraft(); c != nil {
+				if c.EngineMode == spacecraft.EngineRCS {
+					a.statusMsg = fmt.Sprintf("rcs pulse %g m/s", c.RCSPulseDV())
+				} else {
+					a.statusMsg = fmt.Sprintf("rcs pulse %g m/s (press r for rcs)", c.RCSPulseDV())
+				}
+				a.statusExpires = time.Now().Add(3 * time.Second)
+			}
+			return a, nil
 		case key.Matches(m, a.keys.NextCraft):
 			a.world.CycleActiveCraft(1)
 			return a, nil

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -119,6 +119,11 @@ type Keymap struct {
 	// keypress in addition to setting the held attitude.
 	CycleEngine key.Binding
 
+	// CycleRCSScale (v0.24.5+): step the RCS per-pulse Δv magnitude
+	// across 0.1 → 0.01 → 0.001 m/s for fine orbital-period trim. Bound
+	// to `p` for "pulse." Only affects RCS-mode pulses.
+	CycleRCSScale key.Binding
+
 	// NextCraft / PrevCraft (v0.8.1+): cycle the active craft in the
 	// multi-craft slate. No-op when only one craft is loaded.
 	NextCraft key.Binding
@@ -301,6 +306,7 @@ func DefaultKeymap() Keymap {
 		AttitudeRadialIn:    key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "attitude: radial-")),
 		ToggleBurn:          key.NewBinding(key.WithKeys("b"), key.WithHelp("b", "engage / cut manual burn")),
 		CycleEngine:         key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "engine: main / rcs")),
+		CycleRCSScale:       key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "rcs pulse step (fine)")),
 		NextCraft:           key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next craft")),
 		PrevCraft:           key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev craft")),
 		CraftSlot:           key.NewBinding(key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"), key.WithHelp("1-9", "jump to craft N")),

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -91,6 +91,7 @@ var helpSections = []helpSection{
 		{"?", "reset pitch trim to 0"},
 		{"b", "engage / cut the manual burn (main engine)"},
 		{"r", "engine: main / rcs"},
+		{"p", "rcs pulse step: 0.1 / 0.01 / 0.001 m/s (fine trim)"},
 		{"k", "SAS model: slew / instant"},
 		{";", "NavMode cycle: Orbit → Surface → Target"},
 	}},

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -271,6 +271,11 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 			fmt.Sprintf("  monoprop:  %.0f kg", c.Monoprop),
 			fmt.Sprintf("  rcs Δv:    %.0f m/s", c.RCSDeltaV()),
 		)
+		// In RCS mode, surface the per-pulse step so the player can see
+		// the fine-trim level the `p` key cycles. v0.24.5+.
+		if c.EngineMode == spacecraft.EngineRCS {
+			lines = append(lines, fmt.Sprintf("  rcs pulse: %g m/s", c.RCSPulseDV()))
+		}
 	}
 	return lines
 }


### PR DESCRIPTION
## What

A new `p` key cycles the RCS per-pulse Δv across **0.1 → 0.01 → 0.001 m/s** for fine orbital-period trim. Default behaviour (0.1 m/s) is unchanged until you press `p`.

## Why

RCS pulses were a hardcoded 0.1 m/s. At a typical comsat orbit that moves the far apsis ~1.3 km ≈ **~1.3 s of period** per pulse — but the period readout now shows seconds (v0.24.4), so you can see a sub-1.3 s error you can't null without overshooting. A relay-comsat has no main engine, so RCS is its only trim tool. This gives it a finer one.

Modelled as a **finer impulsive quantum**, not a continuous RCS throttle: each tap stays an exact, predictable Δv (a held continuous throttle would mean eyeballing how long to fire). A 0.01 m/s step → ~0.13 s of period, comfortably under the readout.

## How

- `Spacecraft.RCSFineLevel` — per-craft, **transient** (not in the save DTO → no schema bump; resets to coarse on load, dropped on dock like `AttitudeMode`/`EngineMode`).
- `Spacecraft.RCSPulseDV()` — `RCSDvQuantum / 10^level`, out-of-range → coarse fallback; `ApplyRCSPulseWithTarget` reads it instead of the constant.
- `World.CycleRCSPulseScale()` — steps the level `0→1→2→0`, nil-safe.
- TUI: `p` binding (`input.go`), handler with a status toast (`app.go`), PROPELLANT chip shows `rcs pulse: <x> m/s` in RCS mode (`orbit_chips.go`), F1 help entry (`help.go`).
- Docs: `controls.md` key table + RCS paragraph; `constellation-deploy.md` trim note.

## Test
- `spacecraft`: `TestApplyRCSPulseFineLevelScalesDV` — pulse Δv = `0.1/10^N`, out-of-range falls back to coarse.
- `sim`: `TestCycleRCSPulseScaleWrapsAndScalesPulse` (level + delivered Δv per step) and `TestCycleRCSPulseScaleNilSafe`.
- `go vet ./...` clean; `go test ./... -race -count=1` → 1392 pass.