### PR TITLE
feat(mp): #252 — the rendezvous arm becomes a standing mutual intent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1659,19 +1659,27 @@ _Avoid_: Warp lock (it doesn't pin to 1×), warp vote.
 
 **Rendezvous Warp**:
 The **mutual-consent** trigger of Co-Warp: it couples two *same-Subspace*
-players *before* the proximity gate so they can fast-forward the coast
-to an encounter together instead of desyncing on independent warp. Each
+players *before* the proximity gate so they can fast-forward a whole
+rendezvous together instead of desyncing on independent warp. Each
 player **Engages** it toward the other — a Session-screen row action to
 initiate, a main-screen key to join a pending one; there is no separate
 accept verb, the responder Engages the same Rendezvous Warp. Once both
-have Engaged, their Subspaces rate-lock (min-wins) and Auto-Warp to the
-committed **Time of Closest Approach**, arriving already Co-Warped with
-Δt≈0 — the coupling then continues seamlessly as **Proximity Co-Warp**
-without a drop-and-recouple. The initiator's TCA is authoritative
-(carried in the request). The committed encounter is *held* through the
-coast: a degrading encounter warns but never re-targets, and either
-player may cancel at any time (both release at the same synced sim-time).
-Prerequisite: same Subspace — a diverged pair **Syncs** first.
+have Engaged, the arm is a **standing mutual intent** — "we are
+rendezvousing", not a commitment to one encounter. The pair's Subspaces
+rate-lock and Auto-Warp coasts to the committed **Time of Closest
+Approach** (the initiator's TCA, carried in the request, is the first
+one), but reaching it is a *waypoint*, not the end: outside proximity
+couple range the next encounter is re-derived — a passive flyby is a
+legitimate waypoint — and the coast continues, the earlier of the two
+sides' re-derived τs winning so both stay aimed at the same waypoint.
+Every maneuver of the approach sequence is thus flown rate-locked, with
+no Sync between maneuvers. Each waypoint is *held* while coasted at: a
+degrading encounter warns but never re-targets mid-coast. The intent
+ends exactly two ways — either player cancels (both release at the same
+synced sim-time), or a waypoint arrives inside the proximity gate, where
+**Proximity Co-Warp** takes over without a drop-and-recouple and the arm
+is released. Prerequisite: same Subspace — a diverged pair **Syncs**
+first.
 _Avoid_: Rendezvous request / handshake (there is no offer/accept step),
 Co-Sync (conflates with **Sync**), Warp lock.
 

--- a/internal/relay/cowarp_peers.go
+++ b/internal/relay/cowarp_peers.go
@@ -20,7 +20,22 @@ import (
 // after the report nor an SOI exit — but a burning peer reports every
 // tick (elements change), so the propagation gap it feeds co-warp with is
 // one tick, not one heartbeat.
-func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]string, viewerFP string) []sim.CoWarpPeer {
+//
+// live is the serve layer's session-liveness input: owner fingerprint →
+// has a live session right now (attended or reprieved-away — an Away
+// session is still simulating and still counts; that is the point of the
+// Reprieve). It gates the RENDEZVOUS ARM fields only, not the peer (#252
+// review, finding 1): the store never scrubs reports, so a partner who
+// disconnects for good leaves a frozen report with RendezvousTarget
+// still set — an immortal arm that would hold the survivor's standing
+// intent (and its 0×-hold / dead-orbit coast) forever. A rendezvous
+// intent requires a live SESSION, not a live report; suppressing the arm
+// here makes the sim's normal retract path fire, with its normal cancel
+// chip. A live session's report gaps are unaffected — the arm rides
+// through however stale the report is, so a silent reprieved partner is
+// held for, never cancelled. A nil map means no owner is live (the safe
+// default for callers with no liveness source).
+func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]string, viewerFP string, live map[string]bool) []sim.CoWarpPeer {
 	sysName := w.System().Name
 	viewerT := w.Clock.SimTime
 	var out []sim.CoWarpPeer
@@ -46,20 +61,26 @@ func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]str
 		if len(crafts) == 0 {
 			continue
 		}
-		out = append(out, sim.CoWarpPeer{
+		p := sim.CoWarpPeer{
 			Owner:        rep.Owner,
 			Handle:       handles[rep.Owner],
 			SubspaceTime: rep.SubspaceTime,
 			EffWarp:      rep.EffWarp,
 			Crafts:       crafts,
-			// Rendezvous Warp (v0.29 S1): this peer is armed toward the
-			// viewer iff its report's intent names us. The committed τ rides
-			// along so the responder can adopt the initiator's value.
-			ArmedTowardViewer: rep.RendezvousTarget != "" && rep.RendezvousTarget == viewerFP,
-			RendezvousTau:     rep.RendezvousTau,
-			RendezvousCA:      rep.RendezvousCA,
-			Paused:            rep.Paused,
-		})
+			Paused:       rep.Paused,
+		}
+		// Rendezvous Warp (v0.29 S1): this peer is armed toward the viewer
+		// iff its report's intent names us AND its session is live (#252
+		// review — see the liveness rationale above). The committed τ rides
+		// along so the responder can adopt the initiator's value; a dead
+		// session's τ/CA are suppressed with the arm so nothing downstream
+		// adopts a dead waypoint.
+		if live[rep.Owner] && rep.RendezvousTarget != "" && rep.RendezvousTarget == viewerFP {
+			p.ArmedTowardViewer = true
+			p.RendezvousTau = rep.RendezvousTau
+			p.RendezvousCA = rep.RendezvousCA
+		}
+		out = append(out, p)
 	}
 	return out
 }

--- a/internal/relay/cowarp_peers_test.go
+++ b/internal/relay/cowarp_peers_test.go
@@ -42,7 +42,7 @@ func TestCoWarpMinWinsThroughSeam(t *testing.T) {
 
 	// A evaluates co-warp against the store and clamps to B's cap.
 	handles := map[string]string{ownerB: "bob"}
-	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA)
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, nil)
 	res := wA.ComputeCoWarp(peers, nil)
 	if !res.State.Coupled || res.State.MinWarp != 10 {
 		t.Fatalf("co-warp state = %+v, want coupled at MinWarp 10", res.State)
@@ -66,7 +66,7 @@ func TestCoWarpCoupleThenDecoupleThroughSeam(t *testing.T) {
 	NewReporter(store, ownerA).Tick(wA, time.Now())
 	repB := NewReporter(store, ownerB)
 	repB.Tick(wB, time.Now())
-	res := wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA), nil)
+	res := wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, nil), nil)
 	if !res.State.Coupled || len(res.NewlyCoupled) != 1 {
 		t.Fatalf("first eval = %+v, want a fresh couple", res)
 	}
@@ -76,7 +76,7 @@ func TestCoWarpCoupleThenDecoupleThroughSeam(t *testing.T) {
 	wB.ActiveCraft().State.R.X += 50_000
 	wB.ActiveCraft().State.V.X += 50 // move the elements so the report fires
 	repB.Tick(wB, time.Now().Add(time.Second))
-	res = wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA), res.CoupledOwners)
+	res = wA.ComputeCoWarp(CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, nil), res.CoupledOwners)
 	if res.State.Coupled {
 		t.Error("still coupled after B drifted 50 km")
 	}

--- a/internal/relay/rendezvous_seam_test.go
+++ b/internal/relay/rendezvous_seam_test.go
@@ -28,7 +28,7 @@ func TestRendezvousArmThroughSeam(t *testing.T) {
 	NewReporter(store, ownerB).Tick(wB, time.Now())
 
 	// A adapts B's report — arm-toward-viewer + τ + committed CA survive.
-	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA)
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live(ownerB))
 	if len(peers) != 1 {
 		t.Fatalf("got %d peers, want 1", len(peers))
 	}
@@ -91,8 +91,60 @@ func TestRendezvousArmNotForViewer(t *testing.T) {
 	wB.EngageRendezvousWarp("SHA256:carol", "carol", wA.Clock.SimTime.Add(time.Hour), 0) // toward someone else
 	NewReporter(store, ownerB).Tick(wB, time.Now())
 
-	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA)
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live(ownerB))
 	if len(peers) == 1 && peers[0].ArmedTowardViewer {
 		t.Error("ArmedTowardViewer set for an arm aimed at a third player")
+	}
+}
+
+// live builds the adapter's liveness input marking the given owners as
+// holding live sessions.
+func live(owners ...string) map[string]bool {
+	m := map[string]bool{}
+	for _, o := range owners {
+		m[o] = true
+	}
+	return m
+}
+
+// The rendezvous intent requires a LIVE session, not a live report (#252
+// review, finding 1). The store never scrubs reports, so a partner who
+// disconnects mid-intent and never returns leaves a frozen report with
+// RendezvousTarget still set — without the liveness gate the survivor's
+// ArmedTowardViewer stays true forever, retract is never detected, and
+// the survivor holds/coasts against a dead craft indefinitely. The
+// adapter must suppress the arm fields for an owner with no live
+// session, while a live-but-silent (reprieved-away) owner's arm rides
+// through untouched.
+func TestRendezvousArmRequiresLiveSession(t *testing.T) {
+	store := NewStore()
+	wA, wB := newWorld(t), newWorld(t)
+	wB.Clock.SimTime = wA.Clock.SimTime
+
+	const ownerA, ownerB = "SHA256:alice", "SHA256:bob"
+	handles := map[string]string{ownerB: "bob"}
+	tau := wA.Clock.SimTime.Add(72 * time.Hour)
+	if !wB.EngageRendezvousWarp(ownerA, "alice", tau, 8000) {
+		t.Fatal("B failed to engage")
+	}
+	NewReporter(store, ownerB).Tick(wB, time.Now())
+
+	// B live but silent (reprieved-away): the frozen report's arm holds.
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live(ownerB))
+	if len(peers) != 1 || !peers[0].ArmedTowardViewer {
+		t.Fatal("a live-but-silent session's arm was suppressed — a report gap must not read as retract")
+	}
+
+	// B's session ends (reaped / disconnected for good); the report stays.
+	peers = CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live())
+	if len(peers) != 1 {
+		t.Fatalf("got %d peers, want 1 — liveness suppresses the arm, not the peer", len(peers))
+	}
+	if peers[0].ArmedTowardViewer {
+		t.Error("ArmedTowardViewer true for an owner with no live session — a dead partner's frozen arm is immortal")
+	}
+	if !peers[0].RendezvousTau.IsZero() || peers[0].RendezvousCA != 0 {
+		t.Errorf("RendezvousTau/CA not suppressed with the arm: τ=%v ca=%v",
+			peers[0].RendezvousTau, peers[0].RendezvousCA)
 	}
 }

--- a/internal/serve/rendezvous_chip_test.go
+++ b/internal/serve/rendezvous_chip_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/relay"
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -122,6 +123,81 @@ func TestRendezvousCancelChipOnRetract(t *testing.T) {
 	}
 	if !cancelled {
 		t.Errorf("no cancelled chip after the retract: %+v", w.SessionEvents)
+	}
+}
+
+// Reaching a waypoint outside couple range through the reporting model
+// (#252): the arm survives, the waypoint advances, and the wrapper
+// consumes the advance slate into the waypoint chip — never a silent
+// advance, never an arrival/cancel chip.
+func TestRendezvousWaypointChip(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = srv.HostModel(hostApp)
+	m = tick(m)
+
+	w := hostApp.World()
+	tau := w.Clock.SimTime.Add(2 * time.Minute)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 5.4e6)
+	// gern sits ~5,400 km ahead along-track on a slightly longer period —
+	// far outside the couple gate at τ, but with a FUTURE closest approach
+	// inside the commit horizon so the next waypoint can be derived (a
+	// plain radial offset has its closest approach at t=0).
+	hc := w.ActiveCraft()
+	ahead, ok := physics.KeplerStep(
+		physics.StateVector{R: hc.State.R, V: hc.State.V, M: 1},
+		hc.Primary.GravitationalParameter(), 735)
+	if !ok {
+		t.Fatal("kepler step failed placing gern's craft")
+	}
+	far := gernArmedReport(w, sessiondir.HostFingerprint, tau)
+	far.Crafts[0].R, far.Crafts[0].V = ahead.R, ahead.V.Scale(1.002)
+	srv.relay.Report(far)
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	if !w.RendezvousWarpEngaged() {
+		t.Fatal("mutual arm did not start the coast")
+	}
+
+	// Cross τ far apart; keep the partner's report in the same subspace.
+	w.Clock.SimTime = tau
+	far2 := gernArmedReport(w, sessiondir.HostFingerprint, tau)
+	far2.Crafts[0].R, far2.Crafts[0].V = ahead.R, ahead.V.Scale(1.002)
+	far2.SubspaceTime = tau
+	srv.relay.Report(far2)
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	_ = m
+
+	if w.RendezvousArm == nil || !w.RendezvousWarpEngaged() {
+		t.Fatalf("standing intent did not survive τ outside couple range: arm=%+v autowarp=%+v",
+			w.RendezvousArm, w.AutoWarp)
+	}
+	if !w.RendezvousArm.Tau.After(tau) {
+		t.Errorf("waypoint did not advance: τ=%v (committed %v)", w.RendezvousArm.Tau, tau)
+	}
+	if w.LastRendezvousWaypoint != nil {
+		t.Error("waypoint slate not consumed by the wrapper")
+	}
+	var waypoint, arrivedOrCancelled bool
+	for _, e := range w.SessionEvents {
+		switch e.Kind {
+		case sim.SessionEventRendezvousWaypoint:
+			if e.Handle == "gern" {
+				waypoint = true
+			}
+		case sim.SessionEventRendezvousArrived, sim.SessionEventRendezvousCancelled:
+			arrivedOrCancelled = true
+		}
+	}
+	if !waypoint {
+		t.Errorf("no waypoint chip after the advance: %+v", w.SessionEvents)
+	}
+	if arrivedOrCancelled {
+		t.Errorf("waypoint advance mis-chipped as arrival/cancel: %+v", w.SessionEvents)
 	}
 }
 

--- a/internal/serve/rendezvous_chip_test.go
+++ b/internal/serve/rendezvous_chip_test.go
@@ -36,6 +36,7 @@ func gernArmedReport(w *sim.World, target string, tau time.Time) relay.CraftRepo
 func TestRendezvousArmChipAndRosterMarker(t *testing.T) {
 	srv := newOfflineServer(t)
 	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern") // the partner has a live session (#252 review: a dead session's arm is suppressed)
 
 	hostApp, err := tui.New(nil)
 	if err != nil {
@@ -81,6 +82,7 @@ func TestRendezvousArmChipAndRosterMarker(t *testing.T) {
 func TestRendezvousCancelChipOnRetract(t *testing.T) {
 	srv := newOfflineServer(t)
 	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern") // the partner has a live session (#252 review: a dead session's arm is suppressed)
 
 	hostApp, err := tui.New(nil)
 	if err != nil {
@@ -133,6 +135,7 @@ func TestRendezvousCancelChipOnRetract(t *testing.T) {
 func TestRendezvousWaypointChip(t *testing.T) {
 	srv := newOfflineServer(t)
 	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern") // the partner has a live session (#252 review: a dead session's arm is suppressed)
 
 	hostApp, err := tui.New(nil)
 	if err != nil {
@@ -206,6 +209,7 @@ func TestRendezvousWaypointChip(t *testing.T) {
 func TestRendezvousArrivalChip(t *testing.T) {
 	srv := newOfflineServer(t)
 	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern") // the partner has a live session (#252 review: a dead session's arm is suppressed)
 
 	hostApp, err := tui.New(nil)
 	if err != nil {
@@ -247,5 +251,62 @@ func TestRendezvousArrivalChip(t *testing.T) {
 	}
 	if w.LastRendezvousArrival != nil {
 		t.Error("arrival slate not consumed by the wrapper")
+	}
+}
+
+// A dead partner's frozen report must not keep the standing intent alive
+// (#252 review, finding 1). The relay store never scrubs a report, so a
+// partner who disconnects mid-intent and never returns (e.g. reprieve
+// reaped at the ceiling) leaves RendezvousTarget set forever; under the
+// standing intent nothing else bounds the arm's lifetime. The liveness
+// gate at the peer seam must release the survivor through the normal
+// retract path — cancel chip, no eternal hold — while a live-but-silent
+// (reprieved-away) partner's intent is held.
+func TestRendezvousArmReleasesWhenPartnerSessionEnds(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = srv.HostModel(hostApp)
+	m = tick(m)
+
+	w := hostApp.World()
+	tau := w.Clock.SimTime.Add(3 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 500)
+	srv.relay.Report(gernArmedReport(w, sessiondir.HostFingerprint, tau))
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	if !w.RendezvousWarpEngaged() {
+		t.Fatal("mutual arm did not start the coast")
+	}
+
+	// Reprieved-away shape: the session is live but silent — the report
+	// stays frozen. The intent must be HELD, not read as a retract.
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	if !w.RendezvousWarpEngaged() || w.RendezvousArm == nil {
+		t.Fatal("a live partner's report gap read as retract — silence must be held for")
+	}
+
+	// The session ends for good; the frozen report (arm still set) stays
+	// in the store because nothing scrubs it.
+	srv.presence.markOffline("SHA256:gern")
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	_ = m
+
+	if w.RendezvousArm != nil || w.RendezvousWarpEngaged() {
+		t.Errorf("standing intent survived the partner's session ending: arm=%+v autowarp=%+v",
+			w.RendezvousArm, w.AutoWarp)
+	}
+	var cancelled bool
+	for _, e := range w.SessionEvents {
+		if e.Kind == sim.SessionEventRendezvousCancelled && e.Handle == "gern" {
+			cancelled = true
+		}
+	}
+	if !cancelled {
+		t.Errorf("no cancelled chip after the partner's session died: %+v", w.SessionEvents)
 	}
 }

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -211,10 +211,12 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // emitRendezvousEvents derives the Rendezvous Warp session moments from
 // the World slate's tick-over-tick transitions (v0.29 S2): a partner's
-// new arm toward the viewer, arrival at τ (consuming the sim's
-// LastRendezvousArrival, mirroring the Sync arrival), a cancel/retract
-// releasing an arm before τ, and the hold-τ degrade flag going up. All
-// local-only chips — each side derives its own from its own World.
+// new arm toward the viewer, the proximity handoff (consuming the sim's
+// LastRendezvousArrival, mirroring the Sync arrival), a waypoint advance
+// on the standing intent (#252, consuming LastRendezvousWaypoint), a
+// cancel/retract releasing the arm, and the hold-τ degrade flag going
+// up. All local-only chips — each side derives its own from its own
+// World.
 func (m *reportingModel) emitRendezvousEvents(w *sim.World, now time.Time) {
 	chip := func(kind sim.SessionEventKind, handle string) {
 		m.localEvents = append(m.localEvents, sim.SessionEvent{Kind: kind, Handle: handle, At: now})
@@ -226,6 +228,14 @@ func (m *reportingModel) emitRendezvousEvents(w *sim.World, now time.Time) {
 		w.LastRendezvousArrival = nil
 		chip(sim.SessionEventRendezvousArrived, arr.Handle)
 		arrived = true
+	}
+	// Waypoint advance (#252): the standing intent passed an encounter
+	// outside couple range and re-aimed at the next one. The arm stays
+	// up, so this can never read as a cancel — but it must be visible
+	// (a silent advance reads as the coast being broken).
+	if wp := w.LastRendezvousWaypoint; wp != nil {
+		w.LastRendezvousWaypoint = nil
+		chip(sim.SessionEventRendezvousWaypoint, wp.Handle)
 	}
 	// Outgoing arm released before τ — own cancel, partner retract, or
 	// partner drop all land here.
@@ -517,6 +527,7 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// same tick hosting stops must not fire a spurious chip in the next
 	// hosting session.
 	w.LastRendezvousArrival = nil
+	w.LastRendezvousWaypoint = nil
 	w.LastSyncArrival = nil
 	m.rzPartnerOwner, m.rzPartnerHandle = "", ""
 	m.rzInviteFrom, m.rzInviteHandle = "", ""

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -306,7 +306,22 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	// clamp onto the World for next tick's clampedWarp; emit couple/
 	// release chips on transitions. Same seam as ghosts — reads the
 	// store's reports (which now carry EffWarp), writes transient state.
-	peers := relay.CoWarpPeersFrom(w, others, handles, m.owner)
+	// Session liveness for the adapter's rendezvous-arm gate (#252 review,
+	// finding 1): presence is the serve layer's "has a live session right
+	// now" — marked online at connect/enroll, offline only when the session
+	// unwinds through persistMiddleware. A reprieved-away session's
+	// connection is still up, so it stays online and its arm stays honored
+	// (silence is not retract); a session reaped at the Reprieve ceiling,
+	// or any for-good disconnect, drops out of presence while its final
+	// report sits frozen in the relay store forever — exactly the report
+	// whose arm must NOT keep the survivor's standing intent alive.
+	live := make(map[string]bool, len(others))
+	for _, r := range others {
+		if m.srv.presence.isOnline(r.Owner) {
+			live[r.Owner] = true
+		}
+	}
+	peers := relay.CoWarpPeersFrom(w, others, handles, m.owner, live)
 	// Rendezvous Warp (v0.29 S1): start or cancel the shared coast to the
 	// committed encounter from this tick's mutual-arm state, before the
 	// clamp reads the couple. Arrival + arm bookkeeping live in the sim.

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -36,12 +36,15 @@ type AutoWarpTarget struct {
 	SyncHandle string // whose time we're chasing (arrival chip text)
 	SyncOwner  string // their fingerprint — the serve layer re-freezes T from their latest report (a leader at warp is a moving target)
 
-	// Rendezvous (v0.29 S1, ADR 0034 v0.29 addendum): when true the driver
-	// is the shared coast to a mutually-armed encounter — a fixed sim-time
-	// target like Sync, but the target is held (never re-frozen) and
-	// arrival clears the viewer's RendezvousArm so Proximity Co-Warp takes
-	// over the final approach. Started by DriveRendezvousWarp only once
-	// both players are armed.
+	// Rendezvous (v0.29 S1, ADR 0034 v0.29 addendum; reshaped for #252):
+	// when true the driver is the shared coast of a standing mutual
+	// rendezvous intent. T is the CURRENT waypoint's τ — held while
+	// coasted at, but re-frozen by driveRendezvousCoast whenever the
+	// waypoint advances (τ reached outside couple range) or the partner's
+	// earlier relayed τ is adopted. The driver releases only at the
+	// proximity handoff (τ reached inside couple range, where Proximity
+	// Co-Warp takes over) or on either player's cancel. Started by
+	// DriveRendezvousWarp only once both players are armed.
 	Rendezvous       bool
 	RendezvousOwner  string // partner fingerprint (retract detection + chip)
 	RendezvousHandle string // partner handle (arrival chip text)
@@ -129,17 +132,29 @@ type SyncArrival struct {
 }
 
 // RendezvousArrival marks a completed Rendezvous Warp (v0.29 S1) — set by
-// resolveAutoWarp when the shared coast reaches τ, consumed (and cleared)
-// by the serve wrapper to fire the arrival chip. Transient, like
-// SyncArrival.
+// driveRendezvousCoast at the proximity handoff (the coast reached a
+// waypoint inside couple range, #252), consumed (and cleared) by the
+// serve wrapper to fire the arrival chip. Transient, like SyncArrival.
 type RendezvousArrival struct {
 	Handle string // the partner whose encounter we arrived at
 	Owner  string // their fingerprint
 }
 
+// RendezvousWaypoint marks a passed waypoint on a standing rendezvous
+// intent (#252) — set by driveRendezvousCoast when the coast reaches the
+// committed τ outside couple range and advances to a newly derived
+// encounter. Consumed (and cleared) by the serve wrapper to fire the
+// waypoint chip: an advance must be visible (a silent one reads as the
+// coast being broken), but it is neither an arrival nor a cancel.
+type RendezvousWaypoint struct {
+	Handle string // the partner the intent is held with
+	Owner  string // their fingerprint
+}
+
 // EngageRendezvousWarp records the viewer's Rendezvous Warp intent toward
 // partner, committed to the encounter sim-time tau — the initiator's
-// authoritative TCA (v0.29 S1, ADR 0034 v0.29 addendum). handle is the
+// authoritative TCA, which becomes the standing intent's FIRST waypoint
+// (#252) (v0.29 S1, ADR 0034 v0.29 addendum). handle is the
 // partner's display name, captured here so chips and the HUD never have
 // to resolve a fingerprint through a possibly-stale roster. It does NOT
 // start the shared coast: DriveRendezvousWarp starts it only once the
@@ -214,14 +229,17 @@ func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 	}
 }
 
-// DriveRendezvousWarp starts, holds, or cancels the shared coast to the
-// committed encounter from this tick's mutual-arm state (v0.29 S1).
-// Called each tick after the co-warp peers are built. The coast starts
-// only once BOTH players are armed toward each other in the same Subspace
-// (no solo drift); a genuine retract or disconnect mid-coast cancels —
-// either side's cancel releases both. Arrival is handled in
-// resolveAutoWarp (it clears the arm), so an armless world with the coast
-// still flagged just releases it here defensively.
+// DriveRendezvousWarp starts, holds, advances, or cancels the shared
+// coast of the standing rendezvous intent from this tick's mutual-arm
+// state (v0.29 S1, reshaped for #252). Called each tick after the
+// co-warp peers are built. The coast starts only once BOTH players are
+// armed toward each other in the same Subspace (no solo drift); a
+// genuine retract or disconnect mid-coast cancels — either side's cancel
+// releases both. Reaching the committed τ is resolved HERE, not in
+// resolveAutoWarp, because deciding between the proximity handoff and a
+// waypoint advance needs this tick's peer set (craft ranges + relayed
+// τs), which the sim tick path doesn't carry. An armless world with the
+// coast still flagged just releases it here defensively.
 func (w *World) DriveRendezvousWarp(peers []CoWarpPeer) {
 	w.driveRendezvousCoast(peers)
 	// One shared tail (v0.29 review): the degrade recompute reflects this
@@ -272,6 +290,35 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 			break
 		}
 	}
+	// τ authority across a waypoint advance (#252): both sides re-derive
+	// the next waypoint independently at their own τ-crossing, so their
+	// new τs will disagree (different advisories, different relayed craft
+	// states). Deterministic rule, no negotiation loop: the EARLIER future
+	// τ wins (min-τ) — min is commutative and idempotent, so both sides
+	// converge on the same waypoint within one relay hop, leaning on the
+	// re-freeze below to keep the driver, the arm, and the wire agreeing.
+	// The future-only guard ignores the partner's still-relayed PREVIOUS τ
+	// (now in the past) in the ticks right after an advance; it also lets
+	// a side whose own derivation failed (stale past τ, coasting at the 1×
+	// floor) adopt the partner's fresh waypoint as a rescue. Residual skew
+	// while converging is absorbed by the same-subspace tolerance and the
+	// hold. Documented trade-off: a deliberate re-Engage to a LATER τ
+	// mid-coast cannot win against the partner's earlier relayed τ — with
+	// the arm a standing intent, a waypoint is sequencing, not commitment,
+	// and the earlier encounter is always an acceptable next waypoint.
+	if partner != nil && w.rendezvousWarpEngaged() &&
+		partner.RendezvousTau.After(w.Clock.SimTime) &&
+		(partner.RendezvousTau.Before(arm.Tau) || !arm.Tau.After(w.Clock.SimTime)) {
+		arm.Tau, arm.CommittedCA = partner.RendezvousTau, partner.RendezvousCA
+		arm.degradeBaseSet = false // a new waypoint means a new baseline (#251 interaction)
+		w.AutoWarp.T = arm.Tau
+	}
+	// τ reached (#252): the arm is a standing mutual intent — the
+	// committed encounter is a waypoint, not the end.
+	if w.rendezvousWarpEngaged() && !w.Clock.SimTime.Before(arm.Tau) {
+		w.resolveRendezvousWaypoint(arm, partner, peers)
+		return
+	}
 	switch {
 	case partner != nil && !w.rendezvousWarpEngaged():
 		// Don't clobber an engaged Sync or node-chase (v0.29 review): the
@@ -295,10 +342,11 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 		}
 		w.Clock.Paused = false
 	case partner == nil && w.rendezvousWarpEngaged():
-		// Arrival window (v0.29 review): near τ the partner's arm clearing
-		// is their own ARRIVAL, not a retract — Δt inside the subspace
-		// tolerance means the laggard crosses τ within that window. Finish
-		// the coast; resolveAutoWarp fires the arrival normally.
+		// Arrival window (v0.29 review, re-read for #252): near τ the
+		// partner's arm clearing is their own proximity handoff, not a
+		// retract — Δt inside the subspace tolerance means the laggard
+		// crosses τ within that window. Finish the coast; the waypoint
+		// resolution above then decides handoff-vs-advance at τ.
 		if w.AutoWarp.T.Sub(w.Clock.SimTime).Seconds() <= coWarpSubspaceToleranceSec {
 			return
 		}
@@ -316,6 +364,70 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 			w.RendezvousHold = true
 		}
 	}
+}
+
+// resolveRendezvousWaypoint decides what reaching the committed τ means
+// for the standing intent (#252):
+//   - inside the proximity couple gate → the intent has done its job:
+//     drop to 1×, chip the arrival, release arm + driver. Proximity
+//     Co-Warp continues the SAME coupled state (the wasCoupled hysteresis
+//     in ComputeCoWarp carries it) — no drop-and-recouple tick;
+//   - outside, mutual arm intact → advance: re-derive the next encounter,
+//     re-freeze the driver on it, re-base the degrade baseline, and
+//     record the advance for the waypoint chip;
+//   - outside, mutual arm gone → the partner cancelled at the waypoint
+//     (or handed off on a range measurement we don't share): there is no
+//     standing intent left to advance, so release both, consistent with
+//     the mid-coast retract rule.
+//
+// The handoff check deliberately runs only AT a waypoint, not every
+// coasting tick: a transient pass through 10 km at warp mid-coast is a
+// crossing, not the rendezvous being complete, and must not strand the
+// pair at 1× short of their encounter. At τ the approach ramp has already
+// glided the rate to the 1× floor, which is exactly the state Proximity
+// Co-Warp expects to inherit.
+func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPeer, peers []CoWarpPeer) {
+	anchor := w.ActiveCraft()
+	if anchor != nil && !anchor.Landed && !anchor.Crashed {
+		// Partner matched by identity alone — at the handoff the partner's
+		// own arm may already be cleared (their side resolved first), so
+		// ArmedTowardViewer is deliberately not required here.
+		for i := range peers {
+			if peers[i].Owner != arm.TargetOwner {
+				continue
+			}
+			if rng, vrel, ok := closestApproach(anchor, peers[i].Crafts); ok &&
+				rng <= coWarpCoupleRangeM && vrel <= coWarpCoupleSpeedMs {
+				w.Clock.WarpIdx = 0
+				w.LastRendezvousArrival = &RendezvousArrival{
+					Handle: w.AutoWarp.RendezvousHandle, Owner: w.AutoWarp.RendezvousOwner,
+				}
+				w.RendezvousArm = nil
+				w.DisengageAutoWarp()
+				return
+			}
+			break
+		}
+	}
+	if partner == nil {
+		w.DisengageRendezvousWarp()
+		return
+	}
+	if tau, ca, ok := w.rendezvousNextWaypoint(partner); ok {
+		arm.Tau, arm.CommittedCA = tau, ca
+		arm.degradeBaseSet = false // per-waypoint re-baseline (#251 interaction)
+		w.AutoWarp.T = tau
+		w.LastRendezvousWaypoint = &RendezvousWaypoint{
+			Handle: w.AutoWarp.RendezvousHandle, Owner: w.AutoWarp.RendezvousOwner,
+		}
+		return
+	}
+	// Derivation came up empty this tick (partner craft missing from the
+	// report, or no approach inside the horizon). NOT a cancel — the
+	// intent ends only on explicit cancel or the proximity handoff. Keep
+	// the passed τ: clampedWarp floors a past-τ rendezvous coast at 1×,
+	// and we retry every tick; the partner's relayed τ can also rescue us
+	// via the min-τ adoption above.
 }
 
 // EngageSyncWarp aims Auto-Warp at a fixed sim-time — Sync to another
@@ -402,16 +514,14 @@ func (w *World) resolveAutoWarp() {
 		}
 		return
 	}
-	// Rendezvous mode (v0.29 S1): fixed encounter τ, held (never re-frozen
-	// like a Sync leader). At τ, hand off to Proximity Co-Warp — drop to
-	// 1×, clear the arm, and record the arrival for the S2 chip.
+	// Rendezvous mode (v0.29 S1, reshaped for #252): the arm is a standing
+	// mutual intent and T is only the CURRENT waypoint, so reaching it is
+	// NOT resolved here — deciding between the proximity handoff and a
+	// waypoint advance needs the peer set, which this sim-tick path never
+	// sees. driveRendezvousCoast resolves it on the serve pass of the same
+	// tick; until then clampedWarp floors a past-T rendezvous coast at 1×
+	// so nothing races ahead of an unresolved waypoint.
 	if w.AutoWarp.Rendezvous {
-		if !w.Clock.SimTime.Before(w.AutoWarp.T) {
-			w.Clock.WarpIdx = 0
-			w.LastRendezvousArrival = &RendezvousArrival{Handle: w.AutoWarp.RendezvousHandle, Owner: w.AutoWarp.RendezvousOwner}
-			w.RendezvousArm = nil
-			w.DisengageAutoWarp()
-		}
 		return
 	}
 	n, ok := w.nodeByID(w.AutoWarp.CraftID, w.AutoWarp.NodeID)

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -281,14 +281,24 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	// Partner match is by identity only. The same-subspace gate applies to
 	// STARTING the coast (below) — an engaged coast instead holds through a
 	// transient divergence (v0.29 review): pause/report gaps must not read
-	// as a retract and destroy the mutual encounter.
+	// as a retract and destroy the mutual encounter. peerPresent tells the
+	// waypoint resolution apart the two ways partner can be nil (#252
+	// review, finding 3): report in the set with the arm withdrawn — a
+	// genuine retract (the serve liveness gate also lands here for a dead
+	// session, finding 1) — versus the whole peer absent this tick, which
+	// at/after τ gets the dropout grace instead of an instant release.
 	var partner *CoWarpPeer
+	peerPresent := false
 	for i := range peers {
 		p := &peers[i]
-		if p.Owner == arm.TargetOwner && p.ArmedTowardViewer {
-			partner = p
-			break
+		if p.Owner != arm.TargetOwner {
+			continue
 		}
+		peerPresent = true
+		if p.ArmedTowardViewer {
+			partner = p
+		}
+		break
 	}
 	// τ authority across a waypoint advance (#252): both sides re-derive
 	// the next waypoint independently at their own τ-crossing, so their
@@ -306,8 +316,17 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	// mid-coast cannot win against the partner's earlier relayed τ — with
 	// the arm a standing intent, a waypoint is sequencing, not commitment,
 	// and the earlier encounter is always an acceptable next waypoint.
+	// The min-lead floor (#252 review, finding 4) applies to adoption
+	// exactly as it does to our own derivation: a relayed τ 1 s out would
+	// be crossed next tick, forcing an immediate re-resolution and a
+	// spurious waypoint chip. Deterministic on both sides — the floor is a
+	// shared constant over each side's own clock, and skipping changes
+	// nothing about convergence: a skipped sub-lead τ means we cross our
+	// own τ and re-derive, the partner crosses theirs within the lead and
+	// re-derives too (their derivation refuses sub-lead τs), and min-τ
+	// then converges the two fresh waypoints within one relay hop as usual.
 	if partner != nil && w.rendezvousWarpEngaged() &&
-		partner.RendezvousTau.After(w.Clock.SimTime) &&
+		partner.RendezvousTau.After(w.Clock.SimTime.Add(rendezvousWaypointMinLead)) &&
 		(partner.RendezvousTau.Before(arm.Tau) || !arm.Tau.After(w.Clock.SimTime)) {
 		arm.Tau, arm.CommittedCA = partner.RendezvousTau, partner.RendezvousCA
 		arm.degradeBaseSet = false // a new waypoint means a new baseline (#251 interaction)
@@ -316,7 +335,20 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	// τ reached (#252): the arm is a standing mutual intent — the
 	// committed encounter is a waypoint, not the end.
 	if w.rendezvousWarpEngaged() && !w.Clock.SimTime.Before(arm.Tau) {
-		w.resolveRendezvousWaypoint(arm, partner, peers)
+		w.resolveRendezvousWaypoint(arm, partner, peerPresent, peers)
+		// Hold-the-leader applies whenever the coast is engaged, waypoint
+		// resolved or not (#252 review, finding 2). The past-τ idle
+		// (derivation failing and retrying — a legitimately long-lived
+		// state under the standing intent) used to return before the hold
+		// case below, so a paused or behind-diverged partner no longer
+		// froze the ahead side: the viewer walked on at the 1× floor,
+		// the pair decoupled past the tolerance window, and both then sat
+		// at 1× with a live arm and a gap that never closes. Evaluated
+		// after the resolution so a handoff/release this tick (coast now
+		// disengaged) is never held.
+		if w.rendezvousWarpEngaged() && partner != nil {
+			w.holdRendezvousLeader(partner)
+		}
 		return
 	}
 	switch {
@@ -353,16 +385,22 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 		// Partner genuinely retracted or dropped mid-coast — release both.
 		w.DisengageRendezvousWarp()
 	case partner != nil && w.rendezvousWarpEngaged():
-		// Hold-the-leader (v0.29 review): a paused partner (frozen clock)
-		// or a divergence with the viewer ahead must not let the leader
-		// sail to τ alone. The leader freezes (clampedWarp reads the
-		// flag); the one behind coasts on and closes the gap; the pair
-		// re-locks inside the tolerance. Deadlock-free because only the
-		// AHEAD side ever holds.
-		ahead := w.Clock.SimTime.Sub(partner.SubspaceTime).Seconds()
-		if (partner.Paused && ahead >= 0) || ahead > coWarpSubspaceToleranceSec {
-			w.RendezvousHold = true
-		}
+		w.holdRendezvousLeader(partner)
+	}
+}
+
+// holdRendezvousLeader raises the hold flag when the engaged coast's
+// viewer must wait for its partner (v0.29 review): a paused partner
+// (frozen clock) or a divergence with the viewer ahead must not let the
+// leader sail on alone. The leader freezes (clampedWarp reads the flag);
+// the one behind coasts on and closes the gap; the pair re-locks inside
+// the tolerance. Deadlock-free because only the AHEAD side ever holds.
+// Applies to every engaged coasting tick — pre-τ and the past-τ idle
+// alike (#252 review, finding 2).
+func (w *World) holdRendezvousLeader(partner *CoWarpPeer) {
+	ahead := w.Clock.SimTime.Sub(partner.SubspaceTime).Seconds()
+	if (partner.Paused && ahead >= 0) || ahead > coWarpSubspaceToleranceSec {
+		w.RendezvousHold = true
 	}
 }
 
@@ -375,10 +413,19 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 //   - outside, mutual arm intact → advance: re-derive the next encounter,
 //     re-freeze the driver on it, re-base the degrade baseline, and
 //     record the advance for the waypoint chip;
-//   - outside, mutual arm gone → the partner cancelled at the waypoint
-//     (or handed off on a range measurement we don't share): there is no
-//     standing intent left to advance, so release both, consistent with
-//     the mid-coast retract rule.
+//   - outside, peer present but arm gone → the partner cancelled at the
+//     waypoint (or handed off on a range measurement we don't share, or
+//     their session died and the liveness gate suppressed their frozen
+//     arm — finding 1): there is no standing intent left to advance, so
+//     release both immediately, consistent with the mid-coast retract
+//     rule;
+//   - outside, peer absent from the set entirely → dropout grace (#252
+//     review, finding 3): every pre-τ transient gap is held through, so a
+//     one-tick peer dropout at exactly the crossing tick (all partner
+//     craft filtered that tick) must not destroy the standing intent and
+//     mis-chip "cancelled". Idle — don't advance, don't release — until
+//     the peer has been absent for more than the tolerance window's worth
+//     of sim-time (arm.peerGoneAt), then release as a retract.
 //
 // The handoff check deliberately runs only AT a waypoint, not every
 // coasting tick: a transient pass through 10 km at warp mid-coast is a
@@ -386,7 +433,7 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 // pair at 1× short of their encounter. At τ the approach ramp has already
 // glided the rate to the 1× floor, which is exactly the state Proximity
 // Co-Warp expects to inherit.
-func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPeer, peers []CoWarpPeer) {
+func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPeer, peerPresent bool, peers []CoWarpPeer) {
 	anchor := w.ActiveCraft()
 	if anchor != nil && !anchor.Landed && !anchor.Crashed {
 		// Partner matched by identity alone — at the handoff the partner's
@@ -410,9 +457,23 @@ func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPee
 		}
 	}
 	if partner == nil {
-		w.DisengageRendezvousWarp()
+		// Peer present with the arm withdrawn is a genuine retract (or the
+		// liveness gate's dead-session suppression) — release immediately,
+		// as mid-coast. Only a whole-peer dropout gets the grace.
+		if peerPresent {
+			w.DisengageRendezvousWarp()
+			return
+		}
+		if arm.peerGoneAt.IsZero() {
+			arm.peerGoneAt = w.Clock.SimTime
+			return // idle: clampedWarp floors the past-τ coast at 1×
+		}
+		if w.Clock.SimTime.Sub(arm.peerGoneAt).Seconds() > coWarpSubspaceToleranceSec {
+			w.DisengageRendezvousWarp()
+		}
 		return
 	}
+	arm.peerGoneAt = time.Time{} // peer back inside the grace — full window next time
 	if tau, ca, ok := w.rendezvousNextWaypoint(partner); ok {
 		arm.Tau, arm.CommittedCA = tau, ca
 		arm.degradeBaseSet = false // per-waypoint re-baseline (#251 interaction)

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -108,6 +108,13 @@ type CoWarpPeer struct {
 	// v0.29 addendum). Combined with the viewer's own RendezvousArm
 	// targeting this peer, the two are *mutually* armed and couple before
 	// the proximity gate — the second Co-Warp trigger.
+	//
+	// "Live" means a live SESSION, not merely a live report (#252 review):
+	// the adapter suppresses this flag (and RendezvousTau/CA) for an owner
+	// with no live session, so a disconnected-for-good partner's frozen
+	// report reads as a retract here rather than an immortal arm. A
+	// reprieved-away session still counts as live — its silence is held
+	// for, never cancelled.
 	ArmedTowardViewer bool
 
 	// RendezvousTau is the peer's committed encounter sim-time when
@@ -129,11 +136,23 @@ type CoWarpPeer struct {
 // commitment to one encounter: reaching Tau outside couple range advances
 // the waypoint (Tau/CommittedCA are re-derived and the coast continues)
 // rather than clearing the arm, so the range-free coupling and rate-lock
-// span the whole multi-maneuver approach. The arm ends exactly two ways:
-// an explicit cancel by either player, or the proximity handoff when a
-// waypoint arrives inside couple range and Proximity Co-Warp takes over.
-// Transient like AutoWarp/CoWarp — never persisted; also cleared on
-// partner disconnect.
+// span the whole multi-maneuver approach. The arm ends exactly two ways
+// by intent: an explicit cancel by either player, or the proximity
+// handoff when a waypoint arrives inside couple range and Proximity
+// Co-Warp takes over.
+//
+// Lifetime requires a live partner SESSION (#252 review, finding 1).
+// With the arm unbounded in time, "the partner is still in this" has to
+// mean their session exists — attended or reprieved-away — not that a
+// report of theirs exists: the relay store never scrubs reports, so a
+// partner who disconnects for good leaves a frozen report whose intent
+// bit would otherwise hold this arm (and its 0×-hold or dead-orbit
+// coast) forever. The serve layer enforces it at the peer seam
+// (relay.CoWarpPeersFrom's liveness input): a dead session's relayed arm
+// is suppressed, which the coast reads as a genuine retract — so a
+// partner disconnect releases the arm through the normal cancel path,
+// not through any wire message the departed session never got to send.
+// Transient like AutoWarp/CoWarp — never persisted.
 type RendezvousArm struct {
 	TargetOwner string    // fingerprint of the partner Engaged toward
 	Handle      string    // partner display name, captured at Engage (chips/HUD never fall back to a raw fingerprint)
@@ -152,6 +171,16 @@ type RendezvousArm struct {
 	// degraded encounter measured against the previous waypoint.
 	degradeBaseCA  float64
 	degradeBaseSet bool
+
+	// peerGoneAt is the sim-time the partner's report first vanished from
+	// the peer set entirely while the coast sat at/after τ (#252 review,
+	// finding 3) — zero while the peer is present. A one-tick dropout at
+	// exactly the crossing tick (all partner craft filtered: landed,
+	// cross-system, degenerate KeplerStep) must not destroy the standing
+	// intent when every other transient gap is held through; the coast
+	// idles until the peer has been absent for more than the tolerance
+	// window's worth of sim-time, then releases as a retract.
+	peerGoneAt time.Time
 }
 
 // rendezvousArmedWith reports whether the viewer has Engaged a Rendezvous

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -123,15 +123,22 @@ type CoWarpPeer struct {
 }
 
 // RendezvousArm is the viewer's outgoing Rendezvous Warp intent (v0.29 S1,
-// ADR 0034 v0.29 addendum): the partner they have Engaged toward and the
-// committed encounter sim-time (the initiator's authoritative Time of
-// Closest Approach). Transient like AutoWarp/CoWarp — never persisted,
-// cleared on cancel, on arrival at Tau, and on partner disconnect.
+// ADR 0034 v0.29 addendum): the partner they have Engaged toward, plus the
+// CURRENT waypoint — encounter sim-time and predicted approach. Since #252
+// the arm is a STANDING mutual intent ("we are rendezvousing"), not a
+// commitment to one encounter: reaching Tau outside couple range advances
+// the waypoint (Tau/CommittedCA are re-derived and the coast continues)
+// rather than clearing the arm, so the range-free coupling and rate-lock
+// span the whole multi-maneuver approach. The arm ends exactly two ways:
+// an explicit cancel by either player, or the proximity handoff when a
+// waypoint arrives inside couple range and Proximity Co-Warp takes over.
+// Transient like AutoWarp/CoWarp — never persisted; also cleared on
+// partner disconnect.
 type RendezvousArm struct {
 	TargetOwner string    // fingerprint of the partner Engaged toward
 	Handle      string    // partner display name, captured at Engage (chips/HUD never fall back to a raw fingerprint)
-	Tau         time.Time // committed absolute encounter sim-time
-	CommittedCA float64   // m — the predicted post-plan approach at Tau when Engaged (HUD "committed" row)
+	Tau         time.Time // the current waypoint's absolute encounter sim-time
+	CommittedCA float64   // m — the predicted approach at Tau, re-derived per waypoint (HUD "committed" row)
 
 	// degradeBaseCA is the hold-τ warning baseline: the first approach
 	// actually measured once the shared coast engages (v0.29 review).
@@ -140,6 +147,9 @@ type RendezvousArm struct {
 	// ballistic course, which would flag "degraded" from the first tick
 	// with nothing drifted. Warning on drift past the coast-start
 	// measure keeps the semantics "the encounter got worse mid-coast".
+	// Per-waypoint: degradeBaseSet is reset whenever the waypoint
+	// advances (#252), or every advance would instantly read as a
+	// degraded encounter measured against the previous waypoint.
 	degradeBaseCA  float64
 	degradeBaseSet bool
 }
@@ -244,9 +254,14 @@ func (w *World) ComputeCoWarp(peers []CoWarpPeer, prev map[string]bool) CoWarpRe
 				// Rendezvous trigger (v0.29 S1): both players Engaged toward
 				// each other and share a Subspace — couple *before* the
 				// proximity gate so they can coast to the encounter rate-
-				// locked. On arrival the arm clears; the same coupled state
-				// then continues on the proximity branch below (wasCoupled
-				// carries the hysteresis memory) — no drop-and-recouple.
+				// locked. The arm is a standing intent (#252): it persists
+				// across waypoint advances, so this branch stays the
+				// coupling source for the whole multi-maneuver approach. It
+				// clears only at the proximity handoff (a waypoint reached
+				// inside couple range) or on cancel; at the handoff the same
+				// coupled state continues on the proximity branch below
+				// (wasCoupled carries the hysteresis memory) — no
+				// drop-and-recouple.
 				coupledNow = true
 				// #248: while the shared coast is ENGAGED, this partner's
 				// reported EffWarp must NOT feed the min. The report is their

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -153,6 +153,69 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	return w.Clock.SimTime.Add(time.Duration(tCA * float64(time.Second))), distCA, true
 }
 
+// rendezvousWaypointMinLead is the minimum forward distance a newly
+// derived waypoint must have from SimTime (#252). Guards the advance loop
+// against a closest-approach search whose grid minimum sits essentially
+// at "now" (a pair at their CA and separating): re-committing to a τ a
+// tick away would advance — and chip — every tick. Below the lead the
+// derivation reports not-found and the coast idles at the 1× floor
+// instead.
+const rendezvousWaypointMinLead = 5 * time.Second
+
+// rendezvousNextWaypoint derives the standing intent's next waypoint
+// after the previous one passed (#252). Two paths, mirroring the Engage
+// commit:
+//   - the target slot still holds the armed partner's ghost → reuse
+//     RendezvousCommit verbatim, so a planted next nudge's post-burn
+//     encounter is honoured exactly like the first one was;
+//   - otherwise (player retargeted mid-coast, or the ghost slate is
+//     momentarily stale) → target-slot-independent fallback: the
+//     current-course closest approach against the partner's same-primary
+//     craft from this tick's peer set (min over crafts, like
+//     rendezvousCAAtTau — a deployed probe must not masquerade as the
+//     encounter).
+//
+// A passive-flyby waypoint (no useful nudge, encounter is whatever the
+// current course gives) is a legitimate result, not a failure. ok=false
+// only when no future approach can be found at all this tick.
+func (w *World) rendezvousNextWaypoint(partner *CoWarpPeer) (tau time.Time, ca float64, ok bool) {
+	floor := w.Clock.SimTime.Add(rendezvousWaypointMinLead)
+	if w.Target.Kind == TargetGhost && w.Target.GhostOwner == partner.Owner {
+		if t, c, cok := w.RendezvousCommit(); cok && t.After(floor) {
+			return t, c, true
+		}
+	}
+	active := w.ActiveCraft()
+	if active == nil || active.Landed || active.Crashed {
+		return time.Time{}, 0, false
+	}
+	mu := active.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return time.Time{}, 0, false
+	}
+	best := math.Inf(1)
+	for _, c := range partner.Crafts {
+		if c.Primary != active.Primary.ID {
+			continue
+		}
+		tCA, distCA, _, err := planner.NextClosestApproach(
+			orbital.Vec3State{R: active.State.R, V: active.State.V},
+			orbital.Vec3State{R: c.R, V: c.V},
+			active.Primary, mu, rendezvousCommitHorizonSec)
+		if err != nil || tCA <= 0 {
+			continue
+		}
+		at := w.Clock.SimTime.Add(time.Duration(tCA * float64(time.Second)))
+		if !at.After(floor) {
+			continue
+		}
+		if distCA < best {
+			best, tau, ca, ok = distCA, at, distCA, true
+		}
+	}
+	return tau, ca, ok
+}
+
 // rendezvousTargetPrimary returns the SOI primary the current target
 // orbits, for both a local craft target and a remote ghost (v0.28 S4).
 // ok=false when no relative target is set or the ref is stale.

--- a/internal/sim/rendezvous_review_test.go
+++ b/internal/sim/rendezvous_review_test.go
@@ -268,3 +268,167 @@ func TestRendezvousInviteRequiresSameSubspace(t *testing.T) {
 		t.Errorf("invite surfaced across a subspace divergence: %+v", w.RendezvousInvite)
 	}
 }
+
+// #252 review, finding 2: hold-the-leader applies whenever the coast is
+// engaged, waypoint resolved or not. The past-τ idle (waypoint derivation
+// failing and retrying — a state the standing intent legitimized as
+// long-lived) used to early-return before the hold case, so a paused or
+// behind-diverged partner no longer froze the ahead side: the viewer
+// walked on at the 1× floor, the pair decoupled past the tolerance
+// window, and both then sat at 1× with a live arm and a gap that never
+// closes — permanent divergence, exit only by manual cancel.
+func TestRendezvousHoldAppliesPastTau(t *testing.T) {
+	w, _, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	// Present and armed, but with no same-primary craft in the set — every
+	// waypoint derivation comes up empty, so the coast idles and retries.
+	peer := CoWarpPeer{
+		Owner: "SHA256:gern", Handle: "gern", SubspaceTime: st,
+		EffWarp: 50, ArmedTowardViewer: true, RendezvousTau: tau,
+	}
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	// Past τ, derivation still failing; the partner pauses behind the
+	// viewer → the viewer (ahead) must hold, not walk on at the 1× floor.
+	w.Clock.SimTime = tau.Add(10 * time.Second)
+	peer.Paused = true
+	peer.SubspaceTime = tau.Add(-5 * time.Minute)
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousArm == nil || !w.rendezvousWarpEngaged() {
+		t.Fatal("the past-τ retry released the intent")
+	}
+	if !w.RendezvousHold {
+		t.Error("no hold past τ for a paused, behind partner — the leader walks ahead and the pair diverges for good")
+	}
+	if got := w.EffectiveWarp(); got != 0 {
+		t.Errorf("EffectiveWarp = %v during a past-τ hold, want 0", got)
+	}
+
+	// Partner resumes inside the tolerance → hold releases; the coast
+	// keeps retrying the waypoint (deadlock-free: only the AHEAD side
+	// ever holds, and it just stopped being ahead-of-a-stopped-clock).
+	peer.Paused = false
+	peer.SubspaceTime = w.Clock.SimTime
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousHold {
+		t.Error("hold survived the partner's resume — the pair can't re-lock")
+	}
+	if w.RendezvousArm == nil || !w.rendezvousWarpEngaged() {
+		t.Error("intent lost across the resume")
+	}
+}
+
+// #252 review, finding 3: a transient peer dropout at the τ-crossing tick
+// (all partner craft filtered that tick: landed / cross-system /
+// degenerate KeplerStep → the whole peer absent from the set) must not
+// destroy the standing intent and mis-chip "cancelled" — every other
+// transient gap is held through. The partner has to stay absent for more
+// than the tolerance window's worth of sim-time before the release fires
+// as a retract.
+func TestRendezvousCrossingDropoutGrace(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	peer := armPeer(w, primary, st, 50, "gern")
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	// One-tick dropout at exactly the crossing tick.
+	w.Clock.SimTime = tau
+	w.DriveRendezvousWarp(nil)
+	if w.RendezvousArm == nil || !w.rendezvousWarpEngaged() {
+		t.Fatal("a one-tick peer dropout at the τ-crossing destroyed the standing intent")
+	}
+	if w.LastRendezvousWaypoint != nil {
+		t.Error("waypoint advanced against a missing peer")
+	}
+
+	// Peer back next tick → the coast carries on and the grace clock
+	// clears (a later dropout must get the FULL window again).
+	w.Clock.SimTime = tau.Add(time.Second)
+	peer.SubspaceTime = w.Clock.SimTime
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousArm == nil || !w.rendezvousWarpEngaged() {
+		t.Fatal("intent lost after the peer came back")
+	}
+	if !w.RendezvousArm.peerGoneAt.IsZero() {
+		t.Error("grace clock not cleared by the peer's return")
+	}
+
+	// Gone again, and STAYING gone past the tolerance window of sim-time
+	// → released as a retract.
+	w.Clock.SimTime = tau.Add(2 * time.Second)
+	w.DriveRendezvousWarp(nil)
+	if w.RendezvousArm == nil {
+		t.Fatal("released on the first missing tick — no grace at all")
+	}
+	w.Clock.SimTime = w.Clock.SimTime.Add(time.Duration(coWarpSubspaceToleranceSec)*time.Second + time.Second)
+	w.DriveRendezvousWarp(nil)
+	if w.RendezvousArm != nil || w.rendezvousWarpEngaged() {
+		t.Error("partner absent past the grace window still held — the dropout release never fires")
+	}
+}
+
+// A genuine retract at the crossing tick — peer present, arm withdrawn —
+// still releases both immediately, exactly as mid-coast: the finding-3
+// grace is for peer DROPOUTS only, never for an explicit cancel.
+func TestRendezvousRetractAtCrossingReleasesImmediately(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	peer := armPeer(w, primary, st, 50, "gern")
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	w.Clock.SimTime = tau
+	peer.SubspaceTime = tau
+	peer.ArmedTowardViewer = false // partner cancelled at the waypoint
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousArm != nil || w.rendezvousWarpEngaged() {
+		t.Error("a genuine retract at the crossing was held — the cancel must release both immediately")
+	}
+}
+
+// #252 review, finding 4: a partner-relayed τ inside the waypoint min
+// lead is not adopted. Adopting a τ 1 s out would cross it next tick and
+// force an immediate re-resolution plus a spurious waypoint chip; our own
+// derivation already refuses such a τ (rendezvousWaypointMinLead), so the
+// adoption path must apply the same floor.
+func TestRendezvousMinTauAdoptionRespectsMinLead(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	peer := armPeer(w, primary, st, 50, "gern")
+	peer.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	// Future and earlier than ours, but inside the min lead → skipped.
+	peer.RendezvousTau = st.Add(time.Second)
+	peer.RendezvousCA = 123
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.RendezvousArm.Tau.Equal(tau) {
+		t.Errorf("adopted a sub-min-lead relayed τ: arm.Tau = %v, want the held %v", w.RendezvousArm.Tau, tau)
+	}
+	if !w.AutoWarp.T.Equal(tau) {
+		t.Errorf("driver re-frozen onto a sub-min-lead τ: T = %v", w.AutoWarp.T)
+	}
+
+	// Past the min lead → adopted (min-future-τ authority unchanged).
+	adopt := st.Add(time.Minute)
+	peer.RendezvousTau = adopt
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.RendezvousArm.Tau.Equal(adopt) {
+		t.Errorf("did not adopt the partner's earlier valid τ: arm.Tau = %v, want %v", w.RendezvousArm.Tau, adopt)
+	}
+}

--- a/internal/sim/rendezvous_warp_test.go
+++ b/internal/sim/rendezvous_warp_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 // Hold-τ degrade recompute: while the coast runs, a partner holding the
@@ -146,30 +147,253 @@ func TestDisengageRendezvousWarp(t *testing.T) {
 	}
 }
 
-// Arrival at τ hands off: drop to 1×, clear the arm (proximity co-warp
-// takes over), and record the arrival for the S2 chip.
-func TestRendezvousWarpArrivalHandsOff(t *testing.T) {
+// Reaching τ INSIDE the proximity couple gate ends the standing intent
+// (#252): drop to 1×, clear the arm (Proximity Co-Warp takes over via the
+// wasCoupled hysteresis — no drop-and-recouple tick), and record the
+// arrival for the S2 chip. The resolution lives in driveRendezvousCoast,
+// which has the peer set the couple-range check needs.
+func TestRendezvousCoupleRangeHandoffAtTau(t *testing.T) {
 	w, primary, st := anchorWorld(t)
-	tau := st.Add(72 * time.Hour)
+	tau := st.Add(time.Hour)
 	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
-	peer := armPeer(w, primary, st, 50, "gern")
-	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	near := peerAt(w, primary, st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{}, "gern")
+	near.ArmedTowardViewer = true
+	near.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+	// Hysteresis memory from the coasting ticks (the rendezvous branch
+	// coupled the pair all along).
+	prev := w.ComputeCoWarp([]CoWarpPeer{near}, nil).CoupledOwners
+	if !prev["SHA256:gern"] {
+		t.Fatal("precondition: pair coupled during the coast")
+	}
 
 	w.Clock.WarpIdx = 5
-	w.Clock.SimTime = tau // reached the encounter
-	w.resolveAutoWarp()
+	w.Clock.SimTime = tau // reached the encounter, 5 km out
+	near.SubspaceTime = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
 
 	if w.rendezvousWarpEngaged() {
-		t.Error("coast still engaged past τ")
+		t.Error("coast still engaged after the proximity handoff")
 	}
 	if w.RendezvousArm != nil {
-		t.Error("arm not cleared at arrival (won't hand off to proximity)")
+		t.Error("arm not released at the proximity handoff")
 	}
 	if w.Clock.WarpIdx != 0 {
 		t.Errorf("did not drop to 1× at arrival: WarpIdx = %d", w.Clock.WarpIdx)
 	}
 	if w.LastRendezvousArrival == nil || w.LastRendezvousArrival.Owner != "SHA256:gern" {
 		t.Errorf("arrival not recorded for the chip: %+v", w.LastRendezvousArrival)
+	}
+	// Same tick, no drop-and-recouple: the proximity branch continues the
+	// couple on the hysteresis memory even with the arm gone.
+	near.ArmedTowardViewer = false
+	res := w.ComputeCoWarp([]CoWarpPeer{near}, prev)
+	if !res.State.Coupled {
+		t.Error("pair decoupled on the handoff tick (drop-and-recouple)")
+	}
+	if len(res.Released) != 0 {
+		t.Errorf("spurious release on the handoff tick: %v", res.Released)
+	}
+}
+
+// aheadAlongTrack moves w's active craft ~735 s ahead along its own orbit
+// and stretches its speed by 0.2% (slightly longer period), so against an
+// unmoved twin world the pair is ~5,400 km apart NOW — far outside the
+// couple gate — with a genuine FUTURE closest approach inside the commit
+// horizon (the ahead craft slowly falls back toward the other). A plain
+// radial offset won't do: its closest approach is at t=0 and a waypoint
+// could never be derived.
+func aheadAlongTrack(t *testing.T, w *World) {
+	t.Helper()
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	st, ok := physics.KeplerStep(physics.StateVector{R: c.State.R, V: c.State.V, M: 1}, mu, 735)
+	if !ok {
+		t.Fatal("kepler step failed placing the along-track partner")
+	}
+	c.State.R, c.State.V = st.R, st.V.Scale(1.002)
+}
+
+// crossPeer builds the peer entry world `from` presents to the other
+// world's viewer: from's live craft state and subspace time, a (stale by
+// one exchange) Effective warp, and from's outgoing arm relayed as
+// ArmedTowardViewer + RendezvousTau/CA — the two-world cross-feed the
+// relay actually performs.
+func crossPeer(from *World, owner, handle string, eff float64) []CoWarpPeer {
+	c := from.ActiveCraft()
+	p := CoWarpPeer{
+		Owner: owner, Handle: handle, SubspaceTime: from.Clock.SimTime,
+		EffWarp: eff, ArmedTowardViewer: from.RendezvousArm != nil,
+		Crafts: []CoWarpCraft{{Primary: c.Primary.ID, R: c.State.R, V: c.State.V}},
+	}
+	if arm := from.RendezvousArm; arm != nil {
+		p.RendezvousTau, p.RendezvousCA = arm.Tau, arm.CommittedCA
+	}
+	return []CoWarpPeer{p}
+}
+
+// The arm is a standing mutual intent (#252): reaching the committed τ far
+// outside couple range must NOT clear it — the waypoint advances to a newly
+// derived encounter, the pair stays coupled and rate-locked, the advance is
+// recorded for the chip (a silent advance reads as broken), and both sides
+// converge on the same next τ without a negotiation loop.
+func TestRendezvousArmSurvivesTauOutsideCoupleRange(t *testing.T) {
+	wa, _, sta := anchorWorld(t)
+	wb, _, _ := anchorWorld(t)
+	// The playtest shape: thousands of km at τ, far outside the 10 km gate.
+	aheadAlongTrack(t, wb)
+	tau := sta.Add(time.Hour)
+	wa.EngageRendezvousWarp("SHA256:b", "b", tau, 5.4e6)
+	wb.EngageRendezvousWarp("SHA256:a", "a", tau, 5.4e6)
+
+	effA, effB := wa.EffectiveWarp(), wb.EffectiveWarp()
+	prevA, prevB := map[string]bool{}, map[string]bool{}
+	step := func() {
+		pa := crossPeer(wb, "SHA256:b", "b", effB)
+		pb := crossPeer(wa, "SHA256:a", "a", effA)
+		wa.DriveRendezvousWarp(pa)
+		wb.DriveRendezvousWarp(pb)
+		ra, rb := wa.ComputeCoWarp(pa, prevA), wb.ComputeCoWarp(pb, prevB)
+		wa.CoWarp, wb.CoWarp = ra.State, rb.State
+		prevA, prevB = ra.CoupledOwners, rb.CoupledOwners
+		effA, effB = wa.EffectiveWarp(), wb.EffectiveWarp()
+	}
+	step()
+	if !wa.rendezvousWarpEngaged() || !wb.rendezvousWarpEngaged() {
+		t.Fatal("precondition: shared coast engaged on both sides")
+	}
+
+	// Reach the committed encounter 5,600 km apart.
+	wa.Clock.SimTime, wb.Clock.SimTime = tau, tau
+	step()
+
+	if wa.RendezvousArm == nil || wb.RendezvousArm == nil {
+		t.Fatal("arm cleared at τ outside couple range — the standing intent must survive the waypoint")
+	}
+	if !wa.rendezvousWarpEngaged() || !wb.rendezvousWarpEngaged() {
+		t.Fatal("coast released at τ outside couple range")
+	}
+	if !wa.RendezvousArm.Tau.After(tau) || !wb.RendezvousArm.Tau.After(tau) {
+		t.Errorf("waypoint did not advance past the reached τ: a=%v b=%v (committed %v)",
+			wa.RendezvousArm.Tau, wb.RendezvousArm.Tau, tau)
+	}
+	if wa.LastRendezvousWaypoint == nil {
+		t.Error("no waypoint feedback recorded (a silent advance reads as broken)")
+	}
+	if !wa.CoWarp.Coupled || !wb.CoWarp.Coupled {
+		t.Fatal("pair decoupled across the waypoint advance")
+	}
+
+	// The coast keeps resolving a shared rate above 1× (the #248 exemption
+	// carries across the waypoint).
+	step()
+	if effA <= 1 || effB <= 1 {
+		t.Errorf("coast not rate-locked above 1× past the waypoint: effA=%v effB=%v", effA, effB)
+	}
+	// τ authority: both sides re-derived independently; they must converge
+	// on the same waypoint via the deterministic min-future-τ rule.
+	step()
+	step()
+	if !wa.RendezvousArm.Tau.Equal(wb.RendezvousArm.Tau) {
+		t.Errorf("waypoint τ did not converge: a=%v b=%v",
+			wa.RendezvousArm.Tau, wb.RendezvousArm.Tau)
+	}
+}
+
+// A waypoint advance re-bases the degrade baseline (#251 interaction):
+// without the reset, the new waypoint's approach is measured against the
+// PREVIOUS waypoint's coast-start baseline and instantly reads degraded.
+func TestRendezvousWaypointAdvanceRebasesDegrade(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Minute)
+	a := w.ActiveCraft()
+	peer := func(r, v orbital.Vec3, at time.Time) []CoWarpPeer {
+		return []CoWarpPeer{{
+			Owner: "SHA256:gern", Handle: "gern", SubspaceTime: at, EffWarp: 50,
+			ArmedTowardViewer: true, RendezvousTau: tau,
+			Crafts:            []CoWarpCraft{{Primary: primary, R: r, V: v}},
+		}}
+	}
+
+	// Coast starts against a coincident partner: baseline ≈ 0.
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	w.DriveRendezvousWarp(peer(a.State.R, a.State.V, st))
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+	if !w.RendezvousArm.degradeBaseSet {
+		t.Fatal("precondition: degrade baseline captured at coast start")
+	}
+
+	// τ reached with the partner now thousands of km out along-track (a
+	// future closest approach exists) → waypoint advances; the new
+	// waypoint's approach must become the NEW baseline, not a huge "drift"
+	// against the old ≈0 one.
+	mu := a.Primary.GravitationalParameter()
+	ahead, ok := physics.KeplerStep(physics.StateVector{R: a.State.R, V: a.State.V, M: 1}, mu, 735)
+	if !ok {
+		t.Fatal("kepler step failed placing the far partner")
+	}
+	w.Clock.SimTime = tau
+	w.DriveRendezvousWarp(peer(ahead.R, ahead.V.Scale(1.002), tau))
+	arm := w.RendezvousArm
+	if arm == nil || !arm.Tau.After(tau) {
+		t.Fatalf("waypoint did not advance (arm=%+v)", arm)
+	}
+	if w.RendezvousDegraded {
+		t.Error("advance read as a degraded encounter — baseline not re-based")
+	}
+	if arm.degradeBaseSet && arm.degradeBaseCA <= coWarpCoupleRangeM {
+		t.Errorf("degradeBaseCA = %v, want re-based to the new waypoint's approach (> couple range)",
+			arm.degradeBaseCA)
+	}
+}
+
+// A rendezvous flown as several maneuvers (waypoint after waypoint) keeps
+// both subspace clocks inside the same-subspace tolerance throughout, with
+// no Sync between maneuvers (#252 acceptance).
+func TestRendezvousMultiManeuverHoldsSubspaceTolerance(t *testing.T) {
+	wa, _, sta := anchorWorld(t)
+	wb, _, _ := anchorWorld(t)
+	aheadAlongTrack(t, wb)
+	tau := sta.Add(30 * time.Minute)
+	wa.EngageRendezvousWarp("SHA256:b", "b", tau, 5.4e6)
+	wb.EngageRendezvousWarp("SHA256:a", "a", tau, 5.4e6)
+
+	effA, effB := wa.EffectiveWarp(), wb.EffectiveWarp()
+	prevA, prevB := map[string]bool{}, map[string]bool{}
+	advances := 0
+	for guard := 0; guard < 30000 && advances < 3; guard++ {
+		pa := crossPeer(wb, "SHA256:b", "b", effB)
+		pb := crossPeer(wa, "SHA256:a", "a", effA)
+		wa.DriveRendezvousWarp(pa)
+		wb.DriveRendezvousWarp(pb)
+		ra, rb := wa.ComputeCoWarp(pa, prevA), wb.ComputeCoWarp(pb, prevB)
+		wa.CoWarp, wb.CoWarp = ra.State, rb.State
+		prevA, prevB = ra.CoupledOwners, rb.CoupledOwners
+		effA, effB = wa.EffectiveWarp(), wb.EffectiveWarp()
+
+		if wa.LastRendezvousWaypoint != nil || wb.LastRendezvousWaypoint != nil {
+			advances++
+			wa.LastRendezvousWaypoint, wb.LastRendezvousWaypoint = nil, nil
+		}
+		if wa.RendezvousArm == nil || wb.RendezvousArm == nil {
+			t.Fatalf("standing intent dropped mid-sequence after %d advances", advances)
+		}
+
+		// The tick loop's job, emulated: each side advances at its own
+		// resolved rate.
+		wa.Clock.SimTime = wa.Clock.SimTime.Add(time.Duration(effA * float64(wa.Clock.BaseStep)))
+		wb.Clock.SimTime = wb.Clock.SimTime.Add(time.Duration(effB * float64(wb.Clock.BaseStep)))
+		if d := wa.Clock.SimTime.Sub(wb.Clock.SimTime); d > CoWarpSubspaceTolerance || -d > CoWarpSubspaceTolerance {
+			t.Fatalf("subspace clocks diverged past tolerance mid-sequence: Δt=%v after %d advances", d, advances)
+		}
+	}
+	if advances < 3 {
+		t.Fatalf("only %d waypoint advances inside the tick budget — the coast is not sequencing maneuvers", advances)
 	}
 }
 

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -93,9 +93,10 @@ const (
 	// Rendezvous Warp moments (v0.29 S2) — all local-only: each side's
 	// serve wrapper derives them from its own World transitions.
 	SessionEventRendezvousArmed     // a partner armed toward you ("X wants to rendezvous")
-	SessionEventRendezvousArrived   // the shared coast reached τ ("rendezvous with X — encounter reached")
-	SessionEventRendezvousCancelled // the arm/coast was released before τ ("rendezvous with X cancelled")
+	SessionEventRendezvousArrived   // a waypoint arrived inside couple range — the proximity handoff ("rendezvous with X — encounter reached")
+	SessionEventRendezvousCancelled // the arm/coast was released by a cancel/retract ("rendezvous with X cancelled")
 	SessionEventRendezvousDegraded  // the held encounter slipped past the committed approach
+	SessionEventRendezvousWaypoint  // a waypoint passed outside couple range — the standing intent advanced (#252)
 
 	// SessionEventServerRestart announces an admin-triggered graceful
 	// restart to every connected player before the listener drains

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -210,12 +210,14 @@ type World struct {
 	CoWarp CoWarpState
 
 	// RendezvousArm is the viewer's outgoing Rendezvous Warp intent (v0.29
-	// S1, ADR 0034 v0.29 addendum): the partner Engaged toward and the
-	// committed encounter sim-time. Set by EngageRendezvousWarp, read by
-	// ComputeCoWarp for the mutual-arm couple trigger and by the serve
-	// layer to relay the intent. Transient like CoWarp/AutoWarp — never
-	// persisted, cleared on cancel/arrival/partner-disconnect; nil in
-	// single-player.
+	// S1, ADR 0034 v0.29 addendum; a standing mutual intent since #252):
+	// the partner Engaged toward and the CURRENT waypoint's encounter
+	// sim-time — it survives reaching τ, which only advances the waypoint.
+	// Set by EngageRendezvousWarp, read by ComputeCoWarp for the
+	// mutual-arm couple trigger and by the serve layer to relay the
+	// intent. Transient like CoWarp/AutoWarp — never persisted, cleared on
+	// cancel, on the proximity handoff at couple range, and on partner
+	// disconnect; nil in single-player.
 	RendezvousArm *RendezvousArm
 
 	// RendezvousInvite is the incoming half of the mutual arm (v0.29 S2):
@@ -268,10 +270,17 @@ type World struct {
 	// arrival chips. Transient, like LastDockEvent.
 	LastSyncArrival *SyncArrival
 
-	// LastRendezvousArrival is set when a Rendezvous Warp coast reaches the
-	// committed encounter τ (v0.29 S1) and cleared by the serve wrapper
+	// LastRendezvousArrival is set when a Rendezvous Warp coast reaches a
+	// waypoint inside proximity couple range — the handoff that ends the
+	// standing intent (v0.29 S1, #252) — and cleared by the serve wrapper
 	// after firing the arrival chip. Transient, like LastSyncArrival.
 	LastRendezvousArrival *RendezvousArrival
+
+	// LastRendezvousWaypoint is set when the coast reaches a waypoint
+	// OUTSIDE couple range and advances to a newly derived encounter
+	// (#252) — the intent continues. Consumed by the serve wrapper for
+	// the waypoint chip. Transient, like LastRendezvousArrival.
+	LastRendezvousWaypoint *RendezvousWaypoint
 
 	// CommGraph is the cached per-tick CommNet connectivity result (v0.23 /
 	// ADR 0027): which unmanned probes currently reach a ground station.
@@ -1192,6 +1201,16 @@ func (w *World) clampedWarp() float64 {
 			if selected > maxApproachWarp {
 				selected = maxApproachWarp
 			}
+		} else if w.AutoWarp.Rendezvous && selected > 1 {
+			// #252: a rendezvous coast survives its waypoint (standing
+			// intent), so T can sit at/behind SimTime for the tick(s)
+			// between the sim tick crossing it and the serve pass
+			// resolving it (handoff or advance) — and for as long as a
+			// waypoint re-derivation keeps coming up empty. Without a
+			// floor the approach ramp above no longer applies and the
+			// max-seed would fly the pair past an unresolved waypoint at
+			// the step cap; hold 1× until the waypoint resolves.
+			selected = 1
 		}
 	}
 	mu := w.ActiveCraft().Primary.GravitationalParameter()

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -158,6 +158,11 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			plain("◇ rendezvous: encounter reached — " + e.Handle + " alongside")
 		case sim.SessionEventRendezvousCancelled:
 			plain("◇ rendezvous with " + e.Handle + " cancelled")
+		case sim.SessionEventRendezvousWaypoint:
+			// #252: the standing intent passed an encounter outside couple
+			// range and re-aimed — the RENDEZVOUS chip carries the new τ/CA,
+			// this moment just says the advance was deliberate.
+			plain("◇ rendezvous: waypoint passed — coasting on with " + e.Handle)
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
 		case sim.SessionEventWentQuiet:


### PR DESCRIPTION
Stacked on #254 (`fix/248-coast-rate-deadlock`) — worthless without the min-wins exemption, per the plan's ordering.

## What

Implements the #252 agent brief (the issue-comment contract, superseding the issue body's three options): the Rendezvous Warp arm is no longer a commitment to one encounter that clears at τ — it is a **standing mutual intent** that survives τ, keeps the pair range-free-coupled and rate-locked through the whole multi-maneuver approach, and ends on exactly two conditions: **explicit cancel by either player** (unchanged) or **reaching proximity couple range**, where Proximity Co-Warp takes over (`wasCoupled` hysteresis carries the couple across — no drop-and-recouple tick) and the arm is released.

At τ, in the coast driver:
- **Inside the couple gate** (`closestApproach` + `coWarpCoupleRangeM`/`coWarpCoupleSpeedMs`, unchanged constants): today's arrival — 1×, `RendezvousArrival` chip, arm cleared, driver released.
- **Outside**: advance the waypoint — re-derive the next τ + CA, re-freeze `AutoWarp.T`, reset `degradeBaseSet` (per-waypoint re-baseline; the only degrade contact, keeping the PR D merge clean), and record the advance for a chip.

## Seam chosen for the at-τ resolution

`driveRendezvousCoast` (via a new `resolveRendezvousWaypoint`), **not** `resolveAutoWarp`: choosing handoff-vs-advance needs this tick's peer set (craft ranges for the couple gate, relayed τs for authority), which the sim-tick path never carries. `resolveAutoWarp`'s rendezvous case is now a documented no-op, and `clampedWarp` floors a past-τ rendezvous coast at 1× so the tick(s) between the sim tick crossing T and the serve pass resolving it can't race past an unresolved waypoint at the step cap. On a hosting tick the serve pass runs in the same `TickMsg`, so resolution latency is zero.

## Waypoint derivation

Reuses the Engage-time routine, both paths: when the target slot still holds the armed partner's ghost, `RendezvousCommit` verbatim (post-burn K-nudge advisory encounter → current-course CA fallback); otherwise a target-slot-independent fallback searching `planner.NextClosestApproach` over the partner's same-primary craft from the peer set (min over crafts, mirroring `rendezvousCAAtTau`). **A passive-flyby waypoint is a legitimate advance, not a failure.** No layering move was needed — the routine already lives in `internal/sim` (`rendezvous.go`); the brief's concern about it living above sim didn't materialize. A derivation that comes up empty is NOT a cancel: the coast idles at the 1× floor and retries each tick (the intent still only ends on cancel or handoff). A 5 s minimum lead guards against re-committing to a τ one tick away every tick.

## τ authority on advance

**Min-future-τ wins.** Each engaged tick, a partner-relayed `RendezvousTau` that is strictly in the future and earlier than ours (or ours is stale-past — the rescue case) is adopted, with CA, re-freezing T. Deterministic and identity-free — min is commutative + idempotent, so both sides converge on the same waypoint within one relay hop, no negotiation loop; the future-only guard ignores the partner's still-relayed *previous* τ right after an advance. Residual skew is absorbed by the 120 s tolerance + the hold, per the plan. Documented trade-off (rationale comment in `driveRendezvousCoast`): a deliberate mid-coast re-Engage to a *later* τ cannot win against the partner's earlier relayed τ — under a standing intent a waypoint is sequencing, not commitment.

## Waypoint-advance feedback

New `SessionEventRendezvousWaypoint` chip — `◇ rendezvous: waypoint passed — coasting on with <handle>` — via a `LastRendezvousWaypoint` transient consumed by the serve wrapper (mirroring `LastRendezvousArrival`). The persistent RENDEZVOUS chip already carries the new τ countdown + CA; the transient moment just makes the advance deliberate rather than silent. Touches `buildSessionEventsChip` only, not `buildRendezvousChip` (PR D's surface).

## Tests (red first)

- `TestRendezvousArmSurvivesTauOutsideCoupleRange` — two-world cross-fed (built on the #254 pattern), ~5,400 km at τ: arm survives, waypoint advances, pair stays coupled + above 1×, τs converge.
- `TestRendezvousWaypointAdvanceRebasesDegrade` — no instant degrade after advance; baseline re-bases to the new waypoint's measure.
- `TestRendezvousCoupleRangeHandoffAtTau` — replaces the old `resolveAutoWarp`-seam arrival test: 1×, arrival recorded, arm released, no drop-and-recouple tick.
- `TestRendezvousMultiManeuverHoldsSubspaceTolerance` — 3 waypoint cycles, both clocks inside the tolerance throughout, no Sync.
- `TestRendezvousWaypointChip` (serve) — the wrapper consumes the slate into the waypoint chip; never mis-chips as arrival/cancel.
- Existing cancel/retract/degrade/couple coverage unchanged and green (incl. `TestRendezvousArrivalChip`, whose coincident-partner arrival maps directly onto the new handoff path).

`go vet ./...` clean; `go test ./... -race -count=1` → 1767 passed; `go test ./internal/serve -race -count=3` → 360 passed.

## Also

- `CONTEXT.md` **Rendezvous Warp** entry rewritten to the standing-intent lifetime (the brief's owed doc change). The **Commitment**/**Reprieve** entries were left as-is: 'through to its committed TCA' now reads per-current-waypoint, which is what the serve reprieve (fed by the relayed τ) actually does; note that a reprieved away session that keeps advancing waypoints extends its Commitment — still bounded by `maxUnattendedReprieve`.
- Guardrails honoured: couple range/speed constants, tolerance, and the initial-encounter/nudge algorithms untouched; cross-primary rendezvous still gated upstream; degrade contact limited to the `degradeBaseSet` reset.

Fixes #252