### PR TITLE
fix(mp): gate ghost-path waypoint derivation on shared primary (#261)

### DIFF
--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -138,6 +138,20 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	if active == nil || !w.HasRelativeTarget() {
 		return time.Time{}, 0, false
 	}
+	// Shared-primary gate (#261): the fallback below Kepler-propagates the
+	// target's state around the ACTIVE craft's primary. For a target
+	// orbiting another body, TargetStateRelativeToActivePrimary happily
+	// converts via inertial — but the converted state is not on a conic
+	// around this primary, so a closest approach found on it is
+	// dynamically meaningless. Gate on primary IDENTITY (the same signal
+	// rendezvousNextWaypoint's peer-set fallback filters on, c.Primary ==
+	// active.Primary.ID), never on state math: refusing here lets the
+	// standing intent (#252) fall through to the same-primary peer-set
+	// search and, when that too is empty, to idle-and-retry with the
+	// degrade warning up (armedPartnerLacksLocalCraft).
+	if primary, pok := w.rendezvousTargetPrimary(); !pok || primary.ID != active.Primary.ID {
+		return time.Time{}, 0, false
+	}
 	rT, vT, rok := w.TargetStateRelativeToActivePrimary()
 	if !rok {
 		return time.Time{}, 0, false

--- a/internal/sim/rendezvous_cross_primary_test.go
+++ b/internal/sim/rendezvous_cross_primary_test.go
@@ -1,0 +1,112 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// ghostShapedLike builds a ghost whose CONVERTED viewer-frame state (what
+// TargetStateRelativeToActivePrimary returns) reproduces exactly the given
+// active-primary-relative (r, v) — regardless of which body claims
+// provenance. That isolates the #261 gate: identical geometry, different
+// primary identity, so an ok/refuse flip can only come from the identity
+// check, never from the state math.
+func ghostShapedLike(w *World, provenance bodies.CelestialBody, r, v orbital.Vec3, owner, handle string, craftID uint64) Ghost {
+	active := w.ActiveCraft()
+	return Ghost{
+		Owner:     owner,
+		Handle:    handle,
+		CraftID:   craftID,
+		Name:      "Remote",
+		PrimaryID: provenance.ID,
+		Pos:       w.BodyPosition(active.Primary).Add(r),
+		Vel:       w.bodyInertialVelocity(active.Primary).Add(v).Sub(w.bodyInertialVelocity(provenance)),
+	}
+}
+
+// otherBody returns any body in the active system that is not the active
+// craft's primary — the provenance for a partner who burned out of the
+// shared SOI.
+func otherBody(t *testing.T, w *World) bodies.CelestialBody {
+	t.Helper()
+	primaryID := w.ActiveCraft().Primary.ID
+	for _, b := range w.System().Bodies {
+		if b.ID != primaryID {
+			return b
+		}
+	}
+	t.Fatal("no second body in the system to stage a cross-primary ghost")
+	return bodies.CelestialBody{}
+}
+
+// RendezvousCommit's current-course fallback must not manufacture an
+// encounter from a cross-primary target (#261): the converted state is not
+// on a conic around the viewer's primary, so a closest approach
+// Kepler-propagated there is dynamically meaningless. Gate on primary
+// identity — the same signal the peer-set fallback already filters on.
+//
+// The control (same LEO shape, same-primary provenance) pins that the
+// refusal is the identity gate, not the geometry failing to close.
+func TestRendezvousCommitCrossPrimaryGhostRefuses(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	sister := w.Crafts[1]
+
+	// Control: the sister's LEO shape with same-primary provenance commits.
+	same := ghostShapedLike(w, w.ActiveCraft().Primary, sister.State.R, sister.State.V,
+		"SHA256:gern", "gern", 77)
+	w.Ghosts = []Ghost{same}
+	w.SetTargetGhost(same.Owner, same.CraftID)
+	if _, _, ok := w.RendezvousCommit(); !ok {
+		t.Fatal("control: same-primary ghost with the sister's LEO shape did not commit")
+	}
+
+	// Same converted geometry, cross-primary provenance: refuse.
+	cross := ghostShapedLike(w, otherBody(t, w), sister.State.R, sister.State.V,
+		"SHA256:gern", "gern", 77)
+	w.Ghosts = []Ghost{cross}
+	if tau, _, ok := w.RendezvousCommit(); ok {
+		t.Errorf("RendezvousCommit committed τ=%v against a cross-primary ghost — "+
+			"a viewer-primary-propagated encounter with wrong dynamics (#261)", tau)
+	}
+}
+
+// The standing intent's mid-coast re-derivation (#252) must idle-and-retry
+// when the armed partner has left the shared SOI, not adopt a bogus
+// waypoint via the ghost path: the ghost path reuses RendezvousCommit,
+// whose fallback would otherwise propagate the partner's converted state
+// around the VIEWER's primary. With the ghost path gated, derivation falls
+// through to the peer-set search — which already filters same-primary —
+// finds nothing, and reports not-found (the coast idles at the 1× floor).
+func TestRendezvousNextWaypointCrossPrimaryPartnerIdles(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	sister := w.Crafts[1]
+	other := otherBody(t, w)
+
+	cross := ghostShapedLike(w, other, sister.State.R, sister.State.V,
+		"SHA256:gern", "gern", 77)
+	w.Ghosts = []Ghost{cross}
+	w.SetTargetGhost(cross.Owner, cross.CraftID)
+
+	partner := &CoWarpPeer{
+		Owner: "SHA256:gern", Handle: "gern", SubspaceTime: w.Clock.SimTime,
+		ArmedTowardViewer: true,
+		Crafts:            []CoWarpCraft{{Primary: other.ID, R: sister.State.R, V: sister.State.V}},
+	}
+	if tau, _, ok := w.rendezvousNextWaypoint(partner); ok {
+		t.Errorf("derived a waypoint (τ=%v) from a partner outside the shared SOI — "+
+			"the ghost path leaked past the primary gate (#261)", tau)
+	}
+
+	// Control: the same partner back in the shared SOI derives again — the
+	// idle above is the identity gate, not the geometry.
+	same := ghostShapedLike(w, w.ActiveCraft().Primary, sister.State.R, sister.State.V,
+		"SHA256:gern", "gern", 77)
+	w.Ghosts = []Ghost{same}
+	partner.Crafts[0].Primary = w.ActiveCraft().Primary.ID
+	if _, _, ok := w.rendezvousNextWaypoint(partner); !ok {
+		t.Error("control: same-primary partner failed to derive a waypoint — " +
+			"geometry, not the gate, is failing this test")
+	}
+}


### PR DESCRIPTION
## Mechanism

`RendezvousCommit`'s current-course fallback ran `NextClosestApproach` on `TargetStateRelativeToActivePrimary`'s cross-primary-converted state, Kepler-propagated around the **viewer's** primary (`active.Primary` + its mu) — wrong dynamics for a partner who burned out of the shared SOI: the converted state is not on a conic around the viewer's primary, so any closest approach found on it is dynamically meaningless. Only the peer-set fallback in `rendezvousNextWaypoint` filtered `c.Primary == active.Primary.ID`.

Pre-existing at Engage, but #252 extended the routine to unattended, repeated mid-coast re-derivation: a partner departing the shared SOI could yield bogus waypoints through the ghost path instead of the intended idle-and-retry. ADR 0034 gates cross-primary rendezvous out upstream — this closes the leak.

## Fix

Gate the fallback on primary **identity**, not state math: `rendezvousTargetPrimary()` (already resolves both a local craft target and a ghost's SOI primary) compared by `primary.ID != active.Primary.ID` — the exact signal the peer-set filter uses. On mismatch `RendezvousCommit` reports ok=false, so:

- the ghost path in `rendezvousNextWaypoint` falls through to the same-primary peer-set search;
- when that finds nothing either, the existing idle-and-retry in `resolveRendezvousWaypoint` holds the coast at the 1× floor, with the degrade warning kept up by `armedPartnerLacksLocalCraft` (existing coverage `TestRendezvousDegradeCrossPrimaryWarns`, unchanged).

No cross-frame comparison introduced; `internal/orbital/frame.go` untouched.

**Engage-time behavior tightens too** (intentionally): the Session screen's `SessionCmdRendezvous` handler calls the same `RendezvousCommit`, so initiating toward a cross-primary ghost now refuses with the existing "no closable encounter" toast instead of arming on a bogus τ. No separate screen-level checks added — `RendezvousCommit`'s doc comment already promised ok=false for cross-primary; the code just leaked.

## Test evidence

New `internal/sim/rendezvous_cross_primary_test.go`, red-first on main. Both tests build a ghost whose **converted** viewer-frame state is bit-identical to a known-good same-primary LEO scenario, differing only in primary provenance — so the ok/refuse flip can only come from the identity gate, never the geometry:

- `TestRendezvousCommitCrossPrimaryGhostRefuses` — Engage-time path. Red on main: committed τ against a cross-primary ghost. Green with fix; same-primary control still commits.
- `TestRendezvousNextWaypointCrossPrimaryPartnerIdles` — standing-intent re-derivation with the partner's peer craft also cross-primary. Red on main: derived a waypoint via the ghost path. Green with fix (reports not-found → idle-and-retry); same-primary control still derives.

Suite: `go vet ./...` clean; `go test ./... -race -count=1` all green; `go test ./internal/serve -race -count=3` green (41.5s).

Closes #261
