### PR TITLE
feat(relay,serve,sessiondir): v0.27 S4 — store & subspaces

### DIFF
--- a/cmd/terminal-space-program/main.go
+++ b/cmd/terminal-space-program/main.go
@@ -164,7 +164,14 @@ func main() {
 		fmt.Fprintf(os.Stderr, "terminal-space-program: serving SSH guests on %s (host key %s)\n", srv.Addr(), keyPath)
 	}
 
-	p := tea.NewProgram(app, tea.WithAltScreen(), tea.WithMouseAllMotion())
+	// The host's own game reports into the session store like any
+	// guest's (v0.27 S4) — wrap it when serving.
+	var model tea.Model = app
+	if srv != nil {
+		model = srv.HostModel(app)
+	}
+
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseAllMotion())
 	_, runErr := p.Run()
 	if srv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,0 +1,133 @@
+// Package relay is the multiplayer store (v0.27 S4, ADR 0034): a
+// no-physics, no-clock report/subscribe hub. Sessions report their
+// craft as messages; subscribers read the latest report per player
+// and evaluate ghosts at their own sim-time. Everything crossing this
+// interface is a plain serialisable value — the ssh-only MVP keeps
+// the store in shared memory, and the v2 WebSocket layer must be a
+// pure transport swap over these same messages (store discipline,
+// ADR 0034 addendum).
+package relay
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// CraftState is one vessel on the wire: primary-relative state vector
+// at the owner's subspace time (the exact representation the save
+// envelope uses, and what physics.KeplerStep propagates for ghost
+// evaluation), plus the addressing a viewer needs (system, SOI
+// primary) and display identity. Landed craft carry no meaningful
+// orbit — flagged so renderers skip them while rosters still count
+// them.
+type CraftState struct {
+	ID      uint64       `json:"id"`
+	Name    string       `json:"name"`
+	Glyph   string       `json:"glyph,omitempty"`
+	System  string       `json:"system"`
+	Primary string       `json:"primary"`
+	R       orbital.Vec3 `json:"r"`
+	V       orbital.Vec3 `json:"v"`
+	Landed  bool         `json:"landed,omitempty"`
+}
+
+// CraftReport is one player's full craft set at a moment of their
+// subspace time — set-replace semantics, so a vanished craft (staged
+// away, ended flight) disappears by omission. Identity is the ssh key
+// fingerprint; handles live in the session roster (sessiondir) and
+// are joined by the UI, not duplicated onto the wire.
+type CraftReport struct {
+	Owner        string       `json:"owner"`
+	SubspaceTime time.Time    `json:"subspace_time"`
+	Crafts       []CraftState `json:"crafts"`
+}
+
+// Store holds the latest report per owner and fans new reports out to
+// subscribers. It never inspects craft physics and holds no clock of
+// its own (ADR 0034: the server stores and relays, nothing else).
+type Store struct {
+	mu      sync.RWMutex
+	reports map[string]CraftReport
+	subs    map[int]chan CraftReport
+	nextSub int
+}
+
+func NewStore() *Store {
+	return &Store{
+		reports: map[string]CraftReport{},
+		subs:    map[int]chan CraftReport{},
+	}
+}
+
+// Report replaces the owner's craft set and notifies subscribers. A
+// subscriber that has fallen behind misses intermediate reports, not
+// the latest state — Snapshot always has that.
+func (s *Store) Report(r CraftReport) {
+	s.mu.Lock()
+	s.reports[r.Owner] = r
+	chans := make([]chan CraftReport, 0, len(s.subs))
+	for _, ch := range s.subs {
+		chans = append(chans, ch)
+	}
+	s.mu.Unlock()
+	for _, ch := range chans {
+		select {
+		case ch <- r:
+		default: // slow subscriber: drop — Snapshot recovers
+		}
+	}
+}
+
+// Snapshot returns the latest report per owner, excluding one (a
+// viewer never ghosts itself). Reports are copied; callers may hold
+// them across frames.
+func (s *Store) Snapshot(excludeOwner string) []CraftReport {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]CraftReport, 0, len(s.reports))
+	for owner, r := range s.reports {
+		if owner == excludeOwner {
+			continue
+		}
+		cp := r
+		cp.Crafts = append([]CraftState(nil), r.Crafts...)
+		out = append(out, cp)
+	}
+	return out
+}
+
+// Frontier is the maximum subspace time across every stored report —
+// where a new player joins (you can never start in someone's past,
+// ADR 0034). ok is false while the store is empty.
+func (s *Store) Frontier() (time.Time, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var max time.Time
+	ok := false
+	for _, r := range s.reports {
+		if !ok || r.SubspaceTime.After(max) {
+			max = r.SubspaceTime
+			ok = true
+		}
+	}
+	return max, ok
+}
+
+// Subscribe returns a channel of future reports and a cancel func.
+// The channel is buffered; a subscriber that stalls drops messages
+// rather than blocking reporters.
+func (s *Store) Subscribe() (<-chan CraftReport, func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.nextSub
+	s.nextSub++
+	ch := make(chan CraftReport, 16)
+	s.subs[id] = ch
+	return ch, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		delete(s.subs, id)
+	}
+}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1,0 +1,175 @@
+package relay
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+func newWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	return w
+}
+
+// Report → Snapshot round-trip: a second player sees the first's
+// craft with addressing (system, primary), state vector, and subspace
+// timestamp; the viewer's own reports are excluded.
+func TestReportSnapshotRoundTrip(t *testing.T) {
+	store := NewStore()
+	wA := newWorld(t)
+	repA := NewReporter(store, "SHA256:alice")
+	repA.Tick(wA, time.Now())
+
+	seen := store.Snapshot("SHA256:bob")
+	if len(seen) != 1 {
+		t.Fatalf("Snapshot for bob: %d reports, want 1", len(seen))
+	}
+	r := seen[0]
+	if r.Owner != "SHA256:alice" {
+		t.Errorf("Owner = %q", r.Owner)
+	}
+	if !r.SubspaceTime.Equal(wA.Clock.SimTime) {
+		t.Errorf("SubspaceTime = %v, want %v", r.SubspaceTime, wA.Clock.SimTime)
+	}
+	if len(r.Crafts) != len(wA.Crafts) {
+		t.Fatalf("crafts = %d, want %d", len(r.Crafts), len(wA.Crafts))
+	}
+	c := r.Crafts[0]
+	if c.System != wA.System().Name || c.Primary == "" {
+		t.Errorf("addressing: system=%q primary=%q", c.System, c.Primary)
+	}
+	if c.R.Norm() == 0 || c.V.Norm() == 0 {
+		t.Errorf("state vector empty: R=%v V=%v", c.R, c.V)
+	}
+
+	if own := store.Snapshot("SHA256:alice"); len(own) != 0 {
+		t.Errorf("alice sees her own report: %d", len(own))
+	}
+}
+
+// Coasting doesn't re-report (elements are constant; state vectors
+// move): only element changes or the heartbeat fire.
+func TestChangeDetectionAndHeartbeat(t *testing.T) {
+	store := NewStore()
+	ch, cancel := store.Subscribe()
+	defer cancel()
+	w := newWorld(t)
+	rep := NewReporter(store, "SHA256:alice")
+
+	now := time.Now()
+	rep.Tick(w, now) // first tick always reports
+	if got := drain(ch); got != 1 {
+		t.Fatalf("first tick: %d reports, want 1", got)
+	}
+
+	// Coast: advance the sim a few ticks, wall clock inside heartbeat.
+	for i := 0; i < 5; i++ {
+		w.Tick()
+		rep.Tick(w, now.Add(time.Duration(i+1)*100*time.Millisecond))
+	}
+	if got := drain(ch); got != 0 {
+		t.Errorf("coasting fired %d reports, want 0 (element change detection)", got)
+	}
+
+	// Heartbeat elapses → one report even while coasting.
+	rep.Tick(w, now.Add(Heartbeat+time.Second))
+	if got := drain(ch); got != 1 {
+		t.Errorf("heartbeat: %d reports, want 1", got)
+	}
+
+	// A burn-sized velocity change moves the elements → immediate report.
+	c := w.ActiveCraft()
+	c.State.V.X += 100 // 100 m/s prograde-ish kick
+	rep.Tick(w, now.Add(Heartbeat+1100*time.Millisecond))
+	if got := drain(ch); got != 1 {
+		t.Errorf("element change: %d reports, want 1", got)
+	}
+}
+
+func drain(ch <-chan CraftReport) int {
+	n := 0
+	for {
+		select {
+		case <-ch:
+			n++
+		default:
+			return n
+		}
+	}
+}
+
+// Frontier under divergence: the store's frontier is the max subspace
+// time across players, and a viewer behind it sees it move.
+func TestFrontierUnderDivergence(t *testing.T) {
+	store := NewStore()
+	if _, ok := store.Frontier(); ok {
+		t.Fatal("empty store claims a frontier")
+	}
+	wA, wB := newWorld(t), newWorld(t)
+	// A warps 10 days ahead; B stays put — subspaces diverge.
+	wA.Clock.SimTime = wA.Clock.SimTime.Add(10 * 24 * time.Hour)
+	NewReporter(store, "SHA256:alice").Tick(wA, time.Now())
+	NewReporter(store, "SHA256:bob").Tick(wB, time.Now())
+
+	f, ok := store.Frontier()
+	if !ok {
+		t.Fatal("no frontier with two reports stored")
+	}
+	if !f.Equal(wA.Clock.SimTime) {
+		t.Errorf("frontier = %v, want alice's %v (max of subspaces)", f, wA.Clock.SimTime)
+	}
+	if !f.After(wB.Clock.SimTime) {
+		t.Error("frontier not ahead of the laggard")
+	}
+}
+
+// Concurrent report/subscribe/snapshot is race-clean (the -race run
+// is the assertion; the counts just keep the compiler honest).
+func TestConcurrentReportSubscribe(t *testing.T) {
+	store := NewStore()
+	w := newWorld(t)
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			rep := NewReporter(store, string(rune('a'+n)))
+			for j := 0; j < 50; j++ {
+				rep.Tick(w, time.Now().Add(time.Duration(j)*Heartbeat)) // force reports
+			}
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch, cancel := store.Subscribe()
+		defer cancel()
+		for j := 0; j < 20; j++ {
+			select {
+			case <-ch:
+			case <-time.After(time.Second):
+				return
+			}
+		}
+	}()
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				store.Snapshot("nobody")
+				store.Frontier()
+			}
+		}()
+	}
+	wg.Wait()
+	if got := len(store.Snapshot("nobody")); got != 4 {
+		t.Errorf("owners stored = %d, want 4", got)
+	}
+}

--- a/internal/relay/reporter.go
+++ b/internal/relay/reporter.go
@@ -1,0 +1,140 @@
+package relay
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// Heartbeat is the maximum quiet interval (wall clock) between a
+// session's reports. Change detection below catches every orbit
+// change on the tick it happens, so the heartbeat's only job is
+// bounding subspace-time staleness for the roster's Δt display — a
+// coasting ghost's ORBIT is exact regardless (Kepler evaluation).
+// 5s keeps Δt readable without meaningful traffic; a playtest may
+// move it (v0.27 plan: tunable const with rationale).
+const Heartbeat = 5 * time.Second
+
+// Element-change tolerances for "did the orbit actually change".
+// State vectors move every tick along a coast, but the derived
+// Keplerian elements are constant apart from integrator drift —
+// Verlet truncation wobbles them slightly, so exact comparison would
+// re-report every tick. These bounds sit well above that drift and
+// well below anything a real burn, stage, or SOI transition does.
+const (
+	relTolA   = 1e-6 // semimajor axis, relative
+	absTolE   = 1e-6 // eccentricity, absolute
+	absTolAng = 1e-6 // i / Ω / ω, radians
+)
+
+// Reporter watches one session's World and reports its craft set on
+// element-changing events (burn end, staging, SOI transition — all
+// of which move the derived elements) plus the heartbeat. It carries
+// no goroutine: the session's own tick loop drives Tick, so reports
+// happen at tick boundaries with no cross-goroutine World access.
+type Reporter struct {
+	Owner string
+
+	store    *Store
+	lastWall time.Time
+	lastKeys []craftKey
+}
+
+// craftKey is the per-craft change-detection signature.
+type craftKey struct {
+	id      uint64
+	system  string
+	primary string
+	landed  bool
+	el      orbital.Elements
+}
+
+func NewReporter(store *Store, owner string) *Reporter {
+	return &Reporter{Owner: owner, store: store}
+}
+
+// Tick inspects the world and reports if anything orbit-shaped
+// changed or the heartbeat elapsed. now is wall clock (heartbeat
+// cadence must not warp with sim time).
+func (r *Reporter) Tick(w *sim.World, now time.Time) {
+	keys, states := snapshotWorld(w)
+	due := r.lastWall.IsZero() || now.Sub(r.lastWall) >= Heartbeat
+	if !due && keysEqual(r.lastKeys, keys) {
+		return
+	}
+	r.lastWall = now
+	r.lastKeys = keys
+	r.store.Report(CraftReport{
+		Owner:        r.Owner,
+		SubspaceTime: w.Clock.SimTime,
+		Crafts:       states,
+	})
+}
+
+// snapshotWorld converts the world's craft slate into wire states
+// plus change-detection keys. Craft state is primary-relative already
+// (spacecraft convention), so it goes onto the wire as-is.
+func snapshotWorld(w *sim.World) ([]craftKey, []CraftState) {
+	keys := make([]craftKey, 0, len(w.Crafts))
+	states := make([]CraftState, 0, len(w.Crafts))
+	for _, c := range w.Crafts {
+		if c == nil {
+			continue
+		}
+		system := ""
+		if c.SystemIdx >= 0 && c.SystemIdx < len(w.Systems) {
+			system = w.Systems[c.SystemIdx].Name
+		}
+		var el orbital.Elements
+		if !c.Landed {
+			el = orbital.ElementsFromState(c.State.R, c.State.V, c.Primary.GravitationalParameter())
+		}
+		keys = append(keys, craftKey{
+			id:      c.ID,
+			system:  system,
+			primary: c.Primary.ID,
+			landed:  c.Landed,
+			el:      el,
+		})
+		states = append(states, CraftState{
+			ID:      c.ID,
+			Name:    c.Name,
+			Glyph:   c.Glyph,
+			System:  system,
+			Primary: c.Primary.ID,
+			R:       c.State.R,
+			V:       c.State.V,
+			Landed:  c.Landed,
+		})
+	}
+	return keys, states
+}
+
+func keysEqual(a, b []craftKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].id != b[i].id || a[i].system != b[i].system ||
+			a[i].primary != b[i].primary || a[i].landed != b[i].landed {
+			return false
+		}
+		if !elementsClose(a[i].el, b[i].el) {
+			return false
+		}
+	}
+	return true
+}
+
+func elementsClose(x, y orbital.Elements) bool {
+	scaleA := math.Max(math.Abs(x.A), math.Abs(y.A))
+	if scaleA > 0 && math.Abs(x.A-y.A) > relTolA*scaleA {
+		return false
+	}
+	return math.Abs(x.E-y.E) <= absTolE &&
+		math.Abs(x.I-y.I) <= absTolAng &&
+		math.Abs(x.Omega-y.Omega) <= absTolAng &&
+		math.Abs(x.Arg-y.Arg) <= absTolAng
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -1,0 +1,52 @@
+package serve
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// reportingModel wraps a session's game and feeds the relay store on
+// every sim tick (v0.27 S4). Reports run inside the session's own
+// update loop — same goroutine as the World mutation, so no locking
+// enters the sim. The wrapper is transparent to everything else:
+// input, rendering, and quit pass straight through.
+type reportingModel struct {
+	inner tea.Model
+	app   *tui.App
+	rep   *relay.Reporter
+}
+
+// withReporting wraps app so its world reports to the store as owner.
+func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
+	return reportingModel{inner: app, app: app, rep: relay.NewReporter(s.relay, owner)}
+}
+
+func (m reportingModel) Init() tea.Cmd { return m.inner.Init() }
+
+func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	inner, cmd := m.inner.Update(msg)
+	m.inner = inner
+	if _, ok := msg.(sim.TickMsg); ok {
+		m.rep.Tick(m.app.World(), time.Now())
+	}
+	return m, cmd
+}
+
+func (m reportingModel) View() string { return m.inner.View() }
+
+// HostModel wraps the host's own in-process game so the host's craft
+// enter the store like any guest's (the host is roster entry #1, not
+// a special case on the wire). main runs the returned model.
+func (s *Server) HostModel(app *tui.App) tea.Model {
+	return s.withReporting(app, sessiondir.HostFingerprint)
+}
+
+// Relay exposes the session store (S5/S6 read ghosts and roster
+// state from it).
+func (s *Server) Relay() *relay.Store { return s.relay }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/ssh"
@@ -24,6 +25,7 @@ import (
 	bm "github.com/charmbracelet/wish/bubbletea"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/jasonfen/terminal-space-program/internal/relay"
 	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -51,6 +53,7 @@ type Server struct {
 	ssh   *ssh.Server
 	ln    net.Listener
 	store *sessiondir.Store
+	relay *relay.Store
 }
 
 // DefaultHostKeyPath returns the per-host SSH identity path, sibling
@@ -90,7 +93,7 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store}
+	srv := &Server{store: store, relay: relay.NewStore()}
 	s, err := wish.NewServer(
 		wish.WithAddress(cfg.Addr),
 		wish.WithHostKeyPath(cfg.HostKeyPath),
@@ -176,11 +179,12 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	sess.Context().SetValue(ctxKeyApp, app)
 	sess.Context().SetValue(ctxKeyFingerprint, fp)
 
+	game := s.withReporting(app, fp) // v0.27 S4: sessions feed the store
 	if _, err := s.store.FindPlayer(fp); err == nil {
 		// Enrolled reconnect: no card, no code — resume.
-		return app, opts
+		return game, opts
 	}
-	return newGuestFlow(s.store, fp, app), opts
+	return newGuestFlow(s.store, fp, game), opts
 }
 
 // newGuestApp builds the game for fp: the persisted world when a
@@ -199,6 +203,15 @@ func (s *Server) newGuestApp(fp string) (*tui.App, error) {
 		if app, err = tui.New(nil); err != nil {
 			return nil, err
 		}
+		// Join at the frontier (v0.27 S4, ADR 0034): a NEW player's
+		// clock starts at the max subspace time across live sessions
+		// and persisted payloads — you can never start in someone's
+		// past. Craft state vectors are time-local, so relabelling
+		// "now" is safe. Reconnects (the branch above) keep their own
+		// stored time instead.
+		if f, ok := s.frontier(); ok && f.After(app.World().Clock.SimTime) {
+			app.World().Clock.SimTime = f
+		}
 	default:
 		return nil, err
 	}
@@ -206,6 +219,25 @@ func (s *Server) newGuestApp(fp string) (*tui.App, error) {
 		return s.store.SavePlayer(fp, w)
 	})
 	return app, nil
+}
+
+// frontier combines the live store's max subspace time with the
+// persisted payloads' — offline players hold the frontier too.
+func (s *Server) frontier() (time.Time, bool) {
+	live, okLive := s.relay.Frontier()
+	stored, okStored := s.store.LatestSimTime()
+	switch {
+	case okLive && okStored:
+		if stored.After(live) {
+			return stored, true
+		}
+		return live, true
+	case okLive:
+		return live, true
+	case okStored:
+		return stored, true
+	}
+	return time.Time{}, false
 }
 
 // persistMiddleware writes the final per-player payload after the

--- a/internal/serve/subspace_test.go
+++ b/internal/serve/subspace_test.go
@@ -1,0 +1,136 @@
+package serve
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// newOfflineServer builds a Server with temp state but never starts
+// the listener — the S4 semantics are headless.
+func newOfflineServer(t *testing.T) *Server {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "hostkey"),
+		SessionDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.ln.Close() })
+	return srv
+}
+
+// A new player joins at the frontier: the max subspace time across
+// live reports and persisted payloads, never their past.
+func TestJoinAtFrontier(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	// A live session 10 days ahead holds the frontier.
+	wAhead, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	ahead := wAhead.Clock.SimTime.Add(10 * 24 * time.Hour)
+	wAhead.Clock.SimTime = ahead
+	relay.NewReporter(srv.relay, "SHA256:veteran").Tick(wAhead, time.Now())
+
+	app, err := srv.newGuestApp("SHA256:rookie")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	if got := app.World().Clock.SimTime; !got.Equal(ahead) {
+		t.Errorf("new player joined at %v, want frontier %v", got, ahead)
+	}
+}
+
+// Persisted payloads hold the frontier even when nobody is online —
+// an offline veteran's stored time still floors a new join.
+func TestJoinAtFrontierFromStoredPayload(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	wVet, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	ahead := wVet.Clock.SimTime.Add(30 * 24 * time.Hour)
+	wVet.Clock.SimTime = ahead
+	if err := srv.store.SavePlayer("SHA256:offline-vet", wVet); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	app, err := srv.newGuestApp("SHA256:rookie")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	if got := app.World().Clock.SimTime; !got.Equal(ahead) {
+		t.Errorf("new player joined at %v, want stored frontier %v", got, ahead)
+	}
+}
+
+// A reconnect resumes the player's OWN stored time — behind the
+// frontier is fine; only fresh joins snap forward.
+func TestReconnectKeepsOwnTime(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	wOwn, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	own := wOwn.Clock.SimTime.Add(2 * 24 * time.Hour)
+	wOwn.Clock.SimTime = own
+	if err := srv.store.SavePlayer("SHA256:me", wOwn); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	// Someone else is far ahead, both live and stored.
+	wAhead, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	wAhead.Clock.SimTime = wAhead.Clock.SimTime.Add(20 * 24 * time.Hour)
+	relay.NewReporter(srv.relay, "SHA256:veteran").Tick(wAhead, time.Now())
+
+	app, err := srv.newGuestApp("SHA256:me")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	if got := app.World().Clock.SimTime; !got.Equal(own) {
+		t.Errorf("reconnect resumed at %v, want own stored %v", got, own)
+	}
+}
+
+// The host's wrapped model reports into the store on ticks under the
+// host fingerprint — the host is a first-class session on the wire.
+func TestHostModelReports(t *testing.T) {
+	srv := newOfflineServer(t)
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = srv.HostModel(hostApp)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 45})
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+
+	seen := srv.relay.Snapshot("SHA256:some-guest")
+	if len(seen) != 1 || seen[0].Owner != sessiondir.HostFingerprint {
+		t.Fatalf("store after host tick = %+v, want one report owned by %q", seen, sessiondir.HostFingerprint)
+	}
+	if len(seen[0].Crafts) == 0 {
+		t.Error("host report carries no craft")
+	}
+	// The wrapper is transparent: the frame is still the game.
+	if out := stripANSI(m.View()); !strings.Contains(out, "warp 1x") {
+		t.Errorf("wrapped host model broke rendering:\n%s", firstLines(out, 3))
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -318,3 +318,40 @@ func (s *Store) HasPayload(fingerprint string) bool {
 	_, err := os.Stat(s.payloadPath(fingerprint))
 	return err == nil
 }
+
+// LatestSimTime scans every persisted player payload for the maximum
+// stored subspace time — offline players hold the frontier (v0.27 S4,
+// ADR 0034: you can never start in someone's past, online or not).
+// ok is false when no payload parses. Unreadable files are skipped:
+// frontier is a floor, not an integrity check.
+func (s *Store) LatestSimTime() (time.Time, bool) {
+	entries, err := os.ReadDir(filepath.Join(s.dir, "players"))
+	if err != nil {
+		return time.Time{}, false
+	}
+	var max time.Time
+	found := false
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(s.dir, "players", e.Name()))
+		if err != nil {
+			continue
+		}
+		var probe struct {
+			Payload struct {
+				SimTimeNano int64 `json:"sim_time_unix_nano"`
+			} `json:"payload"`
+		}
+		if json.Unmarshal(data, &probe) != nil || probe.Payload.SimTimeNano == 0 {
+			continue
+		}
+		t := time.Unix(0, probe.Payload.SimTimeNano).UTC()
+		if !found || t.After(max) {
+			max = t
+			found = true
+		}
+	}
+	return max, found
+}


### PR DESCRIPTION
Fourth slice of the v0.27 multiplayer ssh-only MVP (ADR 0034 + v0.27-plan).

## What

- **`internal/relay`** — the message-shaped report/subscribe store: `CraftReport` (owner fingerprint, subspace timestamp, craft set) with primary-relative state vectors (the save-envelope representation; `physics.KeplerStep` propagates it directly for S5 ghosts). Set-replace per owner, viewer-excluding `Snapshot`, non-blocking `Subscribe`. Store discipline honored: everything crossing the interface serializes — v2 WebSocket is a transport swap.
- **Reporter** — element-change detection: a coasting craft's state vectors move every tick but its Keplerian elements don't, so tolerances sit above integrator drift and below any real burn/stage/SOI change. Plus a **5s wall heartbeat** (tunable const with rationale) that only bounds roster-Δt staleness.
- **Clocks officially diverge** — every session model (guests, and the host via `HostModel` wrapping in main) reports on its own tick, in its own update goroutine; no locking enters the sim.
- **Frontier** — max subspace time across live reports *and* persisted payloads (`sessiondir.LatestSimTime` scans envelopes), so an offline veteran still floors a new join. Fresh joins snap forward; **reconnects keep their own stored time**.

## Acceptance (per plan)

Two-World table tests: report/subscribe round-trip · coast suppression + heartbeat + element-change fire · frontier under divergence · join-at-frontier (live + stored variants) · reconnect-keeps-own-time · host-model reporting · concurrent report/subscribe under `-race`.

Full suite: 1,516 tests, `-race` clean; `go vet` clean.