### PR TITLE
feat(mp): ~ chat input overlay with @handle tab-complete (ADR 0035 S3)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -161,7 +161,26 @@ type App struct {
 	// n/N/Esc cancels. Session-only state — not persisted (the
 	// confirmation has no meaning across a save / load boundary).
 	endFlightConfirm bool
+
+	// Chat input overlay (ADR 0035 S3). App-level rather than a screen
+	// so the capturingText obligation is one unconditional check — not
+	// another arm of the per-screen switch a future screen could forget.
+	// While chatOpen the sim keeps running and every key is text or an
+	// editing action (accepted cost: flight keys are captured). The tab
+	// state drives @handle completion cycling: chatTabbing marks a cycle
+	// in progress (any edit ends it), chatTabBase is the typed prefix
+	// the candidate list is built from (may legitimately be empty — a
+	// bare @ matches everyone), chatTabIdx the candidate last offered.
+	chatOpen    bool
+	chatInput   []rune
+	chatTabbing bool
+	chatTabBase string
+	chatTabIdx  int
 }
+
+// chatInputRuneCap mirrors the serve-side message cap (the ring
+// truncates authoritatively; capping here keeps typing honest).
+const chatInputRuneCap = 120
 
 // New builds a root App. Returns an error if systems can't load. When
 // scenario is non-nil, the fresh world's default LEO seed is replaced per
@@ -608,6 +627,28 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.world.Clock.Paused = true // freeze the sim while "away"
 			a.boss.Reset()              // fresh lived-in session each open
 			a.active = screenBoss
+			return a, nil
+		}
+		// Chat capture (ADR 0035 S3): while the input is up, every key
+		// is text or an editing action — the unconditional return keeps
+		// flight controls, screens, and the boss key out of reach. Sits
+		// above endFlightConfirm by construction, but the two can't
+		// coexist: the confirm swallows ~, and while chatting E is text.
+		if a.chatOpen {
+			return a.handleChatKey(m)
+		}
+		// ~ opens chat from the flight view (ADR 0035 §4; U+007E, a
+		// different rune from the U+0060 boss key, and absent from every
+		// layout map so normalization passed it through untouched).
+		if a.active == screenOrbit && m.Type == tea.KeyRunes && len(m.Runes) == 1 && m.Runes[0] == '~' {
+			if a.world.Session == nil {
+				// Solo: say so — a dead key reads as broken (v0.30 lesson).
+				a.toast("chat is multiplayer — host or join a session [O]")
+				return a, nil
+			}
+			a.chatOpen = true
+			a.chatInput = a.chatInput[:0]
+			a.chatTabbing = false
 			return a, nil
 		}
 		// v0.11.4+ (ADR 0004): end-flight y/n confirm intercept. When
@@ -1728,6 +1769,11 @@ func (a *App) closeSavesToOrbit() {
 // capturing; the Saves browser only during name entry (Save-As/rename).
 // Extend here as future free-text surfaces (VAB, spawn, search) land.
 func (a *App) capturingText() bool {
+	// The chat overlay is App-level, not a screen — checked before the
+	// per-screen switch so it can never be forgotten there (ADR 0035).
+	if a.chatOpen {
+		return true
+	}
 	switch a.active {
 	case screenBoss:
 		return true
@@ -1737,6 +1783,120 @@ func (a *App) capturingText() bool {
 		return a.session.CapturingText()
 	}
 	return false
+}
+
+// handleChatKey routes every keypress while the chat input is up
+// (ADR 0035 S3). Switch on msg.Type, not String, and return
+// unconditionally — the mint-invite discipline — so nothing leaks to
+// flight controls.
+func (a *App) handleChatKey(m tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.Type {
+	case tea.KeyEscape:
+		a.chatOpen, a.chatInput, a.chatTabbing = false, a.chatInput[:0], false
+	case tea.KeyEnter:
+		return a.sendChat()
+	case tea.KeyBackspace:
+		if len(a.chatInput) > 0 {
+			a.chatInput = a.chatInput[:len(a.chatInput)-1]
+		}
+		a.chatTabbing = false
+	case tea.KeyTab:
+		a.chatTabComplete()
+	case tea.KeySpace:
+		a.chatAppend(' ')
+	case tea.KeyRunes:
+		for _, r := range m.Runes {
+			a.chatAppend(r)
+		}
+	}
+	return a, nil
+}
+
+func (a *App) chatAppend(r rune) {
+	if len(a.chatInput) < chatInputRuneCap {
+		a.chatInput = append(a.chatInput, r)
+	}
+	a.chatTabbing = false
+}
+
+// sendChat parses the drafted line and emits the ChatSendMsg the serve
+// wrapper acts on. A leading @handle addresses a DM: case-insensitive
+// exact match against the ONLINE roster; a miss refuses to send and
+// leaves the text intact — never a silent fall-back to broadcast
+// (ADR 0035 §7).
+func (a *App) sendChat() (tea.Model, tea.Cmd) {
+	text := strings.TrimSpace(string(a.chatInput))
+	if text == "" {
+		a.chatOpen, a.chatInput = false, a.chatInput[:0]
+		return a, nil
+	}
+	msg := ChatSendMsg{Text: text}
+	if strings.HasPrefix(text, "@") {
+		handle, rest, _ := strings.Cut(text[1:], " ")
+		p, ok := a.chatLookup(handle)
+		if !ok {
+			a.toast("no online player \"" + handle + "\" — not sent")
+			return a, nil
+		}
+		rest = strings.TrimSpace(rest)
+		if rest == "" {
+			a.toast("message is empty — not sent")
+			return a, nil
+		}
+		msg = ChatSendMsg{Text: rest, To: p.Fingerprint, ToHandle: p.Handle}
+	}
+	a.chatOpen, a.chatInput, a.chatTabbing = false, a.chatInput[:0], false
+	return a, func() tea.Msg { return msg }
+}
+
+// chatLookup resolves a handle against the online roster, excluding the
+// viewer — you cannot DM yourself, and completion should not offer it.
+func (a *App) chatLookup(handle string) (sim.SessionPlayer, bool) {
+	info := a.world.Session
+	if info == nil {
+		return sim.SessionPlayer{}, false
+	}
+	for _, p := range info.Players {
+		if !p.Online || p.Fingerprint == info.Self {
+			continue
+		}
+		if strings.EqualFold(p.Handle, handle) {
+			return p, true
+		}
+	}
+	return sim.SessionPlayer{}, false
+}
+
+// chatTabComplete completes a leading @prefix against the online
+// roster; repeated tab cycles the matches (ADR 0035 §7). Only the
+// @word itself completes — once a space is typed the handle is
+// committed and tab is inert.
+func (a *App) chatTabComplete() {
+	cur := string(a.chatInput)
+	if !strings.HasPrefix(cur, "@") || strings.ContainsRune(cur, ' ') {
+		return
+	}
+	if !a.chatTabbing {
+		a.chatTabbing, a.chatTabBase, a.chatTabIdx = true, cur[1:], -1
+	}
+	info := a.world.Session
+	if info == nil {
+		return
+	}
+	var cands []string
+	for _, p := range info.Players {
+		if !p.Online || p.Fingerprint == info.Self {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(p.Handle), strings.ToLower(a.chatTabBase)) {
+			cands = append(cands, p.Handle)
+		}
+	}
+	if len(cands) == 0 {
+		return
+	}
+	a.chatTabIdx = (a.chatTabIdx + 1) % len(cands)
+	a.chatInput = []rune("@" + cands[a.chatTabIdx])
 }
 
 // refreshSaves re-lists the directory into the open Saves screen after
@@ -2107,6 +2267,17 @@ func (a *App) View() string {
 		}
 		prompt := fmt.Sprintf("END FLIGHT — remove %s? [y/n]", name)
 		base = overlayBottomBorder(base, a.theme.Alert.Render(prompt), border)
+	}
+	// Chat input (ADR 0035 S3) rides the same band and wins it while
+	// open — it is the live actionable state. A concurrent toast (a DM
+	// refusal) rides along after the draft so refusals stay visible
+	// while the text waits to be fixed.
+	if a.chatOpen {
+		line := "~ " + string(a.chatInput) + "▏"
+		if a.statusMsg != "" && time.Now().Before(a.statusExpires) {
+			line += "  " + a.theme.Warning.Render(a.statusMsg)
+		}
+		base = overlayBottomBorder(base, a.theme.Primary.Render(line), border)
 	}
 	return base
 }

--- a/internal/tui/app_chat_input_test.go
+++ b/internal/tui/app_chat_input_test.go
@@ -1,0 +1,210 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// ADR 0035 S3: the ~ chat input overlay. The sim keeps running while
+// typing; every key is text or an editing action — nothing leaks to
+// flight controls; @handle DMs tab-complete against the online roster.
+
+func newChatApp(t *testing.T) *App {
+	t.Helper()
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.Session = &sim.SessionInfo{
+		Self: "SHA256:me",
+		Players: []sim.SessionPlayer{
+			{Fingerprint: "SHA256:me", Handle: "me", Online: true},
+			{Fingerprint: "SHA256:gern", Handle: "gern", Online: true},
+			{Fingerprint: "SHA256:gale", Handle: "gale", Online: true},
+			{Fingerprint: "SHA256:zed", Handle: "zed", Online: false},
+		},
+	}
+	return a
+}
+
+func chatPress(a *App, msg tea.KeyMsg) tea.Cmd {
+	_, cmd := a.Update(msg)
+	return cmd
+}
+
+func typeRunes(a *App, s string) {
+	for _, r := range s {
+		if r == ' ' {
+			chatPress(a, tea.KeyMsg{Type: tea.KeySpace})
+			continue
+		}
+		chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+func openChat(t *testing.T, a *App) {
+	t.Helper()
+	chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'~'}})
+	if !a.capturingText() {
+		t.Fatalf("~ must open the chat capture")
+	}
+}
+
+// sendMsg runs the Cmd a send produced and returns the ChatSendMsg, or
+// nil if no send happened.
+func sendMsg(cmd tea.Cmd) *ChatSendMsg {
+	if cmd == nil {
+		return nil
+	}
+	if m, ok := cmd().(ChatSendMsg); ok {
+		return &m
+	}
+	return nil
+}
+
+func TestChatTildeOpensAndCaptures(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	// Flight keys are text now — accepted cost (ADR 0035 §5). A typed
+	// backtick must be a literal, not the boss shell (the v0.26 scar).
+	chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'`'}})
+	if a.active != screenOrbit {
+		t.Fatalf("backtick while chatting must not open the boss shell")
+	}
+	typeRunes(a, "hi")
+	if got := string(a.chatInput); got != "`hi" {
+		t.Fatalf("input = %q, want literal backtick + hi", got)
+	}
+}
+
+func TestChatSoloToastsInsteadOfOpening(t *testing.T) {
+	a := newChatApp(t)
+	a.world.Session = nil // solo
+	chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'~'}})
+	if a.capturingText() {
+		t.Fatalf("chat must be unavailable in single-player")
+	}
+	if a.statusMsg == "" {
+		t.Fatalf("a solo ~ must explain itself, not silently no-op (v0.30 lesson)")
+	}
+}
+
+func TestChatEnterBroadcasts(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "burning in 30")
+	cmd := chatPress(a, tea.KeyMsg{Type: tea.KeyEnter})
+	m := sendMsg(cmd)
+	if m == nil || m.Text != "burning in 30" || m.To != "" {
+		t.Fatalf("enter must emit a broadcast ChatSendMsg; got %+v", m)
+	}
+	if a.capturingText() {
+		t.Fatalf("a sent line closes the overlay — back to flying")
+	}
+	if len(a.chatInput) != 0 {
+		t.Fatalf("input must clear after send")
+	}
+}
+
+func TestChatDMResolvesCaseInsensitive(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "@GERN hold your burn")
+	m := sendMsg(chatPress(a, tea.KeyMsg{Type: tea.KeyEnter}))
+	if m == nil || m.To != "SHA256:gern" || m.ToHandle != "gern" {
+		t.Fatalf("@GERN must resolve to gern's fingerprint; got %+v", m)
+	}
+	if m.Text != "hold your burn" {
+		t.Fatalf("DM text must drop the @handle prefix; got %q", m.Text)
+	}
+}
+
+func TestChatDMUnmatchedRefusedTextIntact(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "@nobody you there")
+	cmd := chatPress(a, tea.KeyMsg{Type: tea.KeyEnter})
+	if sendMsg(cmd) != nil {
+		t.Fatalf("an unmatched handle must refuse to send — never fall back to broadcast")
+	}
+	if !a.capturingText() || string(a.chatInput) != "@nobody you there" {
+		t.Fatalf("refusal must leave the typed text intact to be fixed; input=%q open=%v",
+			string(a.chatInput), a.capturingText())
+	}
+	if a.statusMsg == "" {
+		t.Fatalf("refusal must toast")
+	}
+}
+
+func TestChatDMOfflineRefused(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "@zed hi")
+	if sendMsg(chatPress(a, tea.KeyMsg{Type: tea.KeyEnter})) != nil {
+		t.Fatalf("a DM to an offline player must refuse to send")
+	}
+}
+
+func TestChatEscBailsAndClears(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "half a thou")
+	chatPress(a, tea.KeyMsg{Type: tea.KeyEscape})
+	if a.capturingText() {
+		t.Fatalf("esc must bail out")
+	}
+	openChat(t, a)
+	if len(a.chatInput) != 0 {
+		t.Fatalf("a bailed draft must not survive reopen; got %q", string(a.chatInput))
+	}
+}
+
+func TestChatTabCompletesAndCycles(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "@g")
+	chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+	first := string(a.chatInput)
+	if first != "@gern" && first != "@gale" {
+		t.Fatalf("tab must complete @g against the online roster; got %q", first)
+	}
+	chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+	second := string(a.chatInput)
+	if second == first || (second != "@gern" && second != "@gale") {
+		t.Fatalf("repeated tab must cycle matches; got %q then %q", first, second)
+	}
+	chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+	if got := string(a.chatInput); got != first {
+		t.Fatalf("cycling must wrap; got %q, want %q", got, first)
+	}
+}
+
+func TestChatTabIgnoresOfflineAndSelf(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, "@")
+	seen := map[string]bool{}
+	for i := 0; i < 6; i++ {
+		chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+		seen[string(a.chatInput)] = true
+	}
+	if seen["@zed"] {
+		t.Fatalf("tab must not offer offline players")
+	}
+	if seen["@me"] {
+		t.Fatalf("tab must not offer the sender themself")
+	}
+}
+
+func TestChatInputRuneCap(t *testing.T) {
+	a := newChatApp(t)
+	openChat(t, a)
+	typeRunes(a, strings.Repeat("x", 200))
+	if n := len(a.chatInput); n != chatInputRuneCap {
+		t.Fatalf("input must cap at %d runes; got %d", chatInputRuneCap, n)
+	}
+}


### PR DESCRIPTION
Third v0.32 slice (plan: designdocs v0.32-plan.md). Builds on #265/#266.

## What

- `~` opens the chat input from the flight view (U+007E — distinct rune from the U+0060 boss key; absent from every layout map, so normalization passes it through).
- **Capture is App-level state, not a screen**: `capturingText()` checks `chatOpen` unconditionally ahead of the per-screen switch, so the v0.26 QWERTZ/backtick bugs cannot be reintroduced by a forgotten switch arm. Guard test: typed backtick stays a literal, boss shell stays closed.
- Mint-invite key discipline: switch on `msg.Type`, unconditional return — flight keys are text while the cursor is up (accepted ADR cost). Sim keeps running; esc bails and clears.
- Leading `@handle`: case-insensitive exact match against the **online** roster, self excluded. Unmatched/offline → refuse + toast + draft intact (never a silent broadcast fall-back). Tab completes, repeated tab cycles, wraps; offline players and self never offered.
- Solo `~` toasts ('chat is multiplayer — host or join a session [O]') — no dead keys (v0.30 lesson).
- Input rides the canvas bottom-border band; a concurrent toast (DM refusal) renders beside the draft so the refusal is visible while the text waits to be fixed.

## Tests

TDD red-first, 10 cases in `app_chat_input_test.go`. Full suite `-race -count=1` green (1829/19); serve `-count=3` green.