### PR TITLE
S2 (#223): admin role — host delegates, admins manage invites

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -129,6 +129,19 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:
 			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
+		case screens.SessionCmdPromote, screens.SessionCmdDemote:
+			// Delegation is host-only — an admin can neither create nor
+			// remove another admin (single-rooted, v0.30 S2). MayAdminister
+			// passed (host or admin); narrow to the host via MayDelegate.
+			if !m.srv.store.MayDelegate(m.owner) {
+				m.app.Toast("only the host can promote or demote admins")
+				return m, nil
+			}
+			if admin.Cmd.Kind == screens.SessionCmdPromote {
+				_ = m.srv.store.PromoteAdmin(admin.Cmd.Fingerprint)
+			} else {
+				_ = m.srv.store.DemoteAdmin(admin.Cmd.Fingerprint)
+			}
 		}
 		m.metaAt = time.Time{} // force refresh — the list is the feedback
 		m.refreshSession(time.Now())
@@ -295,8 +308,9 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	m.reconcileDocking(w, cw.CoupledOwners, reports, handles, now)
 
 	info := &sim.SessionInfo{
-		IsHost: m.owner == sessiondir.HostFingerprint,
-		Self:   m.owner,
+		IsHost:        m.owner == sessiondir.HostFingerprint,
+		CanAdminister: m.srv.store.MayAdminister(m.owner),
+		Self:          m.owner,
 	}
 	// Rendezvous roster markers (v0.29 S2): who is armed toward the
 	// viewer, and whom the viewer is armed toward.
@@ -331,7 +345,7 @@ func (m *reportingModel) refreshSession(now time.Time) {
 		}
 		info.Players = append(info.Players, row)
 	}
-	if info.IsHost {
+	if info.CanAdminister {
 		for _, inv := range m.meta.Invites {
 			info.Invites = append(info.Invites, sim.SessionInvite{
 				Code:   inv.Code,

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -128,6 +128,13 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screens.SessionCmdRevoke:
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:
+			// Target-aware guardrail (v0.30 S3): an admin may remove guests
+			// but not the host, another admin, or themselves. MayAdminister
+			// passed above; MayRemove adds the actor×target rules.
+			if !m.srv.store.MayRemove(m.owner, admin.Cmd.Fingerprint) {
+				m.app.Toast("you can't remove that player")
+				return m, nil
+			}
 			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
 		case screens.SessionCmdPromote, screens.SessionCmdDemote:
 			// Delegation is host-only — an admin can neither create nor

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -212,3 +212,52 @@ func TestSessionAdminAuthorizedInHandler(t *testing.T) {
 		t.Errorf("guest forged a removal: gern is gone (%v)", err)
 	}
 }
+
+// The host promotes a guest to admin; the admin can then mint/revoke
+// invites, but delegation stays host-only — a forged promote from the
+// admin's own session is refused (v0.30 S2, #223).
+func TestAdminRoleCapabilities(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	enrollDirect(t, srv, "SHA256:newbie", "newbie")
+
+	// Host promotes gern.
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	host := tick(srv.HostModel(hostApp))
+	host, _ = host.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdPromote, Fingerprint: "SHA256:gern",
+	}})
+	_ = host
+	if p, _ := srv.store.FindPlayer("SHA256:gern"); p.Role != sessiondir.RoleAdmin {
+		t.Fatalf("host promote didn't take: role = %q", p.Role)
+	}
+
+	// gern's own session: admin may mint.
+	gernApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	gern := tick(srv.withReporting(gernApp, "SHA256:gern"))
+	// The admin sees the invite pane.
+	if info := gernApp.World().Session; info == nil || !info.CanAdminister || info.IsHost {
+		t.Fatalf("admin slate = %+v (want CanAdminister, not IsHost)", info)
+	}
+	gern, _ = gern.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdMint, Handle: "fromadmin",
+	}})
+	if meta, _ := srv.store.Meta(); len(meta.Invites) != 1 || meta.Invites[0].Handle != "fromadmin" {
+		t.Errorf("admin mint failed: invites = %+v", meta.Invites)
+	}
+
+	// But delegation is host-only: gern forging a promote is refused.
+	gern, _ = gern.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdPromote, Fingerprint: "SHA256:newbie",
+	}})
+	_ = gern
+	if p, _ := srv.store.FindPlayer("SHA256:newbie"); p.Role != sessiondir.RoleGuest {
+		t.Errorf("admin promoted another player: newbie role = %q", p.Role)
+	}
+}

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -261,3 +261,48 @@ func TestAdminRoleCapabilities(t *testing.T) {
 		t.Errorf("admin promoted another player: newbie role = %q", p.Role)
 	}
 }
+
+// An admin can remove a guest, but the removal guardrails hold at the
+// handler even for forged intents: an admin can't remove another admin
+// or the host (v0.30 S3, #224).
+func TestAdminRemovalGuardrails(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:adminA", "adminA")
+	enrollDirect(t, srv, "SHA256:adminB", "adminB")
+	enrollDirect(t, srv, "SHA256:guest", "guest")
+	if err := srv.store.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := srv.store.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	adminApp, err := srv.newGuestApp("SHA256:adminA")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	admin := tick(srv.withReporting(adminApp, "SHA256:adminA"))
+
+	// Forged removal of the host and of another admin: both refused.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: sessiondir.HostFingerprint,
+	}})
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:adminB",
+	}})
+	if _, err := srv.store.FindPlayer(sessiondir.HostFingerprint); err != nil {
+		t.Errorf("admin removed the host: %v", err)
+	}
+	if _, err := srv.store.FindPlayer("SHA256:adminB"); err != nil {
+		t.Errorf("admin removed another admin: %v", err)
+	}
+
+	// A guest, though: allowed.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:guest",
+	}})
+	_ = admin
+	if _, err := srv.store.FindPlayer("SHA256:guest"); !errors.Is(err, sessiondir.ErrNotEnrolled) {
+		t.Errorf("admin couldn't remove a guest: %v", err)
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -438,6 +438,52 @@ func (s *Store) MayDelegate(fingerprint string) bool {
 	return p.Role == RoleHost
 }
 
+// MayRemove reports whether actor may remove target from the roster
+// (v0.30 S3, #224) — the guardrail matrix for the first admin power that
+// can lock someone out. The rules keep escalation single-rooted:
+//
+//   - the actor must carry the admin capability (host or admin);
+//   - nobody removes themselves (avoids a self-inflicted lockout);
+//   - nobody removes the host (the session's root);
+//   - an admin may not remove another admin — only the host may
+//     (mirrors promotion being host-only).
+//
+// Both fingerprints must be enrolled. The store's RemovePlayer still
+// guards the host independently; this predicate is the actor-aware gate
+// the serve handler consults before calling it.
+func (s *Store) MayRemove(actor, target string) bool {
+	if actor == target {
+		return false
+	}
+	m, err := s.Meta()
+	if err != nil {
+		return false
+	}
+	var actorRole, targetRole string
+	var haveActor, haveTarget bool
+	for _, p := range m.Roster {
+		switch p.Fingerprint {
+		case actor:
+			actorRole, haveActor = p.Role, true
+		case target:
+			targetRole, haveTarget = p.Role, true
+		}
+	}
+	if !haveActor || !haveTarget {
+		return false
+	}
+	if !roleMayAdminister(actorRole) {
+		return false
+	}
+	if targetRole == RoleHost {
+		return false
+	}
+	if actorRole == RoleAdmin && targetRole == RoleAdmin {
+		return false
+	}
+	return true
+}
+
 // PromoteAdmin grants the admin role to an enrolled guest by
 // fingerprint. Idempotent — re-promoting an admin is a no-op. The host
 // is rejected (already root) and an unknown fingerprint returns

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -42,11 +42,16 @@ import (
 // migrateMetaV1ToV2; live v0.27 sessions never break.
 const MetaVersion = 2
 
-// Roster roles. Host is the one privileged role (ADR 0034): the
-// player whose machine runs the session, with invite and removal
-// authority. Everyone else is a guest.
+// Roster roles. Host is the session's root operator (ADR 0034): the
+// player whose machine runs the session, with invite/removal authority
+// and the sole power to delegate administration. Admin is a guest the
+// host has promoted — it carries the invite/removal capability but not
+// delegation (single-rooted escalation, v0.30 S2). Everyone else is a
+// guest. The role is a plain persisted string on the roster entry, so
+// adding admin is additive: no MetaVersion bump, no migration.
 const (
 	RoleHost  = "host"
+	RoleAdmin = "admin"
 	RoleGuest = "guest"
 )
 
@@ -414,10 +419,63 @@ func (s *Store) MayAdminister(fingerprint string) bool {
 }
 
 // roleMayAdminister centralises which roster roles carry the admin
-// capability, so granting the admin role (S2) is a one-line change here
-// rather than a re-plumb of every caller.
+// capability (mint/revoke invites, remove guests). The host and any
+// promoted admin qualify; a plain guest does not.
 func roleMayAdminister(role string) bool {
-	return role == RoleHost
+	return role == RoleHost || role == RoleAdmin
+}
+
+// MayDelegate reports whether the fingerprint may promote a guest to
+// admin or demote an admin back to guest. Single-rooted escalation
+// (v0.30 S2): only the host delegates administration — an admin can
+// neither create nor remove another admin. Kept distinct from
+// MayAdminister so the escalation tree stays single-rooted.
+func (s *Store) MayDelegate(fingerprint string) bool {
+	p, err := s.FindPlayer(fingerprint)
+	if err != nil {
+		return false
+	}
+	return p.Role == RoleHost
+}
+
+// PromoteAdmin grants the admin role to an enrolled guest by
+// fingerprint. Idempotent — re-promoting an admin is a no-op. The host
+// is rejected (already root) and an unknown fingerprint returns
+// ErrNotEnrolled. Only the host should call this (enforced at the
+// handler via MayDelegate); the store guards the host-role invariant.
+func (s *Store) PromoteAdmin(fingerprint string) error {
+	return s.setRole(fingerprint, RoleAdmin)
+}
+
+// DemoteAdmin returns an admin to guest by fingerprint. Idempotent for
+// a player already a guest; rejects the host and unknown fingerprints.
+func (s *Store) DemoteAdmin(fingerprint string) error {
+	return s.setRole(fingerprint, RoleGuest)
+}
+
+// setRole is the shared guest↔admin role mutation. The host's role is
+// immutable (it is the single root); an unknown fingerprint is
+// ErrNotEnrolled.
+func (s *Store) setRole(fingerprint, role string) error {
+	if fingerprint == HostFingerprint {
+		return errors.New("sessiondir: can't change the host's role")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return err
+	}
+	for i := range m.Roster {
+		if m.Roster[i].Fingerprint == fingerprint {
+			if m.Roster[i].Role == RoleHost {
+				return errors.New("sessiondir: can't change the host's role")
+			}
+			m.Roster[i].Role = role
+			return s.writeMeta(m)
+		}
+	}
+	return ErrNotEnrolled
 }
 
 // FindPlayer looks a fingerprint up in the roster.

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -111,6 +111,70 @@ func TestMayAdminister(t *testing.T) {
 	}
 }
 
+// PromoteAdmin/DemoteAdmin round-trip a guest through the admin role
+// (v0.30 S2): the role persists, MayAdminister flips with it, delegation
+// stays host-only, and the host's role is immutable.
+func TestPromoteDemoteRole(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	inv, _ := s.MintInvite("dave")
+	if _, err := s.Enroll(inv.Code, "SHA256:dave", "dave"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	// Promote → admin, may administer but may not delegate.
+	if err := s.PromoteAdmin("SHA256:dave"); err != nil {
+		t.Fatalf("PromoteAdmin: %v", err)
+	}
+	if !s.MayAdminister("SHA256:dave") {
+		t.Error("promoted admin may not administer")
+	}
+	if s.MayDelegate("SHA256:dave") {
+		t.Error("admin may delegate — escalation not single-rooted")
+	}
+	if !s.MayDelegate(HostFingerprint) {
+		t.Error("host may not delegate")
+	}
+	// Idempotent grant.
+	if err := s.PromoteAdmin("SHA256:dave"); err != nil {
+		t.Errorf("re-promote not idempotent: %v", err)
+	}
+
+	// Persists across a reopen (role rides the roster string).
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if p, _ := s2.FindPlayer("SHA256:dave"); p.Role != RoleAdmin {
+		t.Errorf("admin role not persisted: role = %q", p.Role)
+	}
+	if m2, _ := s2.Meta(); m2.Version != MetaVersion {
+		t.Errorf("promote bumped MetaVersion to %d (want additive, %d)", m2.Version, MetaVersion)
+	}
+
+	// Demote → guest.
+	if err := s2.DemoteAdmin("SHA256:dave"); err != nil {
+		t.Fatalf("DemoteAdmin: %v", err)
+	}
+	if s2.MayAdminister("SHA256:dave") {
+		t.Error("demoted player still administers")
+	}
+
+	// Guards: host immutable, unknown fingerprint rejected.
+	if err := s2.PromoteAdmin(HostFingerprint); err == nil {
+		t.Error("promoting the host was allowed")
+	}
+	if err := s2.PromoteAdmin("SHA256:nobody"); !errors.Is(err, ErrNotEnrolled) {
+		t.Errorf("promote unknown fingerprint: err = %v, want ErrNotEnrolled", err)
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -175,6 +175,55 @@ func TestPromoteDemoteRole(t *testing.T) {
 	}
 }
 
+// MayRemove encodes the actor×target guardrail matrix (v0.30 S3, #224):
+// host removes guests and admins; an admin removes only guests; nobody
+// removes the host or themselves; guests remove no one.
+func TestMayRemoveGuardrails(t *testing.T) {
+	s := openStore(t)
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	// adminA, adminB (promoted), guestA, guestB.
+	for _, e := range []struct{ fp, handle string }{
+		{"SHA256:adminA", "adminA"}, {"SHA256:adminB", "adminB"},
+		{"SHA256:guestA", "guestA"}, {"SHA256:guestB", "guestB"},
+	} {
+		inv, _ := s.MintInvite(e.handle)
+		if _, err := s.Enroll(inv.Code, e.fp, e.handle); err != nil {
+			t.Fatalf("Enroll %s: %v", e.handle, err)
+		}
+	}
+	if err := s.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := s.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		actor, target  string
+		want           bool
+	}{
+		{"host removes guest", HostFingerprint, "SHA256:guestA", true},
+		{"host removes admin", HostFingerprint, "SHA256:adminA", true},
+		{"host removes self", HostFingerprint, HostFingerprint, false},
+		{"admin removes guest", "SHA256:adminA", "SHA256:guestA", true},
+		{"admin removes another admin", "SHA256:adminA", "SHA256:adminB", false},
+		{"admin removes self", "SHA256:adminA", "SHA256:adminA", false},
+		{"admin removes host", "SHA256:adminA", HostFingerprint, false},
+		{"guest removes guest", "SHA256:guestA", "SHA256:guestB", false},
+		{"guest removes admin", "SHA256:guestA", "SHA256:adminA", false},
+		{"actor not enrolled", "SHA256:nobody", "SHA256:guestA", false},
+		{"target not enrolled", HostFingerprint, "SHA256:nobody", false},
+	}
+	for _, c := range cases {
+		if got := s.MayRemove(c.actor, c.target); got != c.want {
+			t.Errorf("%s: MayRemove(%s, %s) = %v, want %v", c.name, c.actor, c.target, got, c.want)
+		}
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -48,10 +48,15 @@ type SessionInvite struct {
 
 // SessionInfo is the Session screen's whole slate.
 type SessionInfo struct {
-	IsHost  bool
-	Self    string // viewer's fingerprint — the screen marks "you"
-	Players []SessionPlayer
-	Invites []SessionInvite // populated only for the host
+	IsHost bool // viewer is the session's root host (promote/demote, stop-hosting)
+	// CanAdminister is true for the host and any promoted admin (v0.30
+	// S2): the invite pane and mint/revoke are gated on this, not on
+	// IsHost. Authorization is still enforced in the serve handler — this
+	// only drives what the screen offers.
+	CanAdminister bool
+	Self          string // viewer's fingerprint — the screen marks "you"
+	Players       []SessionPlayer
+	Invites       []SessionInvite // populated for the host and admins
 }
 
 // SessionEventKind enumerates the moments the chip stack surfaces.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1776,7 +1776,8 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 	case screens.SessionCmdStopHost:
 		msg := screens.SessionHostMsg{Start: false}
 		return a, func() tea.Msg { return msg }
-	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove:
+	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove,
+		screens.SessionCmdPromote, screens.SessionCmdDemote:
 		msg := screens.SessionAdminMsg{Cmd: cmd}
 		return a, func() tea.Msg { return msg }
 	}

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -50,6 +50,8 @@ const (
 	SessionCmdStartHost   // solo → start hosting (v0.28 S3)
 	SessionCmdStopHost    // hosting → stop the listener (v0.28 S3)
 	SessionCmdRendezvous  // arm a Rendezvous Warp toward Owner's ghost Owner/CraftID (v0.29 S2)
+	SessionCmdPromote     // host promotes Fingerprint (guest → admin) (v0.30 S2)
+	SessionCmdDemote      // host demotes Fingerprint (admin → guest) (v0.30 S2)
 )
 
 // SessionCommand is the screen's finalized action.
@@ -64,8 +66,9 @@ type SessionCommand struct {
 	Time        time.Time // SessionCmdSync: the subspace time to chase
 }
 
-// SessionAdminMsg carries a mint/revoke/remove intent out of the App
-// to the serve-layer wrapper (which owns the session store). In
+// SessionAdminMsg carries a session-admin intent (mint/revoke/remove,
+// or host-only promote/demote) out of the App to the serve-layer
+// wrapper, which owns the session store and enforces authorization. In
 // single-player nothing handles it — the message is inert.
 type SessionAdminMsg struct{ Cmd SessionCommand }
 
@@ -165,7 +168,7 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 	case "down", "j":
 		s.moveCursor(info, +1)
 	case "tab":
-		if info.IsHost && len(info.Invites) > 0 {
+		if info.CanAdminister && len(info.Invites) > 0 {
 			s.inInvites = !s.inInvites
 		}
 	case "t":
@@ -236,12 +239,12 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		}
 		return SessionCommand{Kind: SessionCmdSync, Owner: p.Fingerprint, Handle: p.Handle, Time: w.Clock.SimTime.Add(p.DeltaT)}
 	case "i":
-		if info.IsHost {
+		if info.CanAdminister {
 			s.minting = true
 			s.mintInput = nil
 		}
 	case "r":
-		if info.IsHost && s.inInvites {
+		if info.CanAdminister && s.inInvites {
 			if inv, ok := s.selectedInvite(info); ok {
 				return SessionCommand{Kind: SessionCmdRevoke, Code: inv.Code, Handle: inv.Handle}
 			}
@@ -250,6 +253,21 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		if info.IsHost && !s.inInvites {
 			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
 				s.confirmRemove = true
+			}
+		}
+	case "p":
+		// Host-only delegation (v0.30 S2): promote a guest to admin or
+		// demote an admin back to guest. Single-rooted — an admin never
+		// sees this. Absent on the host's own row and on non-guest/admin
+		// rows.
+		if info.IsHost && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && p.Fingerprint != info.Self {
+				switch p.Role {
+				case "guest":
+					return SessionCommand{Kind: SessionCmdPromote, Fingerprint: p.Fingerprint, Handle: p.Handle}
+				case "admin":
+					return SessionCommand{Kind: SessionCmdDemote, Fingerprint: p.Fingerprint, Handle: p.Handle}
+				}
 			}
 		}
 	case "h":
@@ -334,8 +352,11 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		}
 		name := p.Handle
 		var tags []string
-		if p.Role == "host" {
+		switch p.Role {
+		case "host":
 			tags = append(tags, "host")
+		case "admin":
+			tags = append(tags, "admin")
 		}
 		if p.Fingerprint == info.Self {
 			tags = append(tags, "you")
@@ -365,7 +386,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 			marker, dot, name, where, craft, formatDeltaT(p, info.Self == p.Fingerprint)))
 	}
 
-	if info.IsHost {
+	if info.CanAdminister {
 		b.WriteString("\n" + s.theme.Title.Render(" INVITES ") + "\n\n")
 		// Normalise section focus (review follow-up): revoking the last
 		// invite while focused there must not strand the cursor in an
@@ -399,8 +420,14 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
+	if info.CanAdminister {
+		keys += "  [i] invite  [r] revoke code"
+	}
 	if info.IsHost {
-		keys += "  [i] invite  [r] revoke code  [x] remove player  [h] stop hosting  [tab] section"
+		keys += "  [x] remove player  [p] promote/demote  [h] stop hosting"
+	}
+	if info.CanAdminister {
+		keys += "  [tab] section"
 	}
 	keys += "  [esc] close"
 	b.WriteString(s.theme.Footer.Render(keys))

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -250,8 +250,11 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 			}
 		}
 	case "x":
-		if info.IsHost && !s.inInvites {
-			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
+		// Removal is reachable by the host and admins (v0.30 S3), gated
+		// per-row by the same guardrail the handler enforces: never self,
+		// the host, or (for an admin actor) another admin.
+		if info.CanAdminister && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && mayRemoveRow(info, p) {
 				s.confirmRemove = true
 			}
 		}
@@ -300,6 +303,24 @@ func (s *SessionScreen) selectedInvite(info *sim.SessionInfo) (sim.SessionInvite
 		return sim.SessionInvite{}, false
 	}
 	return info.Invites[s.inviteCursor], true
+}
+
+// mayRemoveRow mirrors sessiondir.MayRemove for UI gating (v0.30 S3):
+// the screen only offers [x] on rows the viewer is actually allowed to
+// remove. The handler re-checks authoritatively — this just avoids
+// dangling a key that would no-op.
+func mayRemoveRow(info *sim.SessionInfo, p sim.SessionPlayer) bool {
+	if !info.CanAdminister {
+		return false
+	}
+	if p.Fingerprint == info.Self || p.Role == "host" {
+		return false
+	}
+	// An admin (can administer but isn't the host) can't remove another admin.
+	if !info.IsHost && p.Role == "admin" {
+		return false
+	}
+	return true
 }
 
 // onlineGuests counts online roster members other than the viewer
@@ -421,10 +442,10 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code"
+		keys += "  [i] invite  [r] revoke code  [x] remove player"
 	}
 	if info.IsHost {
-		keys += "  [x] remove player  [p] promote/demote  [h] stop hosting"
+		keys += "  [p] promote/demote  [h] stop hosting"
 	}
 	if info.CanAdminister {
 		keys += "  [tab] section"

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -286,7 +286,9 @@ func TestSessionScreenAdminView(t *testing.T) {
 	if !strings.Contains(out, "INVITES") || !strings.Contains(out, "[i] invite") {
 		t.Errorf("admin screen missing the invites pane:\n%s", out)
 	}
-	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "[x] remove player") || strings.Contains(out, "stop hosting") {
+	// Admins can remove guests (S3), so [x] is theirs; but delegation and
+	// server lifecycle stay host-only.
+	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "stop hosting") {
 		t.Errorf("admin screen offers host-only keys:\n%s", out)
 	}
 	// [i] arms minting for the admin.
@@ -298,6 +300,54 @@ func TestSessionScreenAdminView(t *testing.T) {
 	s.HandleKey(w, key("j")) // move off self
 	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
 		t.Errorf("admin [p] = %+v, want no command (delegation is host-only)", cmd)
+	}
+}
+
+// Removal row-gating for an admin viewer (v0.30 S3): [x] arms on a
+// guest row, but not on another admin's row, the host's row, or the
+// viewer's own row.
+func TestSessionScreenAdminRemoveGating(t *testing.T) {
+	// Viewer is gern (a promoted admin). Fixture roster: host, gern
+	// (self), dave, pat — mark dave an admin, pat stays a guest.
+	w := sessionWorld(t, false)
+	w.Session.CanAdminister = true
+	w.Session.Players[2].Role = "admin" // dave → admin
+
+	// Row 0 host: not offered.
+	s := NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the host row")
+	}
+
+	// Row 1 self (gern): not offered.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the viewer's own row")
+	}
+
+	// Row 2 dave (admin): an admin can't remove another admin.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on another admin's row")
+	}
+
+	// Row 3 pat (guest): offered → confirm → removal command.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if !s.confirmRemove {
+		t.Fatal("[x] didn't arm on a guest row")
+	}
+	if cmd := s.HandleKey(w, key("y")); cmd.Kind != SessionCmdRemove || cmd.Fingerprint != "SHA256:never" {
+		t.Errorf("guest removal command = %+v", cmd)
 	}
 }
 

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -34,8 +34,9 @@ func sessionWorld(t *testing.T, isHost bool) *sim.World {
 		self = "SHA256:guest"
 	}
 	w.Session = &sim.SessionInfo{
-		IsHost: isHost,
-		Self:   self,
+		IsHost:        isHost,
+		CanAdminister: isHost, // the host administers; admins are covered separately
+		Self:          self,
 		Players: []sim.SessionPlayer{
 			{Fingerprint: "local", Handle: "jason", Role: "host", Online: true,
 				HasReport: true, System: "Sol", Primary: "earth", CraftCount: 2, DeltaT: 0},
@@ -240,6 +241,63 @@ func TestSessionScreenStopHostConfirm(t *testing.T) {
 	s.HandleKey(w, key("h"))
 	if cmd := s.HandleKey(w, key("n")); cmd.Kind != SessionCmdNone {
 		t.Errorf("confirm n = %+v, want no command", cmd)
+	}
+}
+
+// Promote/demote (v0.30 S2) is host-only: [p] on a guest row emits
+// Promote, on an admin row emits Demote, and is inert on the host's own
+// row.
+func TestSessionScreenPromoteKey(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+
+	// Cursor on the host — [p] must not act.
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
+		t.Errorf("[p] on host's own row = %+v, want no command", cmd)
+	}
+
+	s.HandleKey(w, key("j")) // gern (guest)
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdPromote || cmd.Fingerprint != "SHA256:guest" {
+		t.Errorf("[p] on guest = %+v, want Promote", cmd)
+	}
+
+	// Flip gern to admin — [p] now demotes.
+	w.Session.Players[1].Role = "admin"
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdDemote || cmd.Fingerprint != "SHA256:guest" {
+		t.Errorf("[p] on admin = %+v, want Demote", cmd)
+	}
+
+	if !strings.Contains(s.Render(w, 120), "[p] promote/demote") {
+		t.Error("host footer missing the promote/demote hint")
+	}
+	if !strings.Contains(s.Render(w, 120), "admin") {
+		t.Error("admin role tag missing on the roster row")
+	}
+}
+
+// An admin (CanAdminister but not IsHost) sees and uses the invites
+// pane, but never the host-only delegation / removal / lifecycle keys.
+func TestSessionScreenAdminView(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, false)
+	w.Session.CanAdminister = true // promoted admin, still not the host
+
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "INVITES") || !strings.Contains(out, "[i] invite") {
+		t.Errorf("admin screen missing the invites pane:\n%s", out)
+	}
+	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "[x] remove player") || strings.Contains(out, "stop hosting") {
+		t.Errorf("admin screen offers host-only keys:\n%s", out)
+	}
+	// [i] arms minting for the admin.
+	if s.HandleKey(w, key("i")); !s.CapturingText() {
+		t.Error("admin [i] didn't arm the mint input")
+	}
+	s.HandleKey(w, key("esc"))
+	// [p] is inert for a non-host.
+	s.HandleKey(w, key("j")) // move off self
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
+		t.Errorf("admin [p] = %+v, want no command (delegation is host-only)", cmd)
 	}
 }
 


### PR DESCRIPTION
Closes #223. **Stacked on #233 (S1)** — review/merge S1 first; this PR's base is the S1 branch, so its diff is S2-only.

## What

The host can promote an enrolled guest to **admin**; an admin mints and revokes invite codes exactly as the host does.

## How

**`internal/sessiondir`**
- New `RoleAdmin` alongside host/guest. It rides the roster entry's existing persisted role string → **additive, no `MetaVersion` bump, no migration** (constraint confirmed at S2).
- `PromoteAdmin` / `DemoteAdmin` flip a guest through admin: idempotent grant, unknown fingerprint → `ErrNotEnrolled`, the host role is immutable.
- `roleMayAdminister` now returns true for admins → the S1 predicate grants them the invite capability for free.
- `MayDelegate` — a second, host-only predicate for promote/demote. **Single-rooted escalation**: an admin can neither create nor remove another admin. Deliberately distinct from `MayAdminister`.

**`internal/serve`**
- The admin handler narrows promote/demote to `MayDelegate` (host) while mint/revoke stay `MayAdminister` (host or admin).
- `SessionInfo.CanAdminister` (host or admin) drives invite-pane population.

**Session screen**
- Invite pane + `[i]`/`[r]`/`[tab]` gate on `CanAdminister` (was `IsHost`), so admins see and use them.
- New host-only `[p]` promote/demote key flips the selected guest/admin — absent on the host's own row and for admins.
- Roster row shows an `admin` tag.

Role survives reconnect (identity = key fingerprint; roster is persisted).

## Tests
- `TestPromoteDemoteRole` — role round-trip, persistence across reopen, MetaVersion unchanged, host-immutable + unknown-fp guards.
- `TestAdminRoleCapabilities` — host promotes; admin mints; admin's forged promote refused at the handler (host-only delegation).
- `TestSessionScreenPromoteKey` / `TestSessionScreenAdminView` — `[p]` gating, admin sees invites but not host-only keys.

`go vet ./...` clean; `go test ./... -race -count=1` green (1643 tests).