### PR TITLE
fix(mp): toggle paths refuse during an engaged rendezvous coast (#259)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Closing the distance takes orbits of coasting, so warp there *together*:
 closest approach with them. They get a persistent prompt on their main screen —
 `y` joins — and from that moment your warps are rate-locked (slowest wins) all
 the way to the encounter, planted burns firing en route. Either side cancels
-with `/` — and only with `/`: the manual warp keys are inert while the
-coast runs (it owns the rate), so a stray `.` can't tear the rendezvous
-down. If the encounter drifts off the committed approach mid-coast, a
+with `/` — and only with `/`: the manual warp keys and the auto-warp
+toggle (`G` / `[»Burn]`) are inert while the coast runs (it owns the
+rate), so a stray `.` or `G` can't tear the rendezvous down. If the encounter drifts off the committed approach mid-coast, a
 warning chip says so. You arrive at closest approach at 1× — already coupled —
 and slide straight into the final approach.
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -101,7 +101,7 @@ readout shows you why before you watch it fall back.
 | `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
 | `0` | Pause / resume |
 | `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn). Inert while a rendezvous-warp coast is engaged — the coast owns the rate, and `/` is the one gesture that cancels it |
-| `G` | Auto-warp to the next burn — speeds time to 30 seconds before whichever burn fires first (any craft's), ramps back down, and hands you 1× to watch it arm. Tapping `.` / `,` cancels it back to your own warp; click the `[»Burn]` button to do the same |
+| `G` | Auto-warp to the next burn — speeds time to 30 seconds before whichever burn fires first (any craft's), ramps back down, and hands you 1× to watch it arm. Tapping `.` / `,` cancels it back to your own warp; click the `[»Burn]` button to do the same. Inert while a rendezvous-warp coast is engaged — like the warp keys, `/` is the one gesture that cancels the coast |
 | `/` | Cancel warp — drop straight back to 1× from any warp level, and cancel auto-warp or an armed/coasting rendezvous warp if one is running |
 
 ### Keyboard layout
@@ -195,7 +195,7 @@ Click only — no dragging, no scroll-to-zoom.
 
 | Click | Action |
 |---|---|
-| `[»Burn]` (top-right) | Toggle auto-warp to the next burn (same as `G`). Shows `[■Burn]` while running, dimmed when no burn is planned |
+| `[»Burn]` (top-right) | Toggle auto-warp to the next burn (same as `G`, including staying inert during a rendezvous-warp coast). Shows `[■Burn]` while running, dimmed when no burn is planned |
 | `[Menu]` (top-right) | Save / load / settings / controls / quit menu |
 | `[Missions]` (top-right) | Mission ladder — active mission checklist on top, the rest of the program below with locked rungs and pass / fail marks (same as `M`). Off by default; enable a program in `[Menu]` → Settings |
 | A body | Follow it with the camera (same as cursoring onto it) |

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -436,7 +436,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// v0.16 / ADR 0016: the [»Burn] button toggles Auto-Warp
 			// (click-equivalent of `G`). A no-op when no burn is eligible.
 			if a.orbitView.HitBurnButton(m.X, m.Y) {
-				a.world.ToggleAutoWarp()
+				a.toggleAutoWarpBurn()
 				return a, nil
 			}
 			// Framed navball panel is opaque and drawn over the
@@ -894,8 +894,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.AutoWarp):
 			// Toggle Auto-Warp to the globally-soonest burn. A no-op when
 			// no burn is eligible (engage returns false silently).
-			a.world.ToggleAutoWarp()
-			a.world.RecordAction(missions.ActionAutoWarp) // ADR 0025 §7
+			if a.toggleAutoWarpBurn() {
+				a.world.RecordAction(missions.ActionAutoWarp) // ADR 0025 §7
+			}
 			return a, nil
 		case key.Matches(m, a.keys.CancelWarp):
 			// Drop straight to 1× from any warp state: cancel Auto-Warp
@@ -1874,6 +1875,28 @@ func (a *App) applySavesCommand(cmd screens.SavesCommand) (tea.Model, tea.Cmd) {
 		}
 	}
 	return a, nil
+}
+
+// toggleAutoWarpBurn carries the shared intent behind the `G` key and
+// the mouse [»Burn] button: toggle Auto-Warp to the globally-soonest
+// burn. Reports whether the toggle ran.
+//
+// Except during an engaged Rendezvous Warp coast (#259, sibling of
+// #249): ToggleAutoWarp routes through DisengageAutoWarp, which must
+// clear the arm on every cancel path (or DriveRendezvousWarp restarts
+// the coast next tick), and the retraction travels the wire — so a
+// stray G / click silently tore down the rendezvous for BOTH players.
+// As with the warp keys (#256), the guard lives here at the input
+// layer, where the intent is known, and [/] stays the single
+// deliberate cancel gesture — the toggle paths refuse with a toast
+// instead. Plain node-chase / Sync Auto-Warp keeps today's toggle.
+func (a *App) toggleAutoWarpBurn() bool {
+	if a.world.RendezvousWarpEngaged() {
+		a.toast("rendezvous coast running — [/] to cancel")
+		return false
+	}
+	a.world.ToggleAutoWarp()
+	return true
 }
 
 // toast flashes a transient one-line notice in the HUD footer for ~3s

--- a/internal/tui/app_rendezvous_test.go
+++ b/internal/tui/app_rendezvous_test.go
@@ -214,3 +214,65 @@ func TestWarpKeysStillCancelPlainAutoWarp(t *testing.T) {
 		t.Errorf(", did not warp down: WarpIdx %d, want %d", w.Clock.WarpIdx, idx)
 	}
 }
+
+// Toggle paths during an engaged rendezvous coast (#259, sibling of
+// #249): `G` and the mouse [»Burn] button route through ToggleAutoWarp
+// → DisengageAutoWarp, which clears the arm and retracts it over the
+// wire — before the fix one tap silently cancelled the rendezvous for
+// BOTH players. Like the warp keys (#256), they refuse with a toast;
+// [/] stays the single deliberate cancel gesture.
+func TestToggleAutoWarpInertDuringRendezvousCoast(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+	tau := w.Clock.SimTime.Add(3 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", tau, 0)
+	w.AutoWarp = &sim.AutoWarpTarget{T: tau, Rendezvous: true, RendezvousOwner: "SHA256:guest", RendezvousHandle: "gern"}
+
+	// The G key.
+	a.statusMsg = ""
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if w.RendezvousArm == nil {
+		t.Fatal("G cleared the rendezvous arm")
+	}
+	if w.AutoWarp == nil || !w.AutoWarp.Rendezvous {
+		t.Fatalf("G disengaged the rendezvous coast (AutoWarp=%+v)", w.AutoWarp)
+	}
+	if !strings.Contains(a.statusMsg, "/") {
+		t.Errorf("G gave no feedback pointing at [/]: status %q", a.statusMsg)
+	}
+
+	// The mouse [»Burn] button shares the same handler — no mouse-event
+	// test seam exists (HitBurnButton needs a laid-out frame), so the
+	// shared handler is exercised directly.
+	a.statusMsg = ""
+	if a.toggleAutoWarpBurn() {
+		t.Error("toggleAutoWarpBurn reported the toggle ran during an engaged coast")
+	}
+	if w.RendezvousArm == nil {
+		t.Fatal("[»Burn] cleared the rendezvous arm")
+	}
+	if w.AutoWarp == nil || !w.AutoWarp.Rendezvous {
+		t.Fatalf("[»Burn] disengaged the rendezvous coast (AutoWarp=%+v)", w.AutoWarp)
+	}
+	if !strings.Contains(a.statusMsg, "/") {
+		t.Errorf("[»Burn] gave no feedback pointing at [/]: status %q", a.statusMsg)
+	}
+}
+
+// The refusal is scoped to the rendezvous coast: a plain node-chase
+// Auto-Warp keeps today's behavior, where G toggles the driver off.
+func TestToggleAutoWarpStillTogglesPlainAutoWarp(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+	w.AutoWarp = &sim.AutoWarpTarget{T: w.Clock.SimTime.Add(time.Hour)}
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if w.AutoWarp != nil {
+		t.Error("G left a plain node-chase Auto-Warp engaged")
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -80,7 +80,7 @@ var helpSections = []helpSection{
 	{"TIME & WARP", [][2]string{
 		{".", "warp up (1× … 100000×; inert during a rendezvous coast)"},
 		{",", "warp down (inert during a rendezvous coast — [/] cancels)"},
-		{"G", "auto-warp to 30 s before the next burn, then 1×"},
+		{"G", "auto-warp to 30 s before the next burn, then 1× (inert during a rendezvous coast)"},
 		{"y", "join a pending rendezvous warp (when a player arms toward you)"},
 		{"/", "cancel warp — drop to 1× (also cancels auto-warp / rendezvous warp)"},
 		{"0", "pause / resume"},
@@ -149,7 +149,7 @@ var helpSections = []helpSection{
 		{"click node", "open the planner for that node (canvas glyph or NODES row)"},
 		{"click empty", "open the planner at the projected orbit point"},
 		{"click HUD", "open body info"},
-		{"[»Burn]", "toggle auto-warp to the next burn (same as G); [■Burn] while running, dimmed when none planned"},
+		{"[»Burn]", "toggle auto-warp to the next burn (same as G, inert during a rendezvous coast); [■Burn] while running, dimmed when none planned"},
 	}},
 }
 


### PR DESCRIPTION
Closes #259. Sibling of #249 / PR #256 — same defect on the toggle paths.

## Mechanism

`G` (AutoWarp key) and the mouse `[»Burn]` button both called `ToggleAutoWarp()`, which routes an engaged driver through `DisengageAutoWarp()`. That must clear `RendezvousArm` on every cancel path (or `DriveRendezvousWarp` restarts the coast next tick), and the retraction travels the wire — so one stray tap silently cancelled an engaged rendezvous coast for **both** players, with no toast.

## Fix (option 1 from the issue)

Refuse-with-toast, consistent with PR #256's design where `/` stays the single deliberate cancel gesture:

- New shared `App.toggleAutoWarpBurn()` in `internal/tui/app.go` carries the intent behind both the `G` key and the `[»Burn]` click. While `RendezvousWarpEngaged()` it toasts `rendezvous coast running — [/] to cancel` and refuses; otherwise it toggles as before.
- The guard lives at the input layer where intent is known — `ToggleAutoWarp` / `DisengageAutoWarp` bodies are unchanged, same rationale-comment pattern as #256's warp-key guard.
- Plain node-chase / Sync auto-warp keeps today's toggle behavior. The `G` handler's mission `RecordAction(ActionAutoWarp)` now fires only when the toggle actually ran.

**Mouse path note:** no mouse-event test seam exists in the tui package (`HitBurnButton` needs a laid-out frame), so the click handler was rewired onto the shared `toggleAutoWarpBurn` and the shared handler is exercised directly in the test — the guard is common to both entry points by construction.

## Docs

Extended PR #256's inert-during-coast note from `.`/`,` to `G` / `[»Burn]` in the F1 help overlay (`internal/tui/screens/help.go`), `README.md`, and `docs/controls.md`.

## Tests (red-first)

- `TestToggleAutoWarpInertDuringRendezvousCoast` — engaged coast + `G`: arm intact, coast intact (AutoWarp still Rendezvous), toast points at `[/]`; same assertions against `toggleAutoWarpBurn()` directly for the `[»Burn]` path.
- `TestToggleAutoWarpStillTogglesPlainAutoWarp` — plain node-chase auto-warp + `G` still toggles off.
- `go vet ./...` clean; `go test ./... -race -count=1`: 1800 passed in 19 packages.