### PR TITLE
S3 (#224): admins remove guests, with escalation guardrails

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -128,6 +128,13 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screens.SessionCmdRevoke:
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:
+			// Target-aware guardrail (v0.30 S3): an admin may remove guests
+			// but not the host, another admin, or themselves. MayAdminister
+			// passed above; MayRemove adds the actor×target rules.
+			if !m.srv.store.MayRemove(m.owner, admin.Cmd.Fingerprint) {
+				m.app.Toast("you can't remove that player")
+				return m, nil
+			}
 			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
 		case screens.SessionCmdPromote, screens.SessionCmdDemote:
 			// Delegation is host-only — an admin can neither create nor

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -261,3 +261,48 @@ func TestAdminRoleCapabilities(t *testing.T) {
 		t.Errorf("admin promoted another player: newbie role = %q", p.Role)
 	}
 }
+
+// An admin can remove a guest, but the removal guardrails hold at the
+// handler even for forged intents: an admin can't remove another admin
+// or the host (v0.30 S3, #224).
+func TestAdminRemovalGuardrails(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:adminA", "adminA")
+	enrollDirect(t, srv, "SHA256:adminB", "adminB")
+	enrollDirect(t, srv, "SHA256:guest", "guest")
+	if err := srv.store.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := srv.store.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	adminApp, err := srv.newGuestApp("SHA256:adminA")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	admin := tick(srv.withReporting(adminApp, "SHA256:adminA"))
+
+	// Forged removal of the host and of another admin: both refused.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: sessiondir.HostFingerprint,
+	}})
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:adminB",
+	}})
+	if _, err := srv.store.FindPlayer(sessiondir.HostFingerprint); err != nil {
+		t.Errorf("admin removed the host: %v", err)
+	}
+	if _, err := srv.store.FindPlayer("SHA256:adminB"); err != nil {
+		t.Errorf("admin removed another admin: %v", err)
+	}
+
+	// A guest, though: allowed.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:guest",
+	}})
+	_ = admin
+	if _, err := srv.store.FindPlayer("SHA256:guest"); !errors.Is(err, sessiondir.ErrNotEnrolled) {
+		t.Errorf("admin couldn't remove a guest: %v", err)
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -438,6 +438,52 @@ func (s *Store) MayDelegate(fingerprint string) bool {
 	return p.Role == RoleHost
 }
 
+// MayRemove reports whether actor may remove target from the roster
+// (v0.30 S3, #224) — the guardrail matrix for the first admin power that
+// can lock someone out. The rules keep escalation single-rooted:
+//
+//   - the actor must carry the admin capability (host or admin);
+//   - nobody removes themselves (avoids a self-inflicted lockout);
+//   - nobody removes the host (the session's root);
+//   - an admin may not remove another admin — only the host may
+//     (mirrors promotion being host-only).
+//
+// Both fingerprints must be enrolled. The store's RemovePlayer still
+// guards the host independently; this predicate is the actor-aware gate
+// the serve handler consults before calling it.
+func (s *Store) MayRemove(actor, target string) bool {
+	if actor == target {
+		return false
+	}
+	m, err := s.Meta()
+	if err != nil {
+		return false
+	}
+	var actorRole, targetRole string
+	var haveActor, haveTarget bool
+	for _, p := range m.Roster {
+		switch p.Fingerprint {
+		case actor:
+			actorRole, haveActor = p.Role, true
+		case target:
+			targetRole, haveTarget = p.Role, true
+		}
+	}
+	if !haveActor || !haveTarget {
+		return false
+	}
+	if !roleMayAdminister(actorRole) {
+		return false
+	}
+	if targetRole == RoleHost {
+		return false
+	}
+	if actorRole == RoleAdmin && targetRole == RoleAdmin {
+		return false
+	}
+	return true
+}
+
 // PromoteAdmin grants the admin role to an enrolled guest by
 // fingerprint. Idempotent — re-promoting an admin is a no-op. The host
 // is rejected (already root) and an unknown fingerprint returns

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -175,6 +175,55 @@ func TestPromoteDemoteRole(t *testing.T) {
 	}
 }
 
+// MayRemove encodes the actor×target guardrail matrix (v0.30 S3, #224):
+// host removes guests and admins; an admin removes only guests; nobody
+// removes the host or themselves; guests remove no one.
+func TestMayRemoveGuardrails(t *testing.T) {
+	s := openStore(t)
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	// adminA, adminB (promoted), guestA, guestB.
+	for _, e := range []struct{ fp, handle string }{
+		{"SHA256:adminA", "adminA"}, {"SHA256:adminB", "adminB"},
+		{"SHA256:guestA", "guestA"}, {"SHA256:guestB", "guestB"},
+	} {
+		inv, _ := s.MintInvite(e.handle)
+		if _, err := s.Enroll(inv.Code, e.fp, e.handle); err != nil {
+			t.Fatalf("Enroll %s: %v", e.handle, err)
+		}
+	}
+	if err := s.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := s.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		actor, target  string
+		want           bool
+	}{
+		{"host removes guest", HostFingerprint, "SHA256:guestA", true},
+		{"host removes admin", HostFingerprint, "SHA256:adminA", true},
+		{"host removes self", HostFingerprint, HostFingerprint, false},
+		{"admin removes guest", "SHA256:adminA", "SHA256:guestA", true},
+		{"admin removes another admin", "SHA256:adminA", "SHA256:adminB", false},
+		{"admin removes self", "SHA256:adminA", "SHA256:adminA", false},
+		{"admin removes host", "SHA256:adminA", HostFingerprint, false},
+		{"guest removes guest", "SHA256:guestA", "SHA256:guestB", false},
+		{"guest removes admin", "SHA256:guestA", "SHA256:adminA", false},
+		{"actor not enrolled", "SHA256:nobody", "SHA256:guestA", false},
+		{"target not enrolled", HostFingerprint, "SHA256:nobody", false},
+	}
+	for _, c := range cases {
+		if got := s.MayRemove(c.actor, c.target); got != c.want {
+			t.Errorf("%s: MayRemove(%s, %s) = %v, want %v", c.name, c.actor, c.target, got, c.want)
+		}
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -250,8 +250,11 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 			}
 		}
 	case "x":
-		if info.IsHost && !s.inInvites {
-			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
+		// Removal is reachable by the host and admins (v0.30 S3), gated
+		// per-row by the same guardrail the handler enforces: never self,
+		// the host, or (for an admin actor) another admin.
+		if info.CanAdminister && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && mayRemoveRow(info, p) {
 				s.confirmRemove = true
 			}
 		}
@@ -300,6 +303,24 @@ func (s *SessionScreen) selectedInvite(info *sim.SessionInfo) (sim.SessionInvite
 		return sim.SessionInvite{}, false
 	}
 	return info.Invites[s.inviteCursor], true
+}
+
+// mayRemoveRow mirrors sessiondir.MayRemove for UI gating (v0.30 S3):
+// the screen only offers [x] on rows the viewer is actually allowed to
+// remove. The handler re-checks authoritatively — this just avoids
+// dangling a key that would no-op.
+func mayRemoveRow(info *sim.SessionInfo, p sim.SessionPlayer) bool {
+	if !info.CanAdminister {
+		return false
+	}
+	if p.Fingerprint == info.Self || p.Role == "host" {
+		return false
+	}
+	// An admin (can administer but isn't the host) can't remove another admin.
+	if !info.IsHost && p.Role == "admin" {
+		return false
+	}
+	return true
 }
 
 // onlineGuests counts online roster members other than the viewer
@@ -421,10 +442,10 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code"
+		keys += "  [i] invite  [r] revoke code  [x] remove player"
 	}
 	if info.IsHost {
-		keys += "  [x] remove player  [p] promote/demote  [h] stop hosting"
+		keys += "  [p] promote/demote  [h] stop hosting"
 	}
 	if info.CanAdminister {
 		keys += "  [tab] section"

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -286,7 +286,9 @@ func TestSessionScreenAdminView(t *testing.T) {
 	if !strings.Contains(out, "INVITES") || !strings.Contains(out, "[i] invite") {
 		t.Errorf("admin screen missing the invites pane:\n%s", out)
 	}
-	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "[x] remove player") || strings.Contains(out, "stop hosting") {
+	// Admins can remove guests (S3), so [x] is theirs; but delegation and
+	// server lifecycle stay host-only.
+	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "stop hosting") {
 		t.Errorf("admin screen offers host-only keys:\n%s", out)
 	}
 	// [i] arms minting for the admin.
@@ -298,6 +300,54 @@ func TestSessionScreenAdminView(t *testing.T) {
 	s.HandleKey(w, key("j")) // move off self
 	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
 		t.Errorf("admin [p] = %+v, want no command (delegation is host-only)", cmd)
+	}
+}
+
+// Removal row-gating for an admin viewer (v0.30 S3): [x] arms on a
+// guest row, but not on another admin's row, the host's row, or the
+// viewer's own row.
+func TestSessionScreenAdminRemoveGating(t *testing.T) {
+	// Viewer is gern (a promoted admin). Fixture roster: host, gern
+	// (self), dave, pat — mark dave an admin, pat stays a guest.
+	w := sessionWorld(t, false)
+	w.Session.CanAdminister = true
+	w.Session.Players[2].Role = "admin" // dave → admin
+
+	// Row 0 host: not offered.
+	s := NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the host row")
+	}
+
+	// Row 1 self (gern): not offered.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the viewer's own row")
+	}
+
+	// Row 2 dave (admin): an admin can't remove another admin.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on another admin's row")
+	}
+
+	// Row 3 pat (guest): offered → confirm → removal command.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if !s.confirmRemove {
+		t.Fatal("[x] didn't arm on a guest row")
+	}
+	if cmd := s.HandleKey(w, key("y")); cmd.Kind != SessionCmdRemove || cmd.Fingerprint != "SHA256:never" {
+		t.Errorf("guest removal command = %+v", cmd)
 	}
 }
 


### PR DESCRIPTION
Closes #224. **Stacked on #234 (S2)** — base is the S2 branch, so the diff is S3-only.

## What

Extends the admin capability set to the destructive roster action: removing a player. Its own slice because it's the first admin power that can lock someone out.

## Guardrail model (the committed default from the plan)

- an admin may remove **guests**;
- an admin may **not** remove the host, another admin, or themselves;
- only the host may remove/demote an admin — keeps escalation single-rooted.

## How

- `sessiondir.MayRemove(actor, target)` — the actor×target predicate. Actor must carry the admin capability; then: never self, never the host, and an admin-actor can't target another admin. Both fingerprints must be enrolled.
- `serve`: the remove handler consults `MayRemove` (on top of the S1 `MayAdminister` gate) and refuses a disallowed target with a toast — even for a forged intent.
- Session screen: `[x]` is now reachable by admins (was host-only), gated per-row by `mayRemoveRow` (the UI mirror of `MayRemove`) so the key only arms on rows the viewer may act on.

Removal still gates the *next* connect (`RemovePlayer` unchanged, does not kick a live session); a removed player's persisted payload is untouched, exactly as before.

## Tests
- `TestMayRemoveGuardrails` — the full actor×target matrix (host/admin/guest × host/admin/guest, self, unenrolled).
- `TestAdminRemovalGuardrails` (serve) — admin removes a guest; forged removals of the host and of another admin refused at the handler.
- `TestSessionScreenAdminRemoveGating` — `[x]` arms only on a guest row for an admin viewer.

`go vet ./...` clean; `go test ./... -race -count=1` green (1646 tests).