### PR TITLE
feat(save): S1 — saves directory API, Meta header, reserved lanes (v0.26)

### DIFF
--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -56,11 +56,20 @@ import (
 const SchemaVersion = 9
 
 // File is the on-disk envelope.
+//
+// Meta (v0.26 / ADR 0033, schema v9 additive — NO bump, §J) is the
+// saves-browser header: display name, wall-clock SavedAt, in-game
+// epoch, active vessel, system. nil for legacy envelopes (the
+// single-slot Save writer stamps none) — a v9 save lacking Meta still
+// loads, and ReadHeader derives SavedAt from ClockT0 for ordering.
+// SchemaVersion tracks the Payload shape; envelope-level bookkeeping
+// rides along additively.
 type File struct {
 	Version         int     `json:"version"`
 	Generator       string  `json:"generator"`
 	ClockT0         int64   `json:"clock_t0"`
 	BodyCatalogHash string  `json:"body_catalog_hash"`
+	Meta            *Meta   `json:"meta,omitempty"`
 	Payload         Payload `json:"payload"`
 }
 
@@ -415,22 +424,51 @@ func DefaultPath() (string, error) {
 
 // Save serialises w to path, creating parent directories as needed.
 // Atomic on POSIX: writes to a sibling tmpfile and renames into place.
+//
+// This is the legacy single-slot writer — it stamps no Meta, keeping
+// the pre-v0.26 envelope shape byte-compatible for downgraded
+// binaries (ADR 0033 §G leaves the old save.json untouched as a
+// safety net). The saves-directory lanes (saves.go) stamp Meta via
+// the same buildFile + writeFileAtomic path.
 func Save(w *sim.World, path string) error {
-	hash, err := bodies.CatalogHash()
+	f, err := buildFile(w, nil)
 	if err != nil {
 		return err
 	}
-	f := File{
+	return writeFileAtomic(path, f)
+}
+
+// buildFile assembles the on-disk envelope for w, stamping the given
+// Meta header (nil for the legacy Meta-less shape).
+func buildFile(w *sim.World, meta *Meta) (File, error) {
+	hash, err := bodies.CatalogHash()
+	if err != nil {
+		return File{}, err
+	}
+	return File{
 		Version:         SchemaVersion,
 		Generator:       fmt.Sprintf("tsp %s", version.Version),
 		ClockT0:         time.Now().UnixNano(),
 		BodyCatalogHash: hash,
+		Meta:            meta,
 		Payload:         payloadFromWorld(w),
-	}
+	}, nil
+}
+
+// writeFileAtomic marshals the envelope and writes it via the shared
+// tmp + atomic-rename path — every saves-directory writer reuses this
+// (ADR 0033: no new write mechanics).
+func writeFileAtomic(path string, f File) error {
 	data, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal save: %w", err)
 	}
+	return writeAtomic(path, data)
+}
+
+// writeAtomic writes data to path atomically on POSIX: parent dirs
+// created, sibling tmpfile, rename into place.
+func writeAtomic(path string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create save dir: %w", err)
 	}

--- a/internal/save/saves.go
+++ b/internal/save/saves.go
@@ -1,0 +1,424 @@
+// Saves directory API — v0.26 / ADR 0033. The single fixed save.json
+// slot becomes a saves/ directory of flat, independent, nameable
+// Saves. Filenames are opaque (§B — the player-facing name lives in
+// the envelope's Meta header); the directory is the source of truth
+// (§C — the browser scans + header-parses, no sidecar index); the
+// quicksave and autosave lanes are reserved filenames that named
+// saves can never collide with (§D/§E). No SchemaVersion bump (§J) —
+// Meta is additive envelope bookkeeping, the Payload shape is
+// untouched.
+package save
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// Meta is the envelope header the Saves browser lists games by —
+// readable via ReadHeader without hydrating a World or touching the
+// body catalog (ADR 0033 §C). All fields are additive/omit-on-zero so
+// a pre-v0.26 v9 envelope (no meta key) still loads (§J); the legacy
+// single-slot Save writer stamps no Meta at all.
+//
+// SavedAt is wall-clock write time (the newest-first sort key);
+// InGameEpoch is the simulation clock (Payload.SimTimeNano) at save
+// time — the two are distinct and must not be conflated. Name is the
+// player-facing Save name; reserved lanes (quicksave/autosave) leave
+// it empty and are labelled by Lane instead.
+type Meta struct {
+	Name             string    `json:"name,omitempty"`
+	SavedAt          time.Time `json:"saved_at,omitzero"`
+	InGameEpoch      time.Time `json:"in_game_epoch,omitzero"`
+	ActiveVesselName string    `json:"active_vessel_name,omitempty"`
+	SystemName       string    `json:"system_name,omitempty"`
+}
+
+// Lane classifies a saves-directory entry by its reserved-filename
+// namespace (ADR 0033 §D): named saves are written only by explicit
+// Save-As; quicksave/autosave are managed lanes that never collide
+// with them.
+type Lane string
+
+const (
+	LaneNamed     Lane = "named"
+	LaneQuicksave Lane = "quicksave"
+	LaneAutosave  Lane = "autosave"
+)
+
+// QuicksaveID is the fixed quicksave-lane filename F5 always targets
+// (ADR 0033 §D).
+const QuicksaveID = "quicksave.json"
+
+// autosaveIDs is the rotating autosave ring (ADR 0033 §E) — three
+// fixed slots, oldest SavedAt overwritten.
+var autosaveIDs = [3]string{"autosave-1.json", "autosave-2.json", "autosave-3.json"}
+
+// ErrReservedLane is returned when a named-save operation (Overwrite,
+// Rename) targets a reserved quicksave/autosave filename — the lanes
+// are managed and never manually overwritable or renamable (ADR 0033
+// §D/§F).
+var ErrReservedLane = errors.New("save: reserved quicksave/autosave lane")
+
+// SaveInfo is one saves-directory listing entry: the opaque filename
+// (the stable ID every targeted operation takes), its parsed Meta,
+// and which lane the filename falls in.
+type SaveInfo struct {
+	ID   string
+	Meta Meta
+	Lane Lane
+}
+
+// SavesDir returns the saves-directory path,
+// $XDG_STATE_HOME/terminal-space-program/saves/ — the sibling of the
+// legacy DefaultPath save.json (which is retained only for the
+// first-run import probe, ADR 0033 §G).
+func SavesDir() (string, error) {
+	if x := os.Getenv("XDG_STATE_HOME"); x != "" {
+		return filepath.Join(x, "terminal-space-program", "saves"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "terminal-space-program", "saves"), nil
+}
+
+// header is the ReadHeader unmarshal target: the envelope minus the
+// Payload. encoding/json still tokenizes the whole file, but the
+// Payload is never decoded — no World hydration, no body-catalog hit.
+type header struct {
+	Version int   `json:"version"`
+	ClockT0 int64 `json:"clock_t0"`
+	Meta    *Meta `json:"meta"`
+}
+
+// readRawHeader parses the envelope header without any Meta
+// derivation — the autosave ring uses the raw form to tell a
+// Meta-less file (rotation victim) from a stamped one.
+func readRawHeader(path string) (header, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return header{}, fmt.Errorf("read save: %w", err)
+	}
+	var h header
+	if err := json.Unmarshal(data, &h); err != nil {
+		return header{}, fmt.Errorf("parse save: %w", err)
+	}
+	if h.Version < 1 || h.Version > SchemaVersion {
+		return header{}, fmt.Errorf("%w: got %d, want 1..%d", ErrSchemaMismatch, h.Version, SchemaVersion)
+	}
+	return h, nil
+}
+
+// ReadHeader returns the envelope's Meta without hydrating the
+// Payload: no World rebuild, no body-catalog load or hash check (ADR
+// 0033 §C — the browser lists N files this way). For a Meta-less
+// pre-v0.26 envelope, SavedAt is derived from ClockT0 (which is
+// wall-clock save time, so newest-first ordering still works); the
+// in-game date is unknowable from the header and InGameEpoch stays
+// zero — only a full Payload read (Load) can recover it.
+func ReadHeader(path string) (Meta, error) {
+	h, err := readRawHeader(path)
+	if err != nil {
+		return Meta{}, err
+	}
+	if h.Meta != nil {
+		return *h.Meta, nil
+	}
+	var m Meta
+	if h.ClockT0 != 0 {
+		m.SavedAt = time.Unix(0, h.ClockT0).UTC()
+	}
+	return m, nil
+}
+
+// laneOf classifies a filename into its reserved-namespace lane.
+func laneOf(id string) Lane {
+	if id == QuicksaveID {
+		return LaneQuicksave
+	}
+	for _, a := range autosaveIDs {
+		if id == a {
+			return LaneAutosave
+		}
+	}
+	return LaneNamed
+}
+
+// validateID rejects anything that isn't a bare .json filename inside
+// the saves directory — IDs come from List/WriteNamed and never carry
+// path separators.
+func validateID(id string) error {
+	if id == "" || id != filepath.Base(id) || !strings.HasSuffix(id, ".json") {
+		return fmt.Errorf("save: invalid save id %q", id)
+	}
+	return nil
+}
+
+// idPath resolves a validated ID inside the saves directory.
+func idPath(id string) (string, error) {
+	if err := validateID(id); err != nil {
+		return "", err
+	}
+	dir, err := SavesDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, id), nil
+}
+
+// List scans the saves directory and header-parses every entry,
+// newest SavedAt first (ties broken by filename for determinism). A
+// missing directory lists as empty — first run, before any save
+// exists. Entries that fail the header parse (foreign or corrupt
+// files) are skipped rather than aborting the whole listing.
+func List() ([]SaveInfo, error) {
+	dir, err := SavesDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan saves dir: %w", err)
+	}
+	var infos []SaveInfo
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") {
+			continue // tmpfiles (.json.tmp) and strays
+		}
+		m, err := ReadHeader(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		infos = append(infos, SaveInfo{ID: name, Meta: m, Lane: laneOf(name)})
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		ti, tj := infos[i].Meta.SavedAt, infos[j].Meta.SavedAt
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return infos[i].ID < infos[j].ID
+	})
+	return infos, nil
+}
+
+// stampMeta builds the Meta header for a write happening now. name is
+// empty for the reserved lanes (§D — quicksave/autosaves carry full
+// metadata but no player name). The system column is the active
+// vessel's own System (ADR 0015 — per-Vessel binding), falling back
+// to the world-level viewed system when there is no active craft.
+func stampMeta(w *sim.World, name string) *Meta {
+	m := &Meta{
+		Name:        name,
+		SavedAt:     time.Now().UTC(),
+		InGameEpoch: w.Clock.SimTime,
+	}
+	if c := w.ActiveCraft(); c != nil {
+		m.ActiveVesselName = c.Name
+		if c.SystemIdx >= 0 && c.SystemIdx < len(w.Systems) {
+			m.SystemName = w.Systems[c.SystemIdx].Name
+		}
+	}
+	if m.SystemName == "" && w.SystemIdx >= 0 && w.SystemIdx < len(w.Systems) {
+		m.SystemName = w.Systems[w.SystemIdx].Name
+	}
+	return m
+}
+
+// mintCounter disambiguates same-nanosecond mints within a process;
+// the timestamp component keeps IDs unique across processes.
+var mintCounter atomic.Uint64
+
+// mintID mints an opaque named-save filename (ADR 0033 §B). The
+// "save-" prefix keeps the namespace disjoint from the reserved
+// quicksave/autosave filenames by construction, so WriteNamed can
+// never target a reserved lane. Duplicate display names are allowed
+// and never deduped — every Save-As is a new file.
+func mintID() string {
+	return fmt.Sprintf("save-%d-%d.json", time.Now().UnixNano(), mintCounter.Add(1))
+}
+
+// WriteNamed writes w as a new named save (Save-As, ADR 0033 §D —
+// the only writer of the named lane), minting an opaque filename and
+// stamping full Meta. Atomic via the shared tmp+rename path.
+func WriteNamed(w *sim.World, name string) (SaveInfo, error) {
+	dir, err := SavesDir()
+	if err != nil {
+		return SaveInfo{}, err
+	}
+	meta := stampMeta(w, name)
+	f, err := buildFile(w, meta)
+	if err != nil {
+		return SaveInfo{}, err
+	}
+	id := mintID()
+	if err := writeFileAtomic(filepath.Join(dir, id), f); err != nil {
+		return SaveInfo{}, err
+	}
+	return SaveInfo{ID: id, Meta: *meta, Lane: LaneNamed}, nil
+}
+
+// Overwrite rewrites the existing named save id in place with w,
+// preserving its Meta.Name and refreshing the volatile fields
+// (SavedAt, InGameEpoch, ActiveVesselName, SystemName). The target
+// must exist — Overwrite is a browser action on a listed row, never a
+// silent create — and must not be a reserved lane (§D/§F).
+func Overwrite(id string, w *sim.World) error {
+	if laneOf(id) != LaneNamed {
+		return fmt.Errorf("%w: %s", ErrReservedLane, id)
+	}
+	path, err := idPath(id)
+	if err != nil {
+		return err
+	}
+	prev, err := ReadHeader(path)
+	if err != nil {
+		return fmt.Errorf("overwrite target: %w", err)
+	}
+	meta := stampMeta(w, prev.Name)
+	f, err := buildFile(w, meta)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(path, f)
+}
+
+// WriteQuicksave writes w to the fixed quicksave lane (F5, ADR 0033
+// §D) — always quicksave.json, overwritten in place, never a named
+// save. Full Meta is stamped minus a player name so the browser can
+// still render the metadata columns.
+func WriteQuicksave(w *sim.World) error {
+	dir, err := SavesDir()
+	if err != nil {
+		return err
+	}
+	f, err := buildFile(w, stampMeta(w, ""))
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(filepath.Join(dir, QuicksaveID), f)
+}
+
+// WriteAutosave writes w into the rotating autosave ring (ADR 0033
+// §E): a missing slot is filled before any rotation, otherwise the
+// slot with the oldest SavedAt is overwritten — and an unreadable or
+// Meta-less ring file counts as oldest (it is the least valuable
+// thing in the ring, so it goes first).
+func WriteAutosave(w *sim.World) error {
+	dir, err := SavesDir()
+	if err != nil {
+		return err
+	}
+	f, err := buildFile(w, stampMeta(w, ""))
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(filepath.Join(dir, autosaveVictim(dir)), f)
+}
+
+// autosaveVictim picks the ring slot the next autosave overwrites:
+// first missing slot, else unreadable/Meta-less slot, else oldest
+// SavedAt.
+func autosaveVictim(dir string) string {
+	for _, id := range autosaveIDs {
+		if _, err := os.Stat(filepath.Join(dir, id)); err != nil {
+			return id
+		}
+	}
+	victim := autosaveIDs[0]
+	var oldest time.Time
+	haveOldest := false
+	for _, id := range autosaveIDs {
+		h, err := readRawHeader(filepath.Join(dir, id))
+		if err != nil || h.Meta == nil {
+			return id
+		}
+		if !haveOldest || h.Meta.SavedAt.Before(oldest) {
+			victim, oldest, haveOldest = id, h.Meta.SavedAt, true
+		}
+	}
+	return victim
+}
+
+// LoadID fully hydrates the save id from the saves directory — the
+// same validated Load path (schema range, catalog hash, migrations)
+// as the legacy single slot.
+func LoadID(id string) (*sim.World, error) {
+	path, err := idPath(id)
+	if err != nil {
+		return nil, err
+	}
+	return Load(path)
+}
+
+// Delete removes the save id. Reserved lanes are deletable (ADR 0033
+// §F — they are managed, not precious); the caller confirms
+// destructive actions.
+func Delete(id string) error {
+	path, err := idPath(id)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("delete save: %w", err)
+	}
+	return nil
+}
+
+// Rename sets the save's display name — a pure Meta rewrite (ADR 0033
+// §B): same filename, Payload bytes carried through untouched as raw
+// JSON, SavedAt preserved so the rename doesn't reorder the list.
+// Reserved lanes refuse (§F). A Meta-less legacy file gains a Meta on
+// rename, with SavedAt backfilled from ClockT0 (the in-game date
+// stays unknowable from the header and is left zero).
+func Rename(id, name string) error {
+	if laneOf(id) != LaneNamed {
+		return fmt.Errorf("%w: %s", ErrReservedLane, id)
+	}
+	path, err := idPath(id)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read save: %w", err)
+	}
+	// rawFile mirrors File with the Payload held as raw bytes so the
+	// rewrite can't perturb World state it never decoded.
+	var rf struct {
+		Version         int             `json:"version"`
+		Generator       string          `json:"generator"`
+		ClockT0         int64           `json:"clock_t0"`
+		BodyCatalogHash string          `json:"body_catalog_hash"`
+		Meta            *Meta           `json:"meta,omitempty"`
+		Payload         json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(data, &rf); err != nil {
+		return fmt.Errorf("parse save: %w", err)
+	}
+	if rf.Meta == nil {
+		rf.Meta = &Meta{}
+		if rf.ClockT0 != 0 {
+			rf.Meta.SavedAt = time.Unix(0, rf.ClockT0).UTC()
+		}
+	}
+	rf.Meta.Name = name
+	out, err := json.MarshalIndent(rf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal save: %w", err)
+	}
+	return writeAtomic(path, out)
+}

--- a/internal/save/saves_test.go
+++ b/internal/save/saves_test.go
@@ -1,0 +1,572 @@
+package save_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// testSavesDir points SavesDir at a per-test temp root via
+// XDG_STATE_HOME and returns the resolved saves/ directory. The body
+// catalog resolves through XDG_CONFIG_HOME, so redirecting state does
+// not perturb the catalog hash the writers stamp.
+func testSavesDir(t *testing.T) string {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	dir, err := save.SavesDir()
+	if err != nil {
+		t.Fatalf("SavesDir: %v", err)
+	}
+	return dir
+}
+
+func newTestWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	return w
+}
+
+// jsonFiles returns the sorted .json basenames present in dir
+// (ignoring tmpfiles and anything else).
+func jsonFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// compactPayload extracts and compacts the raw payload bytes of the
+// envelope at path, for byte-level does-not-touch-the-World assertions.
+func compactPayload(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var f struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, f.Payload); err != nil {
+		t.Fatalf("compact payload: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestWriteNamedListLoadRoundtrip — ADR 0033 §B/§C. WriteNamed mints an
+// opaque file, List surfaces it with the stamped Meta, and LoadID
+// rehydrates an equivalent World.
+func TestWriteNamedListLoadRoundtrip(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+	w.Clock.SimTime = w.Clock.SimTime.Add(42 * time.Hour)
+
+	info, err := save.WriteNamed(w, "Apollo — pre-TLI")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	if info.ID == "" || info.ID != filepath.Base(info.ID) {
+		t.Fatalf("WriteNamed ID = %q, want a bare filename", info.ID)
+	}
+	if info.Lane != save.LaneNamed {
+		t.Errorf("Lane = %q, want %q", info.Lane, save.LaneNamed)
+	}
+	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != info.ID {
+		t.Fatalf("saves dir = %v, want exactly [%s]", got, info.ID)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("List = %d entries, want 1", len(infos))
+	}
+	m := infos[0].Meta
+	if m.Name != "Apollo — pre-TLI" {
+		t.Errorf("Meta.Name = %q", m.Name)
+	}
+	if m.SavedAt.IsZero() {
+		t.Error("Meta.SavedAt is zero, want stamped wall-clock time")
+	}
+	if !m.InGameEpoch.Equal(w.Clock.SimTime) {
+		t.Errorf("Meta.InGameEpoch = %v, want %v", m.InGameEpoch, w.Clock.SimTime)
+	}
+	if m.ActiveVesselName != w.ActiveCraft().Name {
+		t.Errorf("Meta.ActiveVesselName = %q, want %q", m.ActiveVesselName, w.ActiveCraft().Name)
+	}
+	if m.SystemName == "" {
+		t.Error("Meta.SystemName empty, want the active vessel's system")
+	}
+
+	got, err := save.LoadID(info.ID)
+	if err != nil {
+		t.Fatalf("LoadID: %v", err)
+	}
+	if !got.Clock.SimTime.Equal(w.Clock.SimTime) {
+		t.Errorf("SimTime: got %v want %v", got.Clock.SimTime, w.Clock.SimTime)
+	}
+	if got.ActiveCraft().Name != w.ActiveCraft().Name {
+		t.Errorf("craft name: got %q want %q", got.ActiveCraft().Name, w.ActiveCraft().Name)
+	}
+	if !vecEq(got.ActiveCraft().State.R, w.ActiveCraft().State.R) {
+		t.Errorf("craft R: got %v want %v", got.ActiveCraft().State.R, w.ActiveCraft().State.R)
+	}
+}
+
+// TestReadHeaderSkipsCatalogAndPayload — ADR 0033 §C. A header read
+// must not hit the body catalog (no ErrCatalogMismatch path) and must
+// not hydrate the payload: a file whose hash is bogus and whose
+// payload Load would reject still header-reads cleanly.
+func TestReadHeaderSkipsCatalogAndPayload(t *testing.T) {
+	dir := testSavesDir(t)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "handmade.json")
+	raw := `{
+  "version": 9,
+  "generator": "test",
+  "clock_t0": 1234567890,
+  "body_catalog_hash": "bogus-hash",
+  "meta": {
+    "name": "Handmade",
+    "saved_at": "2026-07-01T12:00:00Z",
+    "in_game_epoch": "1971-01-01T00:00:00Z",
+    "active_vessel_name": "Apollo",
+    "system_name": "Sol"
+  },
+  "payload": {"system_idx": 9999}
+}`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := save.ReadHeader(path)
+	if err != nil {
+		t.Fatalf("ReadHeader: %v", err)
+	}
+	if m.Name != "Handmade" || m.ActiveVesselName != "Apollo" || m.SystemName != "Sol" {
+		t.Errorf("Meta = %+v", m)
+	}
+	if want := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC); !m.SavedAt.Equal(want) {
+		t.Errorf("SavedAt = %v, want %v", m.SavedAt, want)
+	}
+
+	// Sanity: the same file is rejected by the full Load path on the
+	// bogus hash — proving ReadHeader really skipped that check.
+	if _, err := save.Load(path); !errors.Is(err, save.ErrCatalogMismatch) {
+		t.Errorf("Load err = %v, want ErrCatalogMismatch", err)
+	}
+}
+
+// TestMetaLessV9Lists — ADR 0033 §J backward compat. A v9 envelope
+// written before Meta existed lists with SavedAt derived from ClockT0
+// (wall-clock save time — NOT zero, so it must not sort to the
+// bottom), an empty name, an empty in-game date (unknowable from the
+// header), and still LoadIDs.
+func TestMetaLessV9Lists(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	// An older named save first, then the Meta-less file: the
+	// Meta-less one is newer by ClockT0 and must list first.
+	if _, err := save.WriteNamed(w, "older"); err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	// save.Save is the legacy single-slot writer — it stamps no Meta,
+	// which is exactly the pre-v0.26 v9 envelope shape.
+	if err := save.Save(w, filepath.Join(dir, "legacy.json")); err != nil {
+		t.Fatalf("Save (legacy shape): %v", err)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("List = %d entries, want 2", len(infos))
+	}
+	first := infos[0]
+	if first.ID != "legacy.json" {
+		t.Fatalf("newest entry = %q, want legacy.json first (ClockT0-derived SavedAt must not sort to the bottom)", first.ID)
+	}
+	if first.Meta.SavedAt.IsZero() {
+		t.Error("Meta-less SavedAt is zero, want ClockT0-derived")
+	}
+	if first.Meta.Name != "" {
+		t.Errorf("Meta-less Name = %q, want empty", first.Meta.Name)
+	}
+	if !first.Meta.InGameEpoch.IsZero() {
+		t.Errorf("Meta-less InGameEpoch = %v, want zero (unknowable from the header)", first.Meta.InGameEpoch)
+	}
+	if first.Lane != save.LaneNamed {
+		t.Errorf("Lane = %q, want %q", first.Lane, save.LaneNamed)
+	}
+
+	if _, err := save.LoadID("legacy.json"); err != nil {
+		t.Errorf("LoadID(legacy.json): %v", err)
+	}
+}
+
+// TestAutosaveRingRotation — ADR 0033 §E. Four successive autosaves
+// leave exactly the 3 ring files, with the first (oldest) write gone.
+func TestAutosaveRingRotation(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	var stamps []time.Time
+	for i := 0; i < 4; i++ {
+		if err := save.WriteAutosave(w); err != nil {
+			t.Fatalf("WriteAutosave #%d: %v", i+1, err)
+		}
+		// Record the newest SavedAt in the ring after each write.
+		newest := time.Time{}
+		for _, id := range jsonFiles(t, dir) {
+			m, err := save.ReadHeader(filepath.Join(dir, id))
+			if err != nil {
+				t.Fatalf("ReadHeader(%s): %v", id, err)
+			}
+			if m.SavedAt.After(newest) {
+				newest = m.SavedAt
+			}
+		}
+		stamps = append(stamps, newest)
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	files := jsonFiles(t, dir)
+	if len(files) != 3 {
+		t.Fatalf("ring = %v, want exactly 3 files", files)
+	}
+	for _, id := range files {
+		info, err := save.ReadHeader(filepath.Join(dir, id))
+		if err != nil {
+			t.Fatalf("ReadHeader(%s): %v", id, err)
+		}
+		if info.SavedAt.Equal(stamps[0]) {
+			t.Errorf("%s still carries the first write's SavedAt %v — oldest should have been rotated out", id, stamps[0])
+		}
+		if info.Name != "" {
+			t.Errorf("%s Meta.Name = %q, want empty (reserved lanes carry no player name)", id, info.Name)
+		}
+		if info.ActiveVesselName == "" || info.SystemName == "" || info.InGameEpoch.IsZero() {
+			t.Errorf("%s Meta = %+v, want full metadata stamped on the reserved lane", id, info)
+		}
+	}
+}
+
+// TestAutosaveRingFillsEmptySlot — with only 2 ring files present, the
+// next write fills the missing slot rather than rotating over a
+// survivor.
+func TestAutosaveRingFillsEmptySlot(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	for i := 0; i < 3; i++ {
+		if err := save.WriteAutosave(w); err != nil {
+			t.Fatalf("WriteAutosave #%d: %v", i+1, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	victim := filepath.Join(dir, "autosave-2.json")
+	if err := os.Remove(victim); err != nil {
+		t.Fatalf("remove ring slot: %v", err)
+	}
+	survivors := map[string]time.Time{}
+	for _, id := range jsonFiles(t, dir) {
+		m, err := save.ReadHeader(filepath.Join(dir, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		survivors[id] = m.SavedAt
+	}
+
+	if err := save.WriteAutosave(w); err != nil {
+		t.Fatalf("WriteAutosave (fill): %v", err)
+	}
+	files := jsonFiles(t, dir)
+	if len(files) != 3 {
+		t.Fatalf("ring = %v, want 3 files after fill", files)
+	}
+	refilled, err := save.ReadHeader(victim)
+	if err != nil {
+		t.Fatalf("ReadHeader(refilled slot): %v", err)
+	}
+	for id, at := range survivors {
+		m, err := save.ReadHeader(filepath.Join(dir, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !m.SavedAt.Equal(at) {
+			t.Errorf("%s SavedAt changed %v → %v — fill must not rotate a survivor", id, at, m.SavedAt)
+		}
+		if !refilled.SavedAt.After(m.SavedAt) {
+			t.Errorf("refilled slot SavedAt %v not newer than survivor %s (%v)", refilled.SavedAt, id, m.SavedAt)
+		}
+	}
+}
+
+// TestAutosaveRingUnreadableCountsOldest — a corrupt or Meta-less ring
+// file is the first rotation victim.
+func TestAutosaveRingUnreadableCountsOldest(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	for i := 0; i < 3; i++ {
+		if err := save.WriteAutosave(w); err != nil {
+			t.Fatalf("WriteAutosave #%d: %v", i+1, err)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	corrupt := filepath.Join(dir, "autosave-2.json")
+	if err := os.WriteFile(corrupt, []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := map[string]time.Time{}
+	for _, id := range []string{"autosave-1.json", "autosave-3.json"} {
+		m, err := save.ReadHeader(filepath.Join(dir, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[id] = m.SavedAt
+	}
+
+	if err := save.WriteAutosave(w); err != nil {
+		t.Fatalf("WriteAutosave (over corrupt): %v", err)
+	}
+	if _, err := save.ReadHeader(corrupt); err != nil {
+		t.Errorf("corrupt slot not overwritten with a valid save: %v", err)
+	}
+	for id, at := range before {
+		m, err := save.ReadHeader(filepath.Join(dir, id))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !m.SavedAt.Equal(at) {
+			t.Errorf("%s was rotated (%v → %v) — the unreadable slot should have been the victim", id, at, m.SavedAt)
+		}
+	}
+}
+
+// TestQuicksaveLane — ADR 0033 §D. F5's target is the fixed
+// quicksave.json, stamped with full Meta minus a player name.
+func TestQuicksaveLane(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	if err := save.WriteQuicksave(w); err != nil {
+		t.Fatalf("WriteQuicksave: %v", err)
+	}
+	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != save.QuicksaveID {
+		t.Fatalf("saves dir = %v, want exactly [%s]", got, save.QuicksaveID)
+	}
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Lane != save.LaneQuicksave {
+		t.Fatalf("List = %+v, want one quicksave-lane entry", infos)
+	}
+	m := infos[0].Meta
+	if m.Name != "" {
+		t.Errorf("quicksave Meta.Name = %q, want empty", m.Name)
+	}
+	if m.SavedAt.IsZero() || m.InGameEpoch.IsZero() || m.ActiveVesselName == "" || m.SystemName == "" {
+		t.Errorf("quicksave Meta = %+v, want full metadata", m)
+	}
+	// A second quicksave overwrites in place — still one file.
+	if err := save.WriteQuicksave(w); err != nil {
+		t.Fatalf("WriteQuicksave #2: %v", err)
+	}
+	if got := jsonFiles(t, dir); len(got) != 1 {
+		t.Errorf("saves dir = %v, want quicksave overwritten in place", got)
+	}
+}
+
+// TestRenameMetaOnly — ADR 0033 §B. Rename is a pure Meta rewrite:
+// same filename, payload bytes semantically untouched, SavedAt
+// preserved (a rename must not reorder the list).
+func TestRenameMetaOnly(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	info, err := save.WriteNamed(w, "before")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	path := filepath.Join(dir, info.ID)
+	payloadBefore := compactPayload(t, path)
+	metaBefore, err := save.ReadHeader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := save.Rename(info.ID, "after"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+
+	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != info.ID {
+		t.Fatalf("saves dir = %v, want the same single filename %s (no file move)", got, info.ID)
+	}
+	m, err := save.ReadHeader(path)
+	if err != nil {
+		t.Fatalf("ReadHeader after rename: %v", err)
+	}
+	if m.Name != "after" {
+		t.Errorf("Name = %q, want %q", m.Name, "after")
+	}
+	if !m.SavedAt.Equal(metaBefore.SavedAt) {
+		t.Errorf("SavedAt changed %v → %v — rename must not reorder", metaBefore.SavedAt, m.SavedAt)
+	}
+	if !bytes.Equal(compactPayload(t, path), payloadBefore) {
+		t.Error("payload bytes changed across Rename — must be Meta-only")
+	}
+}
+
+// TestReservedLaneInvariant — ADR 0033 §D/§F. Rename and Overwrite
+// refuse the reserved quicksave/autosave filenames.
+func TestReservedLaneInvariant(t *testing.T) {
+	testSavesDir(t)
+	w := newTestWorld(t)
+	if err := save.WriteQuicksave(w); err != nil {
+		t.Fatalf("WriteQuicksave: %v", err)
+	}
+	if err := save.WriteAutosave(w); err != nil {
+		t.Fatalf("WriteAutosave: %v", err)
+	}
+
+	reserved := []string{save.QuicksaveID, "autosave-1.json", "autosave-2.json", "autosave-3.json"}
+	for _, id := range reserved {
+		if err := save.Rename(id, "hijack"); !errors.Is(err, save.ErrReservedLane) {
+			t.Errorf("Rename(%s) err = %v, want ErrReservedLane", id, err)
+		}
+		if err := save.Overwrite(id, w); !errors.Is(err, save.ErrReservedLane) {
+			t.Errorf("Overwrite(%s) err = %v, want ErrReservedLane", id, err)
+		}
+	}
+}
+
+// TestOverwriteRefreshesMeta — Overwrite rewrites the targeted file in
+// place, preserving Meta.Name while refreshing the volatile fields.
+func TestOverwriteRefreshesMeta(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	info, err := save.WriteNamed(w, "keep-this-name")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	before, err := save.ReadHeader(filepath.Join(dir, info.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	w.Clock.SimTime = w.Clock.SimTime.Add(99 * time.Hour)
+	if err := save.Overwrite(info.ID, w); err != nil {
+		t.Fatalf("Overwrite: %v", err)
+	}
+
+	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != info.ID {
+		t.Fatalf("saves dir = %v, want the single overwritten file", got)
+	}
+	m, err := save.ReadHeader(filepath.Join(dir, info.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Name != "keep-this-name" {
+		t.Errorf("Name = %q, want preserved %q", m.Name, "keep-this-name")
+	}
+	if !m.SavedAt.After(before.SavedAt) {
+		t.Errorf("SavedAt = %v, want refreshed past %v", m.SavedAt, before.SavedAt)
+	}
+	if !m.InGameEpoch.Equal(w.Clock.SimTime) {
+		t.Errorf("InGameEpoch = %v, want refreshed to %v", m.InGameEpoch, w.Clock.SimTime)
+	}
+
+	// A missing target is an error, not a silent create.
+	if err := save.Overwrite("save-0-0.json", w); err == nil {
+		t.Error("Overwrite of a nonexistent id succeeded, want error")
+	}
+}
+
+// TestDuplicateNamesTwoFiles — ADR 0033 §B. Save-As is always-new:
+// two WriteNamed with the same display name mint two distinct files,
+// told apart by SavedAt.
+func TestDuplicateNamesTwoFiles(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	a, err := save.WriteNamed(w, "same name")
+	if err != nil {
+		t.Fatalf("WriteNamed #1: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	b, err := save.WriteNamed(w, "same name")
+	if err != nil {
+		t.Fatalf("WriteNamed #2: %v", err)
+	}
+	if a.ID == b.ID {
+		t.Fatalf("both writes minted %q — duplicate names must not collapse to one file", a.ID)
+	}
+	if got := jsonFiles(t, dir); len(got) != 2 {
+		t.Fatalf("saves dir = %v, want 2 files", got)
+	}
+	if !b.Meta.SavedAt.After(a.Meta.SavedAt) {
+		t.Errorf("SavedAt not ordered: a=%v b=%v", a.Meta.SavedAt, b.Meta.SavedAt)
+	}
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 || infos[0].ID != b.ID || infos[1].ID != a.ID {
+		t.Errorf("List order = %+v, want newest (%s) first", infos, b.ID)
+	}
+}
+
+// TestDeleteRemovesTargetedFile — Delete removes exactly the targeted
+// save and nothing else.
+func TestDeleteRemovesTargetedFile(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	a, err := save.WriteNamed(w, "goner")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	b, err := save.WriteNamed(w, "survivor")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+
+	if err := save.Delete(a.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != b.ID {
+		t.Fatalf("saves dir = %v, want exactly [%s]", got, b.ID)
+	}
+}


### PR DESCRIPTION
Implements slice S1 of the v0.26 multi-save cycle: the persistence spine, entirely inside `internal/save` — no TUI, no app wiring. The `File` envelope gains an additive `Meta` header (name, wall-clock `SavedAt`, `InGameEpoch`, active vessel, system; **no SchemaVersion bump**, stays 9), readable via a new `ReadHeader` that skips World hydration and the body-catalog check. New saves-directory API: `SavesDir`/`List` (newest `SavedAt` first, lane-classified), `WriteNamed` (opaque minted filenames, duplicate display names allowed), `Overwrite` (in-place, name-preserving), `WriteQuicksave` (fixed `quicksave.json`), `WriteAutosave` (ring of 3 — fill a missing slot before rotating, unreadable/Meta-less slot counts oldest), `LoadID`, `Delete`, `Rename` (pure Meta rewrite, no file move). Reserved lanes refuse Overwrite/Rename; Meta-less v9 files list via ClockT0-derived `SavedAt` with the in-game date blank; all writers reuse the existing tmp + atomic-rename path. Design: ADR 0033 (§B, §C, §D, §E, §J) / v0.26 plan §S1. TDD: 12 new tests; `go vet ./...` + `go test ./... -race -count=1` green (1435 tests).