### PR TITLE
fix(dock): stop the undock-after-transfer vehicle swap, and say why when undock refuses (#307, #308, #309, #310)

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -54,8 +54,9 @@ type DockRecord struct {
 	returnPayload   *spacecraft.Spacecraft // docker→guest: restored craft on undock/abort
 	transferPayload *spacecraft.Spacecraft // old owner→new owner: the whole migrating stack
 	undockAsk       bool                   // guest→docker: split my component
+	undockRefused   bool                   // docker→guest: your undock was refused, you're still docked (#307)
 	transferTo      string                 // owner→recipient: pending control transfer target
-	aborted         bool                   // docker couldn't fuse — guest reclaims its craft
+	aborted         bool                   // docker couldn't fuse / the stack is gone — the dock ends
 }
 
 // DockChip is a moment the reconcile surfaces for the caller to turn into a
@@ -277,18 +278,37 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 		return false
 
 	case DockActive:
+		// #309: the composite this record names resolves in nobody's World.
+		// Restore keeps the durable fields but the craft payloads are
+		// transient, so a server restart that finds no live composite leaves
+		// the record pointing at nothing — and nothing reaped it: the
+		// fall-through below kept it, [U] kept it, and the guest was flagged
+		// docked-as-guest to a phantom stack indefinitely (measured on the
+		// production host: 5½ hours, cleared only by --reset-fleet). The stack
+		// is gone, so the dock is over; abort it and let the guest's own
+		// reconcile learn that and say so.
+		if _, _, ok := w.CraftByID(r.CompositeID); !ok {
+			r.aborted = true
+			r.undockAsk, r.transferTo = false, ""
+			return false
+		}
 		// Undock request: split the guest's component and hand it back.
 		if r.undockAsk {
 			r.undockAsk = false
-			_, cidx, ok := w.CraftByID(r.CompositeID)
-			if ok {
-				if restored, ok := w.UndockGuest(cidx, r.GuestOwner, r.GuestCraftID); ok {
-					r.returnPayload = restored
-					*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.GuestHandle})
-				}
+			_, cidx, _ := w.CraftByID(r.CompositeID) // resolved above
+			restored, ok := w.UndockGuest(cidx, r.GuestOwner, r.GuestCraftID)
+			if !ok {
+				// #307: the guest's components are no longer the top of the
+				// stack — a control transfer moved them to the bottom without
+				// restacking the vehicle, and peeling the tail there would
+				// hand each player the other's hardware. Refusing is right;
+				// staying silent is what made this look like a broken key, so
+				// tell the guest and leave the dock standing.
+				r.undockRefused = true
+				return false
 			}
-			// If the composite or component is gone, fall through — the guest
-			// side will time out waiting; MVP treats this as the dock ending.
+			r.returnPayload = restored
+			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.GuestHandle})
 			return false
 		}
 		// Transfer request: migrate the whole stack to the guest (roles swap),
@@ -325,9 +345,19 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 // reconcileGuest runs the guest's side of a dock. Returns true when the
 // record is finished and should be dropped.
 func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[string]CraftReport, chips *[]DockChip) bool {
-	// Abort: the docker couldn't fuse — reclaim the handed-over craft.
-	if r.aborted && r.returnPayload != nil {
-		w.AdoptCraft(r.returnPayload, true)
+	// Abort: the dock ended on the docker's side.
+	if r.aborted {
+		if r.returnPayload != nil {
+			// The docker couldn't fuse — reclaim the handed-over craft.
+			w.AdoptCraft(r.returnPayload, true)
+			return true
+		}
+		// #309: nothing comes back — the stack this dock named no longer
+		// exists, so the craft riding in it went with it. Drop the record so
+		// the guest stops being flagged docked-as-guest to a phantom, and say
+		// what happened: the docked marker vanishing on its own is the same
+		// silence this batch is about.
+		*chips = append(*chips, DockChip{Kind: sim.SessionEventDockLost, Handle: r.OwnerHandle})
 		return true
 	}
 	switch r.Phase {
@@ -349,6 +379,12 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 			r.returnPayload = nil
 			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.OwnerHandle})
 			return true
+		}
+		// #307: my undock was refused on the owner's side. I'm still docked —
+		// surface it so the key doesn't read as dead, then carry on.
+		if r.undockRefused {
+			r.undockRefused = false
+			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndockRefused, Handle: r.OwnerHandle})
 		}
 		l.setDockGuest(w, r, reports)
 		return false

--- a/internal/relay/dock_test.go
+++ b/internal/relay/dock_test.go
@@ -297,21 +297,173 @@ func TestTransferAdoptRestampsCollidingCompositeID(t *testing.T) {
 		t.Errorf("native collider id %d no longer resolves to the collider craft", dockerID)
 	}
 
-	// A (now the guest) undocks: B splits it out and hands A's craft back.
+	// A (now the guest) undocks. Its components are at the BOTTOM of the stack
+	// — the transfer flipped the tags without restacking the vehicle — so the
+	// split is refused rather than handing each player the other's hardware
+	// (#307). A stays docked and is TOLD; see
+	// TestUndockAfterTransferRefusesAndTellsTheGuest for the seam-level
+	// assertions and the recovery.
 	if !ledger.RequestUndock(fpA, dockerID) {
 		t.Fatalf("RequestUndock refused for the demoted old owner")
 	}
 	reports = reportMap(store, wA, wB, now.Add(2*time.Second))
-	ledger.Reconcile(wB, fpB, reports) // B splits A's component out
-	ledger.Reconcile(wA, fpA, reports) // A receives its craft home
-	if _, _, ok := wA.CraftByID(dockerID); !ok {
-		t.Fatalf("A never got its craft %d back — permanent desync (finding 1)", dockerID)
+	ledger.Reconcile(wB, fpB, reports) // B attempts the split
+	ledger.Reconcile(wA, fpA, reports) // A learns it was refused
+	if len(wA.Crafts) != 0 {
+		t.Errorf("A received %d craft from a refused undock", len(wA.Crafts))
 	}
-	if wA.DockGuest != nil {
-		t.Errorf("A still docked-as-guest after undock")
+	if wA.DockGuest == nil {
+		t.Errorf("A dropped out of docked-as-guest on a refused undock")
 	}
+	if len(ledger.Records()) != 1 {
+		t.Errorf("ledger holds %d records after a refused undock, want the dock still standing", len(ledger.Records()))
+	}
+}
+
+// TestUndockAfterTransferRefusesAndTellsTheGuest (#307 + #308): the sequence
+// that swapped the two players' vehicles live. A docks B's craft, hands control
+// to B, then asks to undock. Its components now sit at the bottom of the stack
+// while the tags call them the guest's, so the tail peel would return B's
+// vehicle under A's name and stable ID. The split is refused, A is told, and
+// handing control back makes the release work — with the right hardware, checked
+// by MASS, the one field neither the name-rewrite nor the ID-restamp preserves.
+func TestUndockAfterTransferRefusesAndTellsTheGuest(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 400
+	wA, wB := alignedPair(t, guestID)
+	// Distinct vehicles: same-loadout craft would make the mass assertion
+	// vacuous, and mass is the only discriminator the bug leaves intact.
+	wB.ActiveCraft().Stages = spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID).Stages
+	wB.ActiveCraft().SyncFields()
+	dockerID := wA.ActiveCraft().ID
+	massA, massB := wA.ActiveCraft().TotalMass(), wB.ActiveCraft().TotalMass()
+	if massA == massB {
+		t.Fatalf("test vehicles are indistinguishable by mass (%v) — assertions would be vacuous", massA)
+	}
+	now := time.Now()
+
+	// Dock, then hand control to B.
+	ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	if !ledger.RequestTransfer(fpA) {
+		t.Fatalf("RequestTransfer refused")
+	}
+	ledger.Reconcile(wA, fpA, reports)
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports)
+
+	// A asks to undock. Refused — and A hears about it.
+	if !ledger.RequestUndock(fpA, dockerID) {
+		t.Fatalf("RequestUndock refused for the demoted old owner")
+	}
+	reports = reportMap(store, wA, wB, now.Add(2*time.Second))
+	ledger.Reconcile(wB, fpB, reports)
+	chips := ledger.Reconcile(wA, fpA, reports)
+	if len(wA.Crafts) != 0 {
+		t.Fatalf("A received %d craft from a refused undock (mass %v — B's is %v)",
+			len(wA.Crafts), wA.Crafts[0].TotalMass(), massB)
+	}
+	if !hasChip(chips, sim.SessionEventUndockRefused) {
+		t.Errorf("refused undock produced no moment for A — the key reads as dead: %+v", chips)
+	}
+	if wA.DockGuest == nil {
+		t.Errorf("A left docked-as-guest by a refused undock")
+	}
+
+	// Recovery: B hands control back, which puts B's own components on top,
+	// and B releases. Both players end up holding their own vehicle.
+	if !ledger.RequestTransfer(fpB) {
+		t.Fatalf("RequestTransfer back to A refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(3*time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B migrates the stack out
+	ledger.Reconcile(wA, fpA, reports) // A adopts it and owns again
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused for B after the handback")
+	}
+	reports = reportMap(store, wA, wB, now.Add(4*time.Second))
+	ledger.Reconcile(wA, fpA, reports) // A splits B's component out
+	ledger.Reconcile(wB, fpB, reports) // B receives its craft home
+
+	if len(wB.Crafts) != 1 {
+		t.Fatalf("B holds %d craft after the handback release, want 1", len(wB.Crafts))
+	}
+	if got := wB.Crafts[0].TotalMass(); got != massB {
+		t.Errorf("B got a vehicle of mass %v, want its own %v (A's is %v)", got, massB, massA)
+	}
+	if len(wA.Crafts) != 1 {
+		t.Fatalf("A holds %d craft after the handback release, want 1", len(wA.Crafts))
+	}
+	if got := wA.Crafts[0].TotalMass(); got != massA {
+		t.Errorf("A kept a vehicle of mass %v, want its own %v (B's is %v)", got, massA, massB)
+	}
+}
+
+// TestRestoredDockWithNoLiveCompositeIsReaped (#309): a record seeded from the
+// session directory outlives the craft payloads, which are transient. Measured
+// on the production host, such a record sat in DockActive for 5½ hours pointing
+// at a composite that existed in nobody's save — nothing reaped it, and [U] did
+// not clear it either, so the guest stayed flagged docked-as-guest to a phantom
+// stack. The owner's first reconcile must notice and end the dock.
+func TestRestoredDockWithNoLiveCompositeIsReaped(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	wA, wB := alignedPair(t, 400)
+	now := time.Now()
+
+	// Exactly the persisted shape: durable fields only, DockActive, naming a
+	// composite ID that resolves in neither World.
+	const phantomID = 9999
+	if _, _, ok := wA.CraftByID(phantomID); ok {
+		t.Fatalf("phantom composite id %d unexpectedly resolves", phantomID)
+	}
+	ledger.Seed([]DockRecord{{
+		ID: 3, Owner: fpA, OwnerHandle: "alice", DockerCraftID: wA.ActiveCraft().ID,
+		CompositeID: phantomID, GuestOwner: fpB, GuestHandle: "bob",
+		GuestCraftID: 400, Phase: DockActive,
+	}})
+
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wA, fpA, reports) // owner notices the composite is gone
+	chips := ledger.Reconcile(wB, fpB, reports)
+
 	if len(ledger.Records()) != 0 {
-		t.Errorf("ledger still holds %d records after undock", len(ledger.Records()))
+		t.Errorf("phantom dock survived reconcile: %+v", ledger.Records())
+	}
+	if wB.DockGuest != nil {
+		t.Errorf("B still flagged docked-as-guest to a stack that does not exist: %+v", wB.DockGuest)
+	}
+	if !hasChip(chips, sim.SessionEventDockLost) {
+		t.Errorf("the dock ended with no moment for B — the marker just vanishes: %+v", chips)
+	}
+}
+
+// TestUndockAskOnPhantomCompositeReapsRecord (#309): pressing [U] against a
+// restored record whose composite is gone must not leave the record standing.
+// The pre-fix undockAsk branch looked the composite up, failed, and returned
+// false anyway — its comment claimed the guest side would time out, and a sweep
+// for that reaper found none.
+func TestUndockAskOnPhantomCompositeReapsRecord(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	wA, wB := alignedPair(t, 400)
+	now := time.Now()
+	ledger.Seed([]DockRecord{{
+		ID: 4, Owner: fpA, OwnerHandle: "alice", DockerCraftID: wA.ActiveCraft().ID,
+		CompositeID: 8888, GuestOwner: fpB, GuestHandle: "bob",
+		GuestCraftID: 400, Phase: DockActive,
+	}})
+	if !ledger.RequestUndock(fpB, 400) {
+		t.Fatalf("RequestUndock refused on the restored record")
+	}
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+	if len(ledger.Records()) != 0 {
+		t.Errorf("[U] left the phantom dock standing: %+v", ledger.Records())
 	}
 }
 

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -23,21 +23,10 @@ import (
 // AttitudeMode / EngineMode are dropped — they were tied to the
 // composite, which no longer exists.
 func (w *World) Undock(idx int) bool {
-	if idx < 0 || idx >= len(w.Crafts) {
+	if w.UndockRefusal(idx) != "" {
 		return false
 	}
 	c := w.Crafts[idx]
-	if c == nil || len(c.DockedComponents) < 2 {
-		return false
-	}
-	// v0.28 S5: a cross-player stack must not be split locally — that would
-	// clone the guest's craft into this (the owner's) World while the guest
-	// still believes it's docked. The guest undocks their own component
-	// through the dock ledger (UndockGuest); this local path handles only
-	// same-player composites (every component owned by this World).
-	if StackHasGuest(c) {
-		return false
-	}
 
 	// v0.12 / ADR 0009: decide whether the composite carries a full
 	// per-component stage breakdown. When every component records its
@@ -158,6 +147,34 @@ func (w *World) Undock(idx int) bool {
 	w.SetActiveCraftIdx(idx)
 	w.StopManualBurn()
 	return true
+}
+
+// UndockRefusal says, in the player's words, why Undock(idx) will refuse — or
+// "" when it will split the composite. It is exhaustive over Undock's false
+// paths BY CONSTRUCTION: Undock consults it instead of re-deriving the
+// conditions, so the two cannot drift and a refused `U` can never be silent
+// (#308 — live, a legitimate refusal read as "undock is broken" and cost an
+// evening of diagnosis from the wrong premise).
+//
+// Each string names the situation and, where there is one, the way out. The
+// caller renders it verbatim.
+func (w *World) UndockRefusal(idx int) string {
+	if idx < 0 || idx >= len(w.Crafts) || w.Crafts[idx] == nil {
+		return "undock: no vessel selected"
+	}
+	c := w.Crafts[idx]
+	if len(c.DockedComponents) < 2 {
+		return "undock: nothing is docked to this vessel"
+	}
+	// v0.28 S5: a cross-player stack must not be split locally — that would
+	// clone the guest's craft into this (the owner's) World while the guest
+	// still believes it's docked. The guest undocks their own component
+	// through the dock ledger (UndockGuest); this local path handles only
+	// same-player composites (every component owned by this World).
+	if StackHasGuest(c) {
+		return "undock: cross-player stack — the guest releases it from their seat"
+	}
+	return ""
 }
 
 // radialOutUnit returns the unit vector pointing radially outward from the

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -79,11 +79,14 @@ func (w *World) DockGuestCraft(dockerIdx int, guest *spacecraft.Spacecraft, gues
 // when non-zero, disambiguates one guest among several sharing an owner (not
 // reachable in the 2-party MVP).
 //
-// Returns ok=false when the composite has no components tagged for guestOwner
-// (nothing to undock) or the indices are invalid. MVP limitation: a guest that
-// docked a multi-component composite is rebuilt as a single multi-stage craft
-// from its first component's identity — the sub-composite seams are not
-// preserved (passive-station posture docks a single craft; noted for playtest).
+// Returns ok=false when the indices are invalid, or when the guest's sub-stack
+// isn't a peelable top block — see guestTopBlock for what that means and why a
+// refusal beats a mis-slice (#307). The caller must SAY SO rather than drop a
+// refusal on the floor: silence here reads as a broken key from the guest's
+// seat. MVP limitation: a guest that docked a multi-component composite is
+// rebuilt as a single multi-stage craft from its first component's identity —
+// the sub-composite seams are not preserved (passive-station posture docks a
+// single craft; noted for playtest).
 func (w *World) UndockGuest(compositeIdx int, guestOwner string, guestCraftID uint64) (*spacecraft.Spacecraft, bool) {
 	if compositeIdx < 0 || compositeIdx >= len(w.Crafts) || guestOwner == "" {
 		return nil, false
@@ -93,31 +96,8 @@ func (w *World) UndockGuest(compositeIdx int, guestOwner string, guestCraftID ui
 		return nil, false
 	}
 
-	// Collect the guest's components (by owner, optionally pinned to
-	// guestCraftID) and the count of live stages they occupy. Components map
-	// to c.Stages in order (bottom-to-top); the guest's ride on TOP of the
-	// docker's, so their live stages are the tail of c.Stages — the same
-	// geometry Deploy peels.
-	var guestComps []spacecraft.DockedComponent
-	guestStageCnt := 0
-	keepComps := make([]spacecraft.DockedComponent, 0, len(c.DockedComponents))
-	for _, dc := range c.DockedComponents {
-		isGuest := dc.Owner == guestOwner && (guestCraftID == 0 || dc.CraftID == guestCraftID)
-		if isGuest {
-			guestComps = append(guestComps, dc)
-			guestStageCnt += len(dc.Stages)
-		} else {
-			keepComps = append(keepComps, dc)
-		}
-	}
-	if len(guestComps) == 0 {
-		return nil, false
-	}
-	// The guest's stages must tile the top of the composite exactly for the
-	// live-stage peel — every cross-player component carries its Stages
-	// breakdown (DockGuestCraft fuses live craft, never the legacy flat
-	// form), so this holds; refuse rather than mis-slice if it doesn't.
-	if guestStageCnt <= 0 || guestStageCnt >= len(c.Stages) {
+	guestComps, keepComps, guestStageCnt, ok := guestTopBlock(c, guestOwner, guestCraftID)
+	if !ok {
 		return nil, false
 	}
 	keep := len(c.Stages) - guestStageCnt
@@ -139,6 +119,68 @@ func (w *World) UndockGuest(compositeIdx int, guestOwner string, guestCraftID ui
 	c.SyncFields()
 	c.State.M = c.TotalMass()
 	return restored, true
+}
+
+// guestTopBlock resolves the guest's sub-stack inside composite c: the
+// components to peel, the components the composite keeps, and the count of
+// LIVE stages the peel takes off the top of c.Stages. ok=false means the peel
+// is not well-defined and the caller must refuse.
+//
+// The peel is POSITIONAL — the tail of c.Stages — so it is only sound while
+// the OWNERSHIP selector picks the same components position does: the guest's
+// must be the topmost ones, contiguous. That holds at dock time, because
+// DockGuestCraft appends the guest's components last. It stops holding after a
+// control transfer: RetagStackForTransfer rewrites Owner WITHOUT restacking
+// the vehicle, so the demoted owner's components are now the guest's and they
+// sit at the BOTTOM. Slicing the tail there hands each player the other's
+// hardware, under their own name and stable ID, silently and permanently — the
+// tags then describe the corrupted attribution, so a repair dock/undock cycle
+// faithfully re-entrenches it (#307).
+//
+// Refusing is the honest answer rather than peeling the head instead. Staging
+// pops stages off the BOTTOM of c.Stages without touching DockedComponents
+// (staging.go), so head-slicing is not generally well-defined — which is the
+// same reason World.Undock guards its breakdown path with a tiling check
+// before trusting the component→stage correspondence. The one structural
+// correspondence that survives staging is top-anchored, and that is exactly
+// what this function requires. A refused peel is recoverable in play: hand
+// control back, which flips the tags again and puts the other party's
+// components on top, where they can be released.
+func guestTopBlock(c *spacecraft.Spacecraft, guestOwner string, guestCraftID uint64) (guest, keep []spacecraft.DockedComponent, stageCnt int, ok bool) {
+	isGuest := func(dc spacecraft.DockedComponent) bool {
+		return dc.Owner == guestOwner && (guestCraftID == 0 || dc.CraftID == guestCraftID)
+	}
+	// The maximal guest-owned suffix — the block a tail slice would peel.
+	n := len(c.DockedComponents)
+	start := n
+	for start > 0 && isGuest(c.DockedComponents[start-1]) {
+		start--
+	}
+	if start == n {
+		return nil, nil, 0, false // nothing of the guest's is on top
+	}
+	// Every guest component must lie inside that suffix. One below a docker
+	// component means the block is not top-anchored (the post-transfer case).
+	for i := 0; i < start; i++ {
+		if isGuest(c.DockedComponents[i]) {
+			return nil, nil, 0, false
+		}
+	}
+	for _, dc := range c.DockedComponents[start:] {
+		if len(dc.Stages) == 0 {
+			return nil, nil, 0, false // no breakdown — nothing to tile the peel with
+		}
+		stageCnt += len(dc.Stages)
+	}
+	// The peel must leave the docker something to fly, and cannot claim more
+	// live stages than the composite has.
+	if stageCnt <= 0 || stageCnt >= len(c.Stages) {
+		return nil, nil, 0, false
+	}
+	// keep owns its backing array: a later append onto the composite's
+	// component list must not write into the departing guest's entries.
+	keep = append([]spacecraft.DockedComponent(nil), c.DockedComponents[:start]...)
+	return c.DockedComponents[start:], keep, stageCnt, true
 }
 
 // RemoveCraftByID lifts the craft with the given stable ID out of the slate

--- a/internal/sim/docking_guest_test.go
+++ b/internal/sim/docking_guest_test.go
@@ -289,6 +289,99 @@ func TestWithDockCouplingAppendsPartnerWithoutCorruption(t *testing.T) {
 	}
 }
 
+// transferredStack builds a cross-player composite and then flips its
+// ownership tags the way a control transfer does — WITHOUT restacking the
+// vehicle, which is exactly the state #307 lives in. It returns the composite,
+// the two parties' fingerprints AFTER the flip (newGuestFP is the demoted
+// original docker, whose components now sit at the BOTTOM), and each party's
+// pre-dock mass so attribution can be checked by the one field the bug does
+// not rewrite.
+func transferredStack(t *testing.T) (w *World, comp *spacecraft.Spacecraft, newOwnerFP, newGuestFP string, dockerID uint64, dockerMass, guestMass float64) {
+	t.Helper()
+	w, _ = NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+
+	docker := w.Crafts[0]
+	docker.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	vc := math.Sqrt(earth.GravitationalParameter() / docker.State.R.Norm())
+	docker.State.V = orbital.Vec3{Y: vc}
+	dockerID, dockerMass = docker.ID, docker.TotalMass()
+
+	// A DIFFERENT vehicle, so mass tells the two apart. Name and stable ID are
+	// both rewritten on the corrupt path (restoreComponentCraft takes the
+	// component's name, then the caller stamps guestCraftID), so mass is the
+	// only surviving discriminator.
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID)
+	guest.Primary = *earth
+	guest.ID = 99
+	guest.State = physics.StateVector{R: docker.State.R.Add(orbital.Vec3{X: 8}), V: docker.State.V, M: guest.TotalMass()}
+	guestMass = guest.TotalMass()
+	if math.Abs(dockerMass-guestMass) < 1 {
+		t.Fatalf("test vehicles are indistinguishable by mass (%v vs %v) — the assertion would be vacuous", dockerMass, guestMass)
+	}
+
+	newGuestFP, newOwnerFP = "SHA256:alice-the-docker", guestFP
+	comp, _, ok := w.DockGuestCraft(0, guest, newOwnerFP)
+	if !ok {
+		t.Fatalf("DockGuestCraft failed")
+	}
+	// Control transfer: the docker hands the stack to the guest. Tags flip,
+	// the vehicle does not restack — so the demoted docker's components are
+	// now the guest's AND they are the bottom of the stack.
+	RetagStackForTransfer(comp, newGuestFP, newOwnerFP)
+	return w, comp, newOwnerFP, newGuestFP, dockerID, dockerMass, guestMass
+}
+
+// TestUndockGuestRefusesWhenTheGuestIsNotOnTop (#307): after a control
+// transfer the demoted owner's components sit at the BOTTOM of the stack while
+// the ownership tags say they are the guest's. Peeling the tail there returned
+// the OTHER player's vehicle under this player's name and stable ID — silently,
+// and permanently, since a repair dock/undock cycle re-entrenched the corrupted
+// tags. Refuse instead.
+func TestUndockGuestRefusesWhenTheGuestIsNotOnTop(t *testing.T) {
+	w, comp, _, newGuestFP, dockerID, dockerMass, guestMass := transferredStack(t)
+	stackMass := comp.TotalMass()
+
+	restored, ok := w.UndockGuest(0, newGuestFP, dockerID)
+	if ok {
+		// The pre-fix failure: ok, with the wrong hardware attached.
+		t.Fatalf("UndockGuest peeled a bottom-anchored guest: returned mass %v (its own vehicle is %v, the other player's is %v)",
+			restored.TotalMass(), dockerMass, guestMass)
+	}
+	// Refusing must leave the stack whole — no half-split, no mass lost.
+	if got := comp.TotalMass(); math.Abs(got-stackMass) > 1e-6 {
+		t.Errorf("refused undock still mutated the stack: mass %v, want %v", got, stackMass)
+	}
+	if len(comp.DockedComponents) != 2 || !StackHasGuest(comp) {
+		t.Errorf("refused undock disturbed the composite: %d components, cross-player=%v",
+			len(comp.DockedComponents), StackHasGuest(comp))
+	}
+}
+
+// TestUndockGuestAfterTransferBackReturnsTheRightHardware (#307): the guard
+// must be capable of a positive, or the refusal above proves nothing. Handing
+// control back flips the tags again and puts the other party's components on
+// top, where they peel correctly — and the craft that comes home carries ITS
+// OWN mass, which is the attribution the bug got wrong.
+func TestUndockGuestAfterTransferBackReturnsTheRightHardware(t *testing.T) {
+	w, comp, newOwnerFP, newGuestFP, _, dockerMass, guestMass := transferredStack(t)
+
+	// Control goes back to the original docker: the other party is the guest
+	// again, its components on top.
+	RetagStackForTransfer(comp, newOwnerFP, newGuestFP)
+
+	restored, ok := w.UndockGuest(0, newOwnerFP, 99)
+	if !ok {
+		t.Fatal("UndockGuest refused a top-anchored guest — the guard refuses everything")
+	}
+	if got := restored.TotalMass(); math.Abs(got-guestMass) > 1e-3 {
+		t.Errorf("returned craft mass = %v, want the guest's own %v (got the other player's %v?)", got, guestMass, dockerMass)
+	}
+	if got := w.Crafts[0].TotalMass(); math.Abs(got-dockerMass) > 1e-3 {
+		t.Errorf("remaining stack mass = %v, want the docker's own %v", got, dockerMass)
+	}
+}
+
 // TestRetagStackForTransfer: transfer flips ownership — the holder's own
 // components become the departing guest's, and the recipient's guest
 // components become the new holder's own. Idempotent for a same-owner call.

--- a/internal/sim/docking_test.go
+++ b/internal/sim/docking_test.go
@@ -2,6 +2,7 @@ package sim
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
@@ -337,5 +338,69 @@ func TestDockingActivePartnerKeepsName(t *testing.T) {
 	composite := w.Crafts[w.ActiveCraftIdx]
 	if composite.Name != "LM" {
 		t.Errorf("composite name = %q, want LM (active partner)", composite.Name)
+	}
+}
+
+// TestUndockRefusalIsExhaustiveAndSpeaks (#308): every path on which Undock
+// returns false hands back a reason, and a splittable composite hands back
+// none. Live, a legitimate refusal on a cross-player stack was indistinguishable
+// from a dead key and cost an evening of diagnosis; the pairing is what keeps
+// `U` from ever no-opping in silence again.
+func TestUndockRefusalIsExhaustiveAndSpeaks(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+	a := w.Crafts[0]
+	a.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+
+	// Out of range, and a plain (non-composite) craft.
+	for _, idx := range []int{-1, len(w.Crafts)} {
+		if got := w.UndockRefusal(idx); got == "" {
+			t.Errorf("UndockRefusal(%d) on an invalid index gave no reason", idx)
+		}
+	}
+	if got := w.UndockRefusal(0); got == "" {
+		t.Error("UndockRefusal on a plain craft gave no reason")
+	}
+
+	// A cross-player stack: refused (the guest releases it from their seat),
+	// and it must say so.
+	guest := spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID)
+	guest.Primary = *earth
+	guest.ID = 77
+	guest.State = physics.StateVector{R: a.State.R.Add(orbital.Vec3{X: 6}), V: a.State.V, M: guest.TotalMass()}
+	if _, _, ok := w.DockGuestCraft(0, guest, "SHA256:someone"); !ok {
+		t.Fatal("DockGuestCraft failed")
+	}
+	reason := w.UndockRefusal(0)
+	if reason == "" {
+		t.Fatal("UndockRefusal on a cross-player stack gave no reason")
+	}
+	if !strings.Contains(reason, "guest") {
+		t.Errorf("cross-player refusal %q does not point at the guest's seat", reason)
+	}
+	if w.Undock(0) {
+		t.Error("Undock split a cross-player stack locally")
+	}
+
+	// A same-player composite: no reason, and it splits. Without this the
+	// exhaustiveness above would be satisfied by refusing everything.
+	w2, _ := NewWorld()
+	earth2 := w2.Systems[0].FindBody("Earth")
+	lm := spacecraft.NewFromLoadout(spacecraft.LoadoutLanderID)
+	lm.Primary = *earth2
+	lm.State = physics.StateVector{
+		R: w2.Crafts[0].State.R.Add(orbital.Vec3{X: 10}),
+		V: w2.Crafts[0].State.V,
+		M: lm.TotalMass(),
+	}
+	w2.Crafts = append(w2.Crafts, lm)
+	if _, _, ok := w2.checkDocking(); !ok {
+		t.Fatal("expected dock to fire")
+	}
+	if got := w2.UndockRefusal(0); got != "" {
+		t.Errorf("UndockRefusal on a splittable composite = %q, want none", got)
+	}
+	if !w2.Undock(0) {
+		t.Error("Undock refused a composite it reported no reason to refuse")
 	}
 }

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -90,6 +90,16 @@ const (
 	SessionEventUndocked       // cross-player stack split ("undocked from X", v0.28 S5)
 	SessionEventTransfer       // stack control handed over ("control → X", v0.28 S5)
 
+	// SessionEventUndockRefused: my undock-as-guest was refused on the stack
+	// owner's side — my components are no longer the top of the stack, so
+	// peeling them would swap the two players' vehicles (#307). Addressed at
+	// the guest, who pressed the key and is still docked.
+	SessionEventUndockRefused
+	// SessionEventDockLost: the cross-player stack this dock named no longer
+	// exists (#309) — the craft riding in it went with it. Addressed at the
+	// guest, whose docked-as-guest marker would otherwise just vanish.
+	SessionEventDockLost
+
 	// Rendezvous Warp moments (v0.29 S2) — all local-only: each side's
 	// serve wrapper derives them from its own World transitions.
 	SessionEventRendezvousArmed     // a partner armed toward you ("X wants to rendezvous")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1279,11 +1279,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.world.DockGuest != nil {
 				return a, func() tea.Msg { return UndockGuestMsg{} }
 			}
-			if a.world.Undock(a.world.ActiveCraftIdx) {
+			// #308: say why when it refuses. The key is bound and the stack is
+			// real, so a bare no-op reads as a broken game — and the commonest
+			// refusal (a cross-player stack) has an answer the player can act
+			// on. UndockRefusal is exhaustive over Undock's false paths, so
+			// there is no third branch that falls through in silence.
+			if reason := a.world.UndockRefusal(a.world.ActiveCraftIdx); reason != "" {
+				a.statusMsg = reason
+			} else if a.world.Undock(a.world.ActiveCraftIdx) {
 				a.statusMsg = fmt.Sprintf("undocked into %d components", len(a.world.Crafts))
-				a.statusExpires = time.Now().Add(3 * time.Second)
 				a.world.RecordAction(missions.ActionUndock) // ADR 0025 §7
 			}
+			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.TransferControl):
 			// v0.28 S5, ADR 0034 §6: hand a cross-player stack I own to the

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -45,6 +45,16 @@ type OrbitView struct {
 	lastViewMode  sim.ViewMode
 	fitted        bool
 
+	// lastCraftHere completes the framing context (#310). Losing the craft
+	// you are focused on changes the framing as surely as changing focus
+	// does, but Focus.Kind stays FocusCraft, so none of the fields above
+	// move: the centre — recomputed every frame — snapped to the system
+	// origin while the scale stayed at the craft's old alt×3 fit, which in
+	// Sol is the Sun at hard magnification with no explanation. Tracking
+	// craft visibility makes losing (or regaining) it a Framing Event, so
+	// FocusZoomRadius' system-wide fall-through actually runs.
+	lastCraftHere bool
+
 	// baseScale is the auto-fit pixels-per-meter the Framing-Event fit
 	// last computed (FocusZoomRadius). userZoom is the player's manual
 	// `+`/`-` multiplier on top of it: the on-screen scale is
@@ -401,11 +411,13 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// target (body or craft) we still re-center every frame below; this
 	// path only fires when the framing *context* changes, not when the
 	// target moves.
+	craftHere := w.CraftVisibleHere()
 	if v.lastSystemIdx != w.SystemIdx || v.lastFocus != w.Focus ||
-		v.lastViewMode != w.ViewMode || !v.fitted {
+		v.lastViewMode != w.ViewMode || v.lastCraftHere != craftHere || !v.fitted {
 		v.lastSystemIdx = w.SystemIdx
 		v.lastFocus = w.Focus
 		v.lastViewMode = w.ViewMode
+		v.lastCraftHere = craftHere
 		v.fitted = true
 		v.canvas.FitTo(w.FocusZoomRadius())
 		// ADR 0024: a body focused for surface viewing must be zoomed

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -177,6 +177,14 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			plain("◇ undocked from " + e.Handle)
 		case sim.SessionEventTransfer:
 			plain("◇ control handed to " + e.Handle)
+		case sim.SessionEventUndockRefused:
+			// #307: two rows because the second one is the way out — the
+			// refusal alone would leave the player stuck with no next move.
+			rows = append(rows,
+				row{text: "⚠ undock refused — your craft is not on top of the stack", alert: true},
+				row{text: "  have " + e.Handle + " hand control back, then release"})
+		case sim.SessionEventDockLost:
+			rows = append(rows, row{text: "⚠ dock with " + e.Handle + " ended — the stack no longer exists", alert: true})
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
 		case sim.SessionEventWentQuiet:

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -246,7 +246,25 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 		if w.ActiveCraft() != nil {
 			return []string{v.theme.Dim.Render("VESSEL (in Sol — [tab] to switch)")}
 		}
-		return nil
+		// #310: an empty slate used to render nothing at all. The camera
+		// meanwhile fell through to the system origin, so the player was left
+		// staring at a hard-zoomed star with no explanation — live, two people
+		// hunting for exactly this state, one with the source open, failed to
+		// read it for hours. Say it — and say WHY it is empty when we know:
+		// riding in another player's stack is not the same situation as having
+		// no craft, and offering "launch a new flight" there would be wrong.
+		if dg := w.DockGuest; dg != nil {
+			return []string{
+				v.theme.Primary.Render("VESSEL"),
+				"  " + v.theme.Warning.Render("docked in "+dg.OwnerHandle+"'s stack"),
+				v.theme.Dim.Render("  [u] release it"),
+			}
+		}
+		return []string{
+			v.theme.Primary.Render("NO VESSEL"),
+			"  " + v.theme.Warning.Render("your craft slate is empty"),
+			v.theme.Dim.Render("  [n] launch a new flight"),
+		}
 	}
 	c := w.ActiveCraft()
 	lines := []string{

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -640,3 +640,71 @@ func TestBuildNodesChipMergesActiveBurn(t *testing.T) {
 		t.Errorf("chip should be nil with no burn and no nodes, got %v", got)
 	}
 }
+
+// TestEmptySlateSaysSo (#310): with no craft at all the flight view used to
+// render nothing where the VESSEL chip goes, while the camera fell through to
+// the system origin at the old craft-scale zoom — a hard-zoomed star and no
+// explanation. The chip must state the situation and offer the way out, and it
+// must distinguish "you have no craft" from "your craft is riding in someone
+// else's stack", which are different situations with different next moves.
+func TestEmptySlateSaysSo(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Crafts = nil
+	w.ActiveCraftIdx = 0
+
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if out == "" {
+		t.Fatal("empty craft slate renders nothing — the state the player cannot decode")
+	}
+	if !strings.Contains(out, "empty") {
+		t.Errorf("empty-slate chip does not say the slate is empty:\n%s", out)
+	}
+	if !strings.Contains(out, "[n]") {
+		t.Errorf("empty-slate chip offers no way out:\n%s", out)
+	}
+
+	// Docked as guest: the slate is empty for a reason we know, and "launch a
+	// new flight" would be the wrong advice.
+	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:bob", OwnerHandle: "bob"}
+	out = strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "bob") || !strings.Contains(out, "[u]") {
+		t.Errorf("docked-as-guest empty slate does not name the stack or the release key:\n%s", out)
+	}
+	if strings.Contains(out, "[n]") {
+		t.Errorf("docked-as-guest chip offers a new launch as if the craft were gone:\n%s", out)
+	}
+}
+
+// TestLosingTheCraftRefits (#310): losing every craft is a framing change even
+// though Focus.Kind stays FocusCraft. Without it the centre snaps to the system
+// origin (FocusPosition's fall-through) while the scale stays at the craft's
+// alt×3 fit — the two halves of "the view jumped to the Sun, zoomed hard in"
+// from one cause. The fit must be re-resolved, which lands on the system-wide
+// radius instead.
+func TestLosingTheCraftRefits(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Focus = sim.Focus{Kind: sim.FocusCraft}
+	v.Render(w, 0, 120, 40) // first frame fits to the craft's altitude
+	craftScale := v.baseScale
+	if craftScale <= 0 {
+		t.Fatalf("craft-focused fit produced no scale (%v)", craftScale)
+	}
+
+	w.Crafts = nil // the slate empties — [J] hands the last craft away
+	v.Render(w, 0, 120, 40)
+	if v.baseScale == craftScale {
+		t.Errorf("losing the craft left the camera at the craft-scale fit %v — the Sun at hard zoom", craftScale)
+	}
+	// The system-wide fall-through is a far coarser scale than an orbit fit.
+	if v.baseScale >= craftScale {
+		t.Errorf("post-loss fit %v is not zoomed out relative to the craft fit %v", v.baseScale, craftScale)
+	}
+}


### PR DESCRIPTION
Four measured defects from the 2026-08-02 two-bot playtest. They share one
shape: the game knows something and doesn't say it.

Closes #307, closes #308, closes #309, closes #310.

## #307 — undock after `[J]` swapped the two players' vehicles

`UndockGuest` selected components by **ownership** and sliced stages by
**position** (the tail). Those agree at dock time, because `DockGuestCraft`
appends the guest's components last, and stop agreeing after a control
transfer: `RetagStackForTransfer` rewrites `Owner` without restacking, so the
demoted owner's components sit at the *bottom*. The tail peel handed each
player the other's vehicle under their own name and stable ID — silently, and
permanently, since the corrupted tags then describe the wrong attribution and
a repair dock/undock cycle re-entrenches it.

`guestTopBlock` now requires the guest's components to be a contiguous top
block and refuses otherwise, per the issue's fix direction.

**On refusing rather than peeling the head instead** — the alternative would
be to head-slice whenever the breakdown fully tiles. I did not take it,
following the issue: staging pops stages off the bottom of `c.Stages` without
touching `DockedComponents`, so only the top-anchored correspondence survives
staging, and peeling out of the bottom of a live stack also swaps the
composite's firing `Stages[0]` underneath the owner. Flagging it as a real
fork in case it wants revisiting under #313.

The refusal is recoverable in play, and the PR proves it: hand control back,
which flips the tags again and puts the other party's components on top, where
they release correctly with the right hardware.

## #308 — docker-side `[U]` refused in silence

`World.Undock` refused a cross-player stack and set no status message, so a
*correct* refusal was indistinguishable from a dead key. `UndockRefusal` is
exhaustive over `Undock`'s false paths **by construction** — `Undock` consults
it rather than re-deriving the conditions, so the two can't drift — and
`app.go` renders the reason.

The guest side gets the same treatment, which #307's fix makes load-bearing: a
refused undock-as-guest now surfaces a SESSION moment naming the way out.

```
SESSION
⚠ undock refused — your craft is not on top of the stack
  have fenbot hand control back, then release
```

## #309 — phantom dock records were never reaped

A record restored from the session directory outlives the craft payloads,
which are transient. Measured on the production host: a `DockActive` record
naming a composite that existed in nobody's save sat for 5½ hours with the
guest flagged docked-as-guest to a stack that did not exist. Nothing reaped
it, and `[U]` didn't clear it either — the `undockAsk` branch looked the
composite up, failed, and returned `false` anyway.

The owner's reconcile now ends a dock whose `CompositeID` resolves nowhere,
and the guest is told rather than having the docked marker silently vanish.

*Scope note:* the handoff suggested #309 as a separate PR from #307/#308. It
landed here because the reap and the refusal both restructure the same
`reconcileOwner` `DockActive` / `undockAsk` branch — splitting them would have
been an artificial conflict with itself.

## #310 — an empty craft slate gave no indication

Losing every craft changed the camera **centre** (recomputed per frame,
falling through to the system origin) but not the **scale** — `Focus.Kind`
stays `FocusCraft` and nothing else in the framing context moved. That is the
Sun at craft-scale zoom, both halves of the live report from one cause.

Craft visibility is now part of the framing context, so the fit re-resolves to
the system-wide radius; and the pinned chip states the situation instead of
rendering nothing. It distinguishes "you have no craft" from "your craft is
riding in another player's stack", which have different next moves —
suggesting a new launch to a docked-as-guest player would be wrong.

Rendered and looked at, not just asserted:

```
╭───────────────────────────╮
│NO VESSEL                  │
│  your craft slate is empty│
│  [n] launch a new flight  │
╰───────────────────────────╯
```
```
╭───────────────────────╮
│VESSEL                 │
│  docked in bob's stack│
│  [u] release it       │
╰───────────────────────╯
```

## Tests

Every regression instrument was checked against the **pre-fix** code and
observed to fail there — a negative result is not evidence until the
instrument has been shown capable of a positive.

- The #307 assertion is on **mass**: name and stable ID are both rewritten on
  the corrupt path (`restoreComponentCraft` takes the component's name, then
  the caller stamps `guestCraftID`), so mass is the only surviving
  discriminator. Sabotaged back to the old selector, the test reports the
  other vehicle's mass coming home.
- The guard is paired with a **positive control** — transfer back, release,
  both players hold their own vehicle — so it cannot pass by refusing
  everything.
- `TestTransferAdoptRestampsCollidingCompositeID` kept its collision-restamp
  subject; its tail now asserts the refusal and that the dock still stands,
  since with the fix no craft comes home on that path.
- #308's test asserts exhaustiveness *and* that a splittable composite reports
  no reason and splits.

`go vet ./...` and `go test ./... -race -count=1` green (1905 passing).

## Not in scope

- **#311 / #312 / #313** — the durability-of-in-flight-dock-state design
  conversation, to be grilled as one. The #309 reap is deliberately narrow:
  it frees the guest from a phantom, it does not restore the lost craft.
- **#312's docker-side release** — the #308 message deliberately does not
  promise one ("the guest releases it from their seat" is accurate today).