### PR TITLE
fix: four standalone backlog singles (#285, #286, #288/#297, #295)

### DIFF
--- a/internal/orbital/events.go
+++ b/internal/orbital/events.go
@@ -189,6 +189,31 @@ func TimeToRadiusOutbound(state Vec3State, mu, r float64) (float64, bool) {
 	return dt, true
 }
 
+// ApsisDegenerateEcc is the eccentricity below which the apsides stop
+// being locatable points on the orbit (#286). At exactly e = 0 apoapsis
+// is genuinely undefined — every point is the same radius — and
+// TrueAnomalyFromState returns 0 for any such state, so TimeToApoapsis
+// degenerates to a constant half-period no matter where the craft is.
+// Just above zero the apsides exist but the eccentricity vector is
+// numerical noise, so the direction they point in is meaningless too.
+//
+// 1e-6 is ~14 m of apsis separation in LEO: below anything a player can
+// fly to deliberately, and three orders of magnitude under the ~3e-5 the
+// smallest measured remedy pulse produced (0.1 m/s prograde, Ap +0.4 km).
+//
+// This is a DISPLAY convention, not a physics gate: a readout that names
+// a specific instant must not do so when no such instant exists. Node
+// scheduling deliberately does NOT consult it — on a circular orbit
+// every point is apoapsis, so a burn placed at the nominal one is
+// physically identical to any other, and refusing to resolve would leave
+// the node unfired forever.
+const ApsisDegenerateEcc = 1e-6
+
+// ApsisDefined reports whether the apsides are distinguishable enough
+// for an apsis-anchored countdown to mean anything. See
+// ApsisDegenerateEcc.
+func ApsisDefined(e float64) bool { return e >= ApsisDegenerateEcc }
+
 // TimeToApoapsis returns elapsed seconds to the next apoapsis (ν=π).
 // Convenience wrapper around TimeToTrueAnomaly.
 func TimeToApoapsis(state Vec3State, mu float64) float64 {

--- a/internal/relay/active_craft_test.go
+++ b/internal/relay/active_craft_test.go
@@ -1,0 +1,122 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// #288: the roster's LOCATION column told partners where a player's
+// FIRST craft slot was, not where the player actually is. Live, a pilot
+// flying 577 km from their rendezvous partner at Earth was listed at the
+// Sun for the whole session, because slot 0 happened to hold a
+// heliocentric craft. Single-craft players display correctly, which is
+// what masked it.
+//
+// The report is the only thing a roster consumer has to read, so the
+// active craft has to be marked on the wire.
+func TestReportMarksTheActiveCraft(t *testing.T) {
+	w := newWorld(t)
+	moon := w.Systems[0].FindBody("Moon")
+	if moon == nil {
+		t.Skip("Moon not in catalog")
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("crafts = %d, want 2", len(w.Crafts))
+	}
+	w.Crafts[1].Primary = *moon
+
+	store := NewStore()
+	rep := NewReporter(store, "SHA256:alice")
+
+	// Slot 0 (Earth) active.
+	w.SetActiveCraftIdx(0)
+	rep.Tick(w, time.Now())
+	got := storedReport(t, store, "SHA256:alice")
+	active, ok := got.ActiveCraft()
+	if !ok {
+		t.Fatal("report carries no active craft")
+	}
+	if active.ID != w.Crafts[0].ID {
+		t.Errorf("active craft ID = %d, want slot 0's %d", active.ID, w.Crafts[0].ID)
+	}
+
+	// Switch to the Moon craft: the marker follows, and the location a
+	// roster reads off it changes with it.
+	earthPrimary := active.Primary
+	w.SetActiveCraftIdx(1)
+	rep.Tick(w, time.Now().Add(2*Heartbeat))
+	got = storedReport(t, store, "SHA256:alice")
+	active, ok = got.ActiveCraft()
+	if !ok {
+		t.Fatal("report carries no active craft after the switch")
+	}
+	if active.ID != w.Crafts[1].ID {
+		t.Errorf("active craft ID = %d, want slot 1's %d", active.ID, w.Crafts[1].ID)
+	}
+	if active.Primary == earthPrimary {
+		t.Errorf("location still reads %q after switching to the Moon craft", active.Primary)
+	}
+}
+
+// A craft switch has to reach partners promptly — it changes nothing
+// about any orbit, so the element-based change detector cannot see it,
+// and without its own trigger the roster would lie until the next
+// heartbeat.
+func TestCraftSwitchForcesAReport(t *testing.T) {
+	w := newWorld(t)
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	store := NewStore()
+	rep := NewReporter(store, "SHA256:alice")
+	w.SetActiveCraftIdx(0)
+	at := time.Now()
+	rep.Tick(w, at)
+
+	// Well inside the heartbeat, nothing else changed: a switch alone must
+	// still publish.
+	w.SetActiveCraftIdx(1)
+	rep.Tick(w, at.Add(100*time.Millisecond))
+	active, ok := storedReport(t, store, "SHA256:alice").ActiveCraft()
+	if !ok || active.ID != w.Crafts[1].ID {
+		t.Errorf("active craft on the wire = %+v, want slot 1 (ID %d) before the heartbeat",
+			active, w.Crafts[1].ID)
+	}
+}
+
+// An older report with no marker (or a player with no craft at all) must
+// degrade to the previous behaviour rather than losing the row.
+func TestActiveCraftFallsBackToFirstSlot(t *testing.T) {
+	r := CraftReport{Crafts: []CraftState{{ID: 7, Primary: "earth"}, {ID: 9, Primary: "moon"}}}
+	got, ok := r.ActiveCraft()
+	if !ok || got.ID != 7 {
+		t.Errorf("unmarked report ActiveCraft = %+v/%v, want the first slot", got, ok)
+	}
+	if _, ok := (CraftReport{}).ActiveCraft(); ok {
+		t.Error("an empty report claims an active craft")
+	}
+	// A marker naming a craft that is no longer in the set (staged away
+	// between the mark and the send) also falls back rather than vanishing.
+	r.ActiveCraftID = 999
+	if got, ok := r.ActiveCraft(); !ok || got.ID != 7 {
+		t.Errorf("stale marker ActiveCraft = %+v/%v, want the first slot", got, ok)
+	}
+}
+
+// storedReport pulls one owner's latest report back out of a store —
+// the wire's-eye view, as a partner's roster would read it.
+func storedReport(t *testing.T, store *Store, owner string) CraftReport {
+	t.Helper()
+	for _, r := range store.Snapshot("SHA256:nobody") {
+		if r.Owner == owner {
+			return r
+		}
+	}
+	t.Fatalf("no report for %s", owner)
+	return CraftReport{}
+}

--- a/internal/relay/cowarp_peers.go
+++ b/internal/relay/cowarp_peers.go
@@ -87,6 +87,12 @@ func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]str
 			p.ArmedTowardViewer = true
 			p.RendezvousTau = rep.RendezvousTau
 			p.RendezvousCA = rep.RendezvousCA
+			// Name the vessel behind the invite (#295) — the arm always acts
+			// through the reporter's active craft, so the report's marker
+			// (#288) is exactly the right source.
+			if active, aok := rep.ActiveCraft(); aok {
+				p.ActiveCraftName = active.Name
+			}
 		}
 		out = append(out, p)
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -43,6 +43,14 @@ type CraftReport struct {
 	SubspaceTime time.Time    `json:"subspace_time"`
 	Crafts       []CraftState `json:"crafts"`
 
+	// ActiveCraftID names which of Crafts the reporter is actually
+	// flying (#288). Without it a consumer can only read a fixed slot,
+	// which told partners a four-craft pilot was at the Sun for a whole
+	// session because slot 0 held a heliocentric craft. Zero (omitted)
+	// means "unmarked" — ActiveCraft falls back to the first slot, the
+	// pre-#288 behaviour.
+	ActiveCraftID uint64 `json:"active_craft_id,omitempty"`
+
 	// EffWarp is the reporter's current Effective warp — the post-clamp
 	// rate its World actually stepped this report (v0.28 S1, ADR 0034 §5).
 	// Proximity co-warp reads it to take the min over coupled players, so
@@ -66,6 +74,24 @@ type CraftReport struct {
 	// opposed to an EffWarp of 0 from a hold or clamp — the rendezvous
 	// hold-the-leader logic keys on it (v0.29 review).
 	Paused bool `json:"paused,omitempty"`
+}
+
+// ActiveCraft returns the craft the reporter is flying — the one a
+// partner means by "where are they" (#288) and the one any verb aimed at
+// the player acts through. Falls back to the first slot when the report
+// carries no marker or names a craft that has since left the set, so an
+// unmarked report reads exactly as it did before the marker existed.
+// ok=false only for a genuinely empty slate.
+func (r CraftReport) ActiveCraft() (CraftState, bool) {
+	if len(r.Crafts) == 0 {
+		return CraftState{}, false
+	}
+	for _, cs := range r.Crafts {
+		if cs.ID == r.ActiveCraftID {
+			return cs, true
+		}
+	}
+	return r.Crafts[0], true
 }
 
 // Store holds the latest report per owner and fans new reports out to

--- a/internal/relay/rendezvous_craft_seam_test.go
+++ b/internal/relay/rendezvous_craft_seam_test.go
@@ -1,0 +1,47 @@
+package relay
+
+import (
+	"testing"
+	"time"
+)
+
+// #295, partner side across the seam: the initiator's acting craft has
+// to reach the responder's join prompt. The wrong-vessel arm that
+// motivated this was only catchable from the responder's seat, and only
+// via an implausible closest approach — the vessel name is the signal
+// that should have been there.
+//
+// The arm always acts through the reporter's active craft, so the name
+// rides the #288 marker rather than a second wire field.
+func TestInviteCarriesTheInitiatorsCraftAcrossTheSeam(t *testing.T) {
+	store := NewStore()
+	wA, wB := newWorld(t), newWorld(t)
+	wB.Clock.SimTime = wA.Clock.SimTime // same subspace: a joinable invite
+	wB.ActiveCraft().State.R.X += 50_000
+	wB.ActiveCraft().Name = "Relay Tug-1"
+
+	const ownerA, ownerB = "SHA256:alice", "SHA256:bob"
+	handles := map[string]string{ownerA: "alice", ownerB: "bob"}
+	if !wB.EngageRendezvousWarp(ownerA, "alice", wA.Clock.SimTime.Add(72*time.Hour), 8000) {
+		t.Fatal("B failed to engage")
+	}
+	NewReporter(store, ownerB).Tick(wB, time.Now())
+
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live(ownerB), nil)
+	if len(peers) != 1 {
+		t.Fatalf("got %d peers, want 1", len(peers))
+	}
+	if peers[0].ActiveCraftName != "Relay Tug-1" {
+		t.Errorf("peer ActiveCraftName = %q, want the vessel B armed", peers[0].ActiveCraftName)
+	}
+
+	// Through DriveRendezvousWarp onto A's invite slate — what the prompt reads.
+	wA.DriveRendezvousWarp(peers)
+	inv := wA.RendezvousInvite
+	if inv == nil {
+		t.Fatal("no invite raised from an armed peer")
+	}
+	if inv.CraftName != "Relay Tug-1" {
+		t.Errorf("invite CraftName = %q, want the initiator's acting craft", inv.CraftName)
+	}
+}

--- a/internal/relay/reporter.go
+++ b/internal/relay/reporter.go
@@ -44,6 +44,7 @@ type Reporter struct {
 	lastRzTarget string    // last-reported Rendezvous Warp target (v0.29 S1) — a change forces a report
 	lastRzTau    time.Time // last-reported committed τ — a re-commit toward the SAME partner must also propagate promptly (v0.29 review)
 	lastPaused   bool      // last-reported pause state — the partner's hold-the-leader keys on it (v0.29 review)
+	lastActiveID uint64    // last-reported active craft (#288) — a switch moves no orbit, so nothing else would trigger a report
 }
 
 // effWarpRelTol is the relative change in Effective warp that forces a
@@ -88,8 +89,18 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 		rzCA = w.RendezvousArm.CommittedCA
 	}
 	paused := w.Clock.Paused
+	// Active craft (#288): switching craft changes no orbit, so the
+	// element-based change detector below is blind to it — but the roster's
+	// LOCATION and every verb aimed at this player read through it. Force a
+	// report the same way an arm change does, or a partner is told where
+	// someone used to be until the next heartbeat.
+	var activeID uint64
+	if active := w.ActiveCraft(); active != nil {
+		activeID = active.ID
+	}
 	due := r.lastWall.IsZero() || now.Sub(r.lastWall) >= Heartbeat ||
-		r.lastRzTarget != rzTarget || !r.lastRzTau.Equal(rzTau) || r.lastPaused != paused
+		r.lastRzTarget != rzTarget || !r.lastRzTau.Equal(rzTau) || r.lastPaused != paused ||
+		r.lastActiveID != activeID
 	if !due && keysEqual(r.lastKeys, keys) && !effWarpChanged(r.lastEffWarp, effWarp) {
 		return
 	}
@@ -99,10 +110,12 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 	r.lastRzTarget = rzTarget
 	r.lastRzTau = rzTau
 	r.lastPaused = paused
+	r.lastActiveID = activeID
 	r.store.Report(CraftReport{
 		Owner:            r.Owner,
 		SubspaceTime:     w.Clock.SimTime,
 		Crafts:           states,
+		ActiveCraftID:    activeID,
 		EffWarp:          effWarp,
 		RendezvousTarget: rzTarget,
 		RendezvousTau:    rzTau,

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -456,9 +456,12 @@ func (m *reportingModel) refreshSession(now time.Time) {
 			row.HasReport = true
 			row.DeltaT = rep.SubspaceTime.Sub(w.Clock.SimTime)
 			row.CraftCount = len(rep.Crafts)
-			if len(rep.Crafts) > 0 {
-				row.System = rep.Crafts[0].System
-				row.Primary = rep.Crafts[0].Primary
+			// LOCATION follows the craft they are FLYING, not a fixed slot
+			// (#288) — a partner reads this column to find someone, and slot
+			// 0 is wherever their oldest vessel happens to be.
+			if active, aok := rep.ActiveCraft(); aok {
+				row.System = active.System
+				row.Primary = active.Primary
 			}
 		}
 		info.Players = append(info.Players, row)

--- a/internal/serve/roster_location_test.go
+++ b/internal/serve/roster_location_test.go
@@ -1,0 +1,63 @@
+package serve
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// #288 across the whole seam: a guest flying a Moon craft while their
+// first slot orbits Earth must be listed at the Moon on the host's
+// roster. Live this was a pilot 577 km from their rendezvous partner at
+// Earth showing as "Sol/sun" the entire session.
+func TestRosterLocationFollowsTheActiveCraft(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	srv.presence.markOnline("SHA256:gern")
+
+	guestApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	gw := guestApp.World()
+	moon := gw.Systems[0].FindBody("Moon")
+	if moon == nil {
+		t.Skip("Moon not in catalog")
+	}
+	if _, err := gw.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	gw.Crafts[1].Primary = *moon
+	gw.SetActiveCraftIdx(1) // flying the Moon craft; slot 0 is still at Earth
+	guest := tick(srv.withReporting(guestApp, "SHA256:gern"))
+	_ = guest
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	_ = tick(srv.HostModel(hostApp))
+
+	info := hostApp.World().Session
+	if info == nil {
+		t.Fatal("host has no session slate")
+	}
+	var gern *sim.SessionPlayer
+	for i := range info.Players {
+		if info.Players[i].Handle == "gern" {
+			gern = &info.Players[i]
+		}
+	}
+	if gern == nil {
+		t.Fatalf("no gern row: %+v", info.Players)
+	}
+	if gern.Primary != moon.ID {
+		t.Errorf("roster LOCATION primary = %q, want %q (the craft they are flying, not slot 0)",
+			gern.Primary, moon.ID)
+	}
+	if gern.CraftCount != 2 {
+		t.Errorf("craft count = %d, want 2 — LOCATION follows the active craft, the count still covers the fleet",
+			gern.CraftCount)
+	}
+}

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -168,7 +168,18 @@ func (w *World) EngageRendezvousWarp(partner, handle string, tau time.Time, comm
 	if !tau.After(w.Clock.SimTime) {
 		return false
 	}
-	w.RendezvousArm = &RendezvousArm{TargetOwner: partner, Handle: handle, Tau: tau, CommittedCA: committedCA}
+	// The acting craft is captured here for the same reason the handle is
+	// (#295): arming acts on whatever craft is active, and a player who
+	// cycled their slot earlier has no other way to see which vessel just
+	// committed to the encounter.
+	craftName := ""
+	if c := w.ActiveCraft(); c != nil {
+		craftName = c.Name
+	}
+	w.RendezvousArm = &RendezvousArm{
+		TargetOwner: partner, Handle: handle, CraftName: craftName,
+		Tau: tau, CommittedCA: committedCA,
+	}
 	return true
 }
 
@@ -199,10 +210,11 @@ func (w *World) RendezvousWarpEngaged() bool { return w.rendezvousWarpEngaged() 
 // predicted approach the responder adopts verbatim on join. The World
 // slate field of the same name carries at most one (pairwise MVP).
 type RendezvousInvite struct {
-	Owner  string    // partner fingerprint — EngageRendezvousWarp's target on respond
-	Handle string    // display name for the prompt/chip
-	Tau    time.Time // the initiator's committed encounter sim-time
-	CA     float64   // m — the initiator's committed predicted approach
+	Owner     string    // partner fingerprint — EngageRendezvousWarp's target on respond
+	Handle    string    // display name for the prompt/chip
+	CraftName string    // the vessel the initiator armed (#295) — empty when their report carries no marker
+	Tau       time.Time // the initiator's committed encounter sim-time
+	CA        float64   // m — the initiator's committed predicted approach
 
 	// Blocked marks an invite from a subspace-diverged peer (#250): the
 	// intent is live, but the coast could never start across the gap, so
@@ -241,13 +253,15 @@ func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 		}
 		if sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
 			w.RendezvousInvite = &RendezvousInvite{
-				Owner: p.Owner, Handle: p.Handle, Tau: p.RendezvousTau, CA: p.RendezvousCA,
+				Owner: p.Owner, Handle: p.Handle, CraftName: p.ActiveCraftName,
+				Tau: p.RendezvousTau, CA: p.RendezvousCA,
 			}
 			return
 		}
 		if blocked == nil {
 			blocked = &RendezvousInvite{
-				Owner: p.Owner, Handle: p.Handle, Tau: p.RendezvousTau, CA: p.RendezvousCA,
+				Owner: p.Owner, Handle: p.Handle, CraftName: p.ActiveCraftName,
+				Tau: p.RendezvousTau, CA: p.RendezvousCA,
 				Blocked: true, AheadBy: w.Clock.SimTime.Sub(p.SubspaceTime),
 			}
 		}

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -176,6 +176,14 @@ type CoWarpPeer struct {
 	// carried alongside RendezvousTau so a responder adopts the initiator's
 	// authoritative baseline, not its own staler recompute (v0.29 S1).
 	RendezvousCA float64
+
+	// ActiveCraftName is the vessel this peer is flying, read off their
+	// report's active-craft marker (#288). The join prompt names it (#295)
+	// so the responder answers "gern's Relay Tug-1 wants to rendezvous",
+	// not just "gern" — the live wrong-vessel arm was caught from this
+	// seat, and only by an implausible CA. Empty when the peer's report
+	// carries no marker.
+	ActiveCraftName string
 }
 
 // RendezvousArm is the viewer's outgoing Rendezvous Warp intent (v0.29 S1,
@@ -205,6 +213,7 @@ type CoWarpPeer struct {
 type RendezvousArm struct {
 	TargetOwner string    // fingerprint of the partner Engaged toward
 	Handle      string    // partner display name, captured at Engage (chips/HUD never fall back to a raw fingerprint)
+	CraftName   string    // the vessel that armed — captured at Engage (#295), so a wrong-vessel arm is visible from the arming seat
 	Tau         time.Time // the current waypoint's absolute encounter sim-time
 	CommittedCA float64   // m — the predicted approach at Tau, re-derived per waypoint (HUD "committed" row)
 

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -13,12 +13,17 @@ import (
 // Rendezvous advisory errors. Exported so app.go's status flash can
 // switch on them via errors.Is, mirroring the PlanCircularize* family
 // (see maneuver.go:1132). v0.10.2+.
+//
+// The reasons carry no "rendezvous:" prefix (#285): the flight view
+// labels the refusal at the display layer, exactly as it does for
+// `circularize:` and `save:`, so a prefix here rendered twice
+// ("rendezvous: rendezvous: no craft target") on every K refusal.
 var (
-	ErrRendezvousNoTarget           = transferError("rendezvous: no craft target")
-	ErrRendezvousDifferentPrimaries = transferError("rendezvous: target around a different primary")
-	ErrRendezvousAlreadyDocked      = transferError("rendezvous: already in DOCK READY range")
-	ErrRendezvousNoImprovement      = transferError("rendezvous: no useful nudge in range")
-	ErrRendezvousNoCraft            = transferError("rendezvous: no active craft")
+	ErrRendezvousNoTarget           = transferError("no craft target")
+	ErrRendezvousDifferentPrimaries = transferError("target around a different primary")
+	ErrRendezvousAlreadyDocked      = transferError("already in DOCK READY range")
+	ErrRendezvousNoImprovement      = transferError("no useful nudge in range")
+	ErrRendezvousNoCraft            = transferError("no active craft")
 )
 
 // rendezvousAdvisoryCache stores the most recent recommendation so

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2014,7 +2014,11 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		case !ok:
 			a.statusMsg = fmt.Sprintf("no closable encounter with %s — plant a rendezvous nudge [K] first", cmd.Handle)
 		case a.world.EngageRendezvousWarp(cmd.Owner, cmd.Handle, tau, ca):
-			a.statusMsg = fmt.Sprintf("rendezvous armed toward %s — waiting for them to join", cmd.Handle)
+			// Name the acting craft (#295): arming acts on whatever slot is
+			// active, and a player who cycled it earlier has no other way to
+			// catch a wrong-vessel arm before the invitation goes out.
+			a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join",
+				cmd.Handle, screens.CraftTag(a.world.RendezvousArm.CraftName))
 		default:
 			a.statusMsg = fmt.Sprintf("can't arm rendezvous with %s — encounter is in the past", cmd.Handle)
 		}

--- a/internal/tui/app_rendezvous_craft_test.go
+++ b/internal/tui/app_rendezvous_craft_test.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// #295: arming acts on whatever craft is active, and nothing in the arm
+// flow named it. A pilot with four craft who had cycled their active
+// slot earlier armed a rendezvous on a dry science probe instead of the
+// intended tug; the mistake was only visible from the PARTNER's seat, as
+// a wildly wrong closest approach on the join prompt. Name the vessel on
+// the arming side, where the mistake is made.
+func TestRendezvousArmNamesTheActingCraft(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+	w.Ghosts = []sim.Ghost{ghostBesideActive(w, "SHA256:guest", 42)}
+	w.ActiveCraft().Name = "Relay Tug-1"
+
+	a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:guest", CraftID: 42, Handle: "gern",
+	})
+	if w.RendezvousArm == nil {
+		t.Fatal("rendezvous command did not arm")
+	}
+	if w.RendezvousArm.CraftName != "Relay Tug-1" {
+		t.Errorf("arm CraftName = %q, want the acting craft's name", w.RendezvousArm.CraftName)
+	}
+	if !strings.Contains(a.statusMsg, "Relay Tug-1") {
+		t.Errorf("armed status %q does not name the acting craft", a.statusMsg)
+	}
+	if !strings.Contains(a.statusMsg, "gern") {
+		t.Errorf("armed status %q stopped naming the partner", a.statusMsg)
+	}
+}

--- a/internal/tui/app_rendezvous_refusal_test.go
+++ b/internal/tui/app_rendezvous_refusal_test.go
@@ -1,0 +1,37 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// #285: the flight view labels a K refusal "rendezvous:" at the display
+// layer, the way `circularize:` and `save:` are labelled — so the sim's
+// refusal reasons must not carry the label themselves. Before the fix
+// every refusal rendered as "rendezvous: rendezvous: no craft target".
+//
+// Asserted on the composed status line rather than the sentinel strings:
+// the double label is a property of what the player reads, and a future
+// refusal-reason pass (#278) is free to reword the reasons as long as
+// the label still appears once.
+func TestRendezvousRefusalLabelsOnce(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// No craft target — the simplest refusal to provoke from a fresh world.
+	a.world.Target = sim.Target{}
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+
+	if a.statusMsg == "" {
+		t.Fatal("K with no target produced no status message")
+	}
+	if n := strings.Count(a.statusMsg, "rendezvous:"); n != 1 {
+		t.Errorf("status %q carries the rendezvous label %d times, want exactly 1", a.statusMsg, n)
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -953,12 +953,26 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		chipRow("altitude:", fmt.Sprintf("%.1f km", c.Altitude()/1000)),
 		chipRow("Ap:", fmt.Sprintf("%.1f km", apoAlt/1000)),
 	}
-	if tApo := orbital.TimeToApoapsis(st, mu); tApo >= 0 {
-		lines = append(lines, chipRow("t→Ap:", formatDurationShort(tApo)))
+	// On a circular orbit the apsides are not locatable points (#286), so
+	// the countdowns say "—" rather than the constant half-period the
+	// underlying helpers fall back to. A frozen number that looks live is
+	// worse than an honest blank: players read it as phase information and
+	// tried to time rendezvous off two craft that both showed P/2.
+	apsisTime := func(secs float64) (string, bool) {
+		if !orbital.ApsisDefined(el.E) {
+			return "—", true
+		}
+		if secs < 0 {
+			return "", false
+		}
+		return formatDurationShort(secs), true
+	}
+	if s, ok := apsisTime(orbital.TimeToApoapsis(st, mu)); ok {
+		lines = append(lines, chipRow("t→Ap:", s))
 	}
 	lines = append(lines, chipRow("Pe:", fmt.Sprintf("%.1f km", periAlt/1000)))
-	if tPeri := orbital.TimeToPeriapsis(st, mu); tPeri >= 0 {
-		lines = append(lines, chipRow("t→Pe:", formatDurationShort(tPeri)))
+	if s, ok := apsisTime(orbital.TimeToPeriapsis(st, mu)); ok {
+		lines = append(lines, chipRow("t→Pe:", s))
 	}
 	// Full orbital period, alongside the apsis-time readouts — the number
 	// a comsat placement is tuned to (e.g. a synchronous or semi-

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -325,7 +325,7 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		return append(lines, v.theme.Dim.Render("  [/] cancel"))
 	case w.RendezvousArm != nil:
 		arm := w.RendezvousArm
-		status := v.theme.Warning.Render("  armed → " + arm.Handle + " — waiting for them to join")
+		status := v.theme.Warning.Render("  armed → " + arm.Handle + CraftTag(arm.CraftName) + " — waiting for them to join")
 		switch wt := w.RendezvousWait; wt.Reason {
 		case sim.RendezvousWaitSubspaceGap:
 			// #250: "waiting for them to join" would blame the partner for
@@ -366,20 +366,32 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			}
 			return []string{
 				v.theme.Primary.Render("RENDEZVOUS"),
-				v.theme.Dim.Render("  ◇ " + inv.Handle + " wants to rendezvous — " + gap),
+				v.theme.Dim.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous — " + gap),
 				chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 				chipRow("CA:", formatRangeM(inv.CA)),
 			}
 		}
 		return []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
-			v.theme.Warning.Render("  ◇ " + inv.Handle + " wants to rendezvous"),
+			v.theme.Warning.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous"),
 			chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 			chipRow("CA:", formatRangeM(inv.CA)),
 			v.theme.Warning.Render("  [y] join"),
 		}
 	}
 	return nil
+}
+
+// CraftTag renders a vessel name as a parenthetical to hang off a
+// player's handle — "gern (Relay Tug-1)" (#295). Empty for an unnamed
+// craft (an older peer's report carries no active-craft marker), so the
+// caller's line degrades to the bare handle instead of an empty "()".
+// Exported because the flight view's arm toast composes the same line.
+func CraftTag(name string) string {
+	if name == "" {
+		return ""
+	}
+	return " (" + name + ")"
 }
 
 // buildDockGuestChip is the docked-as-guest standing away surface (#253):

--- a/internal/tui/screens/orbit_circular_apsis_test.go
+++ b/internal/tui/screens/orbit_circular_apsis_test.go
@@ -1,0 +1,105 @@
+package screens
+
+import (
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// placeOnConic puts the active craft on the coplanar conic with the given
+// apsis radii, at true anomaly nu. Returns the orbital period.
+func placeOnConic(w *sim.World, rPeri, rApo, nu float64) float64 {
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	a := (rPeri + rApo) / 2
+	e := (rApo - rPeri) / (rApo + rPeri)
+	p := a * (1 - e*e)
+	r := p / (1 + e*math.Cos(nu))
+	// Perifocal position/velocity, then used directly as the equatorial
+	// frame (ω = Ω = i = 0) — enough for an apsis-timing readout.
+	h := math.Sqrt(mu * p)
+	c.State.R.X, c.State.R.Y, c.State.R.Z = r*math.Cos(nu), r*math.Sin(nu), 0
+	c.State.V.X = -mu / h * math.Sin(nu)
+	c.State.V.Y = mu / h * (e + math.Cos(nu))
+	c.State.V.Z = 0
+	return 2 * math.Pi * math.Sqrt(a*a*a/mu)
+}
+
+// apsisRow pulls the value of the named ORBIT chip row out of a render.
+func apsisRow(t *testing.T, out, label string) string {
+	t.Helper()
+	re := regexp.MustCompile(regexp.QuoteMeta(label) + `\s*(\S+)`)
+	m := re.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("no %s row in the render:\n%s", label, out)
+	}
+	return m[1]
+}
+
+// #286: on a perfectly circular orbit every point is at the same radius,
+// so there is no apoapsis or periapsis to count down to. The readout used
+// to print exactly half a period, frozen — a number that looks live and
+// isn't, which players tried to phase off. It has to say so instead.
+//
+// Spawn presets produce exactly-circular orbits, so this is what a player
+// sees on a fresh spawn before any burn adds eccentricity.
+func TestOrbitChipApsisTimesDegenerateOnCircularOrbit(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	r := w.ActiveCraft().Primary.RadiusMeters() + 500e3
+
+	// Two craft positions a quarter turn apart on the SAME circular orbit —
+	// the live symptom was both reading an identical, unmoving P/2.
+	var seen []string
+	for _, nu := range []float64{0, math.Pi / 2} {
+		period := placeOnConic(w, r, r, nu)
+		out := v.Render(w, 0, 200, 60)
+		for _, label := range []string{"t→Ap:", "t→Pe:"} {
+			val := apsisRow(t, out, label)
+			if val != "—" {
+				t.Errorf("circular orbit at ν=%.2f: %s %q, want \"—\" (apsides are undefined at e=0)",
+					nu, label, val)
+			}
+		}
+		seen = append(seen, apsisRow(t, out, "t→Ap:"))
+		_ = period
+	}
+	if len(seen) == 2 && seen[0] != seen[1] {
+		t.Errorf("t→Ap differed between two points on the same circular orbit: %q vs %q", seen[0], seen[1])
+	}
+}
+
+// The companion guard: the fix must not swallow real apsis timers. The
+// live remedy in #286 was a single 0.1 m/s prograde pulse that raised Ap
+// by 0.4 km and restored 1 s/s ticking — that orbit still has to read a
+// duration, and one that moves as the craft advances.
+func TestOrbitChipApsisTimesLiveOnSlightlyEccentricOrbit(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	primaryR := w.ActiveCraft().Primary.RadiusMeters()
+	rPeri, rApo := primaryR+500.0e3, primaryR+500.4e3
+
+	placeOnConic(w, rPeri, rApo, 0)
+	atPeri := apsisRow(t, v.Render(w, 0, 200, 60), "t→Ap:")
+	placeOnConic(w, rPeri, rApo, math.Pi/2)
+	quarterOn := apsisRow(t, v.Render(w, 0, 200, 60), "t→Ap:")
+
+	if strings.Contains(atPeri, "—") || strings.Contains(quarterOn, "—") {
+		t.Fatalf("0.4 km of apsis separation read as degenerate: %q / %q", atPeri, quarterOn)
+	}
+	if atPeri == quarterOn {
+		t.Errorf("t→Ap frozen at %q across a quarter orbit — the timer is not tracking position", atPeri)
+	}
+}

--- a/internal/tui/screens/orbit_rendezvous_craft_test.go
+++ b/internal/tui/screens/orbit_rendezvous_craft_test.go
@@ -1,0 +1,67 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// #295, arming side: the standing RENDEZVOUS chip is what the arming
+// player looks at while they wait, so it carries the acting craft too —
+// not just the partner's handle.
+func TestRendezvousChipNamesTheActingCraft(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.RendezvousArm = &sim.RendezvousArm{
+		TargetOwner: "SHA256:guest", Handle: "gern", CraftName: "Relay Tug-1",
+		Tau: w.Clock.SimTime.Add(2 * time.Hour), CommittedCA: 577_000,
+	}
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	if !strings.Contains(joined, "Relay Tug-1") {
+		t.Errorf("armed chip does not name the acting craft:\n%s", joined)
+	}
+	if !strings.Contains(joined, "gern") {
+		t.Errorf("armed chip stopped naming the partner:\n%s", joined)
+	}
+}
+
+// #295, partner side: the join prompt read "jason wants to rendezvous"
+// — the player, not the vessel. The partner's seat is where the live
+// wrong-vessel arm was actually caught (from an implausible CA), so the
+// craft name belongs on the prompt they answer.
+func TestRendezvousInviteNamesTheInitiatorsCraft(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:host", Handle: "jason", CraftName: "Science Probe-3",
+		Tau: w.Clock.SimTime.Add(2 * time.Hour), CA: 4_498_000,
+	}
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	if !strings.Contains(joined, "Science Probe-3") {
+		t.Errorf("join prompt does not name the initiator's craft:\n%s", joined)
+	}
+	if !strings.Contains(joined, "[y] join") {
+		t.Errorf("join affordance vanished:\n%s", joined)
+	}
+
+	// A report with no craft name (older peer, or a craft that left the
+	// set) must still render a usable prompt rather than an empty paren.
+	w.RendezvousInvite.CraftName = ""
+	bare := strings.Join(v.buildRendezvousChip(w), "\n")
+	if strings.Contains(bare, "()") {
+		t.Errorf("nameless invite rendered an empty parenthetical:\n%s", bare)
+	}
+	if !strings.Contains(bare, "jason wants to rendezvous") {
+		t.Errorf("nameless invite lost its attribution:\n%s", bare)
+	}
+}

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -679,10 +679,19 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		// viewer by construction — you don't ghost yourself — so the count
 		// would always read "(0 here)". It measures what YOU can target,
 		// which is meaningless pointed at yourself.
+		// With no live report there is no count to state (#297): rendering
+		// the zero value turned "hasn't connected since the server started"
+		// into "their fleet is empty" — read, minutes after a fleet-reset
+		// deploy, as the reset having wiped everyone. LOCATION already falls
+		// back to "—" on the same row; the count mirrors it.
 		here := len(playerGhosts(w, p.Fingerprint))
-		craft := fmt.Sprintf("%d craft", p.CraftCount)
-		if p.Fingerprint != info.Self && p.System != "" && p.System == w.System().Name && here < p.CraftCount {
+		craft := "—"
+		switch {
+		case !p.HasReport:
+		case p.Fingerprint != info.Self && p.System != "" && p.System == w.System().Name && here < p.CraftCount:
 			craft = fmt.Sprintf("%d craft (%d here)", p.CraftCount, here)
+		default:
+			craft = fmt.Sprintf("%d craft", p.CraftCount)
 		}
 		b.WriteString("  " + padStyled(marker, 2) + dot + " " +
 			s.nameCell(p.Handle, tags, colName) + " " +

--- a/internal/tui/screens/session_roster_honesty_test.go
+++ b/internal/tui/screens/session_roster_honesty_test.go
@@ -1,0 +1,47 @@
+package screens
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #297: a player the server has no live report for must not be described
+// as having an empty fleet. Right after a server restart every enrolled
+// player is in that state, and "0 craft" read as "the fleet reset wiped
+// them" — minutes after a --reset-fleet deploy, with every save intact on
+// disk holding exactly one vessel.
+//
+// LOCATION already falls back to "—" for the same row; the craft column
+// has to mirror that honesty, reserving "0 craft" for a player who
+// actually reported an empty slate.
+func TestRosterCraftColumnBlankWithoutReport(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w := sessionWorld(t, true)
+	out := s.Render(w, 120)
+
+	// "pat" is the enrolled-but-never-reported row in the fixture.
+	var patRow string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "pat") {
+			patRow = line
+		}
+	}
+	if patRow == "" {
+		t.Fatalf("no pat row in the roster:\n%s", out)
+	}
+	if strings.Contains(patRow, "craft") {
+		t.Errorf("report-less row claims a craft count: %q", patRow)
+	}
+	// Two "—" cells: location and craft, both honest about missing data.
+	if n := strings.Count(patRow, "—"); n < 2 {
+		t.Errorf("report-less row has %d \"—\" cells, want LOCATION and CRAFT both blank: %q", n, patRow)
+	}
+
+	// A player who DID report keeps a real count — including a genuine zero.
+	w.Session.Players[1].CraftCount = 0
+	out = s.Render(w, 120)
+	if !regexp.MustCompile(`gern.*0 craft`).MatchString(out) {
+		t.Errorf("a reported empty slate must still read \"0 craft\":\n%s", out)
+	}
+}


### PR DESCRIPTION
The four cheap standalone singles from the v0.33 ready-for-agent backlog,
one commit each. No ADR cycle work — these were vetted independently and
fit anywhere in the build order.

### `#285` — K refusal toasts double the `rendezvous:` label
The five `PlanRendezvousNudge` refusal reasons each began with
`rendezvous: `, and the flight view prepends the same label the way it
does for `circularize:`/`save:` — so every refusal read
`rendezvous: rendezvous: no useful nudge in range`. The label stays at
the display layer (one site, consistent with its neighbours); the sim's
reasons drop it. Leaves #278 free to reword the reasons themselves.

### `#286` — `t→Ap` / `t→Pe` frozen at P/2 on a circular orbit
On an exactly circular orbit apoapsis is undefined and
`TrueAnomalyFromState` returns 0, so the countdown printed a constant
half-period regardless of position — two craft 13,500 km apart both read
`47m14s` indefinitely. Spawn presets produce exactly-circular orbits, so
a fresh spawn hits it immediately.

The ORBIT chip now renders `—` below `orbital.ApsisDegenerateEcc` (1e-6,
~14 m of apsis separation in LEO — three orders under the ~3e-5 the
smallest measured remedy pulse produced). **Display-only by design:**
node scheduling still resolves "next apoapsis" on a circular orbit,
where every point is as good as another, rather than leaving the node
unfired forever.

### `#288` + `#297` — roster honesty (one slice, as paired on the issues)
Two halves of the roster presenting a guess with the confidence of a
measurement.

- **LOCATION** showed a fixed craft slot's primary, so a pilot 577 km
  from their rendezvous partner at Earth was listed `Sol/sun` all
  session. The wire report gains `ActiveCraftID` and the row reads
  through `CraftReport.ActiveCraft()`. A craft switch moves no orbit, so
  the element-based change detector is blind to it — it gets its own
  re-report trigger rather than waiting on the 5 s heartbeat.
- **CRAFT** rendered the zero value for report-less players, turning
  "hasn't reconnected since the restart" into "their fleet is empty" —
  read, minutes after a `--reset-fleet` deploy, as the reset having
  wiped everyone. It now mirrors LOCATION's `—`, reserving `0 craft` for
  a player who actually reported an empty slate.

Unmarked reports fall back to the first slot, exactly as before.

### `#295` — rendezvous arm doesn't name the acting craft
Captured at Engage and rendered on both seats: `armed → gern (Relay
Tug-1)` on the toast and standing chip, `jason (Relay Tug-1) wants to
rendezvous` on the join prompt. The partner side rides #288's marker
rather than a second wire field — the arm always acts through the
reporter's active craft. A report without the marker degrades to the
bare handle, no empty `()`.

## Testing

TDD throughout; every test was confirmed red first. The #288 roster test
was re-verified load-bearing by reverting the fix in place (reproduces
`earth` where the pilot is at the Moon).

`go vet ./...` clean · `go test ./... -race -count=1` — 1897 passed.

## Not covered

No save-format change. Live verification still owed: the standing chips
and join prompt want a tailnet playtest with a second seat, and #286's
`—` wants a look in the real TUI.

Closes #285, #286, #288, #295, #297
