### PR TITLE
feat(mp): Commitment Reprieve for unattended sessions (ADR 0036, #243)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1723,6 +1723,20 @@ _Avoid_: Hold (already means nearly the opposite under **Rendezvous
 Warp** — freezing the leader's clock for a lagging partner), grace
 period, keepalive, linger.
 
+**Away**:
+The state of a Session that is still simulating with nobody at the
+controls: its player has gone silent, but their craft keep flying, keep
+holding the join frontier, and keep whatever **Commitment** earned them a
+**Reprieve**. Distinct from *offline*, where the Session is gone
+entirely, and from the Reprieve itself, which is what holds an Away
+Session up — an Away Session with no Commitment is simply about to be
+reaped. Measured on a short leash (a minute of silence), because it
+drives display only; the decision to displace an Away Session for a
+reconnecting player uses a far stricter test.
+_Avoid_: Idle (the Session is anything but — it is warping), AFK,
+asleep, disconnected (it is still connected, which is the whole
+problem).
+
 ### Transfer planning
 
 The vocabulary for moving a Vessel from one orbit to another — typically

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1699,6 +1699,30 @@ the Ghost's orbit re-shaping when reports land.
 _Avoid_: Observe mode, follow-cam (it's one Framing Event plus focus,
 not a new mode).
 
+**Commitment**:
+A live mutual obligation between two players that outlives either one's
+attention: an Engaged **Rendezvous Warp** through to its committed Time
+of Closest Approach, or a **Docked-as-Guest** craft riding another
+player's Stack. Distinguished from **Proximity Co-Warp**, which forms by
+itself whenever two players drift close and strands nobody when it
+lapses — a Commitment is entered deliberately, and leaves the other
+player waiting if it dies.
+_Avoid_: Contract, pact, agreement (nothing is offered or accepted —
+both sides simply Engage), lock.
+
+**Reprieve**:
+A stay on a Session's disconnection. A Session whose player has gone
+silent keeps simulating for as long as it carries a live **Commitment**,
+so a closed laptop on one side doesn't strand the other mid-coast or tear
+a docked craft out of their Stack. Bounded at both ends: a Rendezvous
+Warp's Reprieve expires at its committed Time of Closest Approach, a
+dock's after a fixed span, and any Reprieve ends as soon as its
+Commitment resolves. A player may always displace their own reprieved
+Session by reconnecting.
+_Avoid_: Hold (already means nearly the opposite under **Rendezvous
+Warp** — freezing the leader's clock for a lagging partner), grace
+period, keepalive, linger.
+
 ### Transfer planning
 
 The vocabulary for moving a Vessel from one orbit to another — typically

--- a/internal/serve/away.go
+++ b/internal/serve/away.go
@@ -1,0 +1,133 @@
+package serve
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// defaultAwayAfter is how long a session's peer must be silent before the
+// session reads as Away (ADR 0036).
+//
+// Far shorter than the idle timeout on purpose. activityConn stamps on
+// every frame the client drains, so an attended player is normally fresh
+// within a second or two; this only has to clear a briefly static screen,
+// not the ten minutes a reap needs. The asymmetry with the reclaim test
+// is deliberate: this drives display, where being wrong for a moment
+// costs nothing and self-corrects on the player's next frame, while
+// displacing a session is destructive and keeps the strict test.
+const defaultAwayAfter = 60 * time.Second
+
+// isAway reports whether fp's session is still simulating with nobody at
+// the controls. False for a player with no session at all — that is
+// offline, which is a different thing: an Away player's craft keep
+// flying and keep whatever Commitment earned them a Reprieve.
+func (s *Server) isAway(fp string) bool {
+	sess, ok := s.live.get(fp)
+	if !ok || sess.conn == nil {
+		return false
+	}
+	return time.Since(sess.conn.LastIO()) > s.awayAfter
+}
+
+// awayWatch remembers who has been told that a player went quiet, so the
+// transition chips exactly once however long the silence lasts, and the
+// return reaches the same person.
+type awayWatch struct {
+	mu   sync.Mutex
+	told map[string]string // away fingerprint → the partner told about it
+}
+
+func newAwayWatch() *awayWatch { return &awayWatch{told: map[string]string{}} }
+
+func (a *awayWatch) partner(fp string) (string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.told[fp]
+	return p, ok
+}
+
+func (a *awayWatch) set(fp, partner string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.told[fp] = partner
+}
+
+func (a *awayWatch) clear(fp string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.told, fp)
+}
+
+// retain forgets players who no longer hold a session. A session reaped
+// while away is gone for good, and its departure is announced by its own
+// teardown — leaving the record behind would fire a stale "is back" at
+// whoever reconnects on that key next.
+func (a *awayWatch) retain(live map[string]*liveSession) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for fp := range a.told {
+		if _, ok := live[fp]; !ok {
+			delete(a.told, fp)
+		}
+	}
+}
+
+// noteAway turns this sweep's away states into transitions, and chips the
+// player each one costs something: the partner mid-coast, not the whole
+// roster. An uncommitted player going quiet chips nobody — the reap
+// already announces them as left, and two chips for one event is noise.
+//
+// Runs in the sweeper goroutine beside extendReprieves, on the same
+// snapshots, and touches no *sim.World.
+func (s *Server) noteAway(now time.Time) {
+	live := s.live.snapshot()
+	defer s.away.retain(live)
+	if len(live) == 0 {
+		return
+	}
+	reports := s.relay.Snapshot("")
+	docks := s.dock.Records()
+	for fp, sess := range live {
+		away := sess.conn != nil && now.Sub(sess.conn.LastIO()) > s.awayAfter
+		partner, told := s.away.partner(fp)
+		switch {
+		case away && !told:
+			c, ok := commitmentFor(reports, docks, fp)
+			if !ok {
+				continue // nobody is waiting on this session
+			}
+			s.away.set(fp, c.peer)
+			s.presence.eventWith(sim.SessionEventWentQuiet, fp, s.handleOf(fp), c.peer, c.kind.String())
+		case !away && told:
+			// Whoever was told about the departure hears about the return,
+			// even if the Commitment resolved while they were gone —
+			// otherwise the chip that opened the story never closes.
+			s.away.clear(fp)
+			s.presence.event(sim.SessionEventBack, fp, s.handleOf(fp), partner)
+		}
+	}
+}
+
+// handleOf resolves a fingerprint to its roster display name.
+func (s *Server) handleOf(fp string) string {
+	if p, err := s.store.FindPlayer(fp); err == nil {
+		return p.Handle
+	}
+	return ""
+}
+
+// departureKind names what happened to a session that is ending. One that
+// was away did not leave — nobody came back for it. Calling that "left"
+// blames a player for abandoning a coast they never touched, and the
+// rendezvous cancel chip that follows compounds it.
+func departureKind(sess *liveSession, awayAfter time.Duration) sim.SessionEventKind {
+	if sess == nil || sess.conn == nil {
+		return sim.SessionEventLeave
+	}
+	if time.Since(sess.conn.LastIO()) > awayAfter {
+		return sim.SessionEventTimedOut
+	}
+	return sim.SessionEventLeave
+}

--- a/internal/serve/away.go
+++ b/internal/serve/away.go
@@ -60,20 +60,6 @@ func (a *awayWatch) clear(fp string) {
 	delete(a.told, fp)
 }
 
-// retain forgets players who no longer hold a session. A session reaped
-// while away is gone for good, and its departure is announced by its own
-// teardown — leaving the record behind would fire a stale "is back" at
-// whoever reconnects on that key next.
-func (a *awayWatch) retain(live map[string]*liveSession) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	for fp := range a.told {
-		if _, ok := live[fp]; !ok {
-			delete(a.told, fp)
-		}
-	}
-}
-
 // noteAway turns this sweep's away states into transitions, and chips the
 // player each one costs something: the partner mid-coast, not the whole
 // roster. An uncommitted player going quiet chips nobody — the reap
@@ -81,9 +67,15 @@ func (a *awayWatch) retain(live map[string]*liveSession) {
 //
 // Runs in the sweeper goroutine beside extendReprieves, on the same
 // snapshots, and touches no *sim.World.
+//
+// Records are never cleaned up from here. A reclaim leaves the
+// fingerprint out of the registry for the whole teardown-and-payload
+// window, so a sweep that dropped absent fingerprints would delete the
+// record the returning session needs and the partner who was told
+// "went quiet" would never hear it closed. Ending sessions clear their
+// own record in persistMiddleware instead.
 func (s *Server) noteAway(now time.Time) {
 	live := s.live.snapshot()
-	defer s.away.retain(live)
 	if len(live) == 0 {
 		return
 	}

--- a/internal/serve/away_test.go
+++ b/internal/serve/away_test.go
@@ -1,0 +1,239 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// eventsOf collects the presence moments of one kind addressed at `to`.
+func eventsOf(srv *Server, kind sim.SessionEventKind, to string) []sim.SessionEvent {
+	var out []sim.SessionEvent
+	for _, e := range srv.presence.eventsFor(to) {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Away is measured on a short leash. activityConn stamps on every frame
+// the client drains, so an attended player is normally fresh within a
+// second or two — the threshold only has to clear a briefly static
+// screen, not the ten minutes the reap needs.
+func TestIsAway(t *testing.T) {
+	srv := newOfflineServer(t)
+	cases := []struct {
+		name     string
+		lastIO   time.Duration // ago
+		register bool
+		want     bool
+	}{
+		{name: "drained a frame a moment ago", lastIO: time.Second, register: true, want: false},
+		{name: "silent just under the threshold", lastIO: 55 * time.Second, register: true, want: false},
+		{name: "silent past the threshold", lastIO: 90 * time.Second, register: true, want: true},
+		{name: "silent for hours, held by a Commitment", lastIO: 3 * time.Hour, register: true, want: true},
+		// Not registered at all is offline, not away: there is no session
+		// simulating on their behalf.
+		{name: "no session at all", register: false, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv.live = newSessionRegistry()
+			if tc.register {
+				register(t, srv, fpA, time.Now().Add(-tc.lastIO))
+			}
+			if got := srv.isAway(fpA); got != tc.want {
+				t.Errorf("isAway = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The roster is what made this slice necessary: a reprieved session stays
+// Online for hours, so without a distinct Away state the Session screen
+// tells a partner their co-conspirator is at the controls when the chair
+// is empty.
+func TestRosterMarksAway(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, fpA, "vex")
+	srv.presence.markOnline(fpA)
+	register(t, srv, fpA, time.Now().Add(-90*time.Second))
+
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	tick(srv.HostModel(app))
+
+	row := rosterRow(t, app.World(), "vex")
+	if !row.Online {
+		t.Error("an away player is not offline — their session is still simulating")
+	}
+	if !row.Away {
+		t.Error("a session silent for 90s is not marked Away; the roster still claims someone is there")
+	}
+}
+
+func TestRosterDoesNotMarkAnAttendedPlayerAway(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, fpA, "vex")
+	srv.presence.markOnline(fpA)
+	register(t, srv, fpA, time.Now())
+
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	tick(srv.HostModel(app))
+
+	if rosterRow(t, app.World(), "vex").Away {
+		t.Error("a player who just drained a frame was marked Away")
+	}
+}
+
+func rosterRow(t *testing.T, w *sim.World, handle string) sim.SessionPlayer {
+	t.Helper()
+	if w.Session == nil {
+		t.Fatal("no session slate after a tick")
+	}
+	for _, p := range w.Session.Players {
+		if p.Handle == handle {
+			return p
+		}
+	}
+	t.Fatalf("no roster row for %q", handle)
+	return sim.SessionPlayer{}
+}
+
+// The chip goes to the person it costs something: the partner mid-coast,
+// not the whole roster. An uncommitted player going quiet chips nobody —
+// the existing reap already announces them as left ten minutes later, and
+// two chips for one event is noise.
+func TestWentQuietChipsOnlyTheCommittedPartner(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, fpA, "vex")
+	enrollDirect(t, srv, fpC, "kes")
+	silent := time.Now().Add(-90 * time.Second)
+	register(t, srv, fpA, silent) // committed with fpB
+	register(t, srv, fpC, silent) // committed with nobody
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+
+	srv.noteAway(time.Now())
+
+	told := eventsOf(srv, sim.SessionEventWentQuiet, fpB)
+	if len(told) != 1 {
+		t.Fatalf("the committed partner got %d went-quiet chips, want 1", len(told))
+	}
+	if told[0].Handle != "vex" {
+		t.Errorf("chip names %q, want vex", told[0].Handle)
+	}
+	if told[0].Detail != "rendezvous" {
+		t.Errorf("chip detail = %q, want \"rendezvous\" — the partner should learn what is at stake", told[0].Detail)
+	}
+	if got := eventsOf(srv, sim.SessionEventWentQuiet, fpA); len(got) != 0 {
+		t.Errorf("the away player was chipped about themselves (%d)", len(got))
+	}
+	// kes went quiet uncommitted: nobody is waiting on them.
+	for _, viewer := range []string{fpA, fpB, fpC} {
+		for _, e := range eventsOf(srv, sim.SessionEventWentQuiet, viewer) {
+			if e.Handle == "kes" {
+				t.Errorf("an uncommitted player going quiet chipped %q", viewer)
+			}
+		}
+	}
+}
+
+// Going quiet is a transition, not a state. Sweeping every 30s for hours
+// must not produce a chip every 30s for hours.
+func TestWentQuietChipsOnce(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, fpA, "vex")
+	register(t, srv, fpA, time.Now().Add(-90*time.Second))
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+
+	for range 5 {
+		srv.noteAway(time.Now())
+	}
+	if got := eventsOf(srv, sim.SessionEventWentQuiet, fpB); len(got) != 1 {
+		t.Errorf("%d went-quiet chips after five sweeps, want 1", len(got))
+	}
+}
+
+// The return must reach whoever was told about the departure, even if the
+// Commitment has since resolved — otherwise a partner who saw "vex went
+// quiet" never learns they came back.
+func TestBackChipReachesWhoeverWasTold(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, fpA, "vex")
+	register(t, srv, fpA, time.Now().Add(-90*time.Second))
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+	srv.noteAway(time.Now())
+
+	// The coast completes while they are away, and then they wake up.
+	publish(srv, []relay.CraftReport{{Owner: fpA, SubspaceTime: simNoon}, {Owner: fpB, SubspaceTime: simNoon}})
+	srv.live = newSessionRegistry()
+	register(t, srv, fpA, time.Now())
+	srv.noteAway(time.Now())
+
+	back := eventsOf(srv, sim.SessionEventBack, fpB)
+	if len(back) != 1 {
+		t.Fatalf("the partner got %d back chips, want 1 — they were told about the departure", len(back))
+	}
+	if back[0].Handle != "vex" {
+		t.Errorf("back chip names %q, want vex", back[0].Handle)
+	}
+}
+
+// A session that dies while away did not leave — nobody came back for it.
+// Saying "left" would blame a player for abandoning a coast they never
+// touched, and the rendezvous cancel chip that follows compounds it.
+func TestDepartureKindDistinguishesTimingOut(t *testing.T) {
+	srv := newOfflineServer(t)
+	cases := []struct {
+		name   string
+		lastIO time.Duration
+		want   sim.SessionEventKind
+	}{
+		{name: "quit while sitting there", lastIO: time.Second, want: sim.SessionEventLeave},
+		{name: "reaped after going silent", lastIO: 90 * time.Second, want: sim.SessionEventTimedOut},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv.live = newSessionRegistry()
+			register(t, srv, fpA, time.Now().Add(-tc.lastIO))
+			ls, _ := srv.live.get(fpA)
+			if got := departureKind(ls, srv.awayAfter); got != tc.want {
+				t.Errorf("departureKind = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A reclaim is one player resuming, not one leaving and another arriving.
+// Mid-coast the leave chip reads as the rendezvous dying — the opposite of
+// what a reclaim preserves.
+func TestDisplacedSessionAnnouncesNeitherLeaveNorJoin(t *testing.T) {
+	srv := newOfflineServer(t)
+	registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
+	ls, _ := srv.live.get(fpA)
+
+	if ls.displaced.Load() {
+		t.Fatal("a fresh session is already flagged displaced")
+	}
+	srv.reclaimWait = 50 * time.Millisecond
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(ls.done)
+	}()
+	if !srv.displaceAbsent(fpA) {
+		t.Fatal("displaceAbsent refused an absent session")
+	}
+	if !ls.displaced.Load() {
+		t.Error("the displaced session was not flagged, so its teardown will announce a departure " +
+			"that reads as the coast dying")
+	}
+}

--- a/internal/serve/away_test.go
+++ b/internal/serve/away_test.go
@@ -229,7 +229,7 @@ func TestDisplacedSessionAnnouncesNeitherLeaveNorJoin(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		close(ls.done)
 	}()
-	if !srv.displaceAbsent(fpA) {
+	if srv.displaceAbsent(fpA) != reclaimTookOver {
 		t.Fatal("displaceAbsent refused an absent session")
 	}
 	if !ls.displaced.Load() {

--- a/internal/serve/commitment.go
+++ b/internal/serve/commitment.go
@@ -1,0 +1,143 @@
+package serve
+
+import (
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+)
+
+// Reprieve bounds (ADR 0036). A Reprieve ends at the earliest of its
+// Commitment resolving, the cap below, or the owner reconnecting.
+const (
+	// dockReprieveCap is how long a cross-player dock holds a session up
+	// after its player goes quiet. Flat: a dock has no committed end time
+	// to derive one from — it lasts until somebody undocks.
+	dockReprieveCap = 2 * time.Hour
+
+	// rendezvousReprieveMargin covers the gap between the coast's arithmetic
+	// end and the session actually noticing: arrival lands on the session's
+	// own tick, the report crosses to the store, and the sweeper sees it a
+	// tick later.
+	rendezvousReprieveMargin = 5 * time.Minute
+
+	// maxUnattendedReprieve is the ceiling on unattended simulation, counted
+	// from the last time the peer spoke. It exists for the pathological
+	// rendezvous: a TCA committed weeks of sim-time out is normally minutes
+	// of wall time under warp, but a paused or 1×-pinned coast would hold
+	// the connection open for weeks on the same arithmetic. Generous on
+	// purpose — the longest coast actually observed was 2h19m — since
+	// cutting a real coast short is the regression this whole mechanism
+	// exists to prevent, and the ceiling is a backstop, not the working
+	// bound.
+	maxUnattendedReprieve = 4 * time.Hour
+)
+
+// commitmentKind distinguishes the two obligations that earn a Reprieve.
+type commitmentKind int
+
+const (
+	commitRendezvous commitmentKind = iota
+	commitDock
+)
+
+func (k commitmentKind) String() string {
+	if k == commitDock {
+		return "dock"
+	}
+	return "rendezvous"
+}
+
+// commitment is a live mutual obligation between two players that
+// outlives either one's attention (CONTEXT.md). Its session keeps
+// simulating while its player is silent, so that a closed laptop on one
+// side doesn't strand the other mid-coast or tear a docked craft out of
+// their Stack.
+type commitment struct {
+	kind commitmentKind
+	peer string // the other player's fingerprint — the one left waiting
+
+	// toGo is the sim-time still to run before the committed Time of
+	// Closest Approach (rendezvous only).
+	toGo time.Duration
+}
+
+// expiry reports when this Commitment's Reprieve runs out. now is wall
+// clock; lastIO is the instant the session's peer last moved bytes (see
+// activityConn) — the cap has to be counted from there, because counting
+// from now would let an absent session renew its own cap on every sweep.
+func (c commitment) expiry(now, lastIO time.Time) time.Time {
+	if c.kind == commitDock {
+		return lastIO.Add(dockReprieveCap)
+	}
+	// The coast is what has to finish, and its worst case is 1× real time:
+	// the sim-time left to the TCA is therefore an upper bound on the wall
+	// time left, and any warp only brings it in sooner. Recomputed every
+	// sweep, so it converges as the unattended session ticks toward τ.
+	coast := now.Add(c.toGo + rendezvousReprieveMargin)
+	if ceiling := lastIO.Add(maxUnattendedReprieve); coast.After(ceiling) {
+		return ceiling
+	}
+	return coast
+}
+
+// commitmentFor reports fp's live Commitment, if it has one.
+//
+// Pure over two snapshots — relay.Store.Snapshot and DockLedger.Records —
+// which is the point: the sweeper runs outside every session's goroutine
+// and must never touch a *sim.World (internal/relay/reporter.go:35). Both
+// Commitments are already published across that seam under their own
+// locks, and that is exactly why Proximity Co-Warp is excluded: its state
+// (w.CoWarp.Coupled) lives only on the World, so admitting it would mean
+// either a new publishing channel or recomputing the coupling — physics
+// in the reaper, which ADR 0034 rules out.
+//
+// A session holding both obligations reports the dock: it is the one with
+// another player's hardware physically inside it, and in practice the
+// longer-lived of the two.
+func commitmentFor(reports []relay.CraftReport, docks []relay.DockRecord, fp string) (commitment, bool) {
+	// Both endpoints of a live dock are committed. The guest's craft is
+	// fused into the owner's Stack, so if the guest drops the owner is
+	// flying hardware they cannot hand back, and if the owner drops the
+	// guest's craft stops being simulated inside a Stack they cannot
+	// undock from — the split runs on the owner's tick.
+	for _, d := range docks {
+		if d.Phase != relay.DockActive {
+			continue
+		}
+		switch fp {
+		case d.GuestOwner:
+			return commitment{kind: commitDock, peer: d.Owner}, true
+		case d.Owner:
+			return commitment{kind: commitDock, peer: d.GuestOwner}, true
+		}
+	}
+	// A Rendezvous Warp is Engaged only once BOTH players have Engaged
+	// toward each other (CONTEXT.md) — that is when the coast starts and
+	// when either side's disappearance starts costing the other real time.
+	// A lone arm is a pending invite: no coast, nobody committed but the
+	// sender, and the partner simply sees the prompt vanish.
+	own, ok := reportFor(reports, fp)
+	if !ok || own.RendezvousTarget == "" {
+		return commitment{}, false
+	}
+	partner, ok := reportFor(reports, own.RendezvousTarget)
+	if !ok || partner.RendezvousTarget != fp {
+		return commitment{}, false
+	}
+	return commitment{
+		kind: commitRendezvous,
+		peer: partner.Owner,
+		// Read from fp's own report: it is fp's session being reprieved, so
+		// its clock and its committed τ are the consistent pair.
+		toGo: own.RendezvousTau.Sub(own.SubspaceTime),
+	}, true
+}
+
+func reportFor(reports []relay.CraftReport, fp string) (relay.CraftReport, bool) {
+	for _, r := range reports {
+		if r.Owner == fp {
+			return r, true
+		}
+	}
+	return relay.CraftReport{}, false
+}

--- a/internal/serve/commitment.go
+++ b/internal/serve/commitment.go
@@ -14,11 +14,18 @@ const (
 	// to derive one from — it lasts until somebody undocks.
 	dockReprieveCap = 2 * time.Hour
 
-	// rendezvousReprieveMargin covers the gap between the coast's arithmetic
-	// end and the session actually noticing: arrival lands on the session's
-	// own tick, the report crosses to the store, and the sweeper sees it a
-	// tick later.
-	rendezvousReprieveMargin = 5 * time.Minute
+	// rendezvousTauOvershoot is how far past the committed TCA — in SIM
+	// time — a coast may drift before the Reprieve stops being extended.
+	// It covers arrival landing on the session's own tick and the report
+	// crossing to the store, both of which happen after τ in the session's
+	// own clock.
+	//
+	// Sim time, not wall clock, and the distinction matters because the
+	// obvious reading is wrong. Under warp five sim-minutes is a fraction
+	// of a second of real time, so this is no use as a grace period for
+	// wall-clock lag, and it bounds nothing in wall-clock terms: see
+	// commitment.expiry.
+	rendezvousTauOvershoot = 5 * time.Minute
 
 	// maxUnattendedReprieve is the ceiling on unattended simulation, counted
 	// from the last time the peer spoke. It exists for the pathological
@@ -69,11 +76,22 @@ func (c commitment) expiry(now, lastIO time.Time) time.Time {
 	if c.kind == commitDock {
 		return lastIO.Add(dockReprieveCap)
 	}
-	// The coast is what has to finish, and its worst case is 1× real time:
-	// the sim-time left to the TCA is therefore an upper bound on the wall
-	// time left, and any warp only brings it in sooner. Recomputed every
-	// sweep, so it converges as the unattended session ticks toward τ.
-	coast := now.Add(c.toGo + rendezvousReprieveMargin)
+	// Two bounds, and only one of them is a clock.
+	//
+	// The first releases the Reprieve once the coast can no longer be
+	// ahead of the session: it is `now + toGo + overshoot`, but `now`
+	// cancels against the `now.Before(...)` it is compared with, so what
+	// it actually tests is `toGo > -overshoot` — purely a question about
+	// the session's own sim-time, recomputed each sweep as its clock
+	// advances toward τ. It does not bound wall-clock at all, and an
+	// earlier version of this comment claimed it did.
+	//
+	// The wall-clock bound is the second one, and it is the only one: a
+	// ceiling counted from the last time the peer spoke. Without it a τ
+	// committed weeks of sim-time out on a paused or 1×-pinned coast would
+	// hold the connection open indefinitely, because the sim-time test
+	// above would keep passing.
+	coast := now.Add(c.toGo + rendezvousTauOvershoot)
 	if ceiling := lastIO.Add(maxUnattendedReprieve); coast.After(ceiling) {
 		return ceiling
 	}

--- a/internal/serve/commitment_test.go
+++ b/internal/serve/commitment_test.go
@@ -198,7 +198,7 @@ func TestCommitmentExpiry(t *testing.T) {
 			// time left — any warp only makes it arrive sooner.
 			name: "rendezvous: the coast's worst-case wall time plus a margin",
 			c:    commitment{kind: commitRendezvous, toGo: 90 * time.Minute},
-			want: now.Add(90*time.Minute + rendezvousReprieveMargin),
+			want: now.Add(90*time.Minute + rendezvousTauOvershoot),
 		},
 		{
 			// A TCA committed weeks of sim-time out is normally minutes of
@@ -213,7 +213,7 @@ func TestCommitmentExpiry(t *testing.T) {
 			// session's own tick): let it land, don't extend indefinitely.
 			name: "rendezvous: the TCA already went by",
 			c:    commitment{kind: commitRendezvous, toGo: -5 * time.Minute},
-			want: now.Add(-5*time.Minute + rendezvousReprieveMargin),
+			want: now.Add(-5*time.Minute + rendezvousTauOvershoot),
 		},
 	}
 	for _, tc := range cases {

--- a/internal/serve/commitment_test.go
+++ b/internal/serve/commitment_test.go
@@ -1,0 +1,241 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+)
+
+const (
+	fpA = "SHA256:aaa"
+	fpB = "SHA256:bbb"
+	fpC = "SHA256:ccc"
+)
+
+var simNoon = time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+// armed builds a report for owner whose Rendezvous Warp intent names
+// target, committed to tau.
+func armed(owner, target string, tau time.Time) relay.CraftReport {
+	return relay.CraftReport{
+		Owner:            owner,
+		SubspaceTime:     simNoon,
+		RendezvousTarget: target,
+		RendezvousTau:    tau,
+	}
+}
+
+// A Reprieve is earned by an *Engaged* Rendezvous Warp, and a Rendezvous
+// Warp is Engaged only once both players have Engaged toward each other
+// (CONTEXT.md: "Once both have Engaged, their Subspaces rate-lock"). A
+// lone arm is a pending invite: no coast has started, nobody is waiting
+// on a coast, and the partner sees the prompt vanish rather than being
+// stranded by it.
+func TestCommitmentForRendezvous(t *testing.T) {
+	tau := simNoon.Add(90 * time.Minute)
+	cases := []struct {
+		name    string
+		reports []relay.CraftReport
+		want    bool
+	}{
+		{
+			name:    "mutually armed — the coast both players committed to",
+			reports: []relay.CraftReport{armed(fpA, fpB, tau), armed(fpB, fpA, tau)},
+			want:    true,
+		},
+		{
+			name:    "armed alone, partner has not Engaged back",
+			reports: []relay.CraftReport{armed(fpA, fpB, tau), {Owner: fpB, SubspaceTime: simNoon}},
+			want:    false,
+		},
+		{
+			name:    "partner armed toward us, we have not Engaged back",
+			reports: []relay.CraftReport{{Owner: fpA, SubspaceTime: simNoon}, armed(fpB, fpA, tau)},
+			want:    false,
+		},
+		{
+			name:    "armed toward a player who is not reporting at all",
+			reports: []relay.CraftReport{armed(fpA, fpB, tau)},
+			want:    false,
+		},
+		{
+			// Both armed, but not at each other — two unrelated pending
+			// invites, not one mutual encounter.
+			name:    "arms cross past each other",
+			reports: []relay.CraftReport{armed(fpA, fpB, tau), armed(fpB, fpC, tau)},
+			want:    false,
+		},
+		{
+			name:    "no arm at all",
+			reports: []relay.CraftReport{{Owner: fpA, SubspaceTime: simNoon}, {Owner: fpB, SubspaceTime: simNoon}},
+			want:    false,
+		},
+		{
+			name:    "not reporting",
+			reports: nil,
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ok := commitmentFor(tc.reports, nil, fpA)
+			if ok != tc.want {
+				t.Fatalf("commitmentFor = %v, want %v", ok, tc.want)
+			}
+			if !ok {
+				return
+			}
+			if c.kind != commitRendezvous {
+				t.Errorf("kind = %v, want commitRendezvous", c.kind)
+			}
+			if c.peer != fpB {
+				t.Errorf("peer = %q, want %q", c.peer, fpB)
+			}
+			if want := 90 * time.Minute; c.toGo != want {
+				t.Errorf("toGo = %v, want %v (sim-time left to the committed TCA)", c.toGo, want)
+			}
+		})
+	}
+}
+
+// Both ends of a live cross-player dock are committed. The guest's craft
+// is fused into the owner's Stack: if the guest drops, the owner is
+// flying someone else's hardware they cannot give back; if the *owner*
+// drops, the guest's craft stops being simulated inside a stack they
+// cannot undock from, since the split happens on the owner's tick.
+func TestCommitmentForDock(t *testing.T) {
+	active := relay.DockRecord{
+		ID: 1, Owner: fpA, OwnerHandle: "ansi",
+		GuestOwner: fpB, GuestHandle: "vex", Phase: relay.DockActive,
+	}
+	cases := []struct {
+		name     string
+		docks    []relay.DockRecord
+		fp       string
+		want     bool
+		wantPeer string
+	}{
+		{name: "guest riding another player's stack", docks: []relay.DockRecord{active}, fp: fpB, want: true, wantPeer: fpA},
+		{name: "owner carrying another player's craft", docks: []relay.DockRecord{active}, fp: fpA, want: true, wantPeer: fpB},
+		{
+			// Mid-handshake, no craft has changed hands yet, and it resolves
+			// within a tick or two under normal operation.
+			name:  "pending dock",
+			docks: []relay.DockRecord{{ID: 2, Owner: fpA, GuestOwner: fpB, Phase: relay.DockPending}},
+			fp:    fpB,
+			want:  false,
+		},
+		{name: "a dock between two other players", docks: []relay.DockRecord{active}, fp: fpC, want: false},
+		{name: "no docks", docks: nil, fp: fpA, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, ok := commitmentFor(nil, tc.docks, tc.fp)
+			if ok != tc.want {
+				t.Fatalf("commitmentFor = %v, want %v", ok, tc.want)
+			}
+			if !ok {
+				return
+			}
+			if c.kind != commitDock {
+				t.Errorf("kind = %v, want commitDock", c.kind)
+			}
+			if c.peer != tc.wantPeer {
+				t.Errorf("peer = %q, want %q", c.peer, tc.wantPeer)
+			}
+		})
+	}
+}
+
+// The deliberate exclusion (ADR 0036): Proximity Co-Warp forms by itself
+// whenever two players drift close and strands nobody when it lapses —
+// the survivor decouples and warps on. It is also the one coupling whose
+// state lives only on the World, so granting it a Reprieve would put a
+// physics recompute in the sweeper. Two players flying alongside each
+// other with no arm and no dock look exactly like this: uncommitted.
+func TestProximityCoWarpEarnsNoReprieve(t *testing.T) {
+	near := []relay.CraftReport{
+		{Owner: fpA, SubspaceTime: simNoon, EffWarp: 100, Crafts: []relay.CraftState{{ID: 1, Primary: "Terra"}}},
+		{Owner: fpB, SubspaceTime: simNoon, EffWarp: 100, Crafts: []relay.CraftState{{ID: 2, Primary: "Terra"}}},
+	}
+	if _, ok := commitmentFor(near, nil, fpA); ok {
+		t.Error("proximity co-warp earned a Reprieve — it forms by itself and strands nobody, " +
+			"and its state lives only on the World the sweeper must never touch")
+	}
+}
+
+// A dock outlives a rendezvous coast in practice, so it wins when a
+// session somehow holds both.
+func TestCommitmentDockOutranksRendezvous(t *testing.T) {
+	tau := simNoon.Add(10 * time.Minute)
+	reports := []relay.CraftReport{armed(fpA, fpB, tau), armed(fpB, fpA, tau)}
+	docks := []relay.DockRecord{{ID: 1, Owner: fpC, GuestOwner: fpA, Phase: relay.DockActive}}
+	c, ok := commitmentFor(reports, docks, fpA)
+	if !ok || c.kind != commitDock {
+		t.Errorf("commitmentFor = (%v, %v), want a dock Commitment", c.kind, ok)
+	}
+}
+
+func TestCommitmentExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 25, 16, 0, 0, 0, time.UTC)
+	quiet := now.Add(-20 * time.Minute) // the peer stopped speaking 20 min ago
+	cases := []struct {
+		name string
+		c    commitment
+		want time.Time
+	}{
+		{
+			// Flat, and counted from when the peer went quiet — not from now,
+			// or an absent session would renew its own cap every sweep.
+			name: "dock: flat cap from the last time the peer spoke",
+			c:    commitment{kind: commitDock},
+			want: quiet.Add(dockReprieveCap),
+		},
+		{
+			// The coast is what must finish. Its worst case is 1× real time,
+			// so the sim-time left to the TCA is an upper bound on the wall
+			// time left — any warp only makes it arrive sooner.
+			name: "rendezvous: the coast's worst-case wall time plus a margin",
+			c:    commitment{kind: commitRendezvous, toGo: 90 * time.Minute},
+			want: now.Add(90*time.Minute + rendezvousReprieveMargin),
+		},
+		{
+			// A TCA committed weeks of sim-time out is normally minutes of
+			// wall time under warp, but a paused or 1×-pinned session would
+			// hold the connection open for weeks on that arithmetic.
+			name: "rendezvous: a far-off TCA still hits the unattended ceiling",
+			c:    commitment{kind: commitRendezvous, toGo: 30 * 24 * time.Hour},
+			want: quiet.Add(maxUnattendedReprieve),
+		},
+		{
+			// τ passed but the arm has not cleared yet (arrival lands on the
+			// session's own tick): let it land, don't extend indefinitely.
+			name: "rendezvous: the TCA already went by",
+			c:    commitment{kind: commitRendezvous, toGo: -5 * time.Minute},
+			want: now.Add(-5*time.Minute + rendezvousReprieveMargin),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.c.expiry(now, quiet); !got.Equal(tc.want) {
+				t.Errorf("expiry = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The empirical bound the whole feature exists for: the 2026-07-25
+// playtest coast ran 2h19m of real time at 1×, because co-warp pins a
+// coupled pair to the slower player's rate. A ceiling that cannot cover
+// an observed real coast would reintroduce exactly the "strands your
+// partner" regression the Reprieve is here to prevent.
+func TestReprieveCoversAnObservedCoast(t *testing.T) {
+	const observed = 2*time.Hour + 19*time.Minute
+	now := time.Date(2026, 7, 25, 16, 0, 0, 0, time.UTC)
+	c := commitment{kind: commitRendezvous, toGo: observed}
+	if got := c.expiry(now, now); got.Sub(now) < observed {
+		t.Errorf("a %v coast gets only %v of Reprieve — the partner is stranded mid-coast",
+			observed, got.Sub(now))
+	}
+}

--- a/internal/serve/conn.go
+++ b/internal/serve/conn.go
@@ -1,0 +1,88 @@
+package serve
+
+import (
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/charmbracelet/ssh"
+)
+
+// activityConn wraps a session's connection and records the instant it
+// last actually moved bytes (ADR 0036, Commitment Reprieve).
+//
+// A Reprieve keeps an unattended Session alive past the idle timeout,
+// which destroys the only other signal that its player has gone away:
+// the connection dying. This stamp is what remains. It is what makes the
+// Reprieve's cap measurable at all — the cap is counted from when the
+// peer went quiet, and nothing else can say when that was — and it is
+// the only thing that distinguishes *absent, coasting unattended* from
+// *present, on a legitimately long coast*, since a player watching a
+// two-hour burn touches no keys but their terminal keeps draining
+// frames. So it cannot be dropped as an optimisation.
+//
+// Bytes moving is the evidence, not an I/O call returning without error:
+// the absent-peer case is precisely a write that blocks on a full send
+// buffer and comes back having written nothing. A write that moved some
+// bytes and *then* failed still proves the peer was draining until it
+// stopped. (A write only reaches the kernel's send buffer, not the peer's
+// screen — but backpressure from an unacknowledged buffer is exactly the
+// signal the idle timeout itself keys on, so the two agree.)
+//
+// Read lock-free by the sweeper goroutine: a plain atomic, because this
+// is written on the I/O path of every session and read from outside it.
+//
+// Deliberately no SetDeadline or Close of its own. The sweeper extends a
+// Reprieve by calling SetDeadline on a connection whose Write is already
+// blocked — that call is the entire mechanism (ADR 0036, "there is no
+// inline version of this feature"), and a wrapper that shadowed or
+// swallowed it would silently cap every Reprieve at one idle window.
+type activityConn struct {
+	net.Conn
+
+	now    func() time.Time
+	lastIO atomic.Int64 // unix nanos
+}
+
+// newActivityConn wraps c, taking its instants from now (injected so the
+// sweeper's accounting is testable without sleeping).
+func newActivityConn(c net.Conn, now func() time.Time) *activityConn {
+	ac := &activityConn{Conn: c, now: now}
+	// A fresh connection is active. Leaving the stamp at zero would read
+	// as a peer absent since 1970 and cap a Reprieve the instant it opened.
+	ac.stamp()
+	return ac
+}
+
+func (c *activityConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if n > 0 {
+		c.stamp()
+	}
+	return n, err
+}
+
+func (c *activityConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	if n > 0 {
+		c.stamp()
+	}
+	return n, err
+}
+
+func (c *activityConn) stamp() { c.lastIO.Store(c.now().UnixNano()) }
+
+// LastIO reports when the connection last moved bytes in either
+// direction — the measure of how long this session's player has been
+// silent.
+func (c *activityConn) LastIO() time.Time { return time.Unix(0, c.lastIO.Load()) }
+
+// sessionActivity returns the wrapper for the connection behind ctx —
+// stashed there by the ConnCallback in New, which is the only place the
+// raw net.Conn is ever visible. A session reads it through the same
+// Context via sess.Context(). Nil if the server was built without the
+// callback.
+func sessionActivity(ctx ssh.Context) *activityConn {
+	ac, _ := ctx.Value(ctxKeyConn).(*activityConn)
+	return ac
+}

--- a/internal/serve/conn.go
+++ b/internal/serve/conn.go
@@ -86,3 +86,11 @@ func sessionActivity(ctx ssh.Context) *activityConn {
 	ac, _ := ctx.Value(ctxKeyConn).(*activityConn)
 	return ac
 }
+
+// sessionDone returns the channel persistMiddleware closes once this
+// session's payload write has landed — what a reclaiming connection
+// waits on before loading the world.
+func sessionDone(ctx ssh.Context) chan struct{} {
+	done, _ := ctx.Value(ctxKeyDone).(chan struct{})
+	return done
+}

--- a/internal/serve/conn_test.go
+++ b/internal/serve/conn_test.go
@@ -26,6 +26,20 @@ type stubConn struct {
 
 	mu        sync.Mutex
 	deadlines []time.Time
+	closed    bool
+}
+
+func (c *stubConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+
+func (c *stubConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
 }
 
 func (c *stubConn) Read([]byte) (int, error)  { return c.readN, c.readErr }

--- a/internal/serve/conn_test.go
+++ b/internal/serve/conn_test.go
@@ -264,7 +264,7 @@ func TestSessionContextCarriesItsConn(t *testing.T) {
 	}
 	done := make(chan error, 1)
 	go func() { done <- srv.Serve() }()
-	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+	t.Cleanup(func() { stopServer(t, srv, done) })
 
 	signer, fp := newClientKey(t)
 	enrollDirect(t, srv, fp, "vex")

--- a/internal/serve/conn_test.go
+++ b/internal/serve/conn_test.go
@@ -1,0 +1,312 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/ssh"
+	cssh "golang.org/x/crypto/ssh"
+)
+
+// stubConn is a net.Conn whose I/O results and deadline calls the test
+// dictates. Methods the wrapper is not supposed to touch are inherited
+// from the nil embedded interface and panic if it does — which is the
+// point.
+type stubConn struct {
+	net.Conn
+	readN, writeN     int
+	readErr, writeErr error
+
+	mu        sync.Mutex
+	deadlines []time.Time
+}
+
+func (c *stubConn) Read([]byte) (int, error)  { return c.readN, c.readErr }
+func (c *stubConn) Write([]byte) (int, error) { return c.writeN, c.writeErr }
+
+func (c *stubConn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deadlines = append(c.deadlines, t)
+	return nil
+}
+
+func (c *stubConn) deadlinesSet() []time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Time(nil), c.deadlines...)
+}
+
+// fakeClock hands out instants the test controls — no sleeps.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// A Reprieve keeps an unattended session alive, which destroys the only
+// other signal that its player is gone — the connection dying. What is
+// left is this stamp, so it has to mean exactly one thing: the last
+// instant bytes actually crossed the wire.
+func TestActivityConnStampsIOThatMovedBytes(t *testing.T) {
+	start := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		stub *stubConn
+		do   func(*activityConn)
+		want bool
+	}{
+		{
+			name: "write reaches the peer",
+			stub: &stubConn{writeN: 64},
+			do:   func(c *activityConn) { _, _ = c.Write(make([]byte, 64)) },
+			want: true,
+		},
+		{
+			name: "read delivers input",
+			stub: &stubConn{readN: 3},
+			do:   func(c *activityConn) { _, _ = c.Read(make([]byte, 8)) },
+			want: true,
+		},
+		{
+			// The absent-peer case itself: the send buffer is full, the write
+			// blocks and comes back empty. Stamping here would make a sleeping
+			// laptop look present for as long as the server kept trying.
+			name: "write times out having moved nothing",
+			stub: &stubConn{writeErr: os.ErrDeadlineExceeded},
+			do:   func(c *activityConn) { _, _ = c.Write(make([]byte, 64)) },
+			want: false,
+		},
+		{
+			name: "read fails having moved nothing",
+			stub: &stubConn{readErr: io.EOF},
+			do:   func(c *activityConn) { _, _ = c.Read(make([]byte, 8)) },
+			want: false,
+		},
+		{
+			// Bytes moving is the evidence, not the error being nil: the peer
+			// was draining right up until it stopped.
+			name: "partial write then error",
+			stub: &stubConn{writeN: 12, writeErr: os.ErrDeadlineExceeded},
+			do:   func(c *activityConn) { _, _ = c.Write(make([]byte, 64)) },
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clk := &fakeClock{now: start}
+			c := newActivityConn(tc.stub, clk.Now)
+			clk.advance(5 * time.Minute)
+			tc.do(c)
+
+			moved := !c.LastIO().Equal(start)
+			if moved != tc.want {
+				t.Errorf("LastIO advanced = %v, want %v (LastIO %v, opened at %v)",
+					moved, tc.want, c.LastIO(), start)
+			}
+		})
+	}
+}
+
+// A fresh connection is active. Leaving the stamp at the zero time would
+// read as a peer absent since 1970, capping every new session's Reprieve
+// the instant it opened.
+func TestActivityConnOpensStamped(t *testing.T) {
+	start := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	clk := &fakeClock{now: start}
+	c := newActivityConn(&stubConn{}, clk.Now)
+	if got := c.LastIO(); !got.Equal(start) {
+		t.Errorf("LastIO = %v on a conn that has done no I/O, want its open instant %v", got, start)
+	}
+}
+
+// The sweeper extends a Reprieve by calling SetDeadline on a connection
+// whose Write is already blocked — that is the whole mechanism (ADR 0036,
+// "there is no inline version of this feature"). A wrapper that shadowed
+// or swallowed SetDeadline would silently cap every Reprieve at a single
+// idle window, with nothing failing loudly.
+func TestActivityConnPassesSetDeadlineThrough(t *testing.T) {
+	stub := &stubConn{}
+	c := newActivityConn(stub, time.Now)
+	want := time.Date(2026, 7, 25, 14, 30, 0, 0, time.UTC)
+	if err := c.SetDeadline(want); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+	got := stub.deadlinesSet()
+	if len(got) != 1 || !got[0].Equal(want) {
+		t.Errorf("deadlines reaching the connection = %v, want exactly [%v]", got, want)
+	}
+}
+
+// stubCtx is an ssh.Context carrying only what a callback needs: a value
+// bag. The connection metadata accessors are never reached by the code
+// under test.
+type stubCtx struct {
+	context.Context
+	*sync.Mutex
+	mu     sync.Mutex
+	values map[any]any
+}
+
+func newStubCtx() *stubCtx {
+	return &stubCtx{Context: context.Background(), Mutex: &sync.Mutex{}, values: map[any]any{}}
+}
+
+func (c *stubCtx) SetValue(key, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[key] = value
+}
+
+func (c *stubCtx) Value(key any) any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if v, ok := c.values[key]; ok {
+		return v
+	}
+	return c.Context.Value(key)
+}
+
+func (c *stubCtx) User() string                  { return "" }
+func (c *stubCtx) SessionID() string             { return "" }
+func (c *stubCtx) ClientVersion() string         { return "" }
+func (c *stubCtx) ServerVersion() string         { return "" }
+func (c *stubCtx) RemoteAddr() net.Addr          { return nil }
+func (c *stubCtx) LocalAddr() net.Addr           { return nil }
+func (c *stubCtx) Permissions() *ssh.Permissions { return nil }
+
+// Every served connection must be wrapped, and the wrapper must land
+// somewhere a session can reach it: ConnCallback is the only place that
+// ever sees the raw net.Conn, and its ssh.Context is the same one the
+// session later reads through sess.Context().
+func TestServerWrapsConnsAndStashesThem(t *testing.T) {
+	srv := newOfflineServer(t)
+	if srv.ssh.ConnCallback == nil {
+		t.Fatal("no ConnCallback — connections are unwrapped, so nothing records when a peer last spoke")
+	}
+	ctx := newStubCtx()
+	stub := &stubConn{}
+
+	wrapped := srv.ssh.ConnCallback(ctx, stub)
+
+	ac, ok := wrapped.(*activityConn)
+	if !ok {
+		t.Fatalf("ConnCallback returned %T, want *activityConn", wrapped)
+	}
+	if got := sessionActivity(ctx); got != ac {
+		t.Errorf("sessionActivity = %p, want the wrapper handed to the connection (%p)", got, ac)
+	}
+	// It must still be the same connection underneath — a wrapper that
+	// dropped the conn would break every session, loudly.
+	if _, err := ac.Write(nil); err != nil && !errors.Is(err, stub.writeErr) {
+		t.Errorf("Write through the wrapper: %v", err)
+	}
+}
+
+// The stash only works because the Context handed to ConnCallback is the
+// same object a session later reads through sess.Context() — an ssh
+// library property this design leans on, and one a dependency bump could
+// quietly break. Pinned against the real server, over a real connection:
+// the session appearing on the *captured connection's* Context is the
+// proof, and the wrapper found there must be tracking live traffic.
+func TestSessionContextCarriesItsConn(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "ssh_host_ed25519_key"),
+		SessionDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Decorate the real callback rather than replacing it: the production
+	// wrapping still happens, the test just keeps a handle on the Context.
+	inner := srv.ssh.ConnCallback
+	if inner == nil {
+		t.Fatal("no ConnCallback — connections are unwrapped, so no session can find its own")
+	}
+	ctxs := make(chan ssh.Context, 4)
+	srv.ssh.ConnCallback = func(ctx ssh.Context, conn net.Conn) net.Conn {
+		ctxs <- ctx
+		return inner(ctx, conn)
+	}
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "vex")
+	client, err := cssh.Dial("tcp", srv.Addr(), &cssh.ClientConfig{
+		User:            "guest",
+		Auth:            []cssh.AuthMethod{cssh.PublicKeys(signer)},
+		HostKeyCallback: cssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := sess.RequestPty("xterm-256color", 30, 120, cssh.TerminalModes{}); err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	stdout, err := sess.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	go func() { _, _ = io.Copy(io.Discard, stdout) }() // a present peer drains
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+
+	var ctx ssh.Context
+	select {
+	case ctx = <-ctxs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ConnCallback never fired for a real connection")
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for ctx.Value(ssh.ContextKeySession) == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("no session ever appeared on the connection's Context — " +
+				"sess.Context() is no longer the Context ConnCallback saw, so a " +
+				"session can no longer find its own connection")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	ac := sessionActivity(ctx)
+	if ac == nil {
+		t.Fatal("no activityConn on the session's Context")
+	}
+	// And it is tracking this connection's real traffic, not sitting at its
+	// open instant: the session is rendering frames the client is draining.
+	opened := ac.LastIO()
+	for time.Now().Before(deadline) {
+		if ac.LastIO().After(opened) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Errorf("LastIO stuck at %v while the session streamed frames — the wrapper is not on the I/O path", opened)
+}

--- a/internal/serve/idle_timeout_test.go
+++ b/internal/serve/idle_timeout_test.go
@@ -79,7 +79,7 @@ func TestAbsentPeerIsReaped(t *testing.T) {
 	}
 	done := make(chan error, 1)
 	go func() { done <- srv.Serve() }()
-	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+	t.Cleanup(func() { stopServer(t, srv, done) })
 
 	signer, fp := newClientKey(t)
 	enrollDirect(t, srv, fp, "gern")

--- a/internal/serve/idle_timeout_test.go
+++ b/internal/serve/idle_timeout_test.go
@@ -1,0 +1,123 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cssh "golang.org/x/crypto/ssh"
+)
+
+// #243: a guest's game runs server-side on its own tick loop, so a client
+// whose machine sleeps does not stop the session — it leaves a half-open
+// TCP that nothing reaps. The session kept running unattended, presence
+// kept counting it, and its owner stayed locked out behind it.
+
+// waitPresence blocks until fp's online state matches want, or fails.
+func waitPresence(t *testing.T, srv *Server, fp string, want bool, timeout time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if srv.presence.isOnline(fp) == want {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+func TestIdleTimeoutConfigured(t *testing.T) {
+	srv := newOfflineServer(t)
+	if srv.ssh.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v — without it a dead peer's connection never dies",
+			srv.ssh.IdleTimeout, DefaultIdleTimeout)
+	}
+	// No absolute cap: that would disconnect players who are present.
+	if srv.ssh.MaxTimeout != 0 {
+		t.Errorf("MaxTimeout = %v, want unset — an absolute cap would evict active players",
+			srv.ssh.MaxTimeout)
+	}
+}
+
+func TestIdleTimeoutOverridable(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "hostkey"),
+		SessionDir:  t.TempDir(),
+		IdleTimeout: 42 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() { _ = srv.ln.Close() }()
+	if srv.ssh.IdleTimeout != 42*time.Second {
+		t.Errorf("IdleTimeout = %v, want the configured 42s", srv.ssh.IdleTimeout)
+	}
+}
+
+// The behaviour that matters: a peer that stops reading is eventually
+// dropped, freeing its slot. Simulated by completing the SSH handshake
+// and then never draining stdout — the server's frames back up, its
+// write blocks, and the deadline tears the connection down. That is the
+// same path a sleeping laptop takes.
+func TestAbsentPeerIsReaped(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	keyPath := filepath.Join(t.TempDir(), "ssh_host_ed25519_key")
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: keyPath,
+		SessionDir:  t.TempDir(),
+		IdleTimeout: 750 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("host key: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "gern")
+
+	client, err := cssh.Dial("tcp", srv.Addr(), &cssh.ClientConfig{
+		User:            "guest",
+		Auth:            []cssh.AuthMethod{cssh.PublicKeys(signer)},
+		HostKeyCallback: cssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := sess.RequestPty("xterm-256color", 30, 120, cssh.TerminalModes{}); err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	// Never read stdout, never write stdin: from here on this client is
+	// indistinguishable from one whose machine went to sleep.
+	if _, err := sess.StdoutPipe(); err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+
+	// Presence is the race-free observable here: handlers mutate it under
+	// its own mutex, and it is exactly what the lockout depends on. (Not
+	// srv.sessions.Wait() — Wait racing a starting session's Add is
+	// WaitGroup misuse, which the race detector rightly flags.)
+	waitPresence(t, srv, fp, true, 10*time.Second,
+		"the session never came online, so there is nothing to reap")
+	waitPresence(t, srv, fp, false, 30*time.Second,
+		"an absent peer's session was never reaped — it would hold its slot "+
+			"and keep running unattended indefinitely")
+}

--- a/internal/serve/presence.go
+++ b/internal/serve/presence.go
@@ -47,9 +47,18 @@ func (p *presence) isOnline(fp string) bool {
 // event appends a session moment, trimming the ring. to addresses the
 // event at one player (empty = broadcast).
 func (p *presence) event(kind sim.SessionEventKind, owner, handle, to string) {
+	p.eventWith(kind, owner, handle, to, "")
+}
+
+// eventWith is event plus display context — ADR 0036 carries which
+// Commitment is holding an away session up, so the partner learns what is
+// at stake rather than only that someone went quiet.
+func (p *presence) eventWith(kind sim.SessionEventKind, owner, handle, to, detail string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.events = append(p.events, sim.SessionEvent{Kind: kind, Owner: owner, Handle: handle, To: to, At: time.Now()})
+	p.events = append(p.events, sim.SessionEvent{
+		Kind: kind, Owner: owner, Handle: handle, To: to, Detail: detail, At: time.Now(),
+	})
 	if len(p.events) > presenceEventCap {
 		p.events = p.events[len(p.events)-presenceEventCap:]
 	}

--- a/internal/serve/reclaim.go
+++ b/internal/serve/reclaim.go
@@ -1,6 +1,9 @@
 package serve
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // defaultReclaimWait bounds how long a reconnecting player waits for the
 // session they are displacing to write its payload. Generous: the write
@@ -8,8 +11,55 @@ import "time"
 // player a retry.
 const defaultReclaimWait = 10 * time.Second
 
-// displaceAbsent hands fp's slot to a reconnecting player, and reports
-// whether it managed to (ADR 0036).
+// reclaimResult is what a reconnecting connection made of the slot it
+// found occupied.
+type reclaimResult int
+
+const (
+	// reclaimRefused: somebody may still be at the controls. Leave them be.
+	reclaimRefused reclaimResult = iota
+	// reclaimTookOver: the old session is down and its payload is written.
+	reclaimTookOver
+	// reclaimStalled: the old session was torn down but its payload never
+	// landed. The caller must not load the world, but the player is not
+	// being told to disconnect something — it is already gone.
+	reclaimStalled
+)
+
+// admission serialises connections arriving on the same key.
+//
+// Reclaim reads the registry, tears a session down and then waits up to
+// reclaimWait for its payload — a window wide enough for a second
+// connection on the same key to pass the same test and be admitted
+// alongside the first, which is the divergent-World collision the
+// one-session-per-key guard exists to prevent. Held from before the
+// guard until after the winner has registered and marked itself online,
+// so a latecomer either sees a live session or is refused by it.
+//
+// One mutex per fingerprint ever seen, never reclaimed: bounded by the
+// roster, which is a handful of people.
+type admission struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newAdmission() *admission { return &admission{locks: map[string]*sync.Mutex{}} }
+
+// enter blocks until fp is free to admit, and returns the release.
+func (a *admission) enter(fp string) func() {
+	a.mu.Lock()
+	l, ok := a.locks[fp]
+	if !ok {
+		l = &sync.Mutex{}
+		a.locks[fp] = l
+	}
+	a.mu.Unlock()
+	l.Lock()
+	return l.Unlock
+}
+
+// displaceAbsent hands fp's slot to a reconnecting player (ADR 0036).
+// Callers must already hold fp's admission.
 //
 // Without this the Reprieve reintroduces the very lockout the idle
 // timeout was added to fix, and does it worst to the players most likely
@@ -29,17 +79,17 @@ const defaultReclaimWait = 10 * time.Second
 // closed at the very end of persistMiddleware, so a reclaiming session
 // can never read a payload the displaced one is still about to
 // overwrite.
-func (s *Server) displaceAbsent(fp string) bool {
+func (s *Server) displaceAbsent(fp string) reclaimResult {
 	sess, ok := s.live.get(fp)
 	if !ok {
 		// Presence says online but nothing is registered, so the absence
 		// cannot be verified. Refuse rather than admit on faith — the host
 		// plays in-process and is permanently online without ever holding a
 		// session, and letting a key in there would fork its world.
-		return false
+		return reclaimRefused
 	}
 	if sess.conn == nil || time.Since(sess.conn.LastIO()) <= s.idleTimeout {
-		return false
+		return reclaimRefused
 	}
 	// Out of the registry first, so the sweeper stops reprieving something
 	// that is on its way down. Flagged before the close so its teardown
@@ -48,14 +98,19 @@ func (s *Server) displaceAbsent(fp string) bool {
 	s.live.remove(fp, sess)
 	_ = sess.conn.Close()
 	if sess.done == nil {
-		return true
+		return reclaimTookOver
 	}
 	select {
 	case <-sess.done:
-		return true
+		return reclaimTookOver
 	case <-time.After(s.reclaimWait):
-		// Its payload never landed. Being told to try again is recoverable;
-		// silently resuming a world that is about to be overwritten is not.
-		return false
+		// Its payload never landed, so this connection must not load the
+		// world. But the old session has already been closed and cannot come
+		// back: clearing the flag lets its teardown announce the departure
+		// and drop its banked interval like any other ending session, rather
+		// than leaving a player disconnected, unannounced, and holding a
+		// stale bank that would replay at their next connect.
+		sess.displaced.Store(false)
+		return reclaimStalled
 	}
 }

--- a/internal/serve/reclaim.go
+++ b/internal/serve/reclaim.go
@@ -1,0 +1,59 @@
+package serve
+
+import "time"
+
+// defaultReclaimWait bounds how long a reconnecting player waits for the
+// session they are displacing to write its payload. Generous: the write
+// is one small file behind a program teardown, and giving up costs the
+// player a retry.
+const defaultReclaimWait = 10 * time.Second
+
+// displaceAbsent hands fp's slot to a reconnecting player, and reports
+// whether it managed to (ADR 0036).
+//
+// Without this the Reprieve reintroduces the very lockout the idle
+// timeout was added to fix, and does it worst to the players most likely
+// to want back in: the ones mid-encounter, whose lockout would last as
+// long as the coast they committed to.
+//
+// Displacing is only safe because the session being displaced is known
+// unattended. The test is that its peer has been silent for longer than
+// the idle timeout, which means the deadline its own I/O path set has
+// already passed — it is still alive only because the sweeper has been
+// holding it open. A session whose peer spoke recently is somebody at the
+// controls and is never displaced, so the second connection is refused
+// exactly as it was before.
+//
+// The order is load-bearing: close the connection, then wait for the
+// payload write, and only then let the caller load the world. `done` is
+// closed at the very end of persistMiddleware, so a reclaiming session
+// can never read a payload the displaced one is still about to
+// overwrite.
+func (s *Server) displaceAbsent(fp string) bool {
+	sess, ok := s.live.get(fp)
+	if !ok {
+		// Presence says online but nothing is registered, so the absence
+		// cannot be verified. Refuse rather than admit on faith — the host
+		// plays in-process and is permanently online without ever holding a
+		// session, and letting a key in there would fork its world.
+		return false
+	}
+	if sess.conn == nil || time.Since(sess.conn.LastIO()) <= s.idleTimeout {
+		return false
+	}
+	// Out of the registry first, so the sweeper stops reprieving something
+	// that is on its way down.
+	s.live.remove(fp, sess)
+	_ = sess.conn.Close()
+	if sess.done == nil {
+		return true
+	}
+	select {
+	case <-sess.done:
+		return true
+	case <-time.After(s.reclaimWait):
+		// Its payload never landed. Being told to try again is recoverable;
+		// silently resuming a world that is about to be overwritten is not.
+		return false
+	}
+}

--- a/internal/serve/reclaim.go
+++ b/internal/serve/reclaim.go
@@ -42,7 +42,9 @@ func (s *Server) displaceAbsent(fp string) bool {
 		return false
 	}
 	// Out of the registry first, so the sweeper stops reprieving something
-	// that is on its way down.
+	// that is on its way down. Flagged before the close so its teardown
+	// reads the flag and stays quiet: the player is resuming, not leaving.
+	sess.displaced.Store(true)
 	s.live.remove(fp, sess)
 	_ = sess.conn.Close()
 	if sess.done == nil {

--- a/internal/serve/reclaim_test.go
+++ b/internal/serve/reclaim_test.go
@@ -202,7 +202,7 @@ func TestReconnectDisplacesItsOwnReprievedSession(t *testing.T) {
 	srv.reprieveWindow = 250 * time.Millisecond
 	done := make(chan error, 1)
 	go func() { done <- srv.Serve() }()
-	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+	t.Cleanup(func() { stopServer(t, srv, done) })
 
 	signer, fp := newClientKey(t)
 	enrollDirect(t, srv, fp, "vex")

--- a/internal/serve/reclaim_test.go
+++ b/internal/serve/reclaim_test.go
@@ -103,7 +103,7 @@ func TestDisplaceWaitsForThePayloadWrite(t *testing.T) {
 	srv := newOfflineServer(t)
 	stub, done := registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
 
-	returned := make(chan bool, 1)
+	returned := make(chan reclaimResult, 1)
 	go func() { returned <- srv.displaceAbsent(fpA) }()
 
 	// It must have torn the old connection down...
@@ -126,8 +126,8 @@ func TestDisplaceWaitsForThePayloadWrite(t *testing.T) {
 	close(done) // the payload has landed
 	select {
 	case ok := <-returned:
-		if !ok {
-			t.Error("displaceAbsent = false after a clean handover, want true")
+		if ok != reclaimTookOver {
+			t.Error("displaceAbsent did not take over after a clean handover")
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("displaceAbsent never returned after the payload landed")
@@ -144,7 +144,7 @@ func TestDisplaceRefusesAnAttendedSession(t *testing.T) {
 	srv := newOfflineServer(t)
 	stub, _ := registerWithDone(t, srv, fpA, time.Now().Add(-time.Second))
 
-	if srv.displaceAbsent(fpA) {
+	if srv.displaceAbsent(fpA) != reclaimRefused {
 		t.Error("displaced a session whose peer spoke a second ago — that is a player at the controls")
 	}
 	if stub.isClosed() {
@@ -161,8 +161,8 @@ func TestDisplaceRefusesAnAttendedSession(t *testing.T) {
 // session — and letting a key in there would fork its world.
 func TestDisplaceRefusesWhenNothingIsRegistered(t *testing.T) {
 	srv := newOfflineServer(t)
-	if srv.displaceAbsent(fpA) {
-		t.Error("displaceAbsent = true with no registered session — it displaced nothing and said it did")
+	if srv.displaceAbsent(fpA) != reclaimRefused {
+		t.Error("displaceAbsent took over with no registered session — it displaced nothing and said it did")
 	}
 }
 
@@ -175,8 +175,8 @@ func TestDisplaceGivesUpIfThePayloadNeverLands(t *testing.T) {
 	registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
 
 	start := time.Now()
-	if srv.displaceAbsent(fpA) {
-		t.Error("displaceAbsent = true though the displaced session never wrote its payload")
+	if got := srv.displaceAbsent(fpA); got != reclaimStalled {
+		t.Errorf("displaceAbsent = %v, want reclaimStalled — the payload never landed", got)
 	}
 	if elapsed := time.Since(start); elapsed < srv.reclaimWait {
 		t.Errorf("gave up after %v, before the %v it should wait", elapsed, srv.reclaimWait)
@@ -298,4 +298,65 @@ func TestReconnectRefusedWhileAttended(t *testing.T) {
 		t.Error("the attended session was displaced by the second connection")
 	}
 	_ = attended
+}
+
+// Review finding 2. Reclaim reads the registry, tears a session down and
+// then waits up to reclaimWait for its payload. Without a per-key lock
+// two connections on the same key both pass that test and are both
+// admitted — two live sessions loading the same payload into divergent
+// Worlds, which is exactly what the one-session-per-key guard exists to
+// prevent. The wait makes the window orders of magnitude wider than the
+// instantaneous check it replaced.
+func TestReclaimIsSerialisedPerKey(t *testing.T) {
+	srv := newOfflineServer(t)
+	srv.reclaimWait = 2 * time.Second
+	_, done := registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
+
+	results := make(chan reclaimResult, 2)
+	for range 2 {
+		go func() {
+			defer srv.admit.enter(fpA)()
+			results <- srv.displaceAbsent(fpA)
+		}()
+	}
+	// The first one through closes the handover; the second must find the
+	// slot already gone rather than displacing it a second time.
+	time.Sleep(100 * time.Millisecond)
+	close(done)
+
+	var tookOver int
+	for range 2 {
+		select {
+		case r := <-results:
+			if r == reclaimTookOver {
+				tookOver++
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("a reclaim never returned")
+		}
+	}
+	if tookOver != 1 {
+		t.Errorf("%d connections took the slot over, want exactly 1 — two live sessions would load "+
+			"the same payload into divergent Worlds", tookOver)
+	}
+}
+
+// Review finding 3. A reclaim that gives up has already closed the old
+// session and cannot un-close it. Leaving it flagged as displaced means
+// its teardown announces nothing and keeps its banked interval, so the
+// player is disconnected in silence and their next connect replays an
+// interval the saved payload already reflects.
+func TestStalledReclaimReleasesTheOldSession(t *testing.T) {
+	srv := newOfflineServer(t)
+	srv.reclaimWait = 50 * time.Millisecond
+	registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
+	ls, _ := srv.live.get(fpA)
+
+	if got := srv.displaceAbsent(fpA); got != reclaimStalled {
+		t.Fatalf("displaceAbsent = %v, want reclaimStalled", got)
+	}
+	if ls.displaced.Load() {
+		t.Error("the old session is still flagged as handing over to a connection that gave up — " +
+			"its departure goes unannounced and its bank never drops")
+	}
 }

--- a/internal/serve/reclaim_test.go
+++ b/internal/serve/reclaim_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/sim"
 	cssh "golang.org/x/crypto/ssh"
 )
 
@@ -255,6 +256,17 @@ func TestReconnectDisplacesItsOwnReprievedSession(t *testing.T) {
 	}
 	if msg := back.text(); strings.Contains(msg, "already has a live session") {
 		t.Errorf("the reconnecting player was refused: %q", msg)
+	}
+
+	// And it reads as one player resuming, not one leaving and another
+	// arriving (ADR 0036 S5). Mid-coast a leave chip reads as the
+	// rendezvous dying, which is the opposite of what a reclaim preserves.
+	if got := eventsOf(srv, sim.SessionEventLeave, fpB); len(got) != 0 {
+		t.Errorf("a reclaim announced %d departures — mid-coast that reads as the coast dying", len(got))
+	}
+	if got := eventsOf(srv, sim.SessionEventJoin, fpB); len(got) != 1 {
+		t.Errorf("a reclaim announced %d joins, want only the original connect's — an unpaired "+
+			"join arrives as an arrival to a partner who never saw a departure", len(got))
 	}
 	_ = asleep
 }

--- a/internal/serve/reclaim_test.go
+++ b/internal/serve/reclaim_test.go
@@ -1,0 +1,289 @@
+package serve
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cssh "golang.org/x/crypto/ssh"
+)
+
+// shellClient is a connected test client running the game, accumulating
+// whatever the server sent it (when draining).
+type shellClient struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (c *shellClient) text() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+func (c *shellClient) drain(r io.Reader) {
+	b := make([]byte, 4096)
+	for {
+		n, err := r.Read(b)
+		if n > 0 {
+			c.mu.Lock()
+			c.buf.Write(b[:n])
+			c.mu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// dialShell connects signer's key and starts the game. A draining client
+// is a player at the keyboard; a non-draining one is a laptop with the
+// lid shut — the server's frames back up behind it exactly as they would
+// against a sleeping peer.
+func dialShell(t *testing.T, srv *Server, signer cssh.Signer, drain bool) *shellClient {
+	t.Helper()
+	client, err := cssh.Dial("tcp", srv.Addr(), &cssh.ClientConfig{
+		User:            "guest",
+		Auth:            []cssh.AuthMethod{cssh.PublicKeys(signer)},
+		HostKeyCallback: cssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := sess.RequestPty("xterm-256color", 30, 120, cssh.TerminalModes{}); err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	stdout, err := sess.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderr, err := sess.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	sc := &shellClient{}
+	if drain {
+		go sc.drain(stdout)
+		go sc.drain(stderr)
+	}
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+	return sc
+}
+
+// registerWithDone is register() plus the payload-write signal the
+// reclaim path waits on.
+func registerWithDone(t *testing.T, srv *Server, fp string, lastIO time.Time) (*stubConn, chan struct{}) {
+	t.Helper()
+	stub := &stubConn{}
+	done := make(chan struct{})
+	srv.live.add(fp, &liveSession{
+		conn: newActivityConn(stub, func() time.Time { return lastIO }),
+		done: done,
+	})
+	return stub, done
+}
+
+// The invariant the whole reclaim path is built around: the displaced
+// session's payload must be on disk before the reclaiming one loads it.
+// Otherwise the new session reads a world the old one is still about to
+// overwrite, and the coast the player reconnected to watch is lost.
+func TestDisplaceWaitsForThePayloadWrite(t *testing.T) {
+	srv := newOfflineServer(t)
+	stub, done := registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
+
+	returned := make(chan bool, 1)
+	go func() { returned <- srv.displaceAbsent(fpA) }()
+
+	// It must have torn the old connection down...
+	deadline := time.Now().Add(2 * time.Second)
+	for !stub.isClosed() {
+		if time.Now().After(deadline) {
+			t.Fatal("the displaced session's connection was never closed — it keeps running, " +
+				"and the reclaiming player is still locked out")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// ...but not yet handed the world over.
+	select {
+	case <-returned:
+		t.Fatal("displaceAbsent returned before the displaced session's payload was written — " +
+			"the reclaiming session will load a world the old one is about to overwrite")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(done) // the payload has landed
+	select {
+	case ok := <-returned:
+		if !ok {
+			t.Error("displaceAbsent = false after a clean handover, want true")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("displaceAbsent never returned after the payload landed")
+	}
+	if _, still := srv.live.snapshot()[fpA]; still {
+		t.Error("the displaced session is still in the registry — the sweeper would keep reprieving it")
+	}
+}
+
+// A session whose peer is still talking is somebody at the controls.
+// Reprieve or not, it is never displaced: the connection stays up and
+// the second one is refused, exactly as before ADR 0036.
+func TestDisplaceRefusesAnAttendedSession(t *testing.T) {
+	srv := newOfflineServer(t)
+	stub, _ := registerWithDone(t, srv, fpA, time.Now().Add(-time.Second))
+
+	if srv.displaceAbsent(fpA) {
+		t.Error("displaced a session whose peer spoke a second ago — that is a player at the controls")
+	}
+	if stub.isClosed() {
+		t.Error("an attended session's connection was closed")
+	}
+	if _, still := srv.live.snapshot()[fpA]; !still {
+		t.Error("an attended session was dropped from the registry")
+	}
+}
+
+// Presence says online but nothing is registered: the absence cannot be
+// verified, so the connection is refused rather than admitted on faith.
+// The host's in-process game is exactly this — marked online, never a
+// session — and letting a key in there would fork its world.
+func TestDisplaceRefusesWhenNothingIsRegistered(t *testing.T) {
+	srv := newOfflineServer(t)
+	if srv.displaceAbsent(fpA) {
+		t.Error("displaceAbsent = true with no registered session — it displaced nothing and said it did")
+	}
+}
+
+// If the payload never lands, the reclaiming connection must not load
+// the world anyway. Being told to try again is recoverable; silently
+// resuming a stale world is not.
+func TestDisplaceGivesUpIfThePayloadNeverLands(t *testing.T) {
+	srv := newOfflineServer(t)
+	srv.reclaimWait = 100 * time.Millisecond
+	registerWithDone(t, srv, fpA, time.Now().Add(-30*time.Minute))
+
+	start := time.Now()
+	if srv.displaceAbsent(fpA) {
+		t.Error("displaceAbsent = true though the displaced session never wrote its payload")
+	}
+	if elapsed := time.Since(start); elapsed < srv.reclaimWait {
+		t.Errorf("gave up after %v, before the %v it should wait", elapsed, srv.reclaimWait)
+	}
+}
+
+// End to end, and the reason reclaim exists at all: without it the
+// Reprieve reintroduces the exact lockout #246 was written to fix, and
+// worst for the players most likely to want back in — the ones mid-coast,
+// whose lockout would last as long as the encounter they committed to.
+func TestReconnectDisplacesItsOwnReprievedSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "ssh_host_ed25519_key"),
+		SessionDir:  t.TempDir(),
+		IdleTimeout: 400 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.sweepEvery = 25 * time.Millisecond
+	srv.reprieveWindow = 250 * time.Millisecond
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "vex")
+
+	// The laptop that went to sleep mid-coast.
+	asleep := dialShell(t, srv, signer, false)
+	waitPresence(t, srv, fp, true, 10*time.Second, "the session never came online")
+	first, ok := srv.live.snapshot()[fp]
+	if !ok {
+		t.Fatal("the live session is not in the registry")
+	}
+
+	stopArming := make(chan struct{})
+	arming := make(chan struct{})
+	go func() {
+		defer close(arming)
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stopArming:
+				return
+			case <-tick.C:
+				publish(srv, mutualArm(fp, fpB, time.Now().UTC().Add(time.Hour)))
+			}
+		}
+	}()
+	defer func() { close(stopArming); <-arming }()
+
+	// Confirm it really is reprieved — still online well past the idle
+	// timeout, so the reconnect below is displacing a live session rather
+	// than walking into a slot that already emptied.
+	time.Sleep(3 * 400 * time.Millisecond)
+	if !srv.presence.isOnline(fp) {
+		t.Fatal("the session was reaped before the reconnect — nothing left to displace")
+	}
+
+	// The player opens the lid somewhere else and reconnects.
+	back := dialShell(t, srv, signer, true)
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if cur, ok := srv.live.snapshot()[fp]; ok && cur != first {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the reconnecting player never took over their own reprieved session — " +
+				"locked out of their own program behind a socket nobody is using, which is " +
+				"the lockout the idle timeout exists to prevent")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if msg := back.text(); strings.Contains(msg, "already has a live session") {
+		t.Errorf("the reconnecting player was refused: %q", msg)
+	}
+	_ = asleep
+}
+
+// The other side of the same guard: a second key-holder cannot boot a
+// player who is sitting right there.
+func TestReconnectRefusedWhileAttended(t *testing.T) {
+	srv := startTestServer(t)
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "vex")
+
+	attended := dialShell(t, srv, signer, true) // drains stdout: present
+	waitPresence(t, srv, fp, true, 10*time.Second, "the session never came online")
+	first, ok := srv.live.snapshot()[fp]
+	if !ok {
+		t.Fatal("the live session is not in the registry")
+	}
+
+	second := dialShell(t, srv, signer, true)
+	deadline := time.Now().Add(10 * time.Second)
+	for !strings.Contains(second.text(), "already has a live session") {
+		if time.Now().After(deadline) {
+			t.Fatalf("a second connection was not refused while the first is attended; it saw %q",
+				second.text())
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if cur, ok := srv.live.snapshot()[fp]; !ok || cur != first {
+		t.Error("the attended session was displaced by the second connection")
+	}
+	_ = attended
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -369,6 +369,11 @@ func (m *reportingModel) refreshSession(now time.Time) {
 			// live stack.
 			DockedGuest: m.srv.dock.IsGuest(p.Fingerprint),
 
+			// Away (ADR 0036 S5): still simulating, nobody at the controls.
+			// Without it a reprieved session reads as Online for hours and
+			// the roster tells a partner someone is there who is not.
+			Away: m.srv.isAway(p.Fingerprint),
+
 			WantsRendezvous: armedTowardViewer[p.Fingerprint],
 			RendezvousOut:   w.RendezvousArm != nil && w.RendezvousArm.TargetOwner == p.Fingerprint,
 		}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -401,6 +401,10 @@ func (m *reportingModel) refreshSession(now time.Time) {
 
 	// Broadcast moments (own excluded) + this session's local ones.
 	events := m.srv.presence.eventsFor(m.owner)
+	// ADR 0036 S6: bank this session's own moments while nobody is
+	// watching, and replay them when somebody is. Before the TTL trim
+	// below — that trim is what would otherwise destroy them.
+	m.bankOrReplay(w.Clock.SimTime, now)
 	kept := m.localEvents[:0]
 	for _, e := range m.localEvents {
 		if now.Sub(e.At) <= localEventTTL {

--- a/internal/serve/resume.go
+++ b/internal/serve/resume.go
@@ -1,0 +1,116 @@
+package serve
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// heldMomentCap bounds one player's bank. An away session can bank for
+// hours, and the newest moments are the ones that explain the world the
+// player is opening their lid onto.
+const heldMomentCap = 32
+
+// bank is one player's unattended interval: when it opened, in their own
+// sim-time, and the moments that fell during it.
+type bank struct {
+	since   time.Time // sim-time at the first tick the session was seen away
+	moments []sim.SessionEvent
+}
+
+// awayMail holds the moments that fell while a player's session ran
+// unattended, so they can be replayed to the player rather than rendered
+// to an empty chair and aged out by the chip TTL (ADR 0036 S6).
+//
+// Keyed by fingerprint rather than by session, because the two ends of
+// the interval are often different sessions: a reclaim tears the first
+// one down and builds a second. The handoff is safe because
+// displaceAbsent does not return until the displaced session's teardown
+// has completed, so the writer is finished before the reader exists.
+type awayMail struct {
+	mu    sync.Mutex
+	banks map[string]*bank
+}
+
+func newAwayMail() *awayMail { return &awayMail{banks: map[string]*bank{}} }
+
+// hold banks moments for fp, opening the bank at simNow the first time.
+// The opening instant is kept, not refreshed: it is what the elapsed
+// readout is measured from, and a later tick resetting it would report
+// the interval as a few seconds no matter how long it really ran.
+func (a *awayMail) hold(fp string, simNow time.Time, moments []sim.SessionEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b, ok := a.banks[fp]
+	if !ok {
+		b = &bank{since: simNow}
+		a.banks[fp] = b
+	}
+	b.moments = append(b.moments, moments...)
+	if len(b.moments) > heldMomentCap {
+		b.moments = b.moments[len(b.moments)-heldMomentCap:]
+	}
+}
+
+// take empties fp's bank and returns it. ok is false when nothing was
+// banked, which is the ordinary case for a session that never went away.
+func (a *awayMail) take(fp string) ([]sim.SessionEvent, time.Time, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b, ok := a.banks[fp]
+	if !ok {
+		return nil, time.Time{}, false
+	}
+	delete(a.banks, fp)
+	return b.moments, b.since, true
+}
+
+// peek reads a bank without emptying it (tests, and nothing else).
+func (a *awayMail) peek(fp string) ([]sim.SessionEvent, time.Time, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b, ok := a.banks[fp]
+	if !ok {
+		return nil, time.Time{}, false
+	}
+	return b.moments, b.since, true
+}
+
+// drop discards fp's bank. Called when a session ends for real rather
+// than being displaced: the player's next connection is an ordinary
+// reconnect into a saved world, not the far end of an interval they were
+// continuously present for, and replaying one days later would describe a
+// world the payload already reflects.
+func (a *awayMail) drop(fp string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.banks, fp)
+}
+
+// bankOrReplay routes this tick's local moments: into the bank while
+// nobody is watching, out of it when somebody is.
+//
+// A replayed moment is re-stamped. Its original timestamp is hours old,
+// and the chip stack expires by wall clock — delivered as-is it would be
+// expired on arrival, which is exactly the failure this slice exists to
+// fix.
+func (m *reportingModel) bankOrReplay(simNow, now time.Time) {
+	if m.srv.isAway(m.owner) {
+		m.srv.mail.hold(m.owner, simNow, m.localEvents)
+		m.localEvents = nil
+		return
+	}
+	held, since, ok := m.srv.mail.take(m.owner)
+	if !ok {
+		return
+	}
+	// The account comes first, then what it is accounting for.
+	m.localEvents = append(m.localEvents, sim.SessionEvent{
+		Kind: sim.SessionEventResumed, At: now, Elapsed: simNow.Sub(since),
+	})
+	for _, e := range held {
+		e.At = now
+		m.localEvents = append(m.localEvents, e)
+	}
+}

--- a/internal/serve/resume.go
+++ b/internal/serve/resume.go
@@ -1,16 +1,31 @@
 package serve
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
-// heldMomentCap bounds one player's bank. An away session can bank for
-// hours, and the newest moments are the ones that explain the world the
-// player is opening their lid onto.
-const heldMomentCap = 32
+const (
+	// heldMomentCap bounds one player's bank. An away session can bank for
+	// hours, and the newest moments are the ones that explain the world the
+	// player is opening their lid onto.
+	heldMomentCap = 32
+
+	// maxReplayedMoments bounds what reaches the canvas at once. Every
+	// replayed moment is re-stamped to the same instant, so they render as
+	// one block for the full chip TTL; a whole bank would exceed a normal
+	// terminal's height and bury the orbit view it is meant to explain.
+	maxReplayedMoments = 6
+
+	// minReportedAway is the shortest interval worth announcing. A player
+	// who paused, read for a minute and carried on has technically been
+	// unattended by the frames-drained measure, and "resumed — 0s ran while
+	// you were away" is noise about nothing.
+	minReportedAway = time.Minute
+)
 
 // bank is one player's unattended interval: when it opened, in their own
 // sim-time, and the moments that fell during it.
@@ -96,19 +111,60 @@ func (a *awayMail) drop(fp string) {
 // expired on arrival, which is exactly the failure this slice exists to
 // fix.
 func (m *reportingModel) bankOrReplay(simNow, now time.Time) {
+	// Only the session currently holding this slot may touch the bank.
+	//
+	// A displaced session keeps ticking until its program unwinds, and it
+	// leaves the registry at the *start* of the reclaim — closing its
+	// connection is what unblocks its loop, so it reliably gets ticks in
+	// afterwards. Without this guard it reads as not-away (no registry
+	// entry), takes the replay branch, and drains the bank into a slice
+	// discarded seconds later, leaving the returning player with nothing.
+	// The hazard is not the writer outliving the reader; it is the dying
+	// writer becoming a reader.
+	if _, live := m.srv.live.get(m.owner); !live {
+		return
+	}
 	if m.srv.isAway(m.owner) {
+		// Copied, not moved. isAway keys on frames drained, so a player
+		// sitting on a paused, static screen reads as away while being right
+		// there; moving their moments would take chips off the screen of
+		// someone watching. Banking a copy keeps a misclassification free,
+		// which is what the short away threshold assumes.
 		m.srv.mail.hold(m.owner, simNow, m.localEvents)
-		m.localEvents = nil
 		return
 	}
 	held, since, ok := m.srv.mail.take(m.owner)
 	if !ok {
 		return
 	}
+	// Anything still inside its TTL was on screen a moment ago — the copy
+	// above means a player who never really left would otherwise see their
+	// own moments twice.
+	unseen := held[:0]
+	for _, e := range held {
+		if now.Sub(e.At) > localEventTTL {
+			unseen = append(unseen, e)
+		}
+	}
+	held = unseen
+	// The chip stack is corner-anchored on the canvas and every replayed
+	// moment lands at once: a full bank would bury the orbit view and clip
+	// the other chips. Newest kept, the rest counted.
+	dropped := 0
+	if len(held) > maxReplayedMoments {
+		dropped = len(held) - maxReplayedMoments
+		held = held[len(held)-maxReplayedMoments:]
+	}
+	elapsed := simNow.Sub(since)
+	if len(held) == 0 && elapsed < minReportedAway {
+		return // nothing happened, and no time to speak of: no account owed
+	}
 	// The account comes first, then what it is accounting for.
-	m.localEvents = append(m.localEvents, sim.SessionEvent{
-		Kind: sim.SessionEventResumed, At: now, Elapsed: simNow.Sub(since),
-	})
+	resumed := sim.SessionEvent{Kind: sim.SessionEventResumed, At: now, Elapsed: elapsed}
+	if dropped > 0 {
+		resumed.Detail = fmt.Sprintf("+%d earlier", dropped)
+	}
+	m.localEvents = append(m.localEvents, resumed)
 	for _, e := range held {
 		e.At = now
 		m.localEvents = append(m.localEvents, e)

--- a/internal/serve/resume_test.go
+++ b/internal/serve/resume_test.go
@@ -40,10 +40,10 @@ func has(w *sim.World, kind sim.SessionEventKind) bool {
 	return false
 }
 
-// Moments that fall while nobody is watching are banked, not rendered to
-// an empty chair and aged out by a six-second TTL. Without this the coast
-// a player committed to can complete, and every trace of it is gone
-// before they open the lid.
+// Moments that fall while nobody is watching are banked rather than left
+// to age out against a six-second TTL. Without this the coast a player
+// committed to can complete, and every trace of it is gone before they
+// open the lid.
 func TestMomentsHeldWhileAway(t *testing.T) {
 	srv := newOfflineServer(t)
 	app, err := tui.New(nil)
@@ -56,9 +56,6 @@ func TestMomentsHeldWhileAway(t *testing.T) {
 
 	tick(m)
 
-	if has(app.World(), sim.SessionEventRendezvousArrived) {
-		t.Error("a moment was rendered to a session nobody is watching, where it will age out unseen")
-	}
 	held, _, ok := srv.mail.peek(sessiondir.HostFingerprint)
 	if !ok || len(held) != 1 {
 		t.Fatalf("held = %v (ok %v), want the arrival banked", held, ok)
@@ -81,6 +78,10 @@ func TestHeldMomentsReplayedOnReturn(t *testing.T) {
 	m := srv.HostModel(app)
 	arrival(app, "ansi")
 	tick(m)
+	// An hour of away time passes with it banked — long enough that it is
+	// no longer on anyone's screen, so the replay is its only delivery.
+	held, _, _ := srv.mail.peek(sessiondir.HostFingerprint)
+	held[0].At = time.Now().Add(-time.Hour)
 
 	// They open the lid: the connection is answering again.
 	awaySession(t, srv, 0)
@@ -120,8 +121,9 @@ func TestReplayedMomentsAreRestamped(t *testing.T) {
 	srv.mail.hold(sessiondir.HostFingerprint, simNoon, []sim.SessionEvent{
 		{Kind: sim.SessionEventRendezvousArrived, Handle: "ansi", At: time.Now().Add(-2 * time.Hour)},
 	})
+	register(t, srv, sessiondir.HostFingerprint, time.Now()) // live, and answering
 
-	tick(srv.HostModel(app)) // present: nothing registered, so not away
+	tick(srv.HostModel(app))
 
 	if !has(app.World(), sim.SessionEventRendezvousArrived) {
 		t.Errorf("a two-hour-old banked moment did not survive its own replay\n%v", kinds(app.World()))
@@ -171,5 +173,153 @@ func TestBankKeepsItsOpeningInstant(t *testing.T) {
 	}
 	if !since.Equal(simNoon) {
 		t.Errorf("bank opened at %v, want the first sighting %v — a later tick reset the interval", since, simNoon)
+	}
+}
+
+// Review finding 1. displaceAbsent pulls the registry entry at the START
+// of a reclaim, and closing the connection is exactly what unblocks the
+// displaced session's loop — so it reliably ticks again before it exits.
+// Judged only on "is this session away", those ticks read as present,
+// take the replay branch, and drain the bank into a slice discarded
+// seconds later. The returning player then gets nothing, on the one path
+// the whole slice exists for.
+func TestDisplacedSessionDoesNotDrainTheBank(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	awaySession(t, srv, 90*time.Second)
+	m := srv.HostModel(app)
+	arrival(app, "ansi")
+	tick(m)
+	if _, _, ok := srv.mail.peek(sessiondir.HostFingerprint); !ok {
+		t.Fatal("nothing banked; the setup is wrong")
+	}
+
+	// Exactly what a reclaim does, in order.
+	ls, _ := srv.live.get(sessiondir.HostFingerprint)
+	ls.displaced.Store(true)
+	srv.live.remove(sessiondir.HostFingerprint, ls)
+
+	tick(m) // the dying session, still running
+
+	if _, _, ok := srv.mail.peek(sessiondir.HostFingerprint); !ok {
+		t.Fatal("the displaced session drained the bank meant for the connection replacing it — " +
+			"the returning player lands in a jumped world with no account of it")
+	}
+	if has(app.World(), sim.SessionEventResumed) {
+		t.Error("the displaced session rendered a resume to a screen nobody will ever see again")
+	}
+}
+
+// Review finding 4. isAway keys on frames drained, so a player who pauses
+// on a static screen reads as away while sitting right there. Moving
+// their moments into the bank would take chips off the screen of someone
+// watching; a copy costs nothing, which is what the short away threshold
+// assumes.
+func TestMomentsStillRenderForAMisclassifiedPlayer(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	awaySession(t, srv, 90*time.Second)
+	m := srv.HostModel(app)
+	arrival(app, "ansi")
+
+	tick(m)
+
+	if !has(app.World(), sim.SessionEventRendezvousArrived) {
+		t.Error("a moment was taken off the canvas of a player who may be sitting right there")
+	}
+	if _, _, ok := srv.mail.peek(sessiondir.HostFingerprint); !ok {
+		t.Error("nothing banked — a genuinely away player would lose it")
+	}
+}
+
+// And the copy must not come back as a duplicate: a moment still inside
+// its TTL was on screen a moment ago.
+func TestReplaySkipsMomentsStillOnScreen(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	awaySession(t, srv, 90*time.Second)
+	m := srv.HostModel(app)
+	arrival(app, "ansi")
+	tick(m) // seen live, and banked
+
+	awaySession(t, srv, 0) // they were there all along; the screen woke up
+	tick(m)
+
+	var arrivals int
+	for _, e := range app.World().SessionEvents {
+		if e.Kind == sim.SessionEventRendezvousArrived {
+			arrivals++
+		}
+	}
+	if arrivals > 1 {
+		t.Errorf("the same moment rendered %d times — the banked copy came back on top of the one already read", arrivals)
+	}
+	if has(app.World(), sim.SessionEventResumed) {
+		t.Error("a player who never really left was told they resumed")
+	}
+}
+
+// Review finding 7. Every replayed moment is re-stamped to the same
+// instant, so a full bank renders as one block for the whole chip TTL —
+// more rows than a terminal has, burying the orbit view it explains.
+func TestReplayIsBounded(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	old := time.Now().Add(-time.Hour)
+	for i := range heldMomentCap {
+		srv.mail.hold(sessiondir.HostFingerprint, simNoon, []sim.SessionEvent{
+			{Kind: sim.SessionEventCoWarpCoupled, Handle: string(rune('a' + i%26)), At: old},
+		})
+	}
+	register(t, srv, sessiondir.HostFingerprint, time.Now())
+	app.World().Clock.SimTime = simNoon.Add(2 * time.Hour)
+
+	tick(srv.HostModel(app))
+
+	replayed := 0
+	var resumed sim.SessionEvent
+	for _, e := range app.World().SessionEvents {
+		switch e.Kind {
+		case sim.SessionEventCoWarpCoupled:
+			replayed++
+		case sim.SessionEventResumed:
+			resumed = e
+		}
+	}
+	if replayed > maxReplayedMoments {
+		t.Errorf("%d moments replayed at once, want at most %d", replayed, maxReplayedMoments)
+	}
+	if resumed.Detail == "" {
+		t.Error("the dropped moments were not accounted for — the replay silently truncated")
+	}
+}
+
+// A brief pause is not an interval worth announcing.
+func TestTrivialAwayIntervalIsNotAnnounced(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	srv.mail.hold(sessiondir.HostFingerprint, simNoon, nil)
+	register(t, srv, sessiondir.HostFingerprint, time.Now())
+	app.World().Clock.SimTime = simNoon.Add(5 * time.Second)
+
+	tick(srv.HostModel(app))
+
+	if has(app.World(), sim.SessionEventResumed) {
+		t.Error("\"resumed — 5s ran while you were away\" is noise about nothing")
 	}
 }

--- a/internal/serve/resume_test.go
+++ b/internal/serve/resume_test.go
@@ -1,0 +1,175 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// awaySession registers the host's own session as silent for d, so the
+// wrapper's next tick sees itself unattended.
+func awaySession(t *testing.T, srv *Server, d time.Duration) {
+	t.Helper()
+	srv.live = newSessionRegistry()
+	register(t, srv, sessiondir.HostFingerprint, time.Now().Add(-d))
+}
+
+// arrival stages a rendezvous arrival, the cheapest real local moment:
+// the wrapper turns it into a session chip on its next tick.
+func arrival(app *tui.App, handle string) {
+	app.World().LastRendezvousArrival = &sim.RendezvousArrival{Handle: handle, Owner: fpB}
+}
+
+func kinds(w *sim.World) []sim.SessionEventKind {
+	var out []sim.SessionEventKind
+	for _, e := range w.SessionEvents {
+		out = append(out, e.Kind)
+	}
+	return out
+}
+
+func has(w *sim.World, kind sim.SessionEventKind) bool {
+	for _, k := range kinds(w) {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// Moments that fall while nobody is watching are banked, not rendered to
+// an empty chair and aged out by a six-second TTL. Without this the coast
+// a player committed to can complete, and every trace of it is gone
+// before they open the lid.
+func TestMomentsHeldWhileAway(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	awaySession(t, srv, 90*time.Second)
+	m := srv.HostModel(app)
+	arrival(app, "ansi")
+
+	tick(m)
+
+	if has(app.World(), sim.SessionEventRendezvousArrived) {
+		t.Error("a moment was rendered to a session nobody is watching, where it will age out unseen")
+	}
+	held, _, ok := srv.mail.peek(sessiondir.HostFingerprint)
+	if !ok || len(held) != 1 {
+		t.Fatalf("held = %v (ok %v), want the arrival banked", held, ok)
+	}
+	if held[0].Kind != sim.SessionEventRendezvousArrived {
+		t.Errorf("banked %v, want the rendezvous arrival", held[0].Kind)
+	}
+}
+
+// And they are replayed when somebody is there to read them — re-stamped,
+// because a moment that fell two hours ago is new to the player who just
+// arrived and would otherwise be expired on delivery.
+func TestHeldMomentsReplayedOnReturn(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	awaySession(t, srv, 90*time.Second)
+	m := srv.HostModel(app)
+	arrival(app, "ansi")
+	tick(m)
+
+	// They open the lid: the connection is answering again.
+	awaySession(t, srv, 0)
+	// Two hours of sim-time ran while they were gone.
+	app.World().Clock.SimTime = app.World().Clock.SimTime.Add(2 * time.Hour)
+	tick(m)
+
+	w := app.World()
+	if !has(w, sim.SessionEventResumed) {
+		t.Errorf("no resumed chip: the player lands in a world whose clock jumped with no account of it\n%v", kinds(w))
+	}
+	if !has(w, sim.SessionEventRendezvousArrived) {
+		t.Errorf("the banked arrival was never replayed\n%v", kinds(w))
+	}
+	for _, e := range w.SessionEvents {
+		if e.Kind == sim.SessionEventResumed && e.Elapsed < 90*time.Minute {
+			t.Errorf("resumed reports %v of unattended sim-time, want about 2h", e.Elapsed)
+		}
+	}
+	// Drained, not re-delivered every tick from here on.
+	tick(m)
+	if has(app.World(), sim.SessionEventResumed) {
+		t.Error("the resume replayed a second time — it is a moment, not a state")
+	}
+}
+
+// A banked moment is hours old by the time anyone can read it, and the
+// chip stack expires by wall clock. Delivered with its original
+// timestamp it is trimmed on the very tick that replays it — the moment
+// survives the whole away interval only to be dropped on arrival.
+func TestReplayedMomentsAreRestamped(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	srv.mail.hold(sessiondir.HostFingerprint, simNoon, []sim.SessionEvent{
+		{Kind: sim.SessionEventRendezvousArrived, Handle: "ansi", At: time.Now().Add(-2 * time.Hour)},
+	})
+
+	tick(srv.HostModel(app)) // present: nothing registered, so not away
+
+	if !has(app.World(), sim.SessionEventRendezvousArrived) {
+		t.Errorf("a two-hour-old banked moment did not survive its own replay\n%v", kinds(app.World()))
+	}
+}
+
+// A session that really ended takes its bank with it. The player's next
+// connection is an ordinary reconnect into a saved world, not a
+// resumption of an interval they were present for.
+func TestEndedSessionDropsItsBank(t *testing.T) {
+	srv := newOfflineServer(t)
+	srv.mail.hold(fpA, simNoon, []sim.SessionEvent{{Kind: sim.SessionEventRendezvousArrived}})
+
+	srv.mail.drop(fpA)
+
+	if _, _, ok := srv.mail.peek(fpA); ok {
+		t.Error("a bank outlived its session; whoever connects on that key next replays a stale interval")
+	}
+}
+
+// Hours away at a steady drip of moments must not grow without bound.
+func TestHeldMomentsCapped(t *testing.T) {
+	srv := newOfflineServer(t)
+	for i := range heldMomentCap * 3 {
+		srv.mail.hold(fpA, simNoon, []sim.SessionEvent{{Kind: sim.SessionEventCoWarpCoupled, Handle: string(rune('a' + i%26))}})
+	}
+	held, _, ok := srv.mail.peek(fpA)
+	if !ok {
+		t.Fatal("nothing held")
+	}
+	if len(held) > heldMomentCap {
+		t.Errorf("held %d moments, want at most %d — an away session banks for hours", len(held), heldMomentCap)
+	}
+}
+
+// The bank opens at the first moment the session is seen away and keeps
+// that instant, so the elapsed readout measures the whole interval rather
+// than restarting on every tick.
+func TestBankKeepsItsOpeningInstant(t *testing.T) {
+	srv := newOfflineServer(t)
+	srv.mail.hold(fpA, simNoon, nil)
+	srv.mail.hold(fpA, simNoon.Add(time.Hour), nil)
+
+	_, since, ok := srv.mail.peek(fpA)
+	if !ok {
+		t.Fatal("nothing held")
+	}
+	if !since.Equal(simNoon) {
+		t.Errorf("bank opened at %v, want the first sighting %v — a later tick reset the interval", since, simNoon)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -100,6 +100,11 @@ type Server struct {
 	// *sim.World — the sweeper runs outside every session's tick loop.
 	live *sessionRegistry
 
+	// away remembers which players have been announced as gone silent, so
+	// the transition chips once however long the silence lasts and the
+	// return reaches the same partner (ADR 0036 S5).
+	away *awayWatch
+
 	// Reprieve timings, fields rather than constants so tests can drive
 	// the sweeper without real-time waits. idleTimeout is recorded because
 	// the sweeper has to reconstruct the deadline the I/O path would have
@@ -108,6 +113,7 @@ type Server struct {
 	sweepEvery     time.Duration
 	reprieveWindow time.Duration
 	reclaimWait    time.Duration
+	awayAfter      time.Duration
 
 	// persistMu serialises dock cross-ref persists across sessions (v0.28
 	// finding 3). Two sessions racing SetDocks could otherwise interleave
@@ -158,7 +164,7 @@ func New(cfg Config) (*Server, error) {
 		store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(),
 		presence: newPresence(), ver: newVersionSurface(),
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
-		reclaimWait: defaultReclaimWait,
+		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter, away: newAwayWatch(),
 	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
@@ -301,9 +307,13 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	// encounter they committed to. displaceAbsent refuses when anyone
 	// might still be at the controls, and returns only once the displaced
 	// session's payload is safely written.
-	if s.presence.isOnline(fp) && !s.displaceAbsent(fp) {
-		wish.Fatalln(sess, "terminal-space-program: this key already has a live session — disconnect it first")
-		return nil, nil
+	reclaimed := false
+	if s.presence.isOnline(fp) {
+		if !s.displaceAbsent(fp) {
+			wish.Fatalln(sess, "terminal-space-program: this key already has a live session — disconnect it first")
+			return nil, nil
+		}
+		reclaimed = true
 	}
 
 	app, err := s.newGuestApp(fp)
@@ -329,7 +339,13 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 		// Enrolled reconnect: no card, no code — resume. Presence +
 		// join chip fire now; the middleware pairs the leave.
 		s.presence.markOnline(fp)
-		s.presence.event(sim.SessionEventJoin, fp, p.Handle, "")
+		// A reclaim announces nothing (ADR 0036 S5): the displaced session
+		// suppressed its leave, so a join here would arrive unpaired and
+		// read as an arrival to a partner who never saw a departure. The
+		// sweeper's next pass surfaces the return as "is back" instead.
+		if !reclaimed {
+			s.presence.event(sim.SessionEventJoin, fp, p.Handle, "")
+		}
 		sess.Context().SetValue(ctxKeyJoined, true)
 		return game, opts
 	}
@@ -427,14 +443,18 @@ func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 		}
 		// Out of the sweeper's sight before anything else: this connection
 		// is gone, and a Reprieve for it would extend a dead deadline.
-		if ls, ok := sess.Context().Value(ctxKeyLive).(*liveSession); ok {
+		ls, _ := sess.Context().Value(ctxKeyLive).(*liveSession)
+		if ls != nil {
 			s.live.remove(fp, ls)
 		}
 		// Presence: pair the join marked at connect/enroll (v0.27 S6).
 		if joined, _ := sess.Context().Value(ctxKeyJoined).(bool); joined {
 			s.presence.markOffline(fp)
-			if p, err := s.store.FindPlayer(fp); err == nil {
-				s.presence.event(sim.SessionEventLeave, fp, p.Handle, "")
+			// A displaced session announces nothing (ADR 0036 S5): its player
+			// is not leaving, they are resuming on another connection, and
+			// mid-coast a leave chip reads as the rendezvous dying.
+			if p, err := s.store.FindPlayer(fp); err == nil && (ls == nil || !ls.displaced.Load()) {
+				s.presence.event(departureKind(ls, s.awayAfter), fp, p.Handle, "")
 			}
 		}
 		app, ok := sess.Context().Value(ctxKeyApp).(*tui.App)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -105,6 +105,11 @@ type Server struct {
 	// return reaches the same partner (ADR 0036 S5).
 	away *awayWatch
 
+	// mail banks the moments that fall while a session runs unattended,
+	// so the player who comes back gets an account of the interval
+	// instead of a world whose clock silently jumped (ADR 0036 S6).
+	mail *awayMail
+
 	// Reprieve timings, fields rather than constants so tests can drive
 	// the sweeper without real-time waits. idleTimeout is recorded because
 	// the sweeper has to reconstruct the deadline the I/O path would have
@@ -164,7 +169,8 @@ func New(cfg Config) (*Server, error) {
 		store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(),
 		presence: newPresence(), ver: newVersionSurface(),
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
-		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter, away: newAwayWatch(),
+		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter,
+		away: newAwayWatch(), mail: newAwayMail(),
 	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
@@ -453,8 +459,14 @@ func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 			// A displaced session announces nothing (ADR 0036 S5): its player
 			// is not leaving, they are resuming on another connection, and
 			// mid-coast a leave chip reads as the rendezvous dying.
-			if p, err := s.store.FindPlayer(fp); err == nil && (ls == nil || !ls.displaced.Load()) {
-				s.presence.event(departureKind(ls, s.awayAfter), fp, p.Handle, "")
+			if ls == nil || !ls.displaced.Load() {
+				if p, err := s.store.FindPlayer(fp); err == nil {
+					s.presence.event(departureKind(ls, s.awayAfter), fp, p.Handle, "")
+				}
+				// This session ended rather than handing over, so its banked
+				// interval ends with it (ADR 0036 S6). A displaced one leaves
+				// the bank for the connection taking its place.
+				s.mail.drop(fp)
 			}
 		}
 		app, ok := sess.Context().Value(ctxKeyApp).(*tui.App)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -107,6 +107,7 @@ type Server struct {
 	idleTimeout    time.Duration
 	sweepEvery     time.Duration
 	reprieveWindow time.Duration
+	reclaimWait    time.Duration
 
 	// persistMu serialises dock cross-ref persists across sessions (v0.28
 	// finding 3). Two sessions racing SetDocks could otherwise interleave
@@ -157,6 +158,7 @@ func New(cfg Config) (*Server, error) {
 		store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(),
 		presence: newPresence(), ver: newVersionSurface(),
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
+		reclaimWait: defaultReclaimWait,
 	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
@@ -272,6 +274,7 @@ const (
 	ctxKeyJoined // set once this session marked presence-online
 	ctxKeyConn   // the session's activityConn (ADR 0036), stashed by ConnCallback
 	ctxKeyLive   // the session's registry entry (ADR 0036)
+	ctxKeyDone   // closed after this session's final payload write (ADR 0036)
 )
 
 // sessionHandler builds the per-connection model. Enrolled keys go
@@ -291,7 +294,14 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	// One live session per key (review follow-up): a second connection
 	// would load the same payload into a second divergent World and the
 	// two would fight over the relay report and the payload file.
-	if s.presence.isOnline(fp) {
+	//
+	// Unless the session holding the slot is unattended (ADR 0036), in
+	// which case this connection takes it over: without that, a Reprieve
+	// would lock a player out of their own program for as long as the
+	// encounter they committed to. displaceAbsent refuses when anyone
+	// might still be at the controls, and returns only once the displaced
+	// session's payload is safely written.
+	if s.presence.isOnline(fp) && !s.displaceAbsent(fp) {
 		wish.Fatalln(sess, "terminal-space-program: this key already has a live session — disconnect it first")
 		return nil, nil
 	}
@@ -310,7 +320,7 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	// Register for the Reprieve sweeper (ADR 0036) — after the one-session-
 	// per-key guard above, so a refused second connection can never displace
 	// the entry of the session that beat it. Paired in persistMiddleware.
-	ls := &liveSession{conn: sessionActivity(sess.Context())}
+	ls := &liveSession{conn: sessionActivity(sess.Context()), done: sessionDone(sess.Context())}
 	s.live.add(fp, ls)
 	sess.Context().SetValue(ctxKeyLive, ls)
 
@@ -403,6 +413,13 @@ func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 	return func(sess ssh.Session) {
 		s.sessions.Add(1)
 		defer s.sessions.Done()
+		// Opened before the session runs and closed last of all, after the
+		// payload write below (ADR 0036): a connection reclaiming this slot
+		// waits on it, so it can never load a world this session is still
+		// about to overwrite.
+		done := make(chan struct{})
+		defer close(done)
+		sess.Context().SetValue(ctxKeyDone, done)
 		next(sess)
 		fp, ok := sess.Context().Value(ctxKeyFingerprint).(string)
 		if !ok {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -110,6 +110,10 @@ type Server struct {
 	// instead of a world whose clock silently jumped (ADR 0036 S6).
 	mail *awayMail
 
+	// admit serialises connections arriving on the same key across the
+	// whole displace-and-register window (ADR 0036 S4 review).
+	admit *admission
+
 	// Reprieve timings, fields rather than constants so tests can drive
 	// the sweeper without real-time waits. idleTimeout is recorded because
 	// the sweeper has to reconstruct the deadline the I/O path would have
@@ -170,7 +174,7 @@ func New(cfg Config) (*Server, error) {
 		presence: newPresence(), ver: newVersionSurface(),
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
 		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter,
-		away: newAwayWatch(), mail: newAwayMail(),
+		away: newAwayWatch(), mail: newAwayMail(), admit: newAdmission(),
 	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
@@ -313,10 +317,23 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	// encounter they committed to. displaceAbsent refuses when anyone
 	// might still be at the controls, and returns only once the displaced
 	// session's payload is safely written.
+	// Serialised per key from here until this connection has registered and
+	// marked itself online: reclaim tears a session down and then waits for
+	// its payload, and two connections racing through that window would
+	// both be admitted into divergent Worlds.
+	defer s.admit.enter(fp)()
+
 	reclaimed := false
 	if s.presence.isOnline(fp) {
-		if !s.displaceAbsent(fp) {
+		switch s.displaceAbsent(fp) {
+		case reclaimRefused:
 			wish.Fatalln(sess, "terminal-space-program: this key already has a live session — disconnect it first")
+			return nil, nil
+		case reclaimStalled:
+			// Their old session is gone; telling them to disconnect it would
+			// be a lie, and loading its world now could lose the write still
+			// in flight.
+			wish.Fatalln(sess, "terminal-space-program: your previous session is still shutting down — reconnect in a moment")
 			return nil, nil
 		}
 		reclaimed = true
@@ -464,9 +481,15 @@ func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 					s.presence.event(departureKind(ls, s.awayAfter), fp, p.Handle, "")
 				}
 				// This session ended rather than handing over, so its banked
-				// interval ends with it (ADR 0036 S6). A displaced one leaves
-				// the bank for the connection taking its place.
+				// interval ends with it (ADR 0036 S6), and so does any record
+				// that a partner was told it went quiet — there is no return
+				// coming to close that story. A displaced session leaves both
+				// for the connection taking its place, which is why neither is
+				// cleaned up by the sweeper: for the whole reclaim window the
+				// fingerprint holds no registry entry, and a sweep landing
+				// there would drop the record that the "is back" chip needs.
 				s.mail.drop(fp)
+				s.away.clear(fp)
 			}
 		}
 		app, ok := sess.Context().Value(ctxKeyApp).(*tui.App)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -95,6 +95,19 @@ type Server struct {
 	// of racing process exit (review follow-up).
 	sessions sync.WaitGroup
 
+	// live is the session registry the Reprieve sweeper works from (ADR
+	// 0036): fingerprint → the connection behind it. Deliberately holds no
+	// *sim.World — the sweeper runs outside every session's tick loop.
+	live *sessionRegistry
+
+	// Reprieve timings, fields rather than constants so tests can drive
+	// the sweeper without real-time waits. idleTimeout is recorded because
+	// the sweeper has to reconstruct the deadline the I/O path would have
+	// set, to avoid ever shortening one.
+	idleTimeout    time.Duration
+	sweepEvery     time.Duration
+	reprieveWindow time.Duration
+
 	// persistMu serialises dock cross-ref persists across sessions (v0.28
 	// finding 3). Two sessions racing SetDocks could otherwise interleave
 	// stale snapshots and drop a concurrently-added dock; holding this while
@@ -140,7 +153,11 @@ func New(cfg Config) (*Server, error) {
 	if _, err := store.EnsureHost(hostHandle()); err != nil {
 		return nil, fmt.Errorf("serve: enroll host: %w", err)
 	}
-	srv := &Server{store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(), presence: newPresence(), ver: newVersionSurface()}
+	srv := &Server{
+		store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(),
+		presence: newPresence(), ver: newVersionSurface(),
+		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
+	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
 	// a guest whose craft rode along in another player's stack reconnects
@@ -155,6 +172,7 @@ func New(cfg Config) (*Server, error) {
 	if idle == 0 {
 		idle = DefaultIdleTimeout
 	}
+	srv.idleTimeout = idle
 	s, err := wish.NewServer(
 		wish.WithAddress(cfg.Addr),
 		wish.WithHostKeyPath(cfg.HostKeyPath),
@@ -212,6 +230,9 @@ func (s *Server) Addr() string { return s.ln.Addr().String() }
 func (s *Server) Serve() error {
 	stop := make(chan struct{})
 	go s.ver.watch(stop)
+	// The Reprieve sweeper (ADR 0036) lives exactly as long as the
+	// listener. Without it every Reprieve silently caps at one idle window.
+	go s.sweepReprieves(stop)
 	defer close(stop)
 	err := s.ssh.Serve(s.ln)
 	if err != nil && !errors.Is(err, ssh.ErrServerClosed) {
@@ -250,6 +271,7 @@ const (
 	ctxKeyFingerprint
 	ctxKeyJoined // set once this session marked presence-online
 	ctxKeyConn   // the session's activityConn (ADR 0036), stashed by ConnCallback
+	ctxKeyLive   // the session's registry entry (ADR 0036)
 )
 
 // sessionHandler builds the per-connection model. Enrolled keys go
@@ -285,6 +307,12 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	}
 	sess.Context().SetValue(ctxKeyApp, app)
 	sess.Context().SetValue(ctxKeyFingerprint, fp)
+	// Register for the Reprieve sweeper (ADR 0036) — after the one-session-
+	// per-key guard above, so a refused second connection can never displace
+	// the entry of the session that beat it. Paired in persistMiddleware.
+	ls := &liveSession{conn: sessionActivity(sess.Context())}
+	s.live.add(fp, ls)
+	sess.Context().SetValue(ctxKeyLive, ls)
 
 	game := s.withReporting(app, fp) // v0.27 S4: sessions feed the store
 	if p, err := s.store.FindPlayer(fp); err == nil {
@@ -379,6 +407,11 @@ func (s *Server) persistMiddleware(next ssh.Handler) ssh.Handler {
 		fp, ok := sess.Context().Value(ctxKeyFingerprint).(string)
 		if !ok {
 			return
+		}
+		// Out of the sweeper's sight before anything else: this connection
+		// is gone, and a Reprieve for it would extend a dead deadline.
+		if ls, ok := sess.Context().Value(ctxKeyLive).(*liveSession); ok {
+			s.live.remove(fp, ls)
 		}
 		// Presence: pair the join marked at connect/enroll (v0.27 S6).
 		if joined, _ := sess.Context().Value(ctxKeyJoined).(bool); joined {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -36,15 +36,41 @@ import (
 // DefaultPort is the SSH listener port when --serve-port isn't given.
 const DefaultPort = 23234
 
+// DefaultIdleTimeout bounds how long a session may go with no traffic in
+// either direction before the connection is dropped (#243).
+//
+// Without it a connection never dies on its own. A guest's game runs
+// server-side, driven by its own tick loop, so a client whose machine
+// sleeps leaves behind a half-open TCP that nothing reaps: the session
+// keeps running and warping unattended, presence keeps counting it
+// online, and — because a key may hold only one live session — its owner
+// is locked out of their own program behind a socket nobody is using.
+//
+// The deadline covers reads and writes both, which is what makes it bite
+// on an absent peer rather than merely a quiet one: frames the server
+// renders back up in the send buffer, the blocked write passes the
+// deadline, and the connection is torn down through persistMiddleware
+// like any other disconnect — payload written, slot freed.
+//
+// Generous on purpose. The cost of firing early is small (progress is
+// persisted and a reconnect resumes) but not nothing: a player who
+// pauses and walks away renders no new frames, so a short timeout would
+// disconnect someone sitting right there. Ten minutes is far longer than
+// anyone stares at a paused screen and far shorter than a laptop lid
+// stays shut.
+const DefaultIdleTimeout = 10 * time.Minute
+
 // Config shapes a Server. Addr is a listen address ("[host]:port";
 // use port 0 to let the OS pick — Addr() reports the bound address).
 // HostKeyPath locates the server's ed25519 identity; a missing key is
 // generated there on first start. SessionDir is the session store
 // (roster, invites, per-player payloads); empty means the XDG default.
+// IdleTimeout overrides DefaultIdleTimeout; zero takes the default.
 type Config struct {
 	Addr        string
 	HostKeyPath string
 	SessionDir  string
+	IdleTimeout time.Duration
 }
 
 // Server is a running (or startable) SSH listener whose sessions each
@@ -125,9 +151,17 @@ func New(cfg Config) (*Server, error) {
 	// The host plays in-process and is online for the session's whole
 	// life — no join chip for them (serve start isn't a "moment").
 	srv.presence.markOnline(sessiondir.HostFingerprint)
+	idle := cfg.IdleTimeout
+	if idle == 0 {
+		idle = DefaultIdleTimeout
+	}
 	s, err := wish.NewServer(
 		wish.WithAddress(cfg.Addr),
 		wish.WithHostKeyPath(cfg.HostKeyPath),
+		// #243: reap connections whose peer has gone away. Deliberately no
+		// MaxTimeout alongside it — that caps total session life and would
+		// disconnect players who are present and playing.
+		wish.WithIdleTimeout(idle),
 		// Any key may connect — identity is resolved in-session: known
 		// fingerprints resume, unknown ones face the invite-code flow.
 		wish.WithPublicKeyAuth(func(ssh.Context, ssh.PublicKey) bool { return true }),

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -162,6 +162,17 @@ func New(cfg Config) (*Server, error) {
 		// MaxTimeout alongside it — that caps total session life and would
 		// disconnect players who are present and playing.
 		wish.WithIdleTimeout(idle),
+		// ADR 0036: wrap every connection so the instant it last moved bytes
+		// is readable from outside its session's goroutine — the measure of
+		// how long a peer has been silent, and the origin a Reprieve's cap is
+		// counted from. ConnCallback is the only place the raw net.Conn is
+		// visible, and the Context it hands us is the same one the session
+		// reads back through sess.Context().
+		ssh.WrapConn(func(ctx ssh.Context, conn net.Conn) net.Conn {
+			ac := newActivityConn(conn, time.Now)
+			ctx.SetValue(ctxKeyConn, ac)
+			return ac
+		}),
 		// Any key may connect — identity is resolved in-session: known
 		// fingerprints resume, unknown ones face the invite-code flow.
 		wish.WithPublicKeyAuth(func(ssh.Context, ssh.PublicKey) bool { return true }),
@@ -238,6 +249,7 @@ const (
 	ctxKeyApp ctxKey = iota
 	ctxKeyFingerprint
 	ctxKeyJoined // set once this session marked presence-online
+	ctxKeyConn   // the session's activityConn (ADR 0036), stashed by ConnCallback
 )
 
 // sessionHandler builds the per-connection model. Enrolled keys go

--- a/internal/serve/ssh_smoke_test.go
+++ b/internal/serve/ssh_smoke_test.go
@@ -40,8 +40,24 @@ func startTestServer(t *testing.T) *Server {
 		if err := <-done; err != nil {
 			t.Errorf("Serve returned: %v", err)
 		}
+		// Force-closed sessions still unwind through persistMiddleware and
+		// write their payload. Returning without waiting leaves that write
+		// racing t.TempDir's cleanup of the very directory it writes into.
+		srv.Wait(5 * time.Second)
 	})
 	return srv
+}
+
+// stopServer ends the listener, every live session, and the payload
+// writes they unwind into — the teardown any test that opens a real
+// session needs, for the reason above.
+func stopServer(t *testing.T, srv *Server, done chan error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+	<-done
+	srv.Wait(5 * time.Second)
 }
 
 // newClientKey generates a fresh client identity and returns its

--- a/internal/serve/sweep.go
+++ b/internal/serve/sweep.go
@@ -24,6 +24,12 @@ const (
 // (internal/relay/reporter.go:35).
 type liveSession struct {
 	conn *activityConn
+
+	// done is closed once this session's final payload write has landed —
+	// at the very end of persistMiddleware, after SavePlayer. A reclaiming
+	// connection waits on it so it can never load a world the session it
+	// displaced is still about to overwrite.
+	done chan struct{}
 }
 
 // sessionRegistry tracks live sessions by fingerprint so the sweeper can
@@ -53,6 +59,13 @@ func (r *sessionRegistry) remove(fp string, s *liveSession) {
 	if r.live[fp] == s {
 		delete(r.live, fp)
 	}
+}
+
+func (r *sessionRegistry) get(fp string) (*liveSession, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.live[fp]
+	return s, ok
 }
 
 // snapshot copies the registry so the caller can act on it without

--- a/internal/serve/sweep.go
+++ b/internal/serve/sweep.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -24,6 +25,14 @@ const (
 // (internal/relay/reporter.go:35).
 type liveSession struct {
 	conn *activityConn
+
+	// displaced marks a session torn down by its own key reconnecting
+	// (ADR 0036), rather than one that ended. Its teardown announces
+	// nothing: a reclaim is one player resuming, and mid-coast a leave
+	// chip reads as the rendezvous dying — the opposite of what a reclaim
+	// preserves. Written by the reclaiming goroutine, read by the
+	// displaced session's own, so it is atomic.
+	displaced atomic.Bool
 
 	// done is closed once this session's final payload write has landed —
 	// at the very end of persistMiddleware, after SavePlayer. A reclaiming
@@ -101,6 +110,7 @@ func (s *Server) sweepReprieves(stop <-chan struct{}) {
 			return
 		case now := <-tick.C:
 			s.extendReprieves(now)
+			s.noteAway(now)
 		}
 	}
 }

--- a/internal/serve/sweep.go
+++ b/internal/serve/sweep.go
@@ -1,0 +1,134 @@
+package serve
+
+import (
+	"sync"
+	"time"
+)
+
+// Sweeper cadence (ADR 0036).
+const (
+	// defaultSweepEvery is how often the sweeper looks for Commitments.
+	defaultSweepEvery = 30 * time.Second
+
+	// defaultReprieveWindow is how far ahead a sweep pushes a reprieved
+	// connection's deadline. It must exceed the sweep interval, or a
+	// Reprieve would lapse in the gap between two sweeps. Short on purpose:
+	// a Reprieve is released by ceasing to extend, so this window is also
+	// the tail of unattended simulation after a Commitment resolves.
+	defaultReprieveWindow = 2 * time.Minute
+)
+
+// liveSession is a connected player's session as seen from outside its
+// own goroutine. It carries only what the sweeper may safely touch —
+// never a *sim.World, which belongs to the session's tick loop alone
+// (internal/relay/reporter.go:35).
+type liveSession struct {
+	conn *activityConn
+}
+
+// sessionRegistry tracks live sessions by fingerprint so the sweeper can
+// find the connection behind a Commitment.
+type sessionRegistry struct {
+	mu   sync.Mutex
+	live map[string]*liveSession
+}
+
+func newSessionRegistry() *sessionRegistry {
+	return &sessionRegistry{live: map[string]*liveSession{}}
+}
+
+func (r *sessionRegistry) add(fp string, s *liveSession) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.live[fp] = s
+}
+
+// remove drops fp's entry only if it is still s. A key may hold one live
+// session, but a connection refused for that reason still unwinds through
+// the same teardown — matching on identity keeps it from evicting the
+// session that beat it.
+func (r *sessionRegistry) remove(fp string, s *liveSession) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.live[fp] == s {
+		delete(r.live, fp)
+	}
+}
+
+// snapshot copies the registry so the caller can act on it without
+// holding the lock — the copy-then-act idiom relay.Report already uses.
+func (r *sessionRegistry) snapshot() map[string]*liveSession {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]*liveSession, len(r.live))
+	for fp, s := range r.live {
+		out[fp] = s
+	}
+	return out
+}
+
+// sweepReprieves extends the Reprieve of every committed session until
+// stop closes. One goroutine server-wide, started in Serve and stopped on
+// return, mirroring s.ver.watch.
+//
+// It exists because there is no inline version of this feature.
+// serverConn.updateDeadline runs at the *start* of Write; then Write
+// blocks against the absent peer and nothing on the I/O path runs again,
+// so whatever deadline was set last is final. Extending a Reprieve past a
+// single idle window requires an outside goroutine calling SetDeadline —
+// which is safe concurrently and does affect an already-blocked write.
+// Deleting this loop does not merely lose an optimisation: it silently
+// caps every Reprieve at one window.
+func (s *Server) sweepReprieves(stop <-chan struct{}) {
+	tick := time.NewTicker(s.sweepEvery)
+	defer tick.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case now := <-tick.C:
+			s.extendReprieves(now)
+		}
+	}
+}
+
+// extendReprieves is one sweep: find the sessions holding a Commitment
+// and push their connection deadlines out.
+//
+// Everything it reads is a snapshot taken under someone else's lock —
+// the relay store, the dock ledger, the session registry — and every
+// SetDeadline happens outside all of them.
+func (s *Server) extendReprieves(now time.Time) {
+	live := s.live.snapshot()
+	if len(live) == 0 {
+		return
+	}
+	reports := s.relay.Snapshot("") // exclude nobody: every session is a candidate
+	docks := s.dock.Records()
+	for fp, sess := range live {
+		if sess.conn == nil {
+			continue // no way to measure this peer's absence, so no Reprieve to grant
+		}
+		c, ok := commitmentFor(reports, docks, fp)
+		if !ok {
+			continue // nothing is waiting on this session
+		}
+		lastIO := sess.conn.LastIO()
+		if !now.Before(c.expiry(now, lastIO)) {
+			// Capped out. Stop extending and let the standing deadline fire:
+			// never force-expire, so exactly one code path writes deadlines
+			// and there is no ordering race against teardown.
+			continue
+		}
+		deadline := now.Add(s.reprieveWindow)
+		// Never pull a deadline in. The reprieve window is far shorter than
+		// the idle timeout, so a bare now+window would cut short a player who
+		// is present but rendering nothing — a paused screen produces no
+		// frames. lastIO+idleTimeout reconstructs the deadline this session's
+		// own I/O path would have set.
+		if natural := lastIO.Add(s.idleTimeout); natural.After(deadline) {
+			deadline = natural
+		}
+		_ = sess.conn.SetDeadline(deadline)
+	}
+}

--- a/internal/serve/sweep_test.go
+++ b/internal/serve/sweep_test.go
@@ -167,7 +167,7 @@ func TestReprievedSessionOutlivesTheIdleTimeout(t *testing.T) {
 	srv.reprieveWindow = 250 * time.Millisecond
 	done := make(chan error, 1)
 	go func() { done <- srv.Serve() }()
-	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+	t.Cleanup(func() { stopServer(t, srv, done) })
 
 	signer, fp := newClientKey(t)
 	enrollDirect(t, srv, fp, "vex")

--- a/internal/serve/sweep_test.go
+++ b/internal/serve/sweep_test.go
@@ -1,0 +1,302 @@
+package serve
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	cssh "golang.org/x/crypto/ssh"
+)
+
+// register puts a session in the registry with a stub connection whose
+// peer last spoke at lastIO, and hands back the stub for inspection.
+func register(t *testing.T, srv *Server, fp string, lastIO time.Time) *stubConn {
+	t.Helper()
+	stub := &stubConn{}
+	conn := newActivityConn(stub, func() time.Time { return lastIO })
+	srv.live.add(fp, &liveSession{conn: conn})
+	return stub
+}
+
+// mutualArm reports both players as Engaged toward each other, which is
+// what an in-flight shared coast looks like on the wire.
+func mutualArm(a, b string, tau time.Time) []relay.CraftReport {
+	return []relay.CraftReport{armed(a, b, tau), armed(b, a, tau)}
+}
+
+func publish(srv *Server, reports []relay.CraftReport) {
+	for _, r := range reports {
+		srv.relay.Report(r)
+	}
+}
+
+// Only a Commitment earns a Reprieve. An uncommitted session keeps the
+// deadline its own I/O path set and is reaped at the idle timeout like
+// any other absent peer.
+func TestExtendReprievesOnlyCommittedSessions(t *testing.T) {
+	srv := newOfflineServer(t)
+	now := time.Now()
+	absent := now.Add(-30 * time.Minute) // both peers long gone
+
+	committed := register(t, srv, fpA, absent)
+	uncommitted := register(t, srv, fpC, absent)
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+
+	srv.extendReprieves(now)
+
+	if got := committed.deadlinesSet(); len(got) != 1 {
+		t.Errorf("committed session got %d deadline extensions, want 1 — its partner is mid-coast", len(got))
+	}
+	if got := uncommitted.deadlinesSet(); len(got) != 0 {
+		t.Errorf("uncommitted session got %d extensions, want 0 — nothing is waiting on it", len(got))
+	}
+}
+
+// The sweeper may only ever push a deadline further out. It runs on a
+// short window, so a naive "set now + window" would pull a *present*
+// player's deadline in from the idle timeout to a couple of minutes —
+// and a paused player renders no frames, so they would be disconnected
+// while sitting right there.
+func TestExtendReprieveNeverShortensADeadline(t *testing.T) {
+	srv := newOfflineServer(t)
+	now := time.Now()
+	recent := now.Add(-time.Second) // spoke a moment ago: present, just quiet
+
+	stub := register(t, srv, fpA, recent)
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+
+	srv.extendReprieves(now)
+
+	got := stub.deadlinesSet()
+	if len(got) != 1 {
+		t.Fatalf("got %d deadline extensions, want 1", len(got))
+	}
+	if want := recent.Add(srv.idleTimeout); !got[0].Equal(want) {
+		t.Errorf("deadline = %v, want %v — the deadline this session's own I/O path would have set",
+			got[0], want)
+	}
+	if got[0].Before(now.Add(srv.reprieveWindow)) {
+		t.Errorf("deadline %v is inside the reprieve window ending %v — the sweeper shortened it",
+			got[0], now.Add(srv.reprieveWindow))
+	}
+}
+
+// The cap is what bounds unattended simulation. Past it the sweeper
+// stops extending and the standing deadline fires — it never
+// force-expires, so exactly one code path ever writes a deadline and
+// there is no ordering race with teardown.
+func TestExtendReprieveStopsAtTheCap(t *testing.T) {
+	srv := newOfflineServer(t)
+	now := time.Now()
+	// Docked, with a peer absent for longer than a dock's flat cap.
+	stub := register(t, srv, fpA, now.Add(-dockReprieveCap-time.Minute))
+	srv.dock.Seed([]relay.DockRecord{{ID: 1, Owner: fpA, GuestOwner: fpB, Phase: relay.DockActive}})
+
+	srv.extendReprieves(now)
+
+	if got := stub.deadlinesSet(); len(got) != 0 {
+		t.Errorf("a capped-out session was extended to %v — the cap is the only thing bounding "+
+			"unattended simulation", got)
+	}
+}
+
+// The sweeper must be running for the listener's life. This is the
+// finding that inverts the obvious implementation: updateDeadline() runs
+// at the *start* of Write, then Write blocks against the absent peer and
+// nothing on the I/O path runs again, so whatever deadline was set last
+// is final. A goroutine whose only job is to call SetDeadline is not
+// redundant — without it every Reprieve silently caps at one window.
+func TestSweeperRunsForTheListenersLife(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "ssh_host_ed25519_key"),
+		SessionDir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.sweepEvery = 20 * time.Millisecond
+	now := time.Now()
+	stub := register(t, srv, fpA, now.Add(-30*time.Minute))
+	publish(srv, mutualArm(fpA, fpB, simNoon.Add(time.Hour)))
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for len(stub.deadlinesSet()) == 0 {
+		if time.Now().After(deadline) {
+			_ = srv.ln.Close()
+			<-done
+			t.Fatal("no sweep ever extended a committed session's deadline — nothing is holding " +
+				"a Reprieve open, so every one of them expires at a single idle window")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// And it stops with the listener: a sweeper outliving Serve would keep
+	// poking connections belonging to a server that is gone.
+	_ = srv.ln.Close()
+	<-done
+	settled := len(stub.deadlinesSet())
+	time.Sleep(100 * time.Millisecond) // several sweep intervals
+	if got := len(stub.deadlinesSet()); got != settled {
+		t.Errorf("deadline extensions went %d → %d after Serve returned — the sweeper outlived the listener",
+			settled, got)
+	}
+}
+
+// End to end, on the behaviour the whole ADR exists for: a co-op partner
+// closes their laptop mid-coast, and their session must NOT be reaped at
+// the idle timeout, because the coast they committed to is still running
+// and the other player is waiting on it. When the Commitment ends, the
+// same session goes away like any other absent peer.
+func TestReprievedSessionOutlivesTheIdleTimeout(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "ssh_host_ed25519_key"),
+		SessionDir:  t.TempDir(),
+		IdleTimeout: 400 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.sweepEvery = 25 * time.Millisecond
+	srv.reprieveWindow = 250 * time.Millisecond
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() { _ = srv.ln.Close(); <-done })
+
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "vex")
+	client, err := cssh.Dial("tcp", srv.Addr(), &cssh.ClientConfig{
+		User:            "guest",
+		Auth:            []cssh.AuthMethod{cssh.PublicKeys(signer)},
+		HostKeyCallback: cssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := sess.RequestPty("xterm-256color", 30, 120, cssh.TerminalModes{}); err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	if _, err := sess.StdoutPipe(); err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+	// From here the client never drains stdout and never types: a laptop
+	// with the lid shut.
+	waitPresence(t, srv, fp, true, 10*time.Second, "the session never came online")
+
+	// Hold a live Commitment across the wire. The session's own reports
+	// would otherwise overwrite this with its armless truth, so it is
+	// re-asserted until the survival window is over — which is exactly
+	// what a real partner mid-coast keeps reporting.
+	stopArming := make(chan struct{})
+	arming := make(chan struct{})
+	go func() {
+		defer close(arming)
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stopArming:
+				return
+			case <-tick.C:
+				publish(srv, mutualArm(fp, fpB, time.Now().UTC().Add(time.Hour)))
+			}
+		}
+	}()
+
+	// Survive several idle timeouts. Without a Reprieve this session is
+	// gone inside the first one.
+	survive := 6 * 400 * time.Millisecond
+	deadline := time.Now().Add(survive)
+	for time.Now().Before(deadline) {
+		if !srv.presence.isOnline(fp) {
+			close(stopArming)
+			<-arming
+			t.Fatal("a session mid-Commitment was reaped: its partner is left waiting out a " +
+				"coast that will now never complete — the regression the Reprieve exists to prevent")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// Commitment over. The Reprieve is released by ceasing to extend, so
+	// the standing deadline carries it off within one window.
+	close(stopArming)
+	<-arming
+	waitPresence(t, srv, fp, false, 30*time.Second,
+		"an absent peer with no Commitment left was never reaped — the Reprieve became permanent")
+}
+
+// A session leaves the registry when it ends. Otherwise the registry
+// only ever grows, and every sweep for the rest of the server's life
+// pokes deadlines onto connections that are long closed.
+func TestEndedSessionLeavesTheRegistry(t *testing.T) {
+	srv := startTestServer(t)
+	signer, fp := newClientKey(t)
+	enrollDirect(t, srv, fp, "vex")
+
+	client, err := cssh.Dial("tcp", srv.Addr(), &cssh.ClientConfig{
+		User:            "guest",
+		Auth:            []cssh.AuthMethod{cssh.PublicKeys(signer)},
+		HostKeyCallback: cssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := sess.RequestPty("xterm-256color", 30, 120, cssh.TerminalModes{}); err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	if err := sess.Shell(); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+	waitPresence(t, srv, fp, true, 10*time.Second, "the session never came online")
+	if _, ok := srv.live.snapshot()[fp]; !ok {
+		t.Fatal("a live session is missing from the registry — the sweeper cannot find its connection, " +
+			"so it can never be reprieved")
+	}
+
+	_ = client.Close()
+	waitPresence(t, srv, fp, false, 10*time.Second, "the session never went offline")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ok := srv.live.snapshot()[fp]; !ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("an ended session is still in the registry — it grows without bound and every " +
+				"sweep pokes deadlines onto closed connections")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// A survival window shorter than the reprieve window would pass even
+// with a broken sweeper, since a single extension would cover it.
+func TestSweepTestWindowsAreMeaningful(t *testing.T) {
+	srv := newOfflineServer(t)
+	if srv.reprieveWindow <= srv.sweepEvery {
+		t.Errorf("reprieve window %v <= sweep interval %v — a Reprieve would lapse between sweeps",
+			srv.reprieveWindow, srv.sweepEvery)
+	}
+	if srv.idleTimeout <= 0 {
+		t.Error("idleTimeout unrecorded — the sweeper cannot reconstruct the deadline it must not shorten")
+	}
+}

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -31,6 +31,13 @@ type SessionPlayer struct {
 	// the v0.28 "touch" cycle ships cross-player docking.
 	DockedGuest bool
 
+	// Away marks a player whose session is still simulating but who has
+	// gone silent (ADR 0036). Distinct from Online being false, which
+	// means the session is gone: an Away player's craft keep flying, keep
+	// holding the frontier, and keep whatever Commitment earned them a
+	// Reprieve — there is simply nobody at the controls.
+	Away bool
+
 	// WantsRendezvous / RendezvousOut are the roster-row Rendezvous Warp
 	// markers (v0.29 S2): this player is armed toward the viewer awaiting
 	// a response / the viewer is armed toward this player. Both render as
@@ -95,6 +102,13 @@ const (
 	// (v0.30 S4) — a warning, not a silent drop; progress persists and a
 	// reconnect resumes.
 	SessionEventServerRestart
+
+	// Reprieve moments (ADR 0036), addressed at the player holding a
+	// Commitment with the one who went silent — the person whose own
+	// flight now depends on an empty chair.
+	SessionEventWentQuiet // their peer stopped answering; the Commitment holds the session up
+	SessionEventBack      // they are answering again (woken, or reconnected and displaced)
+	SessionEventTimedOut  // the session ended while away — nobody ever came back
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —
@@ -111,4 +125,10 @@ type SessionEvent struct {
 	// is only meaningful to the player whose subspace was joined.
 	// Empty means broadcast (join/leave).
 	To string
+
+	// Detail is extra display context for events that need it — ADR 0036
+	// uses it for which Commitment is holding an away session up
+	// ("rendezvous" / "dock"), so the partner learns what is at stake
+	// rather than only that someone went quiet.
+	Detail string
 }

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -109,6 +109,11 @@ const (
 	SessionEventWentQuiet // their peer stopped answering; the Commitment holds the session up
 	SessionEventBack      // they are answering again (woken, or reconnected and displaced)
 	SessionEventTimedOut  // the session ended while away — nobody ever came back
+
+	// SessionEventResumed opens the replay of everything that happened
+	// while this player's own session ran unattended — local only, and
+	// the only event carrying Elapsed.
+	SessionEventResumed
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —
@@ -131,4 +136,10 @@ type SessionEvent struct {
 	// ("rendezvous" / "dock"), so the partner learns what is at stake
 	// rather than only that someone went quiet.
 	Detail string
+
+	// Elapsed is how much sim-time ran unattended, carried by
+	// SessionEventResumed (ADR 0036 S6). A player who reconnects after
+	// hours away lands in a world whose clock jumped; this is the number
+	// that accounts for it. Zero on every other kind.
+	Elapsed time.Duration
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -171,6 +171,12 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			plain("◇ " + e.Handle + " went quiet — " + held + " held")
 		case sim.SessionEventBack:
 			plain("◇ " + e.Handle + " is back")
+		case sim.SessionEventResumed:
+			// Opens the replay of the interval this player missed (ADR 0036
+			// S6). Sim-time, not wall clock: what matters is how far their
+			// craft flew, which under warp bears no relation to how long
+			// their laptop was shut.
+			plain("◇ resumed — " + compactDuration(e.Elapsed) + " ran while you were away")
 		case sim.SessionEventTimedOut:
 			rows = append(rows, row{text: "⚠ " + e.Handle + "'s session timed out — they never came back", alert: true})
 		case sim.SessionEventServerRestart:

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -176,7 +176,13 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			// S6). Sim-time, not wall clock: what matters is how far their
 			// craft flew, which under warp bears no relation to how long
 			// their laptop was shut.
-			plain("◇ resumed — " + compactDuration(e.Elapsed) + " ran while you were away")
+			resumed := "◇ resumed — " + compactDuration(e.Elapsed) + " ran while you were away"
+			if e.Detail != "" {
+				// The replay is bounded so it cannot bury the orbit view; say
+				// so rather than truncating in silence.
+				resumed += " (" + e.Detail + ")"
+			}
+			plain(resumed)
 		case sim.SessionEventTimedOut:
 			rows = append(rows, row{text: "⚠ " + e.Handle + "'s session timed out — they never came back", alert: true})
 		case sim.SessionEventServerRestart:

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -160,6 +160,19 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			plain("◇ rendezvous with " + e.Handle + " cancelled")
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
+		case sim.SessionEventWentQuiet:
+			// ADR 0036: addressed at the partner holding the Commitment, so
+			// it names what is still being held up rather than merely
+			// reporting that someone stopped answering.
+			held := e.Detail
+			if held == "" {
+				held = "commitment"
+			}
+			plain("◇ " + e.Handle + " went quiet — " + held + " held")
+		case sim.SessionEventBack:
+			plain("◇ " + e.Handle + " is back")
+		case sim.SessionEventTimedOut:
+			rows = append(rows, row{text: "⚠ " + e.Handle + "'s session timed out — they never came back", alert: true})
 		case sim.SessionEventServerRestart:
 			rows = append(rows, row{text: "⚠ server restarting — reconnect in a moment, progress saved", alert: true})
 		}

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -633,6 +633,13 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		if p.Online {
 			dot = s.theme.Primary.Render("●")
 		}
+		// Away (ADR 0036 S5): connected and still simulating, but nobody at
+		// the controls. Half-filled between online and offline, because that
+		// is exactly where the state sits — and dimmed, since the thing the
+		// reader needs to know is that this player will not answer.
+		if p.Away {
+			dot = s.theme.Dim.Render("◐")
+		}
 		var tags []string
 		switch p.Role {
 		case "host":
@@ -642,6 +649,9 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		}
 		if p.Fingerprint == info.Self {
 			tags = append(tags, "you")
+		}
+		if p.Away {
+			tags = append(tags, "away") // ADR 0036 S5: the glyph alone is too subtle to carry it
 		}
 		if p.DockedGuest {
 			tags = append(tags, "docked") // v0.28 S5: live — riding another player's stack

--- a/internal/tui/screens/session_away_test.go
+++ b/internal/tui/screens/session_away_test.go
@@ -98,3 +98,17 @@ func TestWentQuietChipWithoutDetail(t *testing.T) {
 		t.Errorf("chip reads badly without Detail:\n%s", joined)
 	}
 }
+
+// A bounded replay must say what it left out, or a returning player reads
+// six moments as the whole account of a two-hour interval.
+func TestResumeChipReportsWhatItLeftOut(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventResumed, Elapsed: 2 * time.Hour, Detail: "+7 earlier", At: time.Now()},
+	}
+	joined := strings.Join(v.buildSessionEventsChip(w), "\n")
+	if !strings.Contains(joined, "resumed — 2h0m ran while you were away (+7 earlier)") {
+		t.Errorf("truncation went unannounced:\n%s", joined)
+	}
+}

--- a/internal/tui/screens/session_away_test.go
+++ b/internal/tui/screens/session_away_test.go
@@ -1,0 +1,79 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// The Reprieve moments, addressed at the partner whose own flight now
+// depends on an empty chair (ADR 0036 S5).
+func TestSessionEventsChipReprieveKinds(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	now := time.Now()
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventWentQuiet, Handle: "vex", Detail: "rendezvous", At: now},
+		{Kind: sim.SessionEventWentQuiet, Handle: "kes", Detail: "dock", At: now},
+		{Kind: sim.SessionEventBack, Handle: "vex", At: now},
+		{Kind: sim.SessionEventTimedOut, Handle: "kes", At: now},
+	}
+	joined := strings.Join(v.buildSessionEventsChip(w), "\n")
+	for _, want := range []string{
+		// Naming what is held is the point: "went quiet" alone tells the
+		// partner nothing about whether their coast survives.
+		"vex went quiet — rendezvous held",
+		"kes went quiet — dock held",
+		"vex is back",
+		"kes's session timed out — they never came back",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("session chip missing %q:\n%s", want, joined)
+		}
+	}
+	// A session that timed out did not leave; the wording must not be
+	// interchangeable with the ordinary departure.
+	if strings.Contains(joined, "kes left") {
+		t.Errorf("a timed-out session rendered as an ordinary leave:\n%s", joined)
+	}
+}
+
+// The roster is what made slice 5 necessary: a reprieved session stays
+// Online for hours, so an away player must not render identically to one
+// sitting at the keyboard.
+func TestSessionScreenMarksAway(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	w.Session.Players[1].Away = true // gern, still online
+
+	out := s.Render(w, 120)
+
+	if !strings.Contains(out, "away") {
+		t.Errorf("an away player is indistinguishable from an attended one:\n%s", out)
+	}
+	if !strings.Contains(out, "◐") {
+		t.Errorf("no away glyph on the roster:\n%s", out)
+	}
+	// Away is not offline: their session is still simulating, and the row
+	// must not imply their craft have stopped.
+	attended := s.Render(sessionWorld(t, true), 120)
+	if strings.Contains(attended, "away") || strings.Contains(attended, "◐") {
+		t.Errorf("away rendering leaked onto a roster with nobody away:\n%s", attended)
+	}
+}
+
+// Detail is display context, not a required field: a went-quiet chip that
+// somehow arrives without it must still read as a sentence.
+func TestWentQuietChipWithoutDetail(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventWentQuiet, Handle: "vex", At: time.Now()},
+	}
+	joined := strings.Join(v.buildSessionEventsChip(w), "\n")
+	if !strings.Contains(joined, "vex went quiet") || strings.Contains(joined, "—  held") {
+		t.Errorf("chip reads badly without Detail:\n%s", joined)
+	}
+}

--- a/internal/tui/screens/session_away_test.go
+++ b/internal/tui/screens/session_away_test.go
@@ -64,6 +64,27 @@ func TestSessionScreenMarksAway(t *testing.T) {
 	}
 }
 
+// The returning player's account of the interval they missed (ADR 0036
+// S6), opening the replay of the moments that fell while they were gone.
+func TestSessionEventsChipResumed(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	now := time.Now()
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventResumed, Elapsed: 2*time.Hour + 19*time.Minute, At: now},
+		{Kind: sim.SessionEventRendezvousArrived, Handle: "ansi", At: now},
+	}
+	joined := strings.Join(v.buildSessionEventsChip(w), "\n")
+	if !strings.Contains(joined, "resumed — 2h19m ran while you were away") {
+		t.Errorf("resume chip missing or misworded:\n%s", joined)
+	}
+	// The replayed moment rides right behind it, so the elapsed figure has
+	// something to account for.
+	if !strings.Contains(joined, "encounter reached") {
+		t.Errorf("the replayed moment did not render alongside the resume:\n%s", joined)
+	}
+}
+
 // Detail is display context, not a required field: a went-quiet chip that
 // somehow arrives without it must still read as a sentence.
 func TestWentQuietChipWithoutDetail(t *testing.T) {


### PR DESCRIPTION
Fixes #243. See the [correction comment](https://github.com/jasonfen/terminal-space-program/issues/243#issuecomment-5080715684) —
the issue as filed described the wrong mechanism, and this fixes the real one.

Design: **ADR 0036** in the planning vault (`cb301e9`, `fadb42f` carry the
implementation amendments — read them alongside the decision, they hold every
call the code had to make beyond it).

## What actually happens

A guest's game runs **inside the server process** (ADR 0034), driven by its
own tick loop — `reporting.go:188` ticks the reporter on every `sim.TickMsg`
whether or not the client is reachable. A client machine going to sleep
therefore does **not** stop the session. And with no idle timeout on the ssh
server, the half-open TCP was never reaped either.

Three things were wrong at once as a result:

1. The session kept **running and warping unattended** in a shared world.
2. Presence kept counting it online — the roster showed a live dot and an
   advancing clock for someone who had gone to bed.
3. Because a key may hold only one live session, its owner was **locked out of
   their own program** behind a socket nobody was using.

Observed in the live playtest: a player's clock advanced from `+2s` to `+2h6m`
while their laptop was asleep. That is a running session, not a frozen one.

## Why a flat timeout is not the whole fix

`wish.WithIdleTimeout` alone reaps the connection, and on its own it introduces
a worse bug than the one it fixes. Co-warp pins a coupled pair to the *slower*
player's rate, so real coasts are long — the coast flown in the 2026-07-25
playtest ran **2h19m of real time at 1×**. A flat ten-minute reap kills any
in-flight shared coast the moment either side drops. Today's behaviour at least
lets that coast *complete*, so shipping the timeout by itself would trade "runs
forever" for "strands your partner".

## The Reprieve

A session keeps simulating past the idle timeout for as long as it carries a
live **Commitment**: an Engaged Rendezvous Warp through to its committed TCA,
or a cross-player dock. Both terms are in `CONTEXT.md`, along with **Away**.

Proximity co-warp is **excluded** — it forms by itself and strands nobody when
it lapses. That is also what keeps the concurrency trivial: both Commitments are
already published behind mutexes (`relay.Store`, `relay.DockLedger`), whereas
`w.CoWarp.Coupled` lives only on the World, which the sweeper must never touch.

Two findings inverted the obvious implementation, and are worth knowing before
reading the diff:

- **There is no inline version of this.** `serverConn.updateDeadline()` runs at
  the *start* of `Write`; then `Write` blocks against the absent peer and
  nothing on the I/O path runs again, so the last deadline written is final.
  Extending past a single window *requires* an outside goroutine calling
  `SetDeadline`. Deleting that loop doesn't lose an optimisation — it silently
  caps every Reprieve at one window.
- **The cap cannot be measured without the conn wrapper.** The only signal of
  peer-absence is the connection dying, which is exactly what a Reprieve
  prevents. Last-successful-I/O is what remains, and it is also the only thing
  separating *absent, coasting unattended* from *present, on a legitimately long
  coast*.

## The slices

| slice | commit | what |
| --- | --- | --- |
| S1 | `9e0f5cf` | `activityConn` records last-successful-I/O per connection |
| S2 | `d5fad40` | Commitment predicate over the published seams |
| S3 | `33ab453` | the sweeper — one goroutine, copy-then-act, never touches a World |
| S4 | `4940965` | reconnect displaces its own reprieved session |
| S5 | `78cd988` | partner-facing feedback: `Away`, went-quiet / is-back / timed-out |
| S6 | `3d5007f` | replay of the interval a returning player missed |

S4 exists because without it the Reprieve **reintroduces the exact lockout this
PR was opened to fix**, and worst for the players most likely to want back in —
the ones mid-coast, whose lockout would last as long as the encounter they
committed to.

S5 exists because the Reprieve leaves the Session screen actively wrong:
presence is not marked offline until `persistMiddleware` runs, so a reprieved
session read as `Online` for hours.

## What to look at hardest

These went beyond what the ADR settled:

- **A Rendezvous Warp counts only on a mutual arm.** That is what "Engaged"
  means (`CONTEXT.md`: *"Once both have Engaged, their Subspaces rate-lock"*).
  A lone arm is a pending invite — no coast, nobody stranded.
- **Both endpoints of a live dock are committed, not just the guest.** The ADR's
  signal table lists only `IsGuest`/`ActiveGuestDock`. But if the *owner* drops,
  the guest's craft stops being simulated inside a Stack they cannot undock
  from, since the split runs on the owner's tick.
- **The sweep must never shorten a deadline.** `SetDeadline(now + 2min)` is
  *shorter* than the standing idle deadline for the first eight minutes, and a
  paused-but-present player renders no frames — exactly the case the ten minutes
  were chosen for. It takes `max(now+window, lastIO+idleTimeout)`.
- **Constants chosen here, not in the ADR:** `maxUnattendedReprieve` 4h (sized
  against the observed 2h19m coast; a test asserts the ceiling covers it),
  `rendezvousReprieveMargin` 5min, `reclaimWait` 10s, `awayAfter` 60s,
  `heldMomentCap` 32.

`MaxTimeout` stays unset, with a test asserting it: an absolute cap on total
session life would evict players who are present and playing.

## Tests

**1684 → 1754**, `-race -count=1`, `go vet ./...` clean. `./internal/serve` run
repeatedly, since these slices added timing-sensitive tests.

The ones that matter are end-to-end rather than assertions that an option is
set: a client completes the SSH handshake and then never drains stdout — the
same shape as a sleeping laptop. `TestReprievedSessionOutlivesTheIdleTimeout`
survives 6× the idle timeout while a mutual arm is on the wire, then is reaped
once the arm stops. `TestReconnectDisplacesItsOwnReprievedSession` takes over
that same session from a second connection.

Every load-bearing decision was mutation-tested — the change that removes it
fails a named test. Deleting the sweeper goroutine fails two.

## A discarded approach, recorded so it isn't retried

I first built report-staleness detection: stamp report arrival in `relay.Store`,
mark quiet-but-connected players on the roster, refuse `[s]` into them, and let
a key reclaim its own slot from a stale session. Eighteen tests, all green — and
all of it useless, because sessions that keep ticking keep reporting. There is
no staleness to detect. Its close-and-wait machinery was the one salvageable
part and survives in S4.

## Known gaps

- **One invariant is structural, not tested.** `done` closes after `SavePlayer`
  because its `defer` is registered first, so it fires last however the function
  grows. Mutating that line fails nothing — an early close produces a race, not
  a deterministic failure.
- **Never playtested on a real sleeping laptop.** Absence is simulated by a
  client that stops draining stdout. Structurally identical; not the same thing.
- **No code review yet** — the batched pass across all six slices is still owed.
- **A reprieved session is genuinely unattended.** It keeps advancing the
  frontier others are measured against, and its craft can crash or run dry with
  nobody watching. For a mutually committed encounter that is arguably correct —
  both players committed — but the cap is the only thing bounding it. Whether
  unattended time should count toward the join frontier at all is #247.
- **Solo players are not covered.** Someone mid-burn with no Commitment is still
  reaped with the burn unfinished. Folding that in means holding on World state,
  which needs a publishing channel this design deliberately avoids.
- Arming a Rendezvous Warp toward an **Away** player still produces an invite
  nobody will answer. Gating that is a behaviour change, not feedback.
