### PR TITLE
feat(tui,serve): v0.27 S2 — capability floor (size gate + ssh calibration card)

### DIFF
--- a/internal/serve/calibration.go
+++ b/internal/serve/calibration.go
@@ -1,0 +1,83 @@
+package serve
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// calibrationModel fronts every ssh session with a one-shot terminal
+// check (v0.27 S2, ADR 0034): the game's braille canvas and color
+// chips are undetectable server-side, so the player confirms them
+// before the game starts. "y" swaps to the wrapped game model; "n"
+// shows font/TERM help and disconnects on the next key. Local play
+// never sees this — the host's own terminal is theirs to judge.
+type calibrationModel struct {
+	game     tea.Model
+	size     tea.WindowSizeMsg
+	declined bool
+}
+
+// withCalibrationCard wraps a fresh session game behind the card.
+func withCalibrationCard(game tea.Model) tea.Model {
+	return calibrationModel{game: game}
+}
+
+func (m calibrationModel) Init() tea.Cmd { return nil }
+
+func (m calibrationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch v := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.size = v
+		return m, nil
+	case tea.KeyMsg:
+		if m.declined {
+			return m, tea.Quit // any key after the help text disconnects
+		}
+		switch v.String() {
+		case "y", "Y":
+			// Hand over to the game: run its Init (tick loop) and replay
+			// the last known pty size so it lays out immediately.
+			initCmd := m.game.Init()
+			game, sizeCmd := m.game.Update(m.size)
+			return game, tea.Batch(initCmd, sizeCmd)
+		case "n", "N":
+			m.declined = true
+			return m, nil
+		case "q", "ctrl+c", "esc":
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m calibrationModel) View() string {
+	if m.declined {
+		return strings.Join([]string{
+			"",
+			"  This game draws orbits with braille characters and ANSI colors.",
+			"",
+			"  · switch to a monospace font with braille glyphs",
+			"    (JetBrains Mono, Fira Code, Menlo, and most Nerd Fonts work)",
+			"  · make sure your terminal advertises color: TERM=xterm-256color",
+			"",
+			"  Reconnect when ready — press any key to disconnect.",
+			"",
+		}, "\n")
+	}
+	swatches := make([]string, 0, 6)
+	for _, c := range []string{"1", "2", "3", "4", "5", "6"} {
+		swatches = append(swatches, lipgloss.NewStyle().Foreground(lipgloss.Color(c)).Render("██"))
+	}
+	return strings.Join([]string{
+		"",
+		"  TERMINAL SPACE PROGRAM — connection check",
+		"",
+		"  braille:  ⠁⠃⠇⡇⣇⣧⣷⣿⣷⣧⣇⡇⠇⠃⠁   (should be a smooth ramp of dots)",
+		"  colors:   " + strings.Join(swatches, " ") + "   (should be six distinct colors)",
+		"",
+		"  Can you see smooth braille dots and six distinct colors? [y/n]",
+		"",
+	}, "\n")
+}

--- a/internal/serve/calibration_test.go
+++ b/internal/serve/calibration_test.go
@@ -1,0 +1,82 @@
+package serve
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+func newCardSession(t *testing.T) tea.Model {
+	t.Helper()
+	game, _, err := newSessionApp()
+	if err != nil {
+		t.Fatalf("newSessionApp: %v", err)
+	}
+	return withCalibrationCard(game)
+}
+
+// The card renders the braille ramp, color swatches, and the y/n ask.
+func TestCalibrationCardRender(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	out := stripANSI(newCardSession(t).View())
+	for _, want := range []string{"connection check", "⣿", "[y/n]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("card missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// "y" swaps to the game with the pty size replayed — the next frame is
+// the orbit screen, not the card.
+func TestCalibrationAcceptStartsGame(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	m := newCardSession(t)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 45})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	out := stripANSI(m.View())
+	if strings.Contains(out, "[y/n]") {
+		t.Fatal("still on the card after accepting")
+	}
+	if !strings.Contains(out, "warp 1x") {
+		t.Errorf("expected the orbit screen after accept, got:\n%s", firstLines(out, 3))
+	}
+}
+
+// "n" shows the font/TERM help; the next key disconnects.
+func TestCalibrationDeclineHelpsThenQuits(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	m := newCardSession(t)
+	m, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatal("decline should hold the session on the help text, not quit yet")
+	}
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "braille glyphs") || !strings.Contains(out, "press any key to disconnect") {
+		t.Fatalf("expected font/TERM help after decline, got:\n%s", out)
+	}
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd == nil {
+		t.Fatal("expected quit after any key on the help text")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Errorf("expected tea.QuitMsg, got %T", cmd())
+	}
+}
+
+// The shared size gate holds behind the card too: accepting on an
+// undersized pty lands on the gate, not a broken frame (the "gate
+// covered in the ssh session constructor" acceptance).
+func TestCalibrationAcceptIntoSizeGate(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	m := newCardSession(t)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if out := stripANSI(m.View()); !strings.Contains(out, "TERMINAL TOO SMALL") {
+		t.Errorf("expected the size gate on an 80×24 ssh session, got:\n%s", firstLines(out, 5))
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -115,7 +115,9 @@ func sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOption) {
 		wish.Fatalln(sess, "terminal-space-program:", err)
 		return nil, nil
 	}
-	return app, opts
+	// v0.27 S2: guests confirm braille + color rendering before the
+	// game starts — undetectable server-side, so we ask.
+	return withCalibrationCard(app), opts
 }
 
 // newSessionApp is the per-session game factory, split from the ssh

--- a/internal/serve/ssh_smoke_test.go
+++ b/internal/serve/ssh_smoke_test.go
@@ -45,7 +45,15 @@ func TestSSHSmoke(t *testing.T) {
 	sessA := dialGameSession(t, srv.Addr())
 	sessB := dialGameSession(t, srv.Addr())
 
-	// First frame: the orbit screen (system name in the header chip).
+	// First frame: the calibration card (v0.27 S2); accept it on both.
+	for _, s := range []*gameSession{sessA, sessB} {
+		s.waitFor(t, "[y/n]")
+		if _, err := s.stdin.Write([]byte("y")); err != nil {
+			t.Fatalf("accept calibration card: %v", err)
+		}
+	}
+
+	// Then the game: the orbit screen (system name in the header chip).
 	sessA.waitFor(t, "Sol")
 	sessB.waitFor(t, "Sol")
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -199,6 +199,14 @@ func (a *App) Init() tea.Cmd {
 	return sim.TickCmd(a.world.Clock.BaseStep)
 }
 
+// sizeGated reports whether the terminal is below the playable floor
+// (v0.27 S2). Width 0 means no WindowSizeMsg yet — not gated, View's
+// "initializing…" placeholder covers that instant.
+func (a *App) sizeGated() bool {
+	return a.width > 0 &&
+		(a.width < screens.MinTerminalWidth || a.height < screens.MinTerminalHeight)
+}
+
 // Update routes every tea.Msg. Globals handled here; screen-scoped
 // keys delegate to the active screen.
 func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -356,6 +364,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.Action != tea.MouseActionPress || m.Button != tea.MouseButtonLeft {
 			return a, nil
 		}
+		// v0.27 S2: clicks against a gate screen would hit-test stale
+		// layouts — drop them like gated keys.
+		if a.sizeGated() {
+			return a, nil
+		}
 		switch a.active {
 		case screenOrbit:
 			// v0.7.4+: title-bar [Menu] / [Missions] buttons take
@@ -503,6 +516,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.autosave()
 			return a, tea.Quit
+		}
+		// v0.27 S2: while the size gate is up, gameplay keys are
+		// swallowed — the player can't see what a keypress would do.
+		// Quit above stays honored from the gated state.
+		if a.sizeGated() {
+			return a, nil
 		}
 		// Boss key: a single global keypress (backtick) swaps the whole
 		// screen to a fake developer shell, and swaps back on
@@ -1693,6 +1712,12 @@ func finiteBurnDuration(dv, mass, thrust float64) time.Duration {
 func (a *App) View() string {
 	if a.width == 0 {
 		return "initializing…"
+	}
+	// v0.27 S2 (ADR 0034): below the playable floor the gate replaces
+	// every screen — local and ssh alike. The sim keeps ticking; only
+	// rendering and gameplay input are held.
+	if a.sizeGated() {
+		return screens.RenderSizeGate(a.width, a.height)
 	}
 	var base string
 	switch a.active {

--- a/internal/tui/screens/sizegate.go
+++ b/internal/tui/screens/sizegate.go
@@ -1,0 +1,54 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Playable terminal floor (v0.27 S2, ADR 0034). Width is calibrated
+// against the widest fixed element the orbit screen composes (the HUD
+// row measures 104 cells); below it one line wraps and every frame
+// scrolls the terminal. Height 24 keeps the canvas + HUD readable and
+// matches the classic terminal minimum. Shared by local play and ssh
+// sessions — the gate in App.View replaces rendering below this floor.
+const (
+	MinTerminalWidth  = 104
+	MinTerminalHeight = 24
+)
+
+// RenderSizeGate is the blocking too-small screen. Deliberately
+// unstyled: a terminal in a broken state should get the most robust
+// output we can produce. Safe at any size — lines are truncated to w
+// and the block is centered in w×h.
+func RenderSizeGate(w, h int) string {
+	content := []string{
+		"TERMINAL TOO SMALL",
+		"",
+		fmt.Sprintf("now %d×%d — need at least %d×%d", w, h, MinTerminalWidth, MinTerminalHeight),
+		"",
+		"resize the window to keep flying",
+	}
+	pad := (h - len(content)) / 2
+	if pad < 0 {
+		pad = 0
+	}
+	lines := make([]string, 0, h)
+	for i := 0; i < pad; i++ {
+		lines = append(lines, "")
+	}
+	for _, c := range content {
+		if len(lines) >= h && h > 0 {
+			break
+		}
+		r := []rune(c)
+		if len(r) > w && w > 0 {
+			r = r[:w]
+		}
+		left := (w - len(r)) / 2
+		if left < 0 {
+			left = 0
+		}
+		lines = append(lines, strings.Repeat(" ", left)+string(r))
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/tui/size_gate_test.go
+++ b/internal/tui/size_gate_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// The size gate replaces rendering below the playable floor and
+// releases it the moment the terminal grows back (v0.27 S2).
+func TestSizeGateEnterExit(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var m tea.Model = a
+
+	// Exactly at the floor: the game renders, no gate.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: screens.MinTerminalWidth, Height: screens.MinTerminalHeight})
+	if out := m.View(); strings.Contains(out, "TERMINAL TOO SMALL") {
+		t.Errorf("gate shown at the floor size %d×%d", screens.MinTerminalWidth, screens.MinTerminalHeight)
+	}
+
+	// One column under: gated, and the prompt names the floor.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: screens.MinTerminalWidth - 1, Height: 40})
+	out := m.View()
+	if !strings.Contains(out, "TERMINAL TOO SMALL") {
+		t.Fatalf("expected gate below min width, got:\n%s", out)
+	}
+	if !strings.Contains(out, "104×24") {
+		t.Errorf("gate prompt should name the required floor, got:\n%s", out)
+	}
+
+	// One row under: gated too.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: screens.MinTerminalHeight - 1})
+	if !strings.Contains(m.View(), "TERMINAL TOO SMALL") {
+		t.Error("expected gate below min height")
+	}
+
+	// Grow back: the game returns.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 40})
+	if strings.Contains(m.View(), "TERMINAL TOO SMALL") {
+		t.Error("gate did not release after resize above the floor")
+	}
+}
+
+// Gameplay keys are swallowed while gated — a blind keypress must not
+// mutate the world — but the sim keeps ticking underneath.
+func TestSizeGateSwallowsGameplayKeys(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	var m tea.Model = a
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	// WarpUp while gated: dropped.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	if got := a.world.Clock.Warp(); got != 1 {
+		t.Errorf("warp key acted while gated: warp = %v, want 1", got)
+	}
+	// Sim still advances while gated.
+	before := a.world.Clock.SimTime
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	if !a.world.Clock.SimTime.After(before) {
+		t.Error("sim clock frozen while gated; the gate should hold rendering, not time")
+	}
+
+	// After resizing up the same key works again.
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 40})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	if got := a.world.Clock.Warp(); got != 10 {
+		t.Errorf("warp key dead after gate released: warp = %v, want 10", got)
+	}
+	_ = m
+}
+
+// The gate screen itself renders safely at hostile sizes.
+func TestRenderSizeGateTinyTerminal(t *testing.T) {
+	for _, sz := range [][2]int{{10, 3}, {1, 1}, {40, 8}} {
+		out := screens.RenderSizeGate(sz[0], sz[1])
+		lines := strings.Split(out, "\n")
+		if len(lines) > sz[1] {
+			t.Errorf("size %v: %d lines overflow height", sz, len(lines))
+		}
+		for _, l := range lines {
+			if len([]rune(l)) > sz[0] {
+				t.Errorf("size %v: line wider than terminal: %q", sz, l)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Second slice of the v0.27 multiplayer ssh-only MVP (ADR 0034 + v0.27-plan).

## What

- **Min-size gate in the shared App** (local + ssh): below **104×24** a blocking "TERMINAL TOO SMALL — now W×H, need at least 104×24" screen replaces rendering. Gameplay keys and clicks are swallowed while gated (a blind keypress must not mutate the world); quit stays honored; the sim keeps ticking.
- **Floor calibrated empirically**: the orbit HUD row composes 104 fixed cells — at 80×24 (today's silent breakage) one line wraps and every frame scrolls the terminal. Height floor is the classic 24.
- **ssh first-connect calibration card**: braille ramp + six ANSI color swatches + "can you see smooth dots and distinct colors? [y/n]" — glyph support is undetectable server-side. `y` starts the game with the pty size replayed; `n` shows fix-your-font/TERM help and disconnects on the next key. Local play never sees the card.

## Acceptance (per plan)

- Gate enter/exit screen tests at boundary sizes (at-floor, one-under each axis, grow-back release) + gated-key swallow + hostile tiny-terminal render safety.
- Card render / accept / decline tests; **accept-into-gate on an undersized pty** covers the gate in the ssh session constructor.
- The S1 ssh smoke test now drives the card over a real connection.
- Full suite: 1,499 tests, `-race` clean; `go vet` clean.