### PR TITLE
fix(sim,relay,serve): v0.28 batched-review follow-ups (5 findings)

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -213,6 +213,15 @@ func (l *DockLedger) Seed(records []DockRecord) {
 func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]CraftReport) []DockChip {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	// Fast path (v0.28 finding 4): the overwhelmingly common tick has no live
+	// docks, so skip the full owner scan — just clear any stale docked-as-guest
+	// slate and return. Still under the single global lock: the 2-party MVP
+	// runs at a scale where per-tick contention doesn't warrant fine-grained
+	// locking; this only removes the O(records) walk when there's nothing to do.
+	if len(l.records) == 0 {
+		w.DockGuest = nil
+		return nil
+	}
 	var chips []DockChip
 	w.DockGuest = nil // rebuilt below if still a guest in some active dock
 	for id, r := range l.records {

--- a/internal/relay/dock_test.go
+++ b/internal/relay/dock_test.go
@@ -240,6 +240,97 @@ func TestDisconnectReconnectResumesDockedAsGuest(t *testing.T) {
 	}
 }
 
+// TestTransferAdoptRestampsCollidingCompositeID: the migrating composite's
+// origin-World ID collides with a craft native to the recipient's World
+// (per-World ID spaces are independent). The recipient must restamp on adopt so
+// CompositeID resolves the composite — not the colliding native craft — and a
+// later undock-as-guest still hands the old owner its craft back (v0.28
+// finding 1: the permanent-desync regression).
+func TestTransferAdoptRestampsCollidingCompositeID(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 400
+	wA, wB := alignedPair(t, guestID)
+	dockerID := wA.ActiveCraft().ID
+	now := time.Now()
+
+	// Give B a NATIVE craft whose ID equals A's docker/composite ID. After the
+	// stack migrates to B, its origin ID (dockerID) would alias this craft.
+	collider := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	collider.Primary = wB.ActiveCraft().Primary
+	collider.State = wB.ActiveCraft().State
+	collider.ID = dockerID
+	wB.AdoptCraft(collider, false)
+	if collider.ID != dockerID {
+		t.Fatalf("collider not seeded with docker id: %d != %d", collider.ID, dockerID)
+	}
+
+	// Dock: A claims, B hands over, A fuses.
+	ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	if len(wA.Crafts) != 1 || !sim.StackHasGuest(wA.Crafts[0]) {
+		t.Fatalf("A did not fuse a cross-player stack")
+	}
+
+	// Transfer control to B (roles swap). A migrates out, B adopts.
+	if !ledger.RequestTransfer(fpA) {
+		t.Fatalf("RequestTransfer refused")
+	}
+	ledger.Reconcile(wA, fpA, reports) // A migrates the stack out
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B adopts the transferred stack
+
+	// B now owns the composite AND the colliding native craft — both must be
+	// independently addressable, and CompositeID must resolve the composite.
+	rec := ledger.Records()
+	if len(rec) != 1 {
+		t.Fatalf("ledger records = %d, want 1", len(rec))
+	}
+	compID := rec[0].CompositeID
+	comp, _, ok := wB.CraftByID(compID)
+	if !ok || !sim.StackHasGuest(comp) {
+		t.Fatalf("CompositeID %d does not resolve the migrated composite (collision with native id %d)", compID, dockerID)
+	}
+	if c, _, ok := wB.CraftByID(dockerID); !ok || c != collider {
+		t.Errorf("native collider id %d no longer resolves to the collider craft", dockerID)
+	}
+
+	// A (now the guest) undocks: B splits it out and hands A's craft back.
+	if !ledger.RequestUndock(fpA, dockerID) {
+		t.Fatalf("RequestUndock refused for the demoted old owner")
+	}
+	reports = reportMap(store, wA, wB, now.Add(2*time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B splits A's component out
+	ledger.Reconcile(wA, fpA, reports) // A receives its craft home
+	if _, _, ok := wA.CraftByID(dockerID); !ok {
+		t.Fatalf("A never got its craft %d back — permanent desync (finding 1)", dockerID)
+	}
+	if wA.DockGuest != nil {
+		t.Errorf("A still docked-as-guest after undock")
+	}
+	if len(ledger.Records()) != 0 {
+		t.Errorf("ledger still holds %d records after undock", len(ledger.Records()))
+	}
+}
+
+// TestReconcileEmptyLedgerFastPath: with no live docks, Reconcile takes the
+// O(1) fast path — it still clears any stale docked-as-guest slate and returns
+// no chips (v0.28 finding 4).
+func TestReconcileEmptyLedgerFastPath(t *testing.T) {
+	ledger := NewDockLedger()
+	w := newWorld(t)
+	w.DockGuest = &sim.DockGuestLink{OwnerFP: fpA, OwnerHandle: "alice"} // stale
+	chips := ledger.Reconcile(w, fpB, nil)
+	if chips != nil {
+		t.Errorf("empty-ledger Reconcile returned chips: %+v", chips)
+	}
+	if w.DockGuest != nil {
+		t.Errorf("empty-ledger Reconcile did not clear stale DockGuest: %+v", w.DockGuest)
+	}
+}
+
 func hasChip(chips []DockChip, kind sim.SessionEventKind) bool {
 	for _, c := range chips {
 		if c.Kind == kind {

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -50,11 +50,23 @@ func (m *reportingModel) reconcileDocking(w *sim.World, coupled map[string]bool,
 	}
 
 	// Persist the durable cross-ref on any transition so a reconnecting guest
-	// resumes. The ledger is the source of truth; SetDocks writes the full
-	// current snapshot, so concurrent writers from different sessions converge.
+	// resumes.
 	if changed {
-		_ = m.srv.store.SetDocks(recordsToDockLinks(m.srv.dock.Records()))
+		_ = m.srv.persistDocks()
 	}
+}
+
+// persistDocks writes the dock ledger's current durable cross-ref to disk under
+// the persist guard (v0.28 finding 3). The ledger is the source of truth; the
+// guard serialises persists across sessions and dock.Records() is re-snapshotted
+// INSIDE the lock, so the last writer always persists the truly-current full
+// ledger — a concurrent session's newly-added dock can't be lost to a stale
+// snapshot racing to disk (ledger mutations are already ledger-mutex serial, so
+// re-reading under the guard converges the persisted state).
+func (s *Server) persistDocks() error {
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+	return s.store.SetDocks(recordsToDockLinks(s.dock.Records()))
 }
 
 // dockLinksToRecords adapts the persisted cross-ref into live ledger records

--- a/internal/serve/dock_wiring_test.go
+++ b/internal/serve/dock_wiring_test.go
@@ -1,15 +1,67 @@
 package serve
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/relay"
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
 )
+
+// TestPersistDocksConvergesUnderConcurrency: the guarded, re-snapshotting
+// persist keeps the persisted cross-ref equal to the live ledger even when
+// sessions race to persist while docks are being added — no concurrently-added
+// dock is dropped by a stale snapshot (v0.28 finding 3). Runs under -race.
+func TestPersistDocksConvergesUnderConcurrency(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	// Re-snapshot semantics: a single persist writes the CURRENT full ledger.
+	srv.dock.Seed([]relay.DockRecord{{ID: 1, Owner: "a", GuestOwner: "b", GuestCraftID: 10, Phase: relay.DockActive}})
+	if err := srv.persistDocks(); err != nil {
+		t.Fatalf("persistDocks: %v", err)
+	}
+
+	// Race: goroutines add a dock then persist, exercising the guard while the
+	// ledger mutates underneath concurrent snapshots.
+	const n = 8
+	var wg sync.WaitGroup
+	for i := 2; i <= n; i++ {
+		wg.Add(1)
+		go func(id uint64) {
+			defer wg.Done()
+			srv.dock.Seed([]relay.DockRecord{{ID: id, Owner: "a", GuestOwner: "b", GuestCraftID: id, Phase: relay.DockActive}})
+			_ = srv.persistDocks()
+		}(uint64(i))
+	}
+	wg.Wait()
+
+	// A final persist converges the on-disk set to the live ledger.
+	if err := srv.persistDocks(); err != nil {
+		t.Fatalf("final persistDocks: %v", err)
+	}
+	live := srv.dock.Records()
+	meta, err := srv.store.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	if len(meta.Docks) != len(live) {
+		t.Fatalf("persisted %d docks, live ledger has %d — a concurrent add was dropped", len(meta.Docks), len(live))
+	}
+	persisted := map[uint64]bool{}
+	for _, d := range meta.Docks {
+		persisted[d.ID] = true
+	}
+	for _, r := range live {
+		if !persisted[r.ID] {
+			t.Errorf("live dock %d missing from persisted cross-ref", r.ID)
+		}
+	}
+}
 
 // hostStackHasGuest reports whether the host world's first craft is a
 // cross-player stack (composite carrying a guest component).

--- a/internal/serve/inui_hosting_test.go
+++ b/internal/serve/inui_hosting_test.go
@@ -25,6 +25,49 @@ func hostServer(t *testing.T, m tea.Model) *Server {
 	return rm.HostServer()
 }
 
+// TestStopHostingClearsCoWarpAndDockGuest: stopping hosting while co-warp
+// coupled (or docked-as-guest) must clear the coupling slates. The tick path
+// that recomputes them is gated on m.srv != nil, so a stale w.CoWarp.MinWarp
+// would throttle solo warp forever and a stale w.DockGuest would keep a bogus
+// docked-as-guest status (v0.28 finding 2).
+func TestStopHostingClearsCoWarpAndDockGuest(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	m := srv.HostModel(app)
+
+	// Simulate a live co-warp couple + docked-as-guest ride at stop time.
+	w := app.World()
+	w.CoWarp = sim.CoWarpState{Coupled: true, MinWarp: 1, Partners: []string{"gern"}}
+	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:gern", OwnerHandle: "gern"}
+	w.Clock.WarpIdx = 5 // player selects a fast warp
+	if got := w.EffectiveWarp(); got != 1 {
+		t.Fatalf("pre-stop EffectiveWarp = %v, want clamped to co-warp 1×", got)
+	}
+
+	rm, ok := m.(reportingModel)
+	if !ok {
+		t.Fatalf("model is %T, not reportingModel", m)
+	}
+	stopped, _ := rm.stopHosting()
+	if _, ok := stopped.(reportingModel); !ok {
+		t.Fatalf("stopped model is %T", stopped)
+	}
+
+	// Co-warp + dock-guest slates cleared; warp no longer clamped by them.
+	if w.CoWarp.Coupled || w.CoWarp.MinWarp != 0 || w.CoWarp.Partners != nil {
+		t.Errorf("w.CoWarp not reset after stopHosting: %+v", w.CoWarp)
+	}
+	if w.DockGuest != nil {
+		t.Errorf("w.DockGuest not cleared after stopHosting: %+v", w.DockGuest)
+	}
+	if got := w.EffectiveWarp(); got == 1 {
+		t.Errorf("warp still clamped to 1× after stopHosting — stale co-warp clamp persists")
+	}
+}
+
 // A solo wrapper (nil server) is a transparent pass-through: no store,
 // no reports, no session slate — the App plays as if unwrapped.
 func TestSoloWrapperInert(t *testing.T) {

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -354,6 +354,14 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// Session screen shows the [h]-start dead-end again.
 	w := m.app.World()
 	w.Session, w.Ghosts, w.SessionEvents = nil, nil, nil
+	// Clear the multiplayer coupling slates too (v0.28 finding 2): the tick
+	// path that recomputes co-warp / docked-as-guest is gated on m.srv != nil,
+	// so once hosting stops it never runs again. A stale w.CoWarp.MinWarp would
+	// throttle solo warp forever, and a stale w.DockGuest would keep a bogus
+	// docked-as-guest status. Also drop the per-owner hysteresis memory.
+	w.CoWarp = sim.CoWarpState{}
+	w.DockGuest = nil
+	m.coWarp = nil
 	m.meta, m.metaAt = sessiondir.Meta{}, time.Time{}
 	m.localEvents = nil
 	m.app.Toast("hosting stopped")

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -62,6 +62,13 @@ type Server struct {
 	// final persist) so shutdown can wait for payload writes instead
 	// of racing process exit (review follow-up).
 	sessions sync.WaitGroup
+
+	// persistMu serialises dock cross-ref persists across sessions (v0.28
+	// finding 3). Two sessions racing SetDocks could otherwise interleave
+	// stale snapshots and drop a concurrently-added dock; holding this while
+	// re-snapshotting dock.Records() makes the last writer persist the truly-
+	// current full ledger (ledger mutations are already ledger-mutex serial).
+	persistMu sync.Mutex
 }
 
 // DefaultHostKeyPath returns the per-host SSH identity path, sibling

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -182,21 +182,35 @@ func (w *World) RemoveCraftByID(id uint64) (*spacecraft.Spacecraft, bool) {
 	return c, true
 }
 
-// AdoptCraft appends a craft that already carries a stable ID into the slate
-// WITHOUT restamping it (v0.28 S5) — the receiving side of a cross-player
-// handoff: the docker adopting a handed-over guest craft, or the guest
-// receiving its component back on undock. Advances NextCraftID past the
-// adopted ID so a later local spawn can't collide. Optionally makes it active.
+// AdoptCraft appends a craft carrying a stable ID into the slate on the
+// receiving side of a cross-player handoff (v0.28 S5) — the docker adopting a
+// handed-over guest craft, the guest receiving its component back on undock, or
+// a Transfer-Control recipient adopting the whole migrating composite. Craft-ID
+// spaces are PER-WORLD and independent (both start low), so an incoming ID from
+// the origin World can collide with a native craft already in this slate; when
+// it does — or when the craft carries no ID at all — we stamp a FRESH id from
+// NextCraftID (restamped in place, so a caller reading c.ID after the call sees
+// the new id). A non-zero, unused incoming ID is PRESERVED (the guest-gets-its-
+// component-back case, which must keep guestCraftID; NextCraftID only moves
+// forward, so a preserved id never collides with a future local spawn).
+// Advances NextCraftID past a preserved ID and optionally makes it active.
 // Returns the new slate index.
 func (w *World) AdoptCraft(c *spacecraft.Spacecraft, makeActive bool) int {
 	if c == nil {
 		return -1
 	}
+	// Collision check must run BEFORE the append so craftByID scans only the
+	// existing slate, not c itself. A hit forces a fresh stamp below.
+	if c.ID != 0 {
+		if _, _, taken := w.craftByID(c.ID); taken {
+			c.ID = 0
+		}
+	}
 	w.Crafts = append(w.Crafts, c)
 	if c.ID != 0 && w.NextCraftID <= c.ID {
 		w.NextCraftID = c.ID + 1
 	}
-	w.stampCraftID(c) // no-op when it already has an ID
+	w.stampCraftID(c) // no-op when it kept its ID; fresh id when zeroed above
 	idx := len(w.Crafts) - 1
 	if makeActive {
 		w.SetActiveCraftIdx(idx)
@@ -281,7 +295,12 @@ func (s CoWarpState) WithDockCoupling(ownerHandle string, ownerEffWarp float64) 
 		}
 	}
 	if !found && ownerHandle != "" {
-		s.Partners = append(append([]string(nil), s.Partners...), ownerHandle)
+		// Append in place: this runs every tick while docked-as-guest, so the
+		// full-copy form was needless churn. Safe against caller aliasing —
+		// ComputeCoWarp builds a fresh Partners slice each tick and the caller
+		// folds straight back into the same field (w.CoWarp = w.CoWarp.With...),
+		// so no other reference retains the pre-fold slice (v0.28 finding 5).
+		s.Partners = append(s.Partners, ownerHandle)
 	}
 	return s
 }

--- a/internal/sim/docking_guest_test.go
+++ b/internal/sim/docking_guest_test.go
@@ -203,6 +203,84 @@ func TestDockCouplingClampsWorldWarp(t *testing.T) {
 	}
 }
 
+// TestAdoptCraftRestampsOnCollision: adopting a craft whose stable ID collides
+// with a craft already in this World's slate (per-World ID spaces are
+// independent) stamps a fresh unique id IN PLACE, leaving both craft
+// independently addressable via CraftByID (v0.28 finding 1).
+func TestAdoptCraftRestampsOnCollision(t *testing.T) {
+	w, _ := NewWorld()
+	native := w.Crafts[0]
+	nativeID := native.ID
+	if nativeID == 0 {
+		t.Fatal("native craft has no stable ID")
+	}
+
+	// An incoming craft from another World that happens to carry the same ID.
+	incoming := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	incoming.ID = nativeID
+
+	idx := w.AdoptCraft(incoming, false)
+	if idx < 0 {
+		t.Fatalf("AdoptCraft returned %d", idx)
+	}
+	// Restamped in place to a fresh, distinct, nonzero id.
+	if incoming.ID == nativeID || incoming.ID == 0 {
+		t.Fatalf("incoming id = %d (native %d): want a fresh nonzero id", incoming.ID, nativeID)
+	}
+	// Both resolve to the correct craft — no aliasing.
+	if c, _, ok := w.CraftByID(nativeID); !ok || c != native {
+		t.Errorf("native id %d no longer resolves to the native craft", nativeID)
+	}
+	if c, _, ok := w.CraftByID(incoming.ID); !ok || c != incoming {
+		t.Errorf("incoming id %d does not resolve to the incoming craft", incoming.ID)
+	}
+	// NextCraftID stays ahead of the freshly stamped id.
+	if incoming.ID >= w.NextCraftID {
+		t.Errorf("NextCraftID %d not ahead of adopted id %d", w.NextCraftID, incoming.ID)
+	}
+}
+
+// TestAdoptCraftPreservesUnusedID: a non-zero incoming ID not present in the
+// slate is preserved — the guest-gets-its-component-back path must keep
+// guestCraftID unchanged (v0.28 finding 1).
+func TestAdoptCraftPreservesUnusedID(t *testing.T) {
+	w, _ := NewWorld()
+	incoming := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	const unused = 999999
+	incoming.ID = unused
+	w.AdoptCraft(incoming, false)
+	if incoming.ID != unused {
+		t.Errorf("unused id restamped to %d, want preserved %d", incoming.ID, unused)
+	}
+	if w.NextCraftID <= unused {
+		t.Errorf("NextCraftID %d not advanced past adopted id %d", w.NextCraftID, unused)
+	}
+}
+
+// TestWithDockCouplingAppendsPartnerWithoutCorruption: the per-tick fold
+// appends the owner handle in place without disturbing an existing Partners
+// slice's contents (v0.28 finding 5 — in-place append must not corrupt the
+// caller's slice or drop dedup).
+func TestWithDockCouplingAppendsPartnerWithoutCorruption(t *testing.T) {
+	base := CoWarpState{Coupled: true, MinWarp: 100, Partners: []string{"ada"}}
+	got := base.WithDockCoupling("gern", 8)
+	// Owner appended, existing partner intact.
+	if len(got.Partners) != 2 || got.Partners[0] != "ada" || got.Partners[1] != "gern" {
+		t.Errorf("Partners = %v, want [ada gern]", got.Partners)
+	}
+	// Dedup: an owner already present via a range couple is not duplicated.
+	deduped := CoWarpState{Coupled: true, MinWarp: 5, Partners: []string{"gern"}}.WithDockCoupling("gern", 8)
+	n := 0
+	for _, p := range deduped.Partners {
+		if p == "gern" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("owner duplicated in Partners: %v", deduped.Partners)
+	}
+}
+
 // TestRetagStackForTransfer: transfer flips ownership — the holder's own
 // components become the departing guest's, and the recipient's guest
 // components become the new holder's own. Idempotent for a same-owner call.


### PR DESCRIPTION
## v0.28 "contact" — batched `/code-review` follow-ups

Fixes the 5 findings from the single batched review across S1–S6. TDD throughout; the two Finding-1 regression tests were confirmed to FAIL without the source fix.

### F1 (correctness) — cross-World composite ID collision on Transfer Control
`AdoptCraft` kept a migrating composite's origin-World craft ID; because each World has an independent ID space, that ID often collided with a native craft in the recipient's World, so `CraftByID(CompositeID)` resolved the wrong craft and a later undock-as-guest never returned the guest's craft (permanent desync). `AdoptCraft` now checks `craftByID(c.ID)` before append and restamps a fresh id on collision (or `c.ID==0`), preserving a non-zero unused id (the undock-return path keeps `guestCraftID`). Tests: `TestAdoptCraftRestampsOnCollision`, `TestAdoptCraftPreservesUnusedID`, `TestTransferAdoptRestampsCollidingCompositeID` (full transfer→undock round-trip with a colliding composite id).

### F2 (correctness) — stopHosting left stale co-warp / dock-guest state
A host who stopped hosting while co-warp-coupled kept a stale `w.CoWarp.MinWarp` clamp forever in solo play (the recompute is gated on `srv != nil`). `stopHosting` now also resets `w.CoWarp`, `w.DockGuest`, and `m.coWarp`. Test: `TestStopHostingClearsCoWarpAndDockGuest`.

### F3 (correctness, minor) — SetDocks snapshot TOCTOU
Two sessions racing could persist a stale ledger snapshot and drop a concurrently-added dock from the cross-ref. Added `Server.persistMu` + `Server.persistDocks()`, which re-snapshots `dock.Records()` inside the guard before `SetDocks`, so writes converge. Test: `TestPersistDocksConvergesUnderConcurrency` (8 goroutines under `-race`).

### F4 (efficiency) — Reconcile per-tick full pass
Added an O(1) fast path in `Reconcile`: when the ledger is empty, clear `w.DockGuest` and return without the owner scan (the common no-docks tick). Single-lock 2-party-MVP design kept. Test: `TestReconcileEmptyLedgerFastPath`.

### F5 (efficiency) — WithDockCoupling per-tick Partners re-alloc
Replaced the double-`append` full copy with an in-place `append` in the not-found branch (aliasing confirmed safe — ComputeCoWarp rebuilds Partners each tick). Test: `TestWithDockCouplingAppendsPartnerWithoutCorruption`.

### Deviation
F3: extracted `Server.persistDocks()` instead of inlining the guard in `reconcileDocking`, so the convergence property is deterministically testable. Same behavior + guard.

`go vet ./...` clean; `go test ./... -race -count=1` = **1596 passed**. Exactly the two ssh integration tests kept. Closes out the v0.28 review; the tailnet playtest gates the v0.28.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)