### PR TITLE
feat: S2 — app wiring: legacy import, F5/F9 lanes, autosave-on-quit (v0.26)

### DIFF
--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -104,6 +105,18 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: %v\n", err)
 		os.Exit(2)
+	}
+
+	// v0.26 (ADR 0033 §G): one-time migration of the legacy single-slot
+	// save.json into the saves/ directory as a named save. Fires only
+	// while saves/ is absent; the legacy file stays behind untouched as
+	// a downgrade safety net. Never fatal — on failure the player starts
+	// without the import and the probe retries next run (saves/ is only
+	// created by a successful write).
+	if info, imported, err := save.ImportLegacyIfNeeded(); err != nil {
+		fmt.Fprintf(os.Stderr, "terminal-space-program: legacy save import skipped: %v\n", err)
+	} else if imported {
+		fmt.Fprintf(os.Stderr, "terminal-space-program: imported legacy save.json as %q\n", info.Meta.Name)
 	}
 
 	app, err := tui.New(scenario)

--- a/internal/save/import.go
+++ b/internal/save/import.go
@@ -1,0 +1,96 @@
+package save
+
+// Legacy single-slot import — v0.26 / ADR 0033 §G. On the first run
+// of a saves-directory binary, the pre-v0.26 save.json migrates into
+// saves/ as a named save so no player loses their game or wonders
+// where it went on upgrade.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ImportLegacyIfNeeded migrates the legacy single-slot save.json into
+// the saves directory as a named save — once. The probe fires only
+// while saves/ is absent (idempotent: any saves directory, even an
+// empty one, means the import already settled or the player started
+// fresh on v0.26+). The legacy file is read, never rewritten or
+// deleted — it stays behind untouched as a downgrade safety net (§G:
+// a pre-v0.26 binary still reads it).
+//
+// The default name derives from the save's IN-GAME date, which lives
+// in Payload.SimTimeNano — hence the one full unmarshal of the one
+// legacy file. ClockT0 is wall-clock save time, not the in-game date,
+// and must not be substituted; it seeds Meta.SavedAt instead, so the
+// imported entry sorts truthfully in the browser. The payload bytes
+// are carried through raw, Rename-style, with the original schema
+// Version riding along untouched — LoadID migrates it on load like
+// any older save.
+//
+// Returns the imported entry and true when the migration ran; the
+// zero SaveInfo and false when there was nothing to do.
+func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
+	dir, err := SavesDir()
+	if err != nil {
+		return SaveInfo{}, false, err
+	}
+	if _, err := os.Stat(dir); err == nil {
+		return SaveInfo{}, false, nil // saves/ exists — import already settled
+	} else if !os.IsNotExist(err) {
+		return SaveInfo{}, false, fmt.Errorf("probe saves dir: %w", err)
+	}
+	legacy, err := DefaultPath()
+	if err != nil {
+		return SaveInfo{}, false, err
+	}
+	data, err := os.ReadFile(legacy)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return SaveInfo{}, false, nil // fresh install — nothing to import
+		}
+		return SaveInfo{}, false, fmt.Errorf("read legacy save: %w", err)
+	}
+	var rf rawFile
+	if err := json.Unmarshal(data, &rf); err != nil {
+		return SaveInfo{}, false, fmt.Errorf("parse legacy save: %w", err)
+	}
+	if rf.Version < 1 || rf.Version > SchemaVersion {
+		return SaveInfo{}, false, fmt.Errorf("%w: got %d, want 1..%d", ErrSchemaMismatch, rf.Version, SchemaVersion)
+	}
+	// The full-payload decode §G asks for: the in-game date for the
+	// default name, plus the active vessel for the browser columns.
+	var p Payload
+	if err := json.Unmarshal(rf.Payload, &p); err != nil {
+		return SaveInfo{}, false, fmt.Errorf("parse legacy payload: %w", err)
+	}
+	meta := &Meta{Name: "Imported save", SavedAt: time.Now().UTC()}
+	if p.SimTimeNano != 0 {
+		meta.InGameEpoch = time.Unix(0, p.SimTimeNano).UTC()
+		meta.Name = "Imported " + meta.InGameEpoch.Format("2006-01-02")
+	}
+	if rf.ClockT0 != 0 {
+		meta.SavedAt = time.Unix(0, rf.ClockT0).UTC()
+	}
+	if i := p.ActiveCraftIdx; i >= 0 && i < len(p.Crafts) {
+		meta.ActiveVesselName = p.Crafts[i].Name
+	} else if p.Craft != nil {
+		meta.ActiveVesselName = p.Craft.Name // pre-v5 singular form
+	}
+	// SystemName stays empty — resolving Payload.SystemIdx to a name
+	// needs the body catalog, which the import deliberately avoids; the
+	// browser renders a blank system column, same as any Meta-less
+	// legacy entry.
+	rf.Meta = meta
+	out, err := json.MarshalIndent(rf, "", "  ")
+	if err != nil {
+		return SaveInfo{}, false, fmt.Errorf("marshal imported save: %w", err)
+	}
+	id := mintID()
+	if err := writeAtomic(filepath.Join(dir, id), out); err != nil {
+		return SaveInfo{}, false, err
+	}
+	return SaveInfo{ID: id, Meta: *meta, Lane: LaneNamed}, true, nil
+}

--- a/internal/save/import_test.go
+++ b/internal/save/import_test.go
@@ -1,0 +1,175 @@
+package save_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+)
+
+// TestImportLegacyIfNeeded — ADR 0033 §G. A legacy single-slot
+// save.json with no saves/ directory imports exactly once into the
+// named lane, with the default name derived from the IN-GAME date
+// (Payload.SimTimeNano — not ClockT0, which is wall-clock save time),
+// and the legacy file is left byte-identical as the downgrade safety
+// net. A second startup probe is a no-op.
+func TestImportLegacyIfNeeded(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	legacyPath, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if err := save.Save(w, legacyPath); err != nil {
+		t.Fatalf("Save legacy fixture: %v", err)
+	}
+	legacyBefore, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("read legacy fixture: %v", err)
+	}
+
+	info, imported, err := save.ImportLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("ImportLegacyIfNeeded: %v", err)
+	}
+	if !imported {
+		t.Fatal("expected the legacy save to import")
+	}
+	if info.Lane != save.LaneNamed {
+		t.Errorf("Lane = %q, want %q", info.Lane, save.LaneNamed)
+	}
+
+	// The default name carries the in-game date — the world's SimTime,
+	// not the wall-clock write time.
+	wantDate := w.Clock.SimTime.UTC().Format("2006-01-02")
+	if !strings.Contains(info.Meta.Name, wantDate) {
+		t.Errorf("Name = %q, want it to contain the in-game date %q", info.Meta.Name, wantDate)
+	}
+	if got := info.Meta.InGameEpoch.UnixNano(); got != w.Clock.SimTime.UnixNano() {
+		t.Errorf("InGameEpoch = %d, want SimTimeNano %d", got, w.Clock.SimTime.UnixNano())
+	}
+	if info.Meta.SavedAt.IsZero() {
+		t.Error("SavedAt not stamped (should derive from the legacy ClockT0)")
+	}
+	if want := w.ActiveCraft().Name; info.Meta.ActiveVesselName != want {
+		t.Errorf("ActiveVesselName = %q, want %q", info.Meta.ActiveVesselName, want)
+	}
+
+	// Exactly one named save landed in saves/, and it lists.
+	if files := jsonFiles(t, dir); len(files) != 1 {
+		t.Fatalf("saves dir = %v, want exactly the one imported file", files)
+	}
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].ID != info.ID {
+		t.Fatalf("List = %+v, want the single imported entry %q", infos, info.ID)
+	}
+
+	// The imported save fully loads back (payload carried through raw).
+	loaded, err := save.LoadID(info.ID)
+	if err != nil {
+		t.Fatalf("LoadID(imported): %v", err)
+	}
+	if !loaded.Clock.SimTime.Equal(w.Clock.SimTime) {
+		t.Errorf("loaded SimTime = %v, want %v", loaded.Clock.SimTime, w.Clock.SimTime)
+	}
+
+	// The legacy file is untouched — byte-identical (§G: never rewritten
+	// or deleted; a downgraded binary still reads it).
+	legacyAfter, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("re-read legacy: %v", err)
+	}
+	if !bytes.Equal(legacyBefore, legacyAfter) {
+		t.Error("legacy save.json bytes changed — import must leave it untouched")
+	}
+
+	// Second startup: saves/ now exists, so the probe is a no-op even
+	// though the legacy file is still present.
+	if _, again, err := save.ImportLegacyIfNeeded(); err != nil {
+		t.Fatalf("second ImportLegacyIfNeeded: %v", err)
+	} else if again {
+		t.Error("second probe re-imported — must be idempotent")
+	}
+	if files := jsonFiles(t, dir); len(files) != 1 {
+		t.Errorf("saves dir after second probe = %v, want still one file", files)
+	}
+}
+
+// TestImportLegacyIfNeededFreshInstall — no legacy save.json and no
+// saves/: the probe is a silent no-op and does NOT create the saves
+// directory (the first real write does that).
+func TestImportLegacyIfNeededFreshInstall(t *testing.T) {
+	dir := testSavesDir(t)
+
+	if _, imported, err := save.ImportLegacyIfNeeded(); err != nil {
+		t.Fatalf("ImportLegacyIfNeeded: %v", err)
+	} else if imported {
+		t.Error("imported on a fresh install with no legacy file")
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("saves dir stat = %v, want not-exist (probe must not create it)", err)
+	}
+}
+
+// TestImportLegacyIfNeededSavesDirExists — an existing saves/
+// directory (even empty) means the import already settled; the legacy
+// file never re-imports.
+func TestImportLegacyIfNeededSavesDirExists(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	legacyPath, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if err := save.Save(w, legacyPath); err != nil {
+		t.Fatalf("Save legacy fixture: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll saves: %v", err)
+	}
+
+	if _, imported, err := save.ImportLegacyIfNeeded(); err != nil {
+		t.Fatalf("ImportLegacyIfNeeded: %v", err)
+	} else if imported {
+		t.Error("imported despite an existing saves/ directory")
+	}
+	if files := jsonFiles(t, dir); len(files) != 0 {
+		t.Errorf("saves dir = %v, want empty", files)
+	}
+}
+
+// TestImportPreservesSavedAtOrdering — the imported entry's SavedAt
+// derives from the legacy ClockT0 (wall-clock write time), so it
+// sorts truthfully against newer saves rather than jumping to the top
+// of the browser as if written now.
+func TestImportPreservesSavedAtOrdering(t *testing.T) {
+	testSavesDir(t)
+	w := newTestWorld(t)
+
+	legacyPath, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if err := save.Save(w, legacyPath); err != nil {
+		t.Fatalf("Save legacy fixture: %v", err)
+	}
+
+	before := time.Now().Add(-time.Minute)
+	info, imported, err := save.ImportLegacyIfNeeded()
+	if err != nil || !imported {
+		t.Fatalf("ImportLegacyIfNeeded: imported=%v err=%v", imported, err)
+	}
+	// The fixture was written moments ago, so its ClockT0-derived
+	// SavedAt must land within the test's own wall-clock window.
+	if info.Meta.SavedAt.Before(before) || info.Meta.SavedAt.After(time.Now().Add(time.Minute)) {
+		t.Errorf("SavedAt = %v, want within the fixture's write window", info.Meta.SavedAt)
+	}
+}

--- a/internal/save/saves.go
+++ b/internal/save/saves.go
@@ -353,6 +353,18 @@ func autosaveVictim(dir string) string {
 	return victim
 }
 
+// rawFile mirrors File with the Payload held as raw bytes, for
+// envelope-only rewrites (Rename, the legacy import) that must not
+// perturb World state they never decoded.
+type rawFile struct {
+	Version         int             `json:"version"`
+	Generator       string          `json:"generator"`
+	ClockT0         int64           `json:"clock_t0"`
+	BodyCatalogHash string          `json:"body_catalog_hash"`
+	Meta            *Meta           `json:"meta,omitempty"`
+	Payload         json.RawMessage `json:"payload"`
+}
+
 // LoadID fully hydrates the save id from the saves directory — the
 // same validated Load path (schema range, catalog hash, migrations)
 // as the legacy single slot.
@@ -396,16 +408,7 @@ func Rename(id, name string) error {
 	if err != nil {
 		return fmt.Errorf("read save: %w", err)
 	}
-	// rawFile mirrors File with the Payload held as raw bytes so the
-	// rewrite can't perturb World state it never decoded.
-	var rf struct {
-		Version         int             `json:"version"`
-		Generator       string          `json:"generator"`
-		ClockT0         int64           `json:"clock_t0"`
-		BodyCatalogHash string          `json:"body_catalog_hash"`
-		Meta            *Meta           `json:"meta,omitempty"`
-		Payload         json.RawMessage `json:"payload"`
-	}
+	var rf rawFile
 	if err := json.Unmarshal(data, &rf); err != nil {
 		return fmt.Errorf("parse save: %w", err)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"io/fs"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -1155,24 +1157,23 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
-// doSave writes the current world to the default save path.
+// doSave writes the current world to the quicksave lane — F5 always
+// targets quicksave.json (v0.26 / ADR 0033 §D), so it can never touch
+// a named save.
 func (a *App) doSave() error {
-	path, err := save.DefaultPath()
-	if err != nil {
-		return err
-	}
-	return save.Save(a.world, path)
+	return save.WriteQuicksave(a.world)
 }
 
-// doLoad replaces the live world with the one persisted at the default
-// save path. Failures leave the existing world untouched.
+// doLoad replaces the live world with the quicksave lane — F9 stays
+// instant, no confirm (ADR 0033 §H). An empty lane (no F5 yet) is
+// surfaced as a clear "no quicksave" message rather than a raw
+// file-not-found; failures leave the existing world untouched.
 func (a *App) doLoad() error {
-	path, err := save.DefaultPath()
+	w, err := save.LoadID(save.QuicksaveID)
 	if err != nil {
-		return err
-	}
-	w, err := save.Load(path)
-	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return errors.New("no quicksave yet — press F5 first")
+		}
 		return err
 	}
 	a.world = w
@@ -1183,11 +1184,13 @@ func (a *App) doLoad() error {
 	return nil
 }
 
-// autosave persists on quit. Errors are swallowed — the user is leaving
-// and there's no surface to flash a message on. Console-printable saves
-// can be wired later if needed.
+// autosave persists on quit into the rotating autosave ring (v0.26 /
+// ADR 0033 §E) — never the named lane, never the legacy single slot.
+// Errors are swallowed — the user is leaving and there's no surface to
+// flash a message on. Console-printable saves can be wired later if
+// needed.
 func (a *App) autosave() {
-	_ = a.doSave()
+	_ = save.WriteAutosave(a.world)
 }
 
 // handleAttitudeKey dispatches a w/s/a/d/q/e tap. In EngineMain mode
@@ -1282,6 +1285,9 @@ func (a *App) dispatchNavballControl(ctrl screens.NavballControlID) {
 // quit).
 func (a *App) applyMenuAction(action screens.MenuAction) (tea.Model, tea.Cmd) {
 	switch action {
+	// Interim (v0.26 S2): [Save Game]/[Load Game] ride the same
+	// quicksave lane as F5/F9 via doSave/doLoad until S3 replaces both
+	// items with the unified Saves screen (ADR 0033 §F).
 	case screens.MenuActionSave:
 		if err := a.doSave(); err != nil {
 			a.statusMsg = fmt.Sprintf("save failed: %v", err)
@@ -1397,13 +1403,15 @@ func (a *App) cycleLayout() {
 	}
 }
 
-// flashStatus writes a transient message to the HUD footer.
+// flashStatus writes a transient message to the HUD footer. The
+// success path names the quicksave lane — F5/F9 are its only callers
+// (v0.26 / ADR 0033 §D).
 func (a *App) flashStatus(op string, err error) {
 	if err != nil {
 		a.statusMsg = fmt.Sprintf("%s failed: %v", op, err)
 	} else {
-		path, _ := save.DefaultPath()
-		a.statusMsg = fmt.Sprintf("%s ok — %s", op, path)
+		dir, _ := save.SavesDir()
+		a.statusMsg = fmt.Sprintf("%s ok — %s", op, filepath.Join(dir, save.QuicksaveID))
 	}
 	a.statusExpires = time.Now().Add(3 * time.Second)
 }

--- a/internal/tui/app_saves_test.go
+++ b/internal/tui/app_saves_test.go
@@ -1,0 +1,151 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+)
+
+// testStateDirs isolates both the saves directory (XDG_STATE_HOME) and
+// settings.json (XDG_CONFIG_HOME) into per-test temp roots, so the lane
+// tests can't read or clobber the developer's real state, and returns
+// the resolved saves/ dir.
+func testStateDirs(t *testing.T) string {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir, err := save.SavesDir()
+	if err != nil {
+		t.Fatalf("SavesDir: %v", err)
+	}
+	return dir
+}
+
+// savesDirFiles returns the sorted .json basenames in the saves dir
+// (empty when the dir doesn't exist yet).
+func savesDirFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("ReadDir(%s): %v", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".json" {
+			names = append(names, e.Name())
+		}
+	}
+	return names
+}
+
+// TestQuicksaveKeyWritesLane — F5 writes the fixed quicksave lane
+// (quicksave.json, ADR 0033 §D), never a named save, and flashes the
+// ok toast.
+func TestQuicksaveKeyWritesLane(t *testing.T) {
+	dir := testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF5})
+	files := savesDirFiles(t, dir)
+	if len(files) != 1 || files[0] != save.QuicksaveID {
+		t.Fatalf("saves dir = %v, want exactly [%s]", files, save.QuicksaveID)
+	}
+	if !strings.HasPrefix(a.statusMsg, "save ok") {
+		t.Errorf("statusMsg = %q, want a `save ok` toast", a.statusMsg)
+	}
+}
+
+// TestQuickloadKeySwapsWorld — F9 loads the quicksave lane instantly
+// (no confirm, ADR 0033 §H), replacing the world and re-applying the
+// player's mission-program toggles (the v0.21 Slice 7 behaviour the
+// rewire must preserve).
+func TestQuickloadKeySwapsWorld(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF5}) // quicksave at WarpIdx 0
+	old := a.world
+	a.world.Clock.WarpIdx = 4 // diverge so the swap is observable
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+	if a.world == old {
+		t.Fatal("F9 did not replace the world")
+	}
+	if a.world.Clock.WarpIdx != 0 {
+		t.Errorf("WarpIdx = %d, want 0 (the quicksaved state)", a.world.Clock.WarpIdx)
+	}
+	// Settings default both program toggles off — a fresh Load yields the
+	// nil "all enabled" map, so a reapplied (non-nil, empty) set is the
+	// proof the toggles were pushed onto the loaded world.
+	if a.world.MissionProgramEnabled(missions.ProgramTutorial) {
+		t.Error("mission-program toggles not re-applied after quickload")
+	}
+	if a.active != screenOrbit {
+		t.Errorf("active = %v, want screenOrbit after quickload", a.active)
+	}
+	if !strings.HasPrefix(a.statusMsg, "load ok") {
+		t.Errorf("statusMsg = %q, want a `load ok` toast", a.statusMsg)
+	}
+}
+
+// TestQuickloadEmptyLane — F9 before any F5 flashes a clear "no
+// quicksave" message via flashStatus (not a raw file-not-found error)
+// and leaves the live world untouched.
+func TestQuickloadEmptyLane(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	old := a.world
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+	if a.world != old {
+		t.Fatal("F9 on an empty quicksave lane swapped the world")
+	}
+	if !strings.Contains(a.statusMsg, "no quicksave") {
+		t.Errorf("statusMsg = %q, want a clear `no quicksave` message", a.statusMsg)
+	}
+	if strings.Contains(a.statusMsg, "no such file") {
+		t.Errorf("statusMsg = %q leaks a raw file-not-found error", a.statusMsg)
+	}
+}
+
+// TestQuitAutosavesToRing — ctrl+c quit writes the rotating autosave
+// ring (ADR 0033 §E), not a named save and not the legacy single-slot
+// save.json.
+func TestQuitAutosavesToRing(t *testing.T) {
+	dir := testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	files := savesDirFiles(t, dir)
+	if len(files) != 1 || files[0] != "autosave-1.json" {
+		t.Fatalf("saves dir = %v, want exactly [autosave-1.json]", files)
+	}
+	legacyPath, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("quit wrote the legacy save.json (stat err = %v); autosave must use the ring", err)
+	}
+}


### PR DESCRIPTION
## Summary

Slice S2 of the v0.26 multi-save cycle (ADR 0033 — see the planning vault: `adr/0033-multi-save-system-named-saves-quicksave-autosave.md`, plan `v0.26-plan.md` §S2). Points the existing entry points at the S1 (#195) saves-directory lanes; no new screen (that's S3).

- **Legacy import (§G)** — `save.ImportLegacyIfNeeded`: on startup, while `saves/` is absent and the legacy `DefaultPath()` `save.json` exists, import it into `saves/` as a named save. Default name derives from the **in-game date** (`Payload.SimTimeNano` via one full unmarshal — not `ClockT0`, which is wall-clock save time and instead seeds `Meta.SavedAt` so browser ordering stays truthful). Payload bytes are carried through raw (shared `rawFile` type extracted from `Rename`), original schema version rides along, and the legacy file is left **byte-identical** as a downgrade safety net. Idempotent; called once from `main`'s bootstrap, never fatal.
- **F5/F9 (§D/§H)** — `doSave` → `save.WriteQuicksave`; `doLoad` → `save.LoadID(quicksave)`, instant, no confirm. World-swap + `SetEnabledMissionPrograms` reapply preserved; `flashStatus` toasts kept (success path now names the quicksave lane). F9 on an empty lane flashes "no quicksave yet — press F5 first" and does not swap the world.
- **Autosave-on-quit (§E)** — `autosave()` → `save.WriteAutosave` (rotating ring of 3), errors still swallowed.
- Pause-menu `[Save Game]`/`[Load Game]` keep today's one-shot behaviour (riding the same lane via `doSave`/`doLoad`); S3 replaces them with the unified Saves screen.

## Tests

Plan §S2 TDD list, written first:
- Import: one named save with the in-game-date name, Meta fields (SavedAt from ClockT0, InGameEpoch from SimTimeNano, active vessel), legacy bytes untouched, second probe no-op; fresh-install no-op (doesn't create `saves/`); existing-`saves/` no-op.
- F5 writes exactly `quicksave.json`; F9 swaps the world + reapplies mission-program toggles; F9-before-F5 flashes "no quicksave" with no world swap; ctrl+c quit writes `autosave-1.json` (ring), not a named save and not the legacy slot.

`go vet ./...` clean; `go test ./... -race -count=1` — 1443 passed / 16 packages. Also verified end-to-end against a copy of a real legacy save: run 1 imports ("Imported 2000-01-05"), run 2 no-op, legacy file byte-identical.