### PR TITLE
S1 (#222): enforce session-admin authorization in the handler, not the UI

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -113,6 +113,15 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// wrapper owns the store access; the App below only dispatched.
 	// Inert until a server exists (solo has nothing to administer).
 	if admin, ok := msg.(screens.SessionAdminMsg); ok && m.srv != nil {
+		// Authorization is a capability enforced HERE, not in the UI (v0.30
+		// S1, #222). The Session screen hides admin keys from guests, but
+		// that is UX, not the security boundary: a guest's forged intent
+		// reaches this handler directly and must be refused. Refusal is a
+		// silent no-op plus a toast to the sender — never a crash.
+		if !m.srv.store.MayAdminister(m.owner) {
+			m.app.Toast("only the host can administer the session")
+			return m, nil
+		}
 		switch admin.Cmd.Kind {
 		case screens.SessionCmdMint:
 			_, _ = m.srv.store.MintInvite(admin.Cmd.Handle)

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -178,3 +178,37 @@ func TestSessionAdminCommands(t *testing.T) {
 		t.Errorf("remove via admin msg: %v", err)
 	}
 }
+
+// Authorization is enforced in the handler, not the UI (v0.30 S1, #222):
+// an admin intent forged from a guest-owned session — the UI never
+// offers it, but the message reaches the handler directly — is refused,
+// leaving the store untouched.
+func TestSessionAdminAuthorizedInHandler(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	enrollDirect(t, srv, "SHA256:mallory", "mallory")
+
+	guestApp, err := srv.newGuestApp("SHA256:mallory")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	// The guest's own wrapper, owned by the guest fingerprint.
+	guest := tick(srv.withReporting(guestApp, "SHA256:mallory"))
+
+	// Forge each admin intent from the guest session.
+	guest, _ = guest.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdMint, Handle: "sneaky",
+	}})
+	guest, _ = guest.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:gern",
+	}})
+	_ = guest
+
+	meta, _ := srv.store.Meta()
+	if len(meta.Invites) != 0 {
+		t.Errorf("guest forged a mint: invites = %+v", meta.Invites)
+	}
+	if _, err := srv.store.FindPlayer("SHA256:gern"); err != nil {
+		t.Errorf("guest forged a removal: gern is gone (%v)", err)
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -397,6 +397,29 @@ func (s *Store) RemovePlayer(fingerprint string) error {
 	return ErrNotEnrolled
 }
 
+// MayAdminister reports whether the given fingerprint may perform
+// session-admin actions — minting/revoking invites and removing
+// players. It is the single authorization predicate the serve-layer
+// handler consults before acting (v0.30 S1, #222): authorization is a
+// capability decided here, in the store, not a UI-presentation detail.
+// Today only the host qualifies; the admin role (v0.30 S2) extends
+// roleMayAdminister without touching any caller. An unknown or
+// unenrolled fingerprint may not administer.
+func (s *Store) MayAdminister(fingerprint string) bool {
+	p, err := s.FindPlayer(fingerprint)
+	if err != nil {
+		return false
+	}
+	return roleMayAdminister(p.Role)
+}
+
+// roleMayAdminister centralises which roster roles carry the admin
+// capability, so granting the admin role (S2) is a one-line change here
+// rather than a re-plumb of every caller.
+func roleMayAdminister(role string) bool {
+	return role == RoleHost
+}
+
 // FindPlayer looks a fingerprint up in the roster.
 func (s *Store) FindPlayer(fingerprint string) (Player, error) {
 	m, err := s.Meta()

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -84,6 +84,33 @@ func TestEnsureHostIdempotent(t *testing.T) {
 	}
 }
 
+// MayAdminister is the capability predicate the serve handler gates on
+// (v0.30 S1, #222): true for the host, false for guests and for
+// fingerprints not in the roster.
+func TestMayAdminister(t *testing.T) {
+	s := openStore(t)
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	inv, err := s.MintInvite("dave")
+	if err != nil {
+		t.Fatalf("MintInvite: %v", err)
+	}
+	if _, err := s.Enroll(inv.Code, "SHA256:guest", "dave"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	if !s.MayAdminister(HostFingerprint) {
+		t.Error("host may not administer")
+	}
+	if s.MayAdminister("SHA256:guest") {
+		t.Error("guest may administer")
+	}
+	if s.MayAdminister("SHA256:stranger") {
+		t.Error("unenrolled fingerprint may administer")
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.


### PR DESCRIPTION
Closes #222.

## What

Prefactor for the v0.30 admin arc. Moves authorization for the session-admin trio (mint/revoke invite, remove player) out of the Session screen's key-gating and into the serve-layer handler that performs the actions.

Authorization was **presentation-only**: every session (host and guest) runs inside the server process, and the admin-intent handler was gated only on "a server exists" — the sole thing stopping a guest from minting invites was that the UI hid the keys.

## How

- `sessiondir.Store.MayAdminister(fingerprint)` — the single capability predicate: true for the host, false for guests and unenrolled keys. The role check is centralised in `roleMayAdminister`, so granting the admin role in S2 is a one-line extension there.
- The admin-intent handler (`reporting.go`) consults the predicate before acting and refuses an unauthorized intent with a **silent no-op + toast to the sender** (never a crash).

## No-op by design

The host remains the only administrator; the Session screen's gating is unchanged. This slice adds no visible behavior — it exists so the admin-role work that follows is *granting a capability* rather than re-plumbing where the decision lives.

## Tests

- `TestMayAdminister` — predicate true for host, false for guest / unenrolled.
- `TestSessionAdminAuthorizedInHandler` — forges each admin intent from a guest session directly and asserts the store is untouched (the whole point of the slice: proves authorization is no longer presentation-only).
- Existing `TestSessionAdminCommands` still green (host mint/revoke/remove end-to-end).

`go vet ./...` clean; `go test ./... -race -count=1` green (1639 tests).

Part of the v0.30 stack — S2 (#223) builds on this branch.