### PR TITLE
feat(mp): chat chip + docked/undocked/transfer session moments (ADR 0035 S4)

### DIFF
--- a/internal/tui/screens/orbit_chat_chip_test.go
+++ b/internal/tui/screens/orbit_chat_chip_test.go
@@ -1,0 +1,123 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// ADR 0035 S4: the chat chip. Its own builder and corner (session
+// moments own top-left), ~30 s TTL — a coordination line must survive a
+// glance at the navball — showing the last few lines only.
+
+func chatChipWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w := rendezvousChipWorld(t)
+	w.Session = &sim.SessionInfo{Self: "SHA256:me"}
+	return w
+}
+
+func TestChatChipRendersBroadcastAndDMs(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := chatChipWorld(t)
+	now := time.Now()
+	w.ChatLines = []sim.ChatLine{
+		{Owner: "SHA256:gern", Handle: "gern", Text: "node is 200m off", At: now},
+		{Owner: "SHA256:me", Handle: "me", Text: "copy", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", To: "SHA256:me", ToHandle: "me", Text: "hold your burn", At: now},
+		{Owner: "SHA256:me", Handle: "me", To: "SHA256:gern", ToHandle: "gern", Text: "on my way", At: now},
+	}
+	joined := strings.Join(v.buildChatChip(w), "\n")
+	for _, want := range []string{
+		"gern: node is 200m off", // broadcast, sender named
+		"me: copy",               // own broadcast — you see what you said
+		"gern>you: hold your burn", // DM received — visibly distinct
+		">gern: on my way",         // DM sent — the own echo names the target
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("chat chip missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestChatChipTTLAndDepth(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := chatChipWorld(t)
+	now := time.Now()
+	w.ChatLines = []sim.ChatLine{
+		{Owner: "SHA256:gern", Handle: "gern", Text: "ancient", At: now.Add(-chatChipTTL - time.Second)},
+		{Owner: "SHA256:gern", Handle: "gern", Text: "one", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", Text: "two", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", Text: "three", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", Text: "four", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", Text: "five", At: now},
+	}
+	joined := strings.Join(v.buildChatChip(w), "\n")
+	if strings.Contains(joined, "ancient") {
+		t.Errorf("a line older than the chat TTL must age out:\n%s", joined)
+	}
+	if strings.Contains(joined, "gern: one") {
+		t.Errorf("depth cap: only the last %d fresh lines show:\n%s", chatChipDepth, joined)
+	}
+	for _, want := range []string{"two", "three", "four", "five"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("fresh line %q missing:\n%s", want, joined)
+		}
+	}
+}
+
+func TestChatChipNilWhenQuiet(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := chatChipWorld(t)
+	if chip := v.buildChatChip(w); chip != nil {
+		t.Errorf("no chat lines → no chip; got %v", chip)
+	}
+	w.ChatLines = []sim.ChatLine{
+		{Owner: "SHA256:gern", Handle: "gern", Text: "old", At: time.Now().Add(-chatChipTTL - time.Minute)},
+	}
+	if chip := v.buildChatChip(w); chip != nil {
+		t.Errorf("every line aged out → no chip; got %v", chip)
+	}
+}
+
+// The chat chip feeds the width-guard discipline like every
+// glyph-bearing chip state (#253 review).
+func TestChatChipCellWidthConsistent(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := chatChipWorld(t)
+	now := time.Now()
+	w.ChatLines = []sim.ChatLine{
+		{Owner: "SHA256:gern", Handle: "gern", Text: "node is 200m off", At: now},
+		{Owner: "SHA256:me", Handle: "me", To: "SHA256:gern", ToHandle: "gern", Text: "on my way", At: now},
+		{Owner: "SHA256:gern", Handle: "gern", To: "SHA256:me", ToHandle: "me", Text: "hold", At: now},
+	}
+	assertChipCellWidthConsistent(t, "chat chip", v.buildChatChip(w))
+}
+
+// The pre-existing gap ADR 0035 flags as adjacent: kinds 6/7/8 flow
+// through serve/dock.go but had no case in the session chip switch and
+// rendered nothing.
+func TestSessionEventsChipDockKinds(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	now := time.Now()
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventDocked, Handle: "gern", At: now},
+		{Kind: sim.SessionEventUndocked, Handle: "gern", At: now},
+		{Kind: sim.SessionEventTransfer, Handle: "gern", At: now},
+	}
+	chip := v.buildSessionEventsChip(w)
+	joined := strings.Join(chip, "\n")
+	for _, want := range []string{
+		"docked with gern",
+		"undocked from gern",
+		"control handed to gern",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("session chip missing %q:\n%s", want, joined)
+		}
+	}
+	assertChipCellWidthConsistent(t, "session dock kinds", chip)
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -109,6 +109,10 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	add(settings.ChipSOIPass, cornerTopRight, v.buildSOIPassChip(w))
 	// Remaining fixed corners.
 	add(settings.ChipStages, cornerBottomLeft, v.buildStagesChip(w))
+	// CHAT stacks under STAGES, its own corner slot away from the
+	// session moments (ADR 0035 §2). Always-on like SESSION — a
+	// coordination line must not be togglable into silence.
+	add("", cornerBottomLeft, v.buildChatChip(w))
 	// NODES (bottom-right) now also carries any in-flight burn as its
 	// firing head (v0.16). A live burn is safety-critical, so when one is
 	// in flight the chip force-shows — bypassing both the ChipNodes
@@ -167,6 +171,12 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			// range and re-aimed — the RENDEZVOUS chip carries the new τ/CA,
 			// this moment just says the advance was deliberate.
 			plain("◇ rendezvous: waypoint passed — coasting on with " + e.Handle)
+		case sim.SessionEventDocked:
+			plain("◇ docked with " + e.Handle)
+		case sim.SessionEventUndocked:
+			plain("◇ undocked from " + e.Handle)
+		case sim.SessionEventTransfer:
+			plain("◇ control handed to " + e.Handle)
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
 		case sim.SessionEventWentQuiet:
@@ -210,6 +220,53 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 		}
 	}
 	return lines
+}
+
+// chatChipTTL is deliberately long against the 6 s session-moment TTL
+// (ADR 0035 §2): missing "X joined" is fine; missing "burning in 30 s"
+// because you were looking at the navball is not. Depth shows the tail
+// of the conversation, not one nudge. Both playtest-tunable.
+const (
+	chatChipTTL   = 30 * time.Second
+	chatChipDepth = 4
+)
+
+// buildChatChip renders the recent chat lines (ADR 0035 S4) — its own
+// builder and corner so chat volume and session moments never contend.
+// A DM renders visibly distinct from a broadcast: ">gern: …" on the
+// sender's echo, "gern>you: …" for the recipient — ASCII '>' on
+// purpose; the arrow runes are EastAsian-ambiguous width (the ☾-class
+// trap). Nil when quiet or aged out.
+func (v *OrbitView) buildChatChip(w *sim.World) []string {
+	if len(w.ChatLines) == 0 {
+		return nil
+	}
+	self := ""
+	if w.Session != nil {
+		self = w.Session.Self
+	}
+	now := time.Now()
+	var rows []string
+	for _, l := range w.ChatLines {
+		if now.Sub(l.At) > chatChipTTL {
+			continue
+		}
+		switch {
+		case l.To == "":
+			rows = append(rows, v.theme.Dim.Render(l.Handle+": "+l.Text))
+		case l.Owner == self:
+			rows = append(rows, v.theme.Warning.Render(">"+l.ToHandle+": "+l.Text))
+		default:
+			rows = append(rows, v.theme.Warning.Render(l.Handle+">you: "+l.Text))
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if len(rows) > chatChipDepth {
+		rows = rows[len(rows)-chatChipDepth:]
+	}
+	return append([]string{v.theme.Primary.Render("CHAT")}, rows...)
 }
 
 // buildRendezvousChip is the persistent Rendezvous Warp surface (v0.29


### PR DESCRIPTION
Fourth v0.32 slice — completes the ADR 0035 chat feature (S1 #265, S2 #266, S3 #267).

## What

- `buildChatChip`: own builder + corner slot (bottom-left, under STAGES — session moments keep top-left), **30 s TTL / last-4 depth** as named constants (ADR: a coordination line must not vanish because you were looking at the navball; both playtest-tunable). Always-on like SESSION — not togglable into silence.
- DM rendering visibly distinct from broadcast: `>gern: …` (sender echo), `gern>you: …` (recipient), Warning-styled; broadcasts `gern: …` Dim. ASCII `>` deliberately — arrow runes are EastAsian-ambiguous width (the ☾-class trap from #253).
- Chat chip states feed the width-guard test (`assertChipCellWidthConsistent`).
- Adjacent gap ADR 0035 flags, same pass: session kinds 6/7/8 (Docked/Undocked/Transfer) flowed through `serve/dock.go` but had no chip-builder case and rendered nothing. Now: `◇ docked with X` / `◇ undocked from X` / `◇ control handed to X`.

## Tests

TDD red-first (`orbit_chat_chip_test.go`): broadcast+DM forms, TTL aging, depth cap, nil-when-quiet, width-guard, dock kinds. Full suite `-race -count=1` green (1834/19).