### PR TITLE
fix(mp): hand the ship back at τ — range-only release + manual thrust cancels the coast (#298, #299)

### DIFF
--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -524,10 +524,17 @@ func (w *World) holdRendezvousLeader(partner *CoWarpPeer) {
 
 // resolveRendezvousWaypoint decides what reaching the committed τ means
 // for the standing intent (#252):
-//   - inside the proximity couple gate → the intent has done its job:
-//     drop to 1×, chip the arrival, release arm + driver. Proximity
-//     Co-Warp continues the SAME coupled state (the wasCoupled hysteresis
-//     in ComputeCoWarp carries it) — no drop-and-recouple tick;
+//   - inside the couple RANGE — velocity term deliberately not consulted
+//     (#299) → the intent has done its job: drop to 1×, chip the arrival,
+//     release arm + driver. A transfer-orbit encounter always arrives
+//     fast, and killing that velocity needs the pilot burning at closest
+//     approach, which needs the driver released — requiring the velocity
+//     term here made the coast blow through every good encounter. The
+//     velocity term still gates Proximity Co-Warp coupling itself: a slow
+//     arrival continues the SAME coupled state (the wasCoupled hysteresis
+//     in ComputeCoWarp carries it) with no drop-and-recouple tick, a fast
+//     arrival is released-but-not-coupled and couples once the pilot has
+//     matched velocities;
 //   - outside, mutual arm intact → advance: re-derive the next encounter,
 //     re-freeze the driver on it, re-base the degrade baseline, and
 //     record the advance for the waypoint chip;
@@ -561,8 +568,8 @@ func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPee
 			if peers[i].Owner != arm.TargetOwner {
 				continue
 			}
-			if rng, vrel, ok := closestApproach(anchor, peers[i].Crafts); ok &&
-				rng <= coWarpCoupleRangeM && vrel <= coWarpCoupleSpeedMs {
+			if rng, _, ok := closestApproach(anchor, peers[i].Crafts); ok &&
+				rng <= coWarpCoupleRangeM {
 				w.Clock.WarpIdx = 0
 				w.LastRendezvousArrival = &RendezvousArrival{
 					Handle: w.AutoWarp.RendezvousHandle, Owner: w.AutoWarp.RendezvousOwner,

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -80,6 +80,14 @@ func (w *World) StartManualBurn() {
 	// soft-landing's Landed=false→true transition doesn't fire the
 	// ViewLaunch auto-route (which gates on OnPad).
 	c.OnPad = false
+	// #298: the pilot taking manual thrust supersedes the standing
+	// rendezvous intent — release arm + driver so the coast can't warp
+	// against the burn (mirrors the driver yielding to node burns).
+	// Clearing the arm matters as much as the driver: an arm left
+	// standing restarts the coast on the next serve tick.
+	if w.rendezvousWarpEngaged() {
+		w.DisengageRendezvousWarp()
+	}
 	c.ManualBurn = &ManualBurn{StartTime: w.Clock.SimTime}
 }
 

--- a/internal/sim/rcs.go
+++ b/internal/sim/rcs.go
@@ -81,6 +81,12 @@ func (w *World) FireRCSPulse(mode spacecraft.BurnMode) bool {
 	if !w.ActiveCraft().ApplyRCSPulseWithTarget(mode, rT, vT) {
 		return false
 	}
+	// #298: a pulse is Δv the same as a main-engine burn — the pilot
+	// maneuvering supersedes the standing rendezvous intent, so release
+	// arm + driver rather than letting the coast warp against the match.
+	if w.rendezvousWarpEngaged() {
+		w.DisengageRendezvousWarp()
+	}
 	w.recordRCSPuff(dir)
 	return true
 }

--- a/internal/sim/rendezvous_release_test.go
+++ b/internal/sim/rendezvous_release_test.go
@@ -1,0 +1,106 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Reaching the committed τ inside the couple RANGE hands the ship back
+// regardless of the velocity term (#299): a transfer-orbit encounter
+// always arrives fast, and killing that velocity needs the pilot burning
+// at closest approach — which needs the driver released. The velocity
+// term still gates Proximity Co-Warp coupling itself; arriving fast just
+// means released-but-not-coupled.
+func TestRendezvousRangeOnlyHandoffAtTau(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 0)
+	// 5 km out at ~594 m/s relative — the live playtest shape (#299):
+	// deep inside the 35 km range gate, 6× over the 100 m/s velocity term.
+	near := peerAt(w, primary, st, 50, orbital.Vec3{X: 5000}, orbital.Vec3{X: 594}, "gern")
+	near.ArmedTowardViewer = true
+	near.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	w.Clock.WarpIdx = 5
+	w.Clock.SimTime = tau // reached the encounter, 5 km out, fast
+	near.SubspaceTime = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
+
+	if w.rendezvousWarpEngaged() {
+		t.Error("coast still engaged at τ inside couple range — a fast arrival must still hand the ship back")
+	}
+	if w.RendezvousArm != nil {
+		t.Error("arm not released at τ inside couple range")
+	}
+	if w.Clock.WarpIdx != 0 {
+		t.Errorf("did not drop to 1× at arrival: WarpIdx = %d", w.Clock.WarpIdx)
+	}
+	if w.LastRendezvousArrival == nil || w.LastRendezvousArrival.Owner != "SHA256:gern" {
+		t.Errorf("arrival not recorded for the chip: %+v", w.LastRendezvousArrival)
+	}
+	if w.LastRendezvousWaypoint != nil {
+		t.Error("a range-satisfying τ is an arrival, not a waypoint advance")
+	}
+}
+
+// Manual thrust supersedes the standing rendezvous intent (#298): the
+// pilot igniting the main engine under an engaged coast releases arm +
+// driver, mirroring how the driver already yields to planted node burns.
+// The two control authorities must never fight over warp.
+func TestManualThrustReleasesRendezvousCoast(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 5.4e6)
+	near := peerAt(w, primary, st, 50, orbital.Vec3{X: 5.4e6}, orbital.Vec3{}, "gern")
+	near.ArmedTowardViewer = true
+	near.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	w.StartManualBurn()
+	if w.ActiveCraft().ManualBurn == nil {
+		t.Fatal("precondition: manual burn ignited")
+	}
+	if w.rendezvousWarpEngaged() {
+		t.Error("manual ignition left the rendezvous coast engaged — the driver fights the burn (#298)")
+	}
+	if w.RendezvousArm != nil {
+		t.Error("manual ignition left the standing arm — DriveRendezvousWarp would restart the coast next tick")
+	}
+}
+
+// An RCS pulse is Δv the same as a main-engine burn (#298): pulsing
+// under an engaged coast releases the standing intent too — a velocity
+// match flown on RCS must not leave the driver warping against it.
+func TestRCSPulseReleasesRendezvousCoast(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 5.4e6)
+	near := peerAt(w, primary, st, 50, orbital.Vec3{X: 5.4e6}, orbital.Vec3{}, "gern")
+	near.ArmedTowardViewer = true
+	near.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{near})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+
+	w.ActiveCraft().EngineMode = spacecraft.EngineRCS
+	if !w.FireRCSPulse(spacecraft.BurnPrograde) {
+		t.Fatal("precondition: RCS pulse fired")
+	}
+	if w.rendezvousWarpEngaged() {
+		t.Error("RCS pulse left the rendezvous coast engaged (#298)")
+	}
+	if w.RendezvousArm != nil {
+		t.Error("RCS pulse left the standing arm — the coast would restart next tick")
+	}
+}


### PR DESCRIPTION
Fixes #299, fixes #298 — the two halves of the deadlock that made an engaged rendezvous coast unable to complete a rendezvous, found live in the 2026-08-02 two-player dock session.

## #299 — range-only release at τ

`resolveRendezvousWaypoint` released the coast only when closest approach satisfied **both** couple terms (≤35 km AND ≤100 m/s). A transfer-orbit encounter always arrives fast, so a range-satisfying τ never released — the coast fired a waypoint advance and blew through the encounter (live: a 19.66 km pass wasted at 594 m/s).

Now: τ reached **inside the couple range** hands the ship back regardless of the velocity term — drop to 1×, arrival chip, arm + driver released. The velocity term still gates Proximity Co-Warp coupling itself: slow arrivals inherit the coupled state exactly as before (existing `TestRendezvousCoupleRangeHandoffAtTau` unchanged and green); fast arrivals are released-but-not-coupled and couple once the pilot matches velocities. Waypoint advance remains the behavior when the *range* term fails (existing `TestRendezvousArmSurvivesTauOutsideCoupleRange` unchanged and green).

## #298 — manual thrust releases the coast

`StartManualBurn` and `FireRCSPulse` now release the standing intent (arm **and** driver — a surviving arm restarts the coast on the next serve tick). Mirrors the driver's existing yield to planted node burns. Live consequence pre-fix: the driver warped against the pilot's hand-flown velocity match and destroyed a 26 km closest-approach setup.

## Tests

Three new tests in `internal/sim/rendezvous_release_test.go` (TDD — red first, then the fix):
- `TestRendezvousRangeOnlyHandoffAtTau` — the live playtest shape: 5 km at 594 m/s → released, 1×, arrival chip, no waypoint advance
- `TestManualThrustReleasesRendezvousCoast` — ignition under an engaged coast clears arm + driver
- `TestRCSPulseReleasesRendezvousCoast` — same for RCS pulses

`go vet ./...` clean, `go test ./... -race -count=1`: 1885 passed.