### PR TITLE
fix(mp): review fixes for the v0.30 admin arc (S7)

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -146,7 +146,7 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// reaches this handler directly and must be refused. Refusal is a
 		// silent no-op plus a toast to the sender — never a crash.
 		if !m.srv.store.MayAdminister(m.owner) {
-			m.app.Toast("only the host can administer the session")
+			m.app.Toast("you can't administer this session")
 			return m, nil
 		}
 		switch admin.Cmd.Kind {
@@ -522,11 +522,13 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 // restartServer drains every connected player and exits with the
 // supervisor marker so the service manager relaunches the process
 // (v0.30 S4). Authorization is enforced here — an admin (or the host)
-// only; a guest's forged intent is refused with a toast. The drain runs
-// in the background so the triggering session's tick loop isn't blocked;
-// it announces the restart, pauses briefly so connected screens render
-// the warning, then closes the listener (persisting every guest's final
-// payload via persistMiddleware) before os.Exit(42).
+// only; a guest's forged intent is refused with a toast. It persists the
+// restarter's own world synchronously (the one payload the drain can't
+// write), then drains in the background so the triggering session's tick
+// loop isn't blocked; the drain announces the restart, pauses briefly so
+// connected screens render the warning, then closes the listener
+// (persisting every guest's final payload via persistMiddleware) before
+// os.Exit(42).
 func (m reportingModel) restartServer() (tea.Model, tea.Cmd) {
 	if m.srv == nil {
 		return m, nil
@@ -536,9 +538,20 @@ func (m reportingModel) restartServer() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	srv, actor := m.srv, m.owner
+	// Persist the restarter's OWN world first (v0.30 S7 review). The
+	// drain writes every other player's payload through
+	// persistMiddleware, but this App never unwinds that way: the host
+	// has no ssh session at all, and an admin guest's session is the one
+	// session that can't finish while it is the one doing the draining.
+	// os.Exit skips the quit path's autosave, so without this the player
+	// who pressed [u] loses everything since their last periodic save —
+	// all of it, on a box with the autosave interval set to off.
+	// Synchronous, on the update goroutine, because it reads the live
+	// world; the drain goroutine below must not touch it.
+	m.app.PersistNow()
 	// Announce now so the next tick carries the warning to every screen.
 	srv.presence.event(sim.SessionEventServerRestart, actor, "", "")
-	m.app.Toast("restarting server — draining sessions, everyone reconnects")
+	m.app.Toast("restarting server — draining sessions, progress saved")
 	go func() {
 		time.Sleep(restartAnnounceGrace)
 		srv.drainAndClose()

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -2,11 +2,14 @@ package serve
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
@@ -361,4 +364,70 @@ func TestAdminRestartExitsWithMarker(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("restart never exited")
 	}
+}
+
+// The restarting player's own progress must reach disk before the
+// process exits (v0.30 S7 review). The drain persists every OTHER
+// player through persistMiddleware, but os.Exit skips this App's
+// quit-path autosave — and the restarter's own session is the one that
+// can't unwind while it is the one doing the draining. Covers both
+// restarter shapes: the host (local autosave ring) and a promoted
+// admin connected as a guest (the server-side payload sink).
+func TestAdminRestartPersistsRestarterProgress(t *testing.T) {
+	oldExit, oldGrace := exitFunc, restartAnnounceGrace
+	restartAnnounceGrace = 0
+	t.Cleanup(func() { exitFunc, restartAnnounceGrace = oldExit, oldGrace })
+
+	t.Run("promoted admin persists through the guest sink", func(t *testing.T) {
+		srv := newOfflineServer(t)
+		enrollDirect(t, srv, "SHA256:gern", "gern")
+		if err := srv.store.PromoteAdmin("SHA256:gern"); err != nil {
+			t.Fatalf("PromoteAdmin: %v", err)
+		}
+		done := make(chan int, 1)
+		exitFunc = func(code int) { done <- code }
+
+		adminApp, err := srv.newGuestApp("SHA256:gern")
+		if err != nil {
+			t.Fatalf("newGuestApp: %v", err)
+		}
+		persisted := 0
+		adminApp.SetGuestPersistence(func(*sim.World) error { persisted++; return nil })
+
+		admin := tick(srv.withReporting(adminApp, "SHA256:gern"))
+		_, _ = admin.Update(screens.SessionRestartMsg{})
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("restart never exited")
+		}
+		if persisted == 0 {
+			t.Error("the restarting admin's own world was never persisted before exit")
+		}
+	})
+
+	t.Run("host persists into the autosave ring", func(t *testing.T) {
+		srv := newOfflineServer(t) // isolates XDG_STATE_HOME
+		done := make(chan int, 1)
+		exitFunc = func(code int) { done <- code }
+
+		hostApp, err := tui.New(nil)
+		if err != nil {
+			t.Fatalf("tui.New: %v", err)
+		}
+		host := tick(srv.HostModel(hostApp))
+		_, _ = host.Update(screens.SessionRestartMsg{})
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("restart never exited")
+		}
+		dir, err := save.SavesDir()
+		if err != nil {
+			t.Fatalf("SavesDir: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "autosave-1.json")); err != nil {
+			t.Errorf("host restart wrote no autosave (%v) — progress since the last periodic save is lost", err)
+		}
+	})
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1435,6 +1435,14 @@ func (a *App) autosave() {
 	_ = save.WriteAutosave(a.world)
 }
 
+// PersistNow writes the world through whichever persistence surface this
+// App is wired to — the per-player sink in a guest session, the local
+// autosave ring otherwise. It exists for the serve layer's admin
+// drain-and-restart (v0.30 S4), which leaves the process via os.Exit and
+// so never reaches the quit path's autosave. Call it on the Bubble Tea
+// update goroutine: it reads the live world.
+func (a *App) PersistNow() { a.autosave() }
+
 // maybeAutosave fires the periodic autosave (v0.26 S4 / ADR 0033 §E)
 // when the player's wall-clock interval has elapsed since the last
 // fire. now is the tea.Tick timestamp from the current sim.TickMsg —

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -128,10 +128,18 @@ func (s *SessionScreen) HandleKey(w *sim.World, msg tea.KeyMsg) SessionCommand {
 	// Normalise craft-picker focus (v0.30 S6): if the selected player's
 	// targetable ghosts vanished (they landed the craft or left the
 	// system between ticks), pop the sub-list so keys can't strand on an
-	// empty picker.
+	// empty picker. A slate that merely SHRANK clamps instead (S7 review)
+	// — leaving the cursor past the end deadened t/v/w silently.
 	if s.inCraftList {
-		if p, ok := s.selectedPlayer(info); !ok || len(playerGhosts(w, p.Fingerprint)) == 0 {
+		p, ok := s.selectedPlayer(info)
+		n := 0
+		if ok {
+			n = len(playerGhosts(w, p.Fingerprint))
+		}
+		if n == 0 {
 			s.inCraftList = false
+		} else {
+			s.craftCursor = clamp(s.craftCursor, 0, n-1)
 		}
 	}
 
@@ -382,6 +390,12 @@ func (s *SessionScreen) pickGhost(w *sim.World, p sim.SessionPlayer) (g sim.Ghos
 	if len(ghosts) == 1 {
 		return ghosts[0], true, false
 	}
+	// Opening the picker takes focus off the invites pane (S7 review).
+	// t/v/w act on the player row from either section, but the sub-list
+	// only renders when the invites pane isn't focused — so opening it
+	// without this left the screen in an invisible picker mode where j/k
+	// drove a craft cursor the player could not see.
+	s.inInvites = false
 	s.inCraftList, s.craftCursor = true, 0
 	return sim.Ghost{}, false, false
 }

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -658,3 +658,56 @@ func TestSessionScreenTargetableCount(t *testing.T) {
 		t.Errorf("row should distinguish targetable-here count:\n%s", out)
 	}
 }
+
+// Opening the craft picker from the invites pane must pull focus back to
+// the player rows (v0.30 S7 review). t/v/w always act on the selected
+// player row, but the sub-list only renders when the invites pane isn't
+// focused — so without this the screen enters an invisible picker mode
+// where j/k silently drive a craft cursor the player can't see.
+func TestSessionScreenGhostPickerFromInvitesPane(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Ghosts = []sim.Ghost{
+		{Owner: "SHA256:guest", CraftID: 10, Handle: "gern", Name: "Scout"},
+		{Owner: "SHA256:guest", CraftID: 11, Handle: "gern", Name: "Hauler"},
+	}
+	s.HandleKey(w, key("j"))   // gern
+	s.HandleKey(w, key("tab")) // focus the invites pane
+	s.HandleKey(w, key("t"))   // opens the picker
+
+	out := s.Render(w, 120)
+	for _, want := range []string{"Scout", "Hauler"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("picker opened from the invites pane but never rendered %q:\n%s", want, out)
+		}
+	}
+	// The cursor now drives the craft list, not the invites section.
+	s.HandleKey(w, key("j"))
+	if cmd := s.HandleKey(w, key("t")); cmd.Kind != SessionCmdTargetGhost || cmd.CraftID != 11 {
+		t.Errorf("[t] after moving in the picker = %+v, want target craft 11", cmd)
+	}
+}
+
+// A shrinking ghost slate must not strand the craft cursor past the end
+// (v0.30 S7 review): pickGhost would return no selection and no empty
+// flag, so t/v/w silently did nothing — with no toast — until the player
+// happened to press an arrow key.
+func TestSessionScreenGhostPickerSlateShrinks(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Ghosts = []sim.Ghost{
+		{Owner: "SHA256:guest", CraftID: 10, Handle: "gern", Name: "Scout"},
+		{Owner: "SHA256:guest", CraftID: 11, Handle: "gern", Name: "Hauler"},
+		{Owner: "SHA256:guest", CraftID: 12, Handle: "gern", Name: "Probe"},
+	}
+	s.HandleKey(w, key("j")) // gern
+	s.HandleKey(w, key("t")) // open the picker
+	s.HandleKey(w, key("j"))
+	s.HandleKey(w, key("j")) // craft cursor on Probe (index 2)
+
+	// gern lands Probe between ticks: the slate drops to two.
+	w.Ghosts = w.Ghosts[:2]
+	if cmd := s.HandleKey(w, key("t")); cmd.Kind != SessionCmdTargetGhost || cmd.CraftID != 11 {
+		t.Errorf("[t] after the slate shrank = %+v, want the clamped last craft 11", cmd)
+	}
+}


### PR DESCRIPTION
Fixes from the batched code review of S1–S6 (the review the plan gates the `v0.30.0` tag on). Stacked on #238.

### 1. `[u]` restart discarded the restarter's own progress ⚠️

`restartServer` drains, then `os.Exit(42)`. The drain persists every *other* player through `persistMiddleware`, but the restarter's own App never unwinds that way — the host has no ssh session at all, and an admin guest's session is the one session that can't finish while it's the one doing the draining. `os.Exit` skips the quit path's `autosave()`, so the player who pressed `[u]` lost everything since their last periodic save — **the entire session** on a box with the autosave interval set to Off (a supported setting), under a confirm prompt that read *"progress persists"*.

New exported `App.PersistNow()` routes through whichever surface the App is wired to (guest sink or local autosave ring); `restartServer` calls it **synchronously on the update goroutine** — it reads the live world, so the drain goroutine must not.

### 2. The ghost picker could open invisibly from the invites pane

`t`/`v`/`w` act on the selected player row from either section, but `Render` gates the sub-list on `!s.inInvites` and `moveCursor` checks `inCraftList` *before* `inInvites`. So `tab` → `t` on a 2+-craft player left the screen in a picker mode with nothing drawn: `j`/`k` drove an invisible craft cursor, `r` revoked against a now-stale invite cursor, and a second `t` targeted a craft never shown. Opening the picker now clears `inInvites`.

### 3. A shrinking ghost slate deadened `t`/`v`/`w`

The S6 normalisation block popped the sub-list only at **zero** ghosts, never clamping. Drop from 3 craft to 2 with the cursor on index 2 and `pickGhost` returned neither a selection nor `empty` — the verbs silently no-opped, with no toast, until an arrow key happened to clamp. Now it clamps as well as pops.

### Also

The S1 refusal toast still said `"only the host can administer the session"`, which stopped being true in S2.

### Tests

+5, all written red first:
- `TestAdminRestartPersistsRestarterProgress` — both restarter shapes (promoted admin → guest sink; host → autosave ring)
- `TestSessionScreenGhostPickerFromInvitesPane`
- `TestSessionScreenGhostPickerSlateShrinks`

`go vet ./...` clean; `go test ./... -race -count=1` → **1667 passed** in 19 packages.