### PR TITLE
feat(relay,sim,tui,serve): v0.27 S5 — Kepler ghosts

### DIFF
--- a/internal/relay/ghosts.go
+++ b/internal/relay/ghosts.go
@@ -1,0 +1,61 @@
+package relay
+
+import (
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// GhostsFor evaluates every stored report against the viewer's world
+// (v0.27 S5, ADR 0034): each remote craft's last-reported primary-
+// relative state is propagated analytically (KeplerStep, forward OR
+// backward) across the subspace gap to the viewer's sim-time, then
+// rebased onto the primary's position at that time. Gating per ADR
+// 0015: only craft in the viewer's active system appear. Landed craft
+// carry no orbit and are skipped (roster surfaces still count them).
+// handles joins owner fingerprints to display names.
+//
+// Honest staleness: KeplerStep neither detects SOI exits nor knows
+// about burns after the report — the ghost is "where they'd be if
+// they kept coasting", exactly the ADR contract.
+func GhostsFor(w *sim.World, reports []CraftReport, handles map[string]string) []sim.Ghost {
+	sysName := w.System().Name
+	viewerT := w.Clock.SimTime
+	var out []sim.Ghost
+	for _, rep := range reports {
+		dt := viewerT.Sub(rep.SubspaceTime).Seconds()
+		for _, cs := range rep.Crafts {
+			if cs.Landed || cs.System != sysName {
+				continue
+			}
+			primary, ok := bodyByID(w.System(), cs.Primary)
+			if !ok {
+				continue
+			}
+			st, ok := physics.KeplerStep(
+				physics.StateVector{R: cs.R, V: cs.V, M: 1},
+				primary.GravitationalParameter(), dt)
+			if !ok {
+				continue // degenerate state — better no ghost than a wrong one
+			}
+			out = append(out, sim.Ghost{
+				Owner:     rep.Owner,
+				Handle:    handles[rep.Owner],
+				Name:      cs.Name,
+				Glyph:     cs.Glyph,
+				PrimaryID: cs.Primary,
+				Pos:       w.BodyPosition(primary).Add(st.R),
+			})
+		}
+	}
+	return out
+}
+
+func bodyByID(sys bodies.System, id string) (bodies.CelestialBody, bool) {
+	for _, b := range sys.Bodies {
+		if b.ID == id {
+			return b, true
+		}
+	}
+	return bodies.CelestialBody{}, false
+}

--- a/internal/relay/ghosts_test.go
+++ b/internal/relay/ghosts_test.go
@@ -1,0 +1,147 @@
+package relay
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// reportFor snapshots w as a single-owner report.
+func reportFor(t *testing.T, w *sim.World, owner string) CraftReport {
+	t.Helper()
+	store := NewStore()
+	NewReporter(store, owner).Tick(w, time.Now())
+	snaps := store.Snapshot("someone-else")
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(snaps))
+	}
+	return snaps[0]
+}
+
+// A ghost evaluated exactly one orbital period ahead of (or behind)
+// the report lands back on the reported position — the analytic
+// propagation is periodic, and both signs of the subspace gap work.
+func TestGhostPeriodicityAheadAndBehind(t *testing.T) {
+	wOwner, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	rep := reportFor(t, wOwner, "SHA256:owner")
+	cs := rep.Crafts[0]
+
+	c := wOwner.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	period := 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
+
+	for _, dir := range []float64{+1, -1} {
+		viewer, err := sim.NewWorld()
+		if err != nil {
+			t.Fatalf("NewWorld viewer: %v", err)
+		}
+		viewer.Clock.SimTime = rep.SubspaceTime.Add(time.Duration(dir * period * float64(time.Second)))
+		ghosts := GhostsFor(viewer, []CraftReport{rep}, map[string]string{"SHA256:owner": "gern"})
+		if len(ghosts) != len(rep.Crafts) {
+			t.Fatalf("dir %v: %d ghosts, want %d", dir, len(ghosts), len(rep.Crafts))
+		}
+		g := ghosts[0]
+		if g.Handle != "gern" {
+			t.Errorf("handle join failed: %q", g.Handle)
+		}
+		primary, ok := bodyByID(viewer.System(), cs.Primary)
+		if !ok {
+			t.Fatalf("primary %q not found", cs.Primary)
+		}
+		rel := g.Pos.Sub(viewer.BodyPosition(primary))
+		if d := rel.Sub(cs.R).Norm(); d > 1.0 {
+			t.Errorf("dir %v: ghost off by %.3f m after one period (rel=%v want=%v)", dir, d, rel, cs.R)
+		}
+	}
+}
+
+// Ghosts gate to the viewer's active system (ADR 0015 composition).
+func TestGhostOtherSystemInvisible(t *testing.T) {
+	viewer, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	rep := CraftReport{
+		Owner:        "SHA256:owner",
+		SubspaceTime: viewer.Clock.SimTime,
+		Crafts: []CraftState{{
+			ID: 1, Name: "far-away", System: "Definitely-Not-" + viewer.System().Name,
+			Primary: viewer.System().Bodies[0].ID,
+			R:       orbital.Vec3{X: 7e6}, V: orbital.Vec3{Y: 7500},
+		}},
+	}
+	if ghosts := GhostsFor(viewer, []CraftReport{rep}, nil); len(ghosts) != 0 {
+		t.Errorf("other-system craft ghosted: %+v", ghosts)
+	}
+}
+
+// Landed craft carry no orbit and don't ghost.
+func TestGhostLandedSkipped(t *testing.T) {
+	viewer, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	rep := CraftReport{
+		Owner:        "SHA256:owner",
+		SubspaceTime: viewer.Clock.SimTime,
+		Crafts: []CraftState{{
+			ID: 1, Name: "parked", System: viewer.System().Name,
+			Primary: viewer.System().Bodies[0].ID, Landed: true,
+		}},
+	}
+	if ghosts := GhostsFor(viewer, []CraftReport{rep}, nil); len(ghosts) != 0 {
+		t.Errorf("landed craft ghosted: %+v", ghosts)
+	}
+}
+
+// A ghost around a non-home primary (SOI'd, e.g. a moon) rebases onto
+// THAT body's position at the viewer's time.
+func TestGhostSOIPrimaryOffset(t *testing.T) {
+	viewer, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Pick any body with a parent (an orbiting body, not the star).
+	var moon string
+	for _, b := range viewer.System().Bodies {
+		if b.ParentID != "" {
+			moon = b.ID
+			break
+		}
+	}
+	if moon == "" {
+		t.Skip("no orbiting body in system")
+	}
+	primary, _ := bodyByID(viewer.System(), moon)
+	mu := primary.GravitationalParameter()
+	r0 := primary.RadiusMeters() * 1.5
+	rel := orbital.Vec3{X: r0}
+	vel := orbital.Vec3{Y: math.Sqrt(mu / r0)} // circular
+
+	rep := CraftReport{
+		Owner:        "SHA256:owner",
+		SubspaceTime: viewer.Clock.SimTime, // dt = 0: pure rebase check
+		Crafts: []CraftState{{
+			ID: 1, Name: "orbiter", System: viewer.System().Name,
+			Primary: moon, R: rel, V: vel,
+		}},
+	}
+	ghosts := GhostsFor(viewer, []CraftReport{rep}, nil)
+	if len(ghosts) != 1 {
+		t.Fatalf("%d ghosts, want 1", len(ghosts))
+	}
+	want := viewer.BodyPosition(primary).Add(rel)
+	if d := ghosts[0].Pos.Sub(want).Norm(); d > 1e-6 {
+		t.Errorf("SOI'd ghost off its primary by %.3g m", d)
+	}
+	if ghosts[0].PrimaryID != moon {
+		t.Errorf("PrimaryID = %q, want %q", ghosts[0].PrimaryID, moon)
+	}
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -20,11 +20,25 @@ type reportingModel struct {
 	inner tea.Model
 	app   *tui.App
 	rep   *relay.Reporter
+	srv   *Server
+	owner string
+
+	// handle cache: fingerprint → display name, refreshed lazily so
+	// each tick doesn't re-read session.json. A new enrollee's handle
+	// appears within the refresh window.
+	handles   map[string]string
+	handlesAt time.Time
 }
+
+const handleRefresh = 5 * time.Second
 
 // withReporting wraps app so its world reports to the store as owner.
 func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
-	return reportingModel{inner: app, app: app, rep: relay.NewReporter(s.relay, owner)}
+	return reportingModel{
+		inner: app, app: app,
+		rep: relay.NewReporter(s.relay, owner),
+		srv: s, owner: owner,
+	}
 }
 
 func (m reportingModel) Init() tea.Cmd { return m.inner.Init() }
@@ -33,9 +47,33 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	inner, cmd := m.inner.Update(msg)
 	m.inner = inner
 	if _, ok := msg.(sim.TickMsg); ok {
-		m.rep.Tick(m.app.World(), time.Now())
+		now := time.Now()
+		w := m.app.World()
+		m.rep.Tick(w, now)
+		// v0.27 S5: refresh this world's ghost slate from the store —
+		// the screens read w.Ghosts like any other world state.
+		if m.handles == nil || now.Sub(m.handlesAt) >= handleRefresh {
+			m.handles = m.rosterHandles()
+			m.handlesAt = now
+		}
+		w.Ghosts = relay.GhostsFor(w, m.srv.relay.Snapshot(m.owner), m.handles)
 	}
 	return m, cmd
+}
+
+// rosterHandles reads the fingerprint→handle join from the session
+// roster. Failures yield an empty map (ghosts render nameless rather
+// than not at all).
+func (m reportingModel) rosterHandles() map[string]string {
+	meta, err := m.srv.store.Meta()
+	if err != nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(meta.Roster))
+	for _, p := range meta.Roster {
+		out[p.Fingerprint] = p.Handle
+	}
+	return out
 }
 
 func (m reportingModel) View() string { return m.inner.View() }

--- a/internal/sim/ghost.go
+++ b/internal/sim/ghost.go
@@ -1,0 +1,18 @@
+package sim
+
+import "github.com/jasonfen/terminal-space-program/internal/orbital"
+
+// Ghost is one remote player's craft placed at this world's sim-time
+// (v0.27 S5, ADR 0034): the last-reported orbit evaluated analytically
+// at the viewer's clock. Honest staleness by design — it's where
+// they'd be if they kept coasting; a burn on their side invalidates it
+// until the next report corrects. Pure display data: the orbit screen
+// draws it dim with the owner's handle; physics never sees it.
+type Ghost struct {
+	Owner     string // ssh key fingerprint (roster identity)
+	Handle    string // display name, joined from the session roster
+	Name      string // craft name
+	Glyph     string // craft glyph (may be empty)
+	PrimaryID string // SOI primary the ghost orbits
+	Pos       orbital.Vec3
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -194,6 +194,14 @@ type World struct {
 	// Not persisted (rebuilt from the catalog on load).
 	GroundStations []GroundStationPreset
 
+	// Ghosts are other players' craft evaluated at THIS world's
+	// sim-time (v0.27 S5, ADR 0034 — Kepler ghosts). Written each tick
+	// by the multiplayer serve layer from the session store; empty in
+	// single-player. Render-only and transient: never persisted, never
+	// physically interactive, already gated to this world's active
+	// system by the writer.
+	Ghosts []Ghost
+
 	// CommGraph is the cached per-tick CommNet connectivity result (v0.23 /
 	// ADR 0027): which unmanned probes currently reach a ground station.
 	// Rebuilt each Tick by RecomputeCommGraph after physics; read by

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -731,6 +731,26 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// blob over the parent body that doesn't read as an orbit. The
 	// vessel chevron stays drawn so the craft's presence is still
 	// communicated.
+	// v0.27 S5 (ADR 0034): Kepler ghosts — other players' craft,
+	// already evaluated at this world's sim-time and gated to this
+	// system by the serve layer. Dim marker + glyph + handle label,
+	// drawn before own craft so a shared cell always shows the real
+	// vessel. Display only: no hit-test tag, no orbit ellipse — the
+	// marker is the rendezvous cue, the track is the owner's business.
+	for _, g := range w.Ghosts {
+		ghostColor := lipgloss.Color(render.ColorDim)
+		v.canvas.PlotColored(g.Pos, ghostColor)
+		if gl := []rune(g.Glyph); len(gl) > 0 {
+			v.canvas.SetCellOverlayColored(g.Pos, gl[0], ghostColor)
+		}
+		if g.Handle != "" {
+			// Project yields pixel coords; braille cells are 2×4 px.
+			if px, py, ok := v.canvas.Project(g.Pos); ok {
+				v.canvas.SetCellLabelColored(px/2+2, py/4, g.Handle, ghostColor)
+			}
+		}
+	}
+
 	if w.CraftVisibleHere() {
 		c := w.ActiveCraft()
 		muCraft := c.Primary.GravitationalParameter()

--- a/internal/tui/screens/orbit_ghost_test.go
+++ b/internal/tui/screens/orbit_ghost_test.go
@@ -1,0 +1,51 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// Ghost styling (v0.27 S5): a populated w.Ghosts renders the ghost's
+// glyph and handle on the orbit canvas; an empty slate renders none.
+func TestOrbitViewRendersGhosts(t *testing.T) {
+	th := Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+	v := NewOrbitView(th)
+	v.Resize(120, 40)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	before := v.Render(w, 0, 120, 40)
+	if strings.Contains(before, "gern") {
+		t.Fatal("handle rendered with no ghosts set")
+	}
+
+	// Park the ghost on the active craft's orbit, opposite side — on
+	// screen at the default zoom, clear of the vessel's own cell.
+	c := w.ActiveCraft()
+	ghostPos := w.BodyPosition(c.Primary).Add(c.State.R.Scale(-1))
+	w.Ghosts = []sim.Ghost{{
+		Owner: "SHA256:x", Handle: "gern", Name: "gern's ship",
+		Glyph: "◆", PrimaryID: c.Primary.ID, Pos: ghostPos,
+	}}
+	out := v.Render(w, 0, 120, 40)
+	if !strings.Contains(out, "gern") {
+		t.Error("ghost handle not rendered")
+	}
+	if !strings.Contains(out, "◆") {
+		t.Error("ghost glyph not rendered")
+	}
+}


### PR DESCRIPTION
Fifth slice of the v0.27 multiplayer ssh-only MVP (ADR 0034 + v0.27-plan).

## What

- **`relay.GhostsFor`** — evaluates stored reports at the *viewer's* sim-time: reported primary-relative state propagates analytically via `physics.KeplerStep` (forward **or backward** across the subspace gap — a ghost is symmetric whether its owner is ahead or behind you) and rebases onto the primary's position at the viewer's clock. ADR 0015 same-system gating; landed craft skipped; degenerate states drop.
- **`World.Ghosts`** — transient render-only slate on the sim world (never persisted, empty in single-player). The serve reporting wrapper refreshes it each tick from a store snapshot and joins handles from the roster (lazy 5s cache), so screens keep their read-from-world-only contract.
- **Orbit canvas** — ghosts draw dim: marker + glyph + handle label, before own craft (a shared cell always shows the real vessel). No hit-test, no orbit ellipse — Target integration lands with the Session screen (S6), per plan.

## Acceptance (per plan)

- Sim-level ghost-evaluation tests: **one full orbital period ahead and behind** land back on the reported position (<1 m); SOI'd-primary rebase; other-system invisible; landed skipped; handle join.
- Orbit screen ghost-styling test (glyph + handle render; none without ghosts).
- Full suite: 1,521 tests, `-race` clean; `go vet` clean.