### PR TITLE
fix(mp): #248 — exempt the engaged rendezvous coast from co-warp min-wins

### DIFF
--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -153,9 +153,13 @@ func (w *World) rendezvousArmedWith(owner string) bool {
 
 // CoWarpState is the transient co-warp slate the reporting layer writes
 // onto the World each tick and clampedWarp reads: whether the anchor is
-// coupled to anyone this tick and, if so, the min Effective warp to clamp
-// to. Never persisted; empty in single-player. Partners is the coupled
-// handles for HUD/debug.
+// coupled to anyone this tick and the min Effective warp to clamp to.
+// MinWarp 0 with Coupled set means coupled-with-no-clamp (#248): every
+// coupled peer is the engaged rendezvous coast's partner, whose stale
+// reported rate is exempt from min-wins — clampedWarp guards on
+// MinWarp > 0, so both sides derive the coast rate independently instead
+// of deadlocking on each other's report. Never persisted; empty in
+// single-player. Partners is the coupled handles for HUD/debug.
 type CoWarpState struct {
 	Coupled  bool
 	MinWarp  float64
@@ -226,6 +230,7 @@ func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpRe
 	for _, p := range peers {
 		wasCoupled := prev[p.Owner]
 		coupledNow := false
+		clampExempt := false
 		// A non-positive Effective warp (a paused partner, Warp()==0)
 		// imposes no co-warp constraint — the min would freeze the
 		// viewer, which is not what a buddy tapping pause should do. Such
@@ -243,6 +248,20 @@ func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpRe
 				// then continues on the proximity branch below (wasCoupled
 				// carries the hysteresis memory) — no drop-and-recouple.
 				coupledNow = true
+				// #248: while the shared coast is ENGAGED, this partner's
+				// reported EffWarp must NOT feed the min. The report is their
+				// own post-clamp rate, always ≥1 tick stale, so min-wins over
+				// it can only ratchet down — two players engaging at 1× pin
+				// each other at 1× forever and the coast runs in real time.
+				// Instead both sides derive the rate independently and
+				// identically from the shared τ + constants: max-seed →
+				// subspaceStepCap → approach ramp (clampedWarp). Per-peer
+				// exemption, not a blanket skip: a third proximity-coupled
+				// peer still contributes its min below. Legible here because
+				// DriveRendezvousWarp runs before ComputeCoWarp each tick.
+				// Armed-but-not-yet-coasting keeps min-wins (nothing seeds
+				// the rate up yet, and the couple must not outrun the gate).
+				clampExempt = w.rendezvousWarpEngaged()
 			default:
 				if rng, vrel, ok := closestApproach(anchor, p.Crafts); ok {
 					coupledNow = coupleDecide(wasCoupled, rng, vrel)
@@ -258,7 +277,7 @@ func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpRe
 		}
 		if coupledNow {
 			res.State.Partners = append(res.State.Partners, p.Handle)
-			if p.EffWarp < minWarp {
+			if !clampExempt && p.EffWarp < minWarp {
 				minWarp = p.EffWarp
 			}
 		}
@@ -269,9 +288,16 @@ func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpRe
 	// clamp already dropped it from the min. No handle survives to chip a
 	// release, which is acceptable for this edge (the common decouple —
 	// drifting apart in-system — keeps the peer present, so it chips).
-	if len(res.State.Partners) > 0 && !math.IsInf(minWarp, 1) {
+	//
+	// Coupled-with-no-min-contribution (#248: every coupled peer is the
+	// clamp-exempt coast partner) leaves MinWarp at its zero value —
+	// clampedWarp guards on MinWarp > 0, so 0 naturally means "coupled,
+	// no min-wins clamp" and the coast resolves its own rate.
+	if len(res.State.Partners) > 0 {
 		res.State.Coupled = true
-		res.State.MinWarp = minWarp
+		if !math.IsInf(minWarp, 1) {
+			res.State.MinWarp = minWarp
+		}
 	}
 	return res
 }

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -275,7 +275,10 @@ type DockGuestLink struct {
 // resulting MinWarp is the lesser of any range-coupled peer and the owner's
 // warp, so the guest can always select lower (slam 1× and burn) but can't
 // out-warp the owner. A non-positive ownerEffWarp (paused owner) imposes no
-// coupling, matching ComputeCoWarp's paused-peer handling.
+// coupling, matching ComputeCoWarp's paused-peer handling. A coupled state
+// carrying MinWarp 0 (#248: an engaged rendezvous coast exempts its partner
+// from min-wins) still adopts the owner's warp — the coast exemption is the
+// partner's, never the stack owner's, so the guest stays clamped.
 func (s CoWarpState) WithDockCoupling(ownerHandle string, ownerEffWarp float64) CoWarpState {
 	if ownerEffWarp <= 0 {
 		return s

--- a/internal/sim/docking_guest_test.go
+++ b/internal/sim/docking_guest_test.go
@@ -186,6 +186,14 @@ func TestWithDockCouplingMinWins(t *testing.T) {
 	if got.Coupled {
 		t.Error("paused owner (0×) forced a coupling")
 	}
+	// Coupled-with-no-min-contribution (#248: an engaged rendezvous coast
+	// exempts its partner from min-wins, leaving Coupled=true, MinWarp=0):
+	// the owner's warp must still land as the clamp — a guest cannot
+	// out-warp the stack owner just because their coast carries no min.
+	got = CoWarpState{Coupled: true, MinWarp: 0, Partners: []string{"ada"}}.WithDockCoupling("gern", 8)
+	if !got.Coupled || got.MinWarp != 8 {
+		t.Errorf("coupled+0 fold = %+v, want coupled@8 (owner clamp survives the coast exemption)", got)
+	}
 }
 
 // TestDockCouplingClampsWorldWarp: with the fold written onto World.CoWarp,

--- a/internal/sim/rendezvous_cowarp_test.go
+++ b/internal/sim/rendezvous_cowarp_test.go
@@ -77,6 +77,53 @@ func TestRendezvousArmDifferentSubspaceDoesNotCouple(t *testing.T) {
 	}
 }
 
+// Per-peer SCOPE of the #248 min-wins exemption: while the shared coast
+// is engaged, only the armed PARTNER's stale reported rate is excluded
+// from the min — a proximity-coupled third peer must still clamp.
+//
+// This pins the exemption against the tempting refactor to a blanket
+// skip (`if rendezvousWarpEngaged() { skip min accumulation }` before the
+// peer loop): every pairwise test still passes under that form, but a
+// third player station-keeping next to the viewer would lose min-wins
+// entirely — the viewer's max-seeded coast would out-warp them and break
+// the couple's step-in-lock invariant. The exemption is a property of
+// the peer (clampExempt inside the rendezvous branch), not of the tick.
+func TestRendezvousCoastThirdPeerMinStillWins(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+
+	// Partner B: mutually armed, shared coast engaged. Reports 1× — the
+	// stale post-clamp rate the #248 exemption exists to ignore. If it
+	// leaked into the min, MinWarp would come out 1, not 5.
+	partner := armPeer(w, primary, st, 1, "gern")
+	w.EngageRendezvousWarp(partner.Owner, "gern", tau, 0)
+	w.DriveRendezvousWarp([]CoWarpPeer{partner})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: the shared coast did not engage")
+	}
+
+	// Peer C: proximity-coupled the ordinary way (5 km, 0 m/s, same
+	// subspace, same primary), reporting Effective warp 5.
+	third := peerAt(w, primary, st, 5, orbital.Vec3{X: 5000}, orbital.Vec3{}, "cass")
+
+	res := w.ComputeCoWarp([]CoWarpPeer{partner, third}, nil)
+	if !res.State.Coupled {
+		t.Fatal("not coupled to the armed partner + proximity peer")
+	}
+	if len(res.State.Partners) != 2 {
+		t.Fatalf("Partners = %v, want both gern and cass coupled", res.State.Partners)
+	}
+	if res.State.MinWarp != 5 {
+		t.Errorf("MinWarp = %v, want C's 5 (B's stale 1x excluded per-peer, C still clamps)",
+			res.State.MinWarp)
+	}
+	w.CoWarp = res.State
+	if got := w.EffectiveWarp(); got != 5 {
+		t.Errorf("EffectiveWarp = %v, want 5 — the third peer's min must cap the "+
+			"max-seeded coast through clampedWarp", got)
+	}
+}
+
 // Seamless Rendezvous→Proximity handoff at arrival: while mutually armed
 // AND within the gate the pair is coupled; when the arm clears (AutoWarp
 // reached τ) the SAME coupled state continues via the proximity decouple

--- a/internal/sim/rendezvous_warp_test.go
+++ b/internal/sim/rendezvous_warp_test.go
@@ -172,3 +172,57 @@ func TestRendezvousWarpArrivalHandsOff(t *testing.T) {
 		t.Errorf("arrival not recorded for the chip: %+v", w.LastRendezvousArrival)
 	}
 }
+
+// A mutually-armed pair must be able to raise the shared coast's rate.
+//
+// Regression for #248: engaging a rendezvous max-seeds the warp baseline,
+// but mutual arms also couple the pair, and the couple applies min-wins
+// over each partner's last *reported* Effective warp — which is their own
+// post-clamp rate, always at least a tick stale. Two players who both
+// engage at 1x therefore clamp each other to 1x and report 1x forever:
+// min-wins can only ratchet down, so there is no path up and no
+// tie-breaker. The coast then runs in real time (a 3 h encounter takes
+// 3 h of wall clock).
+func TestRendezvousCoastRaisesSharedRate(t *testing.T) {
+	wa, _, sta := anchorWorld(t)
+	wb, _, stb := anchorWorld(t)
+	tau := sta.Add(3 * time.Hour)
+
+	wa.EngageRendezvousWarp("SHA256:b", "b", tau, 0)
+	wb.EngageRendezvousWarp("SHA256:a", "a", tau, 0)
+
+	peer := func(owner, handle string, st time.Time, eff float64) []CoWarpPeer {
+		return []CoWarpPeer{{
+			Owner: owner, Handle: handle, SubspaceTime: st,
+			EffWarp: eff, ArmedTowardViewer: true, RendezvousTau: tau,
+		}}
+	}
+
+	// Each tick every side sees the other's PREVIOUS tick's reported
+	// Effective warp — the staleness relay.Report actually has.
+	effA, effB := wa.EffectiveWarp(), wb.EffectiveWarp()
+	prevA, prevB := map[string]bool{}, map[string]bool{}
+	for tick := 0; tick < 8; tick++ {
+		pa := peer("SHA256:b", "b", stb, effB)
+		pb := peer("SHA256:a", "a", sta, effA)
+		wa.DriveRendezvousWarp(pa)
+		wb.DriveRendezvousWarp(pb)
+		ra := wa.ComputeCoWarp(pa, prevA)
+		rb := wb.ComputeCoWarp(pb, prevB)
+		wa.CoWarp, wb.CoWarp = ra.State, rb.State
+		prevA, prevB = ra.CoupledOwners, rb.CoupledOwners
+		effA, effB = wa.EffectiveWarp(), wb.EffectiveWarp()
+	}
+
+	if !wa.rendezvousWarpEngaged() || !wb.rendezvousWarpEngaged() {
+		t.Fatal("precondition: the shared coast never engaged")
+	}
+	if !wa.CoWarp.Coupled {
+		t.Fatal("precondition: mutual arms did not couple the pair")
+	}
+	if effA <= 1 || effB <= 1 {
+		t.Errorf("shared coast pinned at its starting rate (effA=%v effB=%v): "+
+			"min-wins over a stale report cannot ratchet up, so a %v encounter "+
+			"runs in real time", effA, effB, tau.Sub(sta))
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1117,7 +1117,11 @@ func (w *World) clampedWarp() float64 {
 	// couple/decouple gate + hysteresis live in ComputeCoWarp, here we
 	// only take the min. Placed before the burn/period clamps so those
 	// can only reduce further, and before the degenerate-period early
-	// return so a coupled clamp still applies there.
+	// return so a coupled clamp still applies there. The MinWarp > 0
+	// guard is load-bearing (#248): an engaged rendezvous coast couples
+	// with MinWarp 0 — no min-wins over the partner's stale report —
+	// and resolves its rate from the max-seed above bounded by the
+	// step cap and approach ramp below.
 	if w.CoWarp.Coupled && w.CoWarp.MinWarp > 0 && selected > w.CoWarp.MinWarp {
 		selected = w.CoWarp.MinWarp
 	}


### PR DESCRIPTION
## Root cause

Engaging a rendezvous max-seeds `clampedWarp`'s baseline (`internal/sim/world.go`), but the mutual arm also couples the pair via `ComputeCoWarp`'s rendezvous branch, and the coupled min-wins clamp feeds on the partner's **post-clamp, ≥1-tick-stale reported** `EffWarp`. Min-wins can only ratchet down, so two players who both engage at 1× clamp each other to 1× and report 1× forever — no path up, no tie-breaker. A 3 h coast ran 3 h of wall clock.

## Fix (both-sides-compute, per the plan / agent brief)

- `ComputeCoWarp` rendezvous branch: while the coast is **engaged** (`rendezvousWarpEngaged()` — legible there because `DriveRendezvousWarp` runs first each serve tick), the pair stays `coupledNow = true` but that peer's `EffWarp` is **excluded from the `minWarp` accumulation**. Per-peer exemption — a third proximity-coupled peer still contributes its min.
- `State.Coupled` no longer requires a finite min: coupled-with-no-min-contribution yields `Coupled=true, MinWarp=0`. `clampedWarp` guards on `MinWarp > 0`, so 0 naturally means "no clamp". `CoWarpState` docs updated to carry the new semantics.
- Both sides then resolve the rate independently and identically from shared state: max-seed → `subspaceStepCap` (1200× under current constants) → approach ramp at τ. No round-trip, no deadlock.

No constants changed; τ selection untouched. Armed-but-not-yet-coasting keeps min-wins.

## What still bounds the coast (verified)

- `RendezvousHold`: paused/behind-diverged partner still freezes the leader (`TestRendezvousHoldOnPausedOrDivergedPartner` green, path untouched).
- `subspaceStepCap`: now the load-bearing ceiling — the probe below settles exactly at 1200×.
- 10× burn cap + period guards: applied after the co-warp clamp in `clampedWarp`, untouched.
- Proximity Co-Warp min-wins: **unchanged** — `TestComputeCoWarpMinWinsClampsWorld` green.
- Docked-as-guest: `WithDockCoupling`'s `MinWarp <= 0` overwrite path becomes reachable with coupled+0 states and still adopts the owner's warp — a guest cannot out-warp the stack owner. New case added to `TestWithDockCouplingMinWins`; doc comment updated.

## Test evidence

`TestRendezvousCoastRaisesSharedRate` pasted **verbatim** from the #248 brief (two-world cross-fed — the deadlock does not exist single-world). Red before the fix, failing on the assertion with the brief's exact transcript:

```
--- FAIL: TestRendezvousCoastRaisesSharedRate (0.00s)
    rendezvous_warp_test.go:224: shared coast pinned at its starting rate (effA=1 effB=1): min-wins over a stale report cannot ratchet up, so a 3h0m0s encounter runs in real time
```

After the fix, a probe of the same loop shows both sides at the step-cap ceiling from the first tick, agreeing exactly (acceptance: mutual engage at 1× rises well above 1× within a few ticks; rates agree on both sides):

```
tick 0: effA=1200 effB=1200 minA=0 minB=0
...
tick 7: effA=1200 effB=1200 minA=0 minB=0
--- PASS: TestRendezvousCoastRaisesSharedRate (0.00s)
--- PASS: TestComputeCoWarpMinWinsClampsWorld (0.00s)
```

Full runs:

```
go vet ./...                                  clean
go test ./... -race -count=1                  all packages ok (sim 41.9s, serve 14.5s)
go test ./internal/serve -race -count=3       ok 40.9s
```

Fixes #248