### PR TITLE
fix(save): F1 review slice — import retry gate, unreadable listing, SavedAt/ClockT0 dedup

### DIFF
--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -108,11 +108,12 @@ func main() {
 	}
 
 	// v0.26 (ADR 0033 §G): one-time migration of the legacy single-slot
-	// save.json into the saves/ directory as a named save. Fires only
-	// while saves/ is absent; the legacy file stays behind untouched as
-	// a downgrade safety net. Never fatal — on failure the player starts
-	// without the import and the probe retries next run (saves/ is only
-	// created by a successful write).
+	// save.json into the saves/ directory as a named save. Gated on a
+	// settled-marker (not the mere existence of saves/, which an autosave
+	// or a once-failed import can create), so a failed import retries next
+	// run instead of hiding the legacy save forever. The legacy file stays
+	// behind untouched as a downgrade safety net. Never fatal — on failure
+	// the player just starts without the import.
 	if info, imported, err := save.ImportLegacyIfNeeded(); err != nil {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: legacy save import skipped: %v\n", err)
 	} else if imported {

--- a/internal/save/import.go
+++ b/internal/save/import.go
@@ -13,34 +13,52 @@ import (
 	"time"
 )
 
+// legacyImportMarker is the path of the bookkeeping file that records
+// the one-time legacy save.json → saves/ migration has settled. It sits
+// beside the legacy save.json (the state dir), NOT inside saves/ — so a
+// quicksave/autosave that creates saves/ before the import, or a
+// once-failed import that left an empty saves/ behind, can never be
+// mistaken for a completed migration. The earlier bare os.Stat(saves/)
+// gate had exactly that false positive: any saves/ directory looked
+// "settled", permanently hiding an un-imported legacy save.
+func legacyImportMarker() (string, error) {
+	legacy, err := DefaultPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(legacy), ".legacy-imported"), nil
+}
+
 // ImportLegacyIfNeeded migrates the legacy single-slot save.json into
-// the saves directory as a named save — once. The probe fires only
-// while saves/ is absent (idempotent: any saves directory, even an
-// empty one, means the import already settled or the player started
-// fresh on v0.26+). The legacy file is read, never rewritten or
-// deleted — it stays behind untouched as a downgrade safety net (§G:
-// a pre-v0.26 binary still reads it).
+// the saves directory as a named save — once. It runs whenever the
+// import has not yet settled (the marker is absent) AND a legacy
+// save.json is present; a successful import drops the marker so it
+// never repeats, and a FAILED import leaves the marker absent so the
+// next startup retries (the marker, not the mere existence of saves/,
+// is what gates the retry). The legacy file is read, never rewritten or
+// deleted — it stays behind untouched as a downgrade safety net (§G: a
+// pre-v0.26 binary still reads it).
 //
 // The default name derives from the save's IN-GAME date, which lives
 // in Payload.SimTimeNano — hence the one full unmarshal of the one
 // legacy file. ClockT0 is wall-clock save time, not the in-game date,
-// and must not be substituted; it seeds Meta.SavedAt instead, so the
-// imported entry sorts truthfully in the browser. The payload bytes
-// are carried through raw, Rename-style, with the original schema
-// Version riding along untouched — LoadID migrates it on load like
-// any older save.
+// and must not be substituted; SavedAt derives from it (in memory only
+// — Meta.SavedAt is never persisted) so the imported entry sorts
+// truthfully in the browser. The payload bytes are carried through
+// raw, Rename-style, with the original schema Version riding along
+// untouched — LoadID migrates it on load like any older save.
 //
 // Returns the imported entry and true when the migration ran; the
 // zero SaveInfo and false when there was nothing to do.
 func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
-	dir, err := SavesDir()
+	marker, err := legacyImportMarker()
 	if err != nil {
 		return SaveInfo{}, false, err
 	}
-	if _, err := os.Stat(dir); err == nil {
-		return SaveInfo{}, false, nil // saves/ exists — import already settled
+	if _, err := os.Stat(marker); err == nil {
+		return SaveInfo{}, false, nil // marker present — import already settled
 	} else if !os.IsNotExist(err) {
-		return SaveInfo{}, false, fmt.Errorf("probe saves dir: %w", err)
+		return SaveInfo{}, false, fmt.Errorf("probe import marker: %w", err)
 	}
 	legacy, err := DefaultPath()
 	if err != nil {
@@ -49,7 +67,9 @@ func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
 	data, err := os.ReadFile(legacy)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return SaveInfo{}, false, nil // fresh install — nothing to import
+			// Fresh install — nothing to import. Deliberately no marker:
+			// if a legacy save is ever dropped in later, it still imports.
+			return SaveInfo{}, false, nil
 		}
 		return SaveInfo{}, false, fmt.Errorf("read legacy save: %w", err)
 	}
@@ -66,12 +86,15 @@ func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
 	if err := json.Unmarshal(rf.Payload, &p); err != nil {
 		return SaveInfo{}, false, fmt.Errorf("parse legacy payload: %w", err)
 	}
-	meta := &Meta{Name: "Imported save", SavedAt: time.Now().UTC()}
+	meta := &Meta{Name: "Imported save"}
 	if p.SimTimeNano != 0 {
 		meta.InGameEpoch = time.Unix(0, p.SimTimeNano).UTC()
 		meta.Name = "Imported " + meta.InGameEpoch.Format("2006-01-02")
 	}
 	if rf.ClockT0 != 0 {
+		// Derived, non-persisted (json:"-") — for the returned SaveInfo
+		// and the browser's newest-first sort. The legacy ClockT0 rides
+		// through in rf, so List recomputes the same value on read.
 		meta.SavedAt = time.Unix(0, rf.ClockT0).UTC()
 	}
 	if i := p.ActiveCraftIdx; i >= 0 && i < len(p.Crafts) {
@@ -88,9 +111,29 @@ func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
 	if err != nil {
 		return SaveInfo{}, false, fmt.Errorf("marshal imported save: %w", err)
 	}
+	dir, err := SavesDir()
+	if err != nil {
+		return SaveInfo{}, false, err
+	}
 	id := mintID()
 	if err := writeAtomic(filepath.Join(dir, id), out); err != nil {
 		return SaveInfo{}, false, err
 	}
+	// Settle the migration only after the imported file is safely on
+	// disk. A crash between the two leaves the marker absent → retry
+	// (worst case a duplicate import, never a lost save).
+	if err := markLegacyImported(marker); err != nil {
+		return SaveInfo{}, false, fmt.Errorf("write import marker: %w", err)
+	}
 	return SaveInfo{ID: id, Meta: *meta, Lane: LaneNamed}, true, nil
+}
+
+// markLegacyImported drops the settled-migration marker (finding: the
+// retry gate). The content is human-facing only — presence is what
+// matters.
+func markLegacyImported(marker string) error {
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+	return os.WriteFile(marker, []byte("v0.26 legacy save.json imported (ADR 0033 §G)\n"), 0o644)
 }

--- a/internal/save/import_test.go
+++ b/internal/save/import_test.go
@@ -118,10 +118,14 @@ func TestImportLegacyIfNeededFreshInstall(t *testing.T) {
 	}
 }
 
-// TestImportLegacyIfNeededSavesDirExists — an existing saves/
-// directory (even empty) means the import already settled; the legacy
-// file never re-imports.
-func TestImportLegacyIfNeededSavesDirExists(t *testing.T) {
+// TestImportRetriesWhenSavesDirExistsButNotSettled — regression for the
+// finding-1 retry gate. A saves/ directory that exists for some OTHER
+// reason (a quicksave/autosave wrote it, or a prior import failed after
+// MkdirAll but before the imported file landed) must NOT block the
+// migration: with the settled-marker absent, an existing saves/ dir
+// still imports the legacy save. The old bare-Stat(saves/) gate hid the
+// legacy save forever here.
+func TestImportRetriesWhenSavesDirExistsButNotSettled(t *testing.T) {
 	dir := testSavesDir(t)
 	w := newTestWorld(t)
 
@@ -132,17 +136,56 @@ func TestImportLegacyIfNeededSavesDirExists(t *testing.T) {
 	if err := save.Save(w, legacyPath); err != nil {
 		t.Fatalf("Save legacy fixture: %v", err)
 	}
+	// saves/ already present (a quicksave got there first) but the
+	// migration never settled — no marker.
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("MkdirAll saves: %v", err)
 	}
 
-	if _, imported, err := save.ImportLegacyIfNeeded(); err != nil {
+	_, imported, err := save.ImportLegacyIfNeeded()
+	if err != nil {
 		t.Fatalf("ImportLegacyIfNeeded: %v", err)
-	} else if imported {
-		t.Error("imported despite an existing saves/ directory")
+	}
+	if !imported {
+		t.Fatal("did not import despite an existing-but-unsettled saves/ dir — the legacy save would be lost")
+	}
+	if files := jsonFiles(t, dir); len(files) != 1 {
+		t.Errorf("saves dir = %v, want the one imported file", files)
+	}
+}
+
+// TestImportMarkerBlocksReimport — once the migration has settled (the
+// marker is written), the legacy save never re-imports, even if the
+// player later deletes every file in saves/. The import is one-time;
+// deleting the imported game must not resurrect it every launch.
+func TestImportMarkerBlocksReimport(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	legacyPath, err := save.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if err := save.Save(w, legacyPath); err != nil {
+		t.Fatalf("Save legacy fixture: %v", err)
+	}
+
+	info, imported, err := save.ImportLegacyIfNeeded()
+	if err != nil || !imported {
+		t.Fatalf("first import: imported=%v err=%v", imported, err)
+	}
+	// Player deletes the imported save.
+	if err := save.Delete(info.ID); err != nil {
+		t.Fatalf("Delete imported: %v", err)
+	}
+
+	if _, again, err := save.ImportLegacyIfNeeded(); err != nil {
+		t.Fatalf("second ImportLegacyIfNeeded: %v", err)
+	} else if again {
+		t.Error("re-imported after the marker settled — the migration must be one-time")
 	}
 	if files := jsonFiles(t, dir); len(files) != 0 {
-		t.Errorf("saves dir = %v, want empty", files)
+		t.Errorf("saves dir = %v, want empty (deleted, not resurrected)", files)
 	}
 }
 

--- a/internal/save/saves.go
+++ b/internal/save/saves.go
@@ -29,17 +29,23 @@ import (
 // a pre-v0.26 v9 envelope (no meta key) still loads (§J); the legacy
 // single-slot Save writer stamps no Meta at all.
 //
-// SavedAt is wall-clock write time (the newest-first sort key);
 // InGameEpoch is the simulation clock (Payload.SimTimeNano) at save
-// time — the two are distinct and must not be conflated. Name is the
-// player-facing Save name; reserved lanes (quicksave/autosave) leave
-// it empty and are labelled by Lane instead.
+// time. Name is the player-facing Save name; reserved lanes
+// (quicksave/autosave) leave it empty and are labelled by Lane instead.
 type Meta struct {
 	Name             string    `json:"name,omitempty"`
-	SavedAt          time.Time `json:"saved_at,omitzero"`
 	InGameEpoch      time.Time `json:"in_game_epoch,omitzero"`
 	ActiveVesselName string    `json:"active_vessel_name,omitempty"`
 	SystemName       string    `json:"system_name,omitempty"`
+
+	// SavedAt is the wall-clock write time — but it is NOT persisted
+	// (json:"-"). The envelope's ClockT0 is the single on-disk source of
+	// that timestamp; SavedAt is DERIVED from it on every read (ReadHeader
+	// / List / the import), so assigning this field has no on-disk effect.
+	// It stays on Meta only as the browser's ready-to-render sort +
+	// display value. (Pre-v0.26.0 the two were persisted side by side —
+	// pure duplication; de-duplicated before release, ADR 0033.)
+	SavedAt time.Time `json:"-"`
 }
 
 // Lane classifies a saves-directory entry by its reserved-filename
@@ -71,10 +77,20 @@ var ErrReservedLane = errors.New("save: reserved quicksave/autosave lane")
 // SaveInfo is one saves-directory listing entry: the opaque filename
 // (the stable ID every targeted operation takes), its parsed Meta,
 // and which lane the filename falls in.
+//
+// Unreadable flags an entry whose header would not parse — a corrupt
+// file, or one written by a newer build (a post-downgrade schema-v(N+1)
+// save). List surfaces these rather than dropping them (ADR 0033 §C):
+// silently hiding a file makes a directory that clearly holds saves
+// read as empty, and — worse — a newer-build save would vanish on a
+// downgrade with no trace. The browser renders them dimmed and
+// non-loadable, with Note as the reason; SavedAt/Meta are zero.
 type SaveInfo struct {
-	ID   string
-	Meta Meta
-	Lane Lane
+	ID         string
+	Meta       Meta
+	Lane       Lane
+	Unreadable bool
+	Note       string // human-facing reason when Unreadable (e.g. "newer version", "corrupt")
 }
 
 // SavesDir returns the saves-directory path,
@@ -121,20 +137,21 @@ func readRawHeader(path string) (header, error) {
 
 // ReadHeader returns the envelope's Meta without hydrating the
 // Payload: no World rebuild, no body-catalog load or hash check (ADR
-// 0033 §C — the browser lists N files this way). For a Meta-less
-// pre-v0.26 envelope, SavedAt is derived from ClockT0 (which is
-// wall-clock save time, so newest-first ordering still works); the
-// in-game date is unknowable from the header and InGameEpoch stays
-// zero — only a full Payload read (Load) can recover it.
+// 0033 §C — the browser lists N files this way). SavedAt is always
+// derived from the envelope's ClockT0 (wall-clock save time — the
+// single source of truth, never persisted on Meta itself), so a
+// stamped and a Meta-less pre-v0.26 envelope order identically. The
+// in-game date is unknowable from a Meta-less header and InGameEpoch
+// stays zero — only a full Payload read (Load) can recover it.
 func ReadHeader(path string) (Meta, error) {
 	h, err := readRawHeader(path)
 	if err != nil {
 		return Meta{}, err
 	}
-	if h.Meta != nil {
-		return *h.Meta, nil
-	}
 	var m Meta
+	if h.Meta != nil {
+		m = *h.Meta
+	}
 	if h.ClockT0 != 0 {
 		m.SavedAt = time.Unix(0, h.ClockT0).UTC()
 	}
@@ -179,8 +196,11 @@ func idPath(id string) (string, error) {
 // List scans the saves directory and header-parses every entry,
 // newest SavedAt first (ties broken by filename for determinism). A
 // missing directory lists as empty — first run, before any save
-// exists. Entries that fail the header parse (foreign or corrupt
-// files) are skipped rather than aborting the whole listing.
+// exists. A .json file whose header will not parse (corrupt, or a
+// newer-build schema version after a downgrade) is surfaced as an
+// Unreadable entry rather than silently dropped (§C) — it sorts to the
+// bottom on a zero SavedAt and the browser shows it dimmed and
+// non-loadable. Only non-.json strays and tmpfiles are skipped.
 func List() ([]SaveInfo, error) {
 	dir, err := SavesDir()
 	if err != nil {
@@ -201,6 +221,12 @@ func List() ([]SaveInfo, error) {
 		}
 		m, err := ReadHeader(filepath.Join(dir, name))
 		if err != nil {
+			infos = append(infos, SaveInfo{
+				ID:         name,
+				Lane:       laneOf(name),
+				Unreadable: true,
+				Note:       unreadableNote(err),
+			})
 			continue
 		}
 		infos = append(infos, SaveInfo{ID: name, Meta: m, Lane: laneOf(name)})
@@ -215,15 +241,27 @@ func List() ([]SaveInfo, error) {
 	return infos, nil
 }
 
+// unreadableNote classifies a header-parse failure into a short,
+// player-facing reason for the browser. A schema-range rejection means
+// the file was written by a different (usually newer) build; anything
+// else is treated as corruption.
+func unreadableNote(err error) string {
+	if errors.Is(err, ErrSchemaMismatch) {
+		return "newer version"
+	}
+	return "corrupt"
+}
+
 // stampMeta builds the Meta header for a write happening now. name is
 // empty for the reserved lanes (§D — quicksave/autosaves carry full
 // metadata but no player name). The system column is the active
 // vessel's own System (ADR 0015 — per-Vessel binding), falling back
 // to the world-level viewed system when there is no active craft.
 func stampMeta(w *sim.World, name string) *Meta {
+	// SavedAt is intentionally not stamped here — it is derived from the
+	// envelope ClockT0 on read (see Meta). InGameEpoch is the sim clock.
 	m := &Meta{
 		Name:        name,
-		SavedAt:     time.Now().UTC(),
 		InGameEpoch: w.Clock.SimTime,
 	}
 	if c := w.ActiveCraft(); c != nil {
@@ -268,6 +306,10 @@ func WriteNamed(w *sim.World, name string) (SaveInfo, error) {
 	if err := writeFileAtomic(filepath.Join(dir, id), f); err != nil {
 		return SaveInfo{}, err
 	}
+	// Populate the derived SavedAt in the returned entry from the
+	// envelope ClockT0 just written, so the caller sees the same
+	// wall-clock time List will read back (SavedAt is never persisted).
+	meta.SavedAt = time.Unix(0, f.ClockT0).UTC()
 	return SaveInfo{ID: id, Meta: *meta, Lane: LaneNamed}, nil
 }
 
@@ -314,9 +356,9 @@ func WriteQuicksave(w *sim.World) error {
 
 // WriteAutosave writes w into the rotating autosave ring (ADR 0033
 // §E): a missing slot is filled before any rotation, otherwise the
-// slot with the oldest SavedAt is overwritten — and an unreadable or
-// Meta-less ring file counts as oldest (it is the least valuable
-// thing in the ring, so it goes first).
+// slot with the oldest ClockT0 is overwritten — and an unreadable ring
+// file counts as the first victim (it is the least valuable thing in
+// the ring, so it goes first).
 func WriteAutosave(w *sim.World) error {
 	dir, err := SavesDir()
 	if err != nil {
@@ -330,8 +372,9 @@ func WriteAutosave(w *sim.World) error {
 }
 
 // autosaveVictim picks the ring slot the next autosave overwrites:
-// first missing slot, else unreadable/Meta-less slot, else oldest
-// SavedAt.
+// first missing slot, else unreadable slot, else oldest ClockT0 (the
+// wall-clock write time — SavedAt is derived from it, so comparing the
+// envelope field directly is the same ordering without a Meta derive).
 func autosaveVictim(dir string) string {
 	for _, id := range autosaveIDs {
 		if _, err := os.Stat(filepath.Join(dir, id)); err != nil {
@@ -339,15 +382,15 @@ func autosaveVictim(dir string) string {
 		}
 	}
 	victim := autosaveIDs[0]
-	var oldest time.Time
+	var oldest int64
 	haveOldest := false
 	for _, id := range autosaveIDs {
 		h, err := readRawHeader(filepath.Join(dir, id))
-		if err != nil || h.Meta == nil {
-			return id
+		if err != nil {
+			return id // unreadable ring file — evict first
 		}
-		if !haveOldest || h.Meta.SavedAt.Before(oldest) {
-			victim, oldest, haveOldest = id, h.Meta.SavedAt, true
+		if !haveOldest || h.ClockT0 < oldest {
+			victim, oldest, haveOldest = id, h.ClockT0, true
 		}
 	}
 	return victim
@@ -392,10 +435,11 @@ func Delete(id string) error {
 
 // Rename sets the save's display name — a pure Meta rewrite (ADR 0033
 // §B): same filename, Payload bytes carried through untouched as raw
-// JSON, SavedAt preserved so the rename doesn't reorder the list.
-// Reserved lanes refuse (§F). A Meta-less legacy file gains a Meta on
-// rename, with SavedAt backfilled from ClockT0 (the in-game date
-// stays unknowable from the header and is left zero).
+// JSON, ClockT0 carried through so the rename doesn't reorder the list
+// (SavedAt derives from it, so ordering is preserved for free).
+// Reserved lanes refuse (§F). A Meta-less legacy file gains an empty
+// Meta on rename to hold the name; the in-game date stays unknowable
+// from the header and is left zero.
 func Rename(id, name string) error {
 	if laneOf(id) != LaneNamed {
 		return fmt.Errorf("%w: %s", ErrReservedLane, id)
@@ -414,9 +458,6 @@ func Rename(id, name string) error {
 	}
 	if rf.Meta == nil {
 		rf.Meta = &Meta{}
-		if rf.ClockT0 != 0 {
-			rf.Meta.SavedAt = time.Unix(0, rf.ClockT0).UTC()
-		}
 	}
 	rf.Meta.Name = name
 	out, err := json.MarshalIndent(rf, "", "  ")

--- a/internal/save/saves_test.go
+++ b/internal/save/saves_test.go
@@ -171,8 +171,11 @@ func TestReadHeaderSkipsCatalogAndPayload(t *testing.T) {
 	if m.Name != "Handmade" || m.ActiveVesselName != "Apollo" || m.SystemName != "Sol" {
 		t.Errorf("Meta = %+v", m)
 	}
-	if want := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC); !m.SavedAt.Equal(want) {
-		t.Errorf("SavedAt = %v, want %v", m.SavedAt, want)
+	// SavedAt derives from the envelope clock_t0 (the single source of
+	// truth), NOT from any persisted saved_at key — the "saved_at":
+	// "2026-07-01…" above is an ignored legacy key and must NOT win.
+	if want := time.Unix(0, 1234567890).UTC(); !m.SavedAt.Equal(want) {
+		t.Errorf("SavedAt = %v, want ClockT0-derived %v (saved_at key must be ignored)", m.SavedAt, want)
 	}
 
 	// Sanity: the same file is rejected by the full Load path on the
@@ -568,5 +571,94 @@ func TestDeleteRemovesTargetedFile(t *testing.T) {
 	}
 	if got := jsonFiles(t, dir); len(got) != 1 || got[0] != b.ID {
 		t.Fatalf("saves dir = %v, want exactly [%s]", got, b.ID)
+	}
+}
+
+// TestSavedAtNotPersisted — the wall-clock write time lives ONLY in the
+// envelope's clock_t0; Meta must not also persist a saved_at key (the
+// pre-release duplication that finding 10 removed). List still surfaces
+// a non-zero SavedAt because it derives from clock_t0 on read.
+func TestSavedAtNotPersisted(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	info, err := save.WriteNamed(w, "no dup")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	// The returned entry carries the derived SavedAt (from the ClockT0
+	// just written), so callers still see a real time.
+	if info.Meta.SavedAt.IsZero() {
+		t.Error("returned SavedAt is zero, want the ClockT0-derived write time")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, info.ID))
+	if err != nil {
+		t.Fatalf("read save: %v", err)
+	}
+	if bytes.Contains(raw, []byte("saved_at")) {
+		t.Errorf("save JSON persists a saved_at key — must be derived from clock_t0 only:\n%s", raw)
+	}
+	if !bytes.Contains(raw, []byte("clock_t0")) {
+		t.Errorf("save JSON missing clock_t0 (the wall-clock source of truth):\n%s", raw)
+	}
+
+	// And List recomputes the same SavedAt from clock_t0 on read.
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Meta.SavedAt.IsZero() {
+		t.Errorf("List SavedAt not derived from clock_t0: %+v", infos)
+	}
+}
+
+// TestListSurfacesUnreadable — finding 6. A corrupt .json and a
+// newer-build (schema v+1) save are LISTED as flagged, non-loadable
+// entries rather than silently dropped: a directory that plainly holds
+// files must never render as "(no saves yet)", and a newer-version save
+// must stay visible on a downgrade. Valid saves list normally alongside.
+func TestListSurfacesUnreadable(t *testing.T) {
+	dir := testSavesDir(t)
+	w := newTestWorld(t)
+
+	good, err := save.WriteNamed(w, "readable")
+	if err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "save-corrupt.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newer := `{"version": 999, "generator": "future", "clock_t0": 1, "payload": {}}`
+	if err := os.WriteFile(filepath.Join(dir, "save-newer.json"), []byte(newer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	infos, err := save.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(infos) != 3 {
+		t.Fatalf("List = %d entries, want 3 (1 valid + 2 flagged)", len(infos))
+	}
+
+	byID := map[string]save.SaveInfo{}
+	for _, in := range infos {
+		byID[in.ID] = in
+	}
+	if g := byID[good.ID]; g.Unreadable {
+		t.Errorf("valid save flagged unreadable: %+v", g)
+	}
+	corrupt, ok := byID["save-corrupt.json"]
+	if !ok || !corrupt.Unreadable || corrupt.Note != "corrupt" {
+		t.Errorf("corrupt entry = %+v, want Unreadable with Note=corrupt", corrupt)
+	}
+	future, ok := byID["save-newer.json"]
+	if !ok || !future.Unreadable || future.Note != "newer version" {
+		t.Errorf("newer entry = %+v, want Unreadable with Note=\"newer version\"", future)
+	}
+	// The valid save sorts above the (zero-SavedAt) flagged ones.
+	if infos[0].ID != good.ID {
+		t.Errorf("newest entry = %q, want the valid save %q first", infos[0].ID, good.ID)
 	}
 }

--- a/internal/tui/screens/saves.go
+++ b/internal/tui/screens/saves.go
@@ -231,7 +231,7 @@ func (sc *SavesScreen) HandleKey(msg tea.KeyMsg) SavesCommand {
 		// Rename is a benign Meta edit (no confirm, §H) but is
 		// disabled on the reserved lanes (§F) — they carry no player
 		// name by design.
-		if info, ok := sc.entryAt(sc.cursor); ok && info.Lane == save.LaneNamed {
+		if info, ok := sc.entryAt(sc.cursor); ok && info.Lane == save.LaneNamed && !info.Unreadable {
 			sc.pendingID, sc.pendingName = info.ID, displaySaveName(info)
 			sc.beginNaming(savesStateRename, info.Meta.Name)
 		}
@@ -282,6 +282,11 @@ func (sc *SavesScreen) activateCursor() SavesCommand {
 	if !ok {
 		return SavesCommand{}
 	}
+	if info.Unreadable {
+		// A corrupt / newer-version file can't be loaded or overwritten
+		// in place; it's listed only so it's visible and deletable (§C).
+		return SavesCommand{}
+	}
 	sc.pendingID, sc.pendingName = info.ID, displaySaveName(info)
 	if sc.mode == SavesModeSave {
 		if info.Lane != save.LaneNamed {
@@ -324,6 +329,14 @@ func (sc *SavesScreen) beginNaming(state savesState, prefill string) {
 // legacy file), and a lane badge for the reserved quicksave/autosave
 // lanes — which carry no player name by design (§D).
 func displaySaveName(info save.SaveInfo) string {
+	if info.Unreadable {
+		// Kept within the name column (savesColName=26) so it isn't
+		// ellipsised: "unreadable (newer version)" is exactly 26.
+		if info.Note != "" {
+			return "unreadable (" + info.Note + ")"
+		}
+		return "unreadable"
+	}
 	switch info.Lane {
 	case save.LaneQuicksave:
 		return "[QUICKSAVE]"
@@ -405,12 +418,20 @@ func (sc *SavesScreen) Render(width int) string {
 	// Rows.
 	sc.rowBtns = make([]buttonRange, sc.rowCount())
 	rowIdx := 0
-	addRow := func(body string) {
+	// addRow renders one selectable row. dimmed forces the Dim style even
+	// off-cursor (an unreadable/non-loadable entry) while the cursor
+	// marker still tracks selection so it can be selected for deletion.
+	addRow := func(body string, dimmed bool) {
 		marker := "  "
 		style := sc.theme.Primary
+		if dimmed {
+			style = sc.theme.Dim
+		}
 		if rowIdx == sc.cursor {
 			marker = "▸ "
-			style = sc.theme.Warning
+			if !dimmed {
+				style = sc.theme.Warning
+			}
 		}
 		sc.rowBtns[rowIdx] = buttonRange{
 			row:      len(lines),
@@ -422,14 +443,14 @@ func (sc *SavesScreen) Render(width int) string {
 		rowIdx++
 	}
 	if sc.hasNewRow() {
-		addRow("＋ New save…")
+		addRow("＋ New save…", false)
 	}
 	for _, info := range sc.entries {
 		body := padCell(displaySaveName(info), savesColName) +
 			padCell(formatSavedAt(info.Meta.SavedAt), savesColSavedAt) +
 			padCell(formatInGameDate(info.Meta.InGameEpoch), savesColInGame) +
 			info.Meta.ActiveVesselName
-		addRow(body)
+		addRow(body, info.Unreadable)
 	}
 	if len(sc.entries) == 0 && !sc.hasNewRow() {
 		lines = append(lines, sc.theme.Dim.Render("  (no saves yet — F5 quicksaves, or save from the menu)"))

--- a/internal/tui/screens/saves_test.go
+++ b/internal/tui/screens/saves_test.go
@@ -280,6 +280,44 @@ func TestSavesDeleteConfirm(t *testing.T) {
 	}
 }
 
+// TestSavesUnreadableRowNotLoadable — finding 6. An Unreadable entry
+// (corrupt / newer-version) renders with its reason label but is NOT
+// loadable or renamable; it stays deletable so the player can clear it.
+func TestSavesUnreadableRowNotLoadable(t *testing.T) {
+	entries := []save.SaveInfo{
+		{ID: "save-newer.json", Lane: save.LaneNamed, Unreadable: true, Note: "newer version"},
+	}
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, entries, "default")
+
+	out := sc.Render(110)
+	if !strings.Contains(out, "unreadable (newer version)") {
+		t.Fatalf("unreadable row missing its reason label\n%s", out)
+	}
+	// A directory holding a file must never read as empty.
+	if strings.Contains(out, "no saves yet") {
+		t.Errorf("rendered the empty-list message despite a listed (unreadable) entry\n%s", out)
+	}
+
+	// Enter must NOT open a load confirm — nothing to hydrate.
+	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
+		t.Fatalf("enter on unreadable row returned %v, want None", cmd.Kind)
+	}
+	if strings.Contains(sc.Render(110), "Load and discard") {
+		t.Errorf("unreadable row opened a load confirm")
+	}
+	// Rename disabled.
+	if cmd := sc.HandleKey(keyRunes("r")); cmd.Kind != SavesActionNone || sc.state != savesStateBrowse {
+		t.Fatalf("r on unreadable row: cmd=%v state=%v, want no-op", cmd.Kind, sc.state)
+	}
+	// Delete still works — the player can clear the bad file.
+	sc.HandleKey(keyRunes("d"))
+	cmd := sc.HandleKey(keyRunes("y"))
+	if cmd.Kind != SavesActionDelete || cmd.ID != "save-newer.json" {
+		t.Fatalf("delete of unreadable = %+v, want Delete save-newer.json", cmd)
+	}
+}
+
 // TestSavesSetEntriesClampsCursor — refreshing the list after a delete
 // keeps the cursor in range.
 func TestSavesSetEntriesClampsCursor(t *testing.T) {


### PR DESCRIPTION
First of three v0.26 batch-review fix slices (ADR 0033 multi-save). Save-package findings; F2 (autosave/resume) and F3 (screen render/input) follow. **v0.26.0 is not tagged yet** — these land first.

## Findings addressed

**1 — Import retry gate permanently defeated** (`import.go`). The gate was a bare `os.Stat(SavesDir())`, but `writeAtomic` `MkdirAll`s `saves/` before its tmpfile write and any quicksave/autosave creates the dir — so a once-failed import (ENOSPC/EACCES/read blip) never retried and the legacy `save.json` was invisible forever. Now gated on a **settled-marker** (`.legacy-imported`, beside `save.json`, written only *after* the imported file lands): a failed import retries next run; an unrelated `saves/` dir no longer blocks migration; one-time semantics preserved (marker blocks re-import even if the imported save is later deleted).

**6 — `List` silently dropped unreadable/newer saves** (`saves.go`). A corrupt named save or a post-downgrade schema-v(N+1) save vanished and the browser showed a false "(no saves yet…)". `List` now surfaces them as flagged `Unreadable` entries (`Note` = "corrupt" vs "newer version"); the browser renders them dimmed and non-loadable/non-renamable but still **deletable** so the player can clear them.

**10 — `Meta.SavedAt` duplicated envelope `ClockT0`** (pre-tag cleanup; format has zero external adopters). `saved_at` is no longer persisted (`json:"-"`); `SavedAt` is **derived from `ClockT0`** on every read. Deletes Rename's backfill, import's stamp-then-overwrite, and the Meta-less ordering special case; `autosaveVictim` compares `ClockT0` directly. In-memory ergonomics kept (`WriteNamed`/import populate the derived value on return).

## Tests
- Rewrote the old `SavesDirExists` test (which pinned the *broken* behavior) into `TestImportRetriesWhenSavesDirExistsButNotSettled` + `TestImportMarkerBlocksReimport`.
- Added `TestSavedAtNotPersisted` (asserts on-disk bytes carry `clock_t0`, not `saved_at`), `TestListSurfacesUnreadable`, and screen `TestSavesUnreadableRowNotLoadable`.
- Updated `TestReadHeaderSkipsCatalogAndPayload` for the new invariant (a persisted `saved_at` key is ignored; `ClockT0` wins).

`go vet ./...` + `go test ./... -race -count=1` green (1480 tests). `SchemaVersion` unchanged (9).