### PR TITLE
S4 (#225): admin drain-and-restart from the Session screen

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -65,6 +65,26 @@ type reportingModel struct {
 // keeps the slice from growing over a long session.
 const localEventTTL = 10 * time.Second
 
+// restartExitCode is the dedicated marker the supervising service
+// manager keys on to tell an admin-requested restart from a crash
+// (v0.30 S4, contract agreed with the deploy host): systemd's
+// ExecStopPost runs tsp-adopt (pull + verify + install) only on
+// $EXIT_STATUS == 42, then Restart=always relaunches. 42 is clear of
+// clean-exit (0), Go panic (2), and signal death (128+N), so it is
+// unambiguous. A plain os.Exit, not a signal — a child can't cleanly
+// signal its supervisor to do work between restarts.
+const restartExitCode = 42
+
+// exitFunc indirects os.Exit so the drain-and-restart path is testable
+// without killing the test process. restartAnnounceGrace is the pause
+// between broadcasting the restart notice and closing the listener, so
+// connected screens render the warning before they are dropped; tests
+// zero it.
+var (
+	exitFunc             = os.Exit
+	restartAnnounceGrace = 1500 * time.Millisecond
+)
+
 const metaRefresh = 5 * time.Second
 
 // withReporting wraps app so its world reports to the store as owner.
@@ -88,6 +108,13 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.startHosting()
 		}
 		return m.stopHosting()
+	}
+
+	// Admin server restart (v0.30 S4): drain everyone and exit with the
+	// supervisor marker. Inert without a server; authorization enforced
+	// here, not just in the UI.
+	if _, ok := msg.(screens.SessionRestartMsg); ok && m.srv != nil {
+		return m.restartServer()
 	}
 
 	// Cross-player docking intents (v0.28 S5): the App can't reach the dock
@@ -453,12 +480,7 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	srv := m.srv
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		_ = srv.Shutdown(ctx)
-		cancel()
-		srv.Wait(5 * time.Second)
-	}()
+	go srv.drainAndClose()
 	m.srv, m.rep, m.owner = nil, nil, ""
 	// Back to solo: clear the slates the wrapper had been feeding so the
 	// Session screen shows the [h]-start dead-end again.
@@ -491,6 +513,46 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	m.localEvents = nil
 	m.app.Toast("hosting stopped")
 	return m, nil
+}
+
+// restartServer drains every connected player and exits with the
+// supervisor marker so the service manager relaunches the process
+// (v0.30 S4). Authorization is enforced here — an admin (or the host)
+// only; a guest's forged intent is refused with a toast. The drain runs
+// in the background so the triggering session's tick loop isn't blocked;
+// it announces the restart, pauses briefly so connected screens render
+// the warning, then closes the listener (persisting every guest's final
+// payload via persistMiddleware) before os.Exit(42).
+func (m reportingModel) restartServer() (tea.Model, tea.Cmd) {
+	if m.srv == nil {
+		return m, nil
+	}
+	if !m.srv.store.MayAdminister(m.owner) {
+		m.app.Toast("only an admin can restart the server")
+		return m, nil
+	}
+	srv, actor := m.srv, m.owner
+	// Announce now so the next tick carries the warning to every screen.
+	srv.presence.event(sim.SessionEventServerRestart, actor, "", "")
+	m.app.Toast("restarting server — draining sessions, everyone reconnects")
+	go func() {
+		time.Sleep(restartAnnounceGrace)
+		srv.drainAndClose()
+		exitFunc(restartExitCode)
+	}()
+	return m, nil
+}
+
+// drainAndClose gracefully stops the listener and waits for every
+// in-flight session to unwind, which writes each guest's final payload
+// through persistMiddleware (v0.28 S3). Shared by the host's
+// stop-hosting toggle and the admin restart (v0.30 S4) so the drain
+// lives in one place. It does not exit the process.
+func (s *Server) drainAndClose() {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	_ = s.Shutdown(ctx)
+	cancel()
+	s.Wait(5 * time.Second)
 }
 
 // Relay exposes the session store (tests and later slices read it).

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -346,6 +346,10 @@ func (m *reportingModel) refreshSession(now time.Time) {
 		CanAdminister: m.srv.store.MayAdminister(m.owner),
 		Self:          m.owner,
 	}
+	// Version surface (v0.30 S5): universal readout, adopt gated.
+	if m.srv.ver != nil {
+		info.RunningVersion, info.AvailableVersion, info.AdoptCapable = m.srv.ver.snapshot()
+	}
 	// Rendezvous roster markers (v0.29 S2): who is armed toward the
 	// viewer, and whom the viewer is armed toward.
 	armedTowardViewer := map[string]bool{}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -129,6 +129,19 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:
 			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
+		case screens.SessionCmdPromote, screens.SessionCmdDemote:
+			// Delegation is host-only — an admin can neither create nor
+			// remove another admin (single-rooted, v0.30 S2). MayAdminister
+			// passed (host or admin); narrow to the host via MayDelegate.
+			if !m.srv.store.MayDelegate(m.owner) {
+				m.app.Toast("only the host can promote or demote admins")
+				return m, nil
+			}
+			if admin.Cmd.Kind == screens.SessionCmdPromote {
+				_ = m.srv.store.PromoteAdmin(admin.Cmd.Fingerprint)
+			} else {
+				_ = m.srv.store.DemoteAdmin(admin.Cmd.Fingerprint)
+			}
 		}
 		m.metaAt = time.Time{} // force refresh — the list is the feedback
 		m.refreshSession(time.Now())
@@ -295,8 +308,9 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	m.reconcileDocking(w, cw.CoupledOwners, reports, handles, now)
 
 	info := &sim.SessionInfo{
-		IsHost: m.owner == sessiondir.HostFingerprint,
-		Self:   m.owner,
+		IsHost:        m.owner == sessiondir.HostFingerprint,
+		CanAdminister: m.srv.store.MayAdminister(m.owner),
+		Self:          m.owner,
 	}
 	// Rendezvous roster markers (v0.29 S2): who is armed toward the
 	// viewer, and whom the viewer is armed toward.
@@ -331,7 +345,7 @@ func (m *reportingModel) refreshSession(now time.Time) {
 		}
 		info.Players = append(info.Players, row)
 	}
-	if info.IsHost {
+	if info.CanAdminister {
 		for _, inv := range m.meta.Invites {
 			info.Invites = append(info.Invites, sim.SessionInvite{
 				Code:   inv.Code,

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -128,6 +128,13 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screens.SessionCmdRevoke:
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:
+			// Target-aware guardrail (v0.30 S3): an admin may remove guests
+			// but not the host, another admin, or themselves. MayAdminister
+			// passed above; MayRemove adds the actor×target rules.
+			if !m.srv.store.MayRemove(m.owner, admin.Cmd.Fingerprint) {
+				m.app.Toast("you can't remove that player")
+				return m, nil
+			}
 			_ = m.srv.store.RemovePlayer(admin.Cmd.Fingerprint)
 		case screens.SessionCmdPromote, screens.SessionCmdDemote:
 			// Delegation is host-only — an admin can neither create nor

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -58,6 +58,12 @@ type Server struct {
 	dock     *relay.DockLedger
 	presence *presence
 
+	// ver is the running-vs-available version readout (v0.30 S5). Created
+	// here (no network — just the running version + adopt-capability env);
+	// its background poll starts in Serve, so unit tests that never call
+	// Serve stay off the wire.
+	ver *versionSurface
+
 	// sessions tracks in-flight session handlers (including their
 	// final persist) so shutdown can wait for payload writes instead
 	// of racing process exit (review follow-up).
@@ -108,7 +114,7 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence()}
+	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence(), ver: newVersionSurface()}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
 	// a guest whose craft rode along in another player's stack reconnects
@@ -155,8 +161,13 @@ func hostHandle() string {
 func (s *Server) Addr() string { return s.ln.Addr().String() }
 
 // Serve accepts sessions until Shutdown; it blocks. A graceful
-// shutdown returns nil.
+// shutdown returns nil. The version-surface poll runs for the listener's
+// life (v0.30 S5) — started here, not in New, so it is off the wire in
+// unit tests that never serve.
 func (s *Server) Serve() error {
+	stop := make(chan struct{})
+	go s.ver.watch(stop)
+	defer close(stop)
 	err := s.ssh.Serve(s.ln)
 	if err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 		return err

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -212,3 +212,52 @@ func TestSessionAdminAuthorizedInHandler(t *testing.T) {
 		t.Errorf("guest forged a removal: gern is gone (%v)", err)
 	}
 }
+
+// The host promotes a guest to admin; the admin can then mint/revoke
+// invites, but delegation stays host-only — a forged promote from the
+// admin's own session is refused (v0.30 S2, #223).
+func TestAdminRoleCapabilities(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	enrollDirect(t, srv, "SHA256:newbie", "newbie")
+
+	// Host promotes gern.
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	host := tick(srv.HostModel(hostApp))
+	host, _ = host.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdPromote, Fingerprint: "SHA256:gern",
+	}})
+	_ = host
+	if p, _ := srv.store.FindPlayer("SHA256:gern"); p.Role != sessiondir.RoleAdmin {
+		t.Fatalf("host promote didn't take: role = %q", p.Role)
+	}
+
+	// gern's own session: admin may mint.
+	gernApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	gern := tick(srv.withReporting(gernApp, "SHA256:gern"))
+	// The admin sees the invite pane.
+	if info := gernApp.World().Session; info == nil || !info.CanAdminister || info.IsHost {
+		t.Fatalf("admin slate = %+v (want CanAdminister, not IsHost)", info)
+	}
+	gern, _ = gern.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdMint, Handle: "fromadmin",
+	}})
+	if meta, _ := srv.store.Meta(); len(meta.Invites) != 1 || meta.Invites[0].Handle != "fromadmin" {
+		t.Errorf("admin mint failed: invites = %+v", meta.Invites)
+	}
+
+	// But delegation is host-only: gern forging a promote is refused.
+	gern, _ = gern.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdPromote, Fingerprint: "SHA256:newbie",
+	}})
+	_ = gern
+	if p, _ := srv.store.FindPlayer("SHA256:newbie"); p.Role != sessiondir.RoleGuest {
+		t.Errorf("admin promoted another player: newbie role = %q", p.Role)
+	}
+}

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -261,3 +261,48 @@ func TestAdminRoleCapabilities(t *testing.T) {
 		t.Errorf("admin promoted another player: newbie role = %q", p.Role)
 	}
 }
+
+// An admin can remove a guest, but the removal guardrails hold at the
+// handler even for forged intents: an admin can't remove another admin
+// or the host (v0.30 S3, #224).
+func TestAdminRemovalGuardrails(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:adminA", "adminA")
+	enrollDirect(t, srv, "SHA256:adminB", "adminB")
+	enrollDirect(t, srv, "SHA256:guest", "guest")
+	if err := srv.store.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := srv.store.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	adminApp, err := srv.newGuestApp("SHA256:adminA")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	admin := tick(srv.withReporting(adminApp, "SHA256:adminA"))
+
+	// Forged removal of the host and of another admin: both refused.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: sessiondir.HostFingerprint,
+	}})
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:adminB",
+	}})
+	if _, err := srv.store.FindPlayer(sessiondir.HostFingerprint); err != nil {
+		t.Errorf("admin removed the host: %v", err)
+	}
+	if _, err := srv.store.FindPlayer("SHA256:adminB"); err != nil {
+		t.Errorf("admin removed another admin: %v", err)
+	}
+
+	// A guest, though: allowed.
+	admin, _ = admin.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdRemove, Fingerprint: "SHA256:guest",
+	}})
+	_ = admin
+	if _, err := srv.store.FindPlayer("SHA256:guest"); !errors.Is(err, sessiondir.ErrNotEnrolled) {
+		t.Errorf("admin couldn't remove a guest: %v", err)
+	}
+}

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -306,3 +306,59 @@ func TestAdminRemovalGuardrails(t *testing.T) {
 		t.Errorf("admin couldn't remove a guest: %v", err)
 	}
 }
+
+// An admin restart drains and exits with the supervisor marker; a guest
+// can't trigger it, enforced at the handler (v0.30 S4, #225). The restart
+// is announced to connected players before the listener closes.
+func TestAdminRestartExitsWithMarker(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+
+	// Capture the exit instead of killing the test process; skip the grace.
+	done := make(chan int, 1)
+	oldExit, oldGrace := exitFunc, restartAnnounceGrace
+	exitFunc = func(code int) { done <- code }
+	restartAnnounceGrace = 0
+	t.Cleanup(func() { exitFunc, restartAnnounceGrace = oldExit, oldGrace })
+
+	// A guest can't restart: the forged intent is refused, no exit.
+	guestApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	guest := tick(srv.withReporting(guestApp, "SHA256:gern"))
+	_, _ = guest.Update(screens.SessionRestartMsg{})
+	select {
+	case code := <-done:
+		t.Fatalf("guest triggered a restart (exit %d)", code)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// The host can: it exits with the dedicated marker.
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	host := tick(srv.HostModel(hostApp))
+	_, _ = host.Update(screens.SessionRestartMsg{})
+
+	// The announcement is broadcast synchronously, before the drain.
+	sawAnnounce := false
+	for _, e := range srv.presence.eventsFor("SHA256:gern") {
+		if e.Kind == sim.SessionEventServerRestart {
+			sawAnnounce = true
+		}
+	}
+	if !sawAnnounce {
+		t.Error("restart wasn't announced to connected players")
+	}
+
+	select {
+	case code := <-done:
+		if code != restartExitCode {
+			t.Errorf("restart exit code = %d, want %d", code, restartExitCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("restart never exited")
+	}
+}

--- a/internal/serve/version.go
+++ b/internal/serve/version.go
@@ -1,0 +1,199 @@
+package serve
+
+// Server version surface (v0.30 S5, #226): a courtesy readout of the
+// running server version against the newest published release, wired to
+// the S4 drain-restart so an admin can adopt an update from inside the
+// game. The game NEVER fetches, verifies, or swaps a binary — "adopt"
+// is drain-restart with the exit-42 marker; the supervising service
+// manager on the deploy host pulls the release. The version check only
+// queries the public release feed, and degrades silently on any failure.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/version"
+)
+
+const (
+	// releaseFeedURL is the repo's public tag list on the GitHub API. Tag
+	// names carry a leading "v"; four-part checkpoint tags are filtered
+	// out by the three-part SemVer test, not by the endpoint.
+	releaseFeedURL = "https://api.github.com/repos/jasonfen/terminal-space-program/tags"
+
+	// adoptCapabilityEnv is the supervisor-set marker signalling the host
+	// has adopt tooling (tsp-adopt on ExecStopPost). Only when it is set
+	// does the Session screen offer the [u] restart-to-adopt affordance;
+	// otherwise the version readout still appears but points at the manual
+	// update path, so the UI never offers an update it can't perform.
+	// The exact token is a game↔host contract detail (proposed with ansi).
+	adoptCapabilityEnv = "TSP_ADOPT"
+
+	// versionCheckInterval is deliberately long — this is a courtesy
+	// readout, not a polling service.
+	versionCheckInterval = 6 * time.Hour
+
+	versionFetchTimeout = 10 * time.Second
+)
+
+// versionSurface holds the running-vs-available readout the Session
+// screen shows. available is the newest published three-part SemVer
+// release strictly greater than running, or "" when the check hasn't
+// succeeded or nothing newer exists. adopt records whether the
+// supervisor signalled adopt-capability. fetch is indirected so tests
+// exercise the comparison without touching the network.
+type versionSurface struct {
+	mu        sync.Mutex
+	running   string
+	available string
+	adopt     bool
+	fetch     func() ([]string, error)
+}
+
+func newVersionSurface() *versionSurface {
+	return &versionSurface{
+		running: version.Version,
+		adopt:   os.Getenv(adoptCapabilityEnv) != "",
+		fetch:   fetchReleaseTags,
+	}
+}
+
+// snapshot returns the current readout under the lock.
+func (v *versionSurface) snapshot() (running, available string, adopt bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.running, v.available, v.adopt
+}
+
+// refresh runs one feed check and updates available. A failed or
+// malformed fetch leaves available untouched — the readout degrades
+// silently to the running version alone, never wedging the session.
+func (v *versionSurface) refresh() {
+	tags, err := v.fetch()
+	if err != nil {
+		return
+	}
+	latest := latestRelease(v.running, tags)
+	v.mu.Lock()
+	v.available = latest
+	v.mu.Unlock()
+}
+
+// watch polls the feed on a conservative interval until stop closes. It
+// runs off the tick loop, in its own goroutine. A build whose running
+// version isn't a real three-part SemVer (a dev/test build) never polls
+// — there is nothing to compare against, and it keeps CI off the wire.
+func (v *versionSurface) watch(stop <-chan struct{}) {
+	if _, _, _, ok := parseSemVer(v.running); !ok {
+		return
+	}
+	v.refresh()
+	t := time.NewTicker(versionCheckInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			v.refresh()
+		}
+	}
+}
+
+// fetchReleaseTags reads the repo's tag names off the public GitHub API.
+func fetchReleaseTags() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), versionFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseFeedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("serve: release feed status %d", resp.StatusCode)
+	}
+	var payload []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	tags := make([]string, 0, len(payload))
+	for _, t := range payload {
+		tags = append(tags, t.Name)
+	}
+	return tags, nil
+}
+
+// latestRelease returns the newest tag that is a valid three-part SemVer
+// release strictly greater than running, normalised to leading-v display
+// form ("v0.30.0"), or "" when none qualifies. Four-part checkpoint tags
+// and malformed entries are ignored; comparison is numeric per component
+// (so v0.29.10 > v0.29.9).
+func latestRelease(running string, tags []string) string {
+	best := ""
+	for _, tag := range tags {
+		if _, _, _, ok := parseSemVer(tag); !ok {
+			continue // not a three-part release (checkpoint tag / junk)
+		}
+		if !semVerLess(running, tag) {
+			continue // not newer than what we run
+		}
+		if best == "" || semVerLess(best, tag) {
+			best = tag
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return "v" + strings.TrimPrefix(best, "v")
+}
+
+// parseSemVer parses "vX.Y.Z" (leading v optional) into three
+// non-negative ints. Four-part (checkpoint) tags and anything malformed
+// return ok=false, so they are never treated as releases.
+func parseSemVer(tag string) (maj, min, pat int, ok bool) {
+	parts := strings.Split(strings.TrimPrefix(strings.TrimSpace(tag), "v"), ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var v [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return 0, 0, 0, false
+		}
+		v[i] = n
+	}
+	return v[0], v[1], v[2], true
+}
+
+// semVerLess reports whether a < b as three-part SemVer. An unparseable
+// operand makes the comparison false, so a dev running version never
+// counts as older than any release (no nag) and junk tags never win.
+func semVerLess(a, b string) bool {
+	am, an, ap, aok := parseSemVer(a)
+	bm, bn, bp, bok := parseSemVer(b)
+	if !aok || !bok {
+		return false
+	}
+	if am != bm {
+		return am < bm
+	}
+	if an != bn {
+		return an < bn
+	}
+	return ap < bp
+}

--- a/internal/serve/version_test.go
+++ b/internal/serve/version_test.go
@@ -1,0 +1,64 @@
+package serve
+
+import (
+	"errors"
+	"testing"
+)
+
+// latestRelease picks the newest three-part SemVer strictly greater than
+// the running version, ignoring four-part checkpoint tags and junk, with
+// numeric (not lexical) component comparison (v0.30 S5, #226).
+func TestLatestRelease(t *testing.T) {
+	cases := []struct {
+		name    string
+		running string
+		tags    []string
+		want    string
+	}{
+		{"newer release", "0.29.1", []string{"v0.29.1", "v0.30.0", "v0.28.4"}, "v0.30.0"},
+		{"numeric compare beats lexical", "0.29.9", []string{"v0.29.10"}, "v0.29.10"},
+		{"four-part checkpoint ignored", "0.29.0", []string{"v0.29.1.3"}, ""},
+		{"checkpoint alongside release", "0.29.1", []string{"v0.29.1.3", "v0.30.0"}, "v0.30.0"},
+		{"nothing newer", "0.30.0", []string{"v0.29.1", "v0.30.0"}, ""},
+		{"malformed tags skipped", "0.29.1", []string{"garbage", "v", "v0.30.0"}, "v0.30.0"},
+		{"dev running never nags", "dev", []string{"v0.30.0"}, ""},
+		{"picks the max of several", "0.28.0", []string{"v0.29.0", "v0.30.2", "v0.30.1"}, "v0.30.2"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := latestRelease(c.running, c.tags); got != c.want {
+				t.Errorf("latestRelease(%q, %v) = %q, want %q", c.running, c.tags, got, c.want)
+			}
+		})
+	}
+}
+
+// refresh stores the newest release; a failed fetch degrades silently
+// (available left untouched). adopt-capability comes from the env.
+func TestVersionSurfaceRefresh(t *testing.T) {
+	vs := &versionSurface{running: "0.29.1"}
+
+	// Successful fetch → available set.
+	vs.fetch = func() ([]string, error) { return []string{"v0.30.0", "v0.29.1.9"}, nil }
+	vs.refresh()
+	if _, avail, _ := vs.snapshot(); avail != "v0.30.0" {
+		t.Errorf("available = %q after fetch, want v0.30.0", avail)
+	}
+
+	// A later failed fetch must not clobber the last good reading.
+	vs.fetch = func() ([]string, error) { return nil, errors.New("network down") }
+	vs.refresh()
+	if _, avail, _ := vs.snapshot(); avail != "v0.30.0" {
+		t.Errorf("failed fetch clobbered available to %q", avail)
+	}
+
+	// adopt-capability rides the env marker.
+	t.Setenv(adoptCapabilityEnv, "1")
+	if vs := newVersionSurface(); !vs.adopt {
+		t.Error("adopt not set from env marker")
+	}
+	t.Setenv(adoptCapabilityEnv, "")
+	if vs := newVersionSurface(); vs.adopt {
+		t.Error("adopt set with the env marker cleared")
+	}
+}

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -438,6 +438,52 @@ func (s *Store) MayDelegate(fingerprint string) bool {
 	return p.Role == RoleHost
 }
 
+// MayRemove reports whether actor may remove target from the roster
+// (v0.30 S3, #224) — the guardrail matrix for the first admin power that
+// can lock someone out. The rules keep escalation single-rooted:
+//
+//   - the actor must carry the admin capability (host or admin);
+//   - nobody removes themselves (avoids a self-inflicted lockout);
+//   - nobody removes the host (the session's root);
+//   - an admin may not remove another admin — only the host may
+//     (mirrors promotion being host-only).
+//
+// Both fingerprints must be enrolled. The store's RemovePlayer still
+// guards the host independently; this predicate is the actor-aware gate
+// the serve handler consults before calling it.
+func (s *Store) MayRemove(actor, target string) bool {
+	if actor == target {
+		return false
+	}
+	m, err := s.Meta()
+	if err != nil {
+		return false
+	}
+	var actorRole, targetRole string
+	var haveActor, haveTarget bool
+	for _, p := range m.Roster {
+		switch p.Fingerprint {
+		case actor:
+			actorRole, haveActor = p.Role, true
+		case target:
+			targetRole, haveTarget = p.Role, true
+		}
+	}
+	if !haveActor || !haveTarget {
+		return false
+	}
+	if !roleMayAdminister(actorRole) {
+		return false
+	}
+	if targetRole == RoleHost {
+		return false
+	}
+	if actorRole == RoleAdmin && targetRole == RoleAdmin {
+		return false
+	}
+	return true
+}
+
 // PromoteAdmin grants the admin role to an enrolled guest by
 // fingerprint. Idempotent — re-promoting an admin is a no-op. The host
 // is rejected (already root) and an unknown fingerprint returns

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -42,11 +42,16 @@ import (
 // migrateMetaV1ToV2; live v0.27 sessions never break.
 const MetaVersion = 2
 
-// Roster roles. Host is the one privileged role (ADR 0034): the
-// player whose machine runs the session, with invite and removal
-// authority. Everyone else is a guest.
+// Roster roles. Host is the session's root operator (ADR 0034): the
+// player whose machine runs the session, with invite/removal authority
+// and the sole power to delegate administration. Admin is a guest the
+// host has promoted — it carries the invite/removal capability but not
+// delegation (single-rooted escalation, v0.30 S2). Everyone else is a
+// guest. The role is a plain persisted string on the roster entry, so
+// adding admin is additive: no MetaVersion bump, no migration.
 const (
 	RoleHost  = "host"
+	RoleAdmin = "admin"
 	RoleGuest = "guest"
 )
 
@@ -414,10 +419,63 @@ func (s *Store) MayAdminister(fingerprint string) bool {
 }
 
 // roleMayAdminister centralises which roster roles carry the admin
-// capability, so granting the admin role (S2) is a one-line change here
-// rather than a re-plumb of every caller.
+// capability (mint/revoke invites, remove guests). The host and any
+// promoted admin qualify; a plain guest does not.
 func roleMayAdminister(role string) bool {
-	return role == RoleHost
+	return role == RoleHost || role == RoleAdmin
+}
+
+// MayDelegate reports whether the fingerprint may promote a guest to
+// admin or demote an admin back to guest. Single-rooted escalation
+// (v0.30 S2): only the host delegates administration — an admin can
+// neither create nor remove another admin. Kept distinct from
+// MayAdminister so the escalation tree stays single-rooted.
+func (s *Store) MayDelegate(fingerprint string) bool {
+	p, err := s.FindPlayer(fingerprint)
+	if err != nil {
+		return false
+	}
+	return p.Role == RoleHost
+}
+
+// PromoteAdmin grants the admin role to an enrolled guest by
+// fingerprint. Idempotent — re-promoting an admin is a no-op. The host
+// is rejected (already root) and an unknown fingerprint returns
+// ErrNotEnrolled. Only the host should call this (enforced at the
+// handler via MayDelegate); the store guards the host-role invariant.
+func (s *Store) PromoteAdmin(fingerprint string) error {
+	return s.setRole(fingerprint, RoleAdmin)
+}
+
+// DemoteAdmin returns an admin to guest by fingerprint. Idempotent for
+// a player already a guest; rejects the host and unknown fingerprints.
+func (s *Store) DemoteAdmin(fingerprint string) error {
+	return s.setRole(fingerprint, RoleGuest)
+}
+
+// setRole is the shared guest↔admin role mutation. The host's role is
+// immutable (it is the single root); an unknown fingerprint is
+// ErrNotEnrolled.
+func (s *Store) setRole(fingerprint, role string) error {
+	if fingerprint == HostFingerprint {
+		return errors.New("sessiondir: can't change the host's role")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return err
+	}
+	for i := range m.Roster {
+		if m.Roster[i].Fingerprint == fingerprint {
+			if m.Roster[i].Role == RoleHost {
+				return errors.New("sessiondir: can't change the host's role")
+			}
+			m.Roster[i].Role = role
+			return s.writeMeta(m)
+		}
+	}
+	return ErrNotEnrolled
 }
 
 // FindPlayer looks a fingerprint up in the roster.

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -111,6 +111,70 @@ func TestMayAdminister(t *testing.T) {
 	}
 }
 
+// PromoteAdmin/DemoteAdmin round-trip a guest through the admin role
+// (v0.30 S2): the role persists, MayAdminister flips with it, delegation
+// stays host-only, and the host's role is immutable.
+func TestPromoteDemoteRole(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	inv, _ := s.MintInvite("dave")
+	if _, err := s.Enroll(inv.Code, "SHA256:dave", "dave"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+
+	// Promote → admin, may administer but may not delegate.
+	if err := s.PromoteAdmin("SHA256:dave"); err != nil {
+		t.Fatalf("PromoteAdmin: %v", err)
+	}
+	if !s.MayAdminister("SHA256:dave") {
+		t.Error("promoted admin may not administer")
+	}
+	if s.MayDelegate("SHA256:dave") {
+		t.Error("admin may delegate — escalation not single-rooted")
+	}
+	if !s.MayDelegate(HostFingerprint) {
+		t.Error("host may not delegate")
+	}
+	// Idempotent grant.
+	if err := s.PromoteAdmin("SHA256:dave"); err != nil {
+		t.Errorf("re-promote not idempotent: %v", err)
+	}
+
+	// Persists across a reopen (role rides the roster string).
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if p, _ := s2.FindPlayer("SHA256:dave"); p.Role != RoleAdmin {
+		t.Errorf("admin role not persisted: role = %q", p.Role)
+	}
+	if m2, _ := s2.Meta(); m2.Version != MetaVersion {
+		t.Errorf("promote bumped MetaVersion to %d (want additive, %d)", m2.Version, MetaVersion)
+	}
+
+	// Demote → guest.
+	if err := s2.DemoteAdmin("SHA256:dave"); err != nil {
+		t.Fatalf("DemoteAdmin: %v", err)
+	}
+	if s2.MayAdminister("SHA256:dave") {
+		t.Error("demoted player still administers")
+	}
+
+	// Guards: host immutable, unknown fingerprint rejected.
+	if err := s2.PromoteAdmin(HostFingerprint); err == nil {
+		t.Error("promoting the host was allowed")
+	}
+	if err := s2.PromoteAdmin("SHA256:nobody"); !errors.Is(err, ErrNotEnrolled) {
+		t.Errorf("promote unknown fingerprint: err = %v, want ErrNotEnrolled", err)
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -175,6 +175,55 @@ func TestPromoteDemoteRole(t *testing.T) {
 	}
 }
 
+// MayRemove encodes the actor×target guardrail matrix (v0.30 S3, #224):
+// host removes guests and admins; an admin removes only guests; nobody
+// removes the host or themselves; guests remove no one.
+func TestMayRemoveGuardrails(t *testing.T) {
+	s := openStore(t)
+	if _, err := s.EnsureHost("jason"); err != nil {
+		t.Fatalf("EnsureHost: %v", err)
+	}
+	// adminA, adminB (promoted), guestA, guestB.
+	for _, e := range []struct{ fp, handle string }{
+		{"SHA256:adminA", "adminA"}, {"SHA256:adminB", "adminB"},
+		{"SHA256:guestA", "guestA"}, {"SHA256:guestB", "guestB"},
+	} {
+		inv, _ := s.MintInvite(e.handle)
+		if _, err := s.Enroll(inv.Code, e.fp, e.handle); err != nil {
+			t.Fatalf("Enroll %s: %v", e.handle, err)
+		}
+	}
+	if err := s.PromoteAdmin("SHA256:adminA"); err != nil {
+		t.Fatalf("promote adminA: %v", err)
+	}
+	if err := s.PromoteAdmin("SHA256:adminB"); err != nil {
+		t.Fatalf("promote adminB: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		actor, target  string
+		want           bool
+	}{
+		{"host removes guest", HostFingerprint, "SHA256:guestA", true},
+		{"host removes admin", HostFingerprint, "SHA256:adminA", true},
+		{"host removes self", HostFingerprint, HostFingerprint, false},
+		{"admin removes guest", "SHA256:adminA", "SHA256:guestA", true},
+		{"admin removes another admin", "SHA256:adminA", "SHA256:adminB", false},
+		{"admin removes self", "SHA256:adminA", "SHA256:adminA", false},
+		{"admin removes host", "SHA256:adminA", HostFingerprint, false},
+		{"guest removes guest", "SHA256:guestA", "SHA256:guestB", false},
+		{"guest removes admin", "SHA256:guestA", "SHA256:adminA", false},
+		{"actor not enrolled", "SHA256:nobody", "SHA256:guestA", false},
+		{"target not enrolled", HostFingerprint, "SHA256:nobody", false},
+	}
+	for _, c := range cases {
+		if got := s.MayRemove(c.actor, c.target); got != c.want {
+			t.Errorf("%s: MayRemove(%s, %s) = %v, want %v", c.name, c.actor, c.target, got, c.want)
+		}
+	}
+}
+
 // Invite codes are one-time: enroll consumes; a second enroll (or a
 // bogus code) is rejected. Peek validates without consuming, and the
 // handle is editable at enroll.

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -79,6 +79,12 @@ const (
 	SessionEventRendezvousArrived   // the shared coast reached τ ("rendezvous with X — encounter reached")
 	SessionEventRendezvousCancelled // the arm/coast was released before τ ("rendezvous with X cancelled")
 	SessionEventRendezvousDegraded  // the held encounter slipped past the committed approach
+
+	// SessionEventServerRestart announces an admin-triggered graceful
+	// restart to every connected player before the listener drains
+	// (v0.30 S4) — a warning, not a silent drop; progress persists and a
+	// reconnect resumes.
+	SessionEventServerRestart
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -57,6 +57,16 @@ type SessionInfo struct {
 	Self          string // viewer's fingerprint — the screen marks "you"
 	Players       []SessionPlayer
 	Invites       []SessionInvite // populated for the host and admins
+
+	// Version surface (v0.30 S5). RunningVersion is always set on a
+	// server; AvailableVersion is the newest published release when one is
+	// newer than running (else ""); AdoptCapable is whether the supervisor
+	// signalled adopt-capability — only then is the [u] restart-to-adopt
+	// affordance offered (else the screen points at the manual update
+	// path). The readout is universal; only the adopt action is gated.
+	RunningVersion   string
+	AvailableVersion string
+	AdoptCapable     bool
 }
 
 // SessionEventKind enumerates the moments the chip stack surfaces.

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -48,10 +48,15 @@ type SessionInvite struct {
 
 // SessionInfo is the Session screen's whole slate.
 type SessionInfo struct {
-	IsHost  bool
-	Self    string // viewer's fingerprint — the screen marks "you"
-	Players []SessionPlayer
-	Invites []SessionInvite // populated only for the host
+	IsHost bool // viewer is the session's root host (promote/demote, stop-hosting)
+	// CanAdminister is true for the host and any promoted admin (v0.30
+	// S2): the invite pane and mint/revoke are gated on this, not on
+	// IsHost. Authorization is still enforced in the serve handler — this
+	// only drives what the screen offers.
+	CanAdminister bool
+	Self          string // viewer's fingerprint — the screen marks "you"
+	Players       []SessionPlayer
+	Invites       []SessionInvite // populated for the host and admins
 }
 
 // SessionEventKind enumerates the moments the chip stack surfaces.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1776,7 +1776,8 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 	case screens.SessionCmdStopHost:
 		msg := screens.SessionHostMsg{Start: false}
 		return a, func() tea.Msg { return msg }
-	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove:
+	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove,
+		screens.SessionCmdPromote, screens.SessionCmdDemote:
 		msg := screens.SessionAdminMsg{Cmd: cmd}
 		return a, func() tea.Msg { return msg }
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1776,6 +1776,8 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 	case screens.SessionCmdStopHost:
 		msg := screens.SessionHostMsg{Start: false}
 		return a, func() tea.Msg { return msg }
+	case screens.SessionCmdRestart:
+		return a, func() tea.Msg { return screens.SessionRestartMsg{} }
 	case screens.SessionCmdMint, screens.SessionCmdRevoke, screens.SessionCmdRemove,
 		screens.SessionCmdPromote, screens.SessionCmdDemote:
 		msg := screens.SessionAdminMsg{Cmd: cmd}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -160,6 +160,8 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			plain("◇ rendezvous with " + e.Handle + " cancelled")
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
+		case sim.SessionEventServerRestart:
+			rows = append(rows, row{text: "⚠ server restarting — reconnect in a moment, progress saved", alert: true})
 		}
 	}
 	if len(rows) == 0 {

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -50,6 +50,8 @@ const (
 	SessionCmdStartHost   // solo → start hosting (v0.28 S3)
 	SessionCmdStopHost    // hosting → stop the listener (v0.28 S3)
 	SessionCmdRendezvous  // arm a Rendezvous Warp toward Owner's ghost Owner/CraftID (v0.29 S2)
+	SessionCmdPromote     // host promotes Fingerprint (guest → admin) (v0.30 S2)
+	SessionCmdDemote      // host demotes Fingerprint (admin → guest) (v0.30 S2)
 )
 
 // SessionCommand is the screen's finalized action.
@@ -64,8 +66,9 @@ type SessionCommand struct {
 	Time        time.Time // SessionCmdSync: the subspace time to chase
 }
 
-// SessionAdminMsg carries a mint/revoke/remove intent out of the App
-// to the serve-layer wrapper (which owns the session store). In
+// SessionAdminMsg carries a session-admin intent (mint/revoke/remove,
+// or host-only promote/demote) out of the App to the serve-layer
+// wrapper, which owns the session store and enforces authorization. In
 // single-player nothing handles it — the message is inert.
 type SessionAdminMsg struct{ Cmd SessionCommand }
 
@@ -165,7 +168,7 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 	case "down", "j":
 		s.moveCursor(info, +1)
 	case "tab":
-		if info.IsHost && len(info.Invites) > 0 {
+		if info.CanAdminister && len(info.Invites) > 0 {
 			s.inInvites = !s.inInvites
 		}
 	case "t":
@@ -236,12 +239,12 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		}
 		return SessionCommand{Kind: SessionCmdSync, Owner: p.Fingerprint, Handle: p.Handle, Time: w.Clock.SimTime.Add(p.DeltaT)}
 	case "i":
-		if info.IsHost {
+		if info.CanAdminister {
 			s.minting = true
 			s.mintInput = nil
 		}
 	case "r":
-		if info.IsHost && s.inInvites {
+		if info.CanAdminister && s.inInvites {
 			if inv, ok := s.selectedInvite(info); ok {
 				return SessionCommand{Kind: SessionCmdRevoke, Code: inv.Code, Handle: inv.Handle}
 			}
@@ -250,6 +253,21 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		if info.IsHost && !s.inInvites {
 			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
 				s.confirmRemove = true
+			}
+		}
+	case "p":
+		// Host-only delegation (v0.30 S2): promote a guest to admin or
+		// demote an admin back to guest. Single-rooted — an admin never
+		// sees this. Absent on the host's own row and on non-guest/admin
+		// rows.
+		if info.IsHost && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && p.Fingerprint != info.Self {
+				switch p.Role {
+				case "guest":
+					return SessionCommand{Kind: SessionCmdPromote, Fingerprint: p.Fingerprint, Handle: p.Handle}
+				case "admin":
+					return SessionCommand{Kind: SessionCmdDemote, Fingerprint: p.Fingerprint, Handle: p.Handle}
+				}
 			}
 		}
 	case "h":
@@ -334,8 +352,11 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		}
 		name := p.Handle
 		var tags []string
-		if p.Role == "host" {
+		switch p.Role {
+		case "host":
 			tags = append(tags, "host")
+		case "admin":
+			tags = append(tags, "admin")
 		}
 		if p.Fingerprint == info.Self {
 			tags = append(tags, "you")
@@ -365,7 +386,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 			marker, dot, name, where, craft, formatDeltaT(p, info.Self == p.Fingerprint)))
 	}
 
-	if info.IsHost {
+	if info.CanAdminister {
 		b.WriteString("\n" + s.theme.Title.Render(" INVITES ") + "\n\n")
 		// Normalise section focus (review follow-up): revoking the last
 		// invite while focused there must not strand the cursor in an
@@ -399,8 +420,14 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
+	if info.CanAdminister {
+		keys += "  [i] invite  [r] revoke code"
+	}
 	if info.IsHost {
-		keys += "  [i] invite  [r] revoke code  [x] remove player  [h] stop hosting  [tab] section"
+		keys += "  [x] remove player  [p] promote/demote  [h] stop hosting"
+	}
+	if info.CanAdminister {
+		keys += "  [tab] section"
 	}
 	keys += "  [esc] close"
 	b.WriteString(s.theme.Footer.Render(keys))

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -250,8 +250,11 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 			}
 		}
 	case "x":
-		if info.IsHost && !s.inInvites {
-			if p, ok := s.selectedPlayer(info); ok && p.Role != "host" {
+		// Removal is reachable by the host and admins (v0.30 S3), gated
+		// per-row by the same guardrail the handler enforces: never self,
+		// the host, or (for an admin actor) another admin.
+		if info.CanAdminister && !s.inInvites {
+			if p, ok := s.selectedPlayer(info); ok && mayRemoveRow(info, p) {
 				s.confirmRemove = true
 			}
 		}
@@ -300,6 +303,24 @@ func (s *SessionScreen) selectedInvite(info *sim.SessionInfo) (sim.SessionInvite
 		return sim.SessionInvite{}, false
 	}
 	return info.Invites[s.inviteCursor], true
+}
+
+// mayRemoveRow mirrors sessiondir.MayRemove for UI gating (v0.30 S3):
+// the screen only offers [x] on rows the viewer is actually allowed to
+// remove. The handler re-checks authoritatively — this just avoids
+// dangling a key that would no-op.
+func mayRemoveRow(info *sim.SessionInfo, p sim.SessionPlayer) bool {
+	if !info.CanAdminister {
+		return false
+	}
+	if p.Fingerprint == info.Self || p.Role == "host" {
+		return false
+	}
+	// An admin (can administer but isn't the host) can't remove another admin.
+	if !info.IsHost && p.Role == "admin" {
+		return false
+	}
+	return true
 }
 
 // onlineGuests counts online roster members other than the viewer
@@ -421,10 +442,10 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code"
+		keys += "  [i] invite  [r] revoke code  [x] remove player"
 	}
 	if info.IsHost {
-		keys += "  [x] remove player  [p] promote/demote  [h] stop hosting"
+		keys += "  [p] promote/demote  [h] stop hosting"
 	}
 	if info.CanAdminister {
 		keys += "  [tab] section"

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -30,6 +30,7 @@ type SessionScreen struct {
 	mintInput       []rune
 	confirmRemove   bool // pending [x] confirmation on the selected player
 	confirmStopHost bool // pending [h] stop-hosting confirmation (v0.28 S3)
+	confirmRestart  bool // pending [u] server-restart confirmation (v0.30 S4)
 }
 
 func NewSessionScreen(th Theme) *SessionScreen { return &SessionScreen{theme: th} }
@@ -52,6 +53,7 @@ const (
 	SessionCmdRendezvous  // arm a Rendezvous Warp toward Owner's ghost Owner/CraftID (v0.29 S2)
 	SessionCmdPromote     // host promotes Fingerprint (guest → admin) (v0.30 S2)
 	SessionCmdDemote      // host demotes Fingerprint (admin → guest) (v0.30 S2)
+	SessionCmdRestart     // admin drain-and-restart the server (v0.30 S4)
 )
 
 // SessionCommand is the screen's finalized action.
@@ -78,11 +80,17 @@ type SessionAdminMsg struct{ Cmd SessionCommand }
 // no wrapper (there is always one now) it is inert.
 type SessionHostMsg struct{ Start bool }
 
+// SessionRestartMsg carries an admin's drain-and-restart intent out of
+// the App to the serve-layer wrapper (v0.30 S4). The wrapper enforces
+// authorization, drains connected players, and exits with a marker the
+// supervising service manager restarts on. Inert in single-player.
+type SessionRestartMsg struct{}
+
 // Reset re-arms the screen for a fresh open.
 func (s *SessionScreen) Reset() {
 	s.cursor, s.inviteCursor = 0, 0
 	s.inInvites, s.minting, s.confirmRemove = false, false, false
-	s.confirmStopHost = false
+	s.confirmStopHost, s.confirmRestart = false, false
 	s.mintInput = nil
 }
 
@@ -156,6 +164,14 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		s.confirmStopHost = false
 		if msg.String() == "y" || msg.String() == "Y" {
 			return SessionCommand{Kind: SessionCmdStopHost}
+		}
+		return SessionCommand{}
+	}
+
+	if s.confirmRestart {
+		s.confirmRestart = false
+		if msg.String() == "y" || msg.String() == "Y" {
+			return SessionCommand{Kind: SessionCmdRestart}
 		}
 		return SessionCommand{}
 	}
@@ -278,6 +294,13 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 		// guests. Guests never reach this — their slate is never IsHost.
 		if info.IsHost {
 			s.confirmStopHost = true
+		}
+	case "u":
+		// Admin server restart (v0.30 S4): drain everyone and exit with a
+		// marker the supervisor restarts on. Confirm first (states the
+		// drop count). Host and admins; guests never reach it.
+		if info.CanAdminister {
+			s.confirmRestart = true
 		}
 	}
 	return SessionCommand{}
@@ -440,9 +463,12 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	if s.confirmStopHost {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
+	if s.confirmRestart {
+		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  restart server? drops %d player(s) — progress persists, they reconnect [y/n]", onlineGuests(info))) + "\n")
+	}
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code  [x] remove player"
+		keys += "  [i] invite  [r] revoke code  [x] remove player  [u] restart server"
 	}
 	if info.IsHost {
 		keys += "  [p] promote/demote  [h] stop hosting"

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -346,6 +346,51 @@ func mayRemoveRow(info *sim.SessionInfo, p sim.SessionPlayer) bool {
 	return true
 }
 
+// releasesPageURL is where an install without adopt tooling is pointed
+// to update manually (v0.30 S5).
+const releasesPageURL = "github.com/jasonfen/terminal-space-program/releases"
+
+// adopting reports whether the [u] restart should be framed as adopting
+// an available release: a newer version exists AND the supervisor
+// signalled adopt-capability. Absent either, [u] is a plain restart and
+// the readout points at the manual update path — the UI never offers an
+// update it can't perform.
+func adopting(info *sim.SessionInfo) bool {
+	return info.AvailableVersion != "" && info.AdoptCapable
+}
+
+// restartKeyLabel is the footer label for [u] — "restart to adopt vX"
+// when adopting, else a plain "restart server".
+func restartKeyLabel(info *sim.SessionInfo) string {
+	if adopting(info) {
+		return "[u] restart to adopt " + displayVer(info.AvailableVersion)
+	}
+	return "[u] restart server"
+}
+
+// restartPrompt is the confirmation line for [u], adopt-aware and naming
+// the drop count.
+func restartPrompt(info *sim.SessionInfo) string {
+	if adopting(info) {
+		return fmt.Sprintf("restart to adopt %s? drops %d player(s) — progress persists, they reconnect",
+			displayVer(info.AvailableVersion), onlineGuests(info))
+	}
+	return fmt.Sprintf("restart server? drops %d player(s) — progress persists, they reconnect", onlineGuests(info))
+}
+
+// displayVer normalises a version string for display: a numeric SemVer
+// gets a leading "v" (release ldflags strip it); a non-numeric build
+// string like "dev" is shown as-is.
+func displayVer(v string) string {
+	if v == "" {
+		return v
+	}
+	if v[0] >= '0' && v[0] <= '9' {
+		return "v" + v
+	}
+	return v
+}
+
 // onlineGuests counts online roster members other than the viewer
 // (the host) — the population a stop-hosting drops (v0.28 S3).
 func onlineGuests(info *sim.SessionInfo) int {
@@ -464,11 +509,27 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
 	if s.confirmRestart {
-		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  restart server? drops %d player(s) — progress persists, they reconnect [y/n]", onlineGuests(info))) + "\n")
+		b.WriteString(s.theme.Alert.Render("  "+restartPrompt(info)+" [y/n]") + "\n")
 	}
+
+	// Version surface (v0.30 S5): always show the running version; when a
+	// newer release exists, show it, and — on a box with no adopt tooling
+	// — point at the manual update path so the UI never offers an update
+	// it can't perform.
+	if info.RunningVersion != "" {
+		line := "  running " + displayVer(info.RunningVersion)
+		if info.AvailableVersion != "" {
+			line += " — update available: " + displayVer(info.AvailableVersion)
+		}
+		b.WriteString(s.theme.Dim.Render(line) + "\n")
+		if info.AvailableVersion != "" && !info.AdoptCapable {
+			b.WriteString(s.theme.Dim.Render("  update manually — "+releasesPageURL) + "\n")
+		}
+	}
+
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code  [x] remove player  [u] restart server"
+		keys += "  [i] invite  [r] revoke code  [x] remove player  " + restartKeyLabel(info)
 	}
 	if info.IsHost {
 		keys += "  [p] promote/demote  [h] stop hosting"

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -351,6 +351,51 @@ func TestSessionScreenAdminRemoveGating(t *testing.T) {
 	}
 }
 
+// Restart (v0.30 S4): [u] arms a confirm naming the drop count; y emits
+// the restart command. Reachable by host and admin; a plain guest never
+// sees the key.
+func TestSessionScreenRestartConfirm(t *testing.T) {
+	// Host viewer: one online guest (gern).
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+
+	if cmd := s.HandleKey(w, key("u")); cmd.Kind != SessionCmdNone {
+		t.Fatalf("[u] emitted %v before confirm", cmd.Kind)
+	}
+	if out := s.Render(w, 120); !strings.Contains(out, "restart server? drops 1 player(s)") {
+		t.Errorf("restart confirm prompt missing:\n%s", out)
+	}
+	if !strings.Contains(s.Render(w, 120), "[u] restart server") {
+		t.Error("admin footer missing the restart hint")
+	}
+	if cmd := s.HandleKey(w, key("y")); cmd.Kind != SessionCmdRestart {
+		t.Errorf("confirm y = %+v, want SessionCmdRestart", cmd)
+	}
+	// n cancels.
+	s.HandleKey(w, key("u"))
+	if cmd := s.HandleKey(w, key("n")); cmd.Kind != SessionCmdNone {
+		t.Errorf("confirm n = %+v, want no command", cmd)
+	}
+
+	// An admin (CanAdminister, not IsHost) also gets it.
+	adminScreen := NewSessionScreen(sessionTheme())
+	wa := sessionWorld(t, false)
+	wa.Session.CanAdminister = true
+	if cmd := adminScreen.HandleKey(wa, key("u")); cmd.Kind != SessionCmdNone || !adminScreen.confirmRestart {
+		t.Errorf("admin [u] didn't arm restart confirm (cmd %+v)", cmd)
+	}
+
+	// A guest doesn't: [u] inert, no hint.
+	guestScreen := NewSessionScreen(sessionTheme())
+	wg := sessionWorld(t, false)
+	if cmd := guestScreen.HandleKey(wg, key("u")); cmd.Kind != SessionCmdNone || guestScreen.confirmRestart {
+		t.Errorf("guest [u] armed a restart (cmd %+v)", cmd)
+	}
+	if strings.Contains(guestScreen.Render(wg, 120), "restart server") {
+		t.Error("guest screen offers the restart key")
+	}
+}
+
 // A guest never reaches the host toggle: their slate is never IsHost,
 // so [h] is inert and the stop-hosting hint is absent.
 func TestSessionScreenGuestNoHost(t *testing.T) {

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -286,7 +286,9 @@ func TestSessionScreenAdminView(t *testing.T) {
 	if !strings.Contains(out, "INVITES") || !strings.Contains(out, "[i] invite") {
 		t.Errorf("admin screen missing the invites pane:\n%s", out)
 	}
-	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "[x] remove player") || strings.Contains(out, "stop hosting") {
+	// Admins can remove guests (S3), so [x] is theirs; but delegation and
+	// server lifecycle stay host-only.
+	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "stop hosting") {
 		t.Errorf("admin screen offers host-only keys:\n%s", out)
 	}
 	// [i] arms minting for the admin.
@@ -298,6 +300,54 @@ func TestSessionScreenAdminView(t *testing.T) {
 	s.HandleKey(w, key("j")) // move off self
 	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
 		t.Errorf("admin [p] = %+v, want no command (delegation is host-only)", cmd)
+	}
+}
+
+// Removal row-gating for an admin viewer (v0.30 S3): [x] arms on a
+// guest row, but not on another admin's row, the host's row, or the
+// viewer's own row.
+func TestSessionScreenAdminRemoveGating(t *testing.T) {
+	// Viewer is gern (a promoted admin). Fixture roster: host, gern
+	// (self), dave, pat — mark dave an admin, pat stays a guest.
+	w := sessionWorld(t, false)
+	w.Session.CanAdminister = true
+	w.Session.Players[2].Role = "admin" // dave → admin
+
+	// Row 0 host: not offered.
+	s := NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the host row")
+	}
+
+	// Row 1 self (gern): not offered.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on the viewer's own row")
+	}
+
+	// Row 2 dave (admin): an admin can't remove another admin.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if s.confirmRemove {
+		t.Error("[x] armed on another admin's row")
+	}
+
+	// Row 3 pat (guest): offered → confirm → removal command.
+	s = NewSessionScreen(sessionTheme())
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("x"))
+	if !s.confirmRemove {
+		t.Fatal("[x] didn't arm on a guest row")
+	}
+	if cmd := s.HandleKey(w, key("y")); cmd.Kind != SessionCmdRemove || cmd.Fingerprint != "SHA256:never" {
+		t.Errorf("guest removal command = %+v", cmd)
 	}
 }
 

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -34,8 +34,9 @@ func sessionWorld(t *testing.T, isHost bool) *sim.World {
 		self = "SHA256:guest"
 	}
 	w.Session = &sim.SessionInfo{
-		IsHost: isHost,
-		Self:   self,
+		IsHost:        isHost,
+		CanAdminister: isHost, // the host administers; admins are covered separately
+		Self:          self,
 		Players: []sim.SessionPlayer{
 			{Fingerprint: "local", Handle: "jason", Role: "host", Online: true,
 				HasReport: true, System: "Sol", Primary: "earth", CraftCount: 2, DeltaT: 0},
@@ -240,6 +241,63 @@ func TestSessionScreenStopHostConfirm(t *testing.T) {
 	s.HandleKey(w, key("h"))
 	if cmd := s.HandleKey(w, key("n")); cmd.Kind != SessionCmdNone {
 		t.Errorf("confirm n = %+v, want no command", cmd)
+	}
+}
+
+// Promote/demote (v0.30 S2) is host-only: [p] on a guest row emits
+// Promote, on an admin row emits Demote, and is inert on the host's own
+// row.
+func TestSessionScreenPromoteKey(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+
+	// Cursor on the host — [p] must not act.
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
+		t.Errorf("[p] on host's own row = %+v, want no command", cmd)
+	}
+
+	s.HandleKey(w, key("j")) // gern (guest)
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdPromote || cmd.Fingerprint != "SHA256:guest" {
+		t.Errorf("[p] on guest = %+v, want Promote", cmd)
+	}
+
+	// Flip gern to admin — [p] now demotes.
+	w.Session.Players[1].Role = "admin"
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdDemote || cmd.Fingerprint != "SHA256:guest" {
+		t.Errorf("[p] on admin = %+v, want Demote", cmd)
+	}
+
+	if !strings.Contains(s.Render(w, 120), "[p] promote/demote") {
+		t.Error("host footer missing the promote/demote hint")
+	}
+	if !strings.Contains(s.Render(w, 120), "admin") {
+		t.Error("admin role tag missing on the roster row")
+	}
+}
+
+// An admin (CanAdminister but not IsHost) sees and uses the invites
+// pane, but never the host-only delegation / removal / lifecycle keys.
+func TestSessionScreenAdminView(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, false)
+	w.Session.CanAdminister = true // promoted admin, still not the host
+
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "INVITES") || !strings.Contains(out, "[i] invite") {
+		t.Errorf("admin screen missing the invites pane:\n%s", out)
+	}
+	if strings.Contains(out, "[p] promote/demote") || strings.Contains(out, "[x] remove player") || strings.Contains(out, "stop hosting") {
+		t.Errorf("admin screen offers host-only keys:\n%s", out)
+	}
+	// [i] arms minting for the admin.
+	if s.HandleKey(w, key("i")); !s.CapturingText() {
+		t.Error("admin [i] didn't arm the mint input")
+	}
+	s.HandleKey(w, key("esc"))
+	// [p] is inert for a non-host.
+	s.HandleKey(w, key("j")) // move off self
+	if cmd := s.HandleKey(w, key("p")); cmd.Kind != SessionCmdNone {
+		t.Errorf("admin [p] = %+v, want no command (delegation is host-only)", cmd)
 	}
 }
 

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -396,6 +396,64 @@ func TestSessionScreenRestartConfirm(t *testing.T) {
 	}
 }
 
+// Version surface (v0.30 S5): the running version always shows; an
+// available release reframes [u] as "restart to adopt" only when the box
+// is adopt-capable, otherwise it points at the manual update path and [u]
+// stays a plain restart.
+func TestSessionScreenVersionSurface(t *testing.T) {
+	// Running only, no update.
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Session.RunningVersion = "0.30.0"
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "running v0.30.0") {
+		t.Errorf("running version missing:\n%s", out)
+	}
+	if strings.Contains(out, "update available") || strings.Contains(out, "restart to adopt") {
+		t.Errorf("spurious update UI with no available version:\n%s", out)
+	}
+	if !strings.Contains(out, "[u] restart server") {
+		t.Error("plain restart key missing")
+	}
+
+	// Update available + adopt-capable → adopt framing.
+	s = NewSessionScreen(sessionTheme())
+	w.Session.AvailableVersion = "v0.31.0"
+	w.Session.AdoptCapable = true
+	out = s.Render(w, 120)
+	if !strings.Contains(out, "update available: v0.31.0") {
+		t.Errorf("available version missing:\n%s", out)
+	}
+	if !strings.Contains(out, "[u] restart to adopt v0.31.0") {
+		t.Errorf("adopt affordance missing:\n%s", out)
+	}
+	if strings.Contains(out, "update manually") {
+		t.Error("adopt-capable box shows the manual path")
+	}
+	// The confirm is adopt-aware.
+	s.HandleKey(w, key("u"))
+	if !strings.Contains(s.Render(w, 120), "restart to adopt v0.31.0? drops") {
+		t.Errorf("adopt confirm prompt missing:\n%s", s.Render(w, 120))
+	}
+
+	// Update available + NOT adopt-capable → manual path, plain restart.
+	s = NewSessionScreen(sessionTheme())
+	w.Session.AdoptCapable = false
+	out = s.Render(w, 120)
+	if !strings.Contains(out, "update available: v0.31.0") {
+		t.Error("readout should still show the available version without adopt tooling")
+	}
+	if !strings.Contains(out, "update manually — "+releasesPageURL) {
+		t.Errorf("manual update path missing:\n%s", out)
+	}
+	if strings.Contains(out, "restart to adopt") {
+		t.Error("adopt affordance shown without adopt capability (the UI would lie)")
+	}
+	if !strings.Contains(out, "[u] restart server") {
+		t.Error("plain restart key missing on a non-adopt box")
+	}
+}
+
 // A guest never reaches the host toggle: their slate is never IsHost,
 // so [h] is inert and the stop-hosting hint is absent.
 func TestSessionScreenGuestNoHost(t *testing.T) {


### PR DESCRIPTION
Closes #225. **Stacked on #235 (S3)** — base is the S3 branch, so the diff is S4-only. (Logically S4 depends only on S2; stacked on S3 for a linear merge order.)

## What

Admins get a server lifecycle control: a graceful **restart** that drains the session cleanly instead of dropping players mid-flight. The service manager restarts the process — the game does not respawn itself.

## How

- `serve`: `reportingModel.restartServer()` announces the restart through the presence/event channel, pauses briefly (`restartAnnounceGrace`) so connected screens render the warning, then drains (`Shutdown` + `Wait` persists every guest's final payload via `persistMiddleware`) and `os.Exit(42)`.
- **Exit-42 contract (agreed with ansi):** 42 is the dedicated supervisor marker — distinguishable from clean-exit (0) / Go panic (2) / signal-death (128+N) — so systemd's `ExecStopPost` runs `tsp-adopt` only on it. A plain `os.Exit`, **not a signal**. `exitFunc` / `restartAnnounceGrace` are indirected so the drain path is testable without killing the test process.
- The host's stop-hosting toggle now shares the extracted `drainAndClose()` rather than duplicating `Shutdown`+`Wait`.
- Authorization at the handler: `MayAdminister` (host or admin); a guest's forged `SessionRestartMsg` is refused with a toast.
- Session screen: new `[u]` restart key behind a confirm gate naming the drop count; host + admins only. New `SessionEventServerRestart` renders as an alert chip on connected screens.

Reconnect-resumes-Subspace-time is unchanged — `persistMiddleware` already writes each per-player payload on session unwind; this slice routes both host stop-hosting and admin restart through one drain.

## Tests
- `TestAdminRestartExitsWithMarker` (serve) — guest forged restart refused (no exit); host restart announces + exits with code 42.
- `TestSessionScreenRestartConfirm` — `[u]` confirm gate + drop count, host & admin reachable, guest excluded.
- Existing stop-hosting tests still green after the `drainAndClose` refactor.

`go vet ./...` clean; `go test ./... -race -count=1` green (1648 tests).

## ⚠ Host-side dependency
The adopt half (S5/#226) rides on this exit marker. Host wiring (`ExecStopPost` → `tsp-adopt`, `Restart=always`) is ansi's; pinging them now that the branch exists.