### PR TITLE
feat(sim,tui,docs): v0.28 S6 — spectate [v] + docs pass (ADR 0034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,25 @@ terminal-space-program serve invite dave       # mint a one-time invite code
 ssh -p 23234 your-host                         # guests join from any terminal
 ```
 
+You can also start hosting from inside a running game — no restart, no
+`--serve`: open the `O` session roster and press `h` (press it again to stop,
+which drops guests but keeps everyone's progress).
+
 Guests enroll once with the invite code (their ssh key becomes their identity)
 and get their own persistent space program on your machine. Everyone warps
-time **independently**: other players appear as dim "ghost" craft evaluated
-at *your* clock, and the `O` session roster shows who's ahead or behind —
-`s` sync-warps you forward to a player's time to fly formation. Warp clamps,
-planted burns, and SOI transitions are all honored en route.
+time **independently**: other players appear as dim "ghost" craft — with their
+orbits drawn on your map — evaluated at *your* clock, and the `O` session
+roster shows who's ahead or behind. From that roster, `s` sync-warps you
+forward to a player's time to fly formation, and `v` **spectates** a player —
+fitting the camera to their ghost orbit and following it so you can watch their
+burns play out. Warp clamps, planted burns, and SOI transitions are all honored
+en route.
+
+Once you're together, proximity does the rest: come within 10 km of a player
+you're synced with and your time-warp **couples** to theirs, so neither can
+skip ahead during the approach. Dock your craft to theirs and you fly one
+shared stack — the guest can `U` undock their own component at any time, and
+the pilot can hand the whole stack over with `J` **transfer control**.
 
 ## Custom vehicles
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -97,7 +97,7 @@ readout shows you why before you watch it fall back.
 | `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
 | `i` | Body info screen |
 | `M` | Mission ladder — your program / objective progress, with the active mission's checklist and locked rungs shown with what unlocks them (same screen as the `[Missions]` button). Missions are **off by default** — enable the Tutorial and/or Challenge ladder in `[Menu]` → Settings |
-| `O` | Session roster (multiplayer) — one row per player with online state, last-known system, craft count, and their time offset vs you. `t` targets a player's ghost craft for rendezvous planning; `s` **sync-warps** you forward to a player's time (forward only — a player behind you syncs to you). Hosts also mint (`i`), revoke (`r`) invite codes and remove players (`x`) here, and toggle the SSH listener with `h` (start hosting from single-player; stop it, dropping guests, while hosting). Single-player offers `h` to start hosting in-place — no restart, no `--serve` |
+| `O` | Session roster (multiplayer) — one row per player with online state, last-known system, craft count, and their time offset vs you. `t` targets a player's ghost craft for rendezvous planning; `v` **spectates** — fits the camera to that player's ghost orbit and then follows it, so you can watch their burns re-shape the ellipse (press `f` to return to your own craft); `s` **sync-warps** you forward to a player's time (forward only — a player behind you syncs to you). Hosts also mint (`i`), revoke (`r`) invite codes and remove players (`x`) here, and toggle the SSH listener with `h` (start hosting from single-player; stop it, dropping guests, while hosting). Single-player offers `h` to start hosting in-place — no restart, no `--serve`. Other players' craft are drawn as dim **ghost** orbits on your map (evaluated at *your* clock), and coming within 10 km of a player you're synced with **couples** your time-warp to theirs so neither of you can skip past the other during an approach |
 | `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
 | `0` | Pause / resume |
 | `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn) |
@@ -120,7 +120,7 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `→` / `l` | Move the map cursor to the next body. This cursor feeds the body info screen (`i`) and the porkchop plot (`P`) — it does **not** set your travel target. For that, use `t` / `T` |
 | `←` / `h` | Move the map cursor to the previous body |
 | `+` / `-` | Zoom in / out |
-| `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your craft) |
+| `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your craft). Also the way back from **spectating** a player's ghost (`v` on the `O` roster) — it returns the camera to your own craft |
 | `g` | Reset the camera to the whole system |
 | `v` | Cycle the view (tilted → top → right → bottom → left → flat → launch). Tilted is the default — a 3D-style perspective that shows orbits leaning in space. Views are projections only: the camera re-frames once when you change focus, view, or system, and otherwise stays exactly where you put it — to read an upcoming encounter, focus the body it passes (`f`) and the camera fits to its sphere of influence so the capture curve fills the canvas |
 | `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
@@ -143,6 +143,7 @@ Dvorak, and free per-key remapping aren't supported yet.)
 | `U` | Undock a docked craft back into its parts |
 | `Y` | Deploy the top carried payload as its own craft — releases a satellite/probe/station while you keep flying the carrier (press again to drop the next one). Undock (`U`) instead splits everything and switches you to a released piece |
 | `D` | Apollo transposition — flip the Service Module to the front to do the flying, leaving the Lunar Module as a nose payload (then `U` to release it) |
+| `J` | **Transfer control** of a cross-player docked stack to the guest riding in it — the whole stack, and the flying of it, changes hands instantly (a chip confirms on both sides; refused mid-burn). Multiplayer only; the guest can always `U` **undock** their own component regardless |
 | `V` | Jump to the launch chase-cam, following your active craft |
 | `E` | End the flight — remove a crashed craft after a `y` / `n` confirm |
 

--- a/internal/sim/focus.go
+++ b/internal/sim/focus.go
@@ -1,6 +1,8 @@
 package sim
 
 import (
+	"math"
+
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
@@ -17,6 +19,14 @@ const (
 	// FocusCraft centers on the spacecraft's inertial position. Only
 	// reachable when CraftVisibleHere is true.
 	FocusCraft
+	// FocusGhost centers on a remote player's ghost — the Spectate mode
+	// (v0.28 S6, ADR 0034). Entered only from the Session screen's [v]
+	// row action, never in the CycleFocus rotation. The camera tracks
+	// the ghost's world position each frame; the single Framing-Event
+	// fit frames its drawn orbit extent. Reports moving the ghost never
+	// re-fit (ADR 0021). The ghost is addressed by (owner, craft ID) so
+	// a stale slate degrades gracefully rather than dangling a pointer.
+	FocusGhost
 )
 
 // Focus describes the current OrbitView center. The zero value (FocusSystem,
@@ -24,12 +34,27 @@ const (
 type Focus struct {
 	Kind    FocusKind
 	BodyIdx int
+	// GhostOwner + GhostCraftID address the spectated ghost when
+	// Kind == FocusGhost (v0.28 S6). Kept as a value ref, not a pointer,
+	// so Focus stays comparable — CycleFocus and the orbit screen's
+	// framing-event guard both rely on struct equality.
+	GhostOwner   string
+	GhostCraftID uint64
 }
 
 // CycleFocus advances the focus to the next target (or previous if
 // forward=false). Order: System → Body(0) → Body(1) → … → Body(n-1) →
 // Craft (only if CraftVisibleHere) → System.
 func (w *World) CycleFocus(forward bool) {
+	// Spectate exit (v0.28 S6): a ghost focus is outside the cycle, so any
+	// focus key returns you home rather than advancing off a non-member.
+	// This is the "return-to-own-craft focus key" the Spectate spec names —
+	// one more Framing Event restoring own-craft framing (or the system
+	// view when no craft is visible here).
+	if w.Focus.Kind == FocusGhost {
+		w.Focus = w.ownCraftFocus()
+		return
+	}
 	targets := w.focusTargets()
 	if len(targets) == 0 {
 		return
@@ -49,8 +74,30 @@ func (w *World) CycleFocus(forward bool) {
 	w.Focus = targets[idx]
 }
 
-// ResetFocus snaps back to the system-wide view.
+// ResetFocus snaps back to the system-wide view. Also the coarse exit
+// from Spectate (v0.28 S6) — [g] leaves a ghost focus like any other.
 func (w *World) ResetFocus() { w.Focus = Focus{Kind: FocusSystem} }
+
+// ownCraftFocus is the framing to return to when leaving a transient
+// focus (Spectate): the active craft when it's visible here, else the
+// system view. v0.28 S6.
+func (w *World) ownCraftFocus() Focus {
+	if w.CraftVisibleHere() {
+		return Focus{Kind: FocusCraft}
+	}
+	return Focus{Kind: FocusSystem}
+}
+
+// SpectateGhost enters Spectate mode on a remote player's ghost (v0.28
+// S6, ADR 0034): the camera fits once to the ghost's drawn orbit extent
+// (a Framing Event) then tracks the ghost as focus, pan/zoom free and no
+// re-fit on report corrections. Read-only — it adds no write surface, so
+// it's reachable by host and guest alike. The Session screen is the
+// selection surface; the ref is validated lazily at render (a vanished
+// ghost degrades to the system view via FocusPosition/FocusZoomRadius).
+func (w *World) SpectateGhost(owner string, craftID uint64) {
+	w.Focus = Focus{Kind: FocusGhost, GhostOwner: owner, GhostCraftID: craftID}
+}
 
 // focusTargets enumerates the valid focus cycle for the current system.
 // Rebuilt each cycle rather than cached because CraftVisibleHere is
@@ -78,6 +125,14 @@ func (w *World) FocusPosition() orbital.Vec3 {
 	case FocusCraft:
 		if w.CraftVisibleHere() {
 			return w.CraftInertial()
+		}
+	case FocusGhost:
+		// Track the spectated ghost's world position each frame (v0.28 S6).
+		// A vanished ghost (owner disconnected, craft gone, left system)
+		// degrades to the system origin rather than dangling — Spectate
+		// stays live but the view falls back gracefully.
+		if g, ok := w.ghostByRef(w.Focus.GhostOwner, w.Focus.GhostCraftID); ok {
+			return g.Pos
 		}
 	}
 	return orbital.Vec3{}
@@ -148,6 +203,22 @@ func (w *World) FocusZoomRadius() float64 {
 			}
 			return alt * 3
 		}
+	case FocusGhost:
+		// Frame the ghost's whole drawn ellipse (v0.28 S6, ADR 0034). The
+		// same S2 ghost-orbit pipeline: ElementsFromState off the ghost's
+		// retained primary-relative state and its primary's μ. Centered on
+		// the ghost — a point on its own orbit — the far side of the ellipse
+		// is at most one major axis (2a) away, so 2a frames the whole track
+		// from any phase. Evaluated once, at the Framing Event; report
+		// corrections that move the ghost never re-run this (ADR 0021).
+		if g, ok := w.ghostByRef(w.Focus.GhostOwner, w.Focus.GhostCraftID); ok {
+			if primary, ok := w.bodyInSystemByID(g.PrimaryID); ok {
+				el := orbital.ElementsFromState(g.RelPos, g.Vel, primary.GravitationalParameter())
+				if el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) {
+					return 2 * el.A
+				}
+			}
+		}
 	}
 	return w.systemOutermostRadius()
 }
@@ -207,6 +278,17 @@ func (w *World) FocusName() string {
 		if w.ActiveCraft() != nil {
 			return w.ActiveCraft().Name
 		}
+	case FocusGhost:
+		// Spectate label (v0.28 S6): "spectating <handle>" so the title-bar
+		// focus readout says whose ghost the camera is following.
+		if g, ok := w.ghostByRef(w.Focus.GhostOwner, w.Focus.GhostCraftID); ok {
+			who := g.Handle
+			if who == "" {
+				who = g.Name
+			}
+			return "spectating " + who
+		}
+		return "spectating"
 	}
 	return "System-wide"
 }

--- a/internal/sim/focus_test.go
+++ b/internal/sim/focus_test.go
@@ -1,7 +1,10 @@
 package sim
 
 import (
+	"math"
 	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
 
 // TestFocusDefaultsToCraft: v0.6.1 spawns the camera focused on the
@@ -141,6 +144,59 @@ func TestFocusPositionForCraftMatchesCraftInertial(t *testing.T) {
 	want := w.CraftInertial()
 	if got.Sub(want).Norm() > 1e-6 {
 		t.Errorf("FocusCraft position: got %+v, want %+v", got, want)
+	}
+}
+
+// TestSpectateGhostFocusResolvers: v0.28 S6 — FocusGhost tracks the ghost's
+// world position and fits to its drawn orbit extent (2a), and both resolvers
+// degrade gracefully to the system frame when the ghost ref is stale.
+func TestSpectateGhostFocusResolvers(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 800e3
+	rel := orbital.Vec3{X: r}
+	vel := orbital.Vec3{Y: math.Sqrt(mu / r)}
+	g := Ghost{
+		Owner: "SHA256:guest", CraftID: 7, Handle: "gern", Name: "gern's ship",
+		PrimaryID: c.Primary.ID,
+		Pos:       w.BodyPosition(c.Primary).Add(rel), RelPos: rel, Vel: vel,
+	}
+	w.Ghosts = []Ghost{g}
+
+	w.SpectateGhost(g.Owner, g.CraftID)
+	if w.Focus.Kind != FocusGhost || w.Focus.GhostOwner != g.Owner || w.Focus.GhostCraftID != g.CraftID {
+		t.Fatalf("SpectateGhost focus = %+v", w.Focus)
+	}
+	if got := w.FocusPosition(); got.Sub(g.Pos).Norm() > 1e-6 {
+		t.Errorf("FocusGhost position: got %+v, want ghost Pos %+v", got, g.Pos)
+	}
+	el := orbital.ElementsFromState(rel, vel, mu)
+	if got, want := w.FocusZoomRadius(), 2*el.A; math.Abs(got-want) > want*1e-9 {
+		t.Errorf("FocusGhost zoom radius: got %g, want 2a=%g", got, want)
+	}
+	if w.FocusName() != "spectating gern" {
+		t.Errorf("FocusName = %q, want 'spectating gern'", w.FocusName())
+	}
+
+	// Stale ref (ghost gone): both resolvers fall back, no dangling ref.
+	w.Ghosts = nil
+	if got := w.FocusPosition(); got != (orbital.Vec3{}) {
+		t.Errorf("stale ghost FocusPosition = %+v, want origin", got)
+	}
+	if got := w.FocusZoomRadius(); got != w.systemOutermostRadius() {
+		t.Errorf("stale ghost FocusZoomRadius = %g, want systemOutermostRadius %g", got, w.systemOutermostRadius())
+	}
+
+	// CycleFocus off a ghost returns to own craft (the spectate exit).
+	w.SpectateGhost(g.Owner, g.CraftID)
+	w.CycleFocus(true)
+	if w.Focus.Kind != FocusCraft {
+		t.Errorf("CycleFocus off ghost = %+v, want FocusCraft", w.Focus)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1695,6 +1695,15 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		a.statusMsg = fmt.Sprintf("target: %s's craft", cmd.Handle)
 		a.statusExpires = time.Now().Add(3 * time.Second)
 		a.active = screenOrbit
+	case screens.SessionCmdSpectate:
+		// Spectate (v0.28 S6 / ADR 0034): camera-follow a remote player's
+		// ghost. Read-only — no guestSave gate, reachable by host and guest
+		// alike. Fits once to the ghost's drawn orbit extent (Framing Event)
+		// then tracks it; [f]/[g] return to own-craft framing.
+		a.world.SpectateGhost(cmd.Owner, cmd.CraftID)
+		a.statusMsg = fmt.Sprintf("spectating %s — [f] to return", cmd.Handle)
+		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.active = screenOrbit
 	case screens.SessionCmdSync:
 		// Sync-to (v0.27 S7 / ADR 0034): Auto-Warp to the player's
 		// subspace time. The screen already refused backward targets;

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -50,7 +50,7 @@ var helpSections = []helpSection{
 		{"esc", "back to the map"},
 	}},
 	{"CAMERA & VIEW", [][2]string{
-		{"f / F", "cycle camera focus forward / back (system → bodies → craft)"},
+		{"f / F", "cycle camera focus forward / back (system → bodies → craft; exits spectate)"},
 		{"g", "reset camera to the whole system"},
 		{"+ / -", "zoom in / out"},
 		{"v", "cycle view (tilted / top / right / bottom / left / flat / launch)"},
@@ -65,6 +65,14 @@ var helpSections = []helpSection{
 		{"i", "body info screen"},
 		{"M", "missions ladder (program / objective progress)"},
 		{"O", "session roster (multiplayer: players, Δt, invites, sync-to)"},
+	}},
+	{"MULTIPLAYER (session screen — open with O)", [][2]string{
+		{"t", "target the selected player's ghost craft (rendezvous / K nudge)"},
+		{"v", "spectate — fit + camera-follow their ghost's orbit ([f] to return)"},
+		{"s", "sync-warp forward to a player ahead of you (forward only)"},
+		{"h", "start / stop hosting — accept ssh guests (stop confirms, drops guests)"},
+		{"i / r / x", "host only: mint invite / revoke code / remove player"},
+		{"J", "transfer control of a cross-player docked stack to the guest (map)"},
 	}},
 	{"TIME & WARP", [][2]string{
 		{".", "warp up (1× … 100000×)"},

--- a/internal/tui/screens/orbit_spectate_test.go
+++ b/internal/tui/screens/orbit_spectate_test.go
@@ -1,0 +1,122 @@
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// fitScaleFor builds a throwaway view of the same canvas size and fits it
+// to a world's current Framing-Event radius, returning the resulting
+// px/m scale — the value the real screen must land on after a Framing
+// Event on that focus. Mirrors the orbit_camera_contract_test approach of
+// comparing against an explicit FitTo.
+func fitScaleFor(t *testing.T, w *sim.World, cols, rows int) float64 {
+	t.Helper()
+	exp := NewOrbitView(ghostTestTheme())
+	exp.Resize(cols, rows)
+	exp.canvas.FitTo(w.FocusZoomRadius())
+	return exp.canvas.Scale()
+}
+
+// Spectate fits the camera exactly once to the ghost's DRAWN orbit extent
+// (a Framing Event, ADR 0021), then tracks the ghost — a subsequent ghost
+// report that moves it never re-fits. v0.28 S6.
+func TestSpectateFitsGhostOrbitOnce(t *testing.T) {
+	v := NewOrbitView(ghostTestTheme())
+	v.Resize(200, 60)
+
+	w, ownR, _ := leoWorld(t)
+	g := circularGhost(w, ownR.Norm()*1.6)
+	w.Ghosts = []sim.Ghost{g}
+
+	// Enter Spectate: focus the ghost. The next Render is a Framing Event
+	// fitting the canvas to the ghost's orbit extent (2a).
+	w.SpectateGhost(g.Owner, g.CraftID)
+	if w.Focus.Kind != sim.FocusGhost {
+		t.Fatalf("SpectateGhost did not set FocusGhost: %+v", w.Focus)
+	}
+	v.Render(w, 0, 200, 60)
+	got := v.canvas.Scale()
+
+	// The fit must frame the GHOST's extent, not the own-craft focus.
+	wantGhost := fitScaleFor(t, w, 200, 60)
+	if math.Abs(got-wantGhost) > wantGhost*1e-9 {
+		t.Errorf("spectate scale %.6e != ghost-extent fit %.6e", got, wantGhost)
+	}
+	// Sanity: the ghost sits on a 1.6× larger orbit than the own craft, so
+	// its extent fit is a genuinely different (wider) frame than own-craft.
+	wOwn, _, _ := leoWorld(t)
+	wOwn.Focus = sim.Focus{Kind: sim.FocusCraft}
+	if craftFit := fitScaleFor(t, wOwn, 200, 60); math.Abs(got-craftFit) <= craftFit*1e-9 {
+		t.Errorf("spectate reused the own-craft fit (%.6e); expected a ghost-extent frame", craftFit)
+	}
+
+	// The camera centers on (tracks) the ghost.
+	if d := v.canvas.CenterWorld().Sub(g.Pos).Norm(); d > 1 {
+		t.Errorf("spectate center %.0f km off the ghost — focus tracking broke", d/1e3)
+	}
+
+	// A ghost REPORT lands: it moves along its orbit (new RelPos/Pos). This
+	// is ambient sim state, not a Framing Event — the scale must not re-fit.
+	moved := g
+	rel := orbital.Vec3{Y: ownR.Norm() * 1.6} // quarter turn round the circle
+	moved.RelPos = rel
+	moved.Pos = w.BodyPosition(w.ActiveCraft().Primary).Add(rel)
+	w.Ghosts = []sim.Ghost{moved}
+	v.Render(w, 0, 200, 60)
+
+	if s := v.canvas.Scale(); math.Abs(s-got) > got*1e-9 {
+		t.Errorf("ghost report re-fit the camera: %.6e -> %.6e (ADR 0021: report corrections never re-fit)", got, s)
+	}
+	// Center still tracks the ghost's new position.
+	if d := v.canvas.CenterWorld().Sub(moved.Pos).Norm(); d > 1 {
+		t.Errorf("center did not track the ghost's report: %.0f km off", d/1e3)
+	}
+}
+
+// Exiting Spectate via the return-to-own-craft focus key ([f] → CycleFocus)
+// restores own-craft framing with a fresh Framing Event. v0.28 S6.
+func TestSpectateFocusReturnRestoresOwnCraft(t *testing.T) {
+	v := NewOrbitView(ghostTestTheme())
+	v.Resize(200, 60)
+
+	w, ownR, _ := leoWorld(t)
+	g := circularGhost(w, ownR.Norm()*1.6)
+	w.Ghosts = []sim.Ghost{g}
+	w.SpectateGhost(g.Owner, g.CraftID)
+	v.Render(w, 0, 200, 60)
+	spectateScale := v.canvas.Scale()
+
+	// The "return-to-own-craft focus key" — CycleFocus off a ghost focus
+	// snaps home rather than advancing into the body cycle.
+	w.CycleFocus(true)
+	if w.Focus.Kind != sim.FocusCraft {
+		t.Fatalf("focus-return did not restore own craft: %+v", w.Focus)
+	}
+	v.Render(w, 0, 200, 60)
+
+	// A fresh Framing Event fits to the own craft — a different frame than
+	// the ghost's wider orbit.
+	wantCraft := fitScaleFor(t, w, 200, 60)
+	if got := v.canvas.Scale(); math.Abs(got-wantCraft) > wantCraft*1e-9 {
+		t.Errorf("own-craft framing not restored: scale %.6e != craft fit %.6e", got, wantCraft)
+	}
+	if math.Abs(v.canvas.Scale()-spectateScale) <= spectateScale*1e-9 {
+		t.Error("focus-return left the camera at the spectate frame — no re-fit happened")
+	}
+
+	// [F] (CycleFocus back) and [g] (ResetFocus) also leave a ghost focus.
+	w.SpectateGhost(g.Owner, g.CraftID)
+	w.CycleFocus(false)
+	if w.Focus.Kind == sim.FocusGhost {
+		t.Error("[F] did not exit Spectate")
+	}
+	w.SpectateGhost(g.Owner, g.CraftID)
+	w.ResetFocus()
+	if w.Focus.Kind != sim.FocusSystem {
+		t.Errorf("[g] did not reset a ghost focus to system: %+v", w.Focus)
+	}
+}

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -41,6 +41,7 @@ const (
 	SessionCmdNone SessionCommandKind = iota
 	SessionCmdClose
 	SessionCmdTargetGhost // aim at Owner/CraftID
+	SessionCmdSpectate    // Spectate: camera-follow Owner/CraftID's ghost (v0.28 S6)
 	SessionCmdSync        // Sync-to: Auto-Warp to Time (v0.27 S7)
 	SessionCmdMint        // mint invite for Handle
 	SessionCmdRevoke      // revoke invite Code
@@ -182,6 +183,21 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 			}
 		}
 		return SessionCommand{Kind: SessionCmdToast, Message: p.Handle + " has no craft in this system to target"}
+	case "v":
+		// Spectate (v0.28 S6, ADR 0034): camera-follow the player's ghost.
+		// Absent on your own row — you can't spectate yourself (no ghost of
+		// your own exists in the slate anyway). Read-only; reachable by
+		// host and guest alike.
+		p, ok := s.selectedPlayer(info)
+		if !ok || p.Fingerprint == info.Self {
+			return SessionCommand{}
+		}
+		for _, g := range w.Ghosts {
+			if g.Owner == p.Fingerprint {
+				return SessionCommand{Kind: SessionCmdSpectate, Owner: g.Owner, CraftID: g.CraftID, Handle: p.Handle}
+			}
+		}
+		return SessionCommand{Kind: SessionCmdToast, Message: p.Handle + " has no craft in this system to spectate"}
 	case "s":
 		// Sync-to (v0.27 S7): forward only — the laggard always comes
 		// forward (ADR 0034); someone behind you syncs to you instead.
@@ -352,7 +368,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	if s.confirmStopHost {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
-	keys := "  [t] target craft  [s] sync-to"
+	keys := "  [t] target craft  [v] spectate  [s] sync-to"
 	if info.IsHost {
 		keys += "  [i] invite  [r] revoke code  [x] remove player  [h] stop hosting  [tab] section"
 	}

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -276,3 +276,32 @@ func TestSessionScreenTarget(t *testing.T) {
 		t.Errorf("[t] with no ghost = %+v, want toast", cmd)
 	}
 }
+
+// Spectate flow (v0.28 S6): [v] on a player with a ghost emits the
+// spectate command; on your own row it is absent (no command); on a
+// player with no ghost in the slate it toasts. The footer advertises it.
+func TestSessionScreenSpectate(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Ghosts = []sim.Ghost{{Owner: "SHA256:guest", CraftID: 42, Handle: "gern"}}
+
+	if !strings.Contains(s.Render(w, 120), "[v] spectate") {
+		t.Error("footer missing the [v] spectate hint")
+	}
+
+	// Own row (cursor starts on self): [v] is absent — no spectate command.
+	if cmd := s.HandleKey(w, key("v")); cmd.Kind == SessionCmdSpectate {
+		t.Errorf("[v] on own row emitted spectate: %+v", cmd)
+	}
+
+	s.HandleKey(w, key("j")) // move to gern
+	cmd := s.HandleKey(w, key("v"))
+	if cmd.Kind != SessionCmdSpectate || cmd.Owner != "SHA256:guest" || cmd.CraftID != 42 {
+		t.Errorf("spectate command = %+v, want SessionCmdSpectate owner=SHA256:guest craft=42", cmd)
+	}
+
+	s.HandleKey(w, key("j")) // dave — no ghost in slate
+	if cmd := s.HandleKey(w, key("v")); cmd.Kind != SessionCmdToast {
+		t.Errorf("[v] with no ghost = %+v, want toast", cmd)
+	}
+}


### PR DESCRIPTION
## v0.28 "contact" — Slice S6: Spectate + docs pass (final code slice)

### Part A — Spectate `[v]`
Session-screen row action `[v]` on another player camera-follows their ghost:
- New `sim.Focus` kind `FocusGhost` (value ref — `Focus` stays comparable, which both `CycleFocus` and the orbit screen's framing-event guard depend on). `World.SpectateGhost(owner, craftID)` sets it.
- Setting `w.Focus` to a new value **is** the Framing Event — the orbit screen's existing `lastFocus != w.Focus` guard fires exactly one `FitTo(FocusZoomRadius())`. The new `FocusGhost` branch fits to the ghost's drawn ellipse via the S2 pipeline (`ElementsFromState(g.RelPos, g.Vel, μ)`, returns `2a` so the whole track frames from any phase). No bespoke camera path.
- Per-frame center-tracking is the normal Focus mechanism. A ghost report moves `RelPos`/`Pos` but not `Focus`, so **no re-fit** — the ellipse re-shapes under a steady camera (the "watch a burn" behavior, cheap form, no relay cadence change).
- Exit = `f`/`F` (`CycleFocus`) snaps home when focus is a ghost; `g` (`ResetFocus`) also leaves. Row action absent on your own row. Read-only, so no `guestSave` gate — reachable by host and guest. Stale refs degrade to the system frame.

### Part B — Docs pass (whole cycle's new input)
- **F1 overlay** (`help.go`): new `MULTIPLAYER (session screen — open with O)` section covering `t` target ghost, `v` spectate, `s` sync, `h` host, `i/r/x` host-admin, `J` transfer; `f/F` line amended ("…exits spectate").
- **README.md**: Multiplayer section expanded — in-game `[h]` hosting, ghost orbits on the map, `[v]` spectate, 10 km co-warp coupling, cross-player docking + `[J]` transfer.
- **docs/controls.md**: `O` row enriched (spectate + ghost-orbit/co-warp note, reconciling S3's `h` line), `f/F` map-view row amended, `J` transfer row added.

Passive behaviors (ghost-orbit rendering, co-warp coupling) documented in the README/controls prose mirrors rather than as non-key rows in the overlay.

### Tests (TDD)
`go vet ./...` clean; `go test ./... -race -count=1` = **1589 passed**. New: `orbit_spectate_test.go` (fits once, no re-fit on ghost report, focus-return restores own-craft framing), `session_test.go` `TestSessionScreenSpectate` (emits on a player with a ghost, absent on own row, toasts with no ghost), `focus_test.go` `TestSpectateGhostFocusResolvers` (resolvers + stale-ref degrade + CycleFocus exit). Exactly the two ssh integration tests kept.

### Watch-points for the tailnet playtest
- **Exit key:** no dedicated "focus my own craft" key exists (`g` resets to *system*). Implemented "return-to-own-craft" as `f`/`F` snapping home from a ghost focus; the status toast advertises "[f] to return". Confirm it reads intuitively.
- **Vanished spectated ghost:** if the player disconnects / loses the craft / leaves your system, focus degrades to the system origin rather than auto-exiting (scope-minimal, no auto-release). Revisit if the fall-to-origin feels jarring.
- **`2a` framing** guarantees the whole ellipse but can feel loose on very eccentric ghosts — tuning candidate, not correctness.

Final code slice of v0.28. The single batched `/code-review` across S1–S6 runs next (orchestrator), then the tailnet playtest gates the v0.28.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)