### PR TITLE
feat(sim,relay,serve,sessiondir,tui): v0.28 S5 — cross-player docking (ADR 0034)

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -1,0 +1,379 @@
+package relay
+
+import (
+	"sync"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Cross-player docking ledger (v0.28 S5, ADR 0034 §6 + the 2026-07-14
+// addendum). A cross-player dock spans two players' Worlds, each of which
+// lives in its own session and only ever ticks its OWN World — exactly the
+// constraint co-warp already works under. So the dock is mediated by shared,
+// serialisable ledger state (this file, sibling to the report Store) that
+// each session reconciles against its World once per tick: the guest's tick
+// hands its craft over, the docker's tick fuses it, undock and transfer flow
+// back the same way. Nothing crosses a World boundary except through a ledger
+// payload, so a v2 WebSocket layer serialises the same records + craft
+// payloads (which round-trip through the save package) — store discipline.
+//
+// The durable subset of a record (owner, composite/guest IDs, phase) is what
+// the session directory persists as the reconnect cross-ref; the craft
+// payloads and request flags are transient in-flight handoffs.
+
+// DockPhase is a cross-player dock's lifecycle stage.
+type DockPhase int
+
+const (
+	// DockPending: the docker has claimed a guest craft; the guest hasn't
+	// yet handed its craft over (first the guest's tick removes it from its
+	// World and parks it on the record, then the docker's tick fuses it).
+	DockPending DockPhase = iota
+	// DockActive: the guest craft is fused into the docker's stack and the
+	// ride is live — the guest is Docked-as-Guest, warp-coupled to the stack.
+	DockActive
+)
+
+// DockRecord is one cross-player dock. The exported fields are the durable
+// cross-ref (persisted in the session directory); the unexported fields are
+// transient in-process handoffs consumed on the reconciling side's tick.
+type DockRecord struct {
+	ID            uint64
+	Owner         string // current stack owner fingerprint (flips on transfer)
+	OwnerHandle   string
+	DockerCraftID uint64 // the owner's craft that leads the fused stack
+	CompositeID   uint64 // the fused stack's craft ID in the owner's World (0 until fused)
+	GuestOwner    string // the guest player fingerprint
+	GuestHandle   string
+	GuestCraftID  uint64 // the guest's craft riding in the stack (returned on undock)
+	Phase         DockPhase
+
+	// transient handoffs — in-process craft moves (a v2 wire serialises them)
+	guestPayload    *spacecraft.Spacecraft // guest→docker: craft to fuse
+	returnPayload   *spacecraft.Spacecraft // docker→guest: restored craft on undock/abort
+	transferPayload *spacecraft.Spacecraft // old owner→new owner: the whole migrating stack
+	undockAsk       bool                   // guest→docker: split my component
+	transferTo      string                 // owner→recipient: pending control transfer target
+	aborted         bool                   // docker couldn't fuse — guest reclaims its craft
+}
+
+// DockChip is a moment the reconcile surfaces for the caller to turn into a
+// session chip (docked / undocked / control transfer).
+type DockChip struct {
+	Kind   sim.SessionEventKind
+	Handle string
+}
+
+// DockLedger is the shared, in-process ledger of live cross-player docks.
+// Every mutation takes the lock; a v2 wire keeps the same call surface with
+// the store behind it.
+type DockLedger struct {
+	mu      sync.Mutex
+	records map[uint64]*DockRecord
+	nextID  uint64
+}
+
+// NewDockLedger builds an empty ledger.
+func NewDockLedger() *DockLedger {
+	return &DockLedger{records: map[uint64]*DockRecord{}}
+}
+
+// Claim opens a cross-player dock: the docker (owner) claims a guest craft it
+// has closed on. Refused (ok=false) when either craft is already engaged in a
+// dock — the guard that keeps a simultaneous mutual approach from opening two
+// crossed records (the ledger mutex serialises, so the first writer wins; the
+// passive-station MVP posture means only one side is actively claiming).
+func (l *DockLedger) Claim(owner, ownerHandle string, dockerCraftID uint64, guestOwner, guestHandle string, guestCraftID uint64) (*DockRecord, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if r.involvesCraft(owner, dockerCraftID) || r.involvesCraft(guestOwner, guestCraftID) {
+			return nil, false
+		}
+	}
+	l.nextID++
+	r := &DockRecord{
+		ID:            l.nextID,
+		Owner:         owner,
+		OwnerHandle:   ownerHandle,
+		DockerCraftID: dockerCraftID,
+		GuestOwner:    guestOwner,
+		GuestHandle:   guestHandle,
+		GuestCraftID:  guestCraftID,
+		Phase:         DockPending,
+	}
+	l.records[r.ID] = r
+	return r, true
+}
+
+// involvesCraft reports whether (fp, craftID) is either endpoint of r.
+func (r *DockRecord) involvesCraft(fp string, craftID uint64) bool {
+	return (r.Owner == fp && r.DockerCraftID == craftID) ||
+		(r.GuestOwner == fp && r.GuestCraftID == craftID)
+}
+
+// RequestUndock flags the guest's active dock for a split (guest-initiated,
+// any time — ADR 0034 §6). The docker's next reconcile performs the actual
+// UndockGuest and hands the craft back. ok is false when no active dock
+// matches (nothing to undock).
+func (l *DockLedger) RequestUndock(guestOwner string, guestCraftID uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if r.GuestOwner == guestOwner && r.GuestCraftID == guestCraftID && r.Phase == DockActive {
+			r.undockAsk = true
+			return true
+		}
+	}
+	return false
+}
+
+// RequestTransfer flags the owner's active stack for a control handover to
+// the guest (2-party: the recipient is unambiguous — ADR 0034 addendum). The
+// docker's next reconcile migrates the stack unless it's mid-burn (refused,
+// retried). ok is false when the caller owns no active cross-player stack.
+func (l *DockLedger) RequestTransfer(owner string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if r.Owner == owner && r.Phase == DockActive {
+			r.transferTo = r.GuestOwner
+			return true
+		}
+	}
+	return false
+}
+
+// ActiveGuestDock returns the active record in which fp is the guest, if any —
+// the tui reads it to route the Undock key to RequestUndock and to show the
+// docked-as-guest status.
+func (l *DockLedger) ActiveGuestDock(fp string) (*DockRecord, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if r.GuestOwner == fp && r.Phase == DockActive {
+			cp := *r
+			return &cp, true
+		}
+	}
+	return nil, false
+}
+
+// Records returns a durable-field snapshot of every live dock — the session
+// directory persists this as the reconnect cross-ref.
+func (l *DockLedger) Records() []DockRecord {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]DockRecord, 0, len(l.records))
+	for _, r := range l.records {
+		out = append(out, DockRecord{
+			ID: r.ID, Owner: r.Owner, OwnerHandle: r.OwnerHandle,
+			DockerCraftID: r.DockerCraftID, CompositeID: r.CompositeID,
+			GuestOwner: r.GuestOwner, GuestHandle: r.GuestHandle,
+			GuestCraftID: r.GuestCraftID, Phase: r.Phase,
+		})
+	}
+	return out
+}
+
+// Seed installs durable records (from the session directory on server start)
+// so a dock that outlived a restart resumes. Only the durable fields are
+// carried; the in-flight payload handoffs were transient and are gone.
+func (l *DockLedger) Seed(records []DockRecord) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range records {
+		rec := r
+		l.records[rec.ID] = &rec
+		if rec.ID >= l.nextID {
+			l.nextID = rec.ID
+		}
+	}
+}
+
+// Reconcile advances every dock touching owner against owner's World w for
+// one tick, moving craft across the World seam through the ledger payloads,
+// and returns any chips to surface. reports supplies the current per-owner
+// CraftReport (for the guest's warp coupling to the stack owner). w.DockGuest
+// is rebuilt each call — set when this player is Docked-as-Guest, nil otherwise.
+func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]CraftReport) []DockChip {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var chips []DockChip
+	w.DockGuest = nil // rebuilt below if still a guest in some active dock
+	for id, r := range l.records {
+		switch {
+		case r.Owner == owner:
+			if l.reconcileOwner(w, r, &chips) {
+				delete(l.records, id)
+			}
+		case r.GuestOwner == owner:
+			if l.reconcileGuest(w, r, reports, &chips) {
+				delete(l.records, id)
+			}
+		}
+	}
+	return chips
+}
+
+// reconcileOwner runs the stack owner's side of a dock. Returns true when the
+// record is finished and should be dropped.
+func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockChip) bool {
+	// Transfer arrival: this session just became the stack's owner (roles
+	// swapped on the old owner's tick). Adopt the migrated composite into
+	// this World and fly it — the new owner is no longer a guest.
+	if r.transferPayload != nil {
+		w.AdoptCraft(r.transferPayload, true)
+		r.CompositeID = r.transferPayload.ID
+		r.transferPayload = nil
+		*chips = append(*chips, DockChip{Kind: sim.SessionEventTransfer, Handle: r.GuestHandle})
+		return false
+	}
+	switch r.Phase {
+	case DockPending:
+		if r.guestPayload == nil {
+			return false // waiting for the guest to hand over
+		}
+		guest := r.guestPayload
+		r.guestPayload = nil
+		_, idx, ok := w.CraftByID(r.DockerCraftID)
+		if !ok {
+			// The docker's craft vanished (staged / ended flight) between
+			// claim and handover — abort: hand the guest's craft back.
+			r.returnPayload, r.aborted = guest, true
+			return false
+		}
+		comp, _, ok := w.DockGuestCraft(idx, guest, r.GuestOwner)
+		if !ok {
+			r.returnPayload, r.aborted = guest, true
+			return false
+		}
+		r.CompositeID = comp.ID
+		r.Phase = DockActive
+		*chips = append(*chips, DockChip{Kind: sim.SessionEventDocked, Handle: r.GuestHandle})
+		return false
+
+	case DockActive:
+		// Undock request: split the guest's component and hand it back.
+		if r.undockAsk {
+			r.undockAsk = false
+			_, cidx, ok := w.CraftByID(r.CompositeID)
+			if ok {
+				if restored, ok := w.UndockGuest(cidx, r.GuestOwner, r.GuestCraftID); ok {
+					r.returnPayload = restored
+					*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.GuestHandle})
+				}
+			}
+			// If the composite or component is gone, fall through — the guest
+			// side will time out waiting; MVP treats this as the dock ending.
+			return false
+		}
+		// Transfer request: migrate the whole stack to the guest (roles swap),
+		// unless mid-burn (refused, retried next tick).
+		if r.transferTo != "" {
+			comp, _, ok := w.CraftByID(r.CompositeID)
+			if !ok {
+				r.transferTo = ""
+				return false
+			}
+			if sim.StackMidBurn(comp) {
+				return false // refused mid-burn — retry
+			}
+			newOwner := r.transferTo
+			oldOwner, oldOwnerHandle := r.Owner, r.OwnerHandle
+			oldDockerCraftID := r.DockerCraftID
+			removed, _ := w.RemoveCraftByID(r.CompositeID)
+			sim.RetagStackForTransfer(removed, oldOwner, newOwner)
+			// Swap roles: the old owner becomes the guest of the new owner.
+			r.transferPayload = removed
+			r.transferTo = ""
+			r.Owner, r.OwnerHandle = newOwner, r.GuestHandle
+			r.DockerCraftID = r.GuestCraftID
+			r.GuestOwner, r.GuestHandle = oldOwner, oldOwnerHandle
+			r.GuestCraftID = oldDockerCraftID
+			*chips = append(*chips, DockChip{Kind: sim.SessionEventTransfer, Handle: r.OwnerHandle})
+			return false
+		}
+		return false
+	}
+	return false
+}
+
+// reconcileGuest runs the guest's side of a dock. Returns true when the
+// record is finished and should be dropped.
+func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[string]CraftReport, chips *[]DockChip) bool {
+	// Abort: the docker couldn't fuse — reclaim the handed-over craft.
+	if r.aborted && r.returnPayload != nil {
+		w.AdoptCraft(r.returnPayload, true)
+		return true
+	}
+	switch r.Phase {
+	case DockPending:
+		if r.guestPayload == nil && !r.aborted {
+			c, ok := w.RemoveCraftByID(r.GuestCraftID)
+			if !ok {
+				return true // my craft is gone — abandon the dock
+			}
+			r.guestPayload = c
+		}
+		l.setDockGuest(w, r, reports)
+		return false
+
+	case DockActive:
+		// Undock/abort completion: the docker handed my craft back.
+		if r.returnPayload != nil {
+			w.AdoptCraft(r.returnPayload, true)
+			r.returnPayload = nil
+			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.OwnerHandle})
+			return true
+		}
+		l.setDockGuest(w, r, reports)
+		return false
+	}
+	return false
+}
+
+// setDockGuest writes the guest's docked-as-guest link so the serve layer can
+// fold the min-wins coupling to the stack owner into the guest's co-warp state.
+func (l *DockLedger) setDockGuest(w *sim.World, r *DockRecord, reports map[string]CraftReport) {
+	var ownerEff float64
+	if rep, ok := reports[r.Owner]; ok {
+		ownerEff = rep.EffWarp
+	}
+	w.DockGuest = &sim.DockGuestLink{
+		OwnerFP:      r.Owner,
+		OwnerHandle:  r.OwnerHandle,
+		OwnerEffWarp: ownerEff,
+		GuestCraftID: r.GuestCraftID,
+	}
+}
+
+// DetectGuestContact returns a guest ghost the viewer's active craft has
+// closed to within the docking gates, among owners the viewer is co-warp
+// coupled to (coupled) — the cross-player analogue of checkDocking, which can't
+// fire because a ghost isn't in the local slate. The viewer must not already
+// be flying a cross-player stack or riding as a guest. ok is false when there's
+// no contact. The serve layer turns a hit into a ledger Claim.
+func DetectGuestContact(w *sim.World, coupled map[string]bool) (ghostOwner string, ghostCraftID uint64, ok bool) {
+	active := w.ActiveCraft()
+	if active == nil || active.Landed || active.Crashed || w.DockGuest != nil {
+		return "", 0, false
+	}
+	if sim.StackHasGuest(active) {
+		return "", 0, false // already a cross-player stack
+	}
+	for _, g := range w.Ghosts {
+		if !coupled[g.Owner] || g.PrimaryID != active.Primary.ID {
+			continue
+		}
+		if active.State.R.Sub(g.RelPos).Norm() > sim.DockingDistM {
+			continue
+		}
+		if active.State.V.Sub(g.Vel).Norm() > sim.DockingVMS {
+			continue
+		}
+		return g.Owner, g.CraftID, true
+	}
+	return "", 0, false
+}

--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -160,6 +160,19 @@ func (l *DockLedger) ActiveGuestDock(fp string) (*DockRecord, bool) {
 	return nil, false
 }
 
+// IsGuest reports whether fp is the guest in any active cross-player dock —
+// the source for the Session roster's Docked-as-Guest marker (v0.28 S5).
+func (l *DockLedger) IsGuest(fp string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if r.GuestOwner == fp && r.Phase == DockActive {
+			return true
+		}
+	}
+	return false
+}
+
 // Records returns a durable-field snapshot of every live dock — the session
 // directory persists this as the reconnect cross-ref.
 func (l *DockLedger) Records() []DockRecord {

--- a/internal/relay/dock_test.go
+++ b/internal/relay/dock_test.go
@@ -1,0 +1,250 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+const (
+	fpA = "SHA256:alice"
+	fpB = "SHA256:bob"
+)
+
+// reportMap ticks both Worlds into the store and returns the owner→report
+// map the dock reconcile reads (for the guest's warp coupling).
+func reportMap(store *Store, wA, wB *sim.World, now time.Time) map[string]CraftReport {
+	NewReporter(store, fpA).Tick(wA, now)
+	NewReporter(store, fpB).Tick(wB, now)
+	out := map[string]CraftReport{}
+	for _, r := range store.Snapshot("") {
+		out[r.Owner] = r
+	}
+	return out
+}
+
+// alignedPair builds two Worlds in the same subspace with co-located,
+// velocity-matched active craft (so contact detection and co-warp gate), and
+// stamps a distinct guest craft ID.
+func alignedPair(t *testing.T, guestID uint64) (*sim.World, *sim.World) {
+	t.Helper()
+	wA, wB := newWorld(t), newWorld(t)
+	wB.Clock.SimTime = wA.Clock.SimTime
+	wB.ActiveCraft().ID = guestID
+	wB.ActiveCraft().State = wA.ActiveCraft().State // range 0, v_rel 0
+	return wA, wB
+}
+
+// TestCrossPlayerDockHandshakeAndUndock is the master two-World test: A claims
+// a dock on B's craft; B hands it over (docked-as-guest); A fuses one stack it
+// owns; the guest is min-wins coupled to the owner and can't out-warp it; B
+// undocks any-time and gets its craft back live at the matching seam.
+func TestCrossPlayerDockHandshakeAndUndock(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 200
+	wA, wB := alignedPair(t, guestID)
+	dockerID := wA.ActiveCraft().ID
+	now := time.Now()
+
+	// A claims (as the detector would once co-warp coupled + within gates).
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); !ok {
+		t.Fatalf("Claim refused")
+	}
+
+	// Guest tick: B hands its craft over and goes docked-as-guest.
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	if wB.DockGuest == nil || wB.DockGuest.OwnerFP != fpA {
+		t.Fatalf("B not docked-as-guest: %+v", wB.DockGuest)
+	}
+	if len(wB.Crafts) != 0 {
+		t.Fatalf("B still holds %d craft after handover, want 0", len(wB.Crafts))
+	}
+
+	// Owner tick: A fuses the guest into one stack it owns.
+	chips := ledger.Reconcile(wA, fpA, reports)
+	if len(wA.Crafts) != 1 || !sim.StackHasGuest(wA.Crafts[0]) {
+		t.Fatalf("A did not fuse a cross-player stack: crafts=%d", len(wA.Crafts))
+	}
+	if wA.Crafts[0].ID != dockerID {
+		t.Errorf("stack identity = %d, want docker %d (docker owns)", wA.Crafts[0].ID, dockerID)
+	}
+	if !hasChip(chips, sim.SessionEventDocked) {
+		t.Errorf("no docked chip: %+v", chips)
+	}
+
+	// Guest coupling min-wins: A picks 1×; B (docked-as-guest) can't out-warp it.
+	wA.Clock.WarpIdx = 0 // owner 1×
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports)
+	// The serve layer folds the coupling after ComputeCoWarp; do it here.
+	wB.CoWarp = wB.CoWarp.WithDockCoupling(wB.DockGuest.OwnerHandle, wB.DockGuest.OwnerEffWarp)
+	wB.Clock.WarpIdx = 5 // B wants max warp
+	if got := wB.EffectiveWarp(); got != 1 {
+		t.Errorf("docked-as-guest B EffectiveWarp = %v, want clamped to owner 1×", got)
+	}
+
+	stack := wA.Crafts[0]
+	stackR, stackV := stack.State.R, stack.State.V
+
+	// Undock any-time: B requests, A splits + returns, B receives home.
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(2*time.Second))
+	ledger.Reconcile(wA, fpA, reports) // A splits the guest out
+	uChips := ledger.Reconcile(wB, fpB, reports) // B receives its craft
+
+	if wB.DockGuest != nil {
+		t.Errorf("B still docked-as-guest after undock")
+	}
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not get craft %d back", guestID)
+	}
+	if got.State.R != stackR || got.State.V != stackV {
+		t.Errorf("returned craft state %v/%v != stack seam %v/%v", got.State.R, got.State.V, stackR, stackV)
+	}
+	if !hasChip(uChips, sim.SessionEventUndocked) {
+		t.Errorf("no undocked chip: %+v", uChips)
+	}
+	// A's stack reverted to its plain docker craft.
+	if len(wA.Crafts) != 1 || sim.StackHasGuest(wA.Crafts[0]) {
+		t.Errorf("A's composite did not revert after undock")
+	}
+	// The dock is fully torn down.
+	if len(ledger.Records()) != 0 {
+		t.Errorf("ledger still holds %d records after undock", len(ledger.Records()))
+	}
+}
+
+// TestGuestVesselSwitchRetainsCoupling: a guest flying ANOTHER craft they own
+// stays docked-as-guest and coupled — vessel-switch doesn't drop the ride.
+func TestGuestVesselSwitchRetainsCoupling(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 300
+	wA, wB := alignedPair(t, guestID)
+	// Give B a second craft to fly while its first rides in A's stack.
+	second := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	second.Primary = wB.ActiveCraft().Primary
+	second.State = wB.ActiveCraft().State
+	wB.AdoptCraft(second, false)
+	secondID := second.ID
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports) // hand over craft 1
+	ledger.Reconcile(wA, fpA, reports) // fuse
+
+	// B flies its second craft.
+	if _, idx, ok := wB.CraftByID(secondID); ok {
+		wB.SetActiveCraftIdx(idx)
+	} else {
+		t.Fatalf("B lost its second craft on handover")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports)
+	if wB.DockGuest == nil {
+		t.Errorf("guest dropped its docked-as-guest state after vessel switch")
+	}
+	if wB.ActiveCraft() == nil || wB.ActiveCraft().ID != secondID {
+		t.Errorf("guest not flying its second craft")
+	}
+}
+
+// TestTransferControlSwapsRolesRefusedMidBurn: a mid-burn stack refuses the
+// transfer; once the burn ends the whole stack migrates to the guest and the
+// roles swap (old owner becomes the guest).
+func TestTransferControlSwapsRolesRefusedMidBurn(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 400
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	stack := wA.Crafts[0]
+
+	// Mid-burn: transfer is refused (stack stays with A).
+	stack.ManualBurn = &spacecraft.ManualBurn{StartTime: wA.Clock.SimTime}
+	if !ledger.RequestTransfer(fpA) {
+		t.Fatalf("RequestTransfer refused outright")
+	}
+	ledger.Reconcile(wA, fpA, reports)
+	if len(wA.Crafts) != 1 || !sim.StackHasGuest(wA.Crafts[0]) {
+		t.Fatalf("stack migrated while mid-burn (should be refused)")
+	}
+
+	// Burn ends: the transfer goes through, roles swap.
+	stack.ManualBurn = nil
+	chips := ledger.Reconcile(wA, fpA, reports) // A migrates the stack out
+	if len(wA.Crafts) != 0 {
+		t.Errorf("A still holds the stack after transfer: %d", len(wA.Crafts))
+	}
+	if !hasChip(chips, sim.SessionEventTransfer) {
+		t.Errorf("no transfer chip: %+v", chips)
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B adopts the stack (now owner)
+	if len(wB.Crafts) != 1 || !sim.StackHasGuest(wB.Crafts[0]) {
+		t.Fatalf("B did not adopt the transferred stack")
+	}
+	if wB.DockGuest != nil {
+		t.Errorf("new owner B still marked docked-as-guest")
+	}
+	ledger.Reconcile(wA, fpA, reports) // A becomes the guest
+	if wA.DockGuest == nil || wA.DockGuest.OwnerFP != fpB {
+		t.Errorf("old owner A not demoted to guest: %+v", wA.DockGuest)
+	}
+}
+
+// TestDisconnectReconnectResumesDockedAsGuest: the durable record survives a
+// server restart (Seed) and a reconnecting guest resumes docked-as-guest,
+// coupled to the stack — the craft rode along in the owner's stack.
+func TestDisconnectReconnectResumesDockedAsGuest(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 500
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+
+	// Persisted cross-ref (durable subset only).
+	durable := ledger.Records()
+	if len(durable) != 1 || durable[0].Phase != DockActive {
+		t.Fatalf("durable record = %+v", durable)
+	}
+
+	// Server restart: fresh ledger seeded from disk; B reconnects with NO
+	// craft for guestID (it rode along in A's stack, absent from B's payload).
+	fresh := NewDockLedger()
+	fresh.Seed(durable)
+	wBReconnect := newWorld(t)
+	wBReconnect.Crafts = nil
+	wBReconnect.Clock.SimTime = wA.Clock.SimTime
+	reports = reportMap(store, wA, wBReconnect, now.Add(time.Minute))
+	fresh.Reconcile(wBReconnect, fpB, reports)
+	if wBReconnect.DockGuest == nil || wBReconnect.DockGuest.OwnerFP != fpA {
+		t.Errorf("reconnecting guest did not resume docked-as-guest: %+v", wBReconnect.DockGuest)
+	}
+}
+
+func hasChip(chips []DockChip, kind sim.SessionEventKind) bool {
+	for _, c := range chips {
+		if c.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -376,6 +376,15 @@ type DockedComponent struct {
 	// sim.Undock fall back to the legacy single-stage rebuild —
 	// matching every pre-ADR-0009 composite.
 	Stages []Stage `json:"stages,omitempty"`
+	// Owner / CraftID (v0.28 S5, ADR 0034 cross-player docking): the
+	// component's ownership provenance. Owner is a guest player's
+	// fingerprint when this component rides in the docker's stack; empty
+	// for a same-player composite. CraftID is the component's pre-dock
+	// stable ID, handed back on cross-player undock. Additive omitempty,
+	// no schema bump — absent → "" / 0, exactly a single-World composite,
+	// so every pre-v0.28 save and all local docking round-trips unchanged.
+	Owner   string `json:"owner,omitempty"`
+	CraftID uint64 `json:"craft_id,omitempty"`
 }
 
 // ActiveBurn mirrors sim.ActiveBurn. Throttle (v0.7.6+, schema v4)
@@ -625,6 +634,8 @@ func payloadFromWorld(w *sim.World) Payload {
 				CanSoftLand:      dc.CanSoftLand,
 				HasParachute:     dc.HasParachute,
 				Stages:           simStagesToWire(dc.Stages),
+				Owner:            dc.Owner,
+				CraftID:          dc.CraftID,
 			})
 		}
 		for _, n := range c.Nodes {
@@ -868,6 +879,8 @@ func worldFromPayload(p Payload, systems []bodies.System) (*sim.World, error) {
 				CanSoftLand:      dc.CanSoftLand,
 				HasParachute:     dc.HasParachute,
 				Stages:           wireStagesToSim(dc.Stages),
+				Owner:            dc.Owner,
+				CraftID:          dc.CraftID,
 			})
 		}
 		// v0.8.1+: per-craft Nodes / ActiveBurn loaded directly from

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -1,0 +1,88 @@
+package serve
+
+import (
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// Cross-player docking wiring (v0.28 S5). The reconcile hub in reporting.go
+// calls reconcileDocking once per tick after ghosts + co-warp are refreshed:
+// detect a fresh contact against a co-warp-coupled ghost, advance every dock
+// touching this session against its World, fold the guest's warp coupling, and
+// persist the durable cross-ref when a dock transitions. The heavy lifting is
+// in relay.DockLedger; this is the serve-side glue that gives it the current
+// World, roster handles, and disk.
+
+// reconcileDocking runs this session's cross-player docking for one tick.
+// coupled is ComputeCoWarp's per-owner coupled map; reports is the owner→report
+// map; handles is fingerprint→handle. Chips it produces are appended to the
+// session's local event slate. w is the session's World (already ghost/co-warp
+// refreshed this tick).
+func (m *reportingModel) reconcileDocking(w *sim.World, coupled map[string]bool, reports map[string]relay.CraftReport, handles map[string]string, now time.Time) {
+	changed := false
+
+	// Detect a fresh contact: the active craft has closed on a co-warp-coupled
+	// ghost within the docking gates. Claim it (docker owns) — the guest's next
+	// tick hands the craft over. Idempotent via the ledger's engaged-craft guard.
+	if ghostOwner, ghostCraftID, ok := relay.DetectGuestContact(w, coupled); ok {
+		if active := w.ActiveCraft(); active != nil {
+			ownHandle := handles[m.owner]
+			if _, claimed := m.srv.dock.Claim(m.owner, ownHandle, active.ID, ghostOwner, handles[ghostOwner], ghostCraftID); claimed {
+				changed = true
+			}
+		}
+	}
+
+	// Advance every dock touching this session against its World.
+	chips := m.srv.dock.Reconcile(w, m.owner, reports)
+	for _, c := range chips {
+		m.localEvents = append(m.localEvents, sim.SessionEvent{Kind: c.Kind, Handle: c.Handle, At: now})
+		changed = true
+	}
+
+	// Docked-as-guest: fold the min-wins coupling to the stack owner into the
+	// co-warp state (reuses S1's clampedWarp clamp), on top of any range couple.
+	if w.DockGuest != nil {
+		w.CoWarp = w.CoWarp.WithDockCoupling(w.DockGuest.OwnerHandle, w.DockGuest.OwnerEffWarp)
+	}
+
+	// Persist the durable cross-ref on any transition so a reconnecting guest
+	// resumes. The ledger is the source of truth; SetDocks writes the full
+	// current snapshot, so concurrent writers from different sessions converge.
+	if changed {
+		_ = m.srv.store.SetDocks(recordsToDockLinks(m.srv.dock.Records()))
+	}
+}
+
+// dockLinksToRecords adapts the persisted cross-ref into live ledger records
+// (durable fields only — the transient handoff payloads were not persisted).
+func dockLinksToRecords(links []sessiondir.DockLink) []relay.DockRecord {
+	out := make([]relay.DockRecord, 0, len(links))
+	for _, l := range links {
+		out = append(out, relay.DockRecord{
+			ID: l.ID, Owner: l.Owner, OwnerHandle: l.OwnerHandle,
+			DockerCraftID: l.DockerCraftID, CompositeID: l.CompositeID,
+			GuestOwner: l.GuestOwner, GuestHandle: l.GuestHandle,
+			GuestCraftID: l.GuestCraftID, Phase: relay.DockPhase(l.Phase),
+		})
+	}
+	return out
+}
+
+// recordsToDockLinks projects the live ledger's durable fields to the
+// persisted form.
+func recordsToDockLinks(recs []relay.DockRecord) []sessiondir.DockLink {
+	out := make([]sessiondir.DockLink, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, sessiondir.DockLink{
+			ID: r.ID, Owner: r.Owner, OwnerHandle: r.OwnerHandle,
+			DockerCraftID: r.DockerCraftID, CompositeID: r.CompositeID,
+			GuestOwner: r.GuestOwner, GuestHandle: r.GuestHandle,
+			GuestCraftID: r.GuestCraftID, Phase: int(r.Phase),
+		})
+	}
+	return out
+}

--- a/internal/serve/dock_wiring_test.go
+++ b/internal/serve/dock_wiring_test.go
@@ -1,0 +1,90 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// hostStackHasGuest reports whether the host world's first craft is a
+// cross-player stack (composite carrying a guest component).
+func hostStackHasGuest(w *sim.World) bool {
+	return len(w.Crafts) > 0 && sim.StackHasGuest(w.Crafts[0])
+}
+
+// TestCrossPlayerDockThroughReportingModels drives the full serve seam: two
+// sessions (host + guest) share one server (store + relay + dock ledger). With
+// the guest's craft coincident and co-warp-coupled, the host's tick detects
+// contact and claims; the guest's tick hands its craft over; the host's tick
+// fuses one cross-player stack it owns; the guest goes docked-as-guest and the
+// roster marker lights up. Exercised end-to-end under -race across the store.
+func TestCrossPlayerDockThroughReportingModels(t *testing.T) {
+	const guestFP = "SHA256:gern"
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, guestFP, "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New host: %v", err)
+	}
+	guestApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New guest: %v", err)
+	}
+	var host tea.Model = srv.HostModel(hostApp)
+	var guest tea.Model = srv.withReporting(guestApp, guestFP)
+
+	hw, gw := hostApp.World(), guestApp.World()
+	gw.Clock.SimTime = hw.Clock.SimTime
+	gw.ActiveCraft().ID = 777
+	gw.ActiveCraft().State = hw.ActiveCraft().State
+
+	// Prime the guest first (no host report in the store yet → no couple, no
+	// claim), then the host — so the host's priming tick is the one that sees
+	// the coupled guest ghost and claims, making the host the docker.
+	guest = tick(guest)
+	host = tick(host)
+
+	for i := 0; i < 6 && !hostStackHasGuest(hw); i++ {
+		// Keep the two in the same subspace and, while the guest still holds
+		// its craft, co-located so co-warp couples and contact is detected.
+		// The host ticks first each round, so the host is the one that detects
+		// contact and claims — it becomes the docker (both sides would
+		// otherwise race; the ledger's engaged-craft guard keeps it to one
+		// record, but tick order decides the docker).
+		gw.Clock.SimTime = hw.Clock.SimTime
+		if gc, hc := gw.ActiveCraft(), hw.ActiveCraft(); gc != nil && hc != nil && !hostStackHasGuest(hw) {
+			gc.State = hc.State
+		}
+		host, _ = host.Update(sim.TickMsg(time.Now()))
+		guest, _ = guest.Update(sim.TickMsg(time.Now()))
+	}
+
+	if !hostStackHasGuest(hw) {
+		t.Fatalf("host never fused a cross-player stack (crafts=%d, coupled=%v)", len(hw.Crafts), hw.CoWarp.Coupled)
+	}
+	if gw.DockGuest == nil || gw.DockGuest.OwnerFP != sessiondir.HostFingerprint {
+		t.Errorf("guest world not docked-as-guest: %+v", gw.DockGuest)
+	}
+	if hw.Session == nil {
+		t.Fatalf("host session slate nil")
+	}
+	var marked bool
+	for _, p := range hw.Session.Players {
+		if p.Fingerprint == guestFP && p.DockedGuest {
+			marked = true
+		}
+	}
+	if !marked {
+		t.Errorf("guest not marked docked-as-guest on the roster: %+v", hw.Session.Players)
+	}
+	meta, _ := srv.store.Meta()
+	if len(meta.Docks) != 1 || meta.Docks[0].GuestOwner != guestFP {
+		t.Errorf("dock cross-ref not persisted: %+v", meta.Docks)
+	}
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -81,6 +81,25 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.stopHosting()
 	}
 
+	// Cross-player docking intents (v0.28 S5): the App can't reach the dock
+	// ledger (sim sits below serve), so a flight key emits one of these and
+	// the wrapper acts on it. Inert without a server. RequestUndock is the
+	// guest's undock-anytime signal; RequestTransfer hands the stack over.
+	if _, ok := msg.(tui.UndockGuestMsg); ok {
+		if m.srv != nil {
+			if w := m.app.World(); w.DockGuest != nil {
+				m.srv.dock.RequestUndock(m.owner, w.DockGuest.GuestCraftID)
+			}
+		}
+		return m, nil
+	}
+	if _, ok := msg.(tui.TransferControlMsg); ok {
+		if m.srv != nil {
+			m.srv.dock.RequestTransfer(m.owner)
+		}
+		return m, nil
+	}
+
 	// Session-admin intents from the Session screen (v0.27 S6): the
 	// wrapper owns the store access; the App below only dispatched.
 	// Inert until a server exists (solo has nothing to administer).
@@ -189,6 +208,14 @@ func (m *reportingModel) refreshSession(now time.Time) {
 			w.AutoWarp.T = rep.SubspaceTime
 		}
 	}
+	// Cross-player docking (v0.28 S5): detect contact against a co-warp-
+	// coupled ghost, advance every dock touching this session, fold the
+	// docked-as-guest coupling, and persist the cross-ref on transitions.
+	// Runs after ghosts + co-warp so detection sees fresh ghost positions
+	// and cw.CoupledOwners, and before the roster build so DockedGuest is
+	// current. Mutates w (fuses/splits craft) — same goroutine as the tick.
+	m.reconcileDocking(w, cw.CoupledOwners, reports, handles, now)
+
 	info := &sim.SessionInfo{
 		IsHost: m.owner == sessiondir.HostFingerprint,
 		Self:   m.owner,
@@ -199,6 +226,10 @@ func (m *reportingModel) refreshSession(now time.Time) {
 			Handle:      p.Handle,
 			Role:        p.Role,
 			Online:      m.srv.presence.isOnline(p.Fingerprint),
+			// Docked-as-Guest marker goes live in v0.28 S5 (inert in v0.27):
+			// true while any of this player's craft rides in another player's
+			// live stack.
+			DockedGuest: m.srv.dock.IsGuest(p.Fingerprint),
 		}
 		if rep, ok := reports[p.Fingerprint]; ok {
 			row.HasReport = true

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -55,6 +55,7 @@ type Server struct {
 	ln       net.Listener
 	store    *sessiondir.Store
 	relay    *relay.Store
+	dock     *relay.DockLedger
 	presence *presence
 
 	// sessions tracks in-flight session handlers (including their
@@ -100,7 +101,14 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store, relay: relay.NewStore(), presence: newPresence()}
+	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence()}
+	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
+	// durable cross-ref persisted in session.json seeds the live ledger, so
+	// a guest whose craft rode along in another player's stack reconnects
+	// straight back into docked-as-guest.
+	if m, err := store.Meta(); err == nil {
+		srv.dock.Seed(dockLinksToRecords(m.Docks))
+	}
 	// The host plays in-process and is online for the session's whole
 	// life — no join chip for them (serve start isn't a "moment").
 	srv.presence.markOnline(sessiondir.HostFingerprint)

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -33,7 +33,14 @@ import (
 
 // MetaVersion is the session.json schema version. Bump + migrate on
 // shape changes, mirroring the save-envelope discipline.
-const MetaVersion = 1
+//
+// v1 (v0.27): roster + invites + catalog hash.
+// v2 (v0.28 S5): adds Docks — the cross-player-dock cross-ref, so a
+// guest riding another player's stack (whose craft therefore isn't in
+// its own payload) resumes docked-as-guest on reconnect. A v1
+// session.json migrates forward (Docks defaults empty) via
+// migrateMetaV1ToV2; live v0.27 sessions never break.
+const MetaVersion = 2
 
 // Roster roles. Host is the one privileged role (ADR 0034): the
 // player whose machine runs the session, with invite and removal
@@ -70,12 +77,36 @@ type Invite struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// DockLink is one cross-player dock's durable cross-ref (v0.28 S5, ADR
+// 0034 §6). It is the persisted, serialisable subset of the live
+// relay.DockRecord — enough for a reconnecting session to resume: the
+// stack owner + composite, and the guest player + their craft riding in
+// it. The transient in-flight payloads (the craft handoffs) are NOT
+// persisted; a dock that was mid-handshake at shutdown resolves fresh.
+// Phase is the relay.DockPhase int (0 pending / 1 active); sessiondir
+// stays below relay so it carries the raw int rather than importing it.
+type DockLink struct {
+	ID            uint64 `json:"id"`
+	Owner         string `json:"owner"`
+	OwnerHandle   string `json:"owner_handle,omitempty"`
+	DockerCraftID uint64 `json:"docker_craft_id"`
+	CompositeID   uint64 `json:"composite_id,omitempty"`
+	GuestOwner    string `json:"guest_owner"`
+	GuestHandle   string `json:"guest_handle,omitempty"`
+	GuestCraftID  uint64 `json:"guest_craft_id"`
+	Phase         int    `json:"phase"`
+}
+
 // Meta is the session.json shape.
 type Meta struct {
 	Version         int      `json:"version"`
 	BodyCatalogHash string   `json:"body_catalog_hash"`
 	Roster          []Player `json:"roster"`
 	Invites         []Invite `json:"invites"`
+	// Docks is the cross-player-dock cross-ref (v2+, v0.28 S5). Empty
+	// in a fresh or non-docking session; the serve layer syncs it from
+	// the live relay ledger on change.
+	Docks []DockLink `json:"docks,omitempty"`
 }
 
 // Store owns one session directory. All mutations re-read
@@ -141,7 +172,44 @@ func (s *Store) readMeta() (Meta, error) {
 	if m.Version > MetaVersion {
 		return Meta{}, fmt.Errorf("sessiondir: session.json version %d is newer than this build (%d)", m.Version, MetaVersion)
 	}
+	migrateMeta(&m)
 	return m, nil
+}
+
+// migrateMeta walks a just-read Meta forward through the typed migration
+// ladder to the current MetaVersion, mirroring save.Load's per-step
+// migrateV{N}toV{N+1} discipline. Each step is a pure shape fix; the last
+// stamps Version = MetaVersion so a re-write persists at the current schema.
+func migrateMeta(m *Meta) {
+	if m.Version < 2 {
+		migrateMetaV1ToV2(m)
+	}
+	m.Version = MetaVersion
+}
+
+// migrateMetaV1ToV2 carries a v0.27 session (roster/invites, no docks)
+// forward: v1 had no cross-player docking, so Docks is simply absent. The
+// nil default is already correct — the function exists to keep the ladder
+// explicit and to give the next shape change a home. v0.28 S5.
+func migrateMetaV1ToV2(m *Meta) {
+	if m.Docks == nil {
+		m.Docks = nil // explicit: a v1 session never had docks
+	}
+}
+
+// SetDocks persists the cross-player-dock cross-ref (v0.28 S5). The serve
+// layer calls it when the live relay ledger changes, so a reconnecting
+// guest resumes docked-as-guest. Re-reads under the lock so a concurrent
+// roster edit isn't clobbered.
+func (s *Store) SetDocks(docks []DockLink) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return err
+	}
+	m.Docks = docks
+	return s.writeMeta(m)
 }
 
 // writeMeta persists atomically (tmpfile + rename), matching the save

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -275,3 +275,79 @@ func TestLoadPlayerErrors(t *testing.T) {
 		t.Errorf("stale catalog: err = %v, want save.ErrCatalogMismatch", err)
 	}
 }
+
+// TestMigrateV1SessionForward — a live v0.27 session.json (schema v1:
+// roster + invites, no docks) must survive into v0.28. Writing a raw v1
+// file and reading it back migrates to the current MetaVersion with the
+// roster intact and an empty Docks; a re-write persists at v2. This is the
+// load-bearing "sessions migrate, never break" guarantee (ADR 0034 addendum).
+func TestMigrateV1SessionForward(t *testing.T) {
+	dir := t.TempDir()
+	// Hand-write a v0.27-shaped session.json (Version 1, no docks field).
+	v1 := `{
+  "version": 1,
+  "body_catalog_hash": "deadbeef",
+  "roster": [
+    {"fingerprint": "local", "handle": "jason", "role": "host", "calibrated": true},
+    {"fingerprint": "SHA256:gern", "handle": "gern", "role": "guest", "calibrated": true}
+  ],
+  "invites": [{"code": "AB2C-DE3F", "handle": "ada"}]
+}`
+	if err := os.MkdirAll(dir+"/players", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/session.json", []byte(v1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(dir) // Open must not re-init over the existing file
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	m, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	if m.Version != MetaVersion {
+		t.Errorf("migrated Version = %d, want %d", m.Version, MetaVersion)
+	}
+	if len(m.Roster) != 2 || m.Roster[1].Handle != "gern" {
+		t.Errorf("roster not carried forward: %+v", m.Roster)
+	}
+	if len(m.Invites) != 1 || m.Invites[0].Code != "AB2C-DE3F" {
+		t.Errorf("invites not carried forward: %+v", m.Invites)
+	}
+	if len(m.Docks) != 0 {
+		t.Errorf("migrated v1 session gained docks: %+v", m.Docks)
+	}
+	if m.BodyCatalogHash != "deadbeef" {
+		t.Errorf("catalog hash changed on migrate: %q", m.BodyCatalogHash)
+	}
+
+	// A dock cross-ref persists and round-trips at v2.
+	links := []DockLink{{
+		ID: 1, Owner: "local", OwnerHandle: "jason", DockerCraftID: 1,
+		CompositeID: 1, GuestOwner: "SHA256:gern", GuestHandle: "gern",
+		GuestCraftID: 200, Phase: 1,
+	}}
+	if err := s.SetDocks(links); err != nil {
+		t.Fatalf("SetDocks: %v", err)
+	}
+	m2, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta after SetDocks: %v", err)
+	}
+	if len(m2.Docks) != 1 || m2.Docks[0].GuestCraftID != 200 || m2.Docks[0].Phase != 1 {
+		t.Errorf("dock cross-ref not persisted: %+v", m2.Docks)
+	}
+
+	// The on-disk file is now stamped v2.
+	data, _ := os.ReadFile(dir + "/session.json")
+	var probe struct {
+		Version int `json:"version"`
+	}
+	_ = json.Unmarshal(data, &probe)
+	if probe.Version != MetaVersion {
+		t.Errorf("on-disk version = %d, want %d", probe.Version, MetaVersion)
+	}
+}

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -30,6 +30,14 @@ func (w *World) Undock(idx int) bool {
 	if c == nil || len(c.DockedComponents) < 2 {
 		return false
 	}
+	// v0.28 S5: a cross-player stack must not be split locally — that would
+	// clone the guest's craft into this (the owner's) World while the guest
+	// still believes it's docked. The guest undocks their own component
+	// through the dock ledger (UndockGuest); this local path handles only
+	// same-player composites (every component owned by this World).
+	if StackHasGuest(c) {
+		return false
+	}
 
 	// v0.12 / ADR 0009: decide whether the composite carries a full
 	// per-component stage breakdown. When every component records its

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -415,17 +415,33 @@ func (w *World) DockCrafts(idxA, idxB int) {
 	if idxB == w.ActiveCraftIdx {
 		lead, drop = idxB, idxA
 	}
+	w.fuseComposite(lead, drop)
+}
+
+// fuseComposite fuses the craft at dropIdx into the craft at leadIdx,
+// producing one composite that keeps the LEAD's identity, and returns the
+// composite plus its slate index after the drop slot is removed. Unlike
+// DockCrafts (which picks lead/drop from ActiveCraftIdx), the caller fixes
+// which slot leads — DockGuestCraft forces the docker to lead so the fused
+// stack takes on the docker's identity and this World's ownership regardless
+// of which slot is active. The mass/velocity/stage/component/reindex math is
+// identical to the classic single-World dock. ok is false for invalid or nil
+// slots or a zero-mass pair. v0.28 S5.
+func (w *World) fuseComposite(lead, drop int) (*spacecraft.Spacecraft, int, bool) {
+	if lead == drop || lead < 0 || drop < 0 || lead >= len(w.Crafts) || drop >= len(w.Crafts) {
+		return nil, -1, false
+	}
 	a := w.Crafts[lead]
 	b := w.Crafts[drop]
 	if a == nil || b == nil {
-		return
+		return nil, -1, false
 	}
 
 	mA := a.TotalMass()
 	mB := b.TotalMass()
 	mTotal := mA + mB
 	if mTotal <= 0 {
-		return
+		return nil, -1, false
 	}
 
 	composite := *a // shallow copy preserves the lead partner's identity.
@@ -514,4 +530,5 @@ func (w *World) DockCrafts(idxA, idxB int) {
 		// craft pointer follows. Same craft, no target rebind.
 		w.ActiveCraftIdx--
 	}
+	return &composite, newLead, true
 }

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -1,0 +1,240 @@
+package sim
+
+import (
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Cross-player docking (v0.28 S5, ADR 0034 §6 + the 2026-07-14 addendum).
+//
+// A cross-player dock fuses ONE stack simulated by exactly one client —
+// the docker (active approacher). The other player's craft rides in that
+// stack as a DockedComponent tagged with its owner's fingerprint and its
+// pre-dock stable ID, so the guest can undock it — anywhere, anytime —
+// and get it back home unchanged. These are the sim-level primitives the
+// serve/relay reconcile loop calls once the cross-World handover has moved
+// the guest craft into (or out of) the docker's World; the cross-World
+// message plumbing lives in internal/relay (DockLedger). The MVP posture
+// is active-vehicle-docks-to-passive-station (ADR addendum): a coasting
+// guest is Kepler-exact between reports, so final approach isn't
+// heartbeat-gated.
+
+// DockGuestCraft fuses guest into the docker's craft at dockerIdx, producing
+// one composite OWNED by this World (the docker's). The composite keeps the
+// docker's identity; guest rides as one or more DockedComponents tagged with
+// guestOwner (the guest player's fingerprint) so UndockGuest can peel exactly
+// the guest's sub-stack back out. guest is appended to the slate and consumed
+// by the fusion — the caller (serve, after the guest World handed the payload
+// over) passes a craft that already carries its pre-dock stable ID. Returns
+// the composite, its slate index, and ok=false for a bad index / nil guest /
+// failed fuse.
+//
+// Ownership: the docker is always the fusion lead, regardless of which slot
+// is active, so the stack's identity + this World's simulation authority are
+// the docker's per ADR 0034 §6. The guest's contributed components are the
+// trailing entries of the flattened DockedComponents list (fuseComposite
+// appends the drop's components last); tagging those with guestOwner is the
+// whole cross-player marking.
+func (w *World) DockGuestCraft(dockerIdx int, guest *spacecraft.Spacecraft, guestOwner string) (*spacecraft.Spacecraft, int, bool) {
+	if dockerIdx < 0 || dockerIdx >= len(w.Crafts) || guest == nil || guestOwner == "" {
+		return nil, -1, false
+	}
+	// How many components the guest contributes once flattened: its own
+	// component list, or one (AsDockedComponent) when it's a plain craft.
+	guestComps := len(guest.DockedComponents)
+	if guestComps == 0 {
+		guestComps = 1
+	}
+	w.Crafts = append(w.Crafts, guest)
+	guestIdx := len(w.Crafts) - 1
+	comp, idx, ok := w.fuseComposite(dockerIdx, guestIdx)
+	if !ok {
+		return nil, -1, false
+	}
+	// Tag the guest's trailing components. Leave any already-owned tag
+	// intact (a guest sub-stack that itself contains a further-nested guest
+	// keeps that provenance — not reachable in the 2-party MVP, but the
+	// guard keeps the tagging idempotent under a re-dock).
+	n := len(comp.DockedComponents)
+	for i := n - guestComps; i < n; i++ {
+		if i >= 0 && comp.DockedComponents[i].Owner == "" {
+			comp.DockedComponents[i].Owner = guestOwner
+		}
+	}
+	return comp, idx, true
+}
+
+// UndockGuest splits the guest's sub-stack out of the composite at
+// compositeIdx and RETURNS the restored guest craft (NOT added to this
+// World — the serve layer injects it into the guest's own World at the
+// matching seam). The docker's composite shrinks in place, keeping its
+// current flight (no active switch, no burn stop — like Deploy, since the
+// composite persists). Reverts to a plain craft when only the docker's own
+// components remain.
+//
+// The restored craft is placed at the composite's CURRENT state (r, v) and
+// stamped with the guest's original stable ID (guestCraftID), so it returns
+// to the guest exactly where the stack is — "times always match at the seam"
+// (ADR addendum: this is what keeps undock-anytime sound). guestOwner selects
+// which components peel off; guestCraftID both stamps the return identity and,
+// when non-zero, disambiguates one guest among several sharing an owner (not
+// reachable in the 2-party MVP).
+//
+// Returns ok=false when the composite has no components tagged for guestOwner
+// (nothing to undock) or the indices are invalid. MVP limitation: a guest that
+// docked a multi-component composite is rebuilt as a single multi-stage craft
+// from its first component's identity — the sub-composite seams are not
+// preserved (passive-station posture docks a single craft; noted for playtest).
+func (w *World) UndockGuest(compositeIdx int, guestOwner string, guestCraftID uint64) (*spacecraft.Spacecraft, bool) {
+	if compositeIdx < 0 || compositeIdx >= len(w.Crafts) || guestOwner == "" {
+		return nil, false
+	}
+	c := w.Crafts[compositeIdx]
+	if c == nil || len(c.DockedComponents) < 2 {
+		return nil, false
+	}
+
+	// Collect the guest's components (by owner, optionally pinned to
+	// guestCraftID) and the count of live stages they occupy. Components map
+	// to c.Stages in order (bottom-to-top); the guest's ride on TOP of the
+	// docker's, so their live stages are the tail of c.Stages — the same
+	// geometry Deploy peels.
+	var guestComps []spacecraft.DockedComponent
+	guestStageCnt := 0
+	keepComps := make([]spacecraft.DockedComponent, 0, len(c.DockedComponents))
+	for _, dc := range c.DockedComponents {
+		isGuest := dc.Owner == guestOwner && (guestCraftID == 0 || dc.CraftID == guestCraftID)
+		if isGuest {
+			guestComps = append(guestComps, dc)
+			guestStageCnt += len(dc.Stages)
+		} else {
+			keepComps = append(keepComps, dc)
+		}
+	}
+	if len(guestComps) == 0 {
+		return nil, false
+	}
+	// The guest's stages must tile the top of the composite exactly for the
+	// live-stage peel — every cross-player component carries its Stages
+	// breakdown (DockGuestCraft fuses live craft, never the legacy flat
+	// form), so this holds; refuse rather than mis-slice if it doesn't.
+	if guestStageCnt <= 0 || guestStageCnt >= len(c.Stages) {
+		return nil, false
+	}
+	keep := len(c.Stages) - guestStageCnt
+	payloadStages := append([]spacecraft.Stage(nil), c.Stages[keep:]...)
+
+	// Rebuild the guest craft from its first component's identity + the
+	// peeled live stages, at the composite's current state. restoreComponentCraft
+	// backfills a command source + syncs the flat mirrors from Stages[0].
+	restored := w.restoreComponentCraft(c, guestComps[0], payloadStages, c.State.R, c.State.V)
+	restored.ID = guestCraftID // return home with the same stable identity
+
+	// Shrink the composite: drop the guest's stages + components. Own backing
+	// arrays so the departing craft never aliases the composite's slices.
+	c.Stages = append([]spacecraft.Stage(nil), c.Stages[:keep]...)
+	c.DockedComponents = keepComps
+	if len(c.DockedComponents) < 2 {
+		c.DockedComponents = nil // only the docker's own core is left
+	}
+	c.SyncFields()
+	c.State.M = c.TotalMass()
+	return restored, true
+}
+
+// tagStackOwnership is the Transfer-control retag (v0.28 S5, ADR 0034 §6 +
+// addendum): handing an entire cross-player stack from fromOwner to toOwner
+// flips every component's provenance. Components owned by the World that held
+// the stack (Owner=="") become fromOwner's (they're now the GUEST's ride);
+// components owned by toOwner become the new holder's own (Owner clears). The
+// stack's physical fusion is unchanged — only the ownership tags move, so the
+// new owner's World adopts the composite and the old owner becomes the guest.
+// Idempotent for a same-owner call. Pure over c; the caller migrates the
+// composite between Worlds around it.
+func tagStackOwnership(c *spacecraft.Spacecraft, fromOwner, toOwner string) {
+	if c == nil || fromOwner == toOwner {
+		return
+	}
+	for i := range c.DockedComponents {
+		switch c.DockedComponents[i].Owner {
+		case "":
+			c.DockedComponents[i].Owner = fromOwner
+		case toOwner:
+			c.DockedComponents[i].Owner = ""
+		}
+	}
+}
+
+// RetagStackForTransfer is the exported form of tagStackOwnership for the
+// serve/relay layer that migrates a stack between player Worlds on a Transfer
+// Control (v0.28 S5). fromOwner is the fingerprint of the World the stack is
+// leaving; toOwner is the fingerprint of the World adopting it. After this the
+// composite's components describe the post-transfer roles: the departing owner
+// rides as a guest, the recipient owns its own core.
+func RetagStackForTransfer(c *spacecraft.Spacecraft, fromOwner, toOwner string) {
+	tagStackOwnership(c, fromOwner, toOwner)
+}
+
+// DockGuestLink is the transient docked-as-guest slate the serve layer
+// writes onto World.DockGuest each tick while one of this player's craft
+// rides in another player's stack (v0.28 S5). It names the stack owner (for
+// the coupling + the "docked with X" status) and carries the owner's current
+// Effective warp so the guest's clampedWarp can fold in the min-wins coupling.
+// GuestCraftID is the guest's own craft riding in the stack — the ID the
+// Undock-as-guest signal hands to the owner's UndockGuest. Never persisted.
+type DockGuestLink struct {
+	OwnerFP      string  // stack owner's fingerprint (the docker / current holder)
+	OwnerHandle  string  // stack owner's display handle (for chips + status)
+	OwnerEffWarp float64 // owner's reported Effective warp — the coupling min
+	GuestCraftID uint64  // the guest's craft riding in the stack
+}
+
+// WithDockCoupling folds a docked-as-guest coupling into the co-warp state
+// (v0.28 S5). While a player is Docked-as-Guest their whole subspace is
+// warp-coupled to the stack regardless of range — the guest's craft is IN
+// the stack, not near it, so the range-gated ComputeCoWarp can't express
+// this; instead the serve layer folds the stack owner's Effective warp in
+// here after ComputeCoWarp. Reuses the exact S1 clamp: clampedWarp already
+// reads CoWarp.Coupled / MinWarp, so no new clamp is needed. min-wins — the
+// resulting MinWarp is the lesser of any range-coupled peer and the owner's
+// warp, so the guest can always select lower (slam 1× and burn) but can't
+// out-warp the owner. A non-positive ownerEffWarp (paused owner) imposes no
+// coupling, matching ComputeCoWarp's paused-peer handling.
+func (s CoWarpState) WithDockCoupling(ownerHandle string, ownerEffWarp float64) CoWarpState {
+	if ownerEffWarp <= 0 {
+		return s
+	}
+	if !s.Coupled || s.MinWarp <= 0 || ownerEffWarp < s.MinWarp {
+		s.MinWarp = ownerEffWarp
+	}
+	s.Coupled = true
+	// Surface the owner in Partners for the HUD when not already present via
+	// a range couple (dedup keeps a guest who is ALSO range-near the owner
+	// from showing twice).
+	found := false
+	for _, p := range s.Partners {
+		if p == ownerHandle {
+			found = true
+			break
+		}
+	}
+	if !found && ownerHandle != "" {
+		s.Partners = append(append([]string(nil), s.Partners...), ownerHandle)
+	}
+	return s
+}
+
+// StackHasGuest reports whether the craft is a composite carrying any
+// cross-player (guest-owned) component — i.e. a cross-player stack rather than
+// a plain single-World composite. Used by the transfer-control and
+// undock-as-guest routing to tell a cross-player stack apart.
+func StackHasGuest(c *spacecraft.Spacecraft) bool {
+	if c == nil {
+		return false
+	}
+	for _, dc := range c.DockedComponents {
+		if dc.Owner != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -141,6 +141,69 @@ func (w *World) UndockGuest(compositeIdx int, guestOwner string, guestCraftID ui
 	return restored, true
 }
 
+// RemoveCraftByID lifts the craft with the given stable ID out of the slate
+// and returns it (v0.28 S5) — the guest side of a cross-player dock, where a
+// player's craft leaves their own World to ride in the docker's stack. The
+// active-craft index follows the removal so the player keeps flying a valid
+// craft (or, if they removed their only craft while docking as guest, the
+// index clamps and ActiveCraft() may be nil until they switch/undock). ok is
+// false when no craft matches. The returned craft is detached — the caller
+// hands it to the ledger; nothing in this World still references it.
+func (w *World) RemoveCraftByID(id uint64) (*spacecraft.Spacecraft, bool) {
+	_, idx, ok := w.craftByID(id)
+	if !ok {
+		return nil, false
+	}
+	c := w.Crafts[idx]
+	// Checkpoint the outgoing active target before the slate shifts.
+	if w.ActiveCraftIdx >= 0 && w.ActiveCraftIdx < len(w.Crafts) {
+		if a := w.Crafts[w.ActiveCraftIdx]; a != nil {
+			a.Target = w.Target
+		}
+	}
+	active := w.ActiveCraftIdx
+	w.Crafts = append(w.Crafts[:idx], w.Crafts[idx+1:]...)
+	switch {
+	case idx < active:
+		active--
+	case idx == active:
+		// The active craft left; land on a neighbouring slot if any.
+		if active >= len(w.Crafts) {
+			active = len(w.Crafts) - 1
+		}
+	}
+	if active < 0 {
+		w.ActiveCraftIdx = 0 // empty slate — index is inert until a craft returns
+		w.Target = spacecraft.Target{}
+	} else {
+		w.ActiveCraftIdx = -1 // force SetActiveCraftIdx to load the new active's target
+		w.SetActiveCraftIdx(active)
+	}
+	return c, true
+}
+
+// AdoptCraft appends a craft that already carries a stable ID into the slate
+// WITHOUT restamping it (v0.28 S5) — the receiving side of a cross-player
+// handoff: the docker adopting a handed-over guest craft, or the guest
+// receiving its component back on undock. Advances NextCraftID past the
+// adopted ID so a later local spawn can't collide. Optionally makes it active.
+// Returns the new slate index.
+func (w *World) AdoptCraft(c *spacecraft.Spacecraft, makeActive bool) int {
+	if c == nil {
+		return -1
+	}
+	w.Crafts = append(w.Crafts, c)
+	if c.ID != 0 && w.NextCraftID <= c.ID {
+		w.NextCraftID = c.ID + 1
+	}
+	w.stampCraftID(c) // no-op when it already has an ID
+	idx := len(w.Crafts) - 1
+	if makeActive {
+		w.SetActiveCraftIdx(idx)
+	}
+	return idx
+}
+
 // tagStackOwnership is the Transfer-control retag (v0.28 S5, ADR 0034 §6 +
 // addendum): handing an entire cross-player stack from fromOwner to toOwner
 // flips every component's provenance. Components owned by the World that held
@@ -221,6 +284,15 @@ func (s CoWarpState) WithDockCoupling(ownerHandle string, ownerEffWarp float64) 
 		s.Partners = append(append([]string(nil), s.Partners...), ownerHandle)
 	}
 	return s
+}
+
+// StackMidBurn reports whether the craft is actively thrusting — a planted
+// finite burn (ActiveBurn) or a player-held manual burn (ManualBurn) in
+// flight (v0.28 S5). Transfer Control is refused while a cross-player stack
+// is mid-burn (ADR 0034 addendum: "refused mid-burn") so the integrator and
+// mass-loss state don't hand off across the ownership seam.
+func StackMidBurn(c *spacecraft.Spacecraft) bool {
+	return c != nil && (c.ActiveBurn != nil || c.ManualBurn != nil)
 }
 
 // StackHasGuest reports whether the craft is a composite carrying any

--- a/internal/sim/docking_guest_test.go
+++ b/internal/sim/docking_guest_test.go
@@ -1,0 +1,240 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+const guestFP = "SHA256:guest-fingerprint"
+
+// TestDockGuestCraftFusesWithDockerOwnership: a cross-player dock fuses one
+// stack owned by the docker (its identity survives) and tags the guest's
+// contributed component with the guest's fingerprint + pre-dock ID.
+func TestDockGuestCraftFusesWithDockerOwnership(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+
+	docker := w.Crafts[0]
+	docker.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	vc := math.Sqrt(earth.GravitationalParameter() / docker.State.R.Norm())
+	docker.State.V = orbital.Vec3{Y: vc}
+	dockerName, dockerID := docker.Name, docker.ID
+	dockerMass := docker.TotalMass()
+
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	guest.Primary = *earth
+	guest.ID = 4242
+	guest.State = physics.StateVector{R: docker.State.R.Add(orbital.Vec3{X: 10}), V: docker.State.V, M: guest.TotalMass()}
+	guestMass := guest.TotalMass()
+
+	comp, idx, ok := w.DockGuestCraft(0, guest, guestFP)
+	if !ok {
+		t.Fatalf("DockGuestCraft failed")
+	}
+	if len(w.Crafts) != 1 {
+		t.Fatalf("slate count = %d, want 1 composite", len(w.Crafts))
+	}
+	if idx != 0 || comp != w.Crafts[0] {
+		t.Errorf("composite index/pointer mismatch: idx=%d", idx)
+	}
+	// Docker owns: composite keeps the docker's identity.
+	if comp.Name != dockerName || comp.ID != dockerID {
+		t.Errorf("composite identity = %q/%d, want docker %q/%d", comp.Name, comp.ID, dockerName, dockerID)
+	}
+	// Mass conserved.
+	if got, want := comp.TotalMass(), dockerMass+guestMass; math.Abs(got-want) > 1e-3 {
+		t.Errorf("composite mass = %v, want %v", got, want)
+	}
+	// Exactly one guest-owned component, tagged + carrying the guest's ID.
+	if !StackHasGuest(comp) {
+		t.Fatal("composite not recognised as a cross-player stack")
+	}
+	var guestComps int
+	for _, dc := range comp.DockedComponents {
+		if dc.Owner == guestFP {
+			guestComps++
+			if dc.CraftID != 4242 {
+				t.Errorf("guest component CraftID = %d, want 4242", dc.CraftID)
+			}
+		}
+	}
+	if guestComps != 1 {
+		t.Errorf("guest-owned components = %d, want 1", guestComps)
+	}
+	// The docker's own component is untagged.
+	for _, dc := range comp.DockedComponents {
+		if dc.CraftID == dockerID && dc.Owner != "" {
+			t.Errorf("docker component tagged with owner %q, want empty", dc.Owner)
+		}
+	}
+}
+
+// TestUndockGuestReturnsCraftAtMatchingState: undocking the guest's component
+// hands back a live craft with the guest's original ID at the composite's
+// current state, shrinks the composite to the docker's plain craft, and
+// conserves mass across the split.
+func TestUndockGuestReturnsCraftAtMatchingState(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+
+	docker := w.Crafts[0]
+	docker.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	vc := math.Sqrt(earth.GravitationalParameter() / docker.State.R.Norm())
+	docker.State.V = orbital.Vec3{Y: vc}
+	dockerID := docker.ID
+	dockerMass := docker.TotalMass()
+
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID)
+	guest.Primary = *earth
+	guest.ID = 99
+	guest.State = physics.StateVector{R: docker.State.R.Add(orbital.Vec3{X: 8}), V: docker.State.V, M: guest.TotalMass()}
+	guestMass := guest.TotalMass()
+
+	comp, _, ok := w.DockGuestCraft(0, guest, guestFP)
+	if !ok {
+		t.Fatalf("DockGuestCraft failed")
+	}
+	stackR, stackV := comp.State.R, comp.State.V
+
+	restored, ok := w.UndockGuest(0, guestFP, 99)
+	if !ok {
+		t.Fatalf("UndockGuest failed")
+	}
+	// Returned home with the same stable ID.
+	if restored.ID != 99 {
+		t.Errorf("restored ID = %d, want 99", restored.ID)
+	}
+	// Matching seam: placed exactly at the stack's current state.
+	if restored.State.R != stackR || restored.State.V != stackV {
+		t.Errorf("restored state %v/%v != stack %v/%v", restored.State.R, restored.State.V, stackR, stackV)
+	}
+	// Mass conserved: restored ≈ guest, remaining composite ≈ docker.
+	if math.Abs(restored.TotalMass()-guestMass) > 1e-3 {
+		t.Errorf("restored mass = %v, want guest %v", restored.TotalMass(), guestMass)
+	}
+	// The restored craft is NOT added to this (the docker's) World — it goes
+	// home. Slate still holds only the shrunken composite.
+	if len(w.Crafts) != 1 {
+		t.Fatalf("docker slate count = %d, want 1 (guest went home)", len(w.Crafts))
+	}
+	shrunk := w.Crafts[0]
+	if shrunk.ID != dockerID {
+		t.Errorf("remaining craft ID = %d, want docker %d", shrunk.ID, dockerID)
+	}
+	if math.Abs(shrunk.TotalMass()-dockerMass) > 1e-3 {
+		t.Errorf("remaining mass = %v, want docker %v", shrunk.TotalMass(), dockerMass)
+	}
+	if StackHasGuest(shrunk) || len(shrunk.DockedComponents) != 0 {
+		t.Errorf("docker reverted to composite: components=%d", len(shrunk.DockedComponents))
+	}
+}
+
+// TestUndockGuestUnknownOwnerNoOp: undocking an owner not present in the
+// stack is a no-op (nothing to hand back).
+func TestUndockGuestUnknownOwnerNoOp(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+	docker := w.Crafts[0]
+	docker.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	guest.Primary = *earth
+	guest.ID = 7
+	guest.State = physics.StateVector{R: docker.State.R.Add(orbital.Vec3{X: 5}), M: guest.TotalMass()}
+	if _, _, ok := w.DockGuestCraft(0, guest, guestFP); !ok {
+		t.Fatalf("dock failed")
+	}
+	if _, ok := w.UndockGuest(0, "SHA256:someone-else", 0); ok {
+		t.Error("UndockGuest returned ok for an owner not in the stack")
+	}
+}
+
+// TestWithDockCouplingMinWins: the docked-as-guest coupling fold sets the
+// state coupled and clamps to the owner's warp, respecting min-wins against
+// any existing range couple, and a paused owner imposes no coupling.
+func TestWithDockCouplingMinWins(t *testing.T) {
+	// From uncoupled: adopt the owner's warp.
+	got := CoWarpState{}.WithDockCoupling("gern", 8)
+	if !got.Coupled || got.MinWarp != 8 {
+		t.Errorf("uncoupled fold = %+v, want coupled@8", got)
+	}
+	// Owner slower than an existing range couple → owner wins (min).
+	got = CoWarpState{Coupled: true, MinWarp: 100, Partners: []string{"ada"}}.WithDockCoupling("gern", 8)
+	if got.MinWarp != 8 {
+		t.Errorf("min-wins fold MinWarp = %v, want 8", got.MinWarp)
+	}
+	// Owner faster than an existing couple → existing min stays.
+	got = CoWarpState{Coupled: true, MinWarp: 5, Partners: []string{"ada"}}.WithDockCoupling("gern", 50)
+	if got.MinWarp != 5 {
+		t.Errorf("faster-owner fold MinWarp = %v, want 5", got.MinWarp)
+	}
+	// Owner listed in Partners for the HUD.
+	found := false
+	for _, p := range got.Partners {
+		if p == "gern" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("owner handle absent from Partners: %v", got.Partners)
+	}
+	// Paused owner: no coupling forced.
+	got = CoWarpState{}.WithDockCoupling("gern", 0)
+	if got.Coupled {
+		t.Error("paused owner (0×) forced a coupling")
+	}
+}
+
+// TestDockCouplingClampsWorldWarp: with the fold written onto World.CoWarp,
+// clampedWarp caps a fast selection to the owner's slow warp — the guest
+// can't out-warp the stack (reuses S1's clamp end to end).
+func TestDockCouplingClampsWorldWarp(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	w.Clock.WarpIdx = 3 // selected 1000×
+	if got := w.EffectiveWarp(); got != 1000 {
+		t.Fatalf("baseline EffectiveWarp = %v, want 1000", got)
+	}
+	w.CoWarp = CoWarpState{}.WithDockCoupling("gern", 1)
+	if eff := w.EffectiveWarp(); eff != 1 {
+		t.Errorf("docked-as-guest EffectiveWarp = %v, want clamped to owner 1×", eff)
+	}
+}
+
+// TestRetagStackForTransfer: transfer flips ownership — the holder's own
+// components become the departing guest's, and the recipient's guest
+// components become the new holder's own. Idempotent for a same-owner call.
+func TestRetagStackForTransfer(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+	docker := w.Crafts[0]
+	docker.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	const fromFP, toFP = "SHA256:alice", "SHA256:bob"
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	guest.Primary = *earth
+	guest.ID = 55
+	guest.State = physics.StateVector{R: docker.State.R.Add(orbital.Vec3{X: 5}), M: guest.TotalMass()}
+	comp, _, _ := w.DockGuestCraft(0, guest, toFP)
+
+	RetagStackForTransfer(comp, fromFP, toFP)
+	// The docker's (holder's) component now belongs to the departing owner;
+	// the recipient's component is now unowned (the new holder's own).
+	for _, dc := range comp.DockedComponents {
+		switch dc.CraftID {
+		case docker.ID:
+			if dc.Owner != fromFP {
+				t.Errorf("holder component owner = %q, want %q", dc.Owner, fromFP)
+			}
+		case 55:
+			if dc.Owner != "" {
+				t.Errorf("recipient component owner = %q, want empty", dc.Owner)
+			}
+		}
+	}
+	// Still a cross-player stack (now owned the other way).
+	if !StackHasGuest(comp) {
+		t.Error("post-transfer stack lost its cross-player provenance")
+	}
+}

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -57,6 +57,9 @@ const (
 	SessionEventSyncedTo       // you arrived at theirs ("synced to X") — local only, never broadcast
 	SessionEventCoWarpCoupled  // co-warp coupled with a nearby player (v0.28 S1) — local only
 	SessionEventCoWarpReleased // co-warp released on separation (v0.28 S1) — local only
+	SessionEventDocked         // cross-player dock fused ("docked with X", v0.28 S5)
+	SessionEventUndocked       // cross-player stack split ("undocked from X", v0.28 S5)
+	SessionEventTransfer       // stack control handed over ("control → X", v0.28 S5)
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -216,6 +216,18 @@ type World struct {
 	Session       *SessionInfo
 	SessionEvents []SessionEvent
 
+	// DockGuest is set when one of this player's craft rides in another
+	// player's live stack (Docked-as-Guest, v0.28 S5, ADR 0034 §6). The
+	// serve layer writes it each tick from the dock ledger; the guest's
+	// whole subspace is then warp-coupled (min-wins) to the stack via
+	// CoWarpState.WithDockCoupling folded into CoWarp, so the guest can
+	// always slam 1× and burn but can't out-warp the owner. nil when not
+	// a guest. Transient, never persisted (the persisted cross-ref lives
+	// in the session directory). Also drives the tui: Undock while a
+	// DockGuest is set signals the owner to split, rather than a local
+	// Undock.
+	DockGuest *DockGuestLink
+
 	// LastSyncArrival is set when a Sync warp reaches its target time
 	// (v0.27 S7) and cleared by the serve wrapper after firing the
 	// arrival chips. Transient, like LastDockEvent.

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1035,6 +1035,16 @@ func (w *World) clampedWarp() float64 {
 		// skipped here: with none of the clamps (period guard, approach
 		// ramps) able to run, forcing the top factor would have nothing
 		// to ramp it back down before a burn.
+		//
+		// Exception (v0.28 S5): a Docked-as-Guest player who handed their
+		// only craft over into another player's stack has an empty slate
+		// but is still warp-coupled to that stack (min-wins, folded onto
+		// CoWarp). Honour that clamp here so the guest can't out-warp the
+		// owner while flying nothing — undock-anytime depends on the seam
+		// times staying locked.
+		if w.CoWarp.Coupled && w.CoWarp.MinWarp > 0 && selected > w.CoWarp.MinWarp {
+			selected = w.CoWarp.MinWarp
+		}
 		return selected
 	}
 	// v0.16 / ADR 0016: while Auto-Warp is engaged (and not paused) the

--- a/internal/spacecraft/spacecraft.go
+++ b/internal/spacecraft/spacecraft.go
@@ -380,6 +380,20 @@ type DockedComponent struct {
 	// firing Stages[0] is drained while docked, so the snapshot fuel
 	// goes stale — see sim.Undock).
 	Stages []Stage
+
+	// Owner + CraftID (v0.28 S5 / ADR 0034 cross-player docking):
+	// ownership provenance for a component in a cross-player stack. Owner
+	// is the guest player's fingerprint when this component rides in
+	// another player's stack; empty means it belongs to the World that
+	// holds the composite (the current stack owner). CraftID is the
+	// component's pre-dock stable Spacecraft.ID — for a guest component
+	// it is the ID UndockGuest hands back so the craft returns to its
+	// owner's World unchanged. Both zero-value/empty for a same-player
+	// dock (the classic single-World composite), so old saves and local
+	// docking are untouched; additive omitempty on the wire, no save
+	// schema bump (matching the CanSoftLand / Stages precedent above).
+	Owner   string
+	CraftID uint64
 }
 
 // AsDockedComponent captures s's identity + capacity fields into a
@@ -404,6 +418,12 @@ func (s *Spacecraft) AsDockedComponent() DockedComponent {
 		// v0.12 / ADR 0009: record the full stage breakdown so a
 		// multi-stage component (the LM) round-trips through Undock.
 		Stages: append([]Stage(nil), s.Stages...),
+		// v0.28 S5: carry the pre-dock stable identity. Local docking
+		// still stamps fresh IDs on undock (Undock ignores this), but a
+		// cross-player dock reads it back so the guest craft returns home
+		// with the same ID. Owner is left empty here — DockGuestCraft
+		// stamps it on the guest's contributed components.
+		CraftID: s.ID,
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -41,6 +41,18 @@ const (
 	screenSession  // v0.27 S6 / ADR 0034: multiplayer roster + invites, on `O`.
 )
 
+// UndockGuestMsg and TransferControlMsg are cross-player-docking intents the
+// App emits up to the serve reporting wrapper, which owns the dock ledger
+// (v0.28 S5). Same pattern as SessionHostMsg / SessionAdminMsg: the App can't
+// reach the ledger (sim sits below serve), so the flight key produces a
+// command the wrapper intercepts in its Update. Both are inert in solo play —
+// the App only emits them for a cross-player stack, which never exists without
+// a server.
+type UndockGuestMsg struct{}
+
+// TransferControlMsg requests handing the active cross-player stack to the guest.
+type TransferControlMsg struct{}
+
 // App is the root tea.Model. It owns the world, theme, keymap, and which
 // screen is active. Screens read from the shared world; they don't
 // mutate it.
@@ -1142,11 +1154,30 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.world.SwitchToCraftIdx(int(m.String()[0]-'0') - 1)
 			return a, nil
 		case key.Matches(m, a.keys.Undock):
+			// v0.28 S5: while docked-as-guest (one of my craft rides in
+			// another player's stack), U signals that stack's owner to split
+			// MY component and hand it back — undock-anytime, never gated
+			// behind the host. Emitted up to the serve reporting wrapper
+			// (which owns the dock ledger); a no-op in solo play.
+			if a.world.DockGuest != nil {
+				return a, func() tea.Msg { return UndockGuestMsg{} }
+			}
 			if a.world.Undock(a.world.ActiveCraftIdx) {
 				a.statusMsg = fmt.Sprintf("undocked into %d components", len(a.world.Crafts))
 				a.statusExpires = time.Now().Add(3 * time.Second)
 				a.world.RecordAction(missions.ActionUndock) // ADR 0025 §7
 			}
+			return a, nil
+		case key.Matches(m, a.keys.TransferControl):
+			// v0.28 S5, ADR 0034 §6: hand a cross-player stack I own to the
+			// guest — instant, roles swap, refused mid-burn (the ledger
+			// enforces the refusal). Only meaningful while flying a stack that
+			// carries a guest and I'm not myself the guest.
+			if active := a.world.ActiveCraft(); active != nil && sim.StackHasGuest(active) && a.world.DockGuest == nil {
+				return a, func() tea.Msg { return TransferControlMsg{} }
+			}
+			a.statusMsg = "transfer: not flying a cross-player stack"
+			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.Deploy):
 			// v0.23 / ADR 0028: release the top carried payload, keep flying the

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -151,6 +151,14 @@ type Keymap struct {
 	// Undock switches to the released vessel and Deploy keeps the carrier.
 	Deploy key.Binding
 
+	// TransferControl (v0.28 S5, ADR 0034 §6): hand a cross-player docked
+	// stack from its owner to the guest, instantly (roles swap; refused
+	// mid-burn). Bound to `J` — free in the keymap and in the uppercase
+	// composite-verb family (U undock / D transpose / Y deploy). Only
+	// meaningful while flying a cross-player stack; a no-op otherwise. The
+	// F1 overlay + README mirror is the S6 docs pass, not bound here.
+	TransferControl key.Binding
+
 	// CycleTarget / ClearTarget (v0.9.0+): unified `World.Target` slot
 	// that planted-Hohmann (`H`) and plane-match (`I`) consume in
 	// place of the pre-v0.9 implicit body cursor. Cycle order:
@@ -315,6 +323,7 @@ func DefaultKeymap() Keymap {
 		Undock:              key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "undock active composite")),
 		Transpose:           key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "transpose (SM → firing core, LM → nose payload)")),
 		Deploy:              key.NewBinding(key.WithKeys("Y"), key.WithHelp("Y", "deploy top payload (keep carrier)")),
+		TransferControl:     key.NewBinding(key.WithKeys("J"), key.WithHelp("J", "transfer control of a cross-player stack")),
 		CycleTarget:         key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "cycle target (body / craft)")),
 		ClearTarget:         key.NewBinding(key.WithKeys("T"), key.WithHelp("T", "clear target")),
 		CycleNavMode:        key.NewBinding(key.WithKeys(";"), key.WithHelp(";", "nav: orbit / surface / target")),

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -302,7 +302,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 			tags = append(tags, "you")
 		}
 		if p.DockedGuest {
-			tags = append(tags, "docked") // inert until v0.28
+			tags = append(tags, "docked") // v0.28 S5: live — riding another player's stack
 		}
 		if len(tags) > 0 {
 			name += s.theme.Dim.Render(" (" + strings.Join(tags, ", ") + ")")


### PR DESCRIPTION
## v0.28 "contact" — Slice S5: Cross-player docking (heavy)

The full contact loop: two co-warp-coupled players dock into one cross-player stack, the guest rides it (free to switch vessels, always able to undock their own component), control can be handed over, and it all survives disconnect/reconnect and a restart. **Tailnet playtest owed** (see below).

### Architecture — one store, no cross-World reach
Each player's session is a separate `*sim.World` in the host process; sessions communicate **only** through the shared `relay` store (same two-World/one-store shape as S1 co-warp). Cross-player docking is mediated by a new serializable **`relay.DockLedger`** each session reconciles against its World once per tick. Nothing crosses a World boundary except a ledger payload — store discipline preserved for the v2 wire.

### What landed
- **sim primitives** (`docking_guest.go`): `DockGuestCraft` (fuse; docker owns, guest rides as an owner-tagged `DockedComponent`), `UndockGuest` (peel the guest's sub-stack back out live at the composite's current state with its original stable ID), `RemoveCraftByID`/`AdoptCraft` (move craft across Worlds preserving IDs), `RetagStackForTransfer`, `StackMidBurn`, `StackHasGuest`. `DockedComponent` gains `Owner`+`CraftID` (**additive omitempty, sim + save mirror — no save-schema bump**). `w.Undock` refuses a cross-player stack (can't split locally).
- **Guest coupling reuses S1**: `CoWarpState.WithDockCoupling` folds an unconditional min-wins coupling onto `World.CoWarp` that `clampedWarp` already reads — no new clamp. Also fixed `clampedWarp`'s empty-slate early return to still honor the co-warp min, so a guest who handed over their only craft can't out-warp the stack.
- **relay ledger + reconcile** (`dock.go`): `Claim`/`RequestUndock`/`RequestTransfer`/`Reconcile`/`Seed`/`Records` + `DetectGuestContact` (cross-player `checkDocking`, gated on co-warp coupling + docking distance/velocity against a ghost).
- **sessiondir migration**: `MetaVersion 1→2` typed ladder (`migrateMeta`/`migrateMetaV1ToV2`) mirroring `save.Load` discipline; `Meta.Docks` carries the durable cross-ref. v0.27 sessions round-trip forward with `docks` empty.
- **serve** (`dock.go`, `reporting.go`, `serve.go`): per-tick `reconcileDocking` (detect→claim→reconcile→fold→persist), `DockedGuest` roster flag + session-screen "docked" tag go **live** (inert in v0.27), ledger seeded from disk on start.
- **tui**: `J` = Transfer Control (roles swap, chip both sides, **refused mid-burn**); `U` while docked-as-guest routes to the owner's ledger (undock-anytime); `UndockGuestMsg`/`TransferControlMsg` bubble to the reporting wrapper.

### Persistence shape
`Meta` v1→v2 adds `docks []DockLink`, where a `DockLink` is the persisted subset of a `DockRecord` (`id, owner, docker_craft_id, composite_id, guest_owner, guest_craft_id, phase` — **no craft payloads**). The docker's fused stack lives in the docker's save payload via `DockedComponent.Owner/CraftID`; the guest's cross-ref is the ledger entry (its craft is absent from its own payload because it rode along).

### Transfer key
Bound **`J`** — free in `input.go`, in the uppercase composite-verb family (U/D/Y). Noted in the binding comment; F1 overlay + README update is S6's docs pass.

### Tests
`go vet ./...` clean; `go test ./... -race -count=1` = **1585 passed**. Two-World sim/relay/serve headless tests: dock fuses with correct ownership; guest min-wins coupling (couples while docked, decouples on undock); guest vessel-switch retains coupling; undock-anytime returns the right component live at matching times; transfer swaps roles + refuses mid-burn; disconnect/reconnect resumes at stack time; sessiondir v1→v2 migration round-trip. Exactly the two ssh integration tests kept.

### Watch-points / owed playtest
1. **Tailnet playtest is owed** — the real two-terminal approach→dock→ride→transfer→undock loop needs live play; cannot run headless. Not faked or stubbed.
2. **Docker selection under simultaneous mutual approach:** the engaged-craft guard keeps it to one record, but *which* side becomes docker is decided by tick order, not strictly "active approacher." Fine for the passive-station MVP posture; flagged.
3. **Passive-target drift** (design's own flagged risk): a target actively translating during final approach drifts from its ghost until burn-end report — MVP posture is active-vehicle-docks-to-passive-station. Preserved, not solved.
4. **Multi-component guest craft:** a guest docking an already-composite craft is rebuilt on undock as one multi-stage craft from its first component's identity (sub-composite seams not preserved). Passive-station posture docks a single craft; noted.

Part of the v0.28 cycle. The single batched `/code-review` across S1–S6 runs at S6 before tagging v0.28.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)