### PR TITLE
fix(mp): name the pre-couple subspace gap instead of blaming the partner (#250)

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -241,8 +241,15 @@ func (m *reportingModel) emitRendezvousEvents(w *sim.World, now time.Time) {
 	}
 
 	// Incoming invite: chip the arm moment; a retracted-unanswered invite
-	// (initiator cancelled, or τ passed) chips as cancelled.
+	// (initiator cancelled, or τ passed) chips as cancelled. A Blocked
+	// invite (#250 subspace gap) is neither: the "[y] join" moment would
+	// lie while the join is suppressed (the persistent chip carries the
+	// attribution), and its appearance is a gap, not a retract — so the
+	// bookkeeping just resets, and re-convergence chips the arm moment
+	// fresh.
 	switch inv := w.RendezvousInvite; {
+	case inv != nil && inv.Blocked:
+		m.rzInviteFrom, m.rzInviteHandle = "", ""
 	case inv != nil && inv.Owner != m.rzInviteFrom:
 		chip(sim.SessionEventRendezvousArmed, inv.Handle)
 		m.rzInviteFrom, m.rzInviteHandle = inv.Owner, inv.Handle
@@ -513,6 +520,7 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	w.RendezvousInvite = nil
 	w.RendezvousDegraded, w.RendezvousApproachM = false, 0
 	w.RendezvousHold = false
+	w.RendezvousWait = sim.RendezvousWait{}
 	// Arrival slates too (v0.29 review): a coast or sync arriving on the
 	// same tick hosting stops must not fire a spurious chip in the next
 	// hosting session.

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -189,9 +189,11 @@ type RendezvousInvite struct {
 	// Blocked marks an invite from a subspace-diverged peer (#250): the
 	// intent is live, but the coast could never start across the gap, so
 	// the prompt renders as a non-joinable attribution ([y] suppressed,
-	// Sync named as the way in) instead of silently vanishing. AheadBy is
-	// the signed viewer-minus-initiator subspace offset (positive: the
-	// viewer is ahead). Both zero while joinable.
+	// the direction-correct Sync named as the way in) instead of silently
+	// vanishing. AheadBy is the signed viewer-minus-initiator subspace
+	// offset (positive: the viewer is ahead — Sync is forward-only, so
+	// then the initiator is the one who must Sync). Both zero while
+	// joinable.
 	Blocked bool
 	AheadBy time.Duration
 }

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -185,6 +185,15 @@ type RendezvousInvite struct {
 	Handle string    // display name for the prompt/chip
 	Tau    time.Time // the initiator's committed encounter sim-time
 	CA     float64   // m — the initiator's committed predicted approach
+
+	// Blocked marks an invite from a subspace-diverged peer (#250): the
+	// intent is live, but the coast could never start across the gap, so
+	// the prompt renders as a non-joinable attribution ([y] suppressed,
+	// Sync named as the way in) instead of silently vanishing. AheadBy is
+	// the signed viewer-minus-initiator subspace offset (positive: the
+	// viewer is ahead). Both zero while joinable.
+	Blocked bool
+	AheadBy time.Duration
 }
 
 // refreshRendezvousInvite rebuilds the invite slate from this tick's
@@ -193,25 +202,94 @@ type RendezvousInvite struct {
 // arm — once mutually armed (or armed elsewhere) there is nothing to
 // respond to. A past-τ arm is dropped here rather than surfaced, since
 // Engage would refuse it (forward-only).
+//
+// A subspace-diverged peer's arm is kept but Blocked (#250) rather than
+// dropped: Engage would succeed yet the coast could never start, so the
+// join affordance is a lie — but so is a prompt that vanishes without
+// attribution. A joinable invite always wins over a blocked one; the
+// blocked one turns joinable again if the pair converges.
 func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 	w.RendezvousInvite = nil
 	if w.RendezvousArm != nil {
 		return
 	}
+	var blocked *RendezvousInvite
 	for i := range peers {
 		p := &peers[i]
-		// Same-subspace gate (v0.29 review): an invite from a diverged
-		// peer is not joinable — Engage would succeed but the coast could
-		// never start, so surfacing it would make the [y] prompt a lie.
-		// The prompt reappears if the pair converges again.
-		if p.ArmedTowardViewer && p.RendezvousTau.After(w.Clock.SimTime) &&
-			sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
+		if !p.ArmedTowardViewer || !p.RendezvousTau.After(w.Clock.SimTime) {
+			continue
+		}
+		if sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
 			w.RendezvousInvite = &RendezvousInvite{
 				Owner: p.Owner, Handle: p.Handle, Tau: p.RendezvousTau, CA: p.RendezvousCA,
 			}
 			return
 		}
+		if blocked == nil {
+			blocked = &RendezvousInvite{
+				Owner: p.Owner, Handle: p.Handle, Tau: p.RendezvousTau, CA: p.RendezvousCA,
+				Blocked: true, AheadBy: w.Clock.SimTime.Sub(p.SubspaceTime),
+			}
+		}
 	}
+	w.RendezvousInvite = blocked
+}
+
+// RendezvousWaitReason classifies why an armed Rendezvous Warp has not
+// started coasting (#250). Deliberately an enum-plus-data shape rather
+// than a bag of bools — #221's CommGraph work wants the same "classify
+// the reason and say it" pattern, so the vocabulary should converge.
+type RendezvousWaitReason int
+
+const (
+	// RendezvousWaitNone: no arm held, or the shared coast is running.
+	RendezvousWaitNone RendezvousWaitReason = iota
+	// RendezvousWaitPartner: genuinely waiting — the partner has not
+	// Engaged back (or has no report in this tick's peer set).
+	RendezvousWaitPartner
+	// RendezvousWaitSubspaceGap: the pair has diverged past
+	// CoWarpSubspaceTolerance, so the coast cannot start no matter what
+	// the partner does — Sync is the only way back.
+	RendezvousWaitSubspaceGap
+)
+
+// RendezvousWait is the classified armed-but-not-coasting slate (#250):
+// the reason the coast has not started, plus the signed viewer-minus-
+// partner subspace offset when that reason is a gap (positive: the
+// viewer warped ahead). Zero value when idle or coasting.
+type RendezvousWait struct {
+	Reason  RendezvousWaitReason
+	AheadBy time.Duration // gap direction/magnitude; zero unless Reason is SubspaceGap
+}
+
+// refreshRendezvousWait reclassifies the armed-but-not-coasting state
+// each tick (#250), after driveRendezvousCoast so it reflects this
+// tick's engaged state. Set/cleared only here — same single-writer
+// ownership as RendezvousHold and the invite slate. The gap check reads
+// the partner's report regardless of ArmedTowardViewer: the initiator
+// case (partner not yet armed back) is exactly where the divergence is
+// otherwise invisible.
+func (w *World) refreshRendezvousWait(peers []CoWarpPeer) {
+	w.RendezvousWait = RendezvousWait{}
+	arm := w.RendezvousArm
+	if arm == nil || w.rendezvousWarpEngaged() {
+		return
+	}
+	for i := range peers {
+		p := &peers[i]
+		if p.Owner != arm.TargetOwner {
+			continue
+		}
+		if !sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
+			w.RendezvousWait = RendezvousWait{
+				Reason:  RendezvousWaitSubspaceGap,
+				AheadBy: w.Clock.SimTime.Sub(p.SubspaceTime),
+			}
+			return
+		}
+		break
+	}
+	w.RendezvousWait = RendezvousWait{Reason: RendezvousWaitPartner}
 }
 
 // DriveRendezvousWarp starts, holds, or cancels the shared coast to the
@@ -224,10 +302,12 @@ func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 // still flagged just releases it here defensively.
 func (w *World) DriveRendezvousWarp(peers []CoWarpPeer) {
 	w.driveRendezvousCoast(peers)
-	// One shared tail (v0.29 review): the degrade recompute reflects this
-	// tick's engaged state, and the invite refresh runs after start/cancel
-	// so a retract this tick can immediately surface another pending arm
-	// (the unarmed viewer is the responder case).
+	// One shared tail (v0.29 review): the wait classification and degrade
+	// recompute reflect this tick's engaged state, and the invite refresh
+	// runs after start/cancel so a retract this tick can immediately
+	// surface another pending arm (the unarmed viewer is the responder
+	// case).
+	w.refreshRendezvousWait(peers)
 	w.refreshRendezvousDegrade(peers)
 	w.refreshRendezvousInvite(peers)
 }

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -192,9 +192,10 @@ func (w *World) CoWarpCoupled() bool { return w.CoWarp.Coupled }
 // the gate wider than one step at any selectable rate, so the clamp
 // always gets a tick in which to act.
 //
-// Armed-but-not-yet-coupled counts too: refreshRendezvousInvite gates the
-// incoming prompt on sameSubspace, so an initiator who races ahead
-// withdraws their own invite before anyone can join it.
+// Armed-but-not-yet-coupled counts too: refreshRendezvousInvite marks
+// the incoming prompt Blocked outside sameSubspace (#250), so an
+// initiator who races ahead turns their own invite non-joinable before
+// anyone can answer it.
 func (w *World) subspaceStepCap() float64 {
 	if !w.CoWarp.Coupled && w.RendezvousArm == nil {
 		return 0

--- a/internal/sim/rendezvous_precouple_test.go
+++ b/internal/sim/rendezvous_precouple_test.go
@@ -1,0 +1,162 @@
+package sim
+
+import (
+	"testing"
+	"time"
+)
+
+// #250: the pre-couple window. Between one player Engaging a Rendezvous
+// Warp and the partner Engaging back, warping can move the pair out of
+// the same-subspace window — the coast then cannot start no matter what
+// the partner does. The world classifies WHY the coast has not started
+// (RendezvousWait) so the HUD can say so instead of blaming the partner,
+// and the responder's invite survives the gap as a Blocked prompt
+// instead of silently vanishing.
+
+func gapDuration() time.Duration {
+	return time.Duration(coWarpSubspaceToleranceSec+1) * time.Second
+}
+
+// An armed viewer whose partner has not Engaged back is genuinely
+// waiting; the same arm across a subspace divergence is not — the
+// classification must distinguish them, with the signed Δt saying who
+// is ahead, and revert to waiting once the pair converges again.
+func TestRendezvousWaitClassifiesPartnerVsGap(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	peer := armPeer(w, primary, st, 50, "gern")
+	peer.ArmedTowardViewer = false // partner hasn't Engaged back
+	w.RendezvousArm = &RendezvousArm{TargetOwner: peer.Owner, Handle: "gern", Tau: tau}
+
+	// Same subspace, partner not armed → genuinely waiting on them.
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitPartner {
+		t.Fatalf("Wait = %+v, want Reason=RendezvousWaitPartner while in-window", got)
+	}
+
+	// Viewer warped past the window → subspace gap, viewer ahead (+Δt).
+	gap := gapDuration()
+	peer.SubspaceTime = st.Add(-gap)
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	got := w.RendezvousWait
+	if got.Reason != RendezvousWaitSubspaceGap {
+		t.Fatalf("Wait = %+v, want Reason=RendezvousWaitSubspaceGap past the window", got)
+	}
+	if got.AheadBy != gap {
+		t.Errorf("AheadBy = %v, want +%v (viewer ahead)", got.AheadBy, gap)
+	}
+
+	// Partner ahead instead → the sign flips.
+	peer.SubspaceTime = st.Add(gap)
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitSubspaceGap || got.AheadBy != -gap {
+		t.Errorf("Wait = %+v, want gap with AheadBy=-%v (partner ahead)", got, gap)
+	}
+
+	// Back inside the window → plain waiting again.
+	peer.SubspaceTime = st.Add(30 * time.Second)
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitPartner || got.AheadBy != 0 {
+		t.Errorf("Wait = %+v, want bare waiting after converging", got)
+	}
+}
+
+// Even a partner who HAS Engaged back cannot couple across the gap: the
+// coast must not start, and the reason is the gap — not waiting.
+func TestRendezvousWaitGapWithMutualArm(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	gap := gapDuration()
+	peer := armPeer(w, primary, st.Add(-gap), 50, "gern")
+	peer.RendezvousTau = tau
+	w.RendezvousArm = &RendezvousArm{TargetOwner: peer.Owner, Handle: "gern", Tau: tau}
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousWarpEngaged() {
+		t.Fatal("coast started across a subspace gap")
+	}
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitSubspaceGap || got.AheadBy != gap {
+		t.Fatalf("Wait = %+v, want gap with AheadBy=+%v", got, gap)
+	}
+
+	// Converged → the coast starts and the wait slate clears.
+	peer.SubspaceTime = st
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.RendezvousWarpEngaged() {
+		t.Fatal("coast did not start after converging")
+	}
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitNone {
+		t.Errorf("Wait = %+v while coasting, want RendezvousWaitNone", got)
+	}
+}
+
+// A partner absent from the peer set entirely (no report) is the bare
+// waiting state — there is no Δt to attribute.
+func TestRendezvousWaitPartnerAbsent(t *testing.T) {
+	w, _, st := anchorWorld(t)
+	w.RendezvousArm = &RendezvousArm{TargetOwner: "SHA256:gern", Handle: "gern", Tau: st.Add(72 * time.Hour)}
+	w.DriveRendezvousWarp(nil)
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitPartner || got.AheadBy != 0 {
+		t.Errorf("Wait = %+v with no partner report, want bare waiting", got)
+	}
+}
+
+// The responder side of #250: an out-of-window invite is kept and
+// exposed as Blocked (with the signed Δt) rather than silently dropped,
+// and becomes joinable again when the pair converges. A past-τ arm is
+// still dropped entirely — Engage would refuse it (forward-only).
+func TestRendezvousInviteBlockedOnSubspaceGap(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	gap := gapDuration()
+	peer := armPeer(w, primary, st.Add(gap), 50, "gern")
+	peer.RendezvousTau = tau
+	peer.RendezvousCA = 1234
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	inv := w.RendezvousInvite
+	if inv == nil {
+		t.Fatal("out-of-window invite vanished — #250 wants it kept, blocked")
+	}
+	if !inv.Blocked {
+		t.Fatal("out-of-window invite not marked Blocked")
+	}
+	if inv.AheadBy != -gap {
+		t.Errorf("AheadBy = %v, want -%v (initiator ahead of the viewer)", inv.AheadBy, gap)
+	}
+	if inv.Owner != peer.Owner || inv.Handle != "gern" || !inv.Tau.Equal(tau) || inv.CA != 1234 {
+		t.Errorf("blocked invite = %+v, want gern's committed τ+CA carried through", inv)
+	}
+
+	// Converged → the same arm surfaces joinable.
+	peer.SubspaceTime = st
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if inv := w.RendezvousInvite; inv == nil || inv.Blocked {
+		t.Errorf("invite = %+v after converging, want joinable (Blocked=false)", inv)
+	}
+
+	// Past τ + gap → dropped entirely, as before (nothing to join, ever).
+	peer.SubspaceTime = st.Add(gap)
+	peer.RendezvousTau = st.Add(-time.Minute)
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousInvite != nil {
+		t.Errorf("invite = %+v for a past τ, want dropped", w.RendezvousInvite)
+	}
+}
+
+// A joinable invite always wins over a blocked one when two peers are
+// armed toward the viewer (pairwise MVP surfaces one prompt).
+func TestRendezvousInviteJoinableWinsOverBlocked(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	blocked := armPeer(w, primary, st.Add(gapDuration()), 50, "far")
+	blocked.RendezvousTau = tau
+	joinable := armPeer(w, primary, st, 50, "gern")
+	joinable.RendezvousTau = tau
+
+	w.DriveRendezvousWarp([]CoWarpPeer{blocked, joinable})
+	inv := w.RendezvousInvite
+	if inv == nil || inv.Blocked || inv.Handle != "gern" {
+		t.Errorf("invite = %+v, want the joinable peer gern over the blocked one", inv)
+	}
+}

--- a/internal/sim/rendezvous_review_test.go
+++ b/internal/sim/rendezvous_review_test.go
@@ -255,8 +255,10 @@ func TestRendezvousCAUsesNearestCraft(t *testing.T) {
 	}
 }
 
-// An invite from a peer in a diverged subspace is not surfaced — the
-// [y] prompt must never offer a join that could not couple.
+// An invite from a peer in a diverged subspace is never JOINABLE — the
+// [y] prompt must not offer a join that could not couple. Since #250 it
+// still surfaces, as a Blocked attribution (the silent drop blamed
+// nobody); the join affordance stays suppressed.
 func TestRendezvousInviteRequiresSameSubspace(t *testing.T) {
 	w, primary, st := anchorWorld(t)
 	peer := armPeer(w, primary, st, 50, "gern")
@@ -264,7 +266,7 @@ func TestRendezvousInviteRequiresSameSubspace(t *testing.T) {
 	peer.SubspaceTime = st.Add(-time.Hour) // a real subspace divergence
 
 	w.DriveRendezvousWarp([]CoWarpPeer{peer})
-	if w.RendezvousInvite != nil {
-		t.Errorf("invite surfaced across a subspace divergence: %+v", w.RendezvousInvite)
+	if inv := w.RendezvousInvite; inv == nil || !inv.Blocked {
+		t.Errorf("invite = %+v across a subspace divergence, want surfaced-but-Blocked (#250)", inv)
 	}
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -223,8 +223,9 @@ type World struct {
 	// Refreshed each tick by DriveRendezvousWarp from the co-warp peer
 	// set; the orbit HUD renders the persistent join prompt from it. Nil
 	// while the viewer holds an outgoing arm (pairwise MVP — respond or
-	// cancel first) and once the committed τ has passed. Transient,
-	// serve-written like CoWarp.
+	// cancel first) and once the committed τ has passed. An invite across
+	// a subspace gap survives with Blocked set (#250) — attributable but
+	// not joinable. Transient, serve-written like CoWarp.
 	RendezvousInvite *RendezvousInvite
 
 	// RendezvousHold freezes the viewer's effective warp while the shared
@@ -234,6 +235,14 @@ type World struct {
 	// DriveRendezvousWarp, read by clampedWarp — a member of the
 	// Effective-≤-Selected clamp family. Transient, serve-written.
 	RendezvousHold bool
+
+	// RendezvousWait classifies why an armed Rendezvous Warp has not
+	// started coasting (#250): genuinely waiting on the partner vs a
+	// subspace gap someone warped open (with the signed Δt saying who is
+	// ahead). Set each tick by DriveRendezvousWarp, read by the armed
+	// RENDEZVOUS chip so it stops blaming the partner for a self-made
+	// gap. Transient, serve-written like RendezvousHold.
+	RendezvousWait RendezvousWait
 
 	// RendezvousDegraded / RendezvousApproachM are the hold-τ degrade slate
 	// (v0.29 S1): while the shared coast runs, DriveRendezvousWarp

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -839,6 +839,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// free key. Forward-only refusal covers a τ that passed
 			// between frames (the invite slate drops it next tick anyway).
 			inv := a.world.RendezvousInvite
+			if inv.Blocked {
+				// #250: a subspace-gapped invite renders join-suppressed;
+				// the key must refuse too — Engage would succeed (τ is
+				// still future) but the coast could never start.
+				a.toast(fmt.Sprintf("can't join %s — subspace gap, Sync to their time first", inv.Handle))
+				return a, nil
+			}
 			if a.world.EngageRendezvousWarp(inv.Owner, inv.Handle, inv.Tau, inv.CA) {
 				a.toast(fmt.Sprintf("rendezvous with %s — coasting to the encounter together", inv.Handle))
 			} else {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -842,8 +842,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if inv.Blocked {
 				// #250: a subspace-gapped invite renders join-suppressed;
 				// the key must refuse too — Engage would succeed (τ is
-				// still future) but the coast could never start.
-				a.toast(fmt.Sprintf("can't join %s — subspace gap, Sync to their time first", inv.Handle))
+				// still future) but the coast could never start. Sync is
+				// forward-only, so a viewer who is ahead can't come back:
+				// the advice flips to the initiator Syncing forward.
+				advice := "Sync to their time first"
+				if inv.AheadBy > 0 {
+					advice = "they must Sync to your time"
+				}
+				a.toast(fmt.Sprintf("can't join %s — subspace gap, %s", inv.Handle, advice))
 				return a, nil
 			}
 			if a.world.EngageRendezvousWarp(inv.Owner, inv.Handle, inv.Tau, inv.CA) {

--- a/internal/tui/app_rendezvous_test.go
+++ b/internal/tui/app_rendezvous_test.go
@@ -86,6 +86,30 @@ func TestRendezvousRespondKey(t *testing.T) {
 	}
 }
 
+// #250: [y] on a blocked (subspace-gapped) invite must refuse — Engage
+// would succeed (τ is still future) but the coast could never start, so
+// the key has to no-op with an attribution instead of arming a dead
+// rendezvous.
+func TestRendezvousRespondKeyRefusesBlockedInvite(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:guest", Handle: "gern",
+		Tau: w.Clock.SimTime.Add(3 * time.Hour), CA: 900,
+		Blocked: true, AheadBy: -3 * time.Minute,
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if w.RendezvousArm != nil {
+		t.Fatal("y armed a rendezvous across a subspace gap (coast can never start)")
+	}
+	if !strings.Contains(a.statusMsg, "Sync") {
+		t.Errorf("refusal %q does not point at Sync as the way in", a.statusMsg)
+	}
+}
+
 // CancelWarp `/` extends to Rendezvous Warp (v0.29 S2): it releases the
 // arm and the shared coast, not just the Auto-Warp driver — otherwise
 // DriveRendezvousWarp would restart the coast next tick.

--- a/internal/tui/app_rendezvous_test.go
+++ b/internal/tui/app_rendezvous_test.go
@@ -89,7 +89,9 @@ func TestRendezvousRespondKey(t *testing.T) {
 // #250: [y] on a blocked (subspace-gapped) invite must refuse — Engage
 // would succeed (τ is still future) but the coast could never start, so
 // the key has to no-op with an attribution instead of arming a dead
-// rendezvous.
+// rendezvous. The refusal's Sync advice is direction-aware (forward-
+// only): a viewer behind can Sync to their time; a viewer ahead cannot,
+// so the initiator must Sync forward instead.
 func TestRendezvousRespondKeyRefusesBlockedInvite(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
@@ -101,12 +103,28 @@ func TestRendezvousRespondKeyRefusesBlockedInvite(t *testing.T) {
 		Tau: w.Clock.SimTime.Add(3 * time.Hour), CA: 900,
 		Blocked: true, AheadBy: -3 * time.Minute,
 	}
+
+	// Viewer behind the initiator: Sync forward is the way in.
 	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if w.RendezvousArm != nil {
 		t.Fatal("y armed a rendezvous across a subspace gap (coast can never start)")
 	}
-	if !strings.Contains(a.statusMsg, "Sync") {
+	if !strings.Contains(a.statusMsg, "Sync to their time first") {
 		t.Errorf("refusal %q does not point at Sync as the way in", a.statusMsg)
+	}
+
+	// Viewer ahead of the initiator: Sync into the past is impossible —
+	// the refusal must not instruct it.
+	w.RendezvousInvite.AheadBy = 3 * time.Minute
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if w.RendezvousArm != nil {
+		t.Fatal("y armed a rendezvous across a viewer-ahead subspace gap")
+	}
+	if !strings.Contains(a.statusMsg, "they must Sync to your time") {
+		t.Errorf("viewer-ahead refusal %q does not flip the advice to the initiator", a.statusMsg)
+	}
+	if strings.Contains(a.statusMsg, "Sync to their time") {
+		t.Errorf("viewer-ahead refusal %q instructs Syncing into the past", a.statusMsg)
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -215,6 +215,11 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 //     join prompt ([y] responds from here, no trip to the Session
 //     screen).
 //
+// Across a subspace gap (#250) the armed and invited states swap their
+// call to action for an attribution: the armed line names who is ahead
+// and points at Sync instead of blaming the partner, and a Blocked
+// invite renders dimmed with [y] suppressed instead of vanishing.
+//
 // Nil when the state machine is idle, which is almost always.
 func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 	now := w.Clock.SimTime
@@ -241,15 +246,37 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		return append(lines, v.theme.Dim.Render("  [/] cancel"))
 	case w.RendezvousArm != nil:
 		arm := w.RendezvousArm
+		status := v.theme.Warning.Render("  armed → " + arm.Handle + " — waiting for them to join")
+		if wt := w.RendezvousWait; wt.Reason == sim.RendezvousWaitSubspaceGap {
+			// #250: "waiting for them to join" would blame the partner for
+			// a gap the viewer (or the partner) warped open — name who is
+			// ahead and the actual fix instead.
+			who := "you are " + compactDuration(wt.AheadBy) + " ahead of " + arm.Handle
+			if wt.AheadBy < 0 {
+				who = arm.Handle + " is " + compactDuration(-wt.AheadBy) + " ahead of you"
+			}
+			status = v.theme.Alert.Render("  cannot couple — " + who + " — Sync to rejoin")
+		}
 		return []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
-			v.theme.Warning.Render("  armed → " + arm.Handle + " — waiting for them to join"),
+			status,
 			chipRow("τ in:", compactDuration(arm.Tau.Sub(now))),
 			chipRow("CA:", formatRangeM(arm.CommittedCA)),
 			v.theme.Dim.Render("  [/] cancel"),
 		}
 	case w.RendezvousInvite != nil:
 		inv := w.RendezvousInvite
+		if inv.Blocked {
+			// #250: the invite is real but unjoinable across the subspace
+			// gap — a dimmed attribution with the join key suppressed, so
+			// the prompt explains itself instead of vanishing.
+			return []string{
+				v.theme.Primary.Render("RENDEZVOUS"),
+				v.theme.Dim.Render("  ◇ " + inv.Handle + " wants to rendezvous — subspace gap, Sync to join"),
+				chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
+				chipRow("CA:", formatRangeM(inv.CA)),
+			}
+		}
 		return []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			v.theme.Warning.Render("  ◇ " + inv.Handle + " wants to rendezvous"),

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -250,12 +250,15 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		if wt := w.RendezvousWait; wt.Reason == sim.RendezvousWaitSubspaceGap {
 			// #250: "waiting for them to join" would blame the partner for
 			// a gap the viewer (or the partner) warped open — name who is
-			// ahead and the actual fix instead.
+			// ahead and the actual fix instead. Sync is forward-only, so
+			// the fix depends on direction: the laggard comes forward.
 			who := "you are " + compactDuration(wt.AheadBy) + " ahead of " + arm.Handle
+			fix := "they must Sync to you"
 			if wt.AheadBy < 0 {
 				who = arm.Handle + " is " + compactDuration(-wt.AheadBy) + " ahead of you"
+				fix = "Sync to rejoin"
 			}
-			status = v.theme.Alert.Render("  cannot couple — " + who + " — Sync to rejoin")
+			status = v.theme.Alert.Render("  cannot couple — " + who + " — " + fix)
 		}
 		return []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
@@ -269,10 +272,16 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		if inv.Blocked {
 			// #250: the invite is real but unjoinable across the subspace
 			// gap — a dimmed attribution with the join key suppressed, so
-			// the prompt explains itself instead of vanishing.
+			// the prompt explains itself instead of vanishing. Sync is
+			// forward-only: a viewer who is ahead cannot Sync back, the
+			// initiator has to come forward.
+			gap := "subspace gap, Sync to join"
+			if inv.AheadBy > 0 {
+				gap = "subspace gap, they must Sync to you"
+			}
 			return []string{
 				v.theme.Primary.Render("RENDEZVOUS"),
-				v.theme.Dim.Render("  ◇ " + inv.Handle + " wants to rendezvous — subspace gap, Sync to join"),
+				v.theme.Dim.Render("  ◇ " + inv.Handle + " wants to rendezvous — " + gap),
 				chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 				chipRow("CA:", formatRangeM(inv.CA)),
 			}

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -62,6 +62,58 @@ func TestRendezvousChipArmedWaiting(t *testing.T) {
 	}
 }
 
+// #250: when the armed pair has diverged past the subspace window, the
+// chip must stop blaming the partner ("waiting for them to join") and
+// name the actual condition — who is ahead, and that Sync is the way
+// back.
+func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", w.Clock.SimTime.Add(2*time.Hour), 900)
+	w.RendezvousWait = sim.RendezvousWait{
+		Reason: sim.RendezvousWaitSubspaceGap, AheadBy: 2 * time.Minute,
+	}
+
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, want := range []string{"cannot couple", "you are 2m0s ahead of gern", "Sync to rejoin"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("gap chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "waiting for them to join") {
+		t.Errorf("gap chip still blames the partner:\n%s", joined)
+	}
+
+	// The partner ahead instead — the wording flips direction.
+	w.RendezvousWait.AheadBy = -2 * time.Minute
+	joined = strings.Join(v.buildRendezvousChip(w), "\n")
+	if !strings.Contains(joined, "gern is 2m0s ahead of you") {
+		t.Errorf("partner-ahead gap not worded from their side:\n%s", joined)
+	}
+}
+
+// #250 responder side: a blocked (subspace-gapped) invite renders as a
+// dimmed attribution with the [y] join affordance suppressed, instead
+// of vanishing.
+func TestRendezvousChipInviteBlocked(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:guest", Handle: "gern",
+		Tau: w.Clock.SimTime.Add(2 * time.Hour), CA: 900,
+		Blocked: true, AheadBy: -3 * time.Minute,
+	}
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, want := range []string{"gern wants to rendezvous", "subspace gap", "Sync to join"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("blocked invite chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "[y]") {
+		t.Errorf("blocked invite still offers [y] join:\n%s", joined)
+	}
+}
+
 func TestRendezvousChipCoastingAndDegraded(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	w := rendezvousChipWorld(t)

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -64,8 +64,9 @@ func TestRendezvousChipArmedWaiting(t *testing.T) {
 
 // #250: when the armed pair has diverged past the subspace window, the
 // chip must stop blaming the partner ("waiting for them to join") and
-// name the actual condition — who is ahead, and that Sync is the way
-// back.
+// name the actual condition — who is ahead, and the direction-correct
+// fix. Sync is forward-only, so a viewer who is ahead cannot Sync back:
+// only the laggard's side may say "Sync to rejoin".
 func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	w := rendezvousChipWorld(t)
@@ -74,27 +75,40 @@ func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
 		Reason: sim.RendezvousWaitSubspaceGap, AheadBy: 2 * time.Minute,
 	}
 
+	// Viewer ahead: Sync (forward-only) can't reach the partner behind —
+	// the partner must come forward.
 	joined := strings.Join(v.buildRendezvousChip(w), "\n")
-	for _, want := range []string{"cannot couple", "you are 2m0s ahead of gern", "Sync to rejoin"} {
+	for _, want := range []string{"cannot couple", "you are 2m0s ahead of gern", "they must Sync to you"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("gap chip missing %q:\n%s", want, joined)
 		}
+	}
+	if strings.Contains(joined, "Sync to rejoin") {
+		t.Errorf("viewer-ahead gap tells the viewer to Sync into the past:\n%s", joined)
 	}
 	if strings.Contains(joined, "waiting for them to join") {
 		t.Errorf("gap chip still blames the partner:\n%s", joined)
 	}
 
-	// The partner ahead instead — the wording flips direction.
+	// The partner ahead instead — the wording flips direction and the
+	// viewer is the one who can Sync forward.
 	w.RendezvousWait.AheadBy = -2 * time.Minute
 	joined = strings.Join(v.buildRendezvousChip(w), "\n")
-	if !strings.Contains(joined, "gern is 2m0s ahead of you") {
-		t.Errorf("partner-ahead gap not worded from their side:\n%s", joined)
+	for _, want := range []string{"gern is 2m0s ahead of you", "Sync to rejoin"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("partner-ahead gap chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "they must Sync to you") {
+		t.Errorf("partner-ahead gap points the fix at the wrong side:\n%s", joined)
 	}
 }
 
 // #250 responder side: a blocked (subspace-gapped) invite renders as a
 // dimmed attribution with the [y] join affordance suppressed, instead
-// of vanishing.
+// of vanishing. The Sync advice is direction-aware (forward-only): a
+// viewer behind the initiator can Sync to join; a viewer ahead cannot,
+// so the initiator must Sync forward instead.
 func TestRendezvousChipInviteBlocked(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	w := rendezvousChipWorld(t)
@@ -103,6 +117,8 @@ func TestRendezvousChipInviteBlocked(t *testing.T) {
 		Tau: w.Clock.SimTime.Add(2 * time.Hour), CA: 900,
 		Blocked: true, AheadBy: -3 * time.Minute,
 	}
+
+	// Viewer behind the initiator: Sync forward is the way in.
 	joined := strings.Join(v.buildRendezvousChip(w), "\n")
 	for _, want := range []string{"gern wants to rendezvous", "subspace gap", "Sync to join"} {
 		if !strings.Contains(joined, want) {
@@ -111,6 +127,22 @@ func TestRendezvousChipInviteBlocked(t *testing.T) {
 	}
 	if strings.Contains(joined, "[y]") {
 		t.Errorf("blocked invite still offers [y] join:\n%s", joined)
+	}
+
+	// Viewer ahead of the initiator: Sync into the past is impossible —
+	// the advice flips to the initiator, [y] stays suppressed.
+	w.RendezvousInvite.AheadBy = 3 * time.Minute
+	joined = strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, want := range []string{"gern wants to rendezvous", "subspace gap", "they must Sync to you"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("viewer-ahead blocked invite chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "Sync to join") {
+		t.Errorf("viewer-ahead blocked invite tells the viewer to Sync into the past:\n%s", joined)
+	}
+	if strings.Contains(joined, "[y]") {
+		t.Errorf("viewer-ahead blocked invite still offers [y] join:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## What

PR E of the Rendezvous Warp fix cluster (#248–#253). Closes #250.

Between one player Engaging a Rendezvous Warp and the partner Engaging back, warping moves the sim clock out of the 120 s same-subspace window. Before this PR that condition was silent and misattributed:

- **Initiator:** the armed chip kept saying `armed → gern — waiting for them to join` — blaming the partner for a gap the viewer warped open.
- **Responder:** the `[y]` invite prompt silently vanished (`refreshRendezvousInvite` gated on `sameSubspace`), with no attribution — and its disappearance chipped as a bogus `cancelled`.

**Feedback only, by decision:** no rate brake / pinning of an armed-but-uncoupled player (pinning to a stale reported rate is the negotiation pattern #248's fix outlaws), no tolerance or warp-ladder constant changes. The brake stays an explicit open question on #250.

## How

- **World-level reason state** (`internal/sim/auto_warp.go`): `RendezvousWait{Reason, AheadBy}` refreshed each tick in the `DriveRendezvousWarp` flow, single-writer like `RendezvousHold`. `Reason` is enum-ish (`None` / `Partner` / `SubspaceGap`) plus the signed viewer−partner Δt — shaped so #221's CommGraph "classify the reason and say it" work can converge on the same pattern. The gap check reads the partner's report regardless of `ArmedTowardViewer`, because the initiator case (partner not yet armed back) is exactly where the divergence was invisible.
- **Armed chip** (`buildRendezvousChip`): in-window keeps `waiting for them to join`; out of window renders `cannot couple — you are 2m0s ahead of gern — Sync to rejoin` (direction-aware wording when the partner is ahead), themed Alert.
- **Responder attribution:** `refreshRendezvousInvite` now keeps an out-of-window invite with `Blocked` + `AheadBy` instead of dropping it; the chip renders it dimmed — `◇ gern wants to rendezvous — subspace gap, Sync to join` — with the `[y]` affordance suppressed. A joinable invite always wins over a blocked one. The `[y]` key path refuses a Blocked invite with a toast (Engage would succeed — τ is still future — but the coast could never start). Past-τ arms are still dropped entirely, unchanged.
- **Serve moments** (`emitRendezvousEvents`): no `[y] join` session moment while an invite is Blocked (the persistent chip carries the attribution); a joinable→blocked transition no longer emits a false `rendezvous cancelled`; blocked→joinable chips the arm moment fresh. Session teardown clears the new slate.

Zombie-arm expiry at τ, coast start/hold/cancel logic, `ComputeCoWarp`/`clampedWarp`, and all constants untouched (kept clear of PR A's clamp surface).

One pre-existing test updated rather than extended: `TestRendezvousInviteRequiresSameSubspace` (rendezvous_review_test.go) asserted the silent drop this PR supersedes — its intent ("never OFFER a join that could not couple") now asserts surfaced-but-Blocked.

## Tests

Red-first; chip-level assertions included (the repo covers chip builders in `orbit_rendezvous_chip_test.go`), plus sim- and app-level:

- `TestRendezvousWaitClassifiesPartnerVsGap` — waiting vs gap, signed Δt both directions, reverts to waiting back inside the window
- `TestRendezvousWaitGapWithMutualArm` — mutual arm across the gap: coast must not start, reason is the gap; converging starts the coast and clears the slate
- `TestRendezvousWaitPartnerAbsent` — no report ⇒ bare waiting
- `TestRendezvousInviteBlockedOnSubspaceGap` — kept-but-blocked, τ+CA carried, joinable again on convergence, past-τ still dropped
- `TestRendezvousInviteJoinableWinsOverBlocked`
- `TestRendezvousChipArmedSubspaceGap` / `TestRendezvousChipInviteBlocked` — wording, direction flip, `[y]` suppression
- `TestRendezvousRespondKeyRefusesBlockedInvite` — `[y]` no-ops with a Sync-pointing toast, no arm set

```
go vet ./...                          clean
go test ./... -race -count=1          1770 passed / 19 packages
go test ./internal/serve -race -count=3   357 passed
```