### PR TITLE
feat(sim,relay,serve,tui): v0.28 S1 — proximity co-warp clamp (ADR 0034)

### DIFF
--- a/internal/relay/cowarp_peers.go
+++ b/internal/relay/cowarp_peers.go
@@ -1,0 +1,58 @@
+package relay
+
+import (
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// CoWarpPeersFrom adapts the store's reports into the sim-level co-warp
+// input (v0.28 S1, ADR 0034 §5) — the relay-side twin of GhostsFor. Each
+// remote craft's last-reported primary-relative state is Kepler-stepped
+// across the subspace gap to the viewer's sim-time (forward OR backward),
+// so range + |v_rel| against the viewer's active craft are geometrically
+// exact for a coasting peer within the same-subspace tolerance. Gating
+// per ADR 0015: only craft in the viewer's active system contribute;
+// landed craft carry no orbit and are skipped. The peer's Owner/Handle,
+// SubspaceTime, and reported EffWarp travel through so ComputeCoWarp can
+// apply the same-subspace gate and the min-over-Effective clamp.
+//
+// Honest staleness matches ghosts: KeplerStep neither sees a peer's burn
+// after the report nor an SOI exit — but a burning peer reports every
+// tick (elements change), so the propagation gap it feeds co-warp with is
+// one tick, not one heartbeat.
+func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]string) []sim.CoWarpPeer {
+	sysName := w.System().Name
+	viewerT := w.Clock.SimTime
+	var out []sim.CoWarpPeer
+	for _, rep := range reports {
+		dt := viewerT.Sub(rep.SubspaceTime).Seconds()
+		var crafts []sim.CoWarpCraft
+		for _, cs := range rep.Crafts {
+			if cs.Landed || cs.System != sysName {
+				continue
+			}
+			primary, ok := bodyByID(w.System(), cs.Primary)
+			if !ok {
+				continue
+			}
+			st, ok := physics.KeplerStep(
+				physics.StateVector{R: cs.R, V: cs.V, M: 1},
+				primary.GravitationalParameter(), dt)
+			if !ok {
+				continue // degenerate state — no peer beats a wrong one
+			}
+			crafts = append(crafts, sim.CoWarpCraft{Primary: cs.Primary, R: st.R, V: st.V})
+		}
+		if len(crafts) == 0 {
+			continue
+		}
+		out = append(out, sim.CoWarpPeer{
+			Owner:        rep.Owner,
+			Handle:       handles[rep.Owner],
+			SubspaceTime: rep.SubspaceTime,
+			EffWarp:      rep.EffWarp,
+			Crafts:       crafts,
+		})
+	}
+	return out
+}

--- a/internal/relay/cowarp_peers_test.go
+++ b/internal/relay/cowarp_peers_test.go
@@ -1,0 +1,86 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// End-to-end across the reporting seam (two Worlds, one store): a burning
+// partner's 10× Effective-warp cap travels on the wire and, via
+// CoWarpPeersFrom → ComputeCoWarp, clamps the coasting viewer to 10×.
+// The suite's -race run is the concurrency assertion on the store.
+func TestCoWarpMinWinsThroughSeam(t *testing.T) {
+	store := NewStore()
+	wA, wB := newWorld(t), newWorld(t) // identical LEO craft → range 0, v_rel 0
+	// Same subspace: align B's clock to A's.
+	wB.Clock.SimTime = wA.Clock.SimTime
+
+	// A wants to warp fast; B is burning, so B's Effective warp caps at 10×.
+	wA.Clock.WarpIdx = 3 // 1000×
+	wB.Clock.WarpIdx = 3 // 1000× selected, but...
+	wB.ActiveCraft().ManualBurn = &spacecraft.ManualBurn{StartTime: wB.Clock.SimTime}
+	if got := wB.EffectiveWarp(); got != 10 {
+		t.Fatalf("burning B EffectiveWarp = %v, want 10× cap", got)
+	}
+
+	const ownerA, ownerB = "SHA256:alice", "SHA256:bob"
+	NewReporter(store, ownerA).Tick(wA, time.Now())
+	NewReporter(store, ownerB).Tick(wB, time.Now())
+
+	// The wire carried B's Effective warp.
+	var seenB CraftReport
+	for _, r := range store.Snapshot(ownerA) {
+		if r.Owner == ownerB {
+			seenB = r
+		}
+	}
+	if seenB.EffWarp != 10 {
+		t.Fatalf("B report EffWarp = %v, want 10 on the wire", seenB.EffWarp)
+	}
+
+	// A evaluates co-warp against the store and clamps to B's cap.
+	handles := map[string]string{ownerB: "bob"}
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles)
+	res := wA.ComputeCoWarp(peers, nil)
+	if !res.State.Coupled || res.State.MinWarp != 10 {
+		t.Fatalf("co-warp state = %+v, want coupled at MinWarp 10", res.State)
+	}
+	wA.CoWarp = res.State
+	if got := wA.EffectiveWarp(); got != 10 {
+		t.Errorf("coasting A EffectiveWarp = %v, want partner's 10× cap through the seam", got)
+	}
+}
+
+// Couple then decouple through the seam: when the partner drifts past the
+// hysteresis band, the next evaluation releases the couple.
+func TestCoWarpCoupleThenDecoupleThroughSeam(t *testing.T) {
+	store := NewStore()
+	wA, wB := newWorld(t), newWorld(t)
+	wB.Clock.SimTime = wA.Clock.SimTime
+	const ownerA, ownerB = "SHA256:alice", "SHA256:bob"
+	handles := map[string]string{ownerB: "bob"}
+
+	// Coincident craft → couple.
+	NewReporter(store, ownerA).Tick(wA, time.Now())
+	repB := NewReporter(store, ownerB)
+	repB.Tick(wB, time.Now())
+	res := wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles), nil)
+	if !res.State.Coupled || len(res.NewlyCoupled) != 1 {
+		t.Fatalf("first eval = %+v, want a fresh couple", res)
+	}
+
+	// B jumps 50 km down-range and re-reports (a burn changes elements →
+	// immediate report). A re-evaluates and releases.
+	wB.ActiveCraft().State.R.X += 50_000
+	wB.ActiveCraft().State.V.X += 50 // move the elements so the report fires
+	repB.Tick(wB, time.Now().Add(time.Second))
+	res = wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles), res.CoupledOwners)
+	if res.State.Coupled {
+		t.Error("still coupled after B drifted 50 km")
+	}
+	if len(res.Released) != 1 || res.Released[0] != "bob" {
+		t.Errorf("Released = %v, want [bob]", res.Released)
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -42,6 +42,13 @@ type CraftReport struct {
 	Owner        string       `json:"owner"`
 	SubspaceTime time.Time    `json:"subspace_time"`
 	Crafts       []CraftState `json:"crafts"`
+
+	// EffWarp is the reporter's current Effective warp — the post-clamp
+	// rate its World actually stepped this report (v0.28 S1, ADR 0034 §5).
+	// Proximity co-warp reads it to take the min over coupled players, so
+	// a partner's 10× burn cap propagates. A plain float, serialisable
+	// like everything else crossing this interface (store discipline).
+	EffWarp float64 `json:"eff_warp,omitempty"`
 }
 
 // Store holds the latest report per owner and fans new reports out to

--- a/internal/relay/reporter.go
+++ b/internal/relay/reporter.go
@@ -37,10 +37,21 @@ const (
 type Reporter struct {
 	Owner string
 
-	store    *Store
-	lastWall time.Time
-	lastKeys []craftKey
+	store       *Store
+	lastWall    time.Time
+	lastKeys    []craftKey
+	lastEffWarp float64
 }
+
+// effWarpRelTol is the relative change in Effective warp that forces a
+// re-report between heartbeats (v0.28 S1). Effective warp changes without
+// any element change — a partner picks a lower warp, or a co-warp min
+// kicks in — and proximity co-warp needs that promptly, not only at the
+// 5 s heartbeat, or two coupled players drift out of the same subspace.
+// A relative tolerance ignores the sub-percent jitter the period-guard
+// clamp shows against Verlet element drift while still firing on any real
+// warp-factor step (all ≥2×).
+const effWarpRelTol = 1e-3
 
 // craftKey is the per-craft change-detection signature.
 type craftKey struct {
@@ -60,17 +71,31 @@ func NewReporter(store *Store, owner string) *Reporter {
 // cadence must not warp with sim time).
 func (r *Reporter) Tick(w *sim.World, now time.Time) {
 	keys, states := snapshotWorld(w)
+	effWarp := w.EffectiveWarp()
 	due := r.lastWall.IsZero() || now.Sub(r.lastWall) >= Heartbeat
-	if !due && keysEqual(r.lastKeys, keys) {
+	if !due && keysEqual(r.lastKeys, keys) && !effWarpChanged(r.lastEffWarp, effWarp) {
 		return
 	}
 	r.lastWall = now
 	r.lastKeys = keys
+	r.lastEffWarp = effWarp
 	r.store.Report(CraftReport{
 		Owner:        r.Owner,
 		SubspaceTime: w.Clock.SimTime,
 		Crafts:       states,
+		EffWarp:      effWarp,
 	})
+}
+
+// effWarpChanged reports whether the Effective warp moved beyond the
+// relative tolerance since the last report — the co-warp re-report
+// trigger (see effWarpRelTol).
+func effWarpChanged(prev, cur float64) bool {
+	scale := math.Max(math.Abs(prev), math.Abs(cur))
+	if scale == 0 {
+		return false
+	}
+	return math.Abs(cur-prev) > effWarpRelTol*scale
 }
 
 // snapshotWorld converts the world's craft slate into wire states

--- a/internal/serve/cowarp_chip_test.go
+++ b/internal/serve/cowarp_chip_test.go
@@ -1,0 +1,65 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// Through the reporting model: a coincident same-subspace partner couples
+// the host's world (min-over-Effective clamp written to World.CoWarp) and
+// fires a "warp coupled with <name>" chip. Exercised end-to-end under
+// -race across the store seam.
+func TestCoWarpChipThroughReportingModel(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = srv.HostModel(hostApp)
+	m = tick(m) // establish the host in the store + world
+
+	// Report gern coincident with the host's craft in the same subspace.
+	w := hostApp.World()
+	hc := w.ActiveCraft()
+	srv.relay.Report(relay.CraftReport{
+		Owner:        "SHA256:gern",
+		SubspaceTime: w.Clock.SimTime,
+		EffWarp:      10, // gern is burn-capped
+		Crafts: []relay.CraftState{{
+			ID:      42,
+			Name:    "Gernaut",
+			System:  w.System().Name,
+			Primary: hc.Primary.ID,
+			R:       hc.State.R,
+			V:       hc.State.V,
+		}},
+	})
+
+	// Next tick evaluates co-warp: couples, clamps, and chips.
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	_ = m
+
+	if !w.CoWarp.Coupled {
+		t.Fatalf("host world not coupled after coincident report: %+v", w.CoWarp)
+	}
+	if w.CoWarp.MinWarp != 10 {
+		t.Errorf("CoWarp.MinWarp = %v, want gern's 10", w.CoWarp.MinWarp)
+	}
+	var coupled bool
+	for _, e := range w.SessionEvents {
+		if e.Kind == sim.SessionEventCoWarpCoupled && e.Handle == "gern" {
+			coupled = true
+		}
+	}
+	if !coupled {
+		t.Errorf("no couple chip emitted: %+v", w.SessionEvents)
+	}
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -32,9 +32,15 @@ type reportingModel struct {
 	metaAt time.Time
 
 	// localEvents are this session's own moments (the "synced to X"
-	// arrival chip) — appended to the world's event slate alongside
-	// the broadcast ring, pruned by the same wall TTL.
+	// arrival chip, co-warp couple/release) — appended to the world's
+	// event slate alongside the broadcast ring, pruned by the same wall
+	// TTL.
 	localEvents []sim.SessionEvent
+
+	// coWarp is the per-owner coupled memory (v0.28 S1) — ComputeCoWarp's
+	// hysteresis input, carried across ticks so a coupled pair keeps the
+	// wider decouple gate. Owner fingerprint → coupled-last-tick.
+	coWarp map[string]bool
 }
 
 // localEventTTL matches the chip's on-screen life; pruning here just
@@ -123,7 +129,28 @@ func (m *reportingModel) refreshSession(now time.Time) {
 		handles[p.Fingerprint] = p.Handle
 	}
 	// Ghosts (S5): everyone else's craft at this world's sim-time.
-	w.Ghosts = relay.GhostsFor(w, m.srv.relay.Snapshot(m.owner), handles)
+	others := m.srv.relay.Snapshot(m.owner)
+	w.Ghosts = relay.GhostsFor(w, others, handles)
+
+	// Co-warp (v0.28 S1, ADR 0034 §5): couple the viewer's active craft
+	// to any nearby same-subspace player and write the min-over-Effective
+	// clamp onto the World for next tick's clampedWarp; emit couple/
+	// release chips on transitions. Same seam as ghosts — reads the
+	// store's reports (which now carry EffWarp), writes transient state.
+	peers := relay.CoWarpPeersFrom(w, others, handles)
+	cw := w.ComputeCoWarp(peers, m.coWarp)
+	m.coWarp = cw.CoupledOwners
+	w.CoWarp = cw.State
+	for _, h := range cw.NewlyCoupled {
+		m.localEvents = append(m.localEvents, sim.SessionEvent{
+			Kind: sim.SessionEventCoWarpCoupled, Handle: h, At: now,
+		})
+	}
+	for _, h := range cw.Released {
+		m.localEvents = append(m.localEvents, sim.SessionEvent{
+			Kind: sim.SessionEventCoWarpReleased, Handle: h, At: now,
+		})
+	}
 
 	// Session slate (S6). Snapshot("") includes the viewer's own
 	// report — the roster row marked "you".

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -79,8 +79,15 @@ func TestSessionSlatePopulated(t *testing.T) {
 	if len(ginfo.Invites) != 0 {
 		t.Error("guest slate leaked invites")
 	}
-	if len(guestApp.World().SessionEvents) != 0 {
-		t.Errorf("guest sees their own join: %+v", guestApp.World().SessionEvents)
+	// The guest's own join is excluded from their chips. (Co-warp couple
+	// chips can appear here — both worlds spawn the same coincident LEO
+	// craft in the same subspace, which legitimately couples, v0.28 S1 —
+	// so assert specifically on the absence of a join chip, the thing
+	// this case is about.)
+	for _, e := range guestApp.World().SessionEvents {
+		if e.Kind == sim.SessionEventJoin {
+			t.Errorf("guest sees a join chip (own join not excluded): %+v", e)
+		}
 	}
 }
 

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -117,6 +117,14 @@ func (w *World) EngageSyncWarp(target time.Time, owner, handle string) bool {
 	if !target.After(w.Clock.SimTime) {
 		return false
 	}
+	// v0.28 S1 (ADR 0034 §5): subspace splits are blocked while co-warped.
+	// Syncing to another subspace would warp the viewer away from the
+	// player they are coupled to — the couple must break (separate past
+	// the hysteresis band) first. min-wins already caps the rate so the
+	// warp couldn't make progress; refusing outright is the legible form.
+	if w.CoWarpCoupled() {
+		return false
+	}
 	w.AutoWarp = &AutoWarpTarget{T: target, Sync: true, SyncOwner: owner, SyncHandle: handle}
 	w.Clock.Paused = false
 	return true

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -1,0 +1,214 @@
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Proximity co-warp (v0.28 S1, ADR 0034 §5 + the 2026-07-14 addendum).
+//
+// Two players whose active craft sit in the same system + SOI primary +
+// subspace and close together are "warp-coupled": their Effective Warp
+// becomes the min over the coupled players' Effective warps, so a
+// partner's 10× burn cap (or lower selection) propagates and both step
+// in lock. This is a new member of the Effective-≤-Selected clamp family
+// in clampedWarp — not a parallel mechanism — plus a split guard
+// (EngageSyncWarp refuses while coupled). Chains A–B–C propagate through
+// the min automatically because each player reports its *post-co-warp*
+// Effective warp; no transitive-closure logic is needed (MVP tests at 2).
+//
+// The gate carries a velocity term (ADR addendum): a fast flyby that
+// merely passes through the radius is a crossing, not a rendezvous, and
+// must not couple. Decouple only past a hysteresis band so station-
+// keeping at the boundary can't flap the clamp or spam chips.
+
+const (
+	// coWarpCoupleRangeM / coWarpCoupleSpeedMs are the couple gate: the
+	// anchor and a peer craft must be within BOTH to begin coupling.
+	// 10 km is a rendezvous neighbourhood; 100 m/s |v_rel| is slow
+	// enough to be station-keeping rather than a flyby. Tunables —
+	// playtest may move them (ADR addendum: "seems good for now").
+	coWarpCoupleRangeM  = 10_000.0
+	coWarpCoupleSpeedMs = 100.0
+
+	// coWarpDecoupleRangeM / coWarpDecoupleSpeedMs are the decouple gate.
+	// Wider than the couple gate on purpose (hysteresis): once coupled,
+	// separation past 12 km OR 120 m/s is required to release. The band
+	// between the two gates is where a coupled pair stays coupled, so
+	// small station-keeping excursions across 10 km / 100 m/s don't flap
+	// the clamp or re-emit couple/release chips every tick. Tunables.
+	coWarpDecoupleRangeM  = 12_000.0
+	coWarpDecoupleSpeedMs = 120.0
+
+	// coWarpSubspaceToleranceSec bounds |Δt| between the viewer's sim-time
+	// and a peer's subspace time for the pair to count as "same subspace".
+	// Load-bearing: it rejects coupling to a time-shifted ghost whose
+	// coasting orbit merely passes through the radius at the viewer's
+	// clock — a different subspace, not a rendezvous (ADR §5). Generous
+	// against the seconds of report/tick lag between genuinely co-warped
+	// players (min-wins keeps their clocks locked, so Δt stays small),
+	// tight against the hours/days a real subspace divergence spans.
+	// Tunable.
+	coWarpSubspaceToleranceSec = 120.0
+)
+
+// CoWarpCraft is one peer craft placed in the anchor's frame — primary-
+// relative position/velocity already propagated to the viewer's sim-time
+// (the relay adapter Kepler-steps the last report across the subspace
+// gap, exactly like a ghost). Only the SOI primary ID and the state
+// vector are needed to gate range + |v_rel| against the viewer's active
+// craft.
+type CoWarpCraft struct {
+	Primary string       // SOI primary ID; must match the anchor's to gate
+	R       orbital.Vec3 // primary-relative position at the viewer's sim-time
+	V       orbital.Vec3 // primary-relative velocity at the viewer's sim-time
+}
+
+// CoWarpPeer is one other player's co-warp contribution: their identity,
+// subspace time, current Effective warp (for the min), and their craft
+// in the viewer's system. Built by the relay adapter (CoWarpPeersFrom)
+// from the store's reports — the sim-level, relay-agnostic input so the
+// couple/decouple math + constants stay in sim (the clamp's home) while
+// sim never imports the wire types above it.
+type CoWarpPeer struct {
+	Owner        string
+	Handle       string
+	SubspaceTime time.Time
+	EffWarp      float64
+	Crafts       []CoWarpCraft
+}
+
+// CoWarpState is the transient co-warp slate the reporting layer writes
+// onto the World each tick and clampedWarp reads: whether the anchor is
+// coupled to anyone this tick and, if so, the min Effective warp to clamp
+// to. Never persisted; empty in single-player. Partners is the coupled
+// handles for HUD/debug.
+type CoWarpState struct {
+	Coupled  bool
+	MinWarp  float64
+	Partners []string
+}
+
+// CoWarpResult is ComputeCoWarp's full output: the State to store on the
+// World, the per-owner coupled flags to feed back as `prev` next tick
+// (the hysteresis memory), and the couple/release transitions the
+// reporting layer turns into chips.
+type CoWarpResult struct {
+	State         CoWarpState
+	CoupledOwners map[string]bool
+	NewlyCoupled  []string // handles that transitioned uncoupled→coupled
+	Released      []string // handles that transitioned coupled→uncoupled
+}
+
+// CoWarpCoupled reports whether the viewer is warp-coupled to any player
+// this tick — read by the split guard (EngageSyncWarp) and available to
+// the HUD. v0.28 S1.
+func (w *World) CoWarpCoupled() bool { return w.CoWarp.Coupled }
+
+// ComputeCoWarp evaluates proximity co-warp against the viewer's active
+// craft (the anchor) for this tick. `prev` is the per-owner coupled map
+// returned last tick — it supplies the hysteresis memory so a coupled
+// pair uses the wider decouple gate. The returned CoupledOwners becomes
+// next tick's `prev`. Pure over its inputs (no World mutation) so the
+// caller assigns State to w.CoWarp; testable with hand-built peers.
+//
+// Anchor gating (ADR 0015 / 0025 precedent): only the viewer's active
+// craft anchors co-warp in the MVP — a passive craft of the viewer near
+// a partner won't couple. A landed or missing anchor couples to nobody.
+func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpResult {
+	res := CoWarpResult{CoupledOwners: map[string]bool{}}
+	anchor := w.ActiveCraft()
+	anchorOK := anchor != nil && !anchor.Landed && !anchor.Crashed
+	viewerT := w.Clock.SimTime
+
+	minWarp := math.Inf(1)
+	for _, p := range peers {
+		wasCoupled := prev[p.Owner]
+		coupledNow := false
+		// A non-positive Effective warp (a paused partner, Warp()==0)
+		// imposes no co-warp constraint — the min would freeze the
+		// viewer, which is not what a buddy tapping pause should do. Such
+		// a partner simply isn't a couple; a real pause stops their
+		// subspace clock, so Δt grows and the subspace gate releases them
+		// within the tolerance window anyway. Gating coupledNow on it
+		// keeps State/chips/clamp consistent (no couple without a clamp).
+		if anchorOK && p.EffWarp > 0 && sameSubspace(viewerT, p.SubspaceTime) {
+			if rng, vrel, ok := closestApproach(anchor, p.Crafts); ok {
+				coupledNow = coupleDecide(wasCoupled, rng, vrel)
+			}
+		}
+		res.CoupledOwners[p.Owner] = coupledNow
+		switch {
+		case coupledNow && !wasCoupled:
+			res.NewlyCoupled = append(res.NewlyCoupled, p.Handle)
+		case !coupledNow && wasCoupled:
+			res.Released = append(res.Released, p.Handle)
+		}
+		if coupledNow {
+			res.State.Partners = append(res.State.Partners, p.Handle)
+			if p.EffWarp < minWarp {
+				minWarp = p.EffWarp
+			}
+		}
+	}
+	// A peer that vanished from the report set (left the system, ended
+	// flight) while coupled is released silently by omission: it is absent
+	// from CoupledOwners so next tick treats it as uncoupled, and the
+	// clamp already dropped it from the min. No handle survives to chip a
+	// release, which is acceptable for this edge (the common decouple —
+	// drifting apart in-system — keeps the peer present, so it chips).
+	if len(res.State.Partners) > 0 && !math.IsInf(minWarp, 1) {
+		res.State.Coupled = true
+		res.State.MinWarp = minWarp
+	}
+	return res
+}
+
+// coupleDecide applies the hysteresis gate: an already-coupled pair stays
+// coupled until it separates past the wider decouple band; an uncoupled
+// pair couples only inside the tighter couple band. Range and |v_rel| are
+// each independently sufficient to break the couple (OR), but both are
+// required to form it (AND) — a slow drift-through at range, or a fast
+// pass at close range, is not a rendezvous.
+func coupleDecide(wasCoupled bool, rangeM, vrelMs float64) bool {
+	if wasCoupled {
+		return rangeM <= coWarpDecoupleRangeM && vrelMs <= coWarpDecoupleSpeedMs
+	}
+	return rangeM <= coWarpCoupleRangeM && vrelMs <= coWarpCoupleSpeedMs
+}
+
+// closestApproach returns the min range (and that craft's |v_rel|) among
+// the peer's craft that share the anchor's SOI primary. ok is false when
+// the peer has no same-primary craft — a cross-primary neighbour isn't a
+// co-warp candidate. Both craft states are primary-relative in the same
+// primary, so the primary's own motion cancels in both the separation and
+// the relative velocity.
+func closestApproach(anchor *spacecraft.Spacecraft, crafts []CoWarpCraft) (rangeM, vrelMs float64, ok bool) {
+	best := math.Inf(1)
+	for _, c := range crafts {
+		if c.Primary != anchor.Primary.ID {
+			continue
+		}
+		r := anchor.State.R.Sub(c.R).Norm()
+		if r < best {
+			best = r
+			rangeM = r
+			vrelMs = anchor.State.V.Sub(c.V).Norm()
+			ok = true
+		}
+	}
+	return rangeM, vrelMs, ok
+}
+
+// sameSubspace reports whether two subspace times are close enough to be
+// the same subspace for co-warp purposes (see coWarpSubspaceToleranceSec).
+func sameSubspace(a, b time.Time) bool {
+	d := a.Sub(b).Seconds()
+	if d < 0 {
+		d = -d
+	}
+	return d <= coWarpSubspaceToleranceSec
+}

--- a/internal/sim/cowarp_test.go
+++ b/internal/sim/cowarp_test.go
@@ -1,0 +1,199 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// anchorWorld returns a fresh World whose active craft is the co-warp
+// anchor, plus that craft's primary ID and its subspace time.
+func anchorWorld(t *testing.T) (*World, string, time.Time) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft to anchor")
+	}
+	return w, c.Primary.ID, w.Clock.SimTime
+}
+
+// peerAt builds a one-craft peer offset from the anchor by (dR, dV) in
+// the anchor's primary frame, at subspace time st with Effective warp ew.
+func peerAt(w *World, primary string, st time.Time, ew float64, dR, dV orbital.Vec3, handle string) CoWarpPeer {
+	a := w.ActiveCraft()
+	return CoWarpPeer{
+		Owner:        "SHA256:" + handle,
+		Handle:       handle,
+		SubspaceTime: st,
+		EffWarp:      ew,
+		Crafts: []CoWarpCraft{{
+			Primary: primary,
+			R:       a.State.R.Add(dR),
+			V:       a.State.V.Add(dV),
+		}},
+	}
+}
+
+// Inside 10 km and ≤100 m/s with the same primary + subspace couples,
+// emits a couple transition, and reports the partner's Effective warp as
+// the min.
+func TestComputeCoWarpCouples(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	peer := peerAt(w, primary, st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, nil)
+	if !res.State.Coupled {
+		t.Fatal("not coupled inside the gate")
+	}
+	if res.State.MinWarp != 50 {
+		t.Errorf("MinWarp = %v, want partner's 50", res.State.MinWarp)
+	}
+	if len(res.NewlyCoupled) != 1 || res.NewlyCoupled[0] != "bob" {
+		t.Errorf("NewlyCoupled = %v, want [bob]", res.NewlyCoupled)
+	}
+	if !res.CoupledOwners["SHA256:bob"] {
+		t.Error("owner not recorded coupled for next tick's hysteresis")
+	}
+}
+
+// A fast pass through the radius is a crossing, not a rendezvous: within
+// 10 km but |v_rel| > 100 m/s does not couple.
+func TestComputeCoWarpFlybyDoesNotCouple(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	peer := peerAt(w, primary, st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{X: 150}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, nil)
+	if res.State.Coupled {
+		t.Error("coupled to a 150 m/s flyby")
+	}
+}
+
+// A peer whose subspace time is beyond the tolerance (a time-shifted
+// ghost) does not couple even if its propagated orbit sits in range.
+func TestComputeCoWarpDifferentSubspaceDoesNotCouple(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	far := st.Add(10 * 24 * time.Hour)
+	peer := peerAt(w, primary, far, 50, orbital.Vec3{X: 5000}, orbital.Vec3{}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, nil)
+	if res.State.Coupled {
+		t.Error("coupled across a 10-day subspace gap")
+	}
+}
+
+// A neighbour bound to a different SOI primary is not a co-warp candidate.
+func TestComputeCoWarpDifferentPrimaryDoesNotCouple(t *testing.T) {
+	w, _, st := anchorWorld(t)
+	peer := peerAt(w, "Luna", st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, nil)
+	if res.State.Coupled {
+		t.Error("coupled to a craft in a different primary's SOI")
+	}
+}
+
+// Hysteresis: in the 10–12 km band, an uncoupled pair stays uncoupled and
+// a coupled pair stays coupled — across repeated ticks, with no flap and
+// no repeated chips.
+func TestComputeCoWarpHysteresisNoFlap(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	// 11 km: inside the decouple band, outside the couple band.
+	band := peerAt(w, primary, st, 50, orbital.Vec3{X: 11000}, orbital.Vec3{}, "bob")
+
+	// Uncoupled entering the band: never couples, never chips.
+	prev := map[string]bool(nil)
+	for i := 0; i < 10; i++ {
+		res := w.ComputeCoWarp([]CoWarpPeer{band}, prev)
+		if res.State.Coupled {
+			t.Fatalf("tick %d: coupled at 11 km from uncoupled", i)
+		}
+		if len(res.NewlyCoupled) != 0 || len(res.Released) != 0 {
+			t.Fatalf("tick %d: spurious transition %+v", i, res)
+		}
+		prev = res.CoupledOwners
+	}
+
+	// Coupled entering the band: stays coupled, never re-chips.
+	prev = map[string]bool{"SHA256:bob": true}
+	for i := 0; i < 10; i++ {
+		res := w.ComputeCoWarp([]CoWarpPeer{band}, prev)
+		if !res.State.Coupled {
+			t.Fatalf("tick %d: released at 11 km from coupled (flap)", i)
+		}
+		if len(res.NewlyCoupled) != 0 || len(res.Released) != 0 {
+			t.Fatalf("tick %d: spurious transition %+v", i, res)
+		}
+		prev = res.CoupledOwners
+	}
+}
+
+// Past the decouple band (>12 km) a coupled pair releases and chips once.
+func TestComputeCoWarpDecouples(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	gone := peerAt(w, primary, st, 50, orbital.Vec3{X: 13000}, orbital.Vec3{}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{gone}, map[string]bool{"SHA256:bob": true})
+	if res.State.Coupled {
+		t.Error("still coupled past 13 km")
+	}
+	if len(res.Released) != 1 || res.Released[0] != "bob" {
+		t.Errorf("Released = %v, want [bob]", res.Released)
+	}
+}
+
+// Min-wins: the coupled clamp takes the minimum Effective warp across
+// coupled peers, and it flows through clampedWarp to cap the anchor.
+func TestComputeCoWarpMinWinsClampsWorld(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	w.Clock.WarpIdx = 3 // selected 1000×
+	if got := w.EffectiveWarp(); got != 1000 {
+		t.Fatalf("baseline EffectiveWarp = %v, want 1000", got)
+	}
+	slow := peerAt(w, primary, st, 10, orbital.Vec3{X: 4000}, orbital.Vec3{}, "bob")  // burn-capped partner
+	fast := peerAt(w, primary, st, 100, orbital.Vec3{X: 6000}, orbital.Vec3{}, "gwen") // coasting partner
+
+	res := w.ComputeCoWarp([]CoWarpPeer{slow, fast}, nil)
+	if res.State.MinWarp != 10 {
+		t.Errorf("MinWarp = %v, want 10 (the min over coupled)", res.State.MinWarp)
+	}
+	w.CoWarp = res.State
+	if got := w.EffectiveWarp(); got != 10 {
+		t.Errorf("coupled EffectiveWarp = %v, want the partner's 10× cap", got)
+	}
+}
+
+// A landed/absent anchor couples to nobody, releasing any prior couple.
+func TestComputeCoWarpLandedAnchorReleases(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	w.ActiveCraft().Landed = true
+	peer := peerAt(w, primary, st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{}, "bob")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, map[string]bool{"SHA256:bob": true})
+	if res.State.Coupled {
+		t.Error("landed anchor coupled")
+	}
+	if res.CoupledOwners["SHA256:bob"] {
+		t.Error("landed anchor kept the couple")
+	}
+}
+
+// Split guard: Sync to another subspace is refused while co-warped, and
+// allowed once separated.
+func TestEngageSyncWarpRefusedWhileCoupled(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	target := w.Clock.SimTime.Add(time.Hour)
+
+	w.CoWarp = CoWarpState{Coupled: true, MinWarp: 10}
+	if w.EngageSyncWarp(target, "SHA256:bob", "bob") {
+		t.Error("Sync engaged while co-warped (subspace split not blocked)")
+	}
+	w.CoWarp = CoWarpState{}
+	if !w.EngageSyncWarp(target, "SHA256:bob", "bob") {
+		t.Error("Sync refused after separation")
+	}
+}

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -53,8 +53,10 @@ type SessionEventKind int
 const (
 	SessionEventJoin SessionEventKind = iota
 	SessionEventLeave
-	SessionEventSync     // someone arrived at your subspace ("X synced to you")
-	SessionEventSyncedTo // you arrived at theirs ("synced to X") — local only, never broadcast
+	SessionEventSync           // someone arrived at your subspace ("X synced to you")
+	SessionEventSyncedTo       // you arrived at theirs ("synced to X") — local only, never broadcast
+	SessionEventCoWarpCoupled  // co-warp coupled with a nearby player (v0.28 S1) — local only
+	SessionEventCoWarpReleased // co-warp released on separation (v0.28 S1) — local only
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -202,6 +202,13 @@ type World struct {
 	// system by the writer.
 	Ghosts []Ghost
 
+	// CoWarp is the transient proximity co-warp slate (v0.28 S1, ADR
+	// 0034 §5): written each tick by the serve layer from ComputeCoWarp,
+	// read by clampedWarp for the min-over-coupled-players clamp. Same
+	// contract as Ghosts — serve-written, transient, never persisted,
+	// zero-value (uncoupled) in single-player.
+	CoWarp CoWarpState
+
 	// Session and SessionEvents are the multiplayer roster slate and
 	// recent join/leave/sync moments (v0.27 S6) — same contract as
 	// Ghosts: serve-layer written, screen read, transient, nil/empty
@@ -1025,6 +1032,19 @@ func (w *World) clampedWarp() float64 {
 	// engaged driver freezes time rather than racing ahead.
 	if w.autoWarpEngaged() && !w.Clock.Paused {
 		selected = WarpFactors[len(WarpFactors)-1]
+	}
+	// v0.28 S1 (ADR 0034 §5): proximity co-warp. While the active craft
+	// is coupled to a nearby same-subspace player, Effective Warp is the
+	// min over the coupled players' Effective warps — a partner's 10×
+	// burn cap (or lower selection) propagates so both step in lock, and
+	// chains propagate hop-by-hop because each reports its post-clamp
+	// rate. Another member of the Effective-≤-Selected family; the
+	// couple/decouple gate + hysteresis live in ComputeCoWarp, here we
+	// only take the min. Placed before the burn/period clamps so those
+	// can only reduce further, and before the degenerate-period early
+	// return so a coupled clamp still applies there.
+	if w.CoWarp.Coupled && w.CoWarp.MinWarp > 0 && selected > w.CoWarp.MinWarp {
+		selected = w.CoWarp.MinWarp
 	}
 	// Any craft in flight in a finite or manual burn forces the
 	// 10× cap — high warp during thrust would let the integrator

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -137,6 +137,10 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			rows = append(rows, "◇ "+e.Handle+" synced to you")
 		case sim.SessionEventSyncedTo:
 			rows = append(rows, "◇ synced to "+e.Handle)
+		case sim.SessionEventCoWarpCoupled:
+			rows = append(rows, "◇ warp coupled with "+e.Handle)
+		case sim.SessionEventCoWarpReleased:
+			rows = append(rows, "◇ warp released with "+e.Handle)
 		}
 	}
 	if len(rows) == 0 {


### PR DESCRIPTION
## v0.28 "contact" — Slice S1: Co-warp clamp

Proximity co-warp as a new member of the Effective-≤-Selected clamp family in `internal/sim/world.go clampedWarp()`. Two synced players whose active craft share system + SOI primary + subspace and sit in range warp-couple: **Effective Warp = min over coupled players' Effective warps**.

### Gate (tunables with rationale comments)
- **Couple:** same system + same SOI primary + same subspace + range ≤ 10 km + |v_rel| ≤ 100 m/s (the velocity term is new this cycle — a fast flyby through the radius is not a rendezvous and must not couple).
- **Decouple:** range > 12 km OR |v_rel| > 120 m/s (hysteresis — station-keeping at the boundary must not flap the clamp or spam chips).
- While coupled: subspace splits blocked; N-chains propagate through the min automatically (no transitive-closure logic; MVP tested at 2).

### Wire / seam
- Cross-World reads ride the existing `reportingModel` per-tick seam. New serializable `CraftReport.EffWarp`; reporter re-reports on Effective-warp change (not just heartbeat) so coupled clocks stay locked. No unserializable wire data.
- Couple/decouple emit chips (`◇ warp coupled with X` / released); HUD shows the coupled rate like any other clamp.

### Tests
Two-World sim table tests under `-race`: couple, flyby rejection, different-subspace, different-primary, hysteresis no-flap (10 ticks each direction), decouple, min-wins through the wire with a real burn, split refusal, chip emission. `go vet ./...` clean; `go test ./... -race -count=1` = **1554 passed**. Exactly the two ssh integration tests kept.

### Watch-points for playtest
- Two players who both just spawned at the default LEO at the same subspace time will couple — semantically correct, but flagged. (One pre-existing test assertion narrowed from "zero SessionEvents" to "no join chip" to match this correct behavior.)
- A paused partner (`EffWarp==0`) imposes no co-warp constraint (safe-non-freeze); ADR is silent on pause — verify it feels right.
- MVP anchors co-warp on the viewer's **active** craft only.
- Gate constants + same-subspace tolerance (120 s) + re-report tolerance (1e-3) are all tunables.

Part of the v0.28 cycle. Batched `/code-review` runs once at S6 before tagging — not per slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)