### PR TITLE
fix(mp): stop blaming the partner while the viewer's own Auto-Warp defers the coast (#260)

### DIFF
--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -271,6 +271,11 @@ const (
 	// CoWarpSubspaceTolerance, so the coast cannot start no matter what
 	// the partner does — Sync is the only way back.
 	RendezvousWaitSubspaceGap
+	// RendezvousWaitSelf: the partner HAS armed back, but the viewer's
+	// own non-rendezvous Auto-Warp (a Sync or node-chase) is engaged —
+	// driveRendezvousCoast defers the coast start rather than clobber it
+	// (#260), so the wait is the viewer's own doing, not the partner's.
+	RendezvousWaitSelf
 )
 
 // RendezvousWait is the classified armed-but-not-coasting slate (#250):
@@ -299,6 +304,21 @@ func (w *World) refreshRendezvousWait(peers []CoWarpPeer) {
 		p := &peers[i]
 		if p.Owner != arm.TargetOwner {
 			continue
+		}
+		// Own-driver deferral (#260): the partner HAS armed back, but the
+		// viewer's own Sync or node-chase holds the driver, so
+		// driveRendezvousCoast defers the coast start. The predicate is an
+		// exact mirror of that don't-clobber branch (partner armed back +
+		// `w.AutoWarp != nil` with the coast not engaged), so the
+		// classifier can never disagree with the driver. Checked BEFORE
+		// the gap — also mirroring the driver's order — because Self is
+		// the actionable reason: the player must release their own driver
+		// first regardless, and that driver may be the very Sync that is
+		// closing the gap ("Sync to rejoin" while already Syncing would
+		// be nonsense advice).
+		if p.ArmedTowardViewer && w.AutoWarp != nil && !w.AutoWarp.Rendezvous {
+			w.RendezvousWait = RendezvousWait{Reason: RendezvousWaitSelf}
+			return
 		}
 		if !sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
 			w.RendezvousWait = RendezvousWait{

--- a/internal/sim/rendezvous_precouple_test.go
+++ b/internal/sim/rendezvous_precouple_test.go
@@ -101,6 +101,86 @@ func TestRendezvousWaitPartnerAbsent(t *testing.T) {
 	}
 }
 
+// #260: with the partner armed back but the viewer's own Sync engaged,
+// driveRendezvousCoast defers the coast start (the don't-clobber rule) —
+// the classification must be RendezvousWaitSelf, not Partner: the partner
+// did join, and the wait is the viewer's own driver. Once that driver
+// releases, the deferred coast starts on the next drive tick.
+func TestRendezvousWaitSelfWhileOwnDriverDefers(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	peer := armPeer(w, primary, st, 50, "gern") // partner HAS armed back
+	peer.RendezvousTau = tau
+	w.RendezvousArm = &RendezvousArm{TargetOwner: peer.Owner, Handle: "gern", Tau: tau}
+	if !w.EngageSyncWarp(st.Add(time.Hour), "SHA256:vex", "vex") {
+		t.Fatal("Sync refused")
+	}
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.RendezvousWarpEngaged() {
+		t.Fatal("coast clobbered the engaged Sync")
+	}
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitSelf || got.AheadBy != 0 {
+		t.Fatalf("Wait = %+v, want RendezvousWaitSelf (own driver defers, partner joined)", got)
+	}
+
+	// Own driver releases → the deferred coast starts, wait slate clears.
+	w.DisengageAutoWarp()
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.RendezvousWarpEngaged() {
+		t.Fatal("coast did not start after the own driver released")
+	}
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitNone {
+		t.Errorf("Wait = %+v after the coast started, want RendezvousWaitNone", got)
+	}
+}
+
+// #260 precedence: an own-driver deferral ALSO across a subspace gap
+// classifies Self, mirroring the driver's order (the don't-clobber check
+// runs before the same-subspace gate) — the player must release their own
+// driver first regardless, and that driver may be the very Sync that is
+// closing the gap. Once it releases, the gap becomes the live reason.
+func TestRendezvousWaitSelfWinsOverGapUntilRelease(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(72 * time.Hour)
+	gap := gapDuration()
+	peer := armPeer(w, primary, st.Add(-gap), 50, "gern") // armed back, viewer ahead
+	peer.RendezvousTau = tau
+	w.RendezvousArm = &RendezvousArm{TargetOwner: peer.Owner, Handle: "gern", Tau: tau}
+	w.AutoWarp = &AutoWarpTarget{T: st.Add(time.Hour)} // an engaged node-chase
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitSelf || got.AheadBy != 0 {
+		t.Fatalf("Wait = %+v, want Self winning over the gap while the own driver defers", got)
+	}
+
+	// Driver released, gap still open → the gap is now the reason.
+	w.DisengageAutoWarp()
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitSubspaceGap || got.AheadBy != gap {
+		t.Errorf("Wait = %+v after release across the gap, want gap with AheadBy=+%v", got, gap)
+	}
+}
+
+// #260 mirror bound: without the partner armed back there is no deferral —
+// the driver's don't-clobber branch never runs — so an engaged own driver
+// must NOT flip the classification away from Partner: releasing it would
+// not start the coast, the partner genuinely hasn't joined.
+func TestRendezvousWaitPartnerStillBlamedWhenNotArmedBack(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	peer := armPeer(w, primary, st, 50, "gern")
+	peer.ArmedTowardViewer = false // partner hasn't Engaged back
+	w.RendezvousArm = &RendezvousArm{TargetOwner: peer.Owner, Handle: "gern", Tau: st.Add(72 * time.Hour)}
+	if !w.EngageSyncWarp(st.Add(time.Hour), "SHA256:vex", "vex") {
+		t.Fatal("Sync refused")
+	}
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if got := w.RendezvousWait; got.Reason != RendezvousWaitPartner {
+		t.Errorf("Wait = %+v with the partner not armed back, want Partner", got)
+	}
+}
+
 // The responder side of #250: an out-of-window invite is kept and
 // exposed as Blocked (with the signed Δt) rather than silently dropped,
 // and becomes joinable again when the pair converges. A past-τ arm is

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -269,7 +269,8 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 	case w.RendezvousArm != nil:
 		arm := w.RendezvousArm
 		status := v.theme.Warning.Render("  armed → " + arm.Handle + " — waiting for them to join")
-		if wt := w.RendezvousWait; wt.Reason == sim.RendezvousWaitSubspaceGap {
+		switch wt := w.RendezvousWait; wt.Reason {
+		case sim.RendezvousWaitSubspaceGap:
 			// #250: "waiting for them to join" would blame the partner for
 			// a gap the viewer (or the partner) warped open — name who is
 			// ahead and the actual fix instead. Sync is forward-only, so
@@ -281,6 +282,11 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 				fix = "Sync to rejoin"
 			}
 			status = v.theme.Alert.Render("  cannot couple — " + who + " — " + fix)
+		case sim.RendezvousWaitSelf:
+			// #260: same misattribution family — the partner DID join, and
+			// the viewer's own Sync or node-chase is what defers the coast.
+			// Own the wait instead of blaming them or advising a Sync.
+			status = v.theme.Warning.Render("  your Auto-Warp is running — coast starts when it releases")
 		}
 		return []string{
 			v.theme.Primary.Render("RENDEZVOUS"),

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -104,6 +104,37 @@ func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
 	}
 }
 
+// #260: while the viewer's own Sync or node-chase defers the coast start
+// (RendezvousWaitSelf), the armed chip must own the wait — name the
+// viewer's running Auto-Warp — and neither blame the partner ("waiting
+// for them to join") nor reach for the gap vocabulary (Sync-to-rejoin):
+// the partner already joined, and no Sync is owed.
+func TestRendezvousChipArmedWaitSelf(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", w.Clock.SimTime.Add(2*time.Hour), 900)
+	w.RendezvousWait = sim.RendezvousWait{Reason: sim.RendezvousWaitSelf}
+
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, want := range []string{
+		"RENDEZVOUS",
+		"your Auto-Warp is running — coast starts when it releases",
+		"[/] cancel",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("wait-self chip missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "waiting for them to join") {
+		t.Errorf("wait-self chip still blames the partner:\n%s", joined)
+	}
+	for _, gapism := range []string{"Sync to rejoin", "they must Sync to you", "cannot couple"} {
+		if strings.Contains(joined, gapism) {
+			t.Errorf("wait-self chip borrows the gap wording %q:\n%s", gapism, joined)
+		}
+	}
+}
+
 // #250 responder side: a blocked (subspace-gapped) invite renders as a
 // dimmed attribution with the [y] join affordance suppressed, instead
 // of vanishing. The Sync advice is direction-aware (forward-only): a


### PR DESCRIPTION
## Mechanism

With a mutual arm in place but the viewer running their own Sync or node-chase, `driveRendezvousCoast` defers the coast start (the don't-clobber rule: the player's explicit Auto-Warp wins). `refreshRendezvousWait` never checked for that deferral, so the armed state fell through to `RendezvousWaitPartner` — the chip said *waiting for them to join* even though the partner HAD armed back, indefinitely until the viewer's own driver released. Same misattribution family as #250/#251.

## Fix

- New `RendezvousWaitSelf` reason (appended to the enum — the #255 enum-plus-data shape stays extensible for #221). Chosen when the partner has armed back AND `w.AutoWarp != nil && !w.AutoWarp.Rendezvous` — an exact mirror of the driver's don't-clobber predicate, so the classifier can never disagree with the driver about why the coast hasn't started.
- **Precedence: Self wins over SubspaceGap**, mirroring the driver's own order (the clobber check runs before the same-subspace gate). Rationale in the code comment: the player must release their own driver first regardless, and that driver may be the very Sync that is closing the gap — rendering *Sync to rejoin* while already Syncing would be nonsense advice. Without the partner armed back there is no deferral, so an engaged own driver does NOT displace Partner/Gap (releasing it wouldn't start the coast).
- Armed chip renders the new reason as `your Auto-Warp is running — coast starts when it releases` (Warning, not Alert — self-inflicted and benign): owns the wait, no partner blame, no Sync advice.

## Tests (red-first on main)

- `TestRendezvousWaitSelfWhileOwnDriverDefers` — arm + partner armed back + own Sync → `RendezvousWaitSelf` (was Partner on main); driver releases → coast starts, wait clears.
- `TestRendezvousWaitSelfWinsOverGapUntilRelease` — Self + gap → Self (was SubspaceGap on main); after release → SubspaceGap with the signed AheadBy.
- `TestRendezvousWaitPartnerStillBlamedWhenNotArmedBack` — pins the mirror bound: own driver without a joined partner stays Partner.
- `TestRendezvousChipArmedWaitSelf` — new line renders; asserts no *waiting for them to join*, no *Sync to rejoin* / *they must Sync to you* / *cannot couple*.

`go vet ./...` clean; `go test ./... -race -count=1` → 1802 passed in 19 packages; `go test ./internal/serve -race -count=3` → 369 passed. All pre-existing wait/chip tests green.

Closes #260