### PR TITLE
S5 (#226): version surface + restart-to-adopt, capability-gated

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -346,6 +346,10 @@ func (m *reportingModel) refreshSession(now time.Time) {
 		CanAdminister: m.srv.store.MayAdminister(m.owner),
 		Self:          m.owner,
 	}
+	// Version surface (v0.30 S5): universal readout, adopt gated.
+	if m.srv.ver != nil {
+		info.RunningVersion, info.AvailableVersion, info.AdoptCapable = m.srv.ver.snapshot()
+	}
 	// Rendezvous roster markers (v0.29 S2): who is armed toward the
 	// viewer, and whom the viewer is armed toward.
 	armedTowardViewer := map[string]bool{}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -58,6 +58,12 @@ type Server struct {
 	dock     *relay.DockLedger
 	presence *presence
 
+	// ver is the running-vs-available version readout (v0.30 S5). Created
+	// here (no network — just the running version + adopt-capability env);
+	// its background poll starts in Serve, so unit tests that never call
+	// Serve stay off the wire.
+	ver *versionSurface
+
 	// sessions tracks in-flight session handlers (including their
 	// final persist) so shutdown can wait for payload writes instead
 	// of racing process exit (review follow-up).
@@ -108,7 +114,7 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence()}
+	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence(), ver: newVersionSurface()}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
 	// a guest whose craft rode along in another player's stack reconnects
@@ -155,8 +161,13 @@ func hostHandle() string {
 func (s *Server) Addr() string { return s.ln.Addr().String() }
 
 // Serve accepts sessions until Shutdown; it blocks. A graceful
-// shutdown returns nil.
+// shutdown returns nil. The version-surface poll runs for the listener's
+// life (v0.30 S5) — started here, not in New, so it is off the wire in
+// unit tests that never serve.
 func (s *Server) Serve() error {
+	stop := make(chan struct{})
+	go s.ver.watch(stop)
+	defer close(stop)
 	err := s.ssh.Serve(s.ln)
 	if err != nil && !errors.Is(err, ssh.ErrServerClosed) {
 		return err

--- a/internal/serve/version.go
+++ b/internal/serve/version.go
@@ -1,0 +1,199 @@
+package serve
+
+// Server version surface (v0.30 S5, #226): a courtesy readout of the
+// running server version against the newest published release, wired to
+// the S4 drain-restart so an admin can adopt an update from inside the
+// game. The game NEVER fetches, verifies, or swaps a binary — "adopt"
+// is drain-restart with the exit-42 marker; the supervising service
+// manager on the deploy host pulls the release. The version check only
+// queries the public release feed, and degrades silently on any failure.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/version"
+)
+
+const (
+	// releaseFeedURL is the repo's public tag list on the GitHub API. Tag
+	// names carry a leading "v"; four-part checkpoint tags are filtered
+	// out by the three-part SemVer test, not by the endpoint.
+	releaseFeedURL = "https://api.github.com/repos/jasonfen/terminal-space-program/tags"
+
+	// adoptCapabilityEnv is the supervisor-set marker signalling the host
+	// has adopt tooling (tsp-adopt on ExecStopPost). Only when it is set
+	// does the Session screen offer the [u] restart-to-adopt affordance;
+	// otherwise the version readout still appears but points at the manual
+	// update path, so the UI never offers an update it can't perform.
+	// The exact token is a game↔host contract detail (proposed with ansi).
+	adoptCapabilityEnv = "TSP_ADOPT"
+
+	// versionCheckInterval is deliberately long — this is a courtesy
+	// readout, not a polling service.
+	versionCheckInterval = 6 * time.Hour
+
+	versionFetchTimeout = 10 * time.Second
+)
+
+// versionSurface holds the running-vs-available readout the Session
+// screen shows. available is the newest published three-part SemVer
+// release strictly greater than running, or "" when the check hasn't
+// succeeded or nothing newer exists. adopt records whether the
+// supervisor signalled adopt-capability. fetch is indirected so tests
+// exercise the comparison without touching the network.
+type versionSurface struct {
+	mu        sync.Mutex
+	running   string
+	available string
+	adopt     bool
+	fetch     func() ([]string, error)
+}
+
+func newVersionSurface() *versionSurface {
+	return &versionSurface{
+		running: version.Version,
+		adopt:   os.Getenv(adoptCapabilityEnv) != "",
+		fetch:   fetchReleaseTags,
+	}
+}
+
+// snapshot returns the current readout under the lock.
+func (v *versionSurface) snapshot() (running, available string, adopt bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.running, v.available, v.adopt
+}
+
+// refresh runs one feed check and updates available. A failed or
+// malformed fetch leaves available untouched — the readout degrades
+// silently to the running version alone, never wedging the session.
+func (v *versionSurface) refresh() {
+	tags, err := v.fetch()
+	if err != nil {
+		return
+	}
+	latest := latestRelease(v.running, tags)
+	v.mu.Lock()
+	v.available = latest
+	v.mu.Unlock()
+}
+
+// watch polls the feed on a conservative interval until stop closes. It
+// runs off the tick loop, in its own goroutine. A build whose running
+// version isn't a real three-part SemVer (a dev/test build) never polls
+// — there is nothing to compare against, and it keeps CI off the wire.
+func (v *versionSurface) watch(stop <-chan struct{}) {
+	if _, _, _, ok := parseSemVer(v.running); !ok {
+		return
+	}
+	v.refresh()
+	t := time.NewTicker(versionCheckInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			v.refresh()
+		}
+	}
+}
+
+// fetchReleaseTags reads the repo's tag names off the public GitHub API.
+func fetchReleaseTags() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), versionFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseFeedURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("serve: release feed status %d", resp.StatusCode)
+	}
+	var payload []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	tags := make([]string, 0, len(payload))
+	for _, t := range payload {
+		tags = append(tags, t.Name)
+	}
+	return tags, nil
+}
+
+// latestRelease returns the newest tag that is a valid three-part SemVer
+// release strictly greater than running, normalised to leading-v display
+// form ("v0.30.0"), or "" when none qualifies. Four-part checkpoint tags
+// and malformed entries are ignored; comparison is numeric per component
+// (so v0.29.10 > v0.29.9).
+func latestRelease(running string, tags []string) string {
+	best := ""
+	for _, tag := range tags {
+		if _, _, _, ok := parseSemVer(tag); !ok {
+			continue // not a three-part release (checkpoint tag / junk)
+		}
+		if !semVerLess(running, tag) {
+			continue // not newer than what we run
+		}
+		if best == "" || semVerLess(best, tag) {
+			best = tag
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return "v" + strings.TrimPrefix(best, "v")
+}
+
+// parseSemVer parses "vX.Y.Z" (leading v optional) into three
+// non-negative ints. Four-part (checkpoint) tags and anything malformed
+// return ok=false, so they are never treated as releases.
+func parseSemVer(tag string) (maj, min, pat int, ok bool) {
+	parts := strings.Split(strings.TrimPrefix(strings.TrimSpace(tag), "v"), ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var v [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return 0, 0, 0, false
+		}
+		v[i] = n
+	}
+	return v[0], v[1], v[2], true
+}
+
+// semVerLess reports whether a < b as three-part SemVer. An unparseable
+// operand makes the comparison false, so a dev running version never
+// counts as older than any release (no nag) and junk tags never win.
+func semVerLess(a, b string) bool {
+	am, an, ap, aok := parseSemVer(a)
+	bm, bn, bp, bok := parseSemVer(b)
+	if !aok || !bok {
+		return false
+	}
+	if am != bm {
+		return am < bm
+	}
+	if an != bn {
+		return an < bn
+	}
+	return ap < bp
+}

--- a/internal/serve/version_test.go
+++ b/internal/serve/version_test.go
@@ -1,0 +1,64 @@
+package serve
+
+import (
+	"errors"
+	"testing"
+)
+
+// latestRelease picks the newest three-part SemVer strictly greater than
+// the running version, ignoring four-part checkpoint tags and junk, with
+// numeric (not lexical) component comparison (v0.30 S5, #226).
+func TestLatestRelease(t *testing.T) {
+	cases := []struct {
+		name    string
+		running string
+		tags    []string
+		want    string
+	}{
+		{"newer release", "0.29.1", []string{"v0.29.1", "v0.30.0", "v0.28.4"}, "v0.30.0"},
+		{"numeric compare beats lexical", "0.29.9", []string{"v0.29.10"}, "v0.29.10"},
+		{"four-part checkpoint ignored", "0.29.0", []string{"v0.29.1.3"}, ""},
+		{"checkpoint alongside release", "0.29.1", []string{"v0.29.1.3", "v0.30.0"}, "v0.30.0"},
+		{"nothing newer", "0.30.0", []string{"v0.29.1", "v0.30.0"}, ""},
+		{"malformed tags skipped", "0.29.1", []string{"garbage", "v", "v0.30.0"}, "v0.30.0"},
+		{"dev running never nags", "dev", []string{"v0.30.0"}, ""},
+		{"picks the max of several", "0.28.0", []string{"v0.29.0", "v0.30.2", "v0.30.1"}, "v0.30.2"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := latestRelease(c.running, c.tags); got != c.want {
+				t.Errorf("latestRelease(%q, %v) = %q, want %q", c.running, c.tags, got, c.want)
+			}
+		})
+	}
+}
+
+// refresh stores the newest release; a failed fetch degrades silently
+// (available left untouched). adopt-capability comes from the env.
+func TestVersionSurfaceRefresh(t *testing.T) {
+	vs := &versionSurface{running: "0.29.1"}
+
+	// Successful fetch → available set.
+	vs.fetch = func() ([]string, error) { return []string{"v0.30.0", "v0.29.1.9"}, nil }
+	vs.refresh()
+	if _, avail, _ := vs.snapshot(); avail != "v0.30.0" {
+		t.Errorf("available = %q after fetch, want v0.30.0", avail)
+	}
+
+	// A later failed fetch must not clobber the last good reading.
+	vs.fetch = func() ([]string, error) { return nil, errors.New("network down") }
+	vs.refresh()
+	if _, avail, _ := vs.snapshot(); avail != "v0.30.0" {
+		t.Errorf("failed fetch clobbered available to %q", avail)
+	}
+
+	// adopt-capability rides the env marker.
+	t.Setenv(adoptCapabilityEnv, "1")
+	if vs := newVersionSurface(); !vs.adopt {
+		t.Error("adopt not set from env marker")
+	}
+	t.Setenv(adoptCapabilityEnv, "")
+	if vs := newVersionSurface(); vs.adopt {
+		t.Error("adopt set with the env marker cleared")
+	}
+}

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -57,6 +57,16 @@ type SessionInfo struct {
 	Self          string // viewer's fingerprint — the screen marks "you"
 	Players       []SessionPlayer
 	Invites       []SessionInvite // populated for the host and admins
+
+	// Version surface (v0.30 S5). RunningVersion is always set on a
+	// server; AvailableVersion is the newest published release when one is
+	// newer than running (else ""); AdoptCapable is whether the supervisor
+	// signalled adopt-capability — only then is the [u] restart-to-adopt
+	// affordance offered (else the screen points at the manual update
+	// path). The readout is universal; only the adopt action is gated.
+	RunningVersion   string
+	AvailableVersion string
+	AdoptCapable     bool
 }
 
 // SessionEventKind enumerates the moments the chip stack surfaces.

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -346,6 +346,51 @@ func mayRemoveRow(info *sim.SessionInfo, p sim.SessionPlayer) bool {
 	return true
 }
 
+// releasesPageURL is where an install without adopt tooling is pointed
+// to update manually (v0.30 S5).
+const releasesPageURL = "github.com/jasonfen/terminal-space-program/releases"
+
+// adopting reports whether the [u] restart should be framed as adopting
+// an available release: a newer version exists AND the supervisor
+// signalled adopt-capability. Absent either, [u] is a plain restart and
+// the readout points at the manual update path — the UI never offers an
+// update it can't perform.
+func adopting(info *sim.SessionInfo) bool {
+	return info.AvailableVersion != "" && info.AdoptCapable
+}
+
+// restartKeyLabel is the footer label for [u] — "restart to adopt vX"
+// when adopting, else a plain "restart server".
+func restartKeyLabel(info *sim.SessionInfo) string {
+	if adopting(info) {
+		return "[u] restart to adopt " + displayVer(info.AvailableVersion)
+	}
+	return "[u] restart server"
+}
+
+// restartPrompt is the confirmation line for [u], adopt-aware and naming
+// the drop count.
+func restartPrompt(info *sim.SessionInfo) string {
+	if adopting(info) {
+		return fmt.Sprintf("restart to adopt %s? drops %d player(s) — progress persists, they reconnect",
+			displayVer(info.AvailableVersion), onlineGuests(info))
+	}
+	return fmt.Sprintf("restart server? drops %d player(s) — progress persists, they reconnect", onlineGuests(info))
+}
+
+// displayVer normalises a version string for display: a numeric SemVer
+// gets a leading "v" (release ldflags strip it); a non-numeric build
+// string like "dev" is shown as-is.
+func displayVer(v string) string {
+	if v == "" {
+		return v
+	}
+	if v[0] >= '0' && v[0] <= '9' {
+		return "v" + v
+	}
+	return v
+}
+
 // onlineGuests counts online roster members other than the viewer
 // (the host) — the population a stop-hosting drops (v0.28 S3).
 func onlineGuests(info *sim.SessionInfo) int {
@@ -464,11 +509,27 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  stop hosting? drops %d guest(s) — progress persists [y/n]", onlineGuests(info))) + "\n")
 	}
 	if s.confirmRestart {
-		b.WriteString(s.theme.Alert.Render(fmt.Sprintf("  restart server? drops %d player(s) — progress persists, they reconnect [y/n]", onlineGuests(info))) + "\n")
+		b.WriteString(s.theme.Alert.Render("  "+restartPrompt(info)+" [y/n]") + "\n")
 	}
+
+	// Version surface (v0.30 S5): always show the running version; when a
+	// newer release exists, show it, and — on a box with no adopt tooling
+	// — point at the manual update path so the UI never offers an update
+	// it can't perform.
+	if info.RunningVersion != "" {
+		line := "  running " + displayVer(info.RunningVersion)
+		if info.AvailableVersion != "" {
+			line += " — update available: " + displayVer(info.AvailableVersion)
+		}
+		b.WriteString(s.theme.Dim.Render(line) + "\n")
+		if info.AvailableVersion != "" && !info.AdoptCapable {
+			b.WriteString(s.theme.Dim.Render("  update manually — "+releasesPageURL) + "\n")
+		}
+	}
+
 	keys := "  [t] target craft  [v] spectate  [s] sync-to  [w] rendezvous warp"
 	if info.CanAdminister {
-		keys += "  [i] invite  [r] revoke code  [x] remove player  [u] restart server"
+		keys += "  [i] invite  [r] revoke code  [x] remove player  " + restartKeyLabel(info)
 	}
 	if info.IsHost {
 		keys += "  [p] promote/demote  [h] stop hosting"

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -396,6 +396,64 @@ func TestSessionScreenRestartConfirm(t *testing.T) {
 	}
 }
 
+// Version surface (v0.30 S5): the running version always shows; an
+// available release reframes [u] as "restart to adopt" only when the box
+// is adopt-capable, otherwise it points at the manual update path and [u]
+// stays a plain restart.
+func TestSessionScreenVersionSurface(t *testing.T) {
+	// Running only, no update.
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Session.RunningVersion = "0.30.0"
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "running v0.30.0") {
+		t.Errorf("running version missing:\n%s", out)
+	}
+	if strings.Contains(out, "update available") || strings.Contains(out, "restart to adopt") {
+		t.Errorf("spurious update UI with no available version:\n%s", out)
+	}
+	if !strings.Contains(out, "[u] restart server") {
+		t.Error("plain restart key missing")
+	}
+
+	// Update available + adopt-capable → adopt framing.
+	s = NewSessionScreen(sessionTheme())
+	w.Session.AvailableVersion = "v0.31.0"
+	w.Session.AdoptCapable = true
+	out = s.Render(w, 120)
+	if !strings.Contains(out, "update available: v0.31.0") {
+		t.Errorf("available version missing:\n%s", out)
+	}
+	if !strings.Contains(out, "[u] restart to adopt v0.31.0") {
+		t.Errorf("adopt affordance missing:\n%s", out)
+	}
+	if strings.Contains(out, "update manually") {
+		t.Error("adopt-capable box shows the manual path")
+	}
+	// The confirm is adopt-aware.
+	s.HandleKey(w, key("u"))
+	if !strings.Contains(s.Render(w, 120), "restart to adopt v0.31.0? drops") {
+		t.Errorf("adopt confirm prompt missing:\n%s", s.Render(w, 120))
+	}
+
+	// Update available + NOT adopt-capable → manual path, plain restart.
+	s = NewSessionScreen(sessionTheme())
+	w.Session.AdoptCapable = false
+	out = s.Render(w, 120)
+	if !strings.Contains(out, "update available: v0.31.0") {
+		t.Error("readout should still show the available version without adopt tooling")
+	}
+	if !strings.Contains(out, "update manually — "+releasesPageURL) {
+		t.Errorf("manual update path missing:\n%s", out)
+	}
+	if strings.Contains(out, "restart to adopt") {
+		t.Error("adopt affordance shown without adopt capability (the UI would lie)")
+	}
+	if !strings.Contains(out, "[u] restart server") {
+		t.Error("plain restart key missing on a non-adopt box")
+	}
+}
+
 // A guest never reaches the host toggle: their slate is never IsHost,
 // so [h] is inert and the stop-hosting hint is absent.
 func TestSessionScreenGuestNoHost(t *testing.T) {


### PR DESCRIPTION
Closes #226. **Stacked on #236 (S4)** — base is the S4 branch, so the diff is S5-only. This is the last code slice of the v0.30 admin arc.

## What

Makes the running server version-aware and wires it to the S4 restart so an admin can adopt a new release from inside the game. **The game never fetches, verifies, or swaps a binary** — "adopt" is the drain-restart with the exit-42 marker; the deploy host's supervisor pulls the release.

## How

- `serve/version.go`: a `versionSurface` polls the public GitHub tag feed on a conservative **6h** interval, **off the tick loop**, in a goroutine started in `Serve` (unit tests never call `Serve`, so they stay off the wire; a dev build whose version isn't a real three-part SemVer never polls). `latestRelease` compares **SemVer-correctly** (v0.29.10 > v0.29.9) and **ignores four-part checkpoint tags**. Any fetch failure or malformed feed **degrades silently** to the running version alone. `fetch` is indirected so the comparison is unit-tested without the network.
- **Adopt is capability-gated:** `newVersionSurface` reads the supervisor's `TSP_ADOPT` marker. The version *readout* is universal; only the `[u] restart-to-adopt` affordance depends on the marker.
- `SessionInfo` carries `RunningVersion` / `AvailableVersion` / `AdoptCapable`; `reporting` fills them from the surface snapshot.
- Session screen: always shows `running vX`; when newer, `update available: vY`. On an adopt-capable box `[u]` reframes to `restart to adopt vY` (confirm + drop count); without adopt tooling it shows `update manually — <releases link>` and `[u]` stays a plain restart — so the UI never offers an update it can't perform.

Adopt is admin-only, enforced at the S4 handler (`MayAdminister`).

## Tests
- `TestLatestRelease` — newer/none/numeric-vs-lexical, four-part checkpoint ignored, malformed skipped, dev-never-nags, max-of-several.
- `TestVersionSurfaceRefresh` — success sets available; a later failed fetch doesn't clobber it; adopt rides the env marker.
- `TestSessionScreenVersionSurface` — running-only; adopt-capable reframes `[u]`; non-adopt shows manual path + plain restart (no lying adopt button).

`go vet ./...` clean; `go test ./... -race -count=1` green (1659 tests).

## ⚠ Host contract (open)
The `TSP_ADOPT` token is the proposed marker — pinged ansi to confirm it (bundled with the exit-42 test ask on #236). If they prefer a different token it's a one-line change in `version.go`.

## Not in this PR
S6 (#220 ghost picker), the batched `/code-review` of S1–S6, the docs pass (F1 + README Session keys; **CONTEXT.md Host rewrite + Admin noun**), and the **v0.30.0 tag** all come after S6 lands, per the plan cutline.