### PR TITLE
fix(mp): v0.32 chat review findings — multi-word handles, ambiguity, draft preservation

### DIFF
--- a/internal/serve/chat.go
+++ b/internal/serve/chat.go
@@ -17,10 +17,15 @@ type chatRing struct {
 	lines []sim.ChatLine
 }
 
-// chatLineCap bounds the ring. Sized so the 3–4 visible lines a chip
-// stack shows can never miss during cross-traffic; eviction only drops
-// lines already far older than the display TTL.
-const chatLineCap = 32
+// The ring prunes by AGE first (chatServerTTL, comfortably past the
+// 30 s chip TTL) — a count-only cap counts lines the viewer can never
+// see, so two other players' DM spam would evict a viewer's still-fresh
+// visible line (v0.32 review finding). chatLineCap remains only as a
+// memory backstop against a flood inside one TTL window.
+const (
+	chatLineCap   = 256
+	chatServerTTL = 2 * time.Minute
+)
 
 // chatMessageRuneCap bounds one message. The mint input's 24 is far too
 // short for "node is 200m off, burning in 30" (ADR 0035 impl. note).
@@ -31,10 +36,16 @@ func newChatRing() *chatRing {
 }
 
 // post appends a line, truncating to chatMessageRuneCap runes and
-// trimming the ring. to/toHandle address a DM (empty = broadcast).
+// pruning the ring. to/toHandle address a DM (empty = broadcast).
 // Roster validation happens in the intent handler, which owns store and
 // presence access — the ring is storage.
 func (c *chatRing) post(owner, handle, to, toHandle, text string) {
+	c.postAt(owner, handle, to, toHandle, text, time.Now())
+}
+
+// postAt is post with an explicit timestamp, split out so tests can
+// exercise the TTL prune without waiting it out.
+func (c *chatRing) postAt(owner, handle, to, toHandle, text string, at time.Time) {
 	if r := []rune(text); len(r) > chatMessageRuneCap {
 		text = string(r[:chatMessageRuneCap])
 	}
@@ -42,8 +53,16 @@ func (c *chatRing) post(owner, handle, to, toHandle, text string) {
 	defer c.mu.Unlock()
 	c.lines = append(c.lines, sim.ChatLine{
 		Owner: owner, Handle: handle, To: to, ToHandle: toHandle,
-		Text: text, At: time.Now(),
+		Text: text, At: at,
 	})
+	cutoff := time.Now().Add(-chatServerTTL)
+	kept := c.lines[:0]
+	for _, l := range c.lines {
+		if l.At.After(cutoff) {
+			kept = append(kept, l)
+		}
+	}
+	c.lines = kept
 	if len(c.lines) > chatLineCap {
 		c.lines = c.lines[len(c.lines)-chatLineCap:]
 	}

--- a/internal/serve/chat_test.go
+++ b/internal/serve/chat_test.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // ADR 0035 §1: chat lives in its own capped ring beside presence, so a
@@ -77,6 +78,31 @@ func TestChatRingTextRuneCap(t *testing.T) {
 	}
 	if !strings.HasPrefix(long, got) {
 		t.Fatalf("truncation must be rune-safe (prefix of the original)")
+	}
+}
+
+func TestChatRingCrossTrafficDoesNotEvictFresh(t *testing.T) {
+	// Review fix (v0.32 batch): the cap used to count lines the viewer
+	// can never see, so B↔C DM spam evicted A's still-fresh broadcast.
+	c := newChatRing()
+	c.post("fpA", "alice", "", "", "my burn is in 40")
+	for i := 0; i < 40; i++ {
+		c.post("fpB", "bob", "fpC", "carol", "spam")
+		c.post("fpC", "carol", "fpB", "bob", "spam back")
+	}
+	lines := c.linesFor("fpA")
+	if len(lines) != 1 || lines[0].Text != "my burn is in 40" {
+		t.Fatalf("third-party DM traffic must not evict a viewer's fresh line; got %d lines", len(lines))
+	}
+}
+
+func TestChatRingPrunesByServerTTL(t *testing.T) {
+	c := newChatRing()
+	c.postAt("fpA", "alice", "", "", "ancient", time.Now().Add(-chatServerTTL-time.Second))
+	c.post("fpA", "alice", "", "", "fresh")
+	lines := c.linesFor("fpB")
+	if len(lines) != 1 || lines[0].Text != "fresh" {
+		t.Fatalf("expired lines must prune on post; got %+v", lines)
 	}
 }
 

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -148,7 +148,12 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if chat.To != "" && !m.srv.presence.isOnline(chat.To) {
+			// Hand the draft back instead of destroying it — the target
+			// can drop in the gap between the roster tick that showed
+			// them online and Enter (v0.32 review finding). Mirrors the
+			// App-side refusals, which all keep the text.
 			m.app.Toast(chat.ToHandle + " is offline — not sent")
+			m.app.RestoreChatDraft("@" + chat.ToHandle + " " + chat.Text)
 			return m, nil
 		}
 		ownHandle := m.owner

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -631,16 +631,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Chat capture (ADR 0035 S3): while the input is up, every key
 		// is text or an editing action — the unconditional return keeps
-		// flight controls, screens, and the boss key out of reach. Sits
-		// above endFlightConfirm by construction, but the two can't
-		// coexist: the confirm swallows ~, and while chatting E is text.
+		// flight controls, screens, and the boss key out of reach.
+		// While chatting E is text, so the end-flight confirm can never
+		// arm underneath an open input.
 		if a.chatOpen {
 			return a.handleChatKey(m)
 		}
 		// ~ opens chat from the flight view (ADR 0035 §4; U+007E, a
 		// different rune from the U+0060 boss key, and absent from every
-		// layout map so normalization passed it through untouched).
-		if a.active == screenOrbit && m.Type == tea.KeyRunes && len(m.Runes) == 1 && m.Runes[0] == '~' {
+		// layout map so normalization passed it through untouched). Not
+		// while the END FLIGHT confirm is armed — the ~ falls through to
+		// the confirm's swallow-everything intercept below, instead of
+		// opening an overlay that hides an armed destructive prompt
+		// (v0.32 review finding).
+		if a.active == screenOrbit && !a.endFlightConfirm && m.Type == tea.KeyRunes && len(m.Runes) == 1 && m.Runes[0] == '~' {
 			if a.world.Session == nil {
 				// Solo: say so — a dead key reads as broken (v0.30 lesson).
 				a.toast("chat is multiplayer — host or join a session [O]")
@@ -1820,10 +1824,15 @@ func (a *App) chatAppend(r rune) {
 }
 
 // sendChat parses the drafted line and emits the ChatSendMsg the serve
-// wrapper acts on. A leading @handle addresses a DM: case-insensitive
-// exact match against the ONLINE roster; a miss refuses to send and
-// leaves the text intact — never a silent fall-back to broadcast
-// (ADR 0035 §7).
+// wrapper acts on. A leading @ addresses a DM: the target is resolved
+// by the LONGEST online-roster handle matching the head of the text
+// (handles may legally contain spaces — "mission control" must be
+// DM-able, and tab-complete produces exactly that draft; v0.32 review
+// finding), case-insensitively, self excluded. A miss refuses to send
+// and leaves the text intact — never a silent fall-back to broadcast
+// (ADR 0035 §7) — and so does an AMBIGUOUS handle (two online players
+// whose handles fold to the same string): a private line must never
+// route by enrollment order (v0.32 review finding).
 func (a *App) sendChat() (tea.Model, tea.Cmd) {
 	text := strings.TrimSpace(string(a.chatInput))
 	if text == "" {
@@ -1832,10 +1841,14 @@ func (a *App) sendChat() (tea.Model, tea.Cmd) {
 	}
 	msg := ChatSendMsg{Text: text}
 	if strings.HasPrefix(text, "@") {
-		handle, rest, _ := strings.Cut(text[1:], " ")
-		p, ok := a.chatLookup(handle)
-		if !ok {
-			a.toast("no online player \"" + handle + "\" — not sent")
+		p, rest, matches := a.chatResolveDM(text[1:])
+		if matches == 0 {
+			first, _, _ := strings.Cut(text[1:], " ")
+			a.toast("no online player \"" + first + "\" — not sent")
+			return a, nil
+		}
+		if matches > 1 {
+			a.toast("\"" + p.Handle + "\" is ambiguous — two players share it; not sent")
 			return a, nil
 		}
 		rest = strings.TrimSpace(rest)
@@ -1849,22 +1862,51 @@ func (a *App) sendChat() (tea.Model, tea.Cmd) {
 	return a, func() tea.Msg { return msg }
 }
 
-// chatLookup resolves a handle against the online roster, excluding the
-// viewer — you cannot DM yourself, and completion should not offer it.
-func (a *App) chatLookup(handle string) (sim.SessionPlayer, bool) {
+// chatResolveDM matches the head of body (the text after the leading @)
+// against the online roster, longest handle first: a handle matches when
+// body starts with it case-insensitively and the next byte is a space or
+// the end. Returns the matched player, the remaining message, and how
+// many ONLINE players carry the winning handle (0 = no match, >1 =
+// ambiguous — the caller refuses).
+func (a *App) chatResolveDM(body string) (sim.SessionPlayer, string, int) {
 	info := a.world.Session
 	if info == nil {
-		return sim.SessionPlayer{}, false
+		return sim.SessionPlayer{}, "", 0
 	}
+	var best sim.SessionPlayer
+	bestLen, matches := 0, 0
 	for _, p := range info.Players {
-		if !p.Online || p.Fingerprint == info.Self {
+		if !p.Online || p.Fingerprint == info.Self || p.Handle == "" {
 			continue
 		}
-		if strings.EqualFold(p.Handle, handle) {
-			return p, true
+		h := p.Handle
+		if len(body) < len(h) || !strings.EqualFold(body[:len(h)], h) {
+			continue
+		}
+		if len(body) > len(h) && body[len(h)] != ' ' {
+			continue
+		}
+		switch {
+		case len(h) > bestLen:
+			best, bestLen, matches = p, len(h), 1
+		case len(h) == bestLen:
+			matches++
 		}
 	}
-	return sim.SessionPlayer{}, false
+	if matches == 0 {
+		return sim.SessionPlayer{}, "", 0
+	}
+	return best, body[bestLen:], matches
+}
+
+// RestoreChatDraft reopens the chat input with the given draft — the
+// serve wrapper's door for handing a refused DM back to the player
+// instead of destroying up to 120 typed runes (v0.32 review finding:
+// the target can go offline between the roster tick and Enter).
+func (a *App) RestoreChatDraft(draft string) {
+	a.chatOpen = true
+	a.chatInput = []rune(draft)
+	a.chatTabbing = false
 }
 
 // chatTabComplete completes a leading @prefix against the online
@@ -1872,11 +1914,15 @@ func (a *App) chatLookup(handle string) (sim.SessionPlayer, bool) {
 // @word itself completes — once a space is typed the handle is
 // committed and tab is inert.
 func (a *App) chatTabComplete() {
-	cur := string(a.chatInput)
-	if !strings.HasPrefix(cur, "@") || strings.ContainsRune(cur, ' ') {
-		return
-	}
+	// The no-spaces guard applies only when STARTING a cycle — while a
+	// cycle is live the input is exactly "@<candidate>", which may
+	// itself contain spaces ("mission control"), and tab must keep
+	// cycling past it to the other candidates (v0.32 review finding).
 	if !a.chatTabbing {
+		cur := string(a.chatInput)
+		if !strings.HasPrefix(cur, "@") || strings.ContainsRune(cur, ' ') {
+			return
+		}
 		a.chatTabbing, a.chatTabBase, a.chatTabIdx = true, cur[1:], -1
 	}
 	info := a.world.Session

--- a/internal/tui/app_chat_input_test.go
+++ b/internal/tui/app_chat_input_test.go
@@ -200,6 +200,90 @@ func TestChatTabIgnoresOfflineAndSelf(t *testing.T) {
 	}
 }
 
+// Review fixes (v0.32 batch): DM parsing must survive the roster's own
+// legal handles, and the input must not fight other armed prompts.
+
+func TestChatDMMultiWordHandle(t *testing.T) {
+	a := newChatApp(t)
+	a.world.Session.Players = append(a.world.Session.Players,
+		sim.SessionPlayer{Fingerprint: "SHA256:mc", Handle: "mission control", Online: true})
+	openChat(t, a)
+	typeRunes(a, "@mission control hold the burn")
+	m := sendMsg(chatPress(a, tea.KeyMsg{Type: tea.KeyEnter}))
+	if m == nil || m.To != "SHA256:mc" || m.ToHandle != "mission control" {
+		t.Fatalf("a handle containing spaces must resolve greedily; got %+v", m)
+	}
+	if m.Text != "hold the burn" {
+		t.Fatalf("the message must be what follows the full handle; got %q", m.Text)
+	}
+}
+
+func TestChatTabCompletedMultiWordHandleSends(t *testing.T) {
+	// The completion the game itself produces must be sendable — the
+	// review scenario had tab produce "@mission control" and Enter
+	// refuse it.
+	a := newChatApp(t)
+	a.world.Session.Players = append(a.world.Session.Players,
+		sim.SessionPlayer{Fingerprint: "SHA256:mc", Handle: "mission control", Online: true})
+	openChat(t, a)
+	typeRunes(a, "@mis")
+	chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+	if got := string(a.chatInput); got != "@mission control" {
+		t.Fatalf("tab must complete the full handle; got %q", got)
+	}
+	typeRunes(a, " go")
+	if m := sendMsg(chatPress(a, tea.KeyMsg{Type: tea.KeyEnter})); m == nil || m.To != "SHA256:mc" {
+		t.Fatalf("the game's own completion must send; got %+v", m)
+	}
+}
+
+func TestChatTabCyclesPastMultiWordCandidate(t *testing.T) {
+	a := newChatApp(t)
+	a.world.Session.Players = append(a.world.Session.Players,
+		sim.SessionPlayer{Fingerprint: "SHA256:mc", Handle: "gern control", Online: true})
+	openChat(t, a)
+	typeRunes(a, "@g")
+	seen := map[string]bool{}
+	for i := 0; i < 6; i++ {
+		chatPress(a, tea.KeyMsg{Type: tea.KeyTab})
+		seen[string(a.chatInput)] = true
+	}
+	if !seen["@gern"] || !seen["@gale"] || !seen["@gern control"] {
+		t.Fatalf("cycling must reach every candidate even past a multi-word completion; saw %v", seen)
+	}
+}
+
+func TestChatDMAmbiguousHandleRefused(t *testing.T) {
+	a := newChatApp(t)
+	a.world.Session.Players = append(a.world.Session.Players,
+		sim.SessionPlayer{Fingerprint: "SHA256:gern2", Handle: "Gern", Online: true})
+	openChat(t, a)
+	typeRunes(a, "@gern which one are you")
+	if sendMsg(chatPress(a, tea.KeyMsg{Type: tea.KeyEnter})) != nil {
+		t.Fatalf("an ambiguous handle (case-collision) must refuse — a private line must never route by enrollment order")
+	}
+	if !a.capturingText() || a.statusMsg == "" {
+		t.Fatalf("ambiguity refusal must toast and keep the draft")
+	}
+}
+
+func TestChatTildeInertDuringEndFlightConfirm(t *testing.T) {
+	a := newChatApp(t)
+	a.endFlightConfirm = true
+	chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'~'}})
+	if a.capturingText() {
+		t.Fatalf("~ must not open chat over an armed END FLIGHT confirm")
+	}
+}
+
+func TestRestoreChatDraft(t *testing.T) {
+	a := newChatApp(t)
+	a.RestoreChatDraft("@gern hold")
+	if !a.capturingText() || string(a.chatInput) != "@gern hold" {
+		t.Fatalf("RestoreChatDraft must reopen the overlay with the draft; input=%q", string(a.chatInput))
+	}
+}
+
 func TestChatInputRuneCap(t *testing.T) {
 	a := newChatApp(t)
 	openChat(t, a)


### PR DESCRIPTION
Fixes the five verified findings from the v0.32 batch adversarial review (chat reviewer). Companion to #272.

1. **Major — handles with spaces were un-DM-able.** `strings.Cut` at the first space made 'mission control' permanently unreachable, and tab-complete produced exactly the draft the send path refused. The target now resolves by **longest online-handle match** at the head of the text; the tab cycle keeps going past a multi-word completion (no-spaces guard only when *starting* a cycle). Red tests: multi-word send, the game's-own-completion-must-send scenario, cycling past a multi-word candidate.
2. **Major — case-colliding handles routed DMs by enrollment order.** Two online 'gern'/'Gern' → the earlier-enrolled one silently got every private line. An ambiguous handle now refuses + toasts + keeps the draft.
3. **Minor — `~` opened over an armed END FLIGHT confirm**, hiding the y/n prompt while it stayed armed. Open now gated on `!endFlightConfirm` (the `~` falls through to the confirm's swallow, making the block comment true).
4. **Minor — the serve-side offline re-check destroyed the draft** (the only refusal path that lost text). The wrapper hands it back via `App.RestoreChatDraft` with the toast.
5. **Minor — cross-traffic eviction.** The 32-line global cap counted lines the viewer can't see, so B↔C DM spam evicted A's fresh broadcast. The ring now prunes by server TTL (2 min, comfortably past the 30 s chip TTL) with a 256-line cap as memory backstop only.

Full suite `-race -count=1` green (1863/19); serve `-count=3` green.