### PR TITLE
feat(tui): S3 — Saves screen: browser, Save-As, delete/rename, load-confirm (v0.26)

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -136,7 +136,7 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `P` | Porkchop plot for the body under the map cursor (not your `t` target). `Enter` on a cell plans that transfer. For another planet only — moon targets point you back to `H`. Press `o` inside for transfer options |
 | `R` | Refine the plan — recompute the transfer from where you are right now and update the arrival |
 | `m` | Open the maneuver planner |
-| `F5` / `F9` | Quicksave / quickload |
+| `F5` / `F9` | Quicksave / quickload — a fixed quick slot, separate from your named saves (see **Saves** below) |
 | `[` / `]` | Switch which craft you're flying (when you have more than one) |
 | `1`–`9` | Jump straight to craft N (does nothing if that slot is empty) |
 | `U` | Undock a docked craft back into its parts |
@@ -144,6 +144,22 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `D` | Apollo transposition — flip the Service Module to the front to do the flying, leaving the Lunar Module as a nose payload (then `U` to release it) |
 | `V` | Jump to the launch chase-cam, following your active craft |
 | `E` | End the flight — remove a crashed craft after a `y` / `n` confirm |
+
+### Saves (`Esc → [Save Game]` / `[Load Game]`)
+
+One browser for every save: your named saves plus the managed quicksave
+(`F5`) and the three rotating autosaves, newest first, with when it was
+saved, the in-game date, and the vessel you were flying. `[Save Game]`
+opens it in save mode (with a `＋ New save…` row), `[Load Game]` in load
+mode.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move the save cursor (click a row to select it; click again to activate) |
+| `Enter` | Load mode: load the save (asks first). Save mode: `＋ New save…` prompts for a name (prefilled with your vessel + in-game day), an existing named save asks to overwrite it |
+| `d` | Delete the highlighted save (asks first — works on quicksave / autosaves too) |
+| `r` | Rename a named save. The quicksave / autosave slots are managed and can't be renamed or overwritten by hand |
+| `Esc` | Back |
 
 ### Manual flight
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -36,6 +36,7 @@ const (
 	screenSettings // v0.13 slice 3: per-Chip visibility toggles, reached from the menu.
 	screenControls // ADR 0022: keyboard-layout selector, reached from the menu.
 	screenVAB      // v0.24 / ADR 0029: Vehicle Assembly (VAB) builder, reached from the menu.
+	screenSaves    // v0.26 / ADR 0033 §F: unified Saves browser, reached from the menu's Save/Load items.
 	screenBoss     // boss key: full-screen fake developer shell (backtick from any screen).
 )
 
@@ -79,6 +80,13 @@ type App struct {
 	// delete) directly — designs are app-managed catalog data, not world
 	// state — so opening it from the menu is the only wiring the App needs.
 	vab *screens.VAB
+
+	// saves is the unified Saves browser (v0.26 / ADR 0033 §F), reached
+	// from both pause-menu items ([Save Game] opens it in save-mode,
+	// [Load Game] in load-mode). The screen is filesystem-free: the App
+	// passes the save.List() listing at open/refresh and dispatches the
+	// returned SavesCommands against the save package.
+	saves *screens.SavesScreen
 
 	// boss is the backtick "boss key" fake shell. bossReturnScreen records
 	// the screen that was active when it opened, and bossPrevPaused records
@@ -164,6 +172,7 @@ func New(scenario *sim.StartScenario) (*App, error) {
 		settingsScreen: screens.NewSettingsScreen(sth),
 		controls:       screens.NewControlsScreen(sth),
 		vab:            screens.NewVAB(sth),
+		saves:          screens.NewSavesScreen(sth),
 		boss:           screens.NewBossShell(sth),
 	}, nil
 }
@@ -443,6 +452,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case screens.ControlsActionCancel:
 				a.active = screenOrbit
 			}
+		case screenSaves:
+			return a.applySavesCommand(a.saves.HandleClick(m.X, m.Y))
 		}
 		return a, nil
 
@@ -599,6 +610,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.active = screenOrbit
 			}
 			return a, nil
+		}
+		// Saves browser (v0.26 / ADR 0033 §F): list navigation, confirm
+		// gates, and the name input all live in the screen; finalised
+		// intents come back as SavesCommands and are dispatched against
+		// the save package here. Handled before the global switch so its
+		// keys (and typed save names) never fall through to flight
+		// controls.
+		if a.active == screenSaves {
+			return a.applySavesCommand(a.saves.HandleKey(m))
 		}
 		// Maneuver screen has its own text input that eats most keys;
 		// esc-to-cancel goes through the screen's handler so it can
@@ -1169,11 +1189,20 @@ func (a *App) doSave() error {
 // surfaced as a clear "no quicksave" message rather than a raw
 // file-not-found; failures leave the existing world untouched.
 func (a *App) doLoad() error {
-	w, err := save.LoadID(save.QuicksaveID)
+	err := a.loadWorldByID(save.QuicksaveID)
+	if errors.Is(err, fs.ErrNotExist) {
+		return errors.New("no quicksave yet — press F5 first")
+	}
+	return err
+}
+
+// loadWorldByID hydrates the save id and swaps it in as the live
+// world — the single world-swap path shared by F9 quickload and the
+// Saves-screen browser load (post-confirm). Failures leave the
+// existing world untouched.
+func (a *App) loadWorldByID(id string) error {
+	w, err := save.LoadID(id)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return errors.New("no quicksave yet — press F5 first")
-		}
 		return err
 	}
 	a.world = w
@@ -1285,26 +1314,15 @@ func (a *App) dispatchNavballControl(ctrl screens.NavballControlID) {
 // quit).
 func (a *App) applyMenuAction(action screens.MenuAction) (tea.Model, tea.Cmd) {
 	switch action {
-	// Interim (v0.26 S2): [Save Game]/[Load Game] ride the same
-	// quicksave lane as F5/F9 via doSave/doLoad until S3 replaces both
-	// items with the unified Saves screen (ADR 0033 §F).
+	// v0.26 S3 (ADR 0033 §F): both menu items open the unified Saves
+	// screen; the entry point selects save-mode vs load-mode. Opening a
+	// screen is reversible, so like Settings/VAB there is no confirm
+	// gate here — the destructive confirms (§H) live in the screen.
 	case screens.MenuActionSave:
-		if err := a.doSave(); err != nil {
-			a.statusMsg = fmt.Sprintf("save failed: %v", err)
-		} else {
-			a.statusMsg = "saved"
-		}
-		a.statusExpires = time.Now().Add(3 * time.Second)
-		a.active = screenOrbit
+		a.openSaves(screens.SavesModeSave)
 		return a, nil
 	case screens.MenuActionLoad:
-		if err := a.doLoad(); err != nil {
-			a.statusMsg = fmt.Sprintf("load failed: %v", err)
-		} else {
-			a.statusMsg = "loaded"
-		}
-		a.statusExpires = time.Now().Add(3 * time.Second)
-		a.active = screenOrbit
+		a.openSaves(screens.SavesModeLoad)
 		return a, nil
 	case screens.MenuActionSettings:
 		// Navigating to a screen is harmless + reversible, so unlike
@@ -1331,6 +1349,96 @@ func (a *App) applyMenuAction(action screens.MenuAction) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	return a, nil
+}
+
+// openSaves lists the saves directory and opens the unified Saves
+// screen (v0.26 / ADR 0033 §F) in the given entry-point mode. A
+// listing failure still opens the (empty) screen with a toast — the
+// save-mode "＋ New save…" row must stay reachable even when the scan
+// hiccups.
+func (a *App) openSaves(mode screens.SavesMode) {
+	entries, err := save.List()
+	if err != nil {
+		a.toast(fmt.Sprintf("saves listing failed: %v", err))
+	}
+	a.saves.Open(mode, entries, defaultSaveName(a.world))
+	a.active = screenSaves
+}
+
+// refreshSaves re-lists the directory into the open Saves screen after
+// an in-screen mutation (delete / rename).
+func (a *App) refreshSaves() {
+	entries, err := save.List()
+	if err != nil {
+		a.toast(fmt.Sprintf("saves listing failed: %v", err))
+		return
+	}
+	a.saves.SetEntries(entries)
+}
+
+// defaultSaveName is the Save-As prefill (ADR 0033 §B): the active
+// vessel plus the in-game day, the latter in the same layout the orbit
+// HUD's clock chip renders.
+func defaultSaveName(w *sim.World) string {
+	day := w.Clock.SimTime.Format("2006-01-02")
+	if c := w.ActiveCraft(); c != nil {
+		return c.Name + " — " + day
+	}
+	return day
+}
+
+// applySavesCommand dispatches a finalised SavesCommand from the Saves
+// screen against the save package. The screen has already run every
+// confirm gate (§H), so each destructive kind executes directly here.
+// Load / Save-As / Overwrite exit to orbit; delete / rename stay on
+// the screen with a refreshed listing.
+func (a *App) applySavesCommand(cmd screens.SavesCommand) (tea.Model, tea.Cmd) {
+	switch cmd.Kind {
+	case screens.SavesActionCancel:
+		a.active = screenOrbit
+	case screens.SavesActionLoad:
+		if err := a.loadWorldByID(cmd.ID); err != nil {
+			a.toast(fmt.Sprintf("load failed: %v", err))
+		} else {
+			a.toast(fmt.Sprintf("loaded %s", cmd.Name))
+		}
+	case screens.SavesActionDelete:
+		if err := save.Delete(cmd.ID); err != nil {
+			a.toast(fmt.Sprintf("delete failed: %v", err))
+		} else {
+			a.toast(fmt.Sprintf("deleted %s", cmd.Name))
+		}
+		a.refreshSaves()
+	case screens.SavesActionRename:
+		if err := save.Rename(cmd.ID, cmd.Name); err != nil {
+			a.toast(fmt.Sprintf("rename failed: %v", err))
+		} else {
+			a.toast(fmt.Sprintf("renamed to '%s'", cmd.Name))
+		}
+		a.refreshSaves()
+	case screens.SavesActionSaveNew:
+		if _, err := save.WriteNamed(a.world, cmd.Name); err != nil {
+			a.toast(fmt.Sprintf("save failed: %v", err))
+		} else {
+			a.toast(fmt.Sprintf("saved '%s'", cmd.Name))
+			a.active = screenOrbit
+		}
+	case screens.SavesActionOverwrite:
+		if err := save.Overwrite(cmd.ID, a.world); err != nil {
+			a.toast(fmt.Sprintf("overwrite failed: %v", err))
+		} else {
+			a.toast(fmt.Sprintf("overwrote '%s'", cmd.Name))
+			a.active = screenOrbit
+		}
+	}
+	return a, nil
+}
+
+// toast flashes a transient one-line notice in the HUD footer for ~3s
+// (the generic sibling of flashStatus, which is F5/F9-specific).
+func (a *App) toast(msg string) {
+	a.statusMsg = msg
+	a.statusExpires = time.Now().Add(3 * time.Second)
 }
 
 // toggleChip flips Chip c's visibility in the shared settings.Settings
@@ -1459,6 +1567,8 @@ func (a *App) View() string {
 		base = a.controls.Render(a.layout, a.width)
 	case screenVAB:
 		base = a.vab.Render(a.width)
+	case screenSaves:
+		base = a.saves.Render(a.width)
 	case screenBoss:
 		base = a.boss.Render(a.width, a.height)
 	default:

--- a/internal/tui/app_saves_screen_test.go
+++ b/internal/tui/app_saves_screen_test.go
@@ -1,0 +1,251 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// keyStr sends a printable key through Update the way the terminal
+// would deliver it.
+func press(a *App, s string) {
+	switch s {
+	case "enter":
+		a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	case "esc":
+		a.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	case "down":
+		a.Update(tea.KeyMsg{Type: tea.KeyDown})
+	default:
+		a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
+	}
+}
+
+// openSavesVia opens the pause menu and presses the given item key
+// ("s" save-mode, "l" load-mode).
+func openSavesVia(t *testing.T, a *App, item string) {
+	t.Helper()
+	press(a, "esc") // orbit → menu
+	if a.active != screenMenu {
+		t.Fatalf("esc did not open the menu (active=%v)", a.active)
+	}
+	press(a, item)
+	if a.active != screenSaves {
+		t.Fatalf("menu %q did not open the Saves screen (active=%v)", item, a.active)
+	}
+}
+
+// TestMenuOpensSavesScreenBothModes — both pause-menu items open the
+// unified Saves screen (ADR 0033 §F), with the entry point selecting
+// save-mode vs load-mode. Replaces the S2 interim one-shot dispatch.
+func TestMenuOpensSavesScreenBothModes(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	openSavesVia(t, a, "s")
+	if a.saves.Mode() != screens.SavesModeSave {
+		t.Errorf("[Save Game] opened mode %v, want save-mode", a.saves.Mode())
+	}
+	press(a, "esc") // back to orbit
+
+	openSavesVia(t, a, "l")
+	if a.saves.Mode() != screens.SavesModeLoad {
+		t.Errorf("[Load Game] opened mode %v, want load-mode", a.saves.Mode())
+	}
+}
+
+// TestSavesScreenSaveAsWritesNamed — the plan's "Save-As with the
+// default name writes a named save; the returned action path hits
+// WriteNamed": accepting the prefilled default mints exactly one
+// named save whose Meta.Name is the default (active vessel +
+// in-game day).
+func TestSavesScreenSaveAsWritesNamed(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	openSavesVia(t, a, "s")
+	press(a, "enter") // New save row → naming (prefilled default)
+	press(a, "enter") // accept the default
+	if a.active != screenOrbit {
+		t.Fatalf("active = %v after Save-As, want screenOrbit", a.active)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Lane != save.LaneNamed {
+		t.Fatalf("saves = %+v, want exactly one named save", infos)
+	}
+	want := defaultSaveName(a.world)
+	if infos[0].Meta.Name != want {
+		t.Errorf("Meta.Name = %q, want the default %q", infos[0].Meta.Name, want)
+	}
+	if !strings.Contains(a.statusMsg, "saved") {
+		t.Errorf("statusMsg = %q, want a saved toast", a.statusMsg)
+	}
+}
+
+// TestSavesScreenOverwritePreservesOthers — the plan's "Overwrite
+// targets the selected file (not a name match) and preserves other
+// saves": with two saves sharing a display name, overwriting the
+// older one leaves the newer file untouched and mints nothing new.
+func TestSavesScreenOverwritePreservesOthers(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	older, err := save.WriteNamed(a.world, "Twin")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	newer, err := save.WriteNamed(a.world, "Twin")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+
+	openSavesVia(t, a, "s")
+	// Rows: [＋ New save…, newer, older] — target the OLDER twin.
+	press(a, "down")
+	press(a, "down")
+	press(a, "enter") // overwrite confirm
+	press(a, "y")
+	if a.active != screenOrbit {
+		t.Fatalf("active = %v after overwrite, want screenOrbit", a.active)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("saves after overwrite = %d files, want 2 (no new mint)", len(infos))
+	}
+	byID := map[string]save.Meta{}
+	for _, in := range infos {
+		byID[in.ID] = in.Meta
+	}
+	got, ok := byID[older.ID]
+	if !ok {
+		t.Fatalf("overwritten file %s vanished", older.ID)
+	}
+	if !got.SavedAt.After(older.Meta.SavedAt) {
+		t.Errorf("overwrite did not refresh SavedAt (%v → %v)", older.Meta.SavedAt, got.SavedAt)
+	}
+	if got.Name != "Twin" {
+		t.Errorf("overwrite lost the display name: %q", got.Name)
+	}
+	other, ok := byID[newer.ID]
+	if !ok {
+		t.Fatalf("sibling save %s vanished", newer.ID)
+	}
+	if !other.SavedAt.Equal(newer.Meta.SavedAt) {
+		t.Errorf("sibling save was touched (SavedAt %v → %v)", newer.Meta.SavedAt, other.SavedAt)
+	}
+}
+
+// TestSavesScreenRenameEditsMeta — the plan's "rename edits Meta on
+// named rows": r + a new name rewrites the display name in place
+// (same ID), and the browser refreshes to show it.
+func TestSavesScreenRenameEditsMeta(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	info, err := save.WriteNamed(a.world, "Before")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+
+	openSavesVia(t, a, "l")
+	press(a, "r")
+	// The input is prefilled with "Before"; type an addition and commit.
+	press(a, "!")
+	press(a, "enter")
+	if a.active != screenSaves {
+		t.Fatalf("active = %v after rename, want to stay on the Saves screen", a.active)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].ID != info.ID {
+		t.Fatalf("saves after rename = %+v, want the same single file", infos)
+	}
+	if infos[0].Meta.Name != "Before!" {
+		t.Errorf("Meta.Name = %q, want %q", infos[0].Meta.Name, "Before!")
+	}
+}
+
+// TestSavesScreenDeleteRemovesRow — the plan's "delete confirm removes
+// the row": d + y deletes the file and the refreshed list drops it.
+func TestSavesScreenDeleteRemovesRow(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := save.WriteNamed(a.world, "Doomed"); err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+
+	openSavesVia(t, a, "l")
+	press(a, "d")
+	press(a, "y")
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("saves after delete = %+v, want none", infos)
+	}
+	if n := a.saves.EntryCount(); n != 0 {
+		t.Errorf("saves screen shows %d rows after delete, want 0 (refresh)", n)
+	}
+}
+
+// TestSavesScreenLoadConfirmGatesWorldSwap — the plan's "load path
+// emits the confirm gate before the world swap": Enter alone must NOT
+// swap the world; y commits the swap and re-applies the
+// mission-program toggles via the shared doLoad path.
+func TestSavesScreenLoadConfirmGatesWorldSwap(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := save.WriteNamed(a.world, "Checkpoint"); err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	old := a.world
+	a.world.Clock.WarpIdx = 4 // diverge so the swap is observable
+
+	openSavesVia(t, a, "l")
+	press(a, "enter") // confirm gate — no swap yet
+	if a.world != old {
+		t.Fatal("Enter swapped the world before the confirm")
+	}
+	press(a, "y")
+	if a.world == old {
+		t.Fatal("confirmed load did not swap the world")
+	}
+	if a.world.Clock.WarpIdx != 0 {
+		t.Errorf("WarpIdx = %d, want 0 (the saved state)", a.world.Clock.WarpIdx)
+	}
+	if a.active != screenOrbit {
+		t.Errorf("active = %v after load, want screenOrbit", a.active)
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -42,6 +42,13 @@ var helpSections = []helpSection{
 		{"q", "quit (confirm + autosave)"},
 		{"ctrl+c", "quit immediately"},
 	}},
+	{"SAVES (menu → Save / Load Game)", [][2]string{
+		{"↑ / ↓", "move the save cursor"},
+		{"enter", "load-mode: load (confirms) · save-mode: new save / overwrite"},
+		{"d", "delete the highlighted save (confirms)"},
+		{"r", "rename a named save (quicksave / autosaves can't be renamed)"},
+		{"esc", "back to the map"},
+	}},
 	{"CAMERA & VIEW", [][2]string{
 		{"f / F", "cycle camera focus forward / back (system → bodies → craft)"},
 		{"g", "reset camera to the whole system"},

--- a/internal/tui/screens/menu.go
+++ b/internal/tui/screens/menu.go
@@ -10,12 +10,14 @@ import (
 // footer prompt with a centered modal that doubles as a "what can I
 // do from here" entry point. v0.7.3.3+.
 //
-// v0.7.4+ adds clickable controls. The list state shows three labelled
-// buttons; clicking any transitions into a confirm sub-state with
-// [Yes] / [No] buttons. Yes triggers the corresponding MenuAction;
-// No returns to the list. The keyboard path keeps the legacy direct
-// flow (s/l/q execute immediately) so muscle memory still works —
-// the confirm gate is for the mouse path only.
+// v0.7.4+ adds clickable controls. Screen-opening rows (Save / Load /
+// VAB / Settings / Controls) fire their action on click directly —
+// opening a screen is reversible. Quit keeps a mouse-only confirm
+// sub-state with [Yes] / [No] buttons; the keyboard path keeps the
+// legacy direct flow (q executes immediately) so muscle memory still
+// works. v0.26 (ADR 0033 §F) rehomed Save / Load onto the Saves
+// screen, which owns its own destructive confirms (§H) — so their
+// click-confirm gates moved there with them.
 type Menu struct {
 	theme Theme
 	mode  menuMode
@@ -38,8 +40,6 @@ type menuMode int
 
 const (
 	menuModeList menuMode = iota
-	menuModeConfirmSave
-	menuModeConfirmLoad
 	menuModeConfirmQuit
 )
 
@@ -158,9 +158,12 @@ func (m *Menu) HandleClick(col, row int) MenuAction {
 		case m.controlsBtn.Hit(col, row):
 			return MenuActionControls
 		case m.saveBtn.Hit(col, row):
-			m.mode = menuModeConfirmSave
+			// v0.26 (ADR 0033 §F): Save / Load open the Saves screen —
+			// reversible like VAB / Settings, so no click-confirm gate;
+			// the screen owns the destructive confirms (§H).
+			return MenuActionSave
 		case m.loadBtn.Hit(col, row):
-			m.mode = menuModeConfirmLoad
+			return MenuActionLoad
 		case m.quitBtn.Hit(col, row):
 			m.mode = menuModeConfirmQuit
 		}
@@ -178,15 +181,10 @@ func (m *Menu) HandleClick(col, row int) MenuAction {
 }
 
 // confirmAction returns the MenuAction matching the current confirm
-// sub-state. Used by both the keyboard "y" / enter path and the
-// mouse [Yes] click path.
+// sub-state (quit is the only one left post-v0.26). Used by both the
+// keyboard "y" / enter path and the mouse [Yes] click path.
 func (m *Menu) confirmAction() MenuAction {
-	switch m.mode {
-	case menuModeConfirmSave:
-		return MenuActionSave
-	case menuModeConfirmLoad:
-		return MenuActionLoad
-	case menuModeConfirmQuit:
+	if m.mode == menuModeConfirmQuit {
 		return MenuActionQuit
 	}
 	return MenuActionNone
@@ -233,10 +231,6 @@ func (m *Menu) Render(width int) string {
 	switch m.mode {
 	case menuModeList:
 		lines = append(lines, m.renderList(rowOffset)...)
-	case menuModeConfirmSave:
-		lines = append(lines, m.renderConfirm(rowOffset, "Save current game to disk?", "save")...)
-	case menuModeConfirmLoad:
-		lines = append(lines, m.renderConfirm(rowOffset, "Load saved game and discard current state?", "load")...)
 	case menuModeConfirmQuit:
 		lines = append(lines, m.renderConfirm(rowOffset, "Quit (autosaves on exit)?", "quit")...)
 	}

--- a/internal/tui/screens/menu_test.go
+++ b/internal/tui/screens/menu_test.go
@@ -71,9 +71,11 @@ func TestMenuButtonRowsMatchRenderedLines(t *testing.T) {
 		}
 	}
 
-	// Confirm state: [Yes] / [No] on the same row recorded.
-	saveCol := (m.saveBtn.colStart + m.saveBtn.colEnd) / 2
-	m.HandleClick(saveCol, m.saveBtn.row)
+	// Confirm state: [Yes] / [No] on the same row recorded. Quit is
+	// the only click-confirm gate left (v0.26 moved Save / Load onto
+	// the Saves screen, which owns its own confirms).
+	quitCol := (m.quitBtn.colStart + m.quitBtn.colEnd) / 2
+	m.HandleClick(quitCol, m.quitBtn.row)
 	out = m.Render(80)
 	lines = strings.Split(out, "\n")
 	if m.yesBtn.row >= len(lines) || !strings.Contains(lines[m.yesBtn.row], "[Yes]") {
@@ -93,11 +95,12 @@ func min(a, b int) int {
 	return b
 }
 
-// TestMenuClickConfirmFlow: clicking Save / Load / Quit in the list
-// state transitions into a confirm sub-screen rather than firing
-// immediately. [Yes] then commits the action; [No] returns to the
-// list. The keyboard direct path still bypasses confirm (covered
-// above) — confirm gating is mouse-only.
+// TestMenuClickConfirmFlow: clicking Quit in the list state
+// transitions into a confirm sub-screen rather than firing
+// immediately; [Yes] then commits, [No] returns to the list. Save /
+// Load clicks fire their action directly — v0.26 (ADR 0033 §F) made
+// them screen-openers like VAB / Settings, with the destructive
+// confirms living on the Saves screen itself.
 func TestMenuClickConfirmFlow(t *testing.T) {
 	th := Theme{
 		Primary: lipgloss.NewStyle(),
@@ -108,13 +111,25 @@ func TestMenuClickConfirmFlow(t *testing.T) {
 	m := NewMenu(th)
 	_ = m.Render(80) // populate button ranges
 
-	// Click Save in the list — should not immediately fire MenuActionSave.
+	// Save / Load clicks open the Saves screen directly — no gate.
 	saveCol := (m.saveBtn.colStart + m.saveBtn.colEnd) / 2
-	if got := m.HandleClick(saveCol, m.saveBtn.row); got != MenuActionNone {
-		t.Errorf("Save list click: got %v, want MenuActionNone (confirm gate)", got)
+	if got := m.HandleClick(saveCol, m.saveBtn.row); got != MenuActionSave {
+		t.Errorf("Save list click: got %v, want MenuActionSave (opens the Saves screen)", got)
 	}
-	if m.mode != menuModeConfirmSave {
-		t.Errorf("mode after Save click = %v, want menuModeConfirmSave", m.mode)
+	_ = m.Render(80)
+	loadCol := (m.loadBtn.colStart + m.loadBtn.colEnd) / 2
+	if got := m.HandleClick(loadCol, m.loadBtn.row); got != MenuActionLoad {
+		t.Errorf("Load list click: got %v, want MenuActionLoad (opens the Saves screen)", got)
+	}
+
+	// Click Quit in the list — should not immediately fire MenuActionQuit.
+	_ = m.Render(80)
+	quitCol := (m.quitBtn.colStart + m.quitBtn.colEnd) / 2
+	if got := m.HandleClick(quitCol, m.quitBtn.row); got != MenuActionNone {
+		t.Errorf("Quit list click: got %v, want MenuActionNone (confirm gate)", got)
+	}
+	if m.mode != menuModeConfirmQuit {
+		t.Errorf("mode after Quit click = %v, want menuModeConfirmQuit", m.mode)
 	}
 
 	// Re-render to populate Yes/No ranges, click No → back to list.
@@ -129,12 +144,11 @@ func TestMenuClickConfirmFlow(t *testing.T) {
 
 	// List → confirm again, this time Yes → commits.
 	_ = m.Render(80)
-	loadCol := (m.loadBtn.colStart + m.loadBtn.colEnd) / 2
-	m.HandleClick(loadCol, m.loadBtn.row)
+	m.HandleClick(quitCol, m.quitBtn.row)
 	_ = m.Render(80)
 	yesCol := (m.yesBtn.colStart + m.yesBtn.colEnd) / 2
-	if got := m.HandleClick(yesCol, m.yesBtn.row); got != MenuActionLoad {
-		t.Errorf("Yes click after Load: got %v, want MenuActionLoad", got)
+	if got := m.HandleClick(yesCol, m.yesBtn.row); got != MenuActionQuit {
+		t.Errorf("Yes click after Quit: got %v, want MenuActionQuit", got)
 	}
 	if m.mode != menuModeList {
 		t.Errorf("mode after Yes click = %v, want menuModeList (back to list)", m.mode)
@@ -161,13 +175,13 @@ func TestMenuKeyboardConfirmStillWorks(t *testing.T) {
 		t.Errorf("HandleKey(y) after Quit click: got %v, want MenuActionQuit", got)
 	}
 
-	// Click Save, then press 'n' to cancel.
+	// Click Quit again, then press 'n' to cancel.
 	m.Reset()
 	_ = m.Render(80)
-	saveCol := (m.saveBtn.colStart + m.saveBtn.colEnd) / 2
-	m.HandleClick(saveCol, m.saveBtn.row)
+	quitCol = (m.quitBtn.colStart + m.quitBtn.colEnd) / 2
+	m.HandleClick(quitCol, m.quitBtn.row)
 	if got := m.HandleKey("n"); got != MenuActionNone {
-		t.Errorf("HandleKey(n) after Save click: got %v, want MenuActionNone", got)
+		t.Errorf("HandleKey(n) after Quit click: got %v, want MenuActionNone", got)
 	}
 	if m.mode != menuModeList {
 		t.Errorf("mode after n: got %v, want menuModeList", m.mode)

--- a/internal/tui/screens/saves.go
+++ b/internal/tui/screens/saves.go
@@ -1,0 +1,488 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+)
+
+// SavesScreen is the unified Saves browser (v0.26 / ADR 0033 §F): one
+// list of every entry in the saves directory — named saves plus the
+// reserved quicksave/autosave lanes — with metadata columns, reached
+// from both pause-menu items. The entry point selects load-mode vs
+// save-mode; save-mode prepends a "＋ New save…" row (Save-As) and
+// turns Enter-on-a-named-row into an overwrite.
+//
+// It follows the MenuAction mold: the screen holds only UI state (the
+// App passes the []save.SaveInfo listing at Open, the way the spawn
+// form receives ListDesigns), and every player intent is returned as
+// a SavesCommand for App.Update to dispatch against the save package —
+// the screen never touches the filesystem or the world.
+type SavesScreen struct {
+	theme Theme
+	mode  SavesMode
+	state savesState
+
+	entries     []save.SaveInfo // as listed by save.List — already newest-first
+	cursor      int             // row index; save-mode row 0 is the New-save row
+	defaultName string          // Save-As prefill: active vessel + in-game day (§B)
+
+	// pendingID/pendingName capture the row a confirm or rename is
+	// about; the display name is echoed in the prompt.
+	pendingID   string
+	pendingName string
+
+	// input is the shared name-entry field (Save-As + rename), the
+	// same bubbles/textinput the maneuver form uses.
+	input textinput.Model
+
+	// Click-target ranges, recomputed each Render (menu buttonRange
+	// pattern). rowBtns aligns 1:1 with the visible rows.
+	backBtn buttonRange
+	rowBtns []buttonRange
+	yesBtn  buttonRange
+	noBtn   buttonRange
+}
+
+// SavesMode is the entry-point flag: which pause-menu item opened the
+// screen (ADR 0033 §F).
+type SavesMode int
+
+const (
+	SavesModeLoad SavesMode = iota
+	SavesModeSave
+)
+
+// savesState tracks the screen's sub-state: browsing the list, one of
+// the three confirm gates (§H — load and delete confirm; overwrite is
+// destructive the same way), or name entry (Save-As / rename).
+type savesState int
+
+const (
+	savesStateBrowse savesState = iota
+	savesStateConfirmLoad
+	savesStateConfirmDelete
+	savesStateConfirmOverwrite
+	savesStateNameNew
+	savesStateRename
+)
+
+// SavesActionKind enumerates the intents the screen hands back to the
+// App. Every destructive kind is only ever emitted after its confirm
+// gate (§H).
+type SavesActionKind int
+
+const (
+	SavesActionNone      SavesActionKind = iota
+	SavesActionCancel                    // esc / [Back] — leave the screen
+	SavesActionLoad                      // load ID (post-confirm)
+	SavesActionDelete                    // delete ID (post-confirm)
+	SavesActionRename                    // rename ID → Name (no gate — benign Meta edit)
+	SavesActionSaveNew                   // Save-As: write a NEW named save called Name
+	SavesActionOverwrite                 // overwrite ID in place (post-confirm)
+)
+
+// SavesCommand is one dispatched intent: the kind plus the target file
+// ID (never a display-name match — duplicate names are legal, §B) and
+// the entered/display name where relevant.
+type SavesCommand struct {
+	Kind SavesActionKind
+	ID   string
+	Name string
+}
+
+func NewSavesScreen(th Theme) *SavesScreen {
+	in := textinput.New()
+	in.CharLimit = 48
+	in.Width = 40
+	return &SavesScreen{theme: th, input: in}
+}
+
+// Open (re)initialises the screen for a fresh visit: the entry-point
+// mode, the current directory listing (newest-first, as save.List
+// returns it), and the Save-As default name computed by the App from
+// the live world (active vessel + in-game day).
+func (sc *SavesScreen) Open(mode SavesMode, entries []save.SaveInfo, defaultName string) {
+	sc.mode = mode
+	sc.entries = entries
+	sc.defaultName = defaultName
+	sc.cursor = 0
+	sc.state = savesStateBrowse
+	sc.pendingID, sc.pendingName = "", ""
+}
+
+// SetEntries refreshes the listing in place (after a delete / rename /
+// Save-As) and clamps the cursor to the new row count.
+func (sc *SavesScreen) SetEntries(entries []save.SaveInfo) {
+	sc.entries = entries
+	if max := sc.rowCount() - 1; sc.cursor > max {
+		sc.cursor = max
+	}
+	if sc.cursor < 0 {
+		sc.cursor = 0
+	}
+}
+
+// Mode reports the entry-point mode the screen was opened in.
+func (sc *SavesScreen) Mode() SavesMode { return sc.mode }
+
+// EntryCount reports the number of listed saves (excluding the
+// save-mode New-save row).
+func (sc *SavesScreen) EntryCount() int { return len(sc.entries) }
+
+// hasNewRow: save-mode prepends the persistent "＋ New save…" row.
+func (sc *SavesScreen) hasNewRow() bool { return sc.mode == SavesModeSave }
+
+// rowCount is the number of selectable rows (entries + the New-save
+// row in save-mode).
+func (sc *SavesScreen) rowCount() int {
+	n := len(sc.entries)
+	if sc.hasNewRow() {
+		n++
+	}
+	return n
+}
+
+// entryAt maps a row index to its SaveInfo, accounting for the
+// save-mode New-save row at index 0. ok=false on the New-save row or
+// an empty list.
+func (sc *SavesScreen) entryAt(row int) (save.SaveInfo, bool) {
+	if sc.hasNewRow() {
+		row--
+	}
+	if row < 0 || row >= len(sc.entries) {
+		return save.SaveInfo{}, false
+	}
+	return sc.entries[row], true
+}
+
+// HandleKey maps a keypress to a SavesCommand. Most keys only mutate
+// screen state (cursor, confirm gates, the name input) and return
+// Kind == SavesActionNone; a command with any other Kind is a
+// finalised intent for the App to dispatch.
+func (sc *SavesScreen) HandleKey(msg tea.KeyMsg) SavesCommand {
+	key := msg.String()
+	switch sc.state {
+	case savesStateNameNew, savesStateRename:
+		switch key {
+		case "esc":
+			sc.state = savesStateBrowse
+			return SavesCommand{}
+		case "enter":
+			name := strings.TrimSpace(sc.input.Value())
+			naming := sc.state
+			sc.state = savesStateBrowse
+			if naming == savesStateNameNew {
+				// Empty / whitespace falls back to the default rather
+				// than minting a nameless save (§B default name).
+				if name == "" {
+					name = sc.defaultName
+				}
+				return SavesCommand{Kind: SavesActionSaveNew, Name: name}
+			}
+			if name == "" {
+				return SavesCommand{} // rename to nothing: keep the old name
+			}
+			return SavesCommand{Kind: SavesActionRename, ID: sc.pendingID, Name: name}
+		default:
+			var cmd tea.Cmd
+			sc.input, cmd = sc.input.Update(msg)
+			_ = cmd // cursor-blink command dropped — static cursor is fine here
+			return SavesCommand{}
+		}
+
+	case savesStateConfirmLoad, savesStateConfirmDelete, savesStateConfirmOverwrite:
+		switch key {
+		case "y", "Y", "enter":
+			return sc.commitConfirm()
+		case "n", "N", "esc":
+			sc.state = savesStateBrowse
+		}
+		return SavesCommand{}
+	}
+
+	// Browse state.
+	switch key {
+	case "esc":
+		return SavesCommand{Kind: SavesActionCancel}
+	case "up":
+		if sc.cursor > 0 {
+			sc.cursor--
+		}
+	case "down":
+		if sc.cursor < sc.rowCount()-1 {
+			sc.cursor++
+		}
+	case "enter":
+		return sc.activateCursor()
+	case "d", "D":
+		// Delete works on every lane — reserved lanes are managed but
+		// deletable (§F); the confirm gate covers the destructiveness.
+		if info, ok := sc.entryAt(sc.cursor); ok {
+			sc.pendingID, sc.pendingName = info.ID, displaySaveName(info)
+			sc.state = savesStateConfirmDelete
+		}
+	case "r", "R":
+		// Rename is a benign Meta edit (no confirm, §H) but is
+		// disabled on the reserved lanes (§F) — they carry no player
+		// name by design.
+		if info, ok := sc.entryAt(sc.cursor); ok && info.Lane == save.LaneNamed {
+			sc.pendingID, sc.pendingName = info.ID, displaySaveName(info)
+			sc.beginNaming(savesStateRename, info.Meta.Name)
+		}
+	}
+	return SavesCommand{}
+}
+
+// HandleClick maps a (col, row) click to the same intents as the
+// keyboard: [Back] cancels; a list-row click selects, and a click on
+// the already-selected row activates it (Enter-equivalent); the
+// confirm [Yes]/[No] buttons commit / back out.
+func (sc *SavesScreen) HandleClick(col, row int) SavesCommand {
+	if sc.backBtn.Hit(col, row) {
+		return SavesCommand{Kind: SavesActionCancel}
+	}
+	switch sc.state {
+	case savesStateBrowse:
+		for i, btn := range sc.rowBtns {
+			if btn.Hit(col, row) {
+				if i == sc.cursor {
+					return sc.activateCursor()
+				}
+				sc.cursor = i
+				return SavesCommand{}
+			}
+		}
+	case savesStateConfirmLoad, savesStateConfirmDelete, savesStateConfirmOverwrite:
+		switch {
+		case sc.yesBtn.Hit(col, row):
+			return sc.commitConfirm()
+		case sc.noBtn.Hit(col, row):
+			sc.state = savesStateBrowse
+		}
+	}
+	return SavesCommand{}
+}
+
+// activateCursor is the Enter action on the current row: New-save row
+// → open naming prefilled with the default; load-mode row → load
+// confirm (§H); save-mode named row → overwrite confirm; save-mode
+// reserved row → no-op (§F: never manually overwritable).
+func (sc *SavesScreen) activateCursor() SavesCommand {
+	if sc.hasNewRow() && sc.cursor == 0 {
+		sc.beginNaming(savesStateNameNew, sc.defaultName)
+		return SavesCommand{}
+	}
+	info, ok := sc.entryAt(sc.cursor)
+	if !ok {
+		return SavesCommand{}
+	}
+	sc.pendingID, sc.pendingName = info.ID, displaySaveName(info)
+	if sc.mode == SavesModeSave {
+		if info.Lane != save.LaneNamed {
+			return SavesCommand{} // reserved lanes: loadable + deletable only (§F)
+		}
+		sc.state = savesStateConfirmOverwrite
+		return SavesCommand{}
+	}
+	sc.state = savesStateConfirmLoad
+	return SavesCommand{}
+}
+
+// commitConfirm resolves the active confirm gate into its finalised
+// command (shared by the keyboard y/enter path and the [Yes] click).
+func (sc *SavesScreen) commitConfirm() SavesCommand {
+	st := sc.state
+	sc.state = savesStateBrowse
+	switch st {
+	case savesStateConfirmLoad:
+		return SavesCommand{Kind: SavesActionLoad, ID: sc.pendingID, Name: sc.pendingName}
+	case savesStateConfirmDelete:
+		return SavesCommand{Kind: SavesActionDelete, ID: sc.pendingID, Name: sc.pendingName}
+	case savesStateConfirmOverwrite:
+		return SavesCommand{Kind: SavesActionOverwrite, ID: sc.pendingID, Name: sc.pendingName}
+	}
+	return SavesCommand{}
+}
+
+// beginNaming enters a name-entry state with the input prefilled and
+// focused, cursor at the end so typing appends.
+func (sc *SavesScreen) beginNaming(state savesState, prefill string) {
+	sc.state = state
+	sc.input.SetValue(prefill)
+	sc.input.CursorEnd()
+	sc.input.Focus()
+}
+
+// displaySaveName is the name cell / prompt label for an entry: the
+// player-facing Meta.Name for named saves ("(unnamed)" for a Meta-less
+// legacy file), and a lane badge for the reserved quicksave/autosave
+// lanes — which carry no player name by design (§D).
+func displaySaveName(info save.SaveInfo) string {
+	switch info.Lane {
+	case save.LaneQuicksave:
+		return "[QUICKSAVE]"
+	case save.LaneAutosave:
+		// "autosave-2.json" → "[AUTOSAVE 2]"
+		n := strings.TrimSuffix(strings.TrimPrefix(info.ID, "autosave-"), ".json")
+		return "[AUTOSAVE " + n + "]"
+	}
+	if info.Meta.Name == "" {
+		return "(unnamed)"
+	}
+	return info.Meta.Name
+}
+
+// formatInGameDate renders Meta.InGameEpoch with the same layout the
+// orbit HUD's clock chip inlines (SimTime.Format("2006-01-02")); a
+// zero epoch (Meta-less legacy header, imported save) renders blank —
+// the date is unknowable without hydrating the Payload.
+func formatInGameDate(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}
+
+// formatSavedAt renders the wall-clock write time in the player's
+// local timezone; blank when unknown.
+func formatSavedAt(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}
+
+// Column layout: marker(2) + name(26) + savedat(18) + ingame(12) + vessel.
+const (
+	savesColName    = 26
+	savesColSavedAt = 18
+	savesColInGame  = 12
+)
+
+// padCell pads / rune-truncates a cell to width (ellipsis on cut),
+// plus two trailing gap spaces.
+func padCell(s string, width int) string {
+	r := []rune(s)
+	if len(r) > width {
+		return string(r[:width-1]) + "…"
+	}
+	return s + strings.Repeat(" ", width-len(r))
+}
+
+// Render composes the screen: title + [Back], the mode header, the
+// column header, one row per entry (cursor-marked), and the
+// state-specific footer (confirm prompt / name input / key legend).
+// Click-target ranges are recorded in absolute row terms, menu-style.
+func (sc *SavesScreen) Render(width int) string {
+	var lines []string
+
+	// Row 0: title + right-aligned [Back] (menu pattern).
+	titleText := "saves — load a game"
+	if sc.mode == SavesModeSave {
+		titleText = "saves — save your game"
+	}
+	const backLabel = "[Back]"
+	pad := width - len([]rune(titleText)) - len([]rune(backLabel))
+	if pad < 1 {
+		pad = 1
+	}
+	backCol := len([]rune(titleText)) + pad
+	sc.backBtn = buttonRange{row: 0, colStart: backCol, colEnd: backCol + len([]rune(backLabel)), set: true}
+	lines = append(lines, sc.theme.Title.Render(titleText)+strings.Repeat(" ", pad)+sc.theme.Primary.Render(backLabel))
+	lines = append(lines, "")
+
+	// Column header.
+	header := "  " + padCell("NAME", savesColName) + padCell("SAVED", savesColSavedAt) +
+		padCell("IN-GAME", savesColInGame) + "VESSEL"
+	lines = append(lines, sc.theme.Dim.Render(header))
+
+	// Rows.
+	sc.rowBtns = make([]buttonRange, sc.rowCount())
+	rowIdx := 0
+	addRow := func(body string) {
+		marker := "  "
+		style := sc.theme.Primary
+		if rowIdx == sc.cursor {
+			marker = "▸ "
+			style = sc.theme.Warning
+		}
+		sc.rowBtns[rowIdx] = buttonRange{
+			row:      len(lines),
+			colStart: 0,
+			colEnd:   width,
+			set:      true,
+		}
+		lines = append(lines, clipLine(marker+style.Render(body), width))
+		rowIdx++
+	}
+	if sc.hasNewRow() {
+		addRow("＋ New save…")
+	}
+	for _, info := range sc.entries {
+		body := padCell(displaySaveName(info), savesColName) +
+			padCell(formatSavedAt(info.Meta.SavedAt), savesColSavedAt) +
+			padCell(formatInGameDate(info.Meta.InGameEpoch), savesColInGame) +
+			info.Meta.ActiveVesselName
+		addRow(body)
+	}
+	if len(sc.entries) == 0 && !sc.hasNewRow() {
+		lines = append(lines, sc.theme.Dim.Render("  (no saves yet — F5 quicksaves, or save from the menu)"))
+	}
+	lines = append(lines, "")
+
+	// State-specific tail: confirm prompt / name input / key legend.
+	sc.yesBtn.set, sc.noBtn.set = false, false
+	switch sc.state {
+	case savesStateConfirmLoad:
+		lines = sc.appendConfirm(lines, "Load and discard current state?")
+	case savesStateConfirmDelete:
+		lines = sc.appendConfirm(lines, fmt.Sprintf("Delete %s? This cannot be undone.", sc.pendingName))
+	case savesStateConfirmOverwrite:
+		lines = sc.appendConfirm(lines, fmt.Sprintf("Overwrite '%s'?", sc.pendingName))
+	case savesStateNameNew, savesStateRename:
+		prompt := "name the new save:"
+		if sc.state == savesStateRename {
+			prompt = "rename to:"
+		}
+		lines = append(lines, "  "+prompt+" "+sc.input.View())
+		lines = append(lines, "")
+		lines = append(lines, sc.theme.Footer.Render("[enter] confirm · [esc] cancel"))
+	default:
+		legend := "[enter] load · [d] delete · [r] rename · [↑/↓] move · [esc] back"
+		if sc.mode == SavesModeSave {
+			legend = "[enter] new save / overwrite · [d] delete · [r] rename · [↑/↓] move · [esc] back"
+		}
+		lines = append(lines, sc.theme.Footer.Render(legend))
+	}
+
+	for i, ln := range lines {
+		lines[i] = clipLine(ln, width)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// appendConfirm appends a §H-style Yes/No confirm block and records
+// the button click targets (menu renderConfirm pattern).
+func (sc *SavesScreen) appendConfirm(lines []string, prompt string) []string {
+	lines = append(lines, "  "+sc.theme.Alert.Render(prompt))
+	lines = append(lines, "")
+	const indent = "  "
+	const yesLabel = "[Yes]"
+	const noLabel = "[No]"
+	const gap = "   "
+	yesCol := len([]rune(indent))
+	noCol := yesCol + len([]rune(yesLabel)) + len([]rune(gap))
+	row := len(lines)
+	sc.yesBtn = buttonRange{row: row, colStart: yesCol, colEnd: yesCol + len([]rune(yesLabel)), set: true}
+	sc.noBtn = buttonRange{row: row, colStart: noCol, colEnd: noCol + len([]rune(noLabel)), set: true}
+	lines = append(lines, indent+sc.theme.Primary.Render(yesLabel)+gap+sc.theme.Primary.Render(noLabel))
+	lines = append(lines, "")
+	lines = append(lines, sc.theme.Footer.Render("[y]es / [n]o / [esc] cancel"))
+	return lines
+}

--- a/internal/tui/screens/saves_test.go
+++ b/internal/tui/screens/saves_test.go
@@ -1,0 +1,356 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+)
+
+// savesTheme returns a style-free Theme so rendered output is plain
+// text (assertable with strings.Contains without ANSI noise).
+func savesTheme() Theme {
+	return Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+}
+
+// savesFixture returns three entries the way save.List would: newest
+// SavedAt first — a named save, an autosave, and a Meta-less legacy
+// import stand-in (blank in-game date + system, per the S1/S2 handoff).
+func savesFixture() []save.SaveInfo {
+	return []save.SaveInfo{
+		{
+			ID: "save-100.json",
+			Meta: save.Meta{
+				Name:             "Apollo run",
+				SavedAt:          time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC),
+				InGameEpoch:      time.Date(2000, 3, 14, 0, 0, 0, 0, time.UTC),
+				ActiveVesselName: "Kern Stack",
+				SystemName:       "Sol",
+			},
+			Lane: save.LaneNamed,
+		},
+		{
+			ID: "autosave-1.json",
+			Meta: save.Meta{
+				SavedAt:          time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC),
+				InGameEpoch:      time.Date(2000, 3, 13, 0, 0, 0, 0, time.UTC),
+				ActiveVesselName: "Probe IV",
+				SystemName:       "Lumen",
+			},
+			Lane: save.LaneAutosave,
+		},
+		{
+			ID: "save-42.json",
+			Meta: save.Meta{
+				// Meta-less legacy header: SavedAt backfilled from ClockT0,
+				// everything else zero.
+				SavedAt: time.Date(2026, 7, 10, 8, 0, 0, 0, time.UTC),
+			},
+			Lane: save.LaneNamed,
+		},
+	}
+}
+
+func keyRunes(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+var (
+	keyEnter = tea.KeyMsg{Type: tea.KeyEnter}
+	keyEsc   = tea.KeyMsg{Type: tea.KeyEsc}
+	keyDown  = tea.KeyMsg{Type: tea.KeyDown}
+)
+
+// TestSavesListRendersRows — the plan's "List renders N rows with the
+// expected columns; newest-first ordering": every entry appears with
+// its name / saved-at / in-game date / vessel columns, reserved lanes
+// carry a badge, and the row order preserves the (already
+// newest-first) List order. Meta-less entries render a blank in-game
+// date rather than the zero time.
+func TestSavesListRendersRows(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	out := sc.Render(110)
+
+	for _, want := range []string{
+		"Apollo run", "2000-03-14", "Kern Stack", // named row columns
+		"[AUTOSAVE 1]", "2000-03-13", "Probe IV", // autosave badge + columns
+		"(unnamed)", // Meta-less legacy entry
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q\n%s", want, out)
+		}
+	}
+	// Saved-at column renders in local time with the shared layout.
+	wantSavedAt := time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC).Local().Format("2006-01-02 15:04")
+	if !strings.Contains(out, wantSavedAt) {
+		t.Errorf("render missing saved-at %q\n%s", wantSavedAt, out)
+	}
+	// Zero InGameEpoch must be blank, never the zero-time text.
+	if strings.Contains(out, "0001-01-01") {
+		t.Errorf("Meta-less entry rendered a zero in-game date\n%s", out)
+	}
+	// Newest-first: the given order is preserved on screen.
+	iApollo := strings.Index(out, "Apollo run")
+	iAuto := strings.Index(out, "[AUTOSAVE 1]")
+	iLegacy := strings.Index(out, "(unnamed)")
+	if !(iApollo < iAuto && iAuto < iLegacy) {
+		t.Errorf("rows out of order: apollo=%d auto=%d legacy=%d", iApollo, iAuto, iLegacy)
+	}
+}
+
+// TestSavesSaveModeShowsNewRow — save-mode prepends the "＋ New save…"
+// row; load-mode does not.
+func TestSavesSaveModeShowsNewRow(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeSave, savesFixture(), "default")
+	if out := sc.Render(110); !strings.Contains(out, "New save") {
+		t.Errorf("save-mode render missing the New save row\n%s", out)
+	}
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	if out := sc.Render(110); strings.Contains(out, "New save") {
+		t.Errorf("load-mode render must not show the New save row\n%s", out)
+	}
+}
+
+// TestSavesSaveAsDefaultName — Enter on the New save row opens the
+// name input prefilled with the default (active vessel + in-game
+// day); Enter again commits a SavesActionSaveNew carrying it.
+func TestSavesSaveAsDefaultName(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeSave, savesFixture(), "Kern Stack — 2000-03-14")
+
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Fatalf("enter on New save row returned %v, want None (opens naming)", cmd.Kind)
+	}
+	if out := sc.Render(110); !strings.Contains(out, "Kern Stack — 2000-03-14") {
+		t.Fatalf("naming input not prefilled with the default name\n%s", out)
+	}
+	cmd := sc.HandleKey(keyEnter)
+	if cmd.Kind != SavesActionSaveNew || cmd.Name != "Kern Stack — 2000-03-14" {
+		t.Fatalf("commit = %+v, want SaveNew with the default name", cmd)
+	}
+}
+
+// TestSavesSaveAsWhitespaceFallsBack — an all-whitespace name falls
+// back to the default rather than writing a nameless save.
+func TestSavesSaveAsWhitespaceFallsBack(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeSave, nil, "fallback name")
+	sc.HandleKey(keyEnter) // open naming
+	sc.input.SetValue("   ")
+	cmd := sc.HandleKey(keyEnter)
+	if cmd.Kind != SavesActionSaveNew || cmd.Name != "fallback name" {
+		t.Fatalf("commit = %+v, want SaveNew with the fallback default", cmd)
+	}
+}
+
+// TestSavesOverwriteTargetsSelectedFile — with two rows sharing the
+// SAME display name, Enter in save-mode confirms and the command
+// carries the selected row's ID, not a name match.
+func TestSavesOverwriteTargetsSelectedFile(t *testing.T) {
+	twin := func(id string, at time.Time) save.SaveInfo {
+		return save.SaveInfo{
+			ID:   id,
+			Meta: save.Meta{Name: "Twin", SavedAt: at},
+			Lane: save.LaneNamed,
+		}
+	}
+	entries := []save.SaveInfo{
+		twin("save-2.json", time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC)),
+		twin("save-1.json", time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)),
+	}
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeSave, entries, "default")
+
+	// Rows: [＋ New save…, save-2, save-1] — select the OLDER twin.
+	sc.HandleKey(keyDown)
+	sc.HandleKey(keyDown)
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Fatalf("enter on named row returned %v, want None (confirm gate)", cmd.Kind)
+	}
+	if out := sc.Render(110); !strings.Contains(out, "Overwrite") {
+		t.Fatalf("no overwrite confirm prompt rendered\n%s", out)
+	}
+	cmd := sc.HandleKey(keyRunes("y"))
+	if cmd.Kind != SavesActionOverwrite || cmd.ID != "save-1.json" {
+		t.Fatalf("confirm = %+v, want Overwrite of save-1.json (the selected file)", cmd)
+	}
+}
+
+// TestSavesReservedLaneNotOverwritable — Enter in save-mode on a
+// reserved lane is a no-op (§F: loadable + deletable only).
+func TestSavesReservedLaneNotOverwritable(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeSave, savesFixture(), "default")
+	// Rows: [new, named, autosave, legacy] — cursor to the autosave.
+	sc.HandleKey(keyDown)
+	sc.HandleKey(keyDown)
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Fatalf("enter on reserved lane returned %v, want None", cmd.Kind)
+	}
+	if out := sc.Render(110); strings.Contains(out, "Overwrite") {
+		t.Fatalf("reserved lane opened an overwrite confirm\n%s", out)
+	}
+}
+
+// TestSavesRenameNamedRow — r on a named row opens the input prefilled
+// with the current name; committing returns SavesActionRename with the
+// row's ID and the new name.
+func TestSavesRenameNamedRow(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	if cmd := sc.HandleKey(keyRunes("r")); cmd.Kind != SavesActionNone {
+		t.Fatalf("r returned %v, want None (opens naming)", cmd.Kind)
+	}
+	if got := sc.input.Value(); got != "Apollo run" {
+		t.Fatalf("rename input prefill = %q, want the current name", got)
+	}
+	sc.input.SetValue("Apollo 11")
+	cmd := sc.HandleKey(keyEnter)
+	if cmd.Kind != SavesActionRename || cmd.ID != "save-100.json" || cmd.Name != "Apollo 11" {
+		t.Fatalf("commit = %+v, want Rename save-100.json → Apollo 11", cmd)
+	}
+}
+
+// TestSavesRenameReservedLaneDisabled — r on a reserved lane is a
+// no-op: no naming state, no command (§F).
+func TestSavesRenameReservedLaneDisabled(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	sc.HandleKey(keyDown) // cursor to the autosave row
+	if cmd := sc.HandleKey(keyRunes("r")); cmd.Kind != SavesActionNone {
+		t.Fatalf("r on reserved lane returned %v, want None", cmd.Kind)
+	}
+	if sc.state != savesStateBrowse {
+		t.Fatalf("r on reserved lane left browse state (state=%v)", sc.state)
+	}
+}
+
+// TestSavesLoadConfirmGate — the plan's "load path emits the confirm
+// gate before the world swap": Enter renders the §H prompt and returns
+// no command; n backs out; y returns SavesActionLoad with the ID.
+func TestSavesLoadConfirmGate(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Fatalf("enter returned %v before the confirm gate", cmd.Kind)
+	}
+	if out := sc.Render(110); !strings.Contains(out, "Load and discard current state?") {
+		t.Fatalf("missing the §H load confirm prompt\n%s", out)
+	}
+	if cmd := sc.HandleKey(keyRunes("n")); cmd.Kind != SavesActionNone {
+		t.Fatalf("n returned %v, want None (back to browse)", cmd.Kind)
+	}
+	sc.HandleKey(keyEnter)
+	cmd := sc.HandleKey(keyRunes("y"))
+	if cmd.Kind != SavesActionLoad || cmd.ID != "save-100.json" {
+		t.Fatalf("confirm = %+v, want Load save-100.json", cmd)
+	}
+}
+
+// TestSavesDeleteConfirm — d opens a delete confirm (destructive, §H);
+// y returns SavesActionDelete with the ID. Reserved lanes are
+// deletable too (§F).
+func TestSavesDeleteConfirm(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	sc.HandleKey(keyDown) // the autosave row — reserved lanes delete fine
+	if cmd := sc.HandleKey(keyRunes("d")); cmd.Kind != SavesActionNone {
+		t.Fatalf("d returned %v, want None (confirm gate)", cmd.Kind)
+	}
+	if out := sc.Render(110); !strings.Contains(out, "Delete") {
+		t.Fatalf("missing the delete confirm prompt\n%s", out)
+	}
+	cmd := sc.HandleKey(keyRunes("y"))
+	if cmd.Kind != SavesActionDelete || cmd.ID != "autosave-1.json" {
+		t.Fatalf("confirm = %+v, want Delete autosave-1.json", cmd)
+	}
+}
+
+// TestSavesSetEntriesClampsCursor — refreshing the list after a delete
+// keeps the cursor in range.
+func TestSavesSetEntriesClampsCursor(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	sc.HandleKey(keyDown)
+	sc.HandleKey(keyDown) // cursor on the last row
+	sc.SetEntries(savesFixture()[:1])
+	if sc.cursor != 0 {
+		t.Fatalf("cursor = %d after shrink to 1 row, want 0", sc.cursor)
+	}
+	// And an emptied list renders its placeholder without panicking.
+	sc.SetEntries(nil)
+	if out := sc.Render(110); !strings.Contains(out, "no saves") {
+		t.Errorf("empty list missing placeholder\n%s", out)
+	}
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Errorf("enter on empty list returned %v, want None", cmd.Kind)
+	}
+}
+
+// TestSavesEscCancels — esc in browse state returns Cancel; esc in a
+// confirm or naming state only backs out to browse.
+func TestSavesEscCancels(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	sc.HandleKey(keyEnter) // confirm-load
+	if cmd := sc.HandleKey(keyEsc); cmd.Kind != SavesActionNone {
+		t.Fatalf("esc in confirm returned %v, want None (back to browse)", cmd.Kind)
+	}
+	if cmd := sc.HandleKey(keyEsc); cmd.Kind != SavesActionCancel {
+		t.Fatalf("esc in browse returned %v, want Cancel", cmd.Kind)
+	}
+}
+
+// TestSavesClickTargets — mouse path: clicking a row moves the cursor;
+// clicking the selected row activates it (same as Enter); the confirm
+// [Yes]/[No] buttons and the title-row [Back] hit-test like the menu's.
+func TestSavesClickTargets(t *testing.T) {
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, savesFixture(), "default")
+	_ = sc.Render(110) // populate click ranges
+
+	// Click the second row: selects it, no action yet.
+	btn := sc.rowBtns[1]
+	col := (btn.colStart + btn.colEnd) / 2
+	if cmd := sc.HandleClick(col, btn.row); cmd.Kind != SavesActionNone {
+		t.Fatalf("first row click returned %v, want None", cmd.Kind)
+	}
+	if sc.cursor != 1 {
+		t.Fatalf("cursor = %d after row click, want 1", sc.cursor)
+	}
+	// Click it again: activates (load confirm opens).
+	_ = sc.Render(110)
+	if cmd := sc.HandleClick(col, btn.row); cmd.Kind != SavesActionNone {
+		t.Fatalf("second row click returned %v, want None (confirm gate)", cmd.Kind)
+	}
+	if sc.state != savesStateConfirmLoad {
+		t.Fatalf("state = %v after activating row click, want confirm-load", sc.state)
+	}
+	// [Yes] click commits the load of the clicked row.
+	_ = sc.Render(110)
+	yes := sc.yesBtn
+	cmd := sc.HandleClick((yes.colStart+yes.colEnd)/2, yes.row)
+	if cmd.Kind != SavesActionLoad || cmd.ID != "autosave-1.json" {
+		t.Fatalf("[Yes] click = %+v, want Load autosave-1.json", cmd)
+	}
+	// [Back] cancels out of the screen.
+	_ = sc.Render(110)
+	back := sc.backBtn
+	if cmd := sc.HandleClick((back.colStart+back.colEnd)/2, back.row); cmd.Kind != SavesActionCancel {
+		t.Fatalf("[Back] click = %+v, want Cancel", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

v0.26 slice S3 (plan: `v0.26-plan.md` §S3; design: ADR 0033 §F/§H — frozen). Builds on S1 (#195, saves-directory API) and S2 (#196, app wiring).

- **New `internal/tui/screens/saves.go`** — unified Saves browser in the MenuAction mold: the App passes the `save.List()` listing at open and dispatches the returned `SavesCommand`s against `internal/save`; the screen never touches the filesystem or the world.
- **List view**: every entry (named + quicksave + autosave-1/2/3), newest-first, columns name / saved-at / in-game date / active vessel. Reserved lanes render `[QUICKSAVE]` / `[AUTOSAVE N]` badges; Meta-less legacy and imported entries render blank in-game date (S2 handoff). In-game date uses the HUD clock chip's `2006-01-02` layout via a small `formatInGameDate` helper.
- **Entry-point mode flag**: `[Save Game]` opens save-mode (persistent `＋ New save…` row → textinput prefilled with active vessel + in-game day → `save.WriteNamed`; Enter on an existing **named** row → "Overwrite '<name>'?" confirm → `save.Overwrite` on that exact file **ID**, never a name match). `[Load Game]` opens load-mode (Enter → "Load and discard current state?" §H confirm → `save.LoadID`).
- **d = delete** (confirm; works on reserved lanes too — §F managed-but-deletable). **r = rename** via `bubbles/textinput` → `save.Rename`; disabled on reserved lanes. Reserved lanes are never overwritable/renamable.
- **Shared load path**: `doLoad`'s world-swap + `SetEnabledMissionPrograms` reapply extracted into `loadWorldByID`, reused by F9 and the browser load (per the S2 handoff — no duplication).
- **Menu integration**: both pause-menu items now open the Saves screen, replacing the S2 interim one-shot quicksave dispatch. Their mouse click-confirm gates are removed (opening a screen is reversible, like VAB/Settings); Quit keeps its gate. Browser toasts use a new generic `toast` helper — `flashStatus` stays F5/F9-specific.
- **Mouse**: buttonRange hit-testing — row click selects, second click activates, [Yes]/[No]/[Back] clickable.
- **Docs**: F1 overlay SAVES section (source of truth) + `docs/controls.md` Saves subsection (README defers its key list to controls.md; S4 owns the fuller README/version-history pass).

## Tests (TDD, per plan S3 list)

13 screen tests + 6 app-level tests: N rows w/ expected columns newest-first; Save-As default name → WriteNamed; overwrite targets the selected file (twin display names) and preserves siblings; rename edits Meta on named rows / no-op on reserved; delete confirm removes the row; load confirm gates the world swap.

`go vet ./...` clean · `go test ./... -race -count=1` → 1462 passed in 16 packages.

## Out of scope

Interval autosave, Settings row, broader docs pass (S4); no changes to physics/sim, SchemaVersion, or the `internal/save` API.