### PR TITLE
feat(commnet): per-primary spawn-form band warnings (#221 part 2)

### DIFF
--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -401,8 +401,15 @@ func (w *World) ActiveCommPath() (points []orbital.Vec3, hops int, connected boo
 // body's position plus the body-fixed surface point (co-rotating with the
 // body) at sim time.
 func (w *World) groundStationWorldPos(st GroundStationPreset, body bodies.CelestialBody) orbital.Vec3 {
+	return w.groundStationWorldPosAt(st, body, w.Clock.SimTime)
+}
+
+// groundStationWorldPosAt is groundStationWorldPos at an explicit time —
+// the band sampler (#221) sweeps station rotation phase through it while
+// the body's orbital position stays frozen at SimTime.
+func (w *World) groundStationWorldPosAt(st GroundStationPreset, body bodies.CelestialBody, t time.Time) orbital.Vec3 {
 	r := body.RadiusMeters()
-	dir := render.BodyFixedToWorld(body, st.LatDeg, st.LonEastDeg, w.Clock.SimTime)
+	dir := render.BodyFixedToWorld(body, st.LatDeg, st.LonEastDeg, t)
 	return w.BodyPosition(body).Add(orbital.Vec3{X: r * dir.X, Y: r * dir.Y, Z: r * dir.Z})
 }
 

--- a/internal/sim/commnet_band.go
+++ b/internal/sim/commnet_band.go
@@ -1,0 +1,135 @@
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Spawn-form band sampling (#221 part 2, ADR 0027 v0.32 amendment §2).
+// The degraded band between the home-telemetry blanket edge and reliable
+// DSN line-of-sight is real (~40-minute blackouts) and DELIBERATE — it is
+// the pressure that makes relay constellations worth building. The spawn
+// form warns about it, and the warning must be computed from the live
+// model per parent body: a label derived from Earth would be exactly
+// inverted at Kern (its radius is ~10× smaller, so its blanket edge is
+// 300 km, not 3,186 km — the amendment's measured table). So this
+// samples the PRODUCTION connectivity solve — same commNode rules, same
+// commLinked, same blanket gate — never a second analytic formula that
+// would drift the moment stations, occlusion, or a user overlay changed.
+
+const (
+	// The two phase axes are sampled independently — time-marching couples
+	// them and aliases at synchronous altitudes (a geostationary probe
+	// never moves relative to the stations, so a time-march reads 0% or
+	// 100% by longitude luck instead of the true equatorial answer).
+	commBandRotationSamples = 16
+	commBandOrbitSamples    = 24
+
+	// CommBandDegradedThreshold: sampled coverage below this flags the
+	// preset. Fractionally under 1.0 to absorb grid-edge noise, so the
+	// blanket / geosync cases read clean.
+	CommBandDegradedThreshold = 0.995
+)
+
+// CommBandCoverage samples connectivity for a hypothetical direct-basic
+// probe in a circular EQUATORIAL orbit of bodyID at altM, over orbit
+// phase × body rotation phase, and returns the connected fraction.
+// ok=false when the body is not in the viewed system. Equatorial in the
+// body-equatorial frame (frame.go is the boundary) — the amendment's
+// scratch harness sampled ecliptic-frame orbits and its inclination
+// figures were confounded with axial tilt; the form spawns exactly one
+// plane (posOrbit has no inclination field), and this samples that
+// plane. Live craft are deliberately excluded: the label describes the
+// preset band of the station model, deterministic per (body, altitude),
+// not the player's current relay constellation.
+func (w *World) CommBandCoverage(bodyID string, altM float64) (float64, bool) {
+	sys := w.System()
+	body := sys.FindBody(bodyID)
+	if body == nil || altM <= 0 {
+		return 0, false
+	}
+
+	// Occluders: every body in the system, frozen at SimTime — orbital
+	// motion over one rotation period is noise at band scale; the parent
+	// itself doesn't move relative to its own stations at all.
+	occ := make([]physics.OccluderBody, 0, len(sys.Bodies))
+	for i := range sys.Bodies {
+		b := sys.Bodies[i]
+		occ = append(occ, physics.OccluderBody{Center: w.BodyPosition(b), Radius: b.RadiusMeters()})
+	}
+
+	// Stations, scoped to this system exactly like RecomputeCommGraph.
+	type stationSpec struct {
+		st GroundStationPreset
+		b  bodies.CelestialBody
+	}
+	stationBodies := map[string]bool{}
+	var sts []stationSpec
+	for _, st := range w.GroundStations {
+		b := sys.FindBody(st.BodyID)
+		if b == nil {
+			continue
+		}
+		stationBodies[st.BodyID] = true
+		sts = append(sts, stationSpec{st: st, b: *b})
+	}
+
+	r := body.RadiusMeters() + altM
+	frame := orbital.ReferenceFrameForPrimary(*body)
+	nearHome := stationBodies[bodyID] && r <= nearHomeRadiiFactor*body.RadiusMeters()
+	bodyPos := w.BodyPosition(*body)
+
+	rotSamples := commBandRotationSamples
+	rotPeriod := body.SideralRotationSeconds()
+	if rotPeriod <= 0 {
+		rotSamples = 1 // a non-rotating body has one station geometry
+	}
+
+	connected, total := 0, 0
+	const probeID = uint64(1)
+	for ri := 0; ri < rotSamples; ri++ {
+		t := w.Clock.SimTime
+		if rotSamples > 1 {
+			t = t.Add(time.Duration(float64(ri) / float64(rotSamples) * rotPeriod * float64(time.Second)))
+		}
+		nodes := make([]commNode, 0, len(sts)+1)
+		for _, ss := range sts {
+			// Only the parent's own stations sweep rotation phase; a ring
+			// on another body is range-dominated at that distance and its
+			// phase is noise.
+			ts := w.Clock.SimTime
+			if ss.st.BodyID == bodyID {
+				ts = t
+			}
+			nodes = append(nodes, commNode{
+				pos:      w.groundStationWorldPosAt(ss.st, ss.b, ts),
+				rangeM:   ss.st.AntennaRangeM,
+				forwards: true,
+				station:  true,
+				bodyID:   ss.st.BodyID,
+			})
+		}
+		for oi := 0; oi < commBandOrbitSamples; oi++ {
+			phi := 2 * math.Pi * float64(oi) / float64(commBandOrbitSamples)
+			rBody := orbital.Vec3{X: r * math.Cos(phi), Y: r * math.Sin(phi)}
+			probe := commNode{
+				pos:      bodyPos.Add(frame.ToWorld(rBody)),
+				rangeM:   spacecraft.AntennaRangeDirectBasic,
+				probe:    true,
+				craftID:  probeID,
+				bodyID:   bodyID,
+				nearHome: nearHome,
+			}
+			if connectivity(append(nodes, probe), occ)[probeID] {
+				connected++
+			}
+			total++
+		}
+	}
+	return float64(connected) / float64(total), true
+}

--- a/internal/sim/commnet_band_test.go
+++ b/internal/sim/commnet_band_test.go
@@ -1,0 +1,80 @@
+package sim
+
+import "testing"
+
+// #221 part 2 (ADR 0027 v0.32 amendment §2): spawn-form band warnings
+// are computed per-primary by sampling the PRODUCTION connectivity
+// model over orbit phase × body rotation phase — never a second
+// analytic formula that drifts the moment stations, occlusion, or a
+// user overlay changes. The amendment's measured table is the oracle:
+// Earth degrades at 5,000/10,000 km; Kern (~10× smaller) is EXACTLY
+// INVERTED — degraded at 500–2,000 km, clean at 5,000+.
+
+func bandWorld(t *testing.T) *World {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	return w
+}
+
+func TestCommBandCoverageEarth(t *testing.T) {
+	w := bandWorld(t)
+
+	if cov, ok := w.CommBandCoverage("earth", 500e3); !ok || cov < 1.0 {
+		t.Errorf("Earth 500 km sits inside the home blanket: cov=%.3f ok=%v, want 1.0", cov, ok)
+	}
+	if cov, ok := w.CommBandCoverage("earth", 5000e3); !ok || cov <= 0.05 || cov >= CommBandDegradedThreshold {
+		t.Errorf("Earth 5,000 km is the measured dead band (~61%%): cov=%.3f ok=%v", cov, ok)
+	}
+	if cov, ok := w.CommBandCoverage("earth", 35786e3); !ok || cov < CommBandDegradedThreshold {
+		t.Errorf("equatorial geosync is clean: cov=%.3f ok=%v", cov, ok)
+	}
+}
+
+func TestCommBandCoverageMarsOutOfReach(t *testing.T) {
+	w := bandWorld(t)
+	cov, ok := w.CommBandCoverage("mars", 5000e3)
+	if !ok {
+		t.Fatalf("mars is in the active system; ok=false")
+	}
+	if cov != 0 {
+		t.Errorf("Mars hosts no stations and sits beyond direct-basic reach of Earth's ring: cov=%.3f, want 0", cov)
+	}
+}
+
+func TestCommBandCoverageKernInversion(t *testing.T) {
+	w := bandWorld(t)
+	kernIdx := -1
+	for i, sys := range w.Systems {
+		if sys.FindBody("kern") != nil {
+			kernIdx = i
+		}
+	}
+	if kernIdx < 0 {
+		t.Skip("no system carries kern (Lumen catalog absent)")
+	}
+	w.SystemIdx = kernIdx
+
+	low, ok := w.CommBandCoverage("kern", 500e3)
+	if !ok {
+		t.Fatalf("kern lookup failed in its own system")
+	}
+	high, _ := w.CommBandCoverage("kern", 5000e3)
+	// The decisive inversion: an Earth-derived label would flag exactly
+	// the wrong presets at Kern.
+	if low >= CommBandDegradedThreshold {
+		t.Errorf("Kern 500 km is in ITS band (blanket edge ≈300 km): cov=%.3f", low)
+	}
+	if high < CommBandDegradedThreshold {
+		t.Errorf("Kern 5,000 km is clean: cov=%.3f", high)
+	}
+}
+
+func TestCommBandCoverageUnknownBody(t *testing.T) {
+	w := bandWorld(t)
+	if _, ok := w.CommBandCoverage("no-such-body", 500e3); ok {
+		t.Errorf("unknown body must report ok=false")
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1027,7 +1027,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// filters the catalog to system-matching craft (sys is a local so
 			// the pointer-receiver Scale() is callable).
 			sys := a.world.System()
-			a.spawn.Reset(sys.Bodies, defaultParentID, designs, sys.Scale())
+			a.spawn.Reset(sys.Bodies, defaultParentID, designs, sys.Scale(), a.world.CommBandCoverage)
 			a.active = screenSpawn
 			a.world.RecordAction(missions.ActionSpawnCraft) // ADR 0025 §7
 			return a, nil

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -79,7 +79,23 @@ type SpawnCraft struct {
 	groupsShowAll bool
 	groupsScale   bodies.ScaleClass
 	groupsValid   bool
+
+	// bandCoverage (#221, ADR 0027 v0.32 amendment §2) samples the live
+	// CommNet model for a (bodyID, altitude) — injected at Reset (the App
+	// passes World.CommBandCoverage) so the form itself never derives
+	// coverage; a second formula here would drift from the model. nil
+	// (tests, no world) ⇒ no warning is ever claimed. bandCache memoises
+	// per parentIdx|altIdx — sampling costs ~400 connectivity solves, fine
+	// once per cursor position, wasteful per render frame.
+	bandCoverage func(bodyID string, altM float64) (float64, bool)
+	bandCache    map[[2]int]float64
 }
+
+// spawnBandDegradedBelow mirrors sim.CommBandDegradedThreshold without
+// importing the value into the render path: coverage under this flags
+// the preset; exactly zero switches to the out-of-reach wording (a
+// relay is a bum steer when nothing is in range at all).
+const spawnBandDegradedBelow = 0.995
 
 // stackFieldIdx is the form-field index of the STACK editor — only
 // reachable (Tab includes it) when the Custom loadout is selected.
@@ -113,7 +129,9 @@ func NewSpawnCraft(th Theme) *SpawnCraft { return &SpawnCraft{theme: th} }
 // the parent-field cursor lands on initially (typically the active
 // craft's current primary). v0.8.2+: replaces the v0.8.2-pre
 // no-arg Reset.
-func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string, designs []spacecraft.Design, systemScale bodies.ScaleClass) {
+func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string, designs []spacecraft.Design, systemScale bodies.ScaleClass, bandCoverage func(bodyID string, altM float64) (float64, bool)) {
+	s.bandCoverage = bandCoverage
+	s.bandCache = map[[2]int]float64{}
 	s.fieldIdx = 0
 	s.loadoutIdx = 0
 	s.customStages = nil
@@ -815,6 +833,9 @@ func (s *SpawnCraft) Render(width int) string {
 		lines = append(lines, s.fieldHeader(3, "ALTITUDE"))
 		altLabel := fmt.Sprintf("%d km", altitudePresets[s.altIdx])
 		lines = append(lines, "  "+s.fieldValueDimmed(3, altLabel, dimAlt))
+		if warn := s.bandWarning(); warn != "" {
+			lines = append(lines, "  "+s.theme.Warning.Render(warn))
+		}
 	}
 
 	// Field 4: direction — toggle. Ignored in launchpad mode.
@@ -832,6 +853,38 @@ func (s *SpawnCraft) Render(width int) string {
 		"[tab] field  [←/→] cycle  [f] system filter  [enter] spawn  [esc] cancel"))
 
 	return strings.Join(lines, "\n")
+}
+
+// bandWarning classifies the focused (parent, altitude) preset against
+// the sampled CommNet coverage (#221): a preset in the degraded band
+// names the band AND the fix (relays); zero coverage is the out-of-range
+// case and must not advise a relay. Empty when the sampler is absent,
+// the position mode doesn't orbit, or coverage is clean — the form never
+// guesses.
+func (s *SpawnCraft) bandWarning() string {
+	if s.bandCoverage == nil || s.posMode != posOrbit {
+		return ""
+	}
+	if s.parentIdx < 0 || s.parentIdx >= len(s.parentBodies) {
+		return ""
+	}
+	key := [2]int{s.parentIdx, s.altIdx}
+	cov, cached := s.bandCache[key]
+	if !cached {
+		c, ok := s.bandCoverage(s.parentBodies[s.parentIdx].ID, s.SelectedAltitudeM())
+		if !ok {
+			return ""
+		}
+		cov = c
+		s.bandCache[key] = cov
+	}
+	switch {
+	case cov <= 0:
+		return "⚠ out of network reach — no signal at this body"
+	case cov < spawnBandDegradedBelow:
+		return fmt.Sprintf("⚠ degraded comms band — ~%d%% coverage, relays advised", int(cov*100+0.5))
+	}
+	return ""
 }
 
 // craftRow renders one selectable CRAFT TYPE row (a catalog loadout, the

--- a/internal/tui/screens/spawn_band_test.go
+++ b/internal/tui/screens/spawn_band_test.go
@@ -1,0 +1,82 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// #221 part 2: the spawn form flags posOrbit presets that fall in the
+// degraded comms band, from the injected per-primary sampler — the form
+// itself never derives coverage.
+
+// bandStub returns a canned coverage per altitude (km-keyed), defaulting
+// to full coverage.
+func bandStub(byAltKm map[int]float64) func(string, float64) (float64, bool) {
+	return func(bodyID string, altM float64) (float64, bool) {
+		if cov, ok := byAltKm[int(altM/1000)]; ok {
+			return cov, true
+		}
+		return 1.0, true
+	}
+}
+
+func bandTestBodies() []bodies.CelestialBody {
+	return []bodies.CelestialBody{{ID: "earth", Name: "Earth"}}
+}
+
+func resetWithBand(s *SpawnCraft, cov func(string, float64) (float64, bool)) {
+	s.Reset(bandTestBodies(), "earth", nil, "", cov)
+}
+
+func TestSpawnFormFlagsDegradedBand(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.61}))
+
+	setAltPreset(t, s, 5000)
+	out := s.Render(80)
+	if !strings.Contains(out, "degraded comms band") || !strings.Contains(out, "relays advised") {
+		t.Errorf("a degraded preset must be flagged with the relay advice:\n%s", out)
+	}
+
+	setAltPreset(t, s, 500)
+	if out := s.Render(80); strings.Contains(out, "degraded comms band") {
+		t.Errorf("a full-coverage preset must not be flagged:\n%s", out)
+	}
+}
+
+func TestSpawnFormOutOfReachWording(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0}))
+	setAltPreset(t, s, 5000)
+	out := s.Render(80)
+	if !strings.Contains(out, "out of network reach") {
+		t.Errorf("zero coverage is the out-of-range case, not the band:\n%s", out)
+	}
+	if strings.Contains(out, "relays advised") {
+		t.Errorf("zero coverage must not advise relays (bum-steer discipline):\n%s", out)
+	}
+}
+
+func TestSpawnFormNoBandWarningWithoutSampler(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(bandTestBodies(), "earth", nil, "", nil)
+	setAltPreset(t, s, 5000)
+	if out := s.Render(80); strings.Contains(out, "degraded comms band") {
+		t.Errorf("no sampler injected → no claim made:\n%s", out)
+	}
+}
+
+// setAltPreset moves the altitude cursor to the preset with the given
+// km value.
+func setAltPreset(t *testing.T, s *SpawnCraft, km int) {
+	t.Helper()
+	for i, v := range altitudePresets {
+		if v == km {
+			s.altIdx = i
+			return
+		}
+	}
+	t.Fatalf("no %d km preset", km)
+}

--- a/internal/tui/screens/spawn_filter_test.go
+++ b/internal/tui/screens/spawn_filter_test.go
@@ -21,7 +21,7 @@ func visibleIDs(s *SpawnCraft) map[string]bool {
 // stripped-back system does the reverse.
 func TestSystemFilterByScaleClass(t *testing.T) {
 	real := NewSpawnCraft(Theme{})
-	real.Reset(nil, "", nil, bodies.ScaleReal)
+	real.Reset(nil, "", nil, bodies.ScaleReal, nil)
 	rv := visibleIDs(real)
 	if !rv["Saturn-V"] {
 		t.Error("real system should show Saturn V")
@@ -31,7 +31,7 @@ func TestSystemFilterByScaleClass(t *testing.T) {
 	}
 
 	strip := NewSpawnCraft(Theme{})
-	strip.Reset(nil, "", nil, bodies.ScaleStrippedBack)
+	strip.Reset(nil, "", nil, bodies.ScaleStrippedBack, nil)
 	sv := visibleIDs(strip)
 	if !sv["Kern-Stack"] {
 		t.Error("stripped-back system should show Kern Stack")
@@ -45,7 +45,7 @@ func TestSystemFilterByScaleClass(t *testing.T) {
 // value) normalizes to real, so it shows the real fleet (ADR 0031 / S10).
 func TestUnsetSystemScaleShowsRealFleet(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	v := visibleIDs(s)
 	if !v["Saturn-V"] || v["Kern-Stack"] {
 		t.Error("unset system scale should behave as real (show real, hide stripped-back)")
@@ -57,7 +57,7 @@ func TestUnsetSystemScaleShowsRealFleet(t *testing.T) {
 // the top of CRAFT TYPE so it can't strand on a now-hidden row (ADR 0031 / S10).
 func TestShowAllToggleRevealsAndRefilters(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, bodies.ScaleReal)
+	s.Reset(nil, "", nil, bodies.ScaleReal, nil)
 	if visibleIDs(s)["Kern-Stack"] {
 		t.Fatal("precondition: Kern Stack hidden under the real filter")
 	}
@@ -88,7 +88,7 @@ func TestShowAllToggleRevealsAndRefilters(t *testing.T) {
 // S11 review fix). Mirrors the field-guarding of the [a]/[x]/[d] stack keys.
 func TestFilterToggleIgnoredInStackEditor(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, bodies.ScaleReal)
+	s.Reset(nil, "", nil, bodies.ScaleReal, nil)
 	// Select Custom and focus the STACK editor.
 	s.fieldIdx = 0
 	for !s.IsCustomSelected() {
@@ -113,7 +113,7 @@ func TestCustomAndDesignsExemptFromFilter(t *testing.T) {
 		{Loadout: spacecraft.LoadoutDef{ID: "lumen-probe", Name: "Lumen Probe", Parts: []spacecraft.PartRef{{PartID: "x"}}}},
 	}
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", designs, bodies.ScaleReal)
+	s.Reset(nil, "", designs, bodies.ScaleReal, nil)
 	v := s.visibleCatalogCount()
 	s.loadoutIdx = v
 	if !s.IsCustomSelected() {
@@ -131,7 +131,7 @@ func TestCustomAndDesignsExemptFromFilter(t *testing.T) {
 // row (ADR 0031 / S10).
 func TestEmptyFilterDegradesGracefully(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, bodies.ScaleClass("exotic"))
+	s.Reset(nil, "", nil, bodies.ScaleClass("exotic"), nil)
 	if got := s.visibleCatalogCount(); got != 0 {
 		t.Fatalf("expected no catalog loadouts for an unknown scale, got %d", got)
 	}

--- a/internal/tui/screens/spawn_group_test.go
+++ b/internal/tui/screens/spawn_group_test.go
@@ -12,7 +12,7 @@ import (
 // (which are about all loadouts, independent of the S10 filter).
 func formShowAll() *SpawnCraft {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	s.showAll = true
 	return s
 }

--- a/internal/tui/screens/spawn_launch_test.go
+++ b/internal/tui/screens/spawn_launch_test.go
@@ -84,7 +84,7 @@ func TestCraftLiftsOff(t *testing.T) {
 // launchpad for an orbit-only craft, but does for a launcher (ADR 0031 / S9).
 func TestLaunchpadGateSkipsOrbitOnlyCraft(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "")
+	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "", nil)
 
 	// Orbit-only: the Comsat Carrier can't lift off Earth.
 	s.loadoutIdx = loadoutIndex(t, s, "Comsat-Carrier-3")
@@ -123,7 +123,7 @@ func TestLaunchpadGateSkipsOrbitOnlyCraft(t *testing.T) {
 // orbit (ADR 0031 / S9). Tests the invariant across the whole list.
 func TestLaunchpadNeverStickyOnOrbitOnlyCraft(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "")
+	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "", nil)
 	s.loadoutIdx = loadoutIndex(t, s, "Saturn-V")
 	s.fieldIdx = 1
 	for i := 0; i < 4 && !s.SelectedLaunchpad(); i++ {
@@ -150,7 +150,7 @@ func TestLaunchpadNeverStickyOnOrbitOnlyCraft(t *testing.T) {
 // not, so toggling must drop launchpad.
 func TestFilterToggleResnapsLaunchpad(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset([]bodies.CelestialBody{superEarthLike()}, "superearth", nil, bodies.ScaleStrippedBack)
+	s.Reset([]bodies.CelestialBody{superEarthLike()}, "superearth", nil, bodies.ScaleStrippedBack, nil)
 	// Filtered (Lumen) top row is Vector V, which lifts off the heavy parent.
 	if got := s.SelectedLoadoutID(); got != "Vector-V" {
 		t.Fatalf("setup: filtered top row = %q, want Vector-V", got)
@@ -176,7 +176,7 @@ func TestFilterToggleResnapsLaunchpad(t *testing.T) {
 // (ADR 0031 / S9 render smoke).
 func TestRenderShowsCrewTags(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "")
+	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "", nil)
 	out := s.Render(120)
 	if !strings.Contains(out, "crewed") {
 		t.Error("render missing a 'crewed' tag (e.g. Apollo Stack)")

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -50,7 +50,7 @@ func selectCustom(s *SpawnCraft) {
 // branch.
 func TestSpawnCustomEntryReachableAndEmpty(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	selectCustom(s)
 
 	if !s.IsCustomSelected() {
@@ -83,7 +83,7 @@ func TestSpawnCustomEntryReachableAndEmpty(t *testing.T) {
 // only once Custom is selected.
 func TestSpawnStackFieldReachableOnlyInCustom(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 
 	// Non-custom: Tab through a full cycle never lands on stackFieldIdx.
 	for i := 0; i < 12; i++ {
@@ -121,7 +121,7 @@ func TestSpawnStackFieldReachableOnlyInCustom(t *testing.T) {
 // CRAFT TYPE, and Tab onward from STACK continues to POSITION (field 1).
 func TestSpawnTabFromCustomReachesStackFirst(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	selectCustom(s)
 
 	if s.fieldIdx != 0 {
@@ -148,7 +148,7 @@ func TestSpawnTabFromCustomReachesStackFirst(t *testing.T) {
 // picker, [a] appends the picked part on top, [x] removes the top.
 func TestSpawnStackAddRemove(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -194,7 +194,7 @@ func TestSpawnListsSavedDesigns(t *testing.T) {
 		{Loadout: spacecraft.LoadoutDef{ID: "mun-hopper", Name: "Mun Hopper", Parts: []spacecraft.PartRef{{PartID: "x"}}}},
 	}
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", designs, "")
+	s.Reset(nil, "", designs, "", nil)
 
 	steps := 0
 	for !s.IsDesignSelected() && steps < len(spacecraft.LoadoutOrder)+5 {
@@ -232,7 +232,7 @@ func pickPart(s *SpawnCraft, id string) {
 // payload without the player marking it by hand.
 func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -256,7 +256,7 @@ func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
 // at least one stage. v0.14 / ADR 0011.
 func TestSpawnDockSeamCycleAndClamp(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 	selectCustom(s)
 	s.fieldIdx = stackFieldIdx
 
@@ -295,7 +295,7 @@ func TestSpawnDockSeamCycleAndClamp(t *testing.T) {
 // for Custom and reflects added parts.
 func TestSpawnRenderShowsStackEditor(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
-	s.Reset(nil, "", nil, "")
+	s.Reset(nil, "", nil, "", nil)
 
 	if strings.Contains(s.Render(80), "STACK (bottom → top)") {
 		t.Error("STACK editor rendered for a non-custom loadout")


### PR DESCRIPTION
Sixth and final code slice of v0.32 — completes #221 with PR #269.

## What

- `World.CommBandCoverage(bodyID, altM)`: samples the **production** connectivity solve (same `commNode` construction, `commLinked`, blanket gate — never a second analytic formula, per the amendment) for a hypothetical direct-basic probe on an equatorial circle at the given altitude.
  - Sampled in the **body-equatorial frame** (`ReferenceFrameForPrimary`) — the amendment's caveat; its scratch harness sampled ecliptic and confounded inclination with axial tilt.
  - Orbit phase × rotation phase as **independent axes** (16×24 grid): a time-march couples them and aliases at synchronous altitudes (geostationary would read 0%/100% by longitude luck).
  - Live craft excluded — the label describes the station model's band, deterministic per (body, altitude), not the player's current relay constellation.
- Spawn form: sampler injected at `Reset` (App passes `World.CommBandCoverage`), memoised per (parent, altitude) cursor position, rendered under the ALTITUDE row for `posOrbit` only. Degraded band → `⚠ degraded comms band — ~N% coverage, relays advised`; zero coverage → `⚠ out of network reach` (a relay would be the bum steer); nil sampler → no claim.

## Amendment oracle verified in tests

Earth: 500 km clean (blanket), 5,000 km degraded (~61%), geosync clean. Mars: 0% (out of reach). **Kern: exactly inverted** — 500 km degraded, 5,000 km clean — the decisive case that kills any Earth-derived hardcoded label.

## Tests

TDD red-first: `commnet_band_test.go` (oracle table + inversion + unknown body), `spawn_band_test.go` (flag wording, out-of-reach wording, no-sampler silence). Full suite `-race -count=1` green (1850/19); serve `-count=3` green.