### PR TITLE
feat(commnet): classify why a probe is disconnected (#221 part 1)

### DIFF
--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -44,7 +44,32 @@ type CommGraph struct {
 	// positions are the same absolute world frame the orbit canvas projects
 	// (body position + state), so the HUD draws segments without rebasing.
 	Paths map[uint64][]orbital.Vec3
+	// Reasons classifies each DISCONNECTED probe (#221, ADR 0027 v0.32
+	// amendment): the bare false collapsed three failure paths and the
+	// chip could only say NO SIGNAL with no hint that a relay — not a
+	// bigger antenna — was the answer (or vice versa). Absent for
+	// connected probes.
+	Reasons map[uint64]CommDisconnectReason
 }
+
+// CommDisconnectReason classifies why a probe has no connection this
+// tick — the enum-plus-data shape from RendezvousWaitReason, scoped to
+// the two reasons that are never actively wrong advice. The finer
+// diagnosis (no antenna fitted, relay chain broken upstream) is
+// deferred: the broken-chain case needs the BFS to report where the
+// chain failed, a larger slice than #221 warrants.
+type CommDisconnectReason int
+
+const (
+	// CommDisconnectNone: connected, not a probe, or not yet classified.
+	CommDisconnectNone CommDisconnectReason = iota
+	// CommDisconnectBlocked: the network is in range but no unoccluded
+	// path exists — the geometry is the problem, a relay is the fix.
+	CommDisconnectBlocked
+	// CommDisconnectOutOfRange: no station or relay is in link range at
+	// all — reach is the problem, a stronger antenna is the fix.
+	CommDisconnectOutOfRange
+)
 
 // HasConnection reports whether the craft with the given ID has a network
 // connection this tick. nil-safe (a not-yet-computed graph → false).
@@ -60,6 +85,16 @@ func (g *CommGraph) Path(id uint64) []orbital.Vec3 {
 		return nil
 	}
 	return g.Paths[id]
+}
+
+// Reason returns why the craft with the given ID is disconnected, or
+// CommDisconnectNone for a connected craft / not-yet-computed graph.
+// nil-safe.
+func (g *CommGraph) Reason(id uint64) CommDisconnectReason {
+	if g == nil {
+		return CommDisconnectNone
+	}
+	return g.Reasons[id]
 }
 
 // commNode is one node in the connectivity graph — a craft antenna or a
@@ -124,6 +159,37 @@ func connectivityFull(nodes []commNode, occ []physics.OccluderBody) connectivity
 		}
 	}
 	return res
+}
+
+// classifyDisconnects is the post-hoc pass over the solved graph (#221):
+// for each disconnected probe, is any piece of the NETWORK — a station
+// or a forwarding relay — within link range, occlusion ignored? If so
+// the failure is geometry (relay needed); if not, reach (stronger
+// antenna). Dead-end neighbours (direct-only craft) don't count: being
+// in range of one says nothing about reaching the network. Pure, like
+// connectivityFull, so it unit-tests on synthetic nodes.
+func classifyDisconnects(nodes []commNode, res connectivityResult) map[uint64]CommDisconnectReason {
+	reasons := map[uint64]CommDisconnectReason{}
+	for i, p := range nodes {
+		if !p.probe || res.connected[p.craftID] {
+			continue
+		}
+		reason := CommDisconnectOutOfRange
+		for j, n := range nodes {
+			if j == i || (!n.station && !n.forwards) {
+				continue
+			}
+			if p.rangeM <= 0 || n.rangeM <= 0 {
+				continue
+			}
+			if n.pos.Sub(p.pos).Norm() <= commLinkRangeM(p.rangeM, n.rangeM) {
+				reason = CommDisconnectBlocked
+				break
+			}
+		}
+		reasons[p.craftID] = reason
+	}
+	return reasons
 }
 
 // nearHomeRadiiFactor sets the "home telemetry blanket": a controllable craft
@@ -285,7 +351,11 @@ func (w *World) RecomputeCommGraph() {
 		}
 		paths[id] = pts
 	}
-	w.CommGraph = &CommGraph{Connected: res.connected, Paths: paths}
+	w.CommGraph = &CommGraph{
+		Connected: res.connected,
+		Paths:     paths,
+		Reasons:   classifyDisconnects(nodes, res),
+	}
 }
 
 // nearestStationPos returns the world position of the closest ground station

--- a/internal/sim/commnet_reason_test.go
+++ b/internal/sim/commnet_reason_test.go
@@ -1,0 +1,106 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// #221 (ADR 0027 amendment, v0.32): CommGraph records WHY a probe is
+// disconnected — two reasons, the minimum that is never actively wrong
+// advice. Telling a deep-space probe to build a relay is a bum steer;
+// telling a 5,000 km satellite to fit a bigger antenna is equally wrong.
+
+func TestDisconnectReasonBlocked(t *testing.T) {
+	// Station in range but a body sits on the segment: the geometry is
+	// the problem, so the advice is a relay.
+	occ := []physics.OccluderBody{{Center: orbital.Vec3{}, Radius: 100}}
+	nodes := []commNode{
+		station(0, -1000, 100000),
+		probeNode(1, 1000, 3000, false),
+	}
+	res := connectivityFull(nodes, occ)
+	reasons := classifyDisconnects(nodes, res)
+	if got := reasons[1]; got != CommDisconnectBlocked {
+		t.Errorf("occluded-but-in-range probe: reason = %v, want CommDisconnectBlocked", got)
+	}
+}
+
+func TestDisconnectReasonOutOfRange(t *testing.T) {
+	rng := commLinkRangeM(100000, 3000)
+	nodes := []commNode{
+		station(0, 0, 100000),
+		probeNode(1, rng*1.5, 3000, false),
+	}
+	res := connectivityFull(nodes, nil)
+	reasons := classifyDisconnects(nodes, res)
+	if got := reasons[1]; got != CommDisconnectOutOfRange {
+		t.Errorf("nothing-in-range probe: reason = %v, want CommDisconnectOutOfRange", got)
+	}
+}
+
+func TestDisconnectReasonIgnoresDeadEndNeighbours(t *testing.T) {
+	// The probe's only in-range neighbour is a direct-only craft — a
+	// dead end that cannot forward. Being "in range" of it says nothing
+	// about reaching the network, so the advice must stay antenna, not
+	// relay.
+	rng := commLinkRangeM(100000, 3000)
+	nodes := []commNode{
+		station(0, rng*3, 100000), // far out of the probe's reach
+		probeNode(1, 0, 3000, false),
+		probeNode(2, 500, 3000, false), // direct-only craft beside the probe
+	}
+	res := connectivityFull(nodes, nil)
+	reasons := classifyDisconnects(nodes, res)
+	if got := reasons[1]; got != CommDisconnectOutOfRange {
+		t.Errorf("probe whose only in-range neighbour is a dead end: reason = %v, want CommDisconnectOutOfRange", got)
+	}
+}
+
+func TestDisconnectReasonConnectedProbeHasNone(t *testing.T) {
+	nodes := []commNode{
+		station(0, 0, 100000),
+		probeNode(1, 1000, 3000, false),
+	}
+	res := connectivityFull(nodes, nil)
+	reasons := classifyDisconnects(nodes, res)
+	if _, present := reasons[1]; present {
+		t.Errorf("a connected probe must carry no disconnect reason; got %v", reasons[1])
+	}
+}
+
+func TestCommGraphReasonAccessorNilSafe(t *testing.T) {
+	var g *CommGraph
+	if got := g.Reason(42); got != CommDisconnectNone {
+		t.Errorf("nil graph: Reason = %v, want CommDisconnectNone", got)
+	}
+	g = &CommGraph{Connected: map[uint64]bool{7: true}}
+	if got := g.Reason(7); got != CommDisconnectNone {
+		t.Errorf("connected probe: Reason = %v, want CommDisconnectNone", got)
+	}
+}
+
+func TestRecomputeCommGraphRecordsReasons(t *testing.T) {
+	// Production integration: the world-level recompute must carry the
+	// classification through — a fresh default world has ground stations
+	// on Earth, so a probe parked mid-band (occlusion-bound) or in deep
+	// space classifies through RecomputeCommGraph without any test-side
+	// shortcut formula (the amendment's per-primary discipline).
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.RecomputeCommGraph()
+	g := w.CommGraph
+	if g == nil {
+		t.Fatalf("RecomputeCommGraph left no graph")
+	}
+	for id, connected := range g.Connected {
+		if connected {
+			if got := g.Reason(id); got != CommDisconnectNone {
+				t.Errorf("connected craft %d carries reason %v", id, got)
+			}
+		}
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -504,20 +504,29 @@ func (v *OrbitView) buildCommsChip(w *sim.World) []string {
 		return nil // crewed craft are never gated; debris has no link to show
 	}
 	_, hops, connected := w.ActiveCommPath()
-	return v.commsChipLines(hops, connected)
+	return v.commsChipLines(hops, connected, w.CommGraph.Reason(c.ID))
 }
 
 // commsChipLines is the pure content selector behind buildCommsChip, split
 // out so the DIRECT / CONNECTED / NO SIGNAL forms are unit-testable without a
 // live World. A connected probe reads DIRECT for a single hop (straight to a
 // station) or "CONNECTED via N hops" through relays; a disconnected probe
-// reads NO SIGNAL in the alert style.
-func (v *OrbitView) commsChipLines(hops int, connected bool) []string {
+// reads NO SIGNAL in the alert style plus the classified cause (#221):
+// name the cause AND the fix, and never steer at the wrong remedy — an
+// unclassified disconnect degrades to the bare form rather than guess.
+func (v *OrbitView) commsChipLines(hops int, connected bool, reason sim.CommDisconnectReason) []string {
 	if !connected {
-		return []string{
+		lines := []string{
 			v.theme.Alert.Render("COMMS"),
 			v.theme.Alert.Render("  ⚠ NO SIGNAL"),
 		}
+		switch reason {
+		case sim.CommDisconnectBlocked:
+			lines = append(lines, v.theme.Dim.Render("  no station in view — relay needed"))
+		case sim.CommDisconnectOutOfRange:
+			lines = append(lines, v.theme.Dim.Render("  out of range — stronger antenna needed"))
+		}
+		return lines
 	}
 	status := fmt.Sprintf("CONNECTED via %d hops", hops)
 	if hops <= 1 {

--- a/internal/tui/screens/orbit_comms_chip_test.go
+++ b/internal/tui/screens/orbit_comms_chip_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCommsChipLinesDirect(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
-	lines := v.commsChipLines(1, true)
+	lines := v.commsChipLines(1, true, sim.CommDisconnectNone)
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "COMMS") {
 		t.Errorf("chip missing COMMS header:\n%s", joined)
@@ -30,7 +30,7 @@ func TestCommsChipLinesDirect(t *testing.T) {
 
 func TestCommsChipLinesRelayed(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
-	joined := strings.Join(v.commsChipLines(3, true), "\n")
+	joined := strings.Join(v.commsChipLines(3, true, sim.CommDisconnectNone), "\n")
 	if !strings.Contains(joined, "CONNECTED via 3 hops") {
 		t.Errorf("a three-hop link should read CONNECTED via 3 hops:\n%s", joined)
 	}
@@ -38,7 +38,7 @@ func TestCommsChipLinesRelayed(t *testing.T) {
 
 func TestCommsChipLinesNoSignal(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
-	joined := strings.Join(v.commsChipLines(0, false), "\n")
+	joined := strings.Join(v.commsChipLines(0, false, sim.CommDisconnectNone), "\n")
 	if !strings.Contains(joined, "NO SIGNAL") {
 		t.Errorf("a disconnected probe should read NO SIGNAL:\n%s", joined)
 	}

--- a/internal/tui/screens/orbit_comms_reason_test.go
+++ b/internal/tui/screens/orbit_comms_reason_test.go
@@ -1,0 +1,61 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// #221: the NO SIGNAL chip names the cause instead of a bare warning —
+// the model was sound, the silence was the defect. Wording discipline
+// from the RendezvousWait work: name the cause, give the fix, never
+// steer the player at the wrong remedy.
+
+func TestCommsChipNoSignalNamesTheCause(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+
+	blocked := strings.Join(v.commsChipLines(0, false, sim.CommDisconnectBlocked), "\n")
+	if !strings.Contains(blocked, "NO SIGNAL") || !strings.Contains(blocked, "no station in view — relay needed") {
+		t.Errorf("blocked probe chip must advise a relay:\n%s", blocked)
+	}
+	if strings.Contains(blocked, "antenna") {
+		t.Errorf("blocked probe chip must not steer at the antenna (bum-steer discipline):\n%s", blocked)
+	}
+
+	ranged := strings.Join(v.commsChipLines(0, false, sim.CommDisconnectOutOfRange), "\n")
+	if !strings.Contains(ranged, "NO SIGNAL") || !strings.Contains(ranged, "out of range — stronger antenna needed") {
+		t.Errorf("out-of-range probe chip must advise the antenna:\n%s", ranged)
+	}
+	if strings.Contains(ranged, "relay") {
+		t.Errorf("out-of-range probe chip must not advise a relay:\n%s", ranged)
+	}
+
+	// Classification can legitimately be absent (a stale pre-#221 graph
+	// mid-tick): degrade to the bare form, never to wrong advice.
+	bare := strings.Join(v.commsChipLines(0, false, sim.CommDisconnectNone), "\n")
+	if !strings.Contains(bare, "NO SIGNAL") {
+		t.Errorf("unclassified disconnect still reads NO SIGNAL:\n%s", bare)
+	}
+	if strings.Contains(bare, "relay") || strings.Contains(bare, "antenna") {
+		t.Errorf("unclassified disconnect must not guess a remedy:\n%s", bare)
+	}
+}
+
+func TestCommsChipConnectedFormsUnchanged(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	direct := strings.Join(v.commsChipLines(1, true, sim.CommDisconnectNone), "\n")
+	if !strings.Contains(direct, "DIRECT") {
+		t.Errorf("single hop reads DIRECT:\n%s", direct)
+	}
+	hops := strings.Join(v.commsChipLines(3, true, sim.CommDisconnectNone), "\n")
+	if !strings.Contains(hops, "CONNECTED via 3 hops") {
+		t.Errorf("multi-hop form regressed:\n%s", hops)
+	}
+}
+
+func TestCommsChipReasonLinesWidthConsistent(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	assertChipCellWidthConsistent(t, "comms blocked", v.commsChipLines(0, false, sim.CommDisconnectBlocked))
+	assertChipCellWidthConsistent(t, "comms out of range", v.commsChipLines(0, false, sim.CommDisconnectOutOfRange))
+}


### PR DESCRIPTION
Fifth v0.32 slice — first half of #221 (ADR 0027 amendment 'targeting v0.32'). Chat slices were #265–#268.

## What

- `CommGraph.Reasons` + `Reason(id)` (nil-safe): post-hoc classification over the same solved nodes, **disconnected probes only**, in the `RendezvousWaitReason` enum-plus-data shape (PR #255's pattern, per the amendment).
- Exactly two reasons — the minimum that is never actively wrong advice: `CommDisconnectBlocked` (network in link range, occlusion ignored → 'no station in view — relay needed') and `CommDisconnectOutOfRange` ('out of range — stronger antenna needed'). Dead-end direct-only neighbours don't count toward 'in range' — being near one says nothing about reaching the network. Four-reason diagnosis (no antenna / broken chain) stays deferred per the amendment.
- Chip: `⚠ NO SIGNAL` gains the cause line; `CommDisconnectNone` (stale pre-#221 graph) degrades to the bare form rather than guessing a remedy. Cause lines feed the width guard.
- **No model retune** — blanket edge, presets, `surfaceTol` untouched; the dead band stays the relay driver by design.

## Tests

TDD red-first: `commnet_reason_test.go` (blocked/out-of-range/dead-end/connected-none/nil-safety/world integration), `orbit_comms_reason_test.go` (cause wording + bum-steer guards + width). Full suite `-race -count=1` green (1843/19).