### PR TITLE
feat(tui,serve,sim,sessiondir): v0.27 S6 — Session screen + chips

### DIFF
--- a/internal/relay/ghosts.go
+++ b/internal/relay/ghosts.go
@@ -40,11 +40,13 @@ func GhostsFor(w *sim.World, reports []CraftReport, handles map[string]string) [
 			}
 			out = append(out, sim.Ghost{
 				Owner:     rep.Owner,
+				CraftID:   cs.ID,
 				Handle:    handles[rep.Owner],
 				Name:      cs.Name,
 				Glyph:     cs.Glyph,
 				PrimaryID: cs.Primary,
 				Pos:       w.BodyPosition(primary).Add(st.R),
+				Vel:       st.V,
 			})
 		}
 	}

--- a/internal/serve/flow.go
+++ b/internal/serve/flow.go
@@ -16,9 +16,10 @@ import (
 // Enrolled reconnects never see this model; the session handler hands
 // them the game directly.
 type guestFlow struct {
-	store *sessiondir.Store
-	fp    string    // ssh public-key fingerprint (the identity)
-	game  tea.Model // *tui.App, guest sink already attached
+	store    *sessiondir.Store
+	fp       string             // ssh public-key fingerprint (the identity)
+	game     tea.Model          // the session's game (guest sink attached)
+	onEnroll func(handle string) // presence/chip hook, fired at commit (may be nil)
 
 	phase    flowPhase
 	declined bool
@@ -36,8 +37,8 @@ const (
 	phaseHandle
 )
 
-func newGuestFlow(store *sessiondir.Store, fp string, game tea.Model) tea.Model {
-	return guestFlow{store: store, fp: fp, game: game}
+func newGuestFlow(store *sessiondir.Store, fp string, game tea.Model, onEnroll func(handle string)) tea.Model {
+	return guestFlow{store: store, fp: fp, game: game, onEnroll: onEnroll}
 }
 
 func (m guestFlow) Init() tea.Cmd { return nil }
@@ -116,13 +117,17 @@ func (m guestFlow) updateCode(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m guestFlow) updateHandle(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch k.Type {
 	case tea.KeyEnter:
-		if _, err := m.store.Enroll(m.code, m.fp, string(m.input)); err != nil {
+		p, err := m.store.Enroll(m.code, m.fp, string(m.input))
+		if err != nil {
 			// The code was spent between Peek and commit (or the handle
 			// is empty) — back to the code prompt with the reason.
 			m.errMsg = err.Error()
 			m.phase = phaseCode
 			m.input = nil
 			return m, nil
+		}
+		if m.onEnroll != nil {
+			m.onEnroll(p.Handle)
 		}
 		return m.startGame()
 	case tea.KeyBackspace:

--- a/internal/serve/flow_test.go
+++ b/internal/serve/flow_test.go
@@ -24,7 +24,7 @@ func newFlowFixture(t *testing.T) (*sessiondir.Store, tea.Model) {
 	if err != nil {
 		t.Fatalf("newSessionApp: %v", err)
 	}
-	return store, newGuestFlow(store, testFP, game)
+	return store, newGuestFlow(store, testFP, game, nil)
 }
 
 func typeString(m tea.Model, s string) tea.Model {

--- a/internal/serve/presence.go
+++ b/internal/serve/presence.go
@@ -1,0 +1,68 @@
+package serve
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// presence tracks who is live right now and the recent join/leave/
+// sync moments (v0.27 S6). Sessions mutate it from their own
+// goroutines; readers copy under the lock.
+type presence struct {
+	mu     sync.Mutex
+	online map[string]int // fingerprint → live session count
+	events []sim.SessionEvent
+}
+
+const presenceEventCap = 32
+
+func newPresence() *presence {
+	return &presence{online: map[string]int{}}
+}
+
+func (p *presence) markOnline(fp string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.online[fp]++
+}
+
+func (p *presence) markOffline(fp string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.online[fp] > 1 {
+		p.online[fp]--
+	} else {
+		delete(p.online, fp)
+	}
+}
+
+func (p *presence) isOnline(fp string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.online[fp] > 0
+}
+
+// event appends a session moment, trimming the ring.
+func (p *presence) event(kind sim.SessionEventKind, owner, handle string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, sim.SessionEvent{Kind: kind, Owner: owner, Handle: handle, At: time.Now()})
+	if len(p.events) > presenceEventCap {
+		p.events = p.events[len(p.events)-presenceEventCap:]
+	}
+}
+
+// eventsFor copies recent events, excluding the viewer's own.
+func (p *presence) eventsFor(viewer string) []sim.SessionEvent {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []sim.SessionEvent
+	for _, e := range p.events {
+		if e.Owner != viewer {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -9,13 +9,15 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
-// reportingModel wraps a session's game and feeds the relay store on
-// every sim tick (v0.27 S4). Reports run inside the session's own
-// update loop — same goroutine as the World mutation, so no locking
-// enters the sim. The wrapper is transparent to everything else:
-// input, rendering, and quit pass straight through.
+// reportingModel wraps a session's game: it feeds the relay store on
+// every sim tick (v0.27 S4), refreshes the world's ghost slate (S5)
+// and session slate (S6), and executes the Session screen's admin
+// commands against the session store — everything runs inside the
+// session's own update loop, same goroutine as the World mutation.
+// The wrapper is transparent to everything else.
 type reportingModel struct {
 	inner tea.Model
 	app   *tui.App
@@ -23,14 +25,14 @@ type reportingModel struct {
 	srv   *Server
 	owner string
 
-	// handle cache: fingerprint → display name, refreshed lazily so
-	// each tick doesn't re-read session.json. A new enrollee's handle
-	// appears within the refresh window.
-	handles   map[string]string
-	handlesAt time.Time
+	// meta cache: roster + invites, refreshed lazily so each tick
+	// doesn't re-read session.json. Admin commands force a refresh so
+	// a freshly minted code shows immediately.
+	meta   sessiondir.Meta
+	metaAt time.Time
 }
 
-const handleRefresh = 5 * time.Second
+const metaRefresh = 5 * time.Second
 
 // withReporting wraps app so its world reports to the store as owner.
 func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
@@ -44,36 +46,89 @@ func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
 func (m reportingModel) Init() tea.Cmd { return m.inner.Init() }
 
 func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Session-admin intents from the Session screen (v0.27 S6): the
+	// wrapper owns the store access; the App below only dispatched.
+	if admin, ok := msg.(screens.SessionAdminMsg); ok {
+		switch admin.Cmd.Kind {
+		case screens.SessionCmdMint:
+			_, _ = m.srv.store.MintInvite(admin.Cmd.Handle)
+		case screens.SessionCmdRevoke:
+			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
+		case screens.SessionCmdRemove:
+			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
+		}
+		m.metaAt = time.Time{} // force refresh — the list is the feedback
+		m.refreshSession(time.Now())
+		return m, nil
+	}
+
 	inner, cmd := m.inner.Update(msg)
 	m.inner = inner
 	if _, ok := msg.(sim.TickMsg); ok {
 		now := time.Now()
-		w := m.app.World()
-		m.rep.Tick(w, now)
-		// v0.27 S5: refresh this world's ghost slate from the store —
-		// the screens read w.Ghosts like any other world state.
-		if m.handles == nil || now.Sub(m.handlesAt) >= handleRefresh {
-			m.handles = m.rosterHandles()
-			m.handlesAt = now
-		}
-		w.Ghosts = relay.GhostsFor(w, m.srv.relay.Snapshot(m.owner), m.handles)
+		m.rep.Tick(m.app.World(), now)
+		m.refreshSession(now)
 	}
 	return m, cmd
 }
 
-// rosterHandles reads the fingerprint→handle join from the session
-// roster. Failures yield an empty map (ghosts render nameless rather
-// than not at all).
-func (m reportingModel) rosterHandles() map[string]string {
-	meta, err := m.srv.store.Meta()
-	if err != nil {
-		return map[string]string{}
+// refreshSession rebuilds the world's ghost + session slates from the
+// store, roster, and presence.
+func (m *reportingModel) refreshSession(now time.Time) {
+	if m.meta.Version == 0 || now.Sub(m.metaAt) >= metaRefresh {
+		if meta, err := m.srv.store.Meta(); err == nil {
+			m.meta = meta
+			m.metaAt = now
+		}
 	}
-	out := make(map[string]string, len(meta.Roster))
-	for _, p := range meta.Roster {
-		out[p.Fingerprint] = p.Handle
+	w := m.app.World()
+
+	handles := make(map[string]string, len(m.meta.Roster))
+	for _, p := range m.meta.Roster {
+		handles[p.Fingerprint] = p.Handle
 	}
-	return out
+	// Ghosts (S5): everyone else's craft at this world's sim-time.
+	w.Ghosts = relay.GhostsFor(w, m.srv.relay.Snapshot(m.owner), handles)
+
+	// Session slate (S6). Snapshot("") includes the viewer's own
+	// report — the roster row marked "you".
+	reports := map[string]relay.CraftReport{}
+	for _, r := range m.srv.relay.Snapshot("") {
+		reports[r.Owner] = r
+	}
+	info := &sim.SessionInfo{
+		IsHost: m.owner == sessiondir.HostFingerprint,
+		Self:   m.owner,
+	}
+	for _, p := range m.meta.Roster {
+		row := sim.SessionPlayer{
+			Fingerprint: p.Fingerprint,
+			Handle:      p.Handle,
+			Role:        p.Role,
+			Online:      m.srv.presence.isOnline(p.Fingerprint),
+		}
+		if rep, ok := reports[p.Fingerprint]; ok {
+			row.HasReport = true
+			row.DeltaT = rep.SubspaceTime.Sub(w.Clock.SimTime)
+			row.CraftCount = len(rep.Crafts)
+			if len(rep.Crafts) > 0 {
+				row.System = rep.Crafts[0].System
+				row.Primary = rep.Crafts[0].Primary
+			}
+		}
+		info.Players = append(info.Players, row)
+	}
+	if info.IsHost {
+		for _, inv := range m.meta.Invites {
+			info.Invites = append(info.Invites, sim.SessionInvite{
+				Code:   inv.Code,
+				Handle: inv.Handle,
+				Age:    now.Sub(inv.CreatedAt),
+			})
+		}
+	}
+	w.Session = info
+	w.SessionEvents = m.srv.presence.eventsFor(m.owner)
 }
 
 func (m reportingModel) View() string { return m.inner.View() }
@@ -85,6 +140,5 @@ func (s *Server) HostModel(app *tui.App) tea.Model {
 	return s.withReporting(app, sessiondir.HostFingerprint)
 }
 
-// Relay exposes the session store (S5/S6 read ghosts and roster
-// state from it).
+// Relay exposes the session store (tests and later slices read it).
 func (s *Server) Relay() *relay.Store { return s.relay }

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -50,10 +50,11 @@ type Config struct {
 // run their own game. The listener is bound in New so port conflicts
 // surface before the host's own TUI takes the screen.
 type Server struct {
-	ssh   *ssh.Server
-	ln    net.Listener
-	store *sessiondir.Store
-	relay *relay.Store
+	ssh      *ssh.Server
+	ln       net.Listener
+	store    *sessiondir.Store
+	relay    *relay.Store
+	presence *presence
 }
 
 // DefaultHostKeyPath returns the per-host SSH identity path, sibling
@@ -93,7 +94,10 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store, relay: relay.NewStore()}
+	srv := &Server{store: store, relay: relay.NewStore(), presence: newPresence()}
+	// The host plays in-process and is online for the session's whole
+	// life — no join chip for them (serve start isn't a "moment").
+	srv.presence.markOnline(sessiondir.HostFingerprint)
 	s, err := wish.NewServer(
 		wish.WithAddress(cfg.Addr),
 		wish.WithHostKeyPath(cfg.HostKeyPath),
@@ -151,6 +155,7 @@ type ctxKey int
 const (
 	ctxKeyApp ctxKey = iota
 	ctxKeyFingerprint
+	ctxKeyJoined // set once this session marked presence-online
 )
 
 // sessionHandler builds the per-connection model. Enrolled keys go
@@ -180,11 +185,23 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	sess.Context().SetValue(ctxKeyFingerprint, fp)
 
 	game := s.withReporting(app, fp) // v0.27 S4: sessions feed the store
-	if _, err := s.store.FindPlayer(fp); err == nil {
-		// Enrolled reconnect: no card, no code — resume.
+	if p, err := s.store.FindPlayer(fp); err == nil {
+		// Enrolled reconnect: no card, no code — resume. Presence +
+		// join chip fire now; the middleware pairs the leave.
+		s.presence.markOnline(fp)
+		s.presence.event(sim.SessionEventJoin, fp, p.Handle)
+		sess.Context().SetValue(ctxKeyJoined, true)
 		return game, opts
 	}
-	return newGuestFlow(s.store, fp, game), opts
+	// Unknown key → enroll flow. Presence starts when (if) the flow
+	// commits the enrollment.
+	ctx := sess.Context()
+	onEnroll := func(handle string) {
+		s.presence.markOnline(fp)
+		s.presence.event(sim.SessionEventJoin, fp, handle)
+		ctx.SetValue(ctxKeyJoined, true)
+	}
+	return newGuestFlow(s.store, fp, game, onEnroll), opts
 }
 
 // newGuestApp builds the game for fp: the persisted world when a
@@ -248,11 +265,18 @@ func (s *Server) frontier() (time.Time, bool) {
 func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 	return func(sess ssh.Session) {
 		next(sess)
-		app, ok := sess.Context().Value(ctxKeyApp).(*tui.App)
+		fp, ok := sess.Context().Value(ctxKeyFingerprint).(string)
 		if !ok {
 			return
 		}
-		fp, ok := sess.Context().Value(ctxKeyFingerprint).(string)
+		// Presence: pair the join marked at connect/enroll (v0.27 S6).
+		if joined, _ := sess.Context().Value(ctxKeyJoined).(bool); joined {
+			s.presence.markOffline(fp)
+			if p, err := s.store.FindPlayer(fp); err == nil {
+				s.presence.event(sim.SessionEventLeave, fp, p.Handle)
+			}
+		}
+		app, ok := sess.Context().Value(ctxKeyApp).(*tui.App)
 		if !ok {
 			return
 		}

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -1,0 +1,123 @@
+package serve
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// tick drives one WindowSize + Tick through a wrapped model.
+func tick(m tea.Model) tea.Model {
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 45})
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	return m
+}
+
+// The wrapper populates the world's session slate: roster rows with
+// presence, Δt, craft counts; invites only for the host; and recent
+// join/leave events (viewer's own excluded).
+func TestSessionSlatePopulated(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	if _, err := srv.store.MintInvite("newbie"); err != nil {
+		t.Fatalf("MintInvite: %v", err)
+	}
+	srv.presence.markOnline("SHA256:gern")
+	srv.presence.event(sim.SessionEventJoin, "SHA256:gern", "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	host := tick(srv.HostModel(hostApp))
+	_ = host
+	w := hostApp.World()
+	info := w.Session
+	if info == nil {
+		t.Fatal("host world has no session slate after a tick")
+	}
+	if !info.IsHost {
+		t.Error("host slate not marked IsHost")
+	}
+	if len(info.Players) != 2 {
+		t.Fatalf("players = %d, want 2 (host + gern)", len(info.Players))
+	}
+	var gern *sim.SessionPlayer
+	for i := range info.Players {
+		if info.Players[i].Handle == "gern" {
+			gern = &info.Players[i]
+		}
+	}
+	if gern == nil || !gern.Online {
+		t.Fatalf("gern row missing or offline: %+v", info.Players)
+	}
+	if len(info.Invites) != 1 || info.Invites[0].Handle != "newbie" {
+		t.Errorf("host invites = %+v", info.Invites)
+	}
+	// The join chip event reaches the host's world (owner ≠ viewer).
+	if len(w.SessionEvents) != 1 || w.SessionEvents[0].Handle != "gern" {
+		t.Errorf("host SessionEvents = %+v", w.SessionEvents)
+	}
+
+	// A guest's slate: no invites, and their own join excluded.
+	guestApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	_ = tick(srv.withReporting(guestApp, "SHA256:gern"))
+	ginfo := guestApp.World().Session
+	if ginfo == nil || ginfo.IsHost {
+		t.Fatalf("guest slate = %+v", ginfo)
+	}
+	if len(ginfo.Invites) != 0 {
+		t.Error("guest slate leaked invites")
+	}
+	if len(guestApp.World().SessionEvents) != 0 {
+		t.Errorf("guest sees their own join: %+v", guestApp.World().SessionEvents)
+	}
+}
+
+// SessionAdminMsg executes mint/revoke/remove against the store and
+// refreshes the slate immediately.
+func TestSessionAdminCommands(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	m := tick(srv.HostModel(hostApp))
+
+	m, _ = m.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdMint, Handle: "newpal",
+	}})
+	meta, _ := srv.store.Meta()
+	if len(meta.Invites) != 1 || meta.Invites[0].Handle != "newpal" {
+		t.Fatalf("mint via admin msg: invites = %+v", meta.Invites)
+	}
+	if inv := hostApp.World().Session.Invites; len(inv) != 1 {
+		t.Errorf("slate not refreshed after mint: %+v", inv)
+	}
+
+	m, _ = m.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRevoke, Code: meta.Invites[0].Code,
+	}})
+	if meta, _ = srv.store.Meta(); len(meta.Invites) != 0 {
+		t.Errorf("revoke via admin msg left invites: %+v", meta.Invites)
+	}
+
+	_, _ = m.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:gern",
+	}})
+	if _, err := srv.store.FindPlayer("SHA256:gern"); !errors.Is(err, sessiondir.ErrNotEnrolled) {
+		t.Errorf("remove via admin msg: %v", err)
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -278,6 +278,48 @@ func normalizeCode(c string) string {
 	return strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(c), "-", ""))
 }
 
+// RevokeInvite deletes an unredeemed code. ErrUnknownInvite when the
+// code doesn't exist (already redeemed, already revoked, or a typo).
+func (s *Store) RevokeInvite(code string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return err
+	}
+	for i, inv := range m.Invites {
+		if normalizeCode(inv.Code) == normalizeCode(code) {
+			m.Invites = append(m.Invites[:i], m.Invites[i+1:]...)
+			return s.writeMeta(m)
+		}
+	}
+	return ErrUnknownInvite
+}
+
+// RemovePlayer drops a guest from the roster: their key no longer
+// resumes and they'd need a fresh invite. The persisted payload stays
+// on disk — a re-invited player finds their program intact. The host
+// entry can't be removed. A live session isn't kicked (MVP): removal
+// gates the NEXT connect.
+func (s *Store) RemovePlayer(fingerprint string) error {
+	if fingerprint == HostFingerprint {
+		return errors.New("sessiondir: can't remove the host")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return err
+	}
+	for i, p := range m.Roster {
+		if p.Fingerprint == fingerprint {
+			m.Roster = append(m.Roster[:i], m.Roster[i+1:]...)
+			return s.writeMeta(m)
+		}
+	}
+	return ErrNotEnrolled
+}
+
 // FindPlayer looks a fingerprint up in the roster.
 func (s *Store) FindPlayer(fingerprint string) (Player, error) {
 	m, err := s.Meta()

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -130,6 +130,53 @@ func TestInviteLifecycle(t *testing.T) {
 	}
 }
 
+// Revoke deletes an unredeemed code; removing a player drops the
+// roster entry but keeps their payload (a re-invite resumes it). The
+// host can't be removed.
+func TestRevokeAndRemove(t *testing.T) {
+	s := openStore(t)
+	inv, err := s.MintInvite("dave")
+	if err != nil {
+		t.Fatalf("MintInvite: %v", err)
+	}
+	if err := s.RevokeInvite(inv.Code); err != nil {
+		t.Fatalf("RevokeInvite: %v", err)
+	}
+	if _, err := s.Peek(inv.Code); !errors.Is(err, ErrUnknownInvite) {
+		t.Error("revoked code still peekable")
+	}
+	if err := s.RevokeInvite(inv.Code); !errors.Is(err, ErrUnknownInvite) {
+		t.Errorf("double revoke: %v", err)
+	}
+
+	inv2, _ := s.MintInvite("dave")
+	if _, err := s.Enroll(inv2.Code, "SHA256:dave", "dave"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if err := s.SavePlayer("SHA256:dave", w); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+	if err := s.RemovePlayer("SHA256:dave"); err != nil {
+		t.Fatalf("RemovePlayer: %v", err)
+	}
+	if _, err := s.FindPlayer("SHA256:dave"); !errors.Is(err, ErrNotEnrolled) {
+		t.Error("removed player still enrolled")
+	}
+	if !s.HasPayload("SHA256:dave") {
+		t.Error("removal deleted the payload; re-invites should resume")
+	}
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemovePlayer(HostFingerprint); err == nil {
+		t.Error("host removal allowed")
+	}
+}
+
 // Player payloads round-trip through the SchemaVersion-8 envelope:
 // the restored world carries the same craft and sim clock.
 func TestPlayerPayloadRoundTrip(t *testing.T) {

--- a/internal/sim/ghost.go
+++ b/internal/sim/ghost.go
@@ -10,9 +10,11 @@ import "github.com/jasonfen/terminal-space-program/internal/orbital"
 // draws it dim with the owner's handle; physics never sees it.
 type Ghost struct {
 	Owner     string // ssh key fingerprint (roster identity)
+	CraftID   uint64 // the remote craft's stable ID (target resolution)
 	Handle    string // display name, joined from the session roster
 	Name      string // craft name
 	Glyph     string // craft glyph (may be empty)
 	PrimaryID string // SOI primary the ghost orbits
-	Pos       orbital.Vec3
+	Pos       orbital.Vec3 // world-frame position at this world's sim-time
+	Vel       orbital.Vec3 // primary-relative velocity at this world's sim-time
 }

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -1,0 +1,68 @@
+package sim
+
+import "time"
+
+// Multiplayer session display state (v0.27 S6, ADR 0034). Like
+// World.Ghosts, everything here is written each tick by the serve
+// layer and only read by screens — transient, never persisted, nil in
+// single-player. The Session screen renders it; the orbit chip stack
+// surfaces recent SessionEvents.
+
+// SessionPlayer is one roster row as the viewer sees it.
+type SessionPlayer struct {
+	Fingerprint string
+	Handle      string
+	Role        string // sessiondir.RoleHost / RoleGuest (plain strings here to keep sim below the store)
+	Online      bool
+
+	// Last-known flight state, from the session store. Zero values
+	// mean "no report yet" (offline since before this server run).
+	System     string
+	Primary    string
+	CraftCount int
+
+	// DeltaT is their subspace time minus the viewer's — positive
+	// means they're ahead. Meaningless (and false) when HasReport is
+	// false.
+	HasReport bool
+	DeltaT    time.Duration
+
+	// DockedGuest marks a player riding someone's stack. Inert until
+	// the v0.28 "touch" cycle ships cross-player docking.
+	DockedGuest bool
+}
+
+// SessionInvite is one outstanding invite code (host's screen only).
+type SessionInvite struct {
+	Code   string
+	Handle string
+	Age    time.Duration
+}
+
+// SessionInfo is the Session screen's whole slate.
+type SessionInfo struct {
+	IsHost  bool
+	Self    string // viewer's fingerprint — the screen marks "you"
+	Players []SessionPlayer
+	Invites []SessionInvite // populated only for the host
+}
+
+// SessionEventKind enumerates the moments the chip stack surfaces.
+type SessionEventKind int
+
+const (
+	SessionEventJoin SessionEventKind = iota
+	SessionEventLeave
+	SessionEventSync
+)
+
+// SessionEvent is a transient session moment (join / leave / sync —
+// the v0.13 chip vocabulary). At is wall clock: chips expire by real
+// seconds regardless of warp. Owner (fingerprint) is never rendered —
+// the serve layer uses it to keep your own join out of your chips.
+type SessionEvent struct {
+	Kind   SessionEventKind
+	Owner  string
+	Handle string
+	At     time.Time
+}

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -23,6 +24,7 @@ const (
 	TargetBody  = spacecraft.TargetBody
 	TargetCraft = spacecraft.TargetCraft
 	TargetSite  = spacecraft.TargetSite
+	TargetGhost = spacecraft.TargetGhost
 )
 
 // SetTargetBody sets the body target by system index. Out-of-range
@@ -168,8 +170,52 @@ func (w *World) TargetState() (orbital.Vec3State, bool) {
 			R: primaryPos.Add(c.State.R),
 			V: primaryV.Add(c.State.V),
 		}, true
+	case TargetGhost:
+		// v0.27 S6 (ADR 0034): a remote player's craft, resolved from
+		// the transient ghost slate — already evaluated at this world's
+		// sim-time. A stale ref (owner offline before this server run,
+		// craft gone, other system) simply doesn't resolve.
+		g, ok := w.ghostByRef(w.Target.GhostOwner, w.Target.CraftID)
+		if !ok {
+			return orbital.Vec3State{}, false
+		}
+		primary, ok := w.bodyInSystemByID(g.PrimaryID)
+		if !ok {
+			return orbital.Vec3State{}, false
+		}
+		return orbital.Vec3State{
+			R: g.Pos,
+			V: w.bodyInertialVelocity(primary).Add(g.Vel),
+		}, true
 	}
 	return orbital.Vec3State{}, false
+}
+
+// ghostByRef finds a ghost by owner + craft ID in the transient slate.
+func (w *World) ghostByRef(owner string, craftID uint64) (Ghost, bool) {
+	for _, g := range w.Ghosts {
+		if g.Owner == owner && g.CraftID == craftID {
+			return g, true
+		}
+	}
+	return Ghost{}, false
+}
+
+// bodyInSystemByID scans the active system for a body ID.
+func (w *World) bodyInSystemByID(id string) (bodies.CelestialBody, bool) {
+	for _, b := range w.System().Bodies {
+		if b.ID == id {
+			return b, true
+		}
+	}
+	return bodies.CelestialBody{}, false
+}
+
+// SetTargetGhost aims the active craft at a remote player's craft
+// (v0.27 S6). The Session screen is the selection surface.
+func (w *World) SetTargetGhost(owner string, craftID uint64) {
+	w.Target = Target{Kind: TargetGhost, CraftID: craftID, GhostOwner: owner}
+	w.mirrorTargetToActiveCraft()
 }
 
 // CraftInertialVelocity returns a craft's velocity in the system-
@@ -196,12 +242,30 @@ func (w *World) CraftInertialVelocity(c *spacecraft.Spacecraft) orbital.Vec3 {
 // in the active's frame. Cross-primary case: convert via inertial,
 // subtract the active primary's pose. v0.9.3+.
 func (w *World) TargetStateRelativeToActivePrimary() (rT, vT orbital.Vec3, ok bool) {
-	if w.Target.Kind != TargetCraft {
+	if w.Target.Kind != TargetCraft && w.Target.Kind != TargetGhost {
 		return orbital.Vec3{}, orbital.Vec3{}, false
 	}
 	active := w.ActiveCraft()
 	if active == nil {
 		return orbital.Vec3{}, orbital.Vec3{}, false
+	}
+	// Ghost targets (v0.27 S6): the slate already holds the ghost's
+	// world-frame position at this world's sim-time, so rendezvous
+	// tooling (closest approach, |v_rel|, TGT nav modes) works against
+	// a remote player's craft exactly as against a local one.
+	if w.Target.Kind == TargetGhost {
+		g, ok := w.ghostByRef(w.Target.GhostOwner, w.Target.CraftID)
+		if !ok {
+			return orbital.Vec3{}, orbital.Vec3{}, false
+		}
+		primary, ok := w.bodyInSystemByID(g.PrimaryID)
+		if !ok {
+			return orbital.Vec3{}, orbital.Vec3{}, false
+		}
+		activePrimaryR := w.BodyPosition(active.Primary)
+		activePrimaryV := w.bodyInertialVelocity(active.Primary)
+		ghostInertialV := w.bodyInertialVelocity(primary).Add(g.Vel)
+		return g.Pos.Sub(activePrimaryR), ghostInertialV.Sub(activePrimaryV), true
 	}
 	t, _, ok := w.craftByID(w.Target.CraftID)
 	if !ok {
@@ -230,6 +294,13 @@ func (w *World) TargetName() string {
 	case TargetCraft:
 		if c, _, ok := w.craftByID(w.Target.CraftID); ok {
 			return c.Name
+		}
+	case TargetGhost:
+		if g, ok := w.ghostByRef(w.Target.GhostOwner, w.Target.CraftID); ok {
+			if g.Handle != "" {
+				return g.Handle + "'s " + g.Name
+			}
+			return g.Name
 		}
 	}
 	return ""

--- a/internal/sim/target_ghost_test.go
+++ b/internal/sim/target_ghost_test.go
@@ -1,0 +1,50 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// A ghost target resolves position/velocity/name from the transient
+// slate; a stale ref resolves to nothing (never a wrong answer).
+func TestTargetGhostResolution(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	primary := w.System().Bodies[0]
+	pos := w.BodyPosition(primary).Add(orbital.Vec3{X: 7e6})
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:gern", CraftID: 42, Handle: "gern",
+		Name: "Aloft", PrimaryID: primary.ID,
+		Pos: pos, Vel: orbital.Vec3{Y: 7500},
+	}}
+
+	w.SetTargetGhost("SHA256:gern", 42)
+	if w.Target.Kind != TargetGhost {
+		t.Fatalf("Kind = %v, want TargetGhost", w.Target.Kind)
+	}
+	st, ok := w.TargetState()
+	if !ok {
+		t.Fatal("TargetState did not resolve a live ghost")
+	}
+	if d := st.R.Sub(pos).Norm(); d > 1e-6 {
+		t.Errorf("ghost target position off by %g m", d)
+	}
+	if name := w.TargetName(); name != "gern's Aloft" {
+		t.Errorf("TargetName = %q", name)
+	}
+	if _, _, ok := w.TargetStateRelativeToActivePrimary(); !ok {
+		t.Error("relative state did not resolve — rendezvous tooling dead vs ghosts")
+	}
+
+	// Slate cleared (owner left, other system): resolves to nothing.
+	w.Ghosts = nil
+	if _, ok := w.TargetState(); ok {
+		t.Error("stale ghost target still resolves")
+	}
+	if name := w.TargetName(); name != "" {
+		t.Errorf("stale ghost TargetName = %q, want empty", name)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -202,6 +202,13 @@ type World struct {
 	// system by the writer.
 	Ghosts []Ghost
 
+	// Session and SessionEvents are the multiplayer roster slate and
+	// recent join/leave/sync moments (v0.27 S6) — same contract as
+	// Ghosts: serve-layer written, screen read, transient, nil/empty
+	// in single-player.
+	Session       *SessionInfo
+	SessionEvents []SessionEvent
+
 	// CommGraph is the cached per-tick CommNet connectivity result (v0.23 /
 	// ADR 0027): which unmanned probes currently reach a ground station.
 	// Rebuilt each Tick by RecomputeCommGraph after physics; read by

--- a/internal/spacecraft/target.go
+++ b/internal/spacecraft/target.go
@@ -23,6 +23,11 @@ const (
 	// TargetSite is reserved; not populated until landing-site
 	// targeting ships post-v0.9.
 	TargetSite
+	// TargetGhost references another player's craft by owner
+	// fingerprint + craft ID (v0.27 S6, ADR 0034). Resolves against
+	// the world's transient ghost slate — a stale ref (owner gone,
+	// craft staged away) resolves to nothing, same as TargetNone.
+	TargetGhost
 )
 
 // Target identifies what a single craft is aiming at. The zero
@@ -33,5 +38,11 @@ const (
 type Target struct {
 	Kind    TargetKind
 	BodyIdx int    // when Kind==TargetBody
-	CraftID uint64 // when Kind==TargetCraft — the target's stable Spacecraft.ID (ADR 0012)
+	CraftID uint64 // when Kind==TargetCraft or TargetGhost — the target's stable Spacecraft.ID (ADR 0012)
+
+	// GhostOwner names the remote player (key fingerprint) when
+	// Kind==TargetGhost (v0.27 S6, ADR 0034). Session-local by
+	// nature: a save that carries a dangling ghost ref just resolves
+	// to nothing on load.
+	GhostOwner string `json:"ghost_owner,omitempty"`
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,6 +38,7 @@ const (
 	screenVAB      // v0.24 / ADR 0029: Vehicle Assembly (VAB) builder, reached from the menu.
 	screenSaves    // v0.26 / ADR 0033 §F: unified Saves browser, reached from the menu's Save/Load items.
 	screenBoss     // boss key: full-screen fake developer shell (backtick from any screen).
+	screenSession  // v0.27 S6 / ADR 0034: multiplayer roster + invites, on `O`.
 )
 
 // App is the root tea.Model. It owns the world, theme, keymap, and which
@@ -95,6 +96,12 @@ type App struct {
 	boss             *screens.BossShell
 	bossReturnScreen screenID
 	bossPrevPaused   bool
+
+	// session is the multiplayer roster screen (v0.27 S6, ADR 0034).
+	// Renders from world.Session (the serve-layer slate); its admin
+	// commands (mint/revoke/remove) are executed by the serve wrapper
+	// via SessionAdminMsg — the App only dispatches.
+	session *screens.SessionScreen
 
 	// savesPrevPaused records the sim pause state when the Saves screen
 	// opened (finding 4). The Saves browser freezes the clock while it is
@@ -197,6 +204,7 @@ func New(scenario *sim.StartScenario) (*App, error) {
 		vab:            screens.NewVAB(sth),
 		saves:          screens.NewSavesScreen(sth),
 		boss:           screens.NewBossShell(sth),
+		session:        screens.NewSessionScreen(sth),
 	}, nil
 }
 
@@ -706,6 +714,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.active == screenSaves {
 			return a.applySavesCommand(a.saves.HandleKey(m))
 		}
+		// Session roster (v0.27 S6 / ADR 0034): navigation, the mint
+		// input, and confirm gates live in the screen; finalised
+		// intents come back as SessionCommands. Handled before the
+		// global switch so typed invite handles never reach flight
+		// controls.
+		if a.active == screenSession {
+			return a.applySessionCommand(a.session.HandleKey(a.world, m))
+		}
 		// Maneuver screen has its own text input that eats most keys;
 		// esc-to-cancel goes through the screen's handler so it can
 		// clean up.
@@ -791,6 +807,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// curated event vocabulary excludes pure-navigation bindings.
 			if a.active == screenOrbit {
 				a.active = screenMissions
+			}
+			return a, nil
+		case key.Matches(m, a.keys.Session):
+			// `O` opens the multiplayer session roster (v0.27 S6 / ADR
+			// 0034). Works in single-player too — the screen explains
+			// how to host.
+			if a.active == screenOrbit {
+				a.session.Reset()
+				a.active = screenSession
 			}
 			return a, nil
 		case key.Matches(m, a.keys.WarpUp):
@@ -1572,6 +1597,8 @@ func (a *App) capturingText() bool {
 		return true
 	case screenSaves:
 		return a.saves.CapturingText()
+	case screenSession:
+		return a.session.CapturingText()
 	}
 	return false
 }
@@ -1596,6 +1623,30 @@ func defaultSaveName(w *sim.World) string {
 		return c.Name + " — " + day
 	}
 	return day
+}
+
+// applySessionCommand dispatches a finalised SessionCommand (v0.27 S6
+// / ADR 0034). Target + toast are world/App-local; the admin trio
+// (mint / revoke / remove) is re-emitted as a SessionAdminMsg for the
+// serve-layer wrapper, which owns the session store — the App knows
+// nothing about sessiondir.
+func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cmd) {
+	switch cmd.Kind {
+	case screens.SessionCmdClose:
+		a.active = screenOrbit
+	case screens.SessionCmdTargetGhost:
+		a.world.SetTargetGhost(cmd.Owner, cmd.CraftID)
+		a.statusMsg = fmt.Sprintf("target: %s's craft", cmd.Handle)
+		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.active = screenOrbit
+	case screens.SessionCmdToast:
+		a.statusMsg = cmd.Message
+		a.statusExpires = time.Now().Add(3 * time.Second)
+	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove:
+		msg := screens.SessionAdminMsg{Cmd: cmd}
+		return a, func() tea.Msg { return msg }
+	}
+	return a, nil
 }
 
 // applySavesCommand dispatches a finalised SavesCommand from the Saves
@@ -1805,6 +1856,8 @@ func (a *App) View() string {
 		base = a.saves.Render(a.width, a.height)
 	case screenBoss:
 		base = a.boss.Render(a.width, a.height)
+	case screenSession:
+		base = a.session.Render(a.world, a.width)
 	default:
 		if a.world.ViewMode == sim.ViewLaunch {
 			base = a.launchView.Render(a.world, a.width, a.height)

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -45,6 +45,7 @@ type Keymap struct {
 	BodyInfo   key.Binding
 	Maneuver   key.Binding
 	Missions   key.Binding
+	Session    key.Binding
 	NextBody   key.Binding
 	PrevBody   key.Binding
 	NextSystem key.Binding
@@ -265,6 +266,7 @@ func DefaultKeymap() Keymap {
 		BodyInfo: key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "body info")),
 		Maneuver: key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "maneuver")),
 		Missions: key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "missions (ladder)")),
+		Session:  key.NewBinding(key.WithKeys("O"), key.WithHelp("O", "session roster (multiplayer)")),
 		NextBody: key.NewBinding(key.WithKeys("right", "l"), key.WithHelp("→/l", "next body")),
 		PrevBody: key.NewBinding(key.WithKeys("left", "h"), key.WithHelp("←/h", "prev body")),
 		// v0.7.3: NextSystem moved s → tab to free `s` for AttitudeRetrograde.

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -61,6 +62,11 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	add(settings.ChipDescent, cornerTopLeft, v.buildDescentChip(w))
 	add(settings.ChipChute, cornerTopLeft, v.buildChuteChip(w))
 	add(settings.ChipAttitude, cornerTopLeft, v.buildAttitudeChip(w))
+	// SESSION moments (v0.27 S6 / ADR 0034): join/leave/sync events as
+	// a transient top-left chip. Always-on when events are fresh (empty
+	// id — moments are too short-lived to warrant a Settings toggle);
+	// declutter still clears it via the empty-id path.
+	add("", cornerTopLeft, v.buildSessionEventsChip(w))
 	// COMMS link status for the active probe (ADR 0027 / C2-7), beneath the
 	// vessel-state readouts. Force-shown while a just-blocked command is
 	// flashing (CommBlockedFlash) — bypassing the toggle + declutter — so the
@@ -104,6 +110,41 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 		}
 	}
 	return chips
+}
+
+// sessionEventChipTTL is how long a join/leave/sync moment stays on
+// the canvas — wall clock, so warp can't stretch or blink it.
+const sessionEventChipTTL = 6 * time.Second
+
+// buildSessionEventsChip renders recent multiplayer session moments
+// (v0.27 S6). Nil outside a session or when every event has aged out.
+func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
+	if len(w.SessionEvents) == 0 {
+		return nil
+	}
+	now := time.Now()
+	var rows []string
+	for _, e := range w.SessionEvents {
+		if now.Sub(e.At) > sessionEventChipTTL {
+			continue
+		}
+		switch e.Kind {
+		case sim.SessionEventJoin:
+			rows = append(rows, "◇ "+e.Handle+" joined")
+		case sim.SessionEventLeave:
+			rows = append(rows, "◇ "+e.Handle+" left")
+		case sim.SessionEventSync:
+			rows = append(rows, "◇ "+e.Handle+" synced to you")
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	lines := []string{v.theme.Primary.Render("SESSION")}
+	for _, r := range rows {
+		lines = append(lines, v.theme.Dim.Render(r))
+	}
+	return lines
 }
 
 // anyActiveBurn reports whether any craft in the slate has an in-flight

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -1,0 +1,306 @@
+package screens
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// SessionScreen is the multiplayer roster (v0.27 S6, ADR 0034): one
+// row per player — online state, handle, last-known system/SOI, craft
+// count, subspace Δt vs the viewer — plus, for the host, the Invites
+// section (mint / outstanding codes / revoke / remove player, the
+// same operations as the `serve invite` CLI). Persistent state gets a
+// screen; moments get chips (the orbit canvas shows join/leave).
+//
+// It renders from w.Session (the serve-layer slate) and returns
+// SessionCommands for the App/serve layers to execute — the screen
+// itself mutates nothing.
+type SessionScreen struct {
+	theme  Theme
+	cursor int // index into the players list
+
+	inviteCursor  int  // index into the invites list (host)
+	inInvites     bool // cursor focus: players vs invites section
+	minting       bool // typing a new invite's handle
+	mintInput     []rune
+	confirmRemove bool // pending [x] confirmation on the selected player
+}
+
+func NewSessionScreen(th Theme) *SessionScreen { return &SessionScreen{theme: th} }
+
+// SessionCommandKind enumerates what the screen asks the app to do.
+type SessionCommandKind int
+
+const (
+	SessionCmdNone SessionCommandKind = iota
+	SessionCmdClose
+	SessionCmdTargetGhost // aim at Owner/CraftID
+	SessionCmdMint        // mint invite for Handle
+	SessionCmdRevoke      // revoke invite Code
+	SessionCmdRemove      // remove player Fingerprint
+	SessionCmdToast       // surface Message
+)
+
+// SessionCommand is the screen's finalized action.
+type SessionCommand struct {
+	Kind        SessionCommandKind
+	Owner       string
+	CraftID     uint64
+	Handle      string
+	Code        string
+	Fingerprint string
+	Message     string
+}
+
+// SessionAdminMsg carries a mint/revoke/remove intent out of the App
+// to the serve-layer wrapper (which owns the session store). In
+// single-player nothing handles it — the message is inert.
+type SessionAdminMsg struct{ Cmd SessionCommand }
+
+// Reset re-arms the screen for a fresh open.
+func (s *SessionScreen) Reset() {
+	s.cursor, s.inviteCursor = 0, 0
+	s.inInvites, s.minting, s.confirmRemove = false, false, false
+	s.mintInput = nil
+}
+
+// CapturingText reports whether the mint input is armed (the App
+// skips keyboard-layout normalization while typing literal text).
+func (s *SessionScreen) CapturingText() bool { return s.minting }
+
+// HandleKey routes a keypress. w supplies the slate (rows, ghosts for
+// targeting).
+func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
+	info := w.Session
+	if info == nil {
+		if msg.String() == "esc" || msg.String() == "O" || msg.String() == "q" {
+			return SessionCommand{Kind: SessionCmdClose}
+		}
+		return SessionCommand{}
+	}
+
+	if s.minting {
+		switch msg.Type {
+		case tea.KeyEnter:
+			handle := strings.TrimSpace(string(s.mintInput))
+			s.minting, s.mintInput = false, nil
+			if handle == "" {
+				return SessionCommand{}
+			}
+			return SessionCommand{Kind: SessionCmdMint, Handle: handle}
+		case tea.KeyEscape:
+			s.minting, s.mintInput = false, nil
+			return SessionCommand{}
+		case tea.KeyBackspace:
+			if len(s.mintInput) > 0 {
+				s.mintInput = s.mintInput[:len(s.mintInput)-1]
+			}
+			return SessionCommand{}
+		case tea.KeyRunes:
+			for _, r := range msg.Runes {
+				if len(s.mintInput) < 24 {
+					s.mintInput = append(s.mintInput, r)
+				}
+			}
+			return SessionCommand{}
+		}
+		return SessionCommand{}
+	}
+
+	if s.confirmRemove {
+		s.confirmRemove = false
+		if msg.String() == "y" || msg.String() == "Y" {
+			if p, ok := s.selectedPlayer(info); ok {
+				return SessionCommand{Kind: SessionCmdRemove, Fingerprint: p.Fingerprint, Handle: p.Handle}
+			}
+		}
+		return SessionCommand{}
+	}
+
+	switch msg.String() {
+	case "esc", "q", "O":
+		return SessionCommand{Kind: SessionCmdClose}
+	case "up", "k":
+		s.moveCursor(info, -1)
+	case "down", "j":
+		s.moveCursor(info, +1)
+	case "tab":
+		if info.IsHost && len(info.Invites) > 0 {
+			s.inInvites = !s.inInvites
+		}
+	case "t":
+		p, ok := s.selectedPlayer(info)
+		if !ok {
+			return SessionCommand{}
+		}
+		if p.Fingerprint == info.Self {
+			return SessionCommand{Kind: SessionCmdToast, Message: "that's you"}
+		}
+		// Aim at the player's first ghosted craft — the slate is
+		// already gated to this system and evaluated at our time.
+		for _, g := range w.Ghosts {
+			if g.Owner == p.Fingerprint {
+				return SessionCommand{Kind: SessionCmdTargetGhost, Owner: g.Owner, CraftID: g.CraftID, Handle: p.Handle}
+			}
+		}
+		return SessionCommand{Kind: SessionCmdToast, Message: p.Handle + " has no craft in this system to target"}
+	case "i":
+		if info.IsHost {
+			s.minting = true
+			s.mintInput = nil
+		}
+	case "r":
+		if info.IsHost && s.inInvites {
+			if inv, ok := s.selectedInvite(info); ok {
+				return SessionCommand{Kind: SessionCmdRevoke, Code: inv.Code, Handle: inv.Handle}
+			}
+		}
+	case "x":
+		if info.IsHost && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
+				s.confirmRemove = true
+			}
+		}
+	}
+	return SessionCommand{}
+}
+
+func (s *SessionScreen) moveCursor(info *sim.SessionInfo, d int) {
+	if s.inInvites {
+		s.inviteCursor = clamp(s.inviteCursor+d, 0, len(info.Invites)-1)
+		return
+	}
+	s.cursor = clamp(s.cursor+d, 0, len(info.Players)-1)
+}
+
+func (s *SessionScreen) selectedPlayer(info *sim.SessionInfo) (sim.SessionPlayer, bool) {
+	if s.cursor < 0 || s.cursor >= len(info.Players) {
+		return sim.SessionPlayer{}, false
+	}
+	return info.Players[s.cursor], true
+}
+
+func (s *SessionScreen) selectedInvite(info *sim.SessionInfo) (sim.SessionInvite, bool) {
+	if s.inviteCursor < 0 || s.inviteCursor >= len(info.Invites) {
+		return sim.SessionInvite{}, false
+	}
+	return info.Invites[s.inviteCursor], true
+}
+
+func clamp(v, lo, hi int) int {
+	if hi < lo {
+		return lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// Render draws the roster.
+func (s *SessionScreen) Render(w *sim.World, width int) string {
+	var b strings.Builder
+	title := s.theme.Title.Render(" SESSION ")
+	info := w.Session
+	if info == nil {
+		b.WriteString(title + "\n\n")
+		b.WriteString("  Not in a multiplayer session.\n\n")
+		b.WriteString(s.theme.Dim.Render("  Host one with --serve; guests join over ssh (see serve invite).") + "\n\n")
+		b.WriteString(s.theme.Footer.Render("  [esc] close"))
+		return b.String()
+	}
+
+	b.WriteString(title + s.theme.Dim.Render(fmt.Sprintf("  %d players", len(info.Players))) + "\n\n")
+	for i, p := range info.Players {
+		marker := "  "
+		if !s.inInvites && i == s.cursor {
+			marker = s.theme.Primary.Render("▸ ")
+		}
+		dot := s.theme.Dim.Render("○")
+		if p.Online {
+			dot = s.theme.Primary.Render("●")
+		}
+		name := p.Handle
+		var tags []string
+		if p.Role == "host" {
+			tags = append(tags, "host")
+		}
+		if p.Fingerprint == info.Self {
+			tags = append(tags, "you")
+		}
+		if p.DockedGuest {
+			tags = append(tags, "docked") // inert until v0.28
+		}
+		if len(tags) > 0 {
+			name += s.theme.Dim.Render(" (" + strings.Join(tags, ", ") + ")")
+		}
+		where := "—"
+		if p.System != "" {
+			where = p.System
+			if p.Primary != "" {
+				where += "/" + p.Primary
+			}
+		}
+		craft := fmt.Sprintf("%d craft", p.CraftCount)
+		b.WriteString(fmt.Sprintf("  %s%s %-32s %-16s %-9s %s\n",
+			marker, dot, name, where, craft, formatDeltaT(p, info.Self == p.Fingerprint)))
+	}
+
+	if info.IsHost {
+		b.WriteString("\n" + s.theme.Title.Render(" INVITES ") + "\n\n")
+		if s.minting {
+			b.WriteString("  new invite handle: " + string(s.mintInput) + "▌\n")
+		} else if len(info.Invites) == 0 {
+			b.WriteString(s.theme.Dim.Render("  no outstanding codes — [i] to mint one") + "\n")
+		}
+		for i, inv := range info.Invites {
+			marker := "  "
+			if s.inInvites && i == s.inviteCursor {
+				marker = s.theme.Primary.Render("▸ ")
+			}
+			b.WriteString(fmt.Sprintf("  %s%s  %-16s %s\n",
+				marker, inv.Code, inv.Handle, s.theme.Dim.Render(compactDuration(inv.Age)+" old")))
+		}
+	}
+
+	b.WriteString("\n")
+	if s.confirmRemove {
+		if p, ok := s.selectedPlayer(info); ok {
+			b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  remove %s from the session? [y/n]", p.Handle)) + "\n")
+		}
+	}
+	keys := "  [t] target craft"
+	if info.IsHost {
+		keys += "  [i] invite  [r] revoke code  [x] remove player  [tab] section"
+	}
+	keys += "  [esc] close"
+	b.WriteString(s.theme.Footer.Render(keys))
+	return b.String()
+}
+
+// formatDeltaT renders the subspace gap: "+2d4h ahead", "-3h12m
+// behind", "in sync" inside a couple of seconds.
+func formatDeltaT(p sim.SessionPlayer, isSelf bool) string {
+	if isSelf {
+		return ""
+	}
+	if !p.HasReport {
+		return "—"
+	}
+	d := p.DeltaT
+	if d > -2*time.Second && d < 2*time.Second {
+		return "in sync"
+	}
+	if d > 0 {
+		return "+" + compactDuration(d) + " ahead"
+	}
+	return "-" + compactDuration(-d) + " behind"
+}

--- a/internal/tui/screens/session_chip_test.go
+++ b/internal/tui/screens/session_chip_test.go
@@ -1,0 +1,49 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// Join/leave/sync moments render as a transient SESSION chip; aged
+// events drop out.
+func TestSessionEventsChip(t *testing.T) {
+	v := NewOrbitView(sessionTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	if lines := v.buildSessionEventsChip(w); lines != nil {
+		t.Fatalf("chip rendered with no events: %v", lines)
+	}
+
+	now := time.Now()
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventJoin, Handle: "gern", At: now},
+		{Kind: sim.SessionEventLeave, Handle: "dave", At: now},
+		{Kind: sim.SessionEventSync, Handle: "pat", At: now},
+		{Kind: sim.SessionEventJoin, Handle: "ancient", At: now.Add(-time.Minute)},
+	}
+	lines := v.buildSessionEventsChip(w)
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"SESSION", "gern joined", "dave left", "pat synced to you"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "ancient") {
+		t.Error("aged-out event still on the chip")
+	}
+
+	// All aged → chip disappears entirely.
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventJoin, Handle: "old", At: now.Add(-time.Hour)},
+	}
+	if lines := v.buildSessionEventsChip(w); lines != nil {
+		t.Errorf("chip rendered from stale events only: %v", lines)
+	}
+}

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -1,0 +1,195 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+func sessionTheme() Theme {
+	return Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle(),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+}
+
+func sessionWorld(t *testing.T, isHost bool) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	self := "local"
+	if !isHost {
+		self = "SHA256:guest"
+	}
+	w.Session = &sim.SessionInfo{
+		IsHost: isHost,
+		Self:   self,
+		Players: []sim.SessionPlayer{
+			{Fingerprint: "local", Handle: "jason", Role: "host", Online: true,
+				HasReport: true, System: "Sol", Primary: "earth", CraftCount: 2, DeltaT: 0},
+			{Fingerprint: "SHA256:guest", Handle: "gern", Role: "guest", Online: true,
+				HasReport: true, System: "Sol", Primary: "moon", CraftCount: 1,
+				DeltaT: 2*24*time.Hour + 4*time.Hour},
+			{Fingerprint: "SHA256:offline", Handle: "dave", Role: "guest", Online: false,
+				HasReport: true, System: "Lumen", Primary: "lumen", CraftCount: 3,
+				DeltaT: -3 * time.Hour},
+			{Fingerprint: "SHA256:never", Handle: "pat", Role: "guest", Online: false},
+		},
+		Invites: []sim.SessionInvite{
+			{Code: "AB2C-DE3F", Handle: "newbie", Age: 3 * time.Minute},
+		},
+	}
+	return w
+}
+
+// Roster rows across state combinations: online/offline dots, host/
+// you tags, ahead/behind/in-sync Δt, no-report placeholder.
+func TestSessionScreenRows(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	out := s.Render(w, 120)
+
+	for _, want := range []string{
+		"jason", "(host, you)",
+		"gern", "Sol/moon", "1 craft", "+2d4h ahead",
+		"dave", "Lumen/lumen", "3 craft", "-3h0m behind",
+		"pat", "—", // never reported
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("roster missing %q:\n%s", want, out)
+		}
+	}
+
+	// Δt formatting directly: in-sync band, and the self row is blank.
+	inSync := sim.SessionPlayer{HasReport: true, DeltaT: time.Second}
+	if got := formatDeltaT(inSync, false); got != "in sync" {
+		t.Errorf("formatDeltaT(1s) = %q, want in sync", got)
+	}
+	if got := formatDeltaT(inSync, true); got != "" {
+		t.Errorf("formatDeltaT(self) = %q, want empty", got)
+	}
+}
+
+// The Invites section renders for the host and not for guests.
+func TestSessionScreenHostVsGuestSections(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+
+	host := s.Render(sessionWorld(t, true), 120)
+	if !strings.Contains(host, "INVITES") || !strings.Contains(host, "AB2C-DE3F") {
+		t.Errorf("host screen missing invites section:\n%s", host)
+	}
+	if !strings.Contains(host, "[i] invite") || !strings.Contains(host, "[x] remove player") {
+		t.Errorf("host screen missing admin key hints:\n%s", host)
+	}
+
+	s2 := NewSessionScreen(sessionTheme())
+	guest := s2.Render(sessionWorld(t, false), 120)
+	if strings.Contains(guest, "INVITES") || strings.Contains(guest, "AB2C-DE3F") {
+		t.Errorf("guest screen leaked the invites section:\n%s", guest)
+	}
+	if strings.Contains(guest, "[i] invite") {
+		t.Error("guest screen offers the invite key")
+	}
+}
+
+// Outside a session the screen explains rather than renders an empty
+// roster.
+func TestSessionScreenSinglePlayer(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "Not in a multiplayer session") {
+		t.Errorf("single-player explainer missing:\n%s", out)
+	}
+}
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEscape}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+// Mint flow: [i] arms the input, typed handle + enter emits the mint
+// command.
+func TestSessionScreenMintFlow(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+
+	if cmd := s.HandleKey(w, key("i")); cmd.Kind != SessionCmdNone {
+		t.Fatalf("[i] emitted %v immediately", cmd.Kind)
+	}
+	if !s.CapturingText() {
+		t.Fatal("mint input not armed after [i]")
+	}
+	for _, r := range "newpal" {
+		s.HandleKey(w, key(string(r)))
+	}
+	cmd := s.HandleKey(w, key("enter"))
+	if cmd.Kind != SessionCmdMint || cmd.Handle != "newpal" {
+		t.Errorf("mint command = %+v", cmd)
+	}
+	if s.CapturingText() {
+		t.Error("mint input still armed after submit")
+	}
+}
+
+// Remove flow: [x] on a guest arms a confirm; y emits the removal;
+// the host row can't be removed.
+func TestSessionScreenRemoveConfirm(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+
+	// Cursor starts on the host — [x] must not arm.
+	s.HandleKey(w, key("x"))
+	if cmd := s.HandleKey(w, key("y")); cmd.Kind == SessionCmdRemove {
+		t.Fatal("removed the host")
+	}
+
+	s.HandleKey(w, key("j")) // down to gern
+	s.HandleKey(w, key("x"))
+	cmd := s.HandleKey(w, key("y"))
+	if cmd.Kind != SessionCmdRemove || cmd.Fingerprint != "SHA256:guest" {
+		t.Errorf("remove command = %+v", cmd)
+	}
+}
+
+// Target flow: [t] on a player with a ghost emits the target command;
+// on yourself it toasts.
+func TestSessionScreenTarget(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Ghosts = []sim.Ghost{{Owner: "SHA256:guest", CraftID: 42, Handle: "gern"}}
+
+	if cmd := s.HandleKey(w, key("t")); cmd.Kind != SessionCmdToast {
+		t.Errorf("[t] on self = %+v, want toast", cmd)
+	}
+	s.HandleKey(w, key("j")) // gern
+	cmd := s.HandleKey(w, key("t"))
+	if cmd.Kind != SessionCmdTargetGhost || cmd.Owner != "SHA256:guest" || cmd.CraftID != 42 {
+		t.Errorf("target command = %+v", cmd)
+	}
+	s.HandleKey(w, key("j")) // dave — no ghost in slate
+	if cmd := s.HandleKey(w, key("t")); cmd.Kind != SessionCmdToast {
+		t.Errorf("[t] with no ghost = %+v, want toast", cmd)
+	}
+}


### PR DESCRIPTION
Sixth slice of the v0.27 multiplayer ssh-only MVP (ADR 0034 + v0.27-plan).

## What

- **Session screen** (`O`, new member of the screen family): one row per player — presence dot, handle + host/you/docked tags (docked marker inert until v0.28), last-known system + SOI primary, craft count, **subspace Δt vs you** ("+2d4h ahead" / "-3h behind" / "in sync"). Single-player shows a how-to-host explainer.
- **Host's INVITES section**: mint (typed handle), outstanding codes with age, revoke, remove player — backed by the same `sessiondir` operations as the CLI (new `RevokeInvite`/`RemovePlayer`; removal keeps the payload so a re-invite resumes; host row protected).
- **Layering**: screen emits `SessionCommand`s → App handles target/toast/close and re-emits admin ops as `SessionAdminMsg` → the serve wrapper executes them against the store. The App never learns about sessiondir.
- **set-Target on a ghost**: new `TargetGhost` kind resolving from the ghost slate — `TargetState`/`TargetName`/relative-state all work, so closest-approach, |v_rel| and TGT nav modes function against a remote player's craft. Stale refs resolve to nothing, never wrong.
- **Chips**: join/leave/sync moments as a transient top-left SESSION chip (6s wall TTL, own events excluded) via serve-side presence + event ring; wrapper writes `World.Session`/`World.SessionEvents` each tick, keeping the screens-read-world contract.

## Acceptance (per plan)

Roster rows across state combinations · host vs non-host sections · chip emission on join/leave (+ aging out) · mint/remove/target key flows · ghost-target resolution incl. stale-ref safety · slate population for host and guest · admin-command execution · store revoke/remove.

Full suite: 1,532 tests, `-race` clean; `go vet` clean. Sync-to is deliberately absent until S7 (per plan: omit rather than stub).