### PR TITLE
fix(serve): make TestReconnectDisplacesItsOwnReprievedSession deterministic

### DIFF
--- a/internal/serve/reclaim_test.go
+++ b/internal/serve/reclaim_test.go
@@ -240,19 +240,28 @@ func TestReconnectDisplacesItsOwnReprievedSession(t *testing.T) {
 		t.Fatal("the session was reaped before the reconnect — nothing left to displace")
 	}
 
-	// The player opens the lid somewhere else and reconnects.
+	// The player opens the lid somewhere else and reconnects. Rather than
+	// polling live.snapshot() against a wall-clock deadline (#318 — the
+	// poll's own lock contention and 25ms sleep granularity were adding to
+	// the load it was trying to observe, and clustered failures landed
+	// right at the old 15s budget on loaded CI runners), wait on the
+	// signal sessionHandler fires the instant the reclaim actually lands.
+	// The 15s budget is now purely a hang guard, not the measured event.
 	back := dialShell(t, srv, signer, true)
-	deadline := time.Now().Add(15 * time.Second)
-	for {
-		if cur, ok := srv.live.snapshot()[fp]; ok && cur != first {
-			break
+	select {
+	case got := <-srv.reclaimed:
+		if got != fp {
+			t.Fatalf("reclaim signal fired for %q, want %q", got, fp)
 		}
-		if time.Now().After(deadline) {
-			t.Fatal("the reconnecting player never took over their own reprieved session — " +
-				"locked out of their own program behind a socket nobody is using, which is " +
-				"the lockout the idle timeout exists to prevent")
-		}
-		time.Sleep(25 * time.Millisecond)
+	case <-time.After(15 * time.Second):
+		t.Fatal("the reconnecting player never took over their own reprieved session — " +
+			"locked out of their own program behind a socket nobody is using, which is " +
+			"the lockout the idle timeout exists to prevent")
+	}
+	if cur, ok := srv.live.snapshot()[fp]; !ok || cur == first {
+		t.Fatal("the reclaim signal fired but the registry entry never changed identity — " +
+			"locked out of their own program behind a socket nobody is using, which is " +
+			"the lockout the idle timeout exists to prevent")
 	}
 	if msg := back.text(); strings.Contains(msg, "already has a live session") {
 		t.Errorf("the reconnecting player was refused: %q", msg)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -116,6 +116,17 @@ type Server struct {
 	// whole displace-and-register window (ADR 0036 S4 review).
 	admit *admission
 
+	// reclaimed fires fp the instant a reconnecting connection finishes
+	// taking over a displaced session's slot in live (ADR 0036) — i.e.
+	// the moment live.snapshot()[fp] gains the new session's identity.
+	// Always allocated, buffered, and sent to non-blocking: production
+	// never reads it, so an unread send is simply dropped and costs one
+	// buffered channel per Server. Exists so tests can select on the
+	// actual event instead of polling live.snapshot() against a wall-clock
+	// deadline (#318) — the poll's own lock contention and sleep
+	// granularity were adding to the load it was trying to observe.
+	reclaimed chan string
+
 	// Reprieve timings, fields rather than constants so tests can drive
 	// the sweeper without real-time waits. idleTimeout is recorded because
 	// the sweeper has to reconstruct the deadline the I/O path would have
@@ -177,6 +188,7 @@ func New(cfg Config) (*Server, error) {
 		live: newSessionRegistry(), sweepEvery: defaultSweepEvery, reprieveWindow: defaultReprieveWindow,
 		reclaimWait: defaultReclaimWait, awayAfter: defaultAwayAfter,
 		away: newAwayWatch(), mail: newAwayMail(), admit: newAdmission(),
+		reclaimed: make(chan string, 4),
 	}
 	// Resume any cross-player docks that outlived a restart (v0.28 S5): the
 	// durable cross-ref persisted in session.json seeds the live ledger, so
@@ -369,6 +381,15 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	ls := &liveSession{conn: sessionActivity(sess.Context()), done: sessionDone(sess.Context())}
 	s.live.add(fp, ls)
 	sess.Context().SetValue(ctxKeyLive, ls)
+	if reclaimed {
+		// The identity change a reconnecting player's own displaced session
+		// just underwent — see the reclaimed field's doc for why this is a
+		// channel rather than a test hook function (#318).
+		select {
+		case s.reclaimed <- fp:
+		default:
+		}
+	}
 
 	game := s.withReporting(app, fp) // v0.27 S4: sessions feed the store
 	if p, err := s.store.FindPlayer(fp); err == nil {


### PR DESCRIPTION
Closes #318

## Mechanism

The test polled `srv.live.snapshot()[fp]` for an identity change every
25ms against a hardcoded 15s deadline, waiting on a real reconnect to
displace a reprieved session end-to-end (close old conn → wait for its
payload write → build the new session → register it). That poll was
itself part of the problem: every 25ms it took the `sessionRegistry`
lock and copied the live map, contending with the test's own 25ms
sweeper tick and 10ms reprieve-arm tick — all of it worse under `-race`.
On a sufficiently loaded runner the real pipeline (or the poll's own
overhead) pushed past 15s, and the four known CI failures clustered
tightly at 16.28–16.35s, just past the deadline.

**Fix:** `sessionHandler` now fires a signal (`Server.reclaimed`, a
`chan string`) the instant a reclaimed session finishes registering in
`live` — the exact moment the poll was trying to observe, delivered as
an event instead of sampled. The channel is:

- **always allocated** (`make(chan string, 4)` in `New`), so there's no
  nil-check race between server start and a test wiring up a listener,
- **sent to non-blocking** (`select { case s.reclaimed <- fp: default:
  }`), so with no reader (the normal production case) it's a dropped
  send and nothing else changes.

The test now does `select` on `srv.reclaimed` with the same 15s budget
as a hang guard (not the measured event), then does one more read of
`live.snapshot()` to confirm the identity actually changed — keeping
the original failure message intact per the issue's ask.

I reused the existing field-based pattern this package already uses for
test-friendliness (`sweepEvery`, `reprieveWindow`, `reclaimWait` are all
fields instead of consts so tests can drive them) rather than injecting
a full fake clock — the registry-identity-change signal is the more
direct fit for what the test actually asserts.

## Sibling tests checked

`TestDisplaceWaitsForThePayloadWrite` and `TestReconnectRefusedWhileAttended`
in the same file also poll a deadline, but neither runs the real `Serve()`
pipeline with the fast sweeper/reprieve tickers this test drives — they
don't share the mechanism that made this one flake, so left unchanged.

## Load testing

`GOMAXPROCS=2` plus a CPU-saturating background job (40+ `yes > /dev/null`
processes, oversubscribing a 10-core box) reproduced the flake reliably on
the **original** polling test and gave a clean before/after:

| | runs | failures | failure timings | pass timings |
|---|---|---|---|---|
| before (poll) | 15 | 4 | 16.27s, 16.30s, 16.42s, 16.49s | ~1.8–2.5s |
| after (signal) | 20 | 0 | — | ~1.8–2.5s |

The failure timings match the CI evidence in the issue (16.28–16.35s)
almost exactly, confirming this reproduces the real mechanism rather
than a different one.

I also reproduced a **harder** failure mode with `GOMAXPROCS=1`: both
the old and new versions failed 5/5 at ~16.8–17.2s. That's a different,
more extreme regime — starving the whole process (including the SSH
handshake and crypto) to one OS thread makes everything uniformly slow
regardless of instrumentation, which isn't representative of a "loaded
CI runner" (real runners aren't forced to one core). `GOMAXPROCS=2` +
background load is the condition that actually differentiates the two
implementations, which is why it's the one reported above.

## Positive control

Temporarily stubbed out the signal send (`if reclaimed && false { ...
}` around the `s.reclaimed <- fp`) and reran:

```
=== RUN   TestReconnectDisplacesItsOwnReprievedSession
    reclaim_test.go:257: the reconnecting player never took over their own reprieved session — locked out of their own program behind a socket nobody is using, which is the lockout the idle timeout exists to prevent
--- FAIL: TestReconnectDisplacesItsOwnReprievedSession (16.35s)
FAIL
```

Red, at ~15s (the hang-guard timeout), with the original failure message
intact — confirming the test still fails when displacement genuinely
doesn't happen. Reverted before committing.

## Verification

- `go test ./internal/serve -run TestReconnectDisplacesItsOwnReprievedSession -race -count=20`: 20/20 pass, ~1.37–1.44s each.
- `go vet ./...`: clean.
- `go test ./... -race -count=1`: all packages green.

Production behavior is unchanged — `reclaimed` is a dead channel with
no reader outside tests.