### PR TITLE
fix(mp): bound per-tick warp to the same-subspace window (#244)

### DIFF
--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -54,6 +54,15 @@ const (
 	// tight against the hours/days a real subspace divergence spans.
 	// Tunable.
 	coWarpSubspaceToleranceSec = 120.0
+
+	// coWarpStepSafety is how many ticks of the same-subspace window a
+	// coupled player must leave in hand (#244). The min-warp clamp is
+	// derived from the partner's relayed report, so it is never fresher
+	// than the previous tick; capping the per-tick advance at the full
+	// window would put a pair exactly on the edge after one unclamped
+	// step and over it after any additional report lag. Two leaves a
+	// whole tick of slack. Tunable.
+	coWarpStepSafety = 2.0
 )
 
 // CoWarpSubspaceTolerance is the exported form of the same-subspace gate
@@ -168,6 +177,34 @@ type CoWarpResult struct {
 // this tick — read by the split guard (EngageSyncWarp) and available to
 // the HUD. v0.28 S1.
 func (w *World) CoWarpCoupled() bool { return w.CoWarp.Coupled }
+
+// subspaceStepCap is the highest Effective Warp a player sharing a
+// subspace may run at, or 0 when nothing is shared and the full ladder
+// stands (#244).
+//
+// The same-subspace gate is a fixed span of sim-time while warp climbs in
+// ×10 rungs, so at the top rungs a single tick covers more sim-time than
+// the window can hold. That matters because the couple itself is gated on
+// sameSubspace: a player who steps out of the window in one tick stops
+// being coupled, which releases the min-warp clamp that was holding them
+// — the escape removes its own brake, and the pair diverges without
+// limit. Bounding the per-tick advance to a fraction of the window keeps
+// the gate wider than one step at any selectable rate, so the clamp
+// always gets a tick in which to act.
+//
+// Armed-but-not-yet-coupled counts too: refreshRendezvousInvite gates the
+// incoming prompt on sameSubspace, so an initiator who races ahead
+// withdraws their own invite before anyone can join it.
+func (w *World) subspaceStepCap() float64 {
+	if !w.CoWarp.Coupled && w.RendezvousArm == nil {
+		return 0
+	}
+	step := w.Clock.BaseStep.Seconds()
+	if step <= 0 {
+		return 0
+	}
+	return coWarpSubspaceToleranceSec / (coWarpStepSafety * step)
+}
 
 // ComputeCoWarp evaluates proximity co-warp against the viewer's active
 // craft (the anchor) for this tick. `prev` is the per-owner coupled map

--- a/internal/sim/cowarp_step_cap_test.go
+++ b/internal/sim/cowarp_step_cap_test.go
@@ -1,0 +1,104 @@
+package sim
+
+import (
+	"testing"
+	"time"
+)
+
+// #244: the same-subspace window is a fixed span of sim-time, but warp
+// moves in ×10 rungs — at the top two the sim-time one tick covers is
+// wider than the window itself, so a coupled player could step clean out
+// of their own subspace before the min-warp clamp (derived from the
+// partner's already-stale report) could bite. Once out, ComputeCoWarp
+// stops coupling them, which releases the clamp entirely.
+//
+// The invariant these tests pin: while coupled or armed, one tick must
+// never advance more sim-time than the window can hold.
+
+// stepSeconds is the sim-time one tick covers at the world's effective
+// warp — the quantity the window has to be able to contain.
+func stepSeconds(w *World) float64 {
+	return w.Clock.BaseStep.Seconds() * w.EffectiveWarp()
+}
+
+// A coupled player who selects the top rung must be held to a rate whose
+// per-tick advance still fits the window. The partner is reported at max
+// warp too, so the ordinary min-warp clamp cannot mask the cap.
+func TestCoupledWarpCannotOutstepSubspaceWindow(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	top := WarpFactors[len(WarpFactors)-1]
+	w.Clock.WarpIdx = len(WarpFactors) - 1
+	w.CoWarp = CoWarpState{Coupled: true, MinWarp: top, Partners: []string{"gern"}}
+
+	if got := stepSeconds(w); got > coWarpSubspaceToleranceSec {
+		t.Errorf("one tick advances %.0f s at %v×, wider than the %.0f s subspace window — "+
+			"a coupled player can step out of their own subspace in a single tick",
+			got, w.EffectiveWarp(), coWarpSubspaceToleranceSec)
+	}
+}
+
+// Same bound while merely armed: an armed player waiting for their
+// partner to join must stay inside the window too, or their own invite
+// stops surfacing (refreshRendezvousInvite gates on sameSubspace) and the
+// rendezvous dies before it starts.
+func TestArmedWarpCannotOutstepSubspaceWindow(t *testing.T) {
+	w, _, st := anchorWorld(t)
+	w.Clock.WarpIdx = len(WarpFactors) - 1
+	w.RendezvousArm = &RendezvousArm{
+		TargetOwner: "SHA256:gern",
+		Handle:      "gern",
+		Tau:         st.Add(4 * time.Hour),
+	}
+
+	if got := stepSeconds(w); got > coWarpSubspaceToleranceSec {
+		t.Errorf("one tick advances %.0f s at %v× while armed, wider than the %.0f s window",
+			got, w.EffectiveWarp(), coWarpSubspaceToleranceSec)
+	}
+}
+
+// The cap is derived from BaseStep and the tolerance rather than written
+// down as a rung, so it stays correct if either moves. Halving BaseStep
+// must let the capped rate double.
+func TestSubspaceStepCapTracksBaseStep(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	w.Clock.WarpIdx = len(WarpFactors) - 1
+	w.CoWarp = CoWarpState{Coupled: true, MinWarp: WarpFactors[len(WarpFactors)-1]}
+
+	coarse := w.EffectiveWarp()
+	w.Clock.BaseStep /= 2
+	fine := w.EffectiveWarp()
+
+	if fine <= coarse {
+		t.Errorf("halving BaseStep left the cap at %v (was %v) — cap is not derived from the step",
+			fine, coarse)
+	}
+	if got := stepSeconds(w); got > coWarpSubspaceToleranceSec {
+		t.Errorf("one tick advances %.0f s after the step change, wider than the %.0f s window",
+			got, coWarpSubspaceToleranceSec)
+	}
+}
+
+// Regression guard: solo play is untouched. A player neither coupled nor
+// armed keeps the full ladder — the cap exists to protect a shared
+// subspace, and there is no shared subspace here.
+func TestSoloWarpIsNotSubspaceCapped(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	top := WarpFactors[len(WarpFactors)-1]
+	w.Clock.WarpIdx = len(WarpFactors) - 1
+
+	if got := w.EffectiveWarp(); got != top {
+		t.Errorf("EffectiveWarp = %v, want the full %v× — solo play must not be subspace-capped", got, top)
+	}
+}
+
+// The cap only ever reduces: a coupled player who selected a rate already
+// inside the window keeps exactly what they chose.
+func TestSubspaceCapNeverRaisesSelectedWarp(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	w.Clock.WarpIdx = 1 // 10×
+	w.CoWarp = CoWarpState{Coupled: true, MinWarp: WarpFactors[len(WarpFactors)-1]}
+
+	if got := w.EffectiveWarp(); got != 10 {
+		t.Errorf("EffectiveWarp = %v, want the selected 10× left untouched", got)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1085,6 +1085,11 @@ func (w *World) clampedWarp() float64 {
 		if w.CoWarp.Coupled && w.CoWarp.MinWarp > 0 && selected > w.CoWarp.MinWarp {
 			selected = w.CoWarp.MinWarp
 		}
+		// #244: a coupled guest flying nothing still owns a subspace clock,
+		// so the same one-tick-inside-the-window bound applies here too.
+		if cap := w.subspaceStepCap(); cap > 0 && selected > cap {
+			selected = cap
+		}
 		return selected
 	}
 	// v0.16 / ADR 0016: while Auto-Warp is engaged (and not paused) the
@@ -1115,6 +1120,15 @@ func (w *World) clampedWarp() float64 {
 	// return so a coupled clamp still applies there.
 	if w.CoWarp.Coupled && w.CoWarp.MinWarp > 0 && selected > w.CoWarp.MinWarp {
 		selected = w.CoWarp.MinWarp
+	}
+	// #244: min-wins above only propagates a partner's *reported* rate,
+	// which is always at least a tick stale — it cannot stop the tick that
+	// leaves the subspace in the first place. Bound the per-tick advance to
+	// a fraction of the same-subspace window so the couple survives long
+	// enough for that clamp to apply. Placed alongside it, before the
+	// burn/period clamps, so those can only reduce further.
+	if cap := w.subspaceStepCap(); cap > 0 && selected > cap {
+		selected = cap
 	}
 	// Any craft in flight in a finite or manual burn forces the
 	// 10× cap — high warp during thrust would let the integrator


### PR DESCRIPTION
Fixes #244.

## The bug

A Rendezvous Warp coast is held together by the co-warp min-warp clamp —
but the couple that applies that clamp is itself gated on `sameSubspace`,
whose window is a fixed **120 s** of sim-time. Warp climbs in ×10 rungs,
so with the 50 ms `BaseStep`:

| warp    | sim-time per tick | vs 120 s window |
| ------- | ----------------- | --------------- |
| 1000×   | 50 s              | fits            |
| 10000×  | 500 s             | 4.2× over       |
| 100000× | 5000 s            | 41× over        |

At either top rung a player stepped clean out of their own subspace in a
single tick. `ComputeCoWarp` then stopped coupling them, which released
the min-warp clamp that had been holding them — the escape removed its
own brake, and the pair diverged without limit.

`min-wins` could not catch this. It propagates the partner's *reported*
rate, which is never fresher than the previous tick, so it cannot stop the
tick that leaves the subspace in the first place.

## The fix

Bound the per-tick advance rather than naming a rung. `subspaceStepCap()`
returns `tolerance / (safety × BaseStep)` while coupled or armed, and 0
otherwise. With `safety = 2` that is **1200×** — 60 s of sim-time per
tick, half the window — leaving a whole tick of slack for the report lag
the clamp depends on.

Derived from `BaseStep` and the tolerance rather than hardcoded, so it
stays correct if either is retuned; `TestSubspaceStepCapTracksBaseStep`
pins that.

Two deliberate scope choices:

- **Armed counts, not just coupled.** `refreshRendezvousInvite` gates the
  incoming prompt on `sameSubspace` as well, so an initiator who raced
  ahead withdrew their own invite before anyone could join it.
- **Solo play is untouched.** The cap protects a shared subspace; with
  none shared it returns 0 and the full ladder stands.
  `TestSoloWarpIsNotSubspaceCapped` guards that.

## Correcting the issue text

#244 says the ≤1000× ceiling makes "a multi-hour τ impractical to
actually fly." That was wrong, and it was my error when filing. At 1200×
a 4-hour τ is **12 seconds** of real time. The bug was never that the
usable rate is too slow — it is that selecting a faster one silently
destroyed the rendezvous. Capping costs effectively nothing.

## Tests

Five new tests in `internal/sim/cowarp_step_cap_test.go`, written first
and confirmed red against the exact reported numbers (`one tick advances
5000 s at 100000×, wider than the 120 s subspace window`):

- coupled player cannot outstep the window
- armed-but-not-yet-coupled likewise
- the cap tracks `BaseStep` rather than being a fixed rung
- solo play keeps the full ladder (regression guard)
- the cap only ever reduces a selected rate

Full suite: **1681 passed**, `-race -count=1`, `go vet ./...` clean.

## Provenance

Found in the first live two-party playtest of the v0.30 multiplayer arc,
not by the unit tests — each clamp is individually correct, and only the
interaction between a 120 s tolerance, a 50 ms tick and a ×10 ladder
breaks it. Observed twice: a joined coast vanished (chip, coupling and arm
all gone) with the partner ending `+5h18m` ahead of a τ committed at
3h57m.

## Not covered

A client that leaves the window by some route other than warp — the
sleeping-machine case in #243 — is untouched by this. That is a separate
mechanism and stays with that issue.