### PR TITLE
fix(tui): F2 review slice — autosave + resume semantics

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -96,6 +96,14 @@ type App struct {
 	bossReturnScreen screenID
 	bossPrevPaused   bool
 
+	// savesPrevPaused records the sim pause state when the Saves screen
+	// opened (finding 4). The Saves browser freezes the clock while it is
+	// up so a save can't capture a world that drifted (or crashed) while
+	// the player typed a name; exit restores the prior state — mirroring
+	// the boss-key save/restore. A load exits by replacing the world
+	// outright, so it never restores this.
+	savesPrevPaused bool
+
 	// statusMsg flashes a one-line notice in the HUD footer for ~3
 	// seconds after save / load. Cleared by clearStatusAfter via a
 	// scheduled tea.Cmd.
@@ -1205,12 +1213,39 @@ func (a *App) doSave() error {
 // instant, no confirm (ADR 0033 §H). An empty lane (no F5 yet) is
 // surfaced as a clear "no quicksave" message rather than a raw
 // file-not-found; failures leave the existing world untouched.
+//
+// When there is no quicksave but an autosave IS on disk (the common
+// quit → relaunch → F9 case, whose quit state landed in the autosave
+// ring, not the quicksave lane), the message points the player at the
+// Saves browser instead of dead-ending — the signpost fix for
+// batch-review finding 5. F9 deliberately does NOT auto-load the
+// autosave: a stray mid-session F9 must never silently discard live
+// progress, so resuming an autosave stays an explicit menu action.
 func (a *App) doLoad() error {
 	err := a.loadWorldByID(save.QuicksaveID)
 	if errors.Is(err, fs.ErrNotExist) {
+		if a.hasResumableAutosave() {
+			return errors.New("no quicksave — press Esc → Load to resume your autosave")
+		}
 		return errors.New("no quicksave yet — press F5 first")
 	}
 	return err
+}
+
+// hasResumableAutosave reports whether the saves directory holds at
+// least one readable autosave-ring entry — the state F9 points the
+// player at when the quicksave lane is empty (finding 5).
+func (a *App) hasResumableAutosave() bool {
+	infos, err := save.List()
+	if err != nil {
+		return false
+	}
+	for _, in := range infos {
+		if in.Lane == save.LaneAutosave && !in.Unreadable {
+			return true
+		}
+	}
+	return false
 }
 
 // loadWorldByID hydrates the save id and swaps it in as the live
@@ -1258,6 +1293,16 @@ func (a *App) maybeAutosave(now time.Time) {
 		return
 	}
 	if now.Sub(a.lastAutosave) < interval {
+		return
+	}
+	// Don't autosave a frozen world. Wall-clock ticks keep flowing while
+	// the sim is paused (pause menu, boss key, maneuver planning, a long
+	// idle), but the state never changes — firing here would evict all
+	// three distinct recovery slots with identical snapshots. The anchor
+	// is intentionally NOT re-armed on this skip, so the first tick after
+	// unpause captures one honest live snapshot instead of none. (Fix:
+	// batch-review finding 2.)
+	if a.world.Clock.Paused {
 		return
 	}
 	a.lastAutosave = now // re-arm even on error so a failing disk isn't hammered every tick
@@ -1404,7 +1449,22 @@ func (a *App) openSaves(mode screens.SavesMode) {
 		a.toast(fmt.Sprintf("saves listing failed: %v", err))
 	}
 	a.saves.Open(mode, entries, defaultSaveName(a.world))
+	// Freeze the clock while the browser is up (finding 4) — a Save-As
+	// captured a drifting world otherwise, since the pause menu itself
+	// keeps the sim running. Restored on exit (see closeSavesToOrbit).
+	a.savesPrevPaused = a.world.Clock.Paused
+	a.world.Clock.Paused = true
 	a.active = screenSaves
+}
+
+// closeSavesToOrbit leaves the Saves browser back to the flight view,
+// restoring the pause state the sim had before it opened (finding 4).
+// Used by every non-load exit — cancel, Save-As, overwrite. A load does
+// NOT route through here: it swaps in a fresh world whose own pause
+// state applies.
+func (a *App) closeSavesToOrbit() {
+	a.world.Clock.Paused = a.savesPrevPaused
+	a.active = screenOrbit
 }
 
 // refreshSaves re-lists the directory into the open Saves screen after
@@ -1437,7 +1497,7 @@ func defaultSaveName(w *sim.World) string {
 func (a *App) applySavesCommand(cmd screens.SavesCommand) (tea.Model, tea.Cmd) {
 	switch cmd.Kind {
 	case screens.SavesActionCancel:
-		a.active = screenOrbit
+		a.closeSavesToOrbit()
 	case screens.SavesActionLoad:
 		if err := a.loadWorldByID(cmd.ID); err != nil {
 			a.toast(fmt.Sprintf("load failed: %v", err))
@@ -1463,14 +1523,14 @@ func (a *App) applySavesCommand(cmd screens.SavesCommand) (tea.Model, tea.Cmd) {
 			a.toast(fmt.Sprintf("save failed: %v", err))
 		} else {
 			a.toast(fmt.Sprintf("saved '%s'", cmd.Name))
-			a.active = screenOrbit
+			a.closeSavesToOrbit()
 		}
 	case screens.SavesActionOverwrite:
 		if err := save.Overwrite(cmd.ID, a.world); err != nil {
 			a.toast(fmt.Sprintf("overwrite failed: %v", err))
 		} else {
 			a.toast(fmt.Sprintf("overwrote '%s'", cmd.Name))
-			a.active = screenOrbit
+			a.closeSavesToOrbit()
 		}
 	}
 	return a, nil

--- a/internal/tui/app_autosave_interval_test.go
+++ b/internal/tui/app_autosave_interval_test.go
@@ -80,6 +80,36 @@ func TestIntervalAutosaveRotatesRing(t *testing.T) {
 	}
 }
 
+// TestIntervalAutosaveSkippedWhilePaused — finding 2. Wall-clock ticks
+// keep flowing while the sim is paused, but the frozen world must not
+// autosave: three idle intervals must not evict all three ring slots
+// with identical snapshots. Unpausing captures exactly one honest
+// snapshot on the next due tick.
+func TestIntervalAutosaveSkippedWhilePaused(t *testing.T) {
+	dir := testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	t0 := time.Now()
+	tickAt(a, t0) // arm
+	a.world.Clock.Paused = true
+
+	for i := 1; i <= 3; i++ {
+		tickAt(a, t0.Add(time.Duration(i)*5*time.Minute))
+	}
+	if files := savesDirFiles(t, dir); len(files) != 0 {
+		t.Fatalf("saves dir = %v after 3 paused intervals, want empty (a frozen world must not autosave)", files)
+	}
+
+	a.world.Clock.Paused = false
+	tickAt(a, t0.Add(4*5*time.Minute))
+	if files := savesDirFiles(t, dir); len(files) != 1 {
+		t.Fatalf("saves dir = %v after unpause, want exactly one autosave", files)
+	}
+}
+
 // TestIntervalAutosaveDisabledByZero — interval 0 ("off") suppresses
 // the periodic autosave entirely, while the on-quit autosave still
 // fires (S2 behaviour, unaffected by the setting).

--- a/internal/tui/app_saves_pause_test.go
+++ b/internal/tui/app_saves_pause_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// TestSavesScreenFreezesSim — finding 4. The pause menu keeps the sim
+// running, so opening the Saves browser must freeze the clock: a Save-As
+// captured a world that drifted (or crashed) while the player typed a
+// name otherwise. Leaving via cancel / Save-As / overwrite restores the
+// pause state the sim had before it opened (mirroring the boss key).
+func TestSavesScreenFreezesSim(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.Clock.Paused {
+		t.Fatal("world started paused — test premise broken")
+	}
+
+	a.openSaves(screens.SavesModeSave)
+	if !a.world.Clock.Paused {
+		t.Error("opening the Saves browser did not freeze the sim (finding 4)")
+	}
+
+	// Cancel restores the prior (running) state and returns to orbit.
+	a.applySavesCommand(screens.SavesCommand{Kind: screens.SavesActionCancel})
+	if a.world.Clock.Paused {
+		t.Error("leaving the Saves browser did not restore the running clock")
+	}
+	if a.active != screenOrbit {
+		t.Errorf("active = %v, want screenOrbit after cancel", a.active)
+	}
+}
+
+// TestSavesScreenRestoresPriorPause — if the sim was ALREADY paused when
+// the browser opened (e.g. opened from a maneuver-planning pause), exit
+// must leave it paused, not force it running.
+func TestSavesScreenRestoresPriorPause(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.Clock.Paused = true
+
+	a.openSaves(screens.SavesModeLoad)
+	if !a.world.Clock.Paused {
+		t.Fatal("browser unfroze an already-paused sim")
+	}
+	a.applySavesCommand(screens.SavesCommand{Kind: screens.SavesActionCancel})
+	if !a.world.Clock.Paused {
+		t.Error("exit forced the clock to run despite a prior paused state")
+	}
+}

--- a/internal/tui/app_saves_test.go
+++ b/internal/tui/app_saves_test.go
@@ -126,6 +126,32 @@ func TestQuickloadEmptyLane(t *testing.T) {
 	}
 }
 
+// TestQuickloadEmptyLanePointsToAutosave — finding 5. When there is no
+// quicksave but an autosave IS on disk (the quit → relaunch → F9 case),
+// F9 stays a no-op signpost — it does NOT auto-load, so a stray
+// mid-session F9 can't silently discard live progress — and the message
+// points the player at the Saves browser (Load) instead of dead-ending.
+func TestQuickloadEmptyLanePointsToAutosave(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.autosave() // a quit-style autosave lands in the ring; no quicksave
+	old := a.world
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+	if a.world != old {
+		t.Fatal("F9 auto-loaded the autosave — it must stay a no-op signpost, not swap the world")
+	}
+	if !strings.Contains(a.statusMsg, "no quicksave") {
+		t.Errorf("statusMsg = %q, want a no-quicksave message", a.statusMsg)
+	}
+	if !strings.Contains(a.statusMsg, "Load") {
+		t.Errorf("statusMsg = %q, want it to point at the Saves browser (Esc → Load)", a.statusMsg)
+	}
+}
+
 // TestQuitAutosavesToRing — ctrl+c quit writes the rotating autosave
 // ring (ADR 0033 §E), not a named save and not the legacy single-slot
 // save.json.


### PR DESCRIPTION
Second of three v0.26 batch-review fix slices (ADR 0033). Autosave/resume UX in `app.go`; disjoint from F1 (save package) and F3 (screen render/input). **v0.26.0 not tagged yet.**

## Findings addressed

**2 — Paused-sim autosave ring flush** (`maybeAutosave`). Ticks keep flowing while the sim is paused (pause menu, boss key, maneuver planning, long idle), but `maybeAutosave` had no pause guard — ~15 idle minutes evicted all three distinct recovery slots with identical snapshots. Now skips when `world.Clock.Paused`, **without re-arming the anchor**, so the first tick after unpause captures one honest live snapshot instead of none.

**4 — Saves browser didn't pause the sim** (`openSaves`). The pause menu keeps the clock running, so the world integrated while the player typed a save name — the confirmed Save-As/Overwrite captured a drifted (possibly crashed) state. `openSaves` now freezes the clock (boss-key `savesPrevPaused` save/restore); `closeSavesToOrbit` restores the prior state on cancel / Save-As / overwrite. A load exits by replacing the world outright, so it never restores. **Menu stays unpaused** by design (only the save-capture surface is frozen).

**5 — quit → relaunch → F9 dead-ended** (`doLoad`). The quit state lands in the autosave ring, not the quicksave lane, so F9 hit "no quicksave yet — press F5 first" with the session sitting in `autosave-1.json`. F9 now points the player at the Saves browser (*"no quicksave — press Esc → Load to resume your autosave"*) when a readable autosave exists (reuses F1's `SaveInfo.Unreadable`). **Deliberately a signpost, not an auto-load** — a stray mid-session F9 must never silently discard live progress, so resuming an autosave stays an explicit menu action.

> **ADR amendment owed (docs pass):** finding 5's chosen behavior — F9 is a signpost to the Saves browser when the quicksave lane is empty; it does not auto-resume the autosave ring. (Maintainer-confirmed: safe/no-footgun over auto-fallback.)

## Tests
Real `App.Update` / `openSaves` / `doLoad` paths: paused-skip + unpause-fires-once, `openSaves` freeze + prior-pause restore, F9 signpost stays a no-op and points at Load. `go vet ./...` + `go test ./... -race -count=1` green (1484). `SchemaVersion` unchanged (9).