### PR TITLE
Rendezvous planner contract: K domain honesty, phasing-coach refusals, CA trend (ADR 0039)

### DIFF
--- a/internal/planner/rendezvous_recommend.go
+++ b/internal/planner/rendezvous_recommend.go
@@ -77,6 +77,15 @@ type RendezvousAdvisory struct {
 	AchievableCA float64 // m — what the recommended burn delivers
 	TArrival     float64 // s — time-to-CA from now after the burn
 
+	// ArrivalSpeed is |v_rel| AT the achieved closest approach (post-burn),
+	// m/s — populated only on Ok=true (ADR 0039 S1). Pure information, no
+	// gate: it sizes the hand-flown part of the job ("CA 9 km, arriving
+	// ~540 m/s") rather than judging it. #290 found this invisible at plan
+	// time: a K-plant that read as a clean success in fact arrived at
+	// 95.4 m/s, 4.6 under the lock gate, with no readout anywhere warning
+	// the player before they committed to it.
+	ArrivalSpeed float64
+
 	LambertIdealDV float64 // m/s — |full Lambert ΔV| (always ≥ DV; gap shows projection loss)
 
 	Reason string // populated when Ok=false: "no improvement available" | "no lambert convergence" | "degenerate axes" | "horizon too short" | "burn too large — use H/I/m" | "burn drops periapsis unsafely"
@@ -131,6 +140,25 @@ func RecommendRendezvousNudge(
 
 	if mu <= 0 || horizon <= 0 {
 		out.Reason = "horizon too short"
+		return out
+	}
+
+	// Step 0 (ADR 0039 S1 / #290): orbit-shape mismatch gate. K's nudge is
+	// a single-axis velocity push on the chaser's EXISTING orbit, not a
+	// re-shape — it works by refining a position offset between two
+	// already-similar orbits. When the chaser and target eccentricities
+	// have drifted apart, the axis projection doesn't converge toward
+	// rendezvous, it walks the chaser further from the target's shape:
+	// #290's live sequence spent 275 m/s across two "successful" nudges
+	// to end up FARTHER away (CA 577 km → 1,110 km) after the first nudge
+	// itself pushed the chaser's shape away from the target's. Refuse
+	// before spending any Lambert work and point at the tools built for
+	// shape changes (circularize [C], transfer [H]) rather than offering
+	// another diverging position-only burn.
+	eccA := orbital.ElementsFromState(stateA.R, stateA.V, mu).E
+	eccB := orbital.ElementsFromState(stateB.R, stateB.V, mu).E
+	if math.Abs(eccA-eccB) > shapeMismatchEccDelta {
+		out.Reason = "orbit shape mismatch"
 		return out
 	}
 
@@ -213,7 +241,7 @@ func RecommendRendezvousNudge(
 		R: stateA.R,
 		V: stateA.V.Add(bestAxisUnit.Scale(bestProj)),
 	}
-	tStar, caStar, _, err := NextClosestApproach(perturbed, stateB, primary, mu, horizon)
+	tStar, caStar, vRelStar, err := NextClosestApproach(perturbed, stateB, primary, mu, horizon)
 	if err != nil {
 		out.Reason = "ca-verify failed"
 		return out
@@ -282,6 +310,7 @@ func RecommendRendezvousNudge(
 	out.AxisUnit = bestAxisUnit
 	out.AchievableCA = caStar
 	out.TArrival = tStar
+	out.ArrivalSpeed = vRelStar.Norm()
 	return out
 }
 
@@ -295,6 +324,20 @@ func RecommendRendezvousNudge(
 // H / I / m planners. Const, not a knob — the player intent is
 // "small nudge to refine an already-close intercept."
 const maxNudgeDV = 300.0 // m/s
+
+// shapeMismatchEccDelta is the eccentricity-difference threshold above
+// which chaser and target are considered shape-mismatched (ADR 0039 S1).
+// Eccentricity is already a dimensionless, scale-free shape measure, so
+// one constant works across every body scale (real vs stripped-back).
+// Calibrated to sit clear of the ordinary near-matched case a nudge is
+// built for (#278's repro — 551×499.8 km vs 500×500 km LEO — is an
+// e-delta of a few thousandths at real-body scale) while still catching
+// a genuinely diverged shape (#290's post-nudge chaser reached e≈0.01–
+// 0.02 after just one bad plant, climbing fast under iteration). Tuned
+// conservatively wide rather than tight: a missed mismatch still falls
+// through to the burn-too-large / periapsis-safety gates below, but a
+// false trigger would refuse K inside its actual working domain.
+const shapeMismatchEccDelta = 0.05
 
 var allAxisLabels = []AxisLabel{
 	AxisPrograde,

--- a/internal/planner/rendezvous_recommend_test.go
+++ b/internal/planner/rendezvous_recommend_test.go
@@ -230,3 +230,97 @@ func TestRecommendRendezvousNudge_PeriapsisGate(t *testing.T) {
 		t.Errorf("expected Reason=\"burn drops periapsis unsafely\" (or ceiling reason if DV exceeds it), got %q (DV=%.0f, axis=%s)", adv.Reason, adv.DV, adv.Axis)
 	}
 }
+
+// eccentricStateAtRadius builds a state at radius r, phase phaseRad, whose
+// velocity is purely tangential at magnitude k times the local circular
+// speed. k > 1 puts r at PERIAPSIS of the resulting ellipse, with
+// eccentricity e = k² − 1 (derived from p = r·k² and r = p/(1+e) at
+// periapsis). k == 1 reproduces circularStateAtRadius exactly.
+func eccentricStateAtRadius(r, phaseRad, k, mu float64) orbital.Vec3State {
+	s := circularStateAtRadius(r, phaseRad, mu)
+	return orbital.Vec3State{R: s.R, V: s.V.Scale(k)}
+}
+
+// TestRecommendRendezvousNudge_ShapeMismatch — ADR 0039 S1 / #290: a
+// chaser on a sharply eccentric orbit (e≈0.69) against a circular target
+// at the same periapsis radius is exactly the shape iterated K-nudges
+// drifted into live (567×408 km chaser vs a ~500×500 km target) — CA
+// *worsened* after the burn because a single-axis nudge cannot correct
+// an orbit-shape mismatch, only a position offset. The gate must refuse
+// before ever running the Lambert lookahead, with a reason distinct from
+// every existing tag so the HUD can point at C/H instead of retrying K.
+func TestRecommendRendezvousNudge_ShapeMismatch(t *testing.T) {
+	r := 6.771e6
+	target := circularStateAtRadius(r, 0, muEarth)
+	chaser := eccentricStateAtRadius(r, -0.5*math.Pi/180, 1.3, muEarth) // e≈0.69
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, 1_000_000)
+	if adv.Ok {
+		t.Fatalf("expected Ok=false for a shape-mismatched chaser/target pair, got DV=%.1f axis=%s", adv.DV, adv.Axis)
+	}
+	if adv.Reason != "orbit shape mismatch" {
+		t.Errorf("Reason = %q, want \"orbit shape mismatch\"", adv.Reason)
+	}
+}
+
+// TestRecommendRendezvousNudge_ArrivalSpeedPopulated — ADR 0039 S1: every
+// successful plant quotes predicted arrival speed as a plain info row
+// ("CA 9 km, arriving ~540 m/s"). #290 traced the earlier blind spot
+// directly: a K-plant that read as a clean "success" in fact arrived at
+// 95.4 m/s, 4.6 under the lock gate, invisible at plan time because
+// nothing on the advisory carried it. ArrivalSpeed must be the |v_rel|
+// AT the achieved closest approach (not the current, pre-burn v_rel),
+// so recompute it independently here and compare.
+func TestRecommendRendezvousNudge_ArrivalSpeedPopulated(t *testing.T) {
+	r := 6.771e6
+	target := circularStateAtRadius(r, 0, muEarth)
+	chaser := circularStateAtRadius(r, -0.5*math.Pi/180, muEarth)
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, currentCA)
+	if !adv.Ok {
+		t.Fatalf("expected Ok=true, got Reason=%q", adv.Reason)
+	}
+	if adv.ArrivalSpeed <= 0 {
+		t.Fatalf("ArrivalSpeed = %.3f, want > 0", adv.ArrivalSpeed)
+	}
+
+	// Independently recompute |v_rel| at the achieved CA from the
+	// perturbed post-burn chaser state and compare.
+	perturbed := orbital.Vec3State{R: chaser.R, V: chaser.V.Add(adv.AxisUnit.Scale(adv.DV))}
+	_, _, wantVRel, err := NextClosestApproach(perturbed, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("verification predictor err: %v", err)
+	}
+	if diff := math.Abs(adv.ArrivalSpeed - wantVRel.Norm()); diff > 1e-6 {
+		t.Errorf("ArrivalSpeed = %.6f, want %.6f (|v_rel| at achieved CA)", adv.ArrivalSpeed, wantVRel.Norm())
+	}
+}
+
+// TestRecommendRendezvousNudge_NearMatchedShapePasses — a small
+// eccentricity delta (e≈0.01, well under the mismatch threshold) must
+// NOT trip the new gate: this is K's actual working domain — a small
+// phase/altitude offset between near-identical orbits (#278's repro:
+// 551×499.8 km vs 500×500 km, e-delta of a few thousandths at LEO
+// scale) — and the existing burn-too-large / periapsis-safety gates
+// downstream already cover it appropriately depending on geometry. This
+// guards the threshold isn't so wide it swallows K's real domain.
+func TestRecommendRendezvousNudge_NearMatchedShapePasses(t *testing.T) {
+	r := 6.771e6
+	target := circularStateAtRadius(r, 0, muEarth)
+	chaser := eccentricStateAtRadius(r, -0.5*math.Pi/180, 1.005, muEarth) // e≈0.01
+
+	_, currentCA, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, muEarth, 6000)
+	if err != nil {
+		t.Fatalf("predictor err: %v", err)
+	}
+
+	adv := RecommendRendezvousNudge(chaser, target, bodies.CelestialBody{}, muEarth, 6000, currentCA)
+	if adv.Reason == "orbit shape mismatch" {
+		t.Errorf("near-matched shapes (e-delta≈0.01) tripped the mismatch gate; got DV=%.1f", adv.DV)
+	}
+}

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -731,6 +731,11 @@ func (w *World) resolveRendezvousWaypoint(arm *RendezvousArm, partner *CoWarpPee
 	}
 	arm.peerGoneAt = time.Time{} // peer back inside the grace — full window next time
 	if tau, ca, ok := w.rendezvousNextWaypoint(partner); ok {
+		// ADR 0039 S3: capture the outgoing CA as the trend row's "previous"
+		// point before it's overwritten — must happen every advance, not
+		// just the first, so the trend always compares the two most recent
+		// waypoints.
+		arm.PrevCommittedCA, arm.PrevCommittedCASet = arm.CommittedCA, true
 		arm.Tau, arm.CommittedCA = tau, ca
 		arm.degradeBaseSet = false // per-waypoint re-baseline (#251 interaction)
 		w.AutoWarp.T = tau

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -531,6 +531,14 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	if partner != nil && w.rendezvousWarpEngaged() &&
 		partner.RendezvousTau.After(w.Clock.SimTime.Add(rendezvousWaypointMinLead)) &&
 		(partner.RendezvousTau.Before(arm.Tau) || !arm.Tau.After(w.Clock.SimTime)) {
+		// ADR 0039 S3 (batch-review follow-up, PR #319): adoption is a
+		// waypoint transition exactly like resolveRendezvousWaypoint's own
+		// derivation below — the degradeBaseSet reset on the next line
+		// already treats it that way ("a new waypoint means a new
+		// baseline"), so the CA trend row must too, or PrevCommittedCA goes
+		// stale across an adoption and the row can compare across TWO
+		// transitions instead of one, misreporting the direction.
+		arm.PrevCommittedCA, arm.PrevCommittedCASet = arm.CommittedCA, true
 		arm.Tau, arm.CommittedCA = partner.RendezvousTau, partner.RendezvousCA
 		arm.degradeBaseSet = false // a new waypoint means a new baseline (#251 interaction)
 		w.AutoWarp.T = arm.Tau

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -324,6 +324,21 @@ type RendezvousArm struct {
 	degradeBaseAt  time.Time
 	degradeBaseSet bool
 
+	// PrevCommittedCA / PrevCommittedCASet (ADR 0039 S3, #281): the CA at
+	// the waypoint immediately before the current one, captured by
+	// resolveRendezvousWaypoint just before it overwrites CommittedCA on
+	// an advance. Feeds the RENDEZVOUS chip's trend row — "did the last
+	// waypoint get better or worse" — a question the degrade watchdog
+	// above can't answer, because its own baseline re-bases with the
+	// drift it's supposed to catch (see degradeBaseCA's doc comment): a
+	// standing intent that worsens by a little every waypoint never trips
+	// it, since each re-derivation re-commits a fresh (worse) baseline.
+	// Unset before the first waypoint advance, so the chip stays silent
+	// until there are two committed CAs to compare — a single point has
+	// no trend.
+	PrevCommittedCA    float64
+	PrevCommittedCASet bool
+
 	// peerGoneAt is the sim-time the partner's report first vanished from
 	// the peer set entirely while the coast sat at/after τ (#252 review,
 	// finding 3) — zero while the peer is present. A one-tick dropout at

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -194,6 +194,27 @@ const rendezvousCommitHorizonSec = 4 * 3600.0
 // useful nudge (the encounter is already set up). ok=false when no
 // encounter can be found at all: no relative target, cross-primary, or
 // no approach inside the horizon — the App toasts instead of arming.
+// rendezvousGapNoteBar is the "far above the lock gate" bar for the
+// engage-time gap note (ADR 0039 S3, #281): a generous multiple of the
+// couple gate, not "just outside" it — a committed CA a little past
+// coWarpCoupleRangeM is still a normal near-miss the coast can plausibly
+// narrow on its own across waypoints. This only fires once riding
+// waypoints alone plainly will not close it — #281's live case grew
+// 4,400 km → 11,049 km, orders of magnitude past this bar, with nothing
+// on screen ever saying a burn was needed.
+const rendezvousGapNoteBar = 3 * coWarpCoupleRangeM // 105 km
+
+// RendezvousNeedsBurnToClose reports whether a committed CA is far
+// enough above the couple/lock gate that a deliberate burn — not just
+// riding waypoints — will be needed to actually close it (ADR 0039 S3).
+// Called at Engage time on both sides (the initiator's own commit and
+// the responder's join, which adopts the same τ/CA off the wire) so the
+// choice to coast toward a wide encounter is visible up front rather
+// than discovered after riding it for days.
+func (w *World) RendezvousNeedsBurnToClose(ca float64) bool {
+	return ca >= rendezvousGapNoteBar
+}
+
 func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	if adv, aok := w.RecommendedRendezvousBurn(); aok && adv.Ok {
 		return w.Clock.SimTime.Add(time.Duration(adv.TArrival * float64(time.Second))), adv.AchievableCA, true

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -24,7 +24,44 @@ var (
 	ErrRendezvousAlreadyDocked      = transferError("already in DOCK READY range")
 	ErrRendezvousNoImprovement      = transferError("no useful nudge in range")
 	ErrRendezvousNoCraft            = transferError("no active vessel")
+
+	// ErrRendezvousShapeMismatch / ErrRendezvousBurnTooLarge /
+	// ErrRendezvousUnsafePeriapsis (ADR 0039 S1, #278): distinct refusal
+	// reasons that used to all collapse into ErrRendezvousNoImprovement.
+	// Each names the actual planner gate that fired and, where one
+	// exists, the remedy — so "the nudge would be expensive" no longer
+	// reads identically to "rendezvous is impossible" or "the geometry is
+	// already optimal". Wording for the burn-too-large case is #278's own
+	// proposed text verbatim.
+	ErrRendezvousShapeMismatch   = transferError("orbits differ in shape — circularize [C] or plan a transfer [H] first")
+	ErrRendezvousBurnTooLarge    = transferError("nudge would exceed the burn ceiling — use the transfer planner [H/I/m]")
+	ErrRendezvousUnsafePeriapsis = transferError("nudge would drop periapsis unsafely — plan a transfer instead [H/I/m]")
 )
+
+// rendezvousReasonToErr maps a planner.RendezvousAdvisory's Reason tag
+// (populated when Ok=false) to the sim-layer sentinel PlanRendezvousNudge
+// returns. #278: collapsing every reason into one string left the player
+// unable to tell "spend more Δv than a nudge allows" from "this is
+// already as good as it gets" from "this cannot ever converge". The four
+// inner Lambert-lookahead dead ends ("no lambert convergence",
+// "degenerate axes", "horizon too short", "ca-verify failed") are not yet
+// split out of the generic ErrRendezvousNoImprovement bucket here — ADR
+// 0039 S2 gives them their own shared phasing-coach wording, matching
+// Engage's own no-encounter refusal.
+func rendezvousReasonToErr(reason string) error {
+	switch reason {
+	case "docked":
+		return ErrRendezvousAlreadyDocked
+	case "orbit shape mismatch":
+		return ErrRendezvousShapeMismatch
+	case "burn too large — use H/I/m":
+		return ErrRendezvousBurnTooLarge
+	case "burn drops periapsis unsafely":
+		return ErrRendezvousUnsafePeriapsis
+	default: // "no improvement available", "no lambert convergence", "degenerate axes", "horizon too short", "ca-verify failed"
+		return ErrRendezvousNoImprovement
+	}
+}
 
 // rendezvousAdvisoryCache stores the most recent recommendation so
 // the per-frame TARGET HUD readout does not have to re-run the
@@ -376,11 +413,10 @@ func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
 		return nil, ErrRendezvousNoImprovement
 	}
 	if !advisory.Ok {
-		// Computed, but the answer is "no useful nudge".
-		if advisory.Reason == "docked" {
-			return nil, ErrRendezvousAlreadyDocked
-		}
-		return nil, ErrRendezvousNoImprovement
+		// Computed, but the answer is "no useful nudge" — #278: the
+		// specific reason travels to the player instead of collapsing
+		// into one generic refusal.
+		return nil, rendezvousReasonToErr(advisory.Reason)
 	}
 
 	leadBuffer := w.rendezvousLeadBuffer(c, advisory.AxisUnit)

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -36,7 +36,26 @@ var (
 	ErrRendezvousShapeMismatch   = transferError("orbits differ in shape — circularize [C] or plan a transfer [H] first")
 	ErrRendezvousBurnTooLarge    = transferError("nudge would exceed the burn ceiling — use the transfer planner [H/I/m]")
 	ErrRendezvousUnsafePeriapsis = transferError("nudge would drop periapsis unsafely — plan a transfer instead [H/I/m]")
+
+	// ErrRendezvousNoEncounter (ADR 0039 S2, #277): the shared
+	// phasing-coach remedy for "no real encounter to score" — both K's
+	// inner Lambert-lookahead dead ends and Engage's own commit-search
+	// failure return this, in the doctrine's own words, so the two
+	// refusal chains stop pointing at each other. Before this, `w` said
+	// "plant a nudge [K] first" and K said "no useful nudge in range" —
+	// each pointing at the other with no way out.
+	ErrRendezvousNoEncounter = transferError(rendezvousPhasingCoachMsg)
 )
+
+// rendezvousPhasingCoachMsg is the doctrine-prescribed remedy surfaced
+// whenever no real encounter can be found on the current courses: a
+// matched-orbit stalemate (zero relative drift, an encounter can never
+// form, #276) and a slow-converging geometry (a real encounter exists
+// but isn't found/committable within the search window, #277) both get
+// the same actionable words, deliberately with no computed numbers (ADR
+// 0039 §2) — "bring the encounter to you" rather than either coasting
+// toward a slow one or being told nothing at all.
+const rendezvousPhasingCoachMsg = "no encounter on current courses — make a phasing burn (wide prograde or radial) and watch the CA shrink"
 
 // rendezvousReasonToErr maps a planner.RendezvousAdvisory's Reason tag
 // (populated when Ok=false) to the sim-layer sentinel PlanRendezvousNudge
@@ -44,10 +63,11 @@ var (
 // unable to tell "spend more Δv than a nudge allows" from "this is
 // already as good as it gets" from "this cannot ever converge". The four
 // inner Lambert-lookahead dead ends ("no lambert convergence",
-// "degenerate axes", "horizon too short", "ca-verify failed") are not yet
-// split out of the generic ErrRendezvousNoImprovement bucket here — ADR
-// 0039 S2 gives them their own shared phasing-coach wording, matching
-// Engage's own no-encounter refusal.
+// "degenerate axes", "horizon too short", "ca-verify failed") share the
+// ADR 0039 §2 phasing-coach bucket: none of them found a real encounter
+// to score, so none of them has a more specific remedy than "make a
+// phasing burn" — the same wording Engage's own no-encounter refusal
+// uses (#277).
 func rendezvousReasonToErr(reason string) error {
 	switch reason {
 	case "docked":
@@ -58,8 +78,10 @@ func rendezvousReasonToErr(reason string) error {
 		return ErrRendezvousBurnTooLarge
 	case "burn drops periapsis unsafely":
 		return ErrRendezvousUnsafePeriapsis
-	default: // "no improvement available", "no lambert convergence", "degenerate axes", "horizon too short", "ca-verify failed"
+	case "no improvement available":
 		return ErrRendezvousNoImprovement
+	default: // "no lambert convergence", "degenerate axes", "horizon too short", "ca-verify failed"
+		return ErrRendezvousNoEncounter
 	}
 }
 

--- a/internal/sim/rendezvous_ca_trend_test.go
+++ b/internal/sim/rendezvous_ca_trend_test.go
@@ -1,0 +1,63 @@
+package sim
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRendezvousArmTracksPrevCommittedCAOnWaypointAdvance — ADR 0039 S3 /
+// #281: the RENDEZVOUS chip needs to tell a converging waypoint sequence
+// from a diverging one — a question the existing degrade watchdog can't
+// answer, because its own baseline re-bases with the drift it's supposed
+// to catch (RendezvousArm.degradeBaseCA's own doc comment: "the baseline
+// moves with the divergence it should be flagging"). PrevCommittedCA
+// captures the waypoint-before-last's committed CA at the moment
+// resolveRendezvousWaypoint advances to a new one, so the chip can
+// compare "was it better or worse last time" without touching the
+// degrade lifetime rules at all.
+func TestRendezvousArmTracksPrevCommittedCAOnWaypointAdvance(t *testing.T) {
+	wa, _, sta := anchorWorld(t)
+	wb, _, _ := anchorWorld(t)
+	aheadAlongTrack(t, wb)
+	tau := sta.Add(time.Hour)
+	wa.EngageRendezvousWarp("SHA256:b", "b", tau, 5.4e6)
+	wb.EngageRendezvousWarp("SHA256:a", "a", tau, 5.4e6)
+
+	effA, effB := wa.EffectiveWarp(), wb.EffectiveWarp()
+	prevA, prevB := map[string]bool{}, map[string]bool{}
+	step := func() {
+		pa := crossPeer(wb, "SHA256:b", "b", effB)
+		pb := crossPeer(wa, "SHA256:a", "a", effA)
+		wa.DriveRendezvousWarp(pa)
+		wb.DriveRendezvousWarp(pb)
+		ra, rb := wa.ComputeCoWarp(pa, prevA), wb.ComputeCoWarp(pb, prevB)
+		wa.CoWarp, wb.CoWarp = ra.State, rb.State
+		prevA, prevB = ra.CoupledOwners, rb.CoupledOwners
+		effA, effB = wa.EffectiveWarp(), wb.EffectiveWarp()
+	}
+	step()
+	if !wa.rendezvousWarpEngaged() {
+		t.Fatal("precondition: shared coast engaged")
+	}
+	if wa.RendezvousArm.PrevCommittedCASet {
+		t.Fatal("precondition: no waypoint advance has happened yet")
+	}
+
+	firstCA := wa.RendezvousArm.CommittedCA
+
+	// Reach the committed encounter far outside couple range — advances
+	// the waypoint rather than clearing the arm (mirrors
+	// TestRendezvousArmSurvivesTauOutsideCoupleRange).
+	wa.Clock.SimTime, wb.Clock.SimTime = tau, tau
+	step()
+
+	if wa.RendezvousArm == nil {
+		t.Fatal("arm cleared at τ outside couple range")
+	}
+	if !wa.RendezvousArm.PrevCommittedCASet {
+		t.Fatal("PrevCommittedCASet not raised after the first waypoint advance")
+	}
+	if wa.RendezvousArm.PrevCommittedCA != firstCA {
+		t.Errorf("PrevCommittedCA = %.0f, want the pre-advance CommittedCA %.0f", wa.RendezvousArm.PrevCommittedCA, firstCA)
+	}
+}

--- a/internal/sim/rendezvous_ca_trend_test.go
+++ b/internal/sim/rendezvous_ca_trend_test.go
@@ -61,3 +61,52 @@ func TestRendezvousArmTracksPrevCommittedCAOnWaypointAdvance(t *testing.T) {
 		t.Errorf("PrevCommittedCA = %.0f, want the pre-advance CommittedCA %.0f", wa.RendezvousArm.PrevCommittedCA, firstCA)
 	}
 }
+
+// TestRendezvousArmTracksPrevCommittedCAOnMinTauAdoption — batch-review
+// follow-up (PR #319): the min-τ adoption path in DriveRendezvousWarp
+// (partner.RendezvousTau wins, ~auto_warp.go:534) overwrites CommittedCA
+// exactly like resolveRendezvousWaypoint's own-derivation advance does,
+// but — unlike that site — did not stamp PrevCommittedCA/
+// PrevCommittedCASet before this fix. The codebase already treats
+// adoption as a new waypoint everywhere else (the adjacent
+// "degradeBaseSet = false // a new waypoint means a new baseline"), so
+// the trend must too: leaving PrevCommittedCA stale here means the row
+// can compare across TWO waypoint transitions instead of one, rendering
+// "↘ shrinking" when the most recent transition actually grew — an
+// actively misleading readout in the one feature whose whole job is
+// telling the pilot honestly whether they are converging.
+func TestRendezvousArmTracksPrevCommittedCAOnMinTauAdoption(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	tau := st.Add(time.Hour)
+	w.EngageRendezvousWarp("SHA256:gern", "gern", tau, 900)
+	peer := armPeer(w, primary, st, 50, "gern")
+	peer.RendezvousTau = tau
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast engaged")
+	}
+	if w.RendezvousArm.PrevCommittedCASet {
+		t.Fatal("precondition: no waypoint transition has happened yet")
+	}
+	preAdoptionCA := w.RendezvousArm.CommittedCA
+
+	// Partner's earlier τ, past the min lead → adopted (mirrors
+	// TestRendezvousMinTauAdoptionRespectsMinLead).
+	adopt := st.Add(time.Minute)
+	peer.RendezvousTau = adopt
+	peer.RendezvousCA = 12_345
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+
+	if !w.RendezvousArm.Tau.Equal(adopt) {
+		t.Fatalf("precondition: adoption did not fire — arm.Tau = %v, want %v", w.RendezvousArm.Tau, adopt)
+	}
+	if w.RendezvousArm.CommittedCA != 12_345 {
+		t.Fatalf("precondition: CommittedCA = %.0f, want the adopted 12345", w.RendezvousArm.CommittedCA)
+	}
+	if !w.RendezvousArm.PrevCommittedCASet {
+		t.Fatal("PrevCommittedCASet not raised on min-τ adoption")
+	}
+	if w.RendezvousArm.PrevCommittedCA != preAdoptionCA {
+		t.Errorf("PrevCommittedCA = %.0f, want the pre-adoption CommittedCA %.0f", w.RendezvousArm.PrevCommittedCA, preAdoptionCA)
+	}
+}

--- a/internal/sim/rendezvous_ghost_test.go
+++ b/internal/sim/rendezvous_ghost_test.go
@@ -75,8 +75,8 @@ func TestPlanRendezvousNudge_GhostRefusalPathsGone(t *testing.T) {
 
 	adv, err := w.PlanRendezvousNudge()
 	if err != nil {
-		if errors.Is(err, ErrRendezvousNoImprovement) {
-			t.Skipf("ghost geometry yielded no useful nudge; not a regression")
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("ghost geometry yielded no useful nudge (%v); not a regression", err)
 		}
 		t.Fatalf("PlanRendezvousNudge against ghost: %v (refusal path not gone)", err)
 	}
@@ -102,8 +102,8 @@ func TestPlanRendezvousNudge_LocalCraftHasNoGhostOwner(t *testing.T) {
 	w := rendezvousTwoCraftWorld(t)
 	c := w.ActiveCraft()
 	if _, err := w.PlanRendezvousNudge(); err != nil {
-		if errors.Is(err, ErrRendezvousNoImprovement) {
-			t.Skip("no useful nudge in this geometry")
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("no useful nudge in this geometry (%v)", err)
 		}
 		t.Fatalf("PlanRendezvousNudge: %v", err)
 	}
@@ -157,8 +157,8 @@ func TestRendezvousGhostNode_StaleNoAutoUpdate(t *testing.T) {
 	c := w.ActiveCraft()
 
 	if _, err := w.PlanRendezvousNudge(); err != nil {
-		if errors.Is(err, ErrRendezvousNoImprovement) {
-			t.Skip("no useful nudge in this geometry")
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("no useful nudge in this geometry (%v)", err)
 		}
 		t.Fatalf("PlanRendezvousNudge: %v", err)
 	}

--- a/internal/sim/rendezvous_refusal_reasons_test.go
+++ b/internal/sim/rendezvous_refusal_reasons_test.go
@@ -49,3 +49,28 @@ func TestRendezvousReasonToErr_S1DistinctReasons(t *testing.T) {
 		}
 	}
 }
+
+// TestRendezvousReasonToErr_S2PhasingCoachBucket — ADR 0039 S2 / #277:
+// the four inner Lambert-lookahead dead ends share ONE remedy — none of
+// them found a real encounter to score, so K has nothing more specific
+// to say than "make a phasing burn". This is the SAME wording Engage's
+// own no-encounter refusal uses (rendezvousPhasingCoachMsg), so the two
+// refusal chains stop pointing at each other: before this, `w` said "use
+// K", and K said "no useful nudge in range" — a dead end with no
+// explanation on either side (#277).
+func TestRendezvousReasonToErr_S2PhasingCoachBucket(t *testing.T) {
+	for _, reason := range []string{
+		"no lambert convergence", "degenerate axes", "horizon too short", "ca-verify failed",
+	} {
+		got := rendezvousReasonToErr(reason)
+		if !errors.Is(got, ErrRendezvousNoEncounter) {
+			t.Errorf("reason %q → %v, want ErrRendezvousNoEncounter", reason, got)
+		}
+	}
+	// "no improvement available" is a DIFFERENT situation (the geometry
+	// is already about as good as a nudge gets) and must stay out of the
+	// phasing-coach bucket.
+	if got := rendezvousReasonToErr("no improvement available"); errors.Is(got, ErrRendezvousNoEncounter) {
+		t.Errorf("\"no improvement available\" wrongly joined the phasing-coach bucket: %v", got)
+	}
+}

--- a/internal/sim/rendezvous_refusal_reasons_test.go
+++ b/internal/sim/rendezvous_refusal_reasons_test.go
@@ -1,0 +1,51 @@
+package sim
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestRendezvousReasonToErr_S1DistinctReasons — #278: before this mapping
+// existed, PlanRendezvousNudge collapsed every non-"docked" planner Reason
+// into the single ErrRendezvousNoImprovement ("no useful nudge in range"),
+// so a genuinely actionable "burn too large" refusal read identically to
+// "no improvement available" (geometry is already optimal) and to a
+// mismatched-shape refusal. This slice (S1) gives each of those a
+// DISTINCT sentinel with its own remedy text. The four inner Lambert-
+// failure tags ("no lambert convergence", "degenerate axes", "horizon too
+// short", "ca-verify failed") are deliberately NOT split out yet — they
+// still fall back to ErrRendezvousNoImprovement here; S2 gives them their
+// own shared phasing-coach wording.
+func TestRendezvousReasonToErr_S1DistinctReasons(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   error
+	}{
+		{"docked", ErrRendezvousAlreadyDocked},
+		{"orbit shape mismatch", ErrRendezvousShapeMismatch},
+		{"burn too large — use H/I/m", ErrRendezvousBurnTooLarge},
+		{"burn drops periapsis unsafely", ErrRendezvousUnsafePeriapsis},
+		{"no improvement available", ErrRendezvousNoImprovement},
+	}
+	for _, c := range cases {
+		got := rendezvousReasonToErr(c.reason)
+		if !errors.Is(got, c.want) {
+			t.Errorf("reason %q → %v, want %v", c.reason, got, c.want)
+		}
+	}
+
+	// The four distinct reasons must not all collapse onto the SAME
+	// error as each other (that was the #278 bug) — check pairwise
+	// inequality among the ones this slice separates.
+	distinct := []error{ErrRendezvousShapeMismatch, ErrRendezvousBurnTooLarge, ErrRendezvousUnsafePeriapsis, ErrRendezvousNoImprovement}
+	for i := range distinct {
+		for j := range distinct {
+			if i == j {
+				continue
+			}
+			if errors.Is(distinct[i], distinct[j]) {
+				t.Errorf("distinct reasons %d and %d map to the same error", i, j)
+			}
+		}
+	}
+}

--- a/internal/sim/rendezvous_refusal_reasons_test.go
+++ b/internal/sim/rendezvous_refusal_reasons_test.go
@@ -10,12 +10,13 @@ import (
 // into the single ErrRendezvousNoImprovement ("no useful nudge in range"),
 // so a genuinely actionable "burn too large" refusal read identically to
 // "no improvement available" (geometry is already optimal) and to a
-// mismatched-shape refusal. This slice (S1) gives each of those a
+// mismatched-shape refusal. rendezvousReasonToErr gives each of those a
 // DISTINCT sentinel with its own remedy text. The four inner Lambert-
 // failure tags ("no lambert convergence", "degenerate axes", "horizon too
-// short", "ca-verify failed") are deliberately NOT split out yet — they
-// still fall back to ErrRendezvousNoImprovement here; S2 gives them their
-// own shared phasing-coach wording.
+// short", "ca-verify failed") are covered separately, by
+// TestRendezvousReasonToErr_S2PhasingCoachBucket below — they share the
+// ADR 0039 §2 phasing-coach wording (ErrRendezvousNoEncounter), not this
+// slice's ErrRendezvousNoImprovement.
 func TestRendezvousReasonToErr_S1DistinctReasons(t *testing.T) {
 	cases := []struct {
 		reason string

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -61,6 +61,52 @@ func TestRecommendedRendezvousBurn_TwoCraftLEO(t *testing.T) {
 	}
 }
 
+// rotateAboutAxis rotates v about unit-ish axis by angle radians
+// (Rodrigues' formula). Test-only helper for constructing a co-orbital
+// lag geometry from an existing circular craft state without hardcoding
+// mu, altitude, or primary.
+func rotateAboutAxis(v, axis orbital.Vec3, angle float64) orbital.Vec3 {
+	axis = axis.Unit()
+	cos, sin := math.Cos(angle), math.Sin(angle)
+	return v.Scale(cos).Add(axis.Cross(v).Scale(sin)).Add(axis.Scale(axis.Dot(v) * (1 - cos)))
+}
+
+// rendezvousSmallLagWorld places the sister craft on the SAME circular
+// orbit as the active craft, lagging by a small phase angle — mirrors
+// the planner package's CoOrbitalLagging fixture so PlanRendezvousNudge
+// has a small, deterministic, always-plantable nudge, unlike
+// rendezvousTwoCraftWorld's ~200 km altitude gap (legitimately "burn too
+// large" territory, ADR 0039 S1).
+func rendezvousSmallLagWorld(t *testing.T) *World {
+	t.Helper()
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := -0.5 * math.Pi / 180
+	target.State.R = rotateAboutAxis(active.State.R, axis, angle)
+	target.State.V = rotateAboutAxis(active.State.V, axis, angle)
+	target.Primary = active.Primary
+	return w
+}
+
+// rendezvousGeometryNotUseful reports whether err is one of the planner
+// refusals meaning "this test's default geometry didn't happen to yield
+// a plantable nudge" — used by tests whose purpose is the plant/gate
+// machinery, not a specific geometry outcome, so they skip rather than
+// fail when the default two-craft setup (or a ghost mirror of it) lands
+// somewhere the Lambert scan legitimately refuses. ADR 0039 S1 split
+// #278's single collapsed reason into several distinct sentinels; any of
+// them here is "not a regression", just a geometry the fixed default
+// spawn (90° phase, matched altitude or not) happened to produce.
+func rendezvousGeometryNotUseful(err error) bool {
+	return errors.Is(err, ErrRendezvousNoImprovement) ||
+		errors.Is(err, ErrRendezvousBurnTooLarge) ||
+		errors.Is(err, ErrRendezvousUnsafePeriapsis) ||
+		errors.Is(err, ErrRendezvousShapeMismatch)
+}
+
 // TestPlanRendezvousNudge_PlantsOneNode — the happy path for the K
 // keybinding's plant action. Verifies node fields match the advisory
 // + the lead buffer + TargetCraftIdx one-based encoding.
@@ -73,8 +119,8 @@ func TestPlanRendezvousNudge_PlantsOneNode(t *testing.T) {
 
 	adv, err := w.PlanRendezvousNudge()
 	if err != nil {
-		if errors.Is(err, ErrRendezvousNoImprovement) {
-			t.Skipf("two-craft LEO geometry yielded no useful nudge in this case; not a regression")
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("two-craft LEO geometry yielded no useful nudge in this case (%v); not a regression", err)
 		}
 		t.Fatalf("PlanRendezvousNudge: %v", err)
 	}
@@ -107,6 +153,33 @@ func TestPlanRendezvousNudge_PlantsOneNode(t *testing.T) {
 	}
 	if n.TriggerTime.Sub(w.Clock.SimTime) < rendezvousBurnLeadMin {
 		t.Errorf("TriggerTime lead %v < min %v", n.TriggerTime.Sub(w.Clock.SimTime), rendezvousBurnLeadMin)
+	}
+}
+
+// TestPlanRendezvousNudge_ArrivalSpeedCarriesThrough — ADR 0039 S1: the
+// planner's ArrivalSpeed (|v_rel| at the achieved CA) must survive
+// unmodified from RecommendRendezvousNudge through PlanRendezvousNudge's
+// returned pointer, since app.go's status flash reads it off exactly
+// this value to render the "arriving ~N m/s" info row.
+func TestPlanRendezvousNudge_ArrivalSpeedCarriesThrough(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not a regression", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if !adv.Ok {
+		t.Fatalf("expected Ok=true, got Reason=%q", adv.Reason)
+	}
+	if adv.ArrivalSpeed <= 0 {
+		t.Errorf("ArrivalSpeed = %.3f, want > 0 on a successful plant", adv.ArrivalSpeed)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected 1 node after plant, got %d", len(c.Nodes))
 	}
 }
 

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -104,7 +104,8 @@ func rendezvousGeometryNotUseful(err error) bool {
 	return errors.Is(err, ErrRendezvousNoImprovement) ||
 		errors.Is(err, ErrRendezvousBurnTooLarge) ||
 		errors.Is(err, ErrRendezvousUnsafePeriapsis) ||
-		errors.Is(err, ErrRendezvousShapeMismatch)
+		errors.Is(err, ErrRendezvousShapeMismatch) ||
+		errors.Is(err, ErrRendezvousNoEncounter)
 }
 
 // TestPlanRendezvousNudge_PlantsOneNode — the happy path for the K

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1158,8 +1158,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					a.statusMsg = fmt.Sprintf("rendezvous: %v", err)
 				} else {
-					a.statusMsg = fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs",
-						adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival)
+					// ADR 0039 S1: arrival speed rides along as a plain info
+					// row — no gate, no judgment, it just sizes the
+					// hand-flown part of the job (#290 found this invisible
+					// at plan time: a "successful" plant that in fact
+					// arrived 4.6 m/s under the lock gate, with nothing on
+					// screen warning the player before they committed).
+					a.statusMsg = fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs, arriving ~%.0f m/s",
+						adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival, adv.ArrivalSpeed)
 				}
 				a.statusExpires = time.Now().Add(3 * time.Second)
 				a.world.RecordAction(missions.ActionPlanRendezvous) // ADR 0025 §7

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2075,7 +2075,12 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		tau, ca, ok := a.world.RendezvousCommit()
 		switch {
 		case !ok:
-			a.statusMsg = fmt.Sprintf("no closable encounter with %s — plant a rendezvous nudge [K] first", cmd.Handle)
+			// ADR 0039 S2 / #277: name the doctrine's own remedy instead of
+			// pointing at K — K's own refusal for this same "no real
+			// encounter" situation used to say the opposite ("no useful
+			// nudge in range"), so the two refusals dead-ended into each
+			// other with no way out. Both sides now coach the same burn.
+			a.statusMsg = fmt.Sprintf("no encounter with %s on current courses — make a phasing burn (wide prograde or radial) and watch the CA shrink", cmd.Handle)
 		// The seat is fixed here (ADR 0037 §2): proposing the rendezvous
 		// makes you pilot-in-command of the pair's time once the terminal
 		// phase begins.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -921,7 +921,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// the moment the seat is taken — it is the only point where the
 			// asymmetry is a choice rather than a surprise.
 			if a.world.EngageRendezvousWarpAs(inv.Owner, inv.Handle, inv.Tau, inv.CA, false) {
-				a.toast(fmt.Sprintf("rendezvous with %s — coasting together; you fly copilot ([,] brakes the pair, [/] cancels)", inv.Handle))
+				a.toast(fmt.Sprintf("rendezvous with %s — coasting together; you fly copilot ([,] brakes the pair, [/] cancels)%s",
+					inv.Handle, rendezvousGapNoteSuffix(a.world, inv.CA)))
 			} else {
 				a.toast(fmt.Sprintf("can't join %s — the encounter time has passed", inv.Handle))
 			}
@@ -2088,8 +2089,8 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 			// Name the acting craft (#295): arming acts on whatever slot is
 			// active, and a player who cycled it earlier has no other way to
 			// catch a wrong-vessel arm before the invitation goes out.
-			a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join",
-				cmd.Handle, screens.CraftTag(a.world.RendezvousArm.CraftName))
+			a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join%s",
+				cmd.Handle, screens.CraftTag(a.world.RendezvousArm.CraftName), rendezvousGapNoteSuffix(a.world, ca))
 		default:
 			a.statusMsg = fmt.Sprintf("can't arm rendezvous with %s — encounter is in the past", cmd.Handle)
 		}
@@ -2231,6 +2232,19 @@ func (a *App) toggleAutoWarpBurn() bool {
 
 // toast flashes a transient one-line notice in the HUD footer for ~3s
 // (the generic sibling of flashStatus, which is F5/F9-specific).
+// rendezvousGapNoteSuffix appends the ADR 0039 S3 gap note to an Engage
+// success message when the committed CA is far above the couple/lock
+// gate — "" otherwise, so callers can splice it in unconditionally.
+// Named at the display layer (the message text) over sim.World's
+// RendezvousNeedsBurnToClose (the domain judgment), mirroring how
+// refusal reasons are composed elsewhere in this file.
+func rendezvousGapNoteSuffix(w *sim.World, ca float64) string {
+	if !w.RendezvousNeedsBurnToClose(ca) {
+		return ""
+	}
+	return " — a burn will be needed to close this"
+}
+
 func (a *App) toast(msg string) {
 	a.statusMsg = msg
 	a.statusExpires = time.Now().Add(3 * time.Second)

--- a/internal/tui/app_rendezvous_engage_test.go
+++ b/internal/tui/app_rendezvous_engage_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// TestEngageRendezvousNoEncounterCoachesPhasingBurn — ADR 0039 S2 / #277:
+// a genuinely stalemated geometry (matched circular orbit, opposite
+// phase — zero relative drift, an encounter can never form on the
+// current courses, #276) must refuse Engage with the doctrine's own
+// phasing-burn remedy, not the old "plant a rendezvous nudge [K] first"
+// — which dead-ended into K's OWN refusal with no explanation on either
+// side.
+func TestEngageRendezvousNoEncounterCoachesPhasingBurn(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	active := a.world.ActiveCraft()
+	if active == nil {
+		t.Fatal("no active craft in a fresh world")
+	}
+	// Opposite phase on the identical circular orbit: relative motion is
+	// exactly zero for all time — the matched-orbit stalemate (#276).
+	a.world.Ghosts = []sim.Ghost{{
+		Owner:     "SHA256:gern",
+		CraftID:   7,
+		Handle:    "gern",
+		Name:      "Aloft",
+		PrimaryID: active.Primary.ID,
+		Pos:       a.world.BodyPosition(active.Primary).Add(active.State.R.Scale(-1)),
+		RelPos:    active.State.R.Scale(-1),
+		Vel:       active.State.V.Scale(-1),
+	}}
+
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
+	})
+	app := model.(*App)
+
+	if app.statusMsg == "" {
+		t.Fatal("Engage produced no status message")
+	}
+	if strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
+		t.Errorf("refusal still points at K instead of coaching the phasing burn directly: %q", app.statusMsg)
+	}
+	if !strings.Contains(app.statusMsg, "make a phasing burn") {
+		t.Errorf("refusal %q missing the phasing-coach remedy", app.statusMsg)
+	}
+}

--- a/internal/tui/app_rendezvous_gap_note_test.go
+++ b/internal/tui/app_rendezvous_gap_note_test.go
@@ -1,0 +1,128 @@
+package tui
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// lagGhostWorld places a ghost on the SAME circular orbit as the active
+// craft, lagging by angleDeg degrees — mirrors the small-lag fixtures
+// used elsewhere in this cycle (S1's arrival-speed test, the sim
+// package's rendezvousSmallLagWorld), just with a Ghost target instead
+// of a local sister craft so the SessionCmdRendezvous initiate path
+// (which requires a ghost) has something to commit to. Larger |angleDeg|
+// gives a larger natural (unburned) closest approach.
+func lagGhostWorld(a *App, angleDeg float64) {
+	active := a.world.ActiveCraft()
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := angleDeg * math.Pi / 180
+	relR := rotateAboutAxis(active.State.R, axis, angle)
+	relV := rotateAboutAxis(active.State.V, axis, angle)
+	a.world.Ghosts = []sim.Ghost{{
+		Owner: "SHA256:gern", CraftID: 7, Handle: "gern", Name: "Aloft",
+		PrimaryID: active.Primary.ID,
+		Pos:       a.world.BodyPosition(active.Primary).Add(relR),
+		RelPos:    relR,
+		Vel:       relV,
+	}}
+}
+
+// TestEngageRendezvousFarCAAddsGapNote — ADR 0039 S3 / #281: Engage on a
+// committed CA far above the 35 km lock gate adds one info line so
+// riding waypoints indefinitely is a visible choice, not a mystery.
+// #281's live case: initiator/target orbits phasing the wrong direction
+// — the coast rode waypoint-to-waypoint for days with committed CA
+// growing 4,400 km → 11,049 km and nothing on screen ever said a burn
+// was needed. This checks the initiator's own Engage (SessionCmdRendezvous).
+func TestEngageRendezvousFarCAAddsGapNote(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.ActiveCraft() == nil {
+		t.Fatal("no active craft in a fresh world")
+	}
+	// -2° of co-orbital lag lands K's own recommended-nudge encounter
+	// (which RendezvousCommit prefers when available) around ~170 km —
+	// comfortably above the 3×-gate bar even though K itself calls the
+	// plant a "success". A K nudge landing outside the couple gate is
+	// exactly the case the gap note exists for.
+	lagGhostWorld(a, -2)
+
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
+	})
+	app := model.(*App)
+
+	if app.statusMsg == "" {
+		t.Fatal("Engage produced no status message")
+	}
+	if strings.Contains(app.statusMsg, "phasing burn") {
+		t.Skipf("Engage refused on this geometry (%q); not exercising the gap note", app.statusMsg)
+	}
+	if !strings.Contains(app.statusMsg, "a burn will be needed to close this") {
+		t.Errorf("armed status %q missing the far-CA gap note", app.statusMsg)
+	}
+}
+
+// TestEngageRendezvousCloseCANoGapNote — the mirror: a committed CA
+// close to the couple gate must NOT carry the note (a normal near-miss
+// the coast can plausibly narrow on its own, not the case where riding
+// waypoints indefinitely is silently the wrong call).
+func TestEngageRendezvousCloseCANoGapNote(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// -0.5° lands K's recommended nudge around ~43 km — just above the
+	// 35 km couple gate itself, but well under the far-CA bar this note
+	// exists for.
+	lagGhostWorld(a, -0.5)
+
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
+	})
+	app := model.(*App)
+
+	if app.statusMsg == "" {
+		t.Fatal("Engage produced no status message")
+	}
+	if strings.Contains(app.statusMsg, "phasing burn") {
+		t.Skipf("Engage refused on this geometry (%q); not exercising the gap note", app.statusMsg)
+	}
+	if strings.Contains(app.statusMsg, "a burn will be needed to close this") {
+		t.Errorf("close-CA armed status wrongly carries the gap note: %q", app.statusMsg)
+	}
+}
+
+// TestJoinRendezvousFarCAAddsGapNote — the responder's Engage (the `y`
+// join path) must carry the same gap note as the initiator's, since it
+// commits to the SAME τ/CA carried in the invite.
+func TestJoinRendezvousFarCAAddsGapNote(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenOrbit
+	a.world.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:host", Handle: "fenbot",
+		Tau: a.world.Clock.SimTime.Add(2 * time.Hour), CA: 500_000,
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+
+	if a.statusMsg == "" {
+		t.Fatal("join produced no status message")
+	}
+	if !strings.Contains(a.statusMsg, "a burn will be needed to close this") {
+		t.Errorf("join status %q missing the far-CA gap note", a.statusMsg)
+	}
+}

--- a/internal/tui/app_rendezvous_success_test.go
+++ b/internal/tui/app_rendezvous_success_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// rotateAboutAxis rotates v about axis by angle radians (Rodrigues'
+// formula). Test-only — mirrors internal/sim's own test helper of the
+// same name, duplicated here since it's unexported in that package.
+func rotateAboutAxis(v, axis orbital.Vec3, angle float64) orbital.Vec3 {
+	axis = axis.Unit()
+	cos, sin := math.Cos(angle), math.Sin(angle)
+	return v.Scale(cos).Add(axis.Cross(v).Scale(sin)).Add(axis.Scale(axis.Dot(v) * (1 - cos)))
+}
+
+// TestRendezvousNudgeSuccessQuotesArrivalSpeed — ADR 0039 S1: every
+// successful K plant quotes predicted arrival speed as a plain info row
+// ("CA 9 km, arriving ~540 m/s" in the ADR's own example). #290 found
+// this invisible at plan time — a K-plant that read as a clean success
+// arrived at 95.4 m/s, 4.6 under the lock gate, with nothing on screen
+// warning the player before they committed to it.
+func TestRendezvousNudgeSuccessQuotesArrivalSpeed(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := a.world.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	active := a.world.Crafts[0]
+	target := a.world.Crafts[1]
+	// Small co-orbital lag — deterministic, always-plantable nudge
+	// (mirrors the sim package's own rendezvousSmallLagWorld fixture).
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := -0.5 * math.Pi / 180
+	target.State.R = rotateAboutAxis(active.State.R, axis, angle)
+	target.State.V = rotateAboutAxis(active.State.V, axis, angle)
+	target.Primary = active.Primary
+	a.world.ActiveCraftIdx = 0
+	a.world.SetTargetCraft(1)
+
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
+
+	if a.statusMsg == "" {
+		t.Fatal("K produced no status message")
+	}
+	if strings.Contains(a.statusMsg, "rendezvous: ") {
+		// A refusal, not a plant — the fixed small-lag geometry should
+		// always plant, but if planner tuning ever changes that, this is
+		// a clearer failure than a silent false-pass below.
+		t.Skipf("K refused on this geometry (%q); not exercising the success message", a.statusMsg)
+	}
+	if !strings.Contains(a.statusMsg, "arriving ~") || !strings.Contains(a.statusMsg, "m/s") {
+		t.Errorf("success status %q missing the arrival-speed info row", a.statusMsg)
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -359,6 +359,12 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		}
 		if arm := w.RendezvousArm; arm != nil {
 			lines = append(lines, chipRow("committed:", formatRangeM(arm.CommittedCA)))
+			// ADR 0039 S3 / #281: the trend across waypoint re-derivations —
+			// distinct from the degrade warning below, which compares
+			// against a baseline that re-bases every waypoint and so can
+			// never catch a standing intent that worsens a little each
+			// time. Silent until there are two committed CAs to compare.
+			lines = append(lines, rendezvousTrendLines(*arm, v.theme)...)
 		}
 		if w.RendezvousApproachM > 0 {
 			lines = append(lines, chipRow("approach:", formatRangeM(w.RendezvousApproachM)))
@@ -440,6 +446,29 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			// are fixed at invite time, so this prompt is the only place the
 			// asymmetry is a choice rather than a later surprise.
 			v.theme.Warning.Render("  [y] join as copilot — " + inv.Handle + " sets the pair's warp"),
+		}
+	}
+	return nil
+}
+
+// rendezvousTrendLines renders the CA trend row (ADR 0039 S3 / #281):
+// silent before the first waypoint advance (arm.PrevCommittedCASet
+// false — a single CA has no trend), a quiet "shrinking" line when the
+// latest waypoint improved on the one before it, or a two-line warning
+// naming both the numbers and the doctrine's own diagnosis when it
+// didn't. Equal values (no change) render nothing — neither claim is
+// true of a flat trend.
+func rendezvousTrendLines(arm sim.RendezvousArm, theme Theme) []string {
+	if !arm.PrevCommittedCASet {
+		return nil
+	}
+	switch {
+	case arm.CommittedCA < arm.PrevCommittedCA:
+		return []string{theme.Dim.Render("  CA " + formatRangeM(arm.CommittedCA) + " ↘ shrinking")}
+	case arm.CommittedCA > arm.PrevCommittedCA:
+		return []string{
+			theme.Alert.Render("  ⚠ CA growing each pass (" + formatRangeM(arm.PrevCommittedCA) + " → " + formatRangeM(arm.CommittedCA) + ")"),
+			theme.Alert.Render("    — phasing direction is wrong"),
 		}
 	}
 	return nil

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -213,6 +213,81 @@ func TestRendezvousChipCoastingAndDegraded(t *testing.T) {
 	}
 }
 
+// TestRendezvousChipTrendRowShrinking — ADR 0039 S3 / #281: once a
+// second waypoint has been derived, the chip shows whether the encounter
+// is converging. A shrinking CommittedCA (577 km → 430 km) reads as
+// quiet good news, not a warning.
+func TestRendezvousChipTrendRowShrinking(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	tau := w.Clock.SimTime.Add(2 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", tau, 430_000)
+	w.AutoWarp = &sim.AutoWarpTarget{
+		T: tau, Rendezvous: true,
+		RendezvousOwner: "SHA256:guest", RendezvousHandle: "gern",
+	}
+	w.RendezvousArm.PrevCommittedCA = 577_000
+	w.RendezvousArm.PrevCommittedCASet = true
+
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	if !strings.Contains(joined, "shrinking") {
+		t.Errorf("no shrinking-trend row for a converging CA:\n%s", joined)
+	}
+	if strings.Contains(joined, "phasing direction is wrong") {
+		t.Errorf("diverging warning shown for a converging CA:\n%s", joined)
+	}
+}
+
+// TestRendezvousChipTrendRowGrowing — the mirror case, matching the
+// ADR's own worked example: committed CA grew 577 km → 1,100 km across a
+// waypoint. Must warn AND name the doctrine's own diagnosis ("phasing
+// direction is wrong") — the degrade watchdog's own baseline can't catch
+// this (it re-bases every waypoint, ADR 0039 S3's whole reason for
+// being), so this trend row is the only signal a diverging standing
+// intent gets.
+func TestRendezvousChipTrendRowGrowing(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	tau := w.Clock.SimTime.Add(2 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", tau, 1_100_000)
+	w.AutoWarp = &sim.AutoWarpTarget{
+		T: tau, Rendezvous: true,
+		RendezvousOwner: "SHA256:guest", RendezvousHandle: "gern",
+	}
+	w.RendezvousArm.PrevCommittedCA = 577_000
+	w.RendezvousArm.PrevCommittedCASet = true
+
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, want := range []string{"⚠", "growing", "phasing direction is wrong"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("diverging-trend row missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+// TestRendezvousChipTrendRowSilentBeforeFirstAdvance — with only the
+// initial commit (no waypoint advance yet), there is exactly one CA data
+// point — no trend to show, and the row must not appear (a false
+// "shrinking"/"growing" claim from a single point would be worse than
+// silence).
+func TestRendezvousChipTrendRowSilentBeforeFirstAdvance(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	tau := w.Clock.SimTime.Add(2 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", tau, 900)
+	w.AutoWarp = &sim.AutoWarpTarget{
+		T: tau, Rendezvous: true,
+		RendezvousOwner: "SHA256:guest", RendezvousHandle: "gern",
+	}
+
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	for _, unwanted := range []string{"shrinking", "growing", "phasing direction is wrong"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("trend row rendered before any waypoint advance (%q present):\n%s", unwanted, joined)
+		}
+	}
+}
+
 // #253: Away is persistent state (the partner's session flies on under the
 // Commitment Reprieve with nobody at the controls), so the coasting chip
 // carries a STANDING away line driven by the world slate — present while


### PR DESCRIPTION
## Summary

Implements ADR 0039 (`adr/0039-rendezvous-planner-contract.md`) in full: three
slices, TDD throughout, one commit per slice. Governing doctrine: **Δv is
cheap, waiting is costly** — arriving hot is fine (ADR 0037's terminal phase
absorbs it); refusals must be domain-honest and always say *why*.

### S1 — K domain honesty (Closes #278)

- `RecommendRendezvousNudge` refuses an orbit-shape-mismatched geometry
  (eccentricity delta > 0.05) *before* running the Lambert lookahead, instead
  of quietly planting a single-axis nudge that walks the chaser further from
  the target (#290's live sequence: 275 m/s spent across two "successful"
  nudges to end up worse than doing nothing). New reason: `"orbit shape
  mismatch"` → `"orbits differ in shape — circularize [C] or plan a transfer
  [H] first"`.
- Every successful plant now quotes predicted arrival speed as a plain info
  row (`...arriving ~N m/s`) — no gate, no judgment. #290 found this invisible
  at plan time: a "successful" plant that in fact arrived 4.6 m/s under the
  lock gate.
- `#278`'s collapsed refusal is split: `"burn too large — use H/I/m"` and
  `"burn drops periapsis unsafely"` now surface as distinct sentinels
  (`ErrRendezvousBurnTooLarge`, `ErrRendezvousUnsafePeriapsis`) instead of the
  generic `"no useful nudge in range"`.

### S2 — Phasing-coach refusals for Engage and K (Closes #277)

- Both refusal chains now share one remedy instead of pointing at each other.
  Before: Engage's commit-search failure said "plant a rendezvous nudge [K]
  first"; K's own inner Lambert dead ends (no convergence, degenerate axes,
  horizon too short, CA-verify failure) said "no useful nudge in range" —
  each pointing at the other with no way out (#277's live dead-end).
- Both now say, verbatim: `"no encounter on current courses — make a phasing
  burn (wide prograde or radial) and watch the CA shrink"` — plain words, no
  computed numbers, covering both the matched-orbit stalemate (#276) and the
  slow-converge case (#277).
- `"no improvement available"` stays on the unchanged `ErrRendezvousNoImprovement`
  — a genuinely different situation (geometry already near-optimal), not "no
  real encounter to score".

### S3 — CA trend row + engage-time gap note (Closes #281)

- The RENDEZVOUS chip's coasting state gains a trend row across waypoint
  re-derivations: `"CA ... ↘ shrinking"` when converging, or a two-line
  warning (`"⚠ CA growing each pass (X → Y)"` / `"— phasing direction is
  wrong"`) when not. This is a **new signal**, not a fix to the existing
  degrade watchdog — that watchdog's baseline re-bases every waypoint by
  design, so it structurally cannot catch a standing intent that worsens a
  little each time (#281's live case: committed CA grew 4,400 km → 11,049 km
  across a multi-day coast with zero signal; a solver sweep confirmed the
  best natural approach over the full 157 h run was ~160 km, never
  reachable).
- `RendezvousArm` gains `PrevCommittedCA`/`PrevCommittedCASet`, captured by
  `resolveRendezvousWaypoint` just before each advance overwrites
  `CommittedCA`. Silent before the first advance and on an exact tie.
- Engage gains a one-line info note when the committed CA is far above the
  35 km lock gate: `"...— a burn will be needed to close this"`, on both the
  initiator's own commit and the responder's join.

## Judgment calls (ADR left latitude)

1. **Shape-mismatch threshold**: eccentricity delta > 0.05, checked *only* on
   eccentricity (not semi-major axis — a size mismatch is already
   "burn too large" territory, appropriately handled). Chosen wide enough to
   clear #278's own repro (551×499.8 km vs 500×500 km, e-delta ≈ 0.004) while
   catching a genuinely diverged shape. This is the one call in the whole
   cycle I'd flag as most likely to need live-playtest retuning — I don't have
   the exact body radius from #290's live session, so I validated against
   synthetic fixtures, not the literal reported numbers.
2. **"Far above the lock gate" bar** (S3's gap note): 3× `coWarpCoupleRangeM`
   (105 km). ADR says "far above", not a number — chosen so a normal
   near-miss just past the 35 km gate doesn't nag, but #281-scale divergence
   (thousands of km) clearly does.
3. **Gap note placement**: implemented as a one-time suffix on the Engage
   success toast (both initiator and responder paths), not a persistent chip
   row. The ADR's "Engage ... adds one info line" reads most literally as
   Engage-time feedback; "riding waypoints indefinitely is a visible choice"
   is satisfied by the toast plus the S3 trend row, which *is* persistent
   through the whole coast.
4. **Trend row wording**: dropped the ADR's parenthetical annotations
   (`"(converging — it's working)"`, `"(diverging — burn the other way)"`)
   from the literal chip text — read those as explanatory prose in the ADR
   document itself, not literal UI copy, consistent with the terse style of
   every other row in this chip.
5. **S1/S2 split of the four inner Lambert-failure reasons**: S1 leaves them
   on the pre-existing generic `ErrRendezvousNoImprovement`; S2 is what moves
   them to the new shared `ErrRendezvousNoEncounter`. This let each slice
   land with its own honest red→green cycle on the same reason tags, per the
   task's TDD-per-slice requirement, rather than S1 pre-empting S2's wording.
6. **#293/#274/#289**: read per the task brief (rulings from the same grill
   session, cited in the ADR's Context section) but confirmed out of scope —
   the ADR's own Slices section lists only S1/S2/S3 tied to #278/#277/#281.
   Not touched here.

## Nothing found underspecified/contradictory beyond the above

The ADR's Consequences section explicitly says "No save-break; all
planner/HUD surface work" — confirmed, `internal/save/` untouched,
`SchemaVersion` unbumped. No keybindings changed, so the F1 help
overlay / README / docs/controls.md needed no updates.

## Test plan

- `go vet ./...` clean.
- `go test ./... -race -count=1` green (matches CI).
- New tests added as `_test.go` siblings per touched file; TDD red output
  observed and recorded per slice before each implementation.
- Existing tests whose skip-guards assumed the old collapsed
  `ErrRendezvousNoImprovement` (three sites in `internal/sim`) updated to a
  shared `rendezvousGeometryNotUseful` helper covering the now-distinct
  reasons — these were pre-existing "skip if this fixture's geometry doesn't
  cooperate" guards, not behavior I changed.