### PR TITLE
fix(tui): F3 review slice — Saves screen render + input routing

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -484,9 +484,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Keyboard-layout normalization (ADR 0022): translate the keypress
 		// from the player's layout back to its QWERTY position before any
 		// matching, so the Keymap and every raw-string handler stay QWERTY.
-		// Skipped for the boss shell, which consumes literal typed text — a
-		// QWERTZ player typing in the fake shell wants their real keycaps.
-		if a.active != screenBoss {
+		// Skipped while a screen is capturing literal text (the boss shell,
+		// a Saves name input) — a QWERTZ player typing there wants their
+		// real keycaps, not a transposed rune (finding 3).
+		if !a.capturingText() {
 			m = normalizeKey(a.layout, m)
 		}
 		// ctrl+c bypasses everything else (standard interrupt
@@ -510,7 +511,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
-		if key.Matches(m, a.keys.BossKey) {
+		// The boss key opens from any screen — EXCEPT while a screen is
+		// capturing literal text (a Saves name input), where a backtick is
+		// a character the player is typing, not the boss hotkey (finding 9).
+		if key.Matches(m, a.keys.BossKey) && !a.capturingText() {
 			a.bossReturnScreen = a.active
 			a.bossPrevPaused = a.world.Clock.Paused
 			a.world.Clock.Paused = true // freeze the sim while "away"
@@ -1467,6 +1471,24 @@ func (a *App) closeSavesToOrbit() {
 	a.active = screenOrbit
 }
 
+// capturingText reports whether the active screen is currently taking
+// literal typed text into a free-text field. While it is, the App
+// bypasses keyboard-layout normalization (finding 3) and the global
+// boss-key intercept (finding 9) so the raw keycaps reach the field: a
+// QWERTZ player's letters aren't transposed and a literal backtick types
+// a backtick instead of opening the boss shell. The boss shell is always
+// capturing; the Saves browser only during name entry (Save-As/rename).
+// Extend here as future free-text surfaces (VAB, spawn, search) land.
+func (a *App) capturingText() bool {
+	switch a.active {
+	case screenBoss:
+		return true
+	case screenSaves:
+		return a.saves.CapturingText()
+	}
+	return false
+}
+
 // refreshSaves re-lists the directory into the open Saves screen after
 // an in-screen mutation (delete / rename).
 func (a *App) refreshSaves() {
@@ -1687,7 +1709,7 @@ func (a *App) View() string {
 	case screenVAB:
 		base = a.vab.Render(a.width)
 	case screenSaves:
-		base = a.saves.Render(a.width)
+		base = a.saves.Render(a.width, a.height)
 	case screenBoss:
 		base = a.boss.Render(a.width, a.height)
 	default:

--- a/internal/tui/app_saves_input_test.go
+++ b/internal/tui/app_saves_input_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/keylayout"
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// enterSaveAsNaming opens the Saves browser in save-mode and steps into
+// the Save-As name-entry field (Enter on the New-save row).
+func enterSaveAsNaming(t *testing.T, a *App) {
+	t.Helper()
+	a.openSaves(screens.SavesModeSave)
+	a.Update(tea.KeyMsg{Type: tea.KeyEnter}) // New-save row → name entry
+	if !a.saves.CapturingText() {
+		t.Fatal("did not enter the Save-As name-entry state")
+	}
+}
+
+// TestSavesNameInputSwallowsBacktick — finding 9. A backtick typed into
+// the Save-As name field is a literal character, NOT the global boss-key
+// hotkey: the screen stays put and the character reaches the input.
+func TestSavesNameInputSwallowsBacktick(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	enterSaveAsNaming(t, a)
+
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("`")})
+	if a.active == screenBoss {
+		t.Fatal("backtick opened the boss shell from the name field (finding 9)")
+	}
+	if a.active != screenSaves {
+		t.Fatalf("active = %v, want screenSaves (still naming)", a.active)
+	}
+	if out := a.saves.Render(200, 40); !strings.Contains(out, "`") {
+		t.Errorf("name input did not receive the literal backtick\n%s", out)
+	}
+}
+
+// TestSavesNameInputNotLayoutNormalized — finding 3. While the name field
+// captures text, keyboard-layout normalization is bypassed so a QWERTZ
+// player's keycaps aren't transposed: a physical 'z' types 'z', not the
+// QWERTY-normalized 'y'.
+func TestSavesNameInputNotLayoutNormalized(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.layout = keylayout.QWERTZ
+
+	// A named save on disk to rename, with a controlled prefill.
+	if _, err := save.WriteNamed(a.world, "abc"); err != nil {
+		t.Fatalf("WriteNamed: %v", err)
+	}
+	a.openSaves(screens.SavesModeLoad) // cursor 0 = the "abc" save
+
+	// 'r' opens rename (browse state still normalizes, but 'r' is not a
+	// swapped key, so it maps to itself and opens the field).
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if !a.saves.CapturingText() {
+		t.Fatalf("'r' did not open rename; active=%v", a.active)
+	}
+
+	// Physical 'z' under QWERTZ would normalize to 'y' — the bypass keeps
+	// it raw.
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("z")})
+	out := a.saves.Render(200, 40)
+	if !strings.Contains(out, "abcz") {
+		t.Errorf("name field did not append the raw 'z' (normalization not bypassed)\n%s", out)
+	}
+	if strings.Contains(out, "abcy") {
+		t.Errorf("name field shows the QWERTY-normalized 'y' — normalization leaked into text capture\n%s", out)
+	}
+}

--- a/internal/tui/screens/saves.go
+++ b/internal/tui/screens/saves.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/save"
 )
@@ -130,6 +131,16 @@ func (sc *SavesScreen) SetEntries(entries []save.SaveInfo) {
 
 // Mode reports the entry-point mode the screen was opened in.
 func (sc *SavesScreen) Mode() SavesMode { return sc.mode }
+
+// CapturingText reports whether the screen is in a free-text sub-state
+// (Save-As / rename name entry) — every keystroke is literal input for
+// the name field, so the App must not keyboard-layout-normalize it or
+// let global hotkeys (the backtick boss key) intercept it (findings 3 +
+// 9). Browse and confirm states are NOT capturing: their keys are
+// commands and route normally.
+func (sc *SavesScreen) CapturingText() bool {
+	return sc.state == savesStateNameNew || sc.state == savesStateRename
+}
 
 // EntryCount reports the number of listed saves (excluding the
 // save-mode New-save row).
@@ -371,28 +382,75 @@ func formatSavedAt(t time.Time) string {
 	return t.Local().Format("2006-01-02 15:04")
 }
 
-// Column layout: marker(2) + name(26) + savedat(18) + ingame(12) + vessel.
+// Column layout: marker(2) + name(26) + savedat(18) + ingame(12) + vessel,
+// each column followed by savesColGap so adjacent cells never fuse.
 const (
 	savesColName    = 26
 	savesColSavedAt = 18
 	savesColInGame  = 12
+	savesColGap     = "  " // explicit inter-column gap (finding 8)
 )
 
-// padCell pads / rune-truncates a cell to width (ellipsis on cut),
-// plus two trailing gap spaces.
+// padCell renders s in a fixed-width column: display-width-truncated
+// (ellipsis on overflow), padded to width, then an explicit 2-space gap.
+// Width is measured with lipgloss.Width (via truncWidth), so wide runes
+// (CJK, emoji) occupy the right number of display cells instead of being
+// over-counted one-per-rune — which previously misaligned every column
+// after a wide cell. The trailing gap stops a full-width cell from
+// fusing into the next column. Apply to plain, un-styled text.
 func padCell(s string, width int) string {
-	r := []rune(s)
-	if len(r) > width {
-		return string(r[:width-1]) + "…"
+	s = truncWidth(s, width)
+	if pad := width - lipgloss.Width(s); pad > 0 {
+		s += strings.Repeat(" ", pad)
 	}
-	return s + strings.Repeat(" ", width-len(r))
+	return s + savesColGap
+}
+
+// listWindow returns the [start,end) slice of the n rows to render so
+// the list plus the screen's fixed chrome fits within height, always
+// keeping the cursor row inside the window. A non-positive height (no
+// budget) or a list that already fits returns the full range. chrome
+// budgets the non-list lines: title + blank + header above, and the
+// blank + the tallest state tail (a §H confirm block) plus the two
+// "N more" indicators below — so the window never overflows even mid
+// confirm.
+func (sc *SavesScreen) listWindow(n, height int) (start, end int) {
+	if height <= 0 {
+		return 0, n
+	}
+	const chrome = 11
+	capRows := height - chrome
+	if capRows < 1 {
+		capRows = 1
+	}
+	if capRows >= n {
+		return 0, n
+	}
+	start = sc.cursor - capRows/2
+	if start < 0 {
+		start = 0
+	}
+	end = start + capRows
+	if end > n {
+		end = n
+		start = end - capRows
+	}
+	if start < 0 {
+		start = 0
+	}
+	return start, end
 }
 
 // Render composes the screen: title + [Back], the mode header, the
-// column header, one row per entry (cursor-marked), and the
+// column header, a cursor-windowed slice of the rows, and the
 // state-specific footer (confirm prompt / name input / key legend).
-// Click-target ranges are recorded in absolute row terms, menu-style.
-func (sc *SavesScreen) Render(width int) string {
+// height bounds the total output so a long list never overflows the
+// alt-screen (which truncates from the TOP, hiding the title/header);
+// the list is windowed around the cursor to fit. A non-positive height
+// disables the clamp (shows everything) — handy for tests and any caller
+// with no height budget. Click-target ranges are recorded in absolute
+// row terms, menu-style.
+func (sc *SavesScreen) Render(width, height int) string {
 	var lines []string
 
 	// Row 0: title + right-aligned [Back] (menu pattern).
@@ -415,44 +473,51 @@ func (sc *SavesScreen) Render(width int) string {
 		padCell("IN-GAME", savesColInGame) + "VESSEL"
 	lines = append(lines, sc.theme.Dim.Render(header))
 
-	// Rows.
-	sc.rowBtns = make([]buttonRange, sc.rowCount())
-	rowIdx := 0
-	// addRow renders one selectable row. dimmed forces the Dim style even
-	// off-cursor (an unreadable/non-loadable entry) while the cursor
-	// marker still tracks selection so it can be selected for deletion.
-	addRow := func(body string, dimmed bool) {
-		marker := "  "
-		style := sc.theme.Primary
-		if dimmed {
-			style = sc.theme.Dim
-		}
-		if rowIdx == sc.cursor {
-			marker = "▸ "
-			if !dimmed {
-				style = sc.theme.Warning
-			}
-		}
-		sc.rowBtns[rowIdx] = buttonRange{
-			row:      len(lines),
-			colStart: 0,
-			colEnd:   width,
-			set:      true,
-		}
-		lines = append(lines, clipLine(marker+style.Render(body), width))
-		rowIdx++
+	// Rows. Assemble every selectable row first (New-save row + entries),
+	// then render only a cursor-centred window that fits the height so the
+	// whole screen stays within the alt-screen (finding 7). rowBtns for
+	// off-window rows stay unset, so a click can never land on a row that
+	// isn't drawn.
+	type savesRow struct {
+		body   string
+		dimmed bool
 	}
+	var rows []savesRow
 	if sc.hasNewRow() {
-		addRow("＋ New save…", false)
+		rows = append(rows, savesRow{body: "＋ New save…"})
 	}
 	for _, info := range sc.entries {
 		body := padCell(displaySaveName(info), savesColName) +
 			padCell(formatSavedAt(info.Meta.SavedAt), savesColSavedAt) +
 			padCell(formatInGameDate(info.Meta.InGameEpoch), savesColInGame) +
 			info.Meta.ActiveVesselName
-		addRow(body, info.Unreadable)
+		rows = append(rows, savesRow{body: body, dimmed: info.Unreadable})
 	}
-	if len(sc.entries) == 0 && !sc.hasNewRow() {
+
+	sc.rowBtns = make([]buttonRange, len(rows))
+	start, end := sc.listWindow(len(rows), height)
+	if start > 0 {
+		lines = append(lines, sc.theme.Dim.Render(fmt.Sprintf("  ↑ %d more", start)))
+	}
+	for i := start; i < end; i++ {
+		marker := "  "
+		style := sc.theme.Primary
+		if rows[i].dimmed {
+			style = sc.theme.Dim
+		}
+		if i == sc.cursor {
+			marker = "▸ "
+			if !rows[i].dimmed {
+				style = sc.theme.Warning
+			}
+		}
+		sc.rowBtns[i] = buttonRange{row: len(lines), colStart: 0, colEnd: width, set: true}
+		lines = append(lines, clipLine(marker+style.Render(rows[i].body), width))
+	}
+	if end < len(rows) {
+		lines = append(lines, sc.theme.Dim.Render(fmt.Sprintf("  ↓ %d more", len(rows)-end)))
+	}
+	if len(rows) == 0 {
 		lines = append(lines, sc.theme.Dim.Render("  (no saves yet — F5 quicksaves, or save from the menu)"))
 	}
 	lines = append(lines, "")

--- a/internal/tui/screens/saves_test.go
+++ b/internal/tui/screens/saves_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -81,7 +82,7 @@ var (
 func TestSavesListRendersRows(t *testing.T) {
 	sc := NewSavesScreen(savesTheme())
 	sc.Open(SavesModeLoad, savesFixture(), "default")
-	out := sc.Render(110)
+	out := sc.Render(110, 40)
 
 	for _, want := range []string{
 		"Apollo run", "2000-03-14", "Kern Stack", // named row columns
@@ -115,11 +116,11 @@ func TestSavesListRendersRows(t *testing.T) {
 func TestSavesSaveModeShowsNewRow(t *testing.T) {
 	sc := NewSavesScreen(savesTheme())
 	sc.Open(SavesModeSave, savesFixture(), "default")
-	if out := sc.Render(110); !strings.Contains(out, "New save") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "New save") {
 		t.Errorf("save-mode render missing the New save row\n%s", out)
 	}
 	sc.Open(SavesModeLoad, savesFixture(), "default")
-	if out := sc.Render(110); strings.Contains(out, "New save") {
+	if out := sc.Render(110, 40); strings.Contains(out, "New save") {
 		t.Errorf("load-mode render must not show the New save row\n%s", out)
 	}
 }
@@ -134,7 +135,7 @@ func TestSavesSaveAsDefaultName(t *testing.T) {
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
 		t.Fatalf("enter on New save row returned %v, want None (opens naming)", cmd.Kind)
 	}
-	if out := sc.Render(110); !strings.Contains(out, "Kern Stack — 2000-03-14") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "Kern Stack — 2000-03-14") {
 		t.Fatalf("naming input not prefilled with the default name\n%s", out)
 	}
 	cmd := sc.HandleKey(keyEnter)
@@ -180,7 +181,7 @@ func TestSavesOverwriteTargetsSelectedFile(t *testing.T) {
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
 		t.Fatalf("enter on named row returned %v, want None (confirm gate)", cmd.Kind)
 	}
-	if out := sc.Render(110); !strings.Contains(out, "Overwrite") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "Overwrite") {
 		t.Fatalf("no overwrite confirm prompt rendered\n%s", out)
 	}
 	cmd := sc.HandleKey(keyRunes("y"))
@@ -200,7 +201,7 @@ func TestSavesReservedLaneNotOverwritable(t *testing.T) {
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
 		t.Fatalf("enter on reserved lane returned %v, want None", cmd.Kind)
 	}
-	if out := sc.Render(110); strings.Contains(out, "Overwrite") {
+	if out := sc.Render(110, 40); strings.Contains(out, "Overwrite") {
 		t.Fatalf("reserved lane opened an overwrite confirm\n%s", out)
 	}
 }
@@ -248,7 +249,7 @@ func TestSavesLoadConfirmGate(t *testing.T) {
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
 		t.Fatalf("enter returned %v before the confirm gate", cmd.Kind)
 	}
-	if out := sc.Render(110); !strings.Contains(out, "Load and discard current state?") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "Load and discard current state?") {
 		t.Fatalf("missing the §H load confirm prompt\n%s", out)
 	}
 	if cmd := sc.HandleKey(keyRunes("n")); cmd.Kind != SavesActionNone {
@@ -271,7 +272,7 @@ func TestSavesDeleteConfirm(t *testing.T) {
 	if cmd := sc.HandleKey(keyRunes("d")); cmd.Kind != SavesActionNone {
 		t.Fatalf("d returned %v, want None (confirm gate)", cmd.Kind)
 	}
-	if out := sc.Render(110); !strings.Contains(out, "Delete") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "Delete") {
 		t.Fatalf("missing the delete confirm prompt\n%s", out)
 	}
 	cmd := sc.HandleKey(keyRunes("y"))
@@ -290,7 +291,7 @@ func TestSavesUnreadableRowNotLoadable(t *testing.T) {
 	sc := NewSavesScreen(savesTheme())
 	sc.Open(SavesModeLoad, entries, "default")
 
-	out := sc.Render(110)
+	out := sc.Render(110, 40)
 	if !strings.Contains(out, "unreadable (newer version)") {
 		t.Fatalf("unreadable row missing its reason label\n%s", out)
 	}
@@ -303,7 +304,7 @@ func TestSavesUnreadableRowNotLoadable(t *testing.T) {
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
 		t.Fatalf("enter on unreadable row returned %v, want None", cmd.Kind)
 	}
-	if strings.Contains(sc.Render(110), "Load and discard") {
+	if strings.Contains(sc.Render(110, 40), "Load and discard") {
 		t.Errorf("unreadable row opened a load confirm")
 	}
 	// Rename disabled.
@@ -331,7 +332,7 @@ func TestSavesSetEntriesClampsCursor(t *testing.T) {
 	}
 	// And an emptied list renders its placeholder without panicking.
 	sc.SetEntries(nil)
-	if out := sc.Render(110); !strings.Contains(out, "no saves") {
+	if out := sc.Render(110, 40); !strings.Contains(out, "no saves") {
 		t.Errorf("empty list missing placeholder\n%s", out)
 	}
 	if cmd := sc.HandleKey(keyEnter); cmd.Kind != SavesActionNone {
@@ -359,7 +360,7 @@ func TestSavesEscCancels(t *testing.T) {
 func TestSavesClickTargets(t *testing.T) {
 	sc := NewSavesScreen(savesTheme())
 	sc.Open(SavesModeLoad, savesFixture(), "default")
-	_ = sc.Render(110) // populate click ranges
+	_ = sc.Render(110, 40) // populate click ranges
 
 	// Click the second row: selects it, no action yet.
 	btn := sc.rowBtns[1]
@@ -371,7 +372,7 @@ func TestSavesClickTargets(t *testing.T) {
 		t.Fatalf("cursor = %d after row click, want 1", sc.cursor)
 	}
 	// Click it again: activates (load confirm opens).
-	_ = sc.Render(110)
+	_ = sc.Render(110, 40)
 	if cmd := sc.HandleClick(col, btn.row); cmd.Kind != SavesActionNone {
 		t.Fatalf("second row click returned %v, want None (confirm gate)", cmd.Kind)
 	}
@@ -379,16 +380,84 @@ func TestSavesClickTargets(t *testing.T) {
 		t.Fatalf("state = %v after activating row click, want confirm-load", sc.state)
 	}
 	// [Yes] click commits the load of the clicked row.
-	_ = sc.Render(110)
+	_ = sc.Render(110, 40)
 	yes := sc.yesBtn
 	cmd := sc.HandleClick((yes.colStart+yes.colEnd)/2, yes.row)
 	if cmd.Kind != SavesActionLoad || cmd.ID != "autosave-1.json" {
 		t.Fatalf("[Yes] click = %+v, want Load autosave-1.json", cmd)
 	}
 	// [Back] cancels out of the screen.
-	_ = sc.Render(110)
+	_ = sc.Render(110, 40)
 	back := sc.backBtn
 	if cmd := sc.HandleClick((back.colStart+back.colEnd)/2, back.row); cmd.Kind != SavesActionCancel {
 		t.Fatalf("[Back] click = %+v, want Cancel", cmd)
 	}
 }
+
+// TestSavesPadCellDisplayWidth — finding 8. padCell measures cells by
+// display width (not rune count) and always leaves a trailing gap, so a
+// wide-rune (CJK/emoji) cell and an overflowing cell both occupy exactly
+// width+gap columns instead of shoving the later columns out of line or
+// fusing into them.
+func TestSavesPadCellDisplayWidth(t *testing.T) {
+	want := savesColName + lipgloss.Width(savesColGap) // width + gap, in display cells
+	cases := map[string]string{
+		"ascii-short": "abc",
+		"cjk-wide":    "好好好", // 3 runes, 6 display cells
+		"overflow":    strings.Repeat("x", 40),
+		"exact-fill":  strings.Repeat("A", savesColName),
+	}
+	for name, in := range cases {
+		got := padCell(in, savesColName)
+		if w := lipgloss.Width(got); w != want {
+			t.Errorf("%s: padCell width = %d display cells, want %d (width+gap)", name, w, want)
+		}
+	}
+	// Overflow ellipsizes rather than fusing.
+	over := strings.TrimRight(padCell(strings.Repeat("x", 40), savesColName), " ")
+	if !strings.HasSuffix(over, "…") {
+		t.Errorf("overflow padCell should ellipsize, got %q", over)
+	}
+}
+
+// TestSavesListWindowsToHeight — finding 7. A list taller than the height
+// budget renders only a cursor-centred window (so the title/header never
+// scroll off the top of the alt-screen), with "more" indicators; the
+// cursor row stays visible and off-window rows record no click target.
+func TestSavesListWindowsToHeight(t *testing.T) {
+	var entries []save.SaveInfo
+	for i := 0; i < 20; i++ {
+		entries = append(entries, save.SaveInfo{
+			ID:   fmt.Sprintf("save-%02d.json", i),
+			Meta: save.Meta{Name: fmt.Sprintf("game-%02d", i), SavedAt: time.Now()},
+			Lane: save.LaneNamed,
+		})
+	}
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, entries, "default")
+	for i := 0; i < 10; i++ { // cursor into the middle
+		sc.HandleKey(keyDown)
+	}
+
+	out := sc.Render(80, 20)
+	if lines := strings.Count(out, "\n") + 1; lines > 20 {
+		t.Errorf("rendered %d lines, want <= height 20 (windowing failed)\n%s", lines, out)
+	}
+	if !strings.Contains(out, "game-10") {
+		t.Errorf("cursor row game-10 not in the window\n%s", out)
+	}
+	if strings.Contains(out, "game-00") {
+		t.Errorf("far row game-00 rendered despite the window\n%s", out)
+	}
+	if !strings.Contains(out, "more") {
+		t.Errorf("no ↑/↓ more indicator rendered\n%s", out)
+	}
+	// Off-window rows carry no click target; the cursor row does.
+	if sc.rowBtns[0].set {
+		t.Error("off-window row 0 recorded a click target — clicks would misfire")
+	}
+	if !sc.rowBtns[10].set {
+		t.Error("cursor row 10 has no click target")
+	}
+}
+


### PR DESCRIPTION
Third and final v0.26 batch-review fix slice (ADR 0033). Saves-browser render + input; builds on merged F1 (#199) and F2 (#200). **v0.26.0 not tagged yet** — docs close-out + a medium re-review come after this merges.

## Findings addressed

**3 + 9 — one mechanism.** A *"capturing literal text"* predicate (`App.capturingText` → `SavesScreen.CapturingText`, true only during Save-As / rename name entry) now gates two global interceptions that were mangling the name field:
- **3** — keyboard-layout normalization transposed typed save names (QWERTZ z↔y; AZERTY worse). Skipped while capturing text.
- **9** — a literal backtick opened the boss shell instead of typing. The boss-key intercept is skipped while capturing text.

Replaces the prior `screenBoss`-only carve-out with a predicate the next free-text surface (VAB / spawn / search) can extend — as the handoff prescribed ("pin the predicate, not another screen-ID carve-out").

**7 — Saves list had no height clamp.** An unbounded list overflowed the alt-screen, which truncates from the **top** (title / header / cursor vanish), and `rowBtns` for pushed-off rows still recorded frame positions so clicks misfired N rows off. `Render` now takes a `height` and windows the list around the cursor (`listWindow`), with "↑/↓ N more" indicators. Off-window rows record **no** click target, so a click can never land on an undrawn row.

**8 — `padCell` fused / misaligned columns.** It measured by rune count (over-counting CJK/emoji, shifting every later column) and left no trailing gap (a full-width name fused into SAVED). Now measures display width via `lipgloss.Width` (reusing `truncWidth`) + an explicit 2-space gap.

## Tests
- Real `App.Update` paths: backtick types into the name field (no boss shell), and a QWERTZ physical `z` stays raw in the field (normalization bypassed).
- `padCell` display-width / gap / overflow-ellipsis (ASCII, CJK, exact-fill, overflow).
- List windows to height: total lines ≤ height, cursor row visible, far row hidden, off-window `rowBtns` unset.
- `Render(width)` → `Render(width, height)`; the 15 screen-test call sites pass a tall height (no clamp), preserving their assertions.

> Note: the alt-screen top-truncation itself needs a live TTY to observe; the windowing logic is verified by its invariants (lines ≤ height, cursor in-window, off-window click targets unset), which is the exact mechanism that prevents it.

`go vet ./...` + `go test ./... -race -count=1` green (1488). `SchemaVersion` unchanged (9).