### PR TITLE
fix(commnet): v0.32 review findings — live-network classification, antenna-aware band warning

### DIFF
--- a/internal/sim/commnet.go
+++ b/internal/sim/commnet.go
@@ -121,6 +121,12 @@ type commNode struct {
 type connectivityResult struct {
 	connected map[uint64]bool
 	paths     map[uint64][]int // probe id → node-index chain probe…station
+	// networked marks, per node index, membership in the live network: a
+	// station, or a forwarder with an unoccluded relay chain to one. The
+	// reason classifier (#221) counts only these as "the network in
+	// range" — a disconnected relay next to a disconnected probe is not
+	// evidence that a relay would help (v0.32 review finding).
+	networked []bool
 }
 
 // connectivity builds the adjacency graph over nodes (a link needs both
@@ -158,16 +164,40 @@ func connectivityFull(nodes []commNode, occ []physics.OccluderBody) connectivity
 			res.paths[nodes[i].craftID] = path
 		}
 	}
+	// Multi-source BFS from every station, expanding through forwarders
+	// only: which nodes are part of the live network? Covers crewed
+	// relays too (they carry no probe BFS entry but forward fine).
+	res.networked = make([]bool, n)
+	var queue []int
+	for i := 0; i < n; i++ {
+		if nodes[i].station {
+			res.networked[i] = true
+			queue = append(queue, i)
+		}
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, nb := range adj[cur] {
+			if res.networked[nb] || !nodes[nb].forwards {
+				continue
+			}
+			res.networked[nb] = true
+			queue = append(queue, nb)
+		}
+	}
 	return res
 }
 
 // classifyDisconnects is the post-hoc pass over the solved graph (#221):
-// for each disconnected probe, is any piece of the NETWORK — a station
-// or a forwarding relay — within link range, occlusion ignored? If so
-// the failure is geometry (relay needed); if not, reach (stronger
-// antenna). Dead-end neighbours (direct-only craft) don't count: being
-// in range of one says nothing about reaching the network. Pure, like
-// connectivityFull, so it unit-tests on synthetic nodes.
+// for each disconnected probe, is any piece of the LIVE network — a
+// station, or a forwarder that itself reaches one (res.networked) —
+// within link range, occlusion ignored? If so the failure is geometry
+// (relay needed); if not, reach (stronger antenna). Dead-end neighbours
+// don't count, and neither does a DISCONNECTED relay: a probe and a
+// relay travelling together beyond every station's reach must both read
+// "stronger antenna", not contradict each other (v0.32 review finding).
+// Pure, like connectivityFull, so it unit-tests on synthetic nodes.
 func classifyDisconnects(nodes []commNode, res connectivityResult) map[uint64]CommDisconnectReason {
 	reasons := map[uint64]CommDisconnectReason{}
 	for i, p := range nodes {
@@ -176,7 +206,7 @@ func classifyDisconnects(nodes []commNode, res connectivityResult) map[uint64]Co
 		}
 		reason := CommDisconnectOutOfRange
 		for j, n := range nodes {
-			if j == i || (!n.station && !n.forwards) {
+			if j == i || !res.networked[j] {
 				continue
 			}
 			if p.rangeM <= 0 || n.rangeM <= 0 {

--- a/internal/sim/commnet_band.go
+++ b/internal/sim/commnet_band.go
@@ -36,22 +36,31 @@ const (
 	CommBandDegradedThreshold = 0.995
 )
 
-// CommBandCoverage samples connectivity for a hypothetical direct-basic
-// probe in a circular EQUATORIAL orbit of bodyID at altM, over orbit
-// phase × body rotation phase, and returns the connected fraction.
-// ok=false when the body is not in the viewed system. Equatorial in the
-// body-equatorial frame (frame.go is the boundary) — the amendment's
-// scratch harness sampled ecliptic-frame orbits and its inclination
-// figures were confounded with axial tilt; the form spawns exactly one
-// plane (posOrbit has no inclination field), and this samples that
-// plane. Live craft are deliberately excluded: the label describes the
-// preset band of the station model, deterministic per (body, altitude),
-// not the player's current relay constellation.
-func (w *World) CommBandCoverage(bodyID string, altM float64) (float64, bool) {
+// CommBandCoverage samples connectivity for a hypothetical probe with
+// the given antenna rated range (≤0 → the direct-basic backfill every
+// non-debris vessel carries) in a circular EQUATORIAL orbit of bodyID
+// at altM, over orbit phase × body rotation phase, and returns the
+// connected fraction. The antenna matters (v0.32 review finding): a
+// Relay-Tug at the Moon links to Earth's ring while a direct-basic
+// probe there is genuinely out of reach — warning the relay spawn "out
+// of network reach" would steer the player off the exact constellation
+// the band exists to motivate. ok=false when the body is not in the
+// viewed system. Equatorial in the body-equatorial frame (frame.go is
+// the boundary) — the amendment's scratch harness sampled ecliptic-
+// frame orbits and its inclination figures were confounded with axial
+// tilt; the form spawns exactly one plane (posOrbit has no inclination
+// field), and this samples that plane. Live craft are deliberately
+// excluded: the label describes the preset band of the station model,
+// deterministic per (body, altitude, antenna), not the player's current
+// relay constellation.
+func (w *World) CommBandCoverage(bodyID string, altM, antennaRangeM float64) (float64, bool) {
 	sys := w.System()
 	body := sys.FindBody(bodyID)
 	if body == nil || altM <= 0 {
 		return 0, false
+	}
+	if antennaRangeM <= 0 {
+		antennaRangeM = spacecraft.DefaultProbeAntennaRangeM
 	}
 
 	// Occluders: every body in the system, frozen at SimTime — orbital
@@ -85,9 +94,15 @@ func (w *World) CommBandCoverage(bodyID string, altM float64) (float64, bool) {
 	bodyPos := w.BodyPosition(*body)
 
 	rotSamples := commBandRotationSamples
-	rotPeriod := body.SideralRotationSeconds()
-	if rotPeriod <= 0 {
-		rotSamples = 1 // a non-rotating body has one station geometry
+	// Sweep by |period|: SideralRotation is signed (retrograde Venus /
+	// Uranus are negative), and a retrograde host sweeps its stations
+	// the same as a prograde one — collapsing to a single sample would
+	// reintroduce the aliasing this grid exists to prevent (v0.32
+	// review finding). Only a genuinely non-rotating body (period 0)
+	// has one station geometry.
+	rotPeriod := math.Abs(body.SideralRotationSeconds())
+	if rotPeriod == 0 {
+		rotSamples = 1
 	}
 
 	connected, total := 0, 0
@@ -119,7 +134,7 @@ func (w *World) CommBandCoverage(bodyID string, altM float64) (float64, bool) {
 			rBody := orbital.Vec3{X: r * math.Cos(phi), Y: r * math.Sin(phi)}
 			probe := commNode{
 				pos:      bodyPos.Add(frame.ToWorld(rBody)),
-				rangeM:   spacecraft.AntennaRangeDirectBasic,
+				rangeM:   antennaRangeM,
 				probe:    true,
 				craftID:  probeID,
 				bodyID:   bodyID,

--- a/internal/sim/commnet_band_test.go
+++ b/internal/sim/commnet_band_test.go
@@ -1,6 +1,10 @@
 package sim
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
 
 // #221 part 2 (ADR 0027 v0.32 amendment §2): spawn-form band warnings
 // are computed per-primary by sampling the PRODUCTION connectivity
@@ -22,20 +26,20 @@ func bandWorld(t *testing.T) *World {
 func TestCommBandCoverageEarth(t *testing.T) {
 	w := bandWorld(t)
 
-	if cov, ok := w.CommBandCoverage("earth", 500e3); !ok || cov < 1.0 {
+	if cov, ok := w.CommBandCoverage("earth", 500e3, 0); !ok || cov < 1.0 {
 		t.Errorf("Earth 500 km sits inside the home blanket: cov=%.3f ok=%v, want 1.0", cov, ok)
 	}
-	if cov, ok := w.CommBandCoverage("earth", 5000e3); !ok || cov <= 0.05 || cov >= CommBandDegradedThreshold {
+	if cov, ok := w.CommBandCoverage("earth", 5000e3, 0); !ok || cov <= 0.05 || cov >= CommBandDegradedThreshold {
 		t.Errorf("Earth 5,000 km is the measured dead band (~61%%): cov=%.3f ok=%v", cov, ok)
 	}
-	if cov, ok := w.CommBandCoverage("earth", 35786e3); !ok || cov < CommBandDegradedThreshold {
+	if cov, ok := w.CommBandCoverage("earth", 35786e3, 0); !ok || cov < CommBandDegradedThreshold {
 		t.Errorf("equatorial geosync is clean: cov=%.3f ok=%v", cov, ok)
 	}
 }
 
 func TestCommBandCoverageMarsOutOfReach(t *testing.T) {
 	w := bandWorld(t)
-	cov, ok := w.CommBandCoverage("mars", 5000e3)
+	cov, ok := w.CommBandCoverage("mars", 5000e3, 0)
 	if !ok {
 		t.Fatalf("mars is in the active system; ok=false")
 	}
@@ -57,11 +61,11 @@ func TestCommBandCoverageKernInversion(t *testing.T) {
 	}
 	w.SystemIdx = kernIdx
 
-	low, ok := w.CommBandCoverage("kern", 500e3)
+	low, ok := w.CommBandCoverage("kern", 500e3, 0)
 	if !ok {
 		t.Fatalf("kern lookup failed in its own system")
 	}
-	high, _ := w.CommBandCoverage("kern", 5000e3)
+	high, _ := w.CommBandCoverage("kern", 5000e3, 0)
 	// The decisive inversion: an Earth-derived label would flag exactly
 	// the wrong presets at Kern.
 	if low >= CommBandDegradedThreshold {
@@ -74,7 +78,24 @@ func TestCommBandCoverageKernInversion(t *testing.T) {
 
 func TestCommBandCoverageUnknownBody(t *testing.T) {
 	w := bandWorld(t)
-	if _, ok := w.CommBandCoverage("no-such-body", 500e3); ok {
+	if _, ok := w.CommBandCoverage("no-such-body", 500e3, 0); ok {
 		t.Errorf("unknown body must report ok=false")
+	}
+}
+
+func TestCommBandCoverageAntennaAware(t *testing.T) {
+	// Review finding (v0.32 batch): the sampler must model the antenna
+	// actually being spawned — a Relay-Tug at the Moon links to Earth's
+	// ring (√(1e9·5e9) ≈ 2.24e9 m > the ~3.84e8 m separation) and must
+	// NOT be warned "out of network reach", while a direct-basic probe
+	// there genuinely is out of reach (√(1e7·5e9) ≈ 2.24e8 m).
+	w := bandWorld(t)
+	basic, ok := w.CommBandCoverage("moon", 100e3, spacecraft.AntennaRangeDirectBasic)
+	if !ok || basic != 0 {
+		t.Errorf("direct-basic at the Moon: cov=%.3f ok=%v, want 0 (out of reach)", basic, ok)
+	}
+	relay, ok := w.CommBandCoverage("moon", 100e3, spacecraft.AntennaRangeRelayCislunar)
+	if !ok || relay <= 0.2 {
+		t.Errorf("relay-cislunar at the Moon reaches Earth's ring: cov=%.3f ok=%v, want well above 0", relay, ok)
 	}
 }

--- a/internal/sim/commnet_reason_test.go
+++ b/internal/sim/commnet_reason_test.go
@@ -58,6 +58,49 @@ func TestDisconnectReasonIgnoresDeadEndNeighbours(t *testing.T) {
 	}
 }
 
+func TestDisconnectReasonIgnoresDisconnectedRelay(t *testing.T) {
+	// Review finding (v0.32 batch): a probe travelling WITH a relay,
+	// both beyond every station's reach — the standard send-a-probe-
+	// plus-relay-outward flow. The dead relay next door is not "the
+	// network in range": another relay changes nothing, so the advice
+	// must be antenna for BOTH craft, and two craft in the identical
+	// predicament must never read contradictory advice.
+	nodes := []commNode{
+		station(0, 1e9, 100000), // far beyond everyone
+		probeNode(1, 0, 3000, false),
+		probeNode(2, 500, 100000, true), // relay antenna, also disconnected
+	}
+	res := connectivityFull(nodes, nil)
+	reasons := classifyDisconnects(nodes, res)
+	if got := reasons[1]; got != CommDisconnectOutOfRange {
+		t.Errorf("probe beside a DISCONNECTED relay: reason = %v, want CommDisconnectOutOfRange (a dead relay is not the network)", got)
+	}
+	if got := reasons[2]; got != CommDisconnectOutOfRange {
+		t.Errorf("the relay itself: reason = %v, want CommDisconnectOutOfRange", got)
+	}
+}
+
+func TestDisconnectReasonCountsConnectedRelay(t *testing.T) {
+	// The complement: a CONNECTED relay in range (occluded from the
+	// probe) IS the network — the geometry is the problem, advise a
+	// relay. Station←→relay link is clear; probe is in range of the
+	// relay only, with a body on that segment.
+	occ := []physics.OccluderBody{{Center: orbital.Vec3{X: 95000}, Radius: 50}}
+	nodes := []commNode{
+		station(0, 0, 100000),
+		probeNode(1, 100000, 3000, false), // out of station range (√(3e3·1e5)≈17.3 km)
+		relayNode(90000, 100000),          // linked to the station, networked
+	}
+	res := connectivityFull(nodes, occ)
+	if res.connected[1] {
+		t.Fatalf("probe should be disconnected (occluded from the relay)")
+	}
+	reasons := classifyDisconnects(nodes, res)
+	if got := reasons[1]; got != CommDisconnectBlocked {
+		t.Errorf("probe occluded from a CONNECTED relay in range: reason = %v, want CommDisconnectBlocked", got)
+	}
+}
+
 func TestDisconnectReasonConnectedProbeHasNone(t *testing.T) {
 	nodes := []commNode{
 		station(0, 0, 100000),

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -81,21 +81,21 @@ type SpawnCraft struct {
 	groupsValid   bool
 
 	// bandCoverage (#221, ADR 0027 v0.32 amendment §2) samples the live
-	// CommNet model for a (bodyID, altitude) — injected at Reset (the App
-	// passes World.CommBandCoverage) so the form itself never derives
-	// coverage; a second formula here would drift from the model. nil
-	// (tests, no world) ⇒ no warning is ever claimed. bandCache memoises
-	// per parentIdx|altIdx — sampling costs ~400 connectivity solves, fine
-	// once per cursor position, wasteful per render frame.
-	bandCoverage func(bodyID string, altM float64) (float64, bool)
-	bandCache    map[[2]int]float64
+	// CommNet model for a (bodyID, altitude, antenna) — injected at Reset
+	// (the App passes World.CommBandCoverage) so the form itself never
+	// derives coverage; a second formula here would drift from the model.
+	// nil (tests, no world) ⇒ no warning is ever claimed. bandCache
+	// memoises per (parent, altitude, antenna) — sampling costs ~400
+	// connectivity solves, fine once per cursor position, wasteful per
+	// render frame.
+	bandCoverage func(bodyID string, altM, antennaRangeM float64) (float64, bool)
+	bandCache    map[bandCacheKey]float64
 }
 
-// spawnBandDegradedBelow mirrors sim.CommBandDegradedThreshold without
-// importing the value into the render path: coverage under this flags
-// the preset; exactly zero switches to the out-of-reach wording (a
-// relay is a bum steer when nothing is in range at all).
-const spawnBandDegradedBelow = 0.995
+type bandCacheKey struct {
+	parentIdx, altIdx int
+	antennaRangeM     float64
+}
 
 // stackFieldIdx is the form-field index of the STACK editor — only
 // reachable (Tab includes it) when the Custom loadout is selected.
@@ -129,9 +129,9 @@ func NewSpawnCraft(th Theme) *SpawnCraft { return &SpawnCraft{theme: th} }
 // the parent-field cursor lands on initially (typically the active
 // craft's current primary). v0.8.2+: replaces the v0.8.2-pre
 // no-arg Reset.
-func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string, designs []spacecraft.Design, systemScale bodies.ScaleClass, bandCoverage func(bodyID string, altM float64) (float64, bool)) {
+func (s *SpawnCraft) Reset(systemBodies []bodies.CelestialBody, defaultParentID string, designs []spacecraft.Design, systemScale bodies.ScaleClass, bandCoverage func(bodyID string, altM, antennaRangeM float64) (float64, bool)) {
 	s.bandCoverage = bandCoverage
-	s.bandCache = map[[2]int]float64{}
+	s.bandCache = map[bandCacheKey]float64{}
 	s.fieldIdx = 0
 	s.loadoutIdx = 0
 	s.customStages = nil
@@ -856,11 +856,15 @@ func (s *SpawnCraft) Render(width int) string {
 }
 
 // bandWarning classifies the focused (parent, altitude) preset against
-// the sampled CommNet coverage (#221): a preset in the degraded band
-// names the band AND the fix (relays); zero coverage is the out-of-range
-// case and must not advise a relay. Empty when the sampler is absent,
-// the position mode doesn't orbit, or coverage is clean — the form never
-// guesses.
+// the sampled CommNet coverage (#221) FOR THE CRAFT BEING SPAWNED: a
+// crewed loadout is never comms-gated so it gets no warning at all, and
+// the sampler models the selected craft's own best antenna — a Relay-Tug
+// at the Moon links home and must not be warned off the exact spawn the
+// band pressure exists to motivate (v0.32 review finding). A preset in
+// the degraded band names the band AND the fix (relays); zero coverage
+// is the out-of-range case and must not advise a relay. Empty when the
+// sampler is absent, the position mode doesn't orbit, or coverage is
+// clean — the form never guesses.
 func (s *SpawnCraft) bandWarning() string {
 	if s.bandCoverage == nil || s.posMode != posOrbit {
 		return ""
@@ -868,10 +872,14 @@ func (s *SpawnCraft) bandWarning() string {
 	if s.parentIdx < 0 || s.parentIdx >= len(s.parentBodies) {
 		return ""
 	}
-	key := [2]int{s.parentIdx, s.altIdx}
+	crewed, antennaRangeM := spawnCommsProfile(s.selectedCraftStages())
+	if crewed {
+		return "" // crewed vessels are never comms-gated
+	}
+	key := bandCacheKey{parentIdx: s.parentIdx, altIdx: s.altIdx, antennaRangeM: antennaRangeM}
 	cov, cached := s.bandCache[key]
 	if !cached {
-		c, ok := s.bandCoverage(s.parentBodies[s.parentIdx].ID, s.SelectedAltitudeM())
+		c, ok := s.bandCoverage(s.parentBodies[s.parentIdx].ID, s.SelectedAltitudeM(), antennaRangeM)
 		if !ok {
 			return ""
 		}
@@ -881,10 +889,27 @@ func (s *SpawnCraft) bandWarning() string {
 	switch {
 	case cov <= 0:
 		return "⚠ out of network reach — no signal at this body"
-	case cov < spawnBandDegradedBelow:
+	case cov < sim.CommBandDegradedThreshold:
 		return fmt.Sprintf("⚠ degraded comms band — ~%d%% coverage, relays advised", int(cov*100+0.5))
 	}
 	return ""
+}
+
+// spawnCommsProfile derives the comms-relevant shape of a stage list the
+// way vessel construction does: crewed if any stage carries a crewed
+// command source, and the best stage antenna's rated range (zero → the
+// caller lets the sampler assume the EnsureCommandSource direct-basic
+// backfill every non-debris vessel receives).
+func spawnCommsProfile(stages []spacecraft.Stage) (crewed bool, antennaRangeM float64) {
+	for _, st := range stages {
+		if st.CommandSource == spacecraft.CommandCrewed {
+			crewed = true
+		}
+		if st.AntennaKind != spacecraft.AntennaNone && st.AntennaRangeM > antennaRangeM {
+			antennaRangeM = st.AntennaRangeM
+		}
+	}
+	return crewed, antennaRangeM
 }
 
 // craftRow renders one selectable CRAFT TYPE row (a catalog loadout, the

--- a/internal/tui/screens/spawn_band_test.go
+++ b/internal/tui/screens/spawn_band_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // #221 part 2: the spawn form flags posOrbit presets that fall in the
@@ -12,9 +13,9 @@ import (
 // itself never derives coverage.
 
 // bandStub returns a canned coverage per altitude (km-keyed), defaulting
-// to full coverage.
-func bandStub(byAltKm map[int]float64) func(string, float64) (float64, bool) {
-	return func(bodyID string, altM float64) (float64, bool) {
+// to full coverage, and records the antenna range of the last call.
+func bandStub(byAltKm map[int]float64) func(string, float64, float64) (float64, bool) {
+	return func(bodyID string, altM, antennaRangeM float64) (float64, bool) {
 		if cov, ok := byAltKm[int(altM/1000)]; ok {
 			return cov, true
 		}
@@ -26,7 +27,7 @@ func bandTestBodies() []bodies.CelestialBody {
 	return []bodies.CelestialBody{{ID: "earth", Name: "Earth"}}
 }
 
-func resetWithBand(s *SpawnCraft, cov func(string, float64) (float64, bool)) {
+func resetWithBand(s *SpawnCraft, cov func(string, float64, float64) (float64, bool)) {
 	s.Reset(bandTestBodies(), "earth", nil, "", cov)
 }
 
@@ -65,6 +66,41 @@ func TestSpawnFormNoBandWarningWithoutSampler(t *testing.T) {
 	setAltPreset(t, s, 5000)
 	if out := s.Render(80); strings.Contains(out, "degraded comms band") {
 		t.Errorf("no sampler injected → no claim made:\n%s", out)
+	}
+}
+
+// Review fixes (v0.32 batch): the warning must describe the craft being
+// spawned — crewed loadouts are never comms-gated so they get no
+// warning, and the sampler receives the selected stack's best antenna
+// so a relay craft isn't warned off the constellation-building spawn.
+
+func TestSpawnFormCrewedLoadoutNeverWarned(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.5}))
+	selectCustom(s)
+	s.customStages = []spacecraft.Stage{{Name: "Pod", CommandSource: spacecraft.CommandCrewed}}
+	setAltPreset(t, s, 5000)
+	if out := s.Render(80); strings.Contains(out, "degraded comms band") || strings.Contains(out, "out of network reach") {
+		t.Errorf("a crewed craft is never comms-gated — no warning applies:\n%s", out)
+	}
+}
+
+func TestSpawnFormPassesSelectedAntennaToSampler(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	var gotRange float64
+	s.Reset(bandTestBodies(), "earth", nil, "", func(bodyID string, altM, antennaRangeM float64) (float64, bool) {
+		gotRange = antennaRangeM
+		return 1.0, true
+	})
+	selectCustom(s)
+	s.customStages = []spacecraft.Stage{{
+		Name: "Bus", CommandSource: spacecraft.CommandProbe,
+		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+	}}
+	setAltPreset(t, s, 5000)
+	_ = s.Render(80)
+	if gotRange != spacecraft.AntennaRangeRelayCislunar {
+		t.Errorf("sampler must receive the selected stack's antenna range; got %g", gotRange)
 	}
 }
 


### PR DESCRIPTION
Fixes the four verified findings from the v0.32 batch adversarial review (commnet reviewer).

1. **Major — dead relay counted as 'network in range'.** A probe + relay travelling together beyond station reach read contradictory advice ('relay needed' / 'stronger antenna'). `connectivityFull` now computes `networked` (multi-source BFS from stations through forwarders — handles crewed relays, which have no probe BFS entry) and `classifyDisconnects` counts only live-network neighbours. Red tests: dead-relay pair both OutOfRange; occluded-from-CONNECTED-relay still Blocked.
2. **Major — band warning ignored the selected craft.** Sampler was pinned to direct-basic: a Relay-Tug at the Moon was warned 'out of network reach' while it actually links Earth's ring (√(1e9·5e9) ≈ 2.24e9 m > 3.84e8 m). `CommBandCoverage` gains the antenna rated range (≤0 → the direct-basic backfill); the form derives crewed + best antenna from `selectedCraftStages()` and never warns a crewed craft. Red tests: Moon basic=0 vs relay>0; crewed suppressed; antenna forwarded to the sampler.
3. **Minor — retrograde rotation aliasing.** `SideralRotation` is signed (Venus, Uranus); the sweep now uses `|period|`, one sample only for genuinely non-rotating bodies.
4. **Minor — threshold duplication.** Form reads `sim.CommBandDegradedThreshold` (already imported) instead of a drifting copy.

Full suite `-race -count=1` green (1855/19).