### PR TITLE
feat(mp): chat intent plumbing App→serve (ADR 0035 S2)

### DIFF
--- a/internal/serve/chat_intent_test.go
+++ b/internal/serve/chat_intent_test.go
@@ -1,0 +1,131 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// ADR 0035 S2: chat intent travels App → serve wrapper as a message
+// (SessionAdminMsg precedent) — the screen never touches shared state.
+
+func newHostModel(t *testing.T, srv *Server) (tea.Model, *tui.App) {
+	t.Helper()
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	return srv.HostModel(hostApp), hostApp
+}
+
+func TestChatSendPostsToRing(t *testing.T) {
+	srv := newOfflineServer(t)
+	m, _ := newHostModel(t, srv)
+
+	m, _ = m.Update(tui.ChatSendMsg{Text: "burning in 30"})
+	_ = m
+
+	lines := srv.chat.linesFor("SHA256:other")
+	if len(lines) != 1 || lines[0].Text != "burning in 30" {
+		t.Fatalf("broadcast must land in the ring; got %+v", lines)
+	}
+	if lines[0].Owner != sessiondir.HostFingerprint {
+		t.Fatalf("owner must be the sender's fingerprint; got %q", lines[0].Owner)
+	}
+	// The handle renders — it must be the roster handle, not the raw
+	// fingerprint.
+	if lines[0].Handle == "" || lines[0].Handle == sessiondir.HostFingerprint {
+		t.Fatalf("handle must resolve through the roster; got %q", lines[0].Handle)
+	}
+}
+
+func TestChatSendDMToOfflineHandleRefused(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern") // enrolled but NOT online
+	m, _ := newHostModel(t, srv)
+
+	m, _ = m.Update(tui.ChatSendMsg{Text: "you there?", To: "SHA256:gern", ToHandle: "gern"})
+	_ = m
+
+	if lines := srv.chat.linesFor("SHA256:gern"); len(lines) != 0 {
+		t.Fatalf("a DM to an offline player must be refused at the handler (defense in depth); got %+v", lines)
+	}
+}
+
+func TestChatSendDMToOnlinePlayerLands(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern")
+	m, _ := newHostModel(t, srv)
+
+	m, _ = m.Update(tui.ChatSendMsg{Text: "hold your burn", To: "SHA256:gern", ToHandle: "gern"})
+	_ = m
+
+	if lines := srv.chat.linesFor("SHA256:gern"); len(lines) != 1 {
+		t.Fatalf("a DM to an online player must land; got %+v", lines)
+	}
+	if lines := srv.chat.linesFor("SHA256:third"); len(lines) != 0 {
+		t.Fatalf("a DM must stay private; got %+v", lines)
+	}
+}
+
+func TestChatSendEmptyTextDropped(t *testing.T) {
+	srv := newOfflineServer(t)
+	m, _ := newHostModel(t, srv)
+
+	m, _ = m.Update(tui.ChatSendMsg{Text: "   "})
+	_ = m
+
+	if lines := srv.chat.linesFor("SHA256:other"); len(lines) != 0 {
+		t.Fatalf("blank messages must not post; got %+v", lines)
+	}
+}
+
+func TestChatSendSoloInert(t *testing.T) {
+	// Without a server the wrapper is inert — chat is unavailable in
+	// single-player like the rest of SessionInfo. Must not panic.
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = reportingModel{inner: app, app: app}
+	m, _ = m.Update(tui.ChatSendMsg{Text: "anyone?"})
+	_ = m
+}
+
+func TestChatLinesReachWorldSlate(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	m, hostApp := newHostModel(t, srv)
+	m = tick(m)
+
+	srv.chat.post("SHA256:gern", "gern", "", "", "node is 200m off")
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	_ = m
+
+	w := hostApp.World()
+	if len(w.ChatLines) != 1 || w.ChatLines[0].Text != "node is 200m off" {
+		t.Fatalf("tick must feed the world's chat slate; got %+v", w.ChatLines)
+	}
+}
+
+func TestStopHostingClearsChatSlate(t *testing.T) {
+	srv := newOfflineServer(t)
+	m, hostApp := newHostModel(t, srv)
+	m = tick(m)
+
+	srv.chat.post("SHA256:gern", "gern", "", "", "bye")
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+
+	m, _ = m.Update(screens.SessionHostMsg{Start: false})
+	_ = m
+	if hostApp.World().ChatLines != nil {
+		t.Fatalf("back to solo: the chat slate must clear with the session slates")
+	}
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -133,6 +134,37 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.srv != nil {
 			m.srv.dock.RequestTransfer(m.owner)
 		}
+		return m, nil
+	}
+
+	// Chat send (ADR 0035 S2): the input overlay emits the line; the
+	// wrapper owns the ring. The overlay already refuses unmatched or
+	// offline @handles (keeping the typed text), but that is UX — this
+	// handler re-checks liveness so a stale roster snapshot can't slip a
+	// DM to a dead session, and resolves the sender's handle through the
+	// roster so the rendered name can't be spoofed by the screen.
+	if chat, ok := msg.(tui.ChatSendMsg); ok {
+		if m.srv == nil || strings.TrimSpace(chat.Text) == "" {
+			return m, nil
+		}
+		if chat.To != "" && !m.srv.presence.isOnline(chat.To) {
+			m.app.Toast(chat.ToHandle + " is offline — not sent")
+			return m, nil
+		}
+		ownHandle := m.owner
+		h, ok := m.handleOf(m.owner)
+		if !ok {
+			// A send can beat the first tick's lazy meta refresh — read
+			// the roster now rather than render a raw fingerprint.
+			if meta, err := m.srv.store.Meta(); err == nil {
+				m.meta, m.metaAt = meta, time.Now()
+				h, ok = m.handleOf(m.owner)
+			}
+		}
+		if ok {
+			ownHandle = h
+		}
+		m.srv.chat.post(m.owner, ownHandle, chat.To, chat.ToHandle, chat.Text)
 		return m, nil
 	}
 
@@ -451,6 +483,10 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	}
 	m.localEvents = kept
 	w.SessionEvents = append(events, m.localEvents...)
+
+	// Chat slate (ADR 0035): the viewer's cut of the chat ring — own
+	// lines included, other players' DMs excluded.
+	w.ChatLines = m.srv.chat.linesFor(m.owner)
 }
 
 func (m reportingModel) View() string { return m.inner.View() }
@@ -536,7 +572,7 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// Back to solo: clear the slates the wrapper had been feeding so the
 	// Session screen shows the [h]-start dead-end again.
 	w := m.app.World()
-	w.Session, w.Ghosts, w.SessionEvents = nil, nil, nil
+	w.Session, w.Ghosts, w.SessionEvents, w.ChatLines = nil, nil, nil, nil
 	// Clear the multiplayer coupling slates too (v0.28 finding 2): the tick
 	// path that recomputes co-warp / docked-as-guest is gated on m.srv != nil,
 	// so once hosting stops it never runs again. A stale w.CoWarp.MinWarp would

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -273,6 +273,11 @@ type World struct {
 	Session       *SessionInfo
 	SessionEvents []SessionEvent
 
+	// ChatLines is the viewer's slice of the transient chat ring
+	// (ADR 0035) — same contract as SessionEvents, but its own ring on
+	// the serve side so chat volume can never evict session moments.
+	ChatLines []ChatLine
+
 	// DockGuest is set when one of this player's craft rides in another
 	// player's live stack (Docked-as-Guest, v0.28 S5, ADR 0034 §6). The
 	// serve layer writes it each tick from the dock ledger; the guest's

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -53,6 +53,17 @@ type UndockGuestMsg struct{}
 // TransferControlMsg requests handing the active cross-player stack to the guest.
 type TransferControlMsg struct{}
 
+// ChatSendMsg is a chat line on its way up to the serve wrapper, which
+// owns the chat ring (ADR 0035). To/ToHandle address a DM at one player
+// (resolved against the online roster before sending); both empty means
+// broadcast. Inert in solo play — chat is unavailable without a session,
+// like the rest of SessionInfo.
+type ChatSendMsg struct {
+	Text     string
+	To       string // target fingerprint, "" = broadcast
+	ToHandle string
+}
+
 // App is the root tea.Model. It owns the world, theme, keymap, and which
 // screen is active. Screens read from the shared world; they don't
 // mutate it.


### PR DESCRIPTION
Second v0.32 slice (plan: designdocs v0.32-plan.md). Builds on #265.

## What

- `tui.ChatSendMsg{Text, To, ToHandle}` — chat line on its way up to the serve wrapper, `SessionAdminMsg`/`UndockGuestMsg` precedent; the screen never touches shared state.
- Handler in `reportingModel.Update`: solo-inert, blank-drop, DM-target liveness re-check at the handler (the UI refusal is S3's UX; this is the boundary), sender handle resolved through the roster — with a direct `store.Meta()` read when a send beats the first lazy refresh, so a raw fingerprint never renders.
- `World.ChatLines` transient slate (same contract as `SessionEvents`), fed per tick from `chatRing.linesFor(owner)`; cleared on stop-hosting alongside the other session slates.

## Tests

TDD red-first (`chat_intent_test.go`): broadcast lands with roster handle, offline-DM refused, online-DM lands + stays private, blank dropped, solo inert, tick feeds the world slate, stop-hosting clears it. Full suite `-race -count=1` green (1819/19); `internal/serve` `-race -count=3` green.