### PR TITLE
fix(save,tui): re-review follow-ups on the v0.26 fix slices

### DIFF
--- a/internal/save/import.go
+++ b/internal/save/import.go
@@ -119,12 +119,14 @@ func ImportLegacyIfNeeded() (SaveInfo, bool, error) {
 	if err := writeAtomic(filepath.Join(dir, id), out); err != nil {
 		return SaveInfo{}, false, err
 	}
-	// Settle the migration only after the imported file is safely on
-	// disk. A crash between the two leaves the marker absent → retry
-	// (worst case a duplicate import, never a lost save).
-	if err := markLegacyImported(marker); err != nil {
-		return SaveInfo{}, false, fmt.Errorf("write import marker: %w", err)
-	}
+	// Settle the migration only after the imported file is safely on disk.
+	// The write is best-effort: the import itself already succeeded, so a
+	// failed marker must NOT be reported as an error — that would mislog
+	// the run as "skipped" even though the save landed. Its only cost is a
+	// harmless duplicate re-import next launch (the save is never lost),
+	// and it can only fail if the same directory we just wrote to became
+	// unwritable, which is vanishingly unlikely.
+	_ = markLegacyImported(marker)
 	return SaveInfo{ID: id, Meta: *meta, Lane: LaneNamed}, true, nil
 }
 

--- a/internal/save/saves.go
+++ b/internal/save/saves.go
@@ -241,15 +241,20 @@ func List() ([]SaveInfo, error) {
 	return infos, nil
 }
 
-// unreadableNote classifies a header-parse failure into a short,
+// unreadableNote classifies a header read/parse failure into a short,
 // player-facing reason for the browser. A schema-range rejection means
-// the file was written by a different (usually newer) build; anything
-// else is treated as corruption.
+// the file was written by a different (usually newer) build; a
+// permission/IO failure means the bytes couldn't be read at all (not
+// that they're bad); anything else is malformed content.
 func unreadableNote(err error) string {
-	if errors.Is(err, ErrSchemaMismatch) {
+	switch {
+	case errors.Is(err, ErrSchemaMismatch):
 		return "newer version"
+	case errors.Is(err, os.ErrPermission):
+		return "no access"
+	default:
+		return "corrupt"
 	}
-	return "corrupt"
 }
 
 // stampMeta builds the Meta header for a write happening now. name is

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -493,6 +493,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// ctrl+c bypasses everything else (standard interrupt
 		// convention). Honored from any screen.
 		if key.Matches(m, a.keys.Quit) {
+			// The Saves browser freezes the clock while it's up (finding 4);
+			// that freeze is transient UI state, not a gameplay pause, so
+			// don't let a quit-from-browser persist Paused=true into the
+			// autosave — restore the pre-open state first so the reloaded
+			// session resumes exactly as it was running.
+			if a.active == screenSaves {
+				a.world.Clock.Paused = a.savesPrevPaused
+			}
 			a.autosave()
 			return a, tea.Quit
 		}

--- a/internal/tui/app_saves_pause_test.go
+++ b/internal/tui/app_saves_pause_test.go
@@ -3,6 +3,9 @@ package tui
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
@@ -33,6 +36,35 @@ func TestSavesScreenFreezesSim(t *testing.T) {
 	}
 	if a.active != screenOrbit {
 		t.Errorf("active = %v, want screenOrbit after cancel", a.active)
+	}
+}
+
+// TestQuitFromSavesDoesNotPersistFreeze — a ctrl+c quit while the Saves
+// browser is open must autosave the pre-open gameplay pause state, not
+// the browser's transient freeze: a session that was running resumes
+// running on reload, not paused.
+func TestQuitFromSavesDoesNotPersistFreeze(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.Clock.Paused {
+		t.Fatal("world started paused — test premise broken")
+	}
+	a.openSaves(screens.SavesModeSave) // freezes the clock
+	if !a.world.Clock.Paused {
+		t.Fatal("openSaves did not freeze the clock")
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyCtrlC}) // quit-autosaves the ring
+
+	w, err := save.LoadID("autosave-1.json")
+	if err != nil {
+		t.Fatalf("LoadID(autosave-1.json): %v", err)
+	}
+	if w.Clock.Paused {
+		t.Error("quit-from-browser persisted the transient freeze (Paused=true); reload should resume running")
 	}
 }
 

--- a/internal/tui/screens/saves.go
+++ b/internal/tui/screens/saves.go
@@ -550,6 +550,16 @@ func (sc *SavesScreen) Render(width, height int) string {
 	for i, ln := range lines {
 		lines[i] = clipLine(ln, width)
 	}
+	// Safety net for terminals too short for even the fixed chrome
+	// (height < ~8): listWindow bounds the LIST, but the header + tail can
+	// still exceed a tiny height. Keep the TOP (title, header, cursor
+	// window) and drop the overflowing tail rather than letting the
+	// alt-screen scroll the title off the top — the exact symptom the
+	// windowing prevents at normal sizes. A no-op whenever the content
+	// already fits (the common case).
+	if height > 0 && len(lines) > height {
+		lines = lines[:height]
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/tui/screens/saves_test.go
+++ b/internal/tui/screens/saves_test.go
@@ -420,6 +420,29 @@ func TestSavesPadCellDisplayWidth(t *testing.T) {
 	}
 }
 
+// TestSavesRenderNeverExceedsHeight — a terminal too short for even the
+// fixed chrome must still not emit more than `height` lines (else the
+// alt-screen scrolls the title off the top). Render clamps as a safety
+// net below the windowing floor.
+func TestSavesRenderNeverExceedsHeight(t *testing.T) {
+	var entries []save.SaveInfo
+	for i := 0; i < 12; i++ {
+		entries = append(entries, save.SaveInfo{
+			ID:   fmt.Sprintf("save-%02d.json", i),
+			Meta: save.Meta{Name: fmt.Sprintf("game-%02d", i), SavedAt: time.Now()},
+			Lane: save.LaneNamed,
+		})
+	}
+	sc := NewSavesScreen(savesTheme())
+	sc.Open(SavesModeLoad, entries, "default")
+	for _, h := range []int{5, 6, 7, 8, 10} {
+		out := sc.Render(80, h)
+		if lines := strings.Count(out, "\n") + 1; lines > h {
+			t.Errorf("Render(_, %d) = %d lines, want <= %d\n%s", h, lines, h, out)
+		}
+	}
+}
+
 // TestSavesListWindowsToHeight — finding 7. A list taller than the height
 // budget renders only a cursor-centred window (so the title/header never
 // scroll off the top of the alt-screen), with "more" indicators; the


### PR DESCRIPTION
The four low-severity findings from the pre-tag medium re-review of the v0.26 fix diff (`1993756..HEAD`). None were tag-blockers; cleaning them up before the tag per maintainer request.

1. **Import marker best-effort** (`import.go`) — a failed `.legacy-imported` marker write *after* the imported file already landed returned `imported=false` + err, so `main.go` mislogged the run as "skipped" and the next launch re-imported a duplicate. The marker is now best-effort (import already succeeded → swallow the marker error); worst case is a harmless duplicate re-import, never a lost save.
2. **Quit-from-Saves pause** (`app.go`) — a ctrl+c quit while the Saves browser was open autosaved the browser's transient clock freeze (`Paused=true`, persisted), so reload started paused. The quit path now restores the pre-open pause state before autosaving.
3. **Render height clamp** (`saves.go`) — `listWindow` bounds the list, but header+tail could still exceed a terminal shorter than the fixed chrome (~<8 rows), re-scrolling the title off the top. `Render` now clamps output to `height` as a safety net (no-op when content fits).
4. **`unreadableNote` label** (`saves.go`) — a permission/IO read failure was labelled "corrupt"; now "no access" for `os.ErrPermission`, keeping "corrupt" for malformed content and "newer version" for schema mismatch.

Tests: quit-from-Saves autosaves the running (not frozen) state; `Render` never exceeds a tiny height across 5/6/7/8/10 rows. Findings 1 & 4 exercise failure paths not portably testable (marker-write-fail-after-success; EACCES, which CI-as-root ignores) — code-only.

`go vet ./...` + `go test ./... -race -count=1` green (1490). No schema change (v9).