### PR TITLE
feat(mp): server-side chat ring beside presence (ADR 0035 S1)

### DIFF
--- a/internal/serve/chat.go
+++ b/internal/serve/chat.go
@@ -1,0 +1,66 @@
+package serve
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// chatRing holds the transient chat lines (ADR 0035 §1): a capped ring
+// separate from presence.events, so a chat flood can never evict
+// join/leave/sync moments, and so the sender sees their own lines
+// without weakening eventsFor's deliberate own-event exclusion.
+// Sessions post from their own goroutines; readers copy under the lock.
+type chatRing struct {
+	mu    sync.Mutex
+	lines []sim.ChatLine
+}
+
+// chatLineCap bounds the ring. Sized so the 3–4 visible lines a chip
+// stack shows can never miss during cross-traffic; eviction only drops
+// lines already far older than the display TTL.
+const chatLineCap = 32
+
+// chatMessageRuneCap bounds one message. The mint input's 24 is far too
+// short for "node is 200m off, burning in 30" (ADR 0035 impl. note).
+const chatMessageRuneCap = 120
+
+func newChatRing() *chatRing {
+	return &chatRing{}
+}
+
+// post appends a line, truncating to chatMessageRuneCap runes and
+// trimming the ring. to/toHandle address a DM (empty = broadcast).
+// Roster validation happens in the intent handler, which owns store and
+// presence access — the ring is storage.
+func (c *chatRing) post(owner, handle, to, toHandle, text string) {
+	if r := []rune(text); len(r) > chatMessageRuneCap {
+		text = string(r[:chatMessageRuneCap])
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, sim.ChatLine{
+		Owner: owner, Handle: handle, To: to, ToHandle: toHandle,
+		Text: text, At: time.Now(),
+	})
+	if len(c.lines) > chatLineCap {
+		c.lines = c.lines[len(c.lines)-chatLineCap:]
+	}
+}
+
+// linesFor copies the lines the viewer may see: every broadcast, plus
+// DMs they sent or received. Unlike presence.eventsFor, the viewer's
+// own lines are included — in chat you must see what you said.
+func (c *chatRing) linesFor(viewer string) []sim.ChatLine {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []sim.ChatLine
+	for _, l := range c.lines {
+		if l.To != "" && l.To != viewer && l.Owner != viewer {
+			continue // a DM between two other players
+		}
+		out = append(out, l)
+	}
+	return out
+}

--- a/internal/serve/chat_test.go
+++ b/internal/serve/chat_test.go
@@ -1,0 +1,95 @@
+package serve
+
+import (
+	"strings"
+	"testing"
+)
+
+// ADR 0035 §1: chat lives in its own capped ring beside presence, so a
+// chat flood can never evict join/leave/sync moments — and so the
+// viewer's own lines are visible without weakening eventsFor's
+// deliberate own-event exclusion.
+
+func TestChatRingOwnLinesVisible(t *testing.T) {
+	c := newChatRing()
+	c.post("fpA", "alice", "", "", "burning in 30")
+	lines := c.linesFor("fpA")
+	if len(lines) != 1 {
+		t.Fatalf("sender must see their own line (ADR 0035: 'you must see what you said'); got %d lines", len(lines))
+	}
+	if lines[0].Text != "burning in 30" || lines[0].Handle != "alice" {
+		t.Fatalf("line mangled: %+v", lines[0])
+	}
+}
+
+func TestChatRingBroadcastVisibleToAll(t *testing.T) {
+	c := newChatRing()
+	c.post("fpA", "alice", "", "", "node is 200m off")
+	for _, viewer := range []string{"fpA", "fpB", "fpC"} {
+		if got := c.linesFor(viewer); len(got) != 1 {
+			t.Fatalf("broadcast must reach %s; got %d lines", viewer, len(got))
+		}
+	}
+}
+
+func TestChatRingDMVisibility(t *testing.T) {
+	c := newChatRing()
+	c.post("fpA", "alice", "fpB", "bob", "hold your burn")
+	if got := c.linesFor("fpA"); len(got) != 1 {
+		t.Fatalf("DM sender must see their own line; got %d", len(got))
+	}
+	if got := c.linesFor("fpB"); len(got) != 1 {
+		t.Fatalf("DM recipient must see the line; got %d", len(got))
+	}
+	if got := c.linesFor("fpC"); len(got) != 0 {
+		t.Fatalf("a DM must never reach a third party; got %d lines", len(got))
+	}
+	// The recipient needs the sender's handle; the sender's own echo
+	// needs the target handle for the visibly-distinct "→bob:" render.
+	if l := c.linesFor("fpB")[0]; l.Handle != "alice" || l.ToHandle != "bob" {
+		t.Fatalf("DM handles mangled: %+v", l)
+	}
+}
+
+func TestChatRingCapEvictsOldest(t *testing.T) {
+	c := newChatRing()
+	for i := 0; i < chatLineCap+8; i++ {
+		c.post("fpA", "alice", "", "", strings.Repeat("x", i%9+1))
+	}
+	lines := c.linesFor("fpB")
+	if len(lines) != chatLineCap {
+		t.Fatalf("ring must trim to chatLineCap=%d; got %d", chatLineCap, len(lines))
+	}
+	// The survivor set is the newest cap-many posts, oldest first.
+	if lines[0].Text == "x" {
+		t.Fatalf("oldest lines must be evicted, ring still starts at the first post")
+	}
+}
+
+func TestChatRingTextRuneCap(t *testing.T) {
+	c := newChatRing()
+	// Multibyte runes: a byte-based truncation would split one in half.
+	long := strings.Repeat("ü", chatMessageRuneCap+40)
+	c.post("fpA", "alice", "", "", long)
+	got := c.linesFor("fpA")[0].Text
+	if n := len([]rune(got)); n != chatMessageRuneCap {
+		t.Fatalf("text must truncate to %d runes; got %d", chatMessageRuneCap, n)
+	}
+	if !strings.HasPrefix(long, got) {
+		t.Fatalf("truncation must be rune-safe (prefix of the original)")
+	}
+}
+
+func TestChatRingIndependentOfPresence(t *testing.T) {
+	// The whole point of the separate ring: chat volume must not evict
+	// presence moments, and presence filtering rules must not leak in.
+	p := newPresence()
+	c := newChatRing()
+	p.event(0, "fpA", "alice", "")
+	for i := 0; i < chatLineCap*2; i++ {
+		c.post("fpA", "alice", "", "", "spam")
+	}
+	if got := p.eventsFor("fpB"); len(got) != 1 {
+		t.Fatalf("chat flood must never evict presence events; got %d", len(got))
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -83,6 +83,7 @@ type Server struct {
 	relay    *relay.Store
 	dock     *relay.DockLedger
 	presence *presence
+	chat     *chatRing
 
 	// ver is the running-vs-available version readout (v0.30 S5). Created
 	// here (no network — just the running version + adopt-capability env);
@@ -171,7 +172,7 @@ func New(cfg Config) (*Server, error) {
 	}
 	srv := &Server{
 		store: store, relay: relay.NewStore(), dock: relay.NewDockLedger(),
-		presence: newPresence(), ver: newVersionSurface(),
+		presence: newPresence(), chat: newChatRing(), ver: newVersionSurface(),
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
 		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter,
 		away: newAwayWatch(), mail: newAwayMail(), admit: newAdmission(),

--- a/internal/sim/chat.go
+++ b/internal/sim/chat.go
@@ -1,0 +1,23 @@
+package sim
+
+import "time"
+
+// ChatLine is one transient chat message (ADR 0035). Same contract as
+// SessionEvent: serve-written, read by screens, never persisted, absent
+// in single-player. Chat is a live co-op coordination tool — lines die
+// with the server process and are stamped in wall clock, never sim time
+// (players hold independent subspace times, so no sim stamp is
+// displayable).
+type ChatLine struct {
+	Owner  string // sender fingerprint — filtering only, never rendered
+	Handle string // sender handle, as rendered
+	Text   string
+
+	// To addresses a DM at one player (fingerprint); empty = broadcast.
+	// ToHandle carries the target's handle so the sender's own echo can
+	// render the visibly-distinct "→handle:" form.
+	To       string
+	ToHandle string
+
+	At time.Time // wall clock: chat expires by real seconds regardless of warp
+}


### PR DESCRIPTION
First slice of v0.32 (ADR 0035 — in-game player chat, transient co-op coordination).

## What

- `sim.ChatLine` — transient chat line, same contract as `SessionEvent` (serve-written, wall-clock stamped, never persisted, absent single-player). Carries `ToHandle` so a DM sender's own echo can render the visibly-distinct `→handle:` form.
- `serve.chatRing` — capped ring **separate from** `presence.events` (ADR 0035 §1): a chat flood can never evict join/leave/sync moments, and `linesFor(viewer)` includes the viewer's own lines without weakening `eventsFor`'s deliberate own-event exclusion.
- 120-rune message cap (`chatMessageRuneCap`), truncation rune-safe.
- Ring wired into `Server` construction.

## What's next (not this PR)

S2 intent plumbing (App → serve wrapper message, `SessionAdminMsg` precedent, roster validation for DMs), S3 `~` input overlay + `capturingText()` arm, S4 chip builder.

## Tests

TDD red-first: `chat_test.go` — own-line visibility, broadcast reach, DM three-party filtering, cap eviction, rune-safe truncation, presence-ring independence. Full suite `-race -count=1` green (1812/19 pkgs); `internal/serve` `-race -count=3` green.

Plan: designdocs `v0.32-plan.md` (41647fb).