### PR TITLE
fix(maneuver): advisory keys replace their own node instead of stacking (#293)

### DIFF
--- a/internal/save/advisory_key_test.go
+++ b/internal/save/advisory_key_test.go
@@ -1,0 +1,50 @@
+package save_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestRoundtripAdvisoryKey — #293: a node's AdvisoryKey (which
+// single-keystroke advisory planter — K/C — planted it) must survive a
+// save/load round-trip, so a reloaded save still replaces its own
+// advisory node on the next press instead of stacking a duplicate
+// alongside it. Additive omitempty, no schema bump: an ordinary node
+// with no AdvisoryKey round-trips as "".
+func TestRoundtripAdvisoryKey(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	base := w.Clock.SimTime
+	w.ActiveCraft().Nodes = []sim.ManeuverNode{
+		{TriggerTime: base.Add(time.Minute), DV: 10, Mode: spacecraft.BurnPrograde, AdvisoryKey: "rendezvous-nudge"},
+		{TriggerTime: base.Add(2 * time.Minute), DV: 20, Mode: spacecraft.BurnPrograde},
+	}
+	w.EnsureNodeIDs()
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	nodes := got.ActiveCraft().Nodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].AdvisoryKey != "rendezvous-nudge" {
+		t.Errorf("AdvisoryKey lost in round-trip: got %q, want %q", nodes[0].AdvisoryKey, "rendezvous-nudge")
+	}
+	if nodes[1].AdvisoryKey != "" {
+		t.Errorf("ordinary node picked up a non-empty AdvisoryKey after round-trip: %q", nodes[1].AdvisoryKey)
+	}
+}

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -115,6 +115,7 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 			TargetCraftID:   n.TargetCraftID,
 			PlaneChangeRad:  n.PlaneChangeRad,
 			BurnDirUnit:     vec3From(n.BurnDirUnit),
+			AdvisoryKey:     n.AdvisoryKey,
 		})
 	}
 	if c.ActiveBurn != nil {
@@ -298,6 +299,7 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			TargetCraftID:  n.TargetCraftID,
 			PlaneChangeRad: n.PlaneChangeRad,
 			BurnDirUnit:    vec3To(n.BurnDirUnit),
+			AdvisoryKey:    n.AdvisoryKey,
 		})
 	}
 	if wc.ActiveBurn != nil {

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -344,6 +344,13 @@ type Node struct {
 	// departure). Additive/omitempty, following the CurrentAttitudeDir
 	// precedent; absent → zero vector for non-BurnVector nodes. No migration.
 	BurnDirUnit Vec3 `json:"burn_dir_unit,omitempty"`
+	// AdvisoryKey (#293, additive omitempty) mirrors
+	// spacecraft.ManeuverNode.AdvisoryKey — which single-keystroke
+	// advisory planter ("rendezvous-nudge" / "circularize") planted this
+	// node, so a repeat press still replaces its own reloaded node
+	// instead of stacking behind it. Absent → "", the correct value for
+	// every node type that predates this field. No migration.
+	AdvisoryKey string `json:"advisory_key,omitempty"`
 }
 
 // DockedComponent mirrors spacecraft.DockedComponent. v0.8.3+.

--- a/internal/sim/advisory_node_test.go
+++ b/internal/sim/advisory_node_test.go
@@ -1,0 +1,89 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestAdvisoryNodeDifferentKeysCoexist — #293's "replace" ruling is scoped
+// to a key replacing its OWN previous unfired node, not to "only one
+// advisory node may ever be queued". Planting via C (circularize) then K
+// (rendezvous nudge) must leave BOTH nodes queued — they carry different
+// AdvisoryKey tags, so neither plant path removes the other's node.
+func TestAdvisoryNodeDifferentKeysCoexist(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	_, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("geometry yielded no useful nudge (%v); not a regression", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("after K: expected 1 node, got %d", got)
+	}
+	nudgeID := c.Nodes[0].ID
+	if c.Nodes[0].AdvisoryKey != AdvisoryKeyRendezvousNudge {
+		t.Errorf("AdvisoryKey = %q, want %q", c.Nodes[0].AdvisoryKey, AdvisoryKeyRendezvousNudge)
+	}
+
+	// Overwrite the craft's live state to a circularize-friendly
+	// elliptical orbit (apoapsis clear of the atmosphere). This only
+	// affects what PlanCircularizeAtApoapsis reads at call time — the
+	// already-planted K node is unaffected by a later state change.
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	const (
+		periAlt = 200e3
+		apoAlt  = 1000e3
+	)
+	rPeri := primaryR + periAlt
+	rApo := primaryR + apoAlt
+	a := (rPeri + rApo) / 2
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	c.State.R = frame.ToWorld(orbital.Vec3{X: rPeri})
+	c.State.V = frame.ToWorld(orbital.Vec3{Y: vPeri})
+
+	if _, err := w.PlanCircularizeAtApoapsis(); err != nil {
+		t.Fatalf("PlanCircularizeAtApoapsis: %v", err)
+	}
+	if got := len(c.Nodes); got != 2 {
+		t.Fatalf("after K then C: expected 2 nodes (both advisories coexist), got %d", got)
+	}
+	// The rendezvous-nudge node from the first plant must still be
+	// present, untouched by the C plant.
+	found := false
+	for _, n := range c.Nodes {
+		if n.ID == nudgeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("C plant removed the earlier K (rendezvous nudge) node — replace must be scoped to the SAME advisory key only")
+	}
+}
+
+// TestReplaceAdvisoryNodeIsNoOpForEmptyKey guards the replace helper's
+// empty-key guard: an empty AdvisoryKey must never match and strip
+// ordinary (non-advisory) planted nodes, e.g. a manual PlanNode or a
+// PlanTransfer leg — those never carry an AdvisoryKey tag.
+func TestReplaceAdvisoryNodeIsNoOpForEmptyKey(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	base := w.Clock.SimTime
+	w.PlanNode(ManeuverNode{TriggerTime: base.Add(60 * time.Second), DV: 10, Mode: spacecraft.BurnPrograde})
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("setup: expected 1 node, got %d", got)
+	}
+	w.replaceAdvisoryNode(c, "")
+	if got := len(c.Nodes); got != 1 {
+		t.Errorf("replaceAdvisoryNode(\"\") must be a no-op; node count = %d, want 1", got)
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1162,12 +1162,17 @@ func (w *World) PlanCircularizeAtApoapsis() (*CircularizePlan, error) {
 		// Already circular (or beyond) at apoapsis — nothing to plant.
 		return nil, ErrCircularizeBadOrbit
 	}
+	// #293: a second C press replaces its own previous unfired
+	// circularize node instead of stacking a stale duplicate behind
+	// it — see the matching comment in PlanRendezvousNudge.
+	w.replaceAdvisoryNode(c, AdvisoryKeyCircularize)
 	w.PlanNode(ManeuverNode{
-		Mode:      spacecraft.BurnPrograde,
-		DV:        dv,
-		Duration:  c.BurnTimeForDV(dv),
-		Event:     spacecraft.TriggerNextApo,
-		PrimaryID: c.Primary.ID,
+		Mode:        spacecraft.BurnPrograde,
+		DV:          dv,
+		Duration:    c.BurnTimeForDV(dv),
+		Event:       spacecraft.TriggerNextApo,
+		PrimaryID:   c.Primary.ID,
+		AdvisoryKey: AdvisoryKeyCircularize,
 	})
 	return &CircularizePlan{
 		DV:        dv,

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -2430,6 +2430,54 @@ func TestPlanCircularizeAtApoapsisPlantsProgradeNode(t *testing.T) {
 	}
 }
 
+// TestPlanCircularizeAtApoapsisSecondPressReplacesOwnNode — #293: a
+// second C press must replace the craft's own previous unfired
+// circularize node rather than stacking a stale duplicate behind it.
+// Node count stays at 1 and the stable ID changes across the two
+// plants, proving the second call is a fresh re-plant rather than a
+// no-op leaving the original node in place.
+func TestPlanCircularizeAtApoapsisSecondPressReplacesOwnNode(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	primaryR := c.Primary.RadiusMeters()
+	const (
+		periAlt = 200e3
+		apoAlt  = 1000e3
+	)
+	rPeri := primaryR + periAlt
+	rApo := primaryR + apoAlt
+	a := (rPeri + rApo) / 2
+	vPeri := math.Sqrt(mu * (2/rPeri - 1/a))
+	frame := orbital.ReferenceFrameForPrimary(c.Primary)
+	c.State.R = frame.ToWorld(orbital.Vec3{X: rPeri})
+	c.State.V = frame.ToWorld(orbital.Vec3{Y: vPeri})
+
+	if _, err := w.PlanCircularizeAtApoapsis(); err != nil {
+		t.Fatalf("PlanCircularizeAtApoapsis (1st press): %v", err)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("after 1st C: expected 1 node, got %d", got)
+	}
+	firstID := c.Nodes[0].ID
+	if firstID == 0 {
+		t.Fatal("first planted node has zero ID")
+	}
+	if c.Nodes[0].AdvisoryKey != AdvisoryKeyCircularize {
+		t.Errorf("AdvisoryKey = %q, want %q", c.Nodes[0].AdvisoryKey, AdvisoryKeyCircularize)
+	}
+
+	if _, err := w.PlanCircularizeAtApoapsis(); err != nil {
+		t.Fatalf("PlanCircularizeAtApoapsis (2nd press): %v", err)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("after 2nd C: expected the node count to STAY at 1 (replace, not stack), got %d", got)
+	}
+	if c.Nodes[0].ID == firstID {
+		t.Error("2nd C plant kept the 1st node's stable ID — expected a fresh re-plant with a new ID")
+	}
+}
+
 // TestPlanCircularizeAtApoapsisRejectsBelowAtmosphere — sub-orbital
 // trajectory whose apoapsis sits inside the atmosphere returns
 // ErrCircularizeBelowAtmosphere; planting in the atmosphere would

--- a/internal/sim/node_identity.go
+++ b/internal/sim/node_identity.go
@@ -54,6 +54,49 @@ func (w *World) EnsureNodeIDs() {
 	}
 }
 
+// Advisory key tags (#293). PlanRendezvousNudge (K) and
+// PlanCircularizeAtApoapsis (C) stamp their planted node's
+// spacecraft.ManeuverNode.AdvisoryKey with one of these so a repeat
+// press replaces its own previous unfired node instead of stacking a
+// stale duplicate behind it — see replaceAdvisoryNode.
+const (
+	AdvisoryKeyRendezvousNudge = "rendezvous-nudge"
+	AdvisoryKeyCircularize     = "circularize"
+)
+
+// replaceAdvisoryNode removes every node on c whose AdvisoryKey matches
+// key before a fresh single-keystroke advisory plant (#293's
+// "replace, don't stack" ruling). No-op when key is empty (guards
+// against accidentally stripping ordinary, non-advisory nodes, which
+// carry the zero-value "" tag) or when no matching node exists (the
+// key's first press).
+//
+// Every node in c.Nodes is by definition unfired — executeDueNodesFor
+// pops fired nodes out of the slice the same tick they fire — so "the
+// craft's own previous UNFIRED node" reduces to exactly this: any
+// currently-queued node carrying the same key. Once a node has fired
+// (moved into c.ActiveBurn or applied instantly) it is already gone
+// from c.Nodes, so a fresh advisory plant after that point starts
+// clean without needing to distinguish fired from unfired itself.
+//
+// Scoped to c's own Nodes slice — replacing an advisory node never
+// touches another craft's queue, and a different AdvisoryKey (e.g. C's
+// node when K is pressed) is left untouched: only the same key's own
+// node is replaced, per the ruling.
+func (w *World) replaceAdvisoryNode(c *spacecraft.Spacecraft, key string) {
+	if key == "" || c == nil {
+		return
+	}
+	kept := c.Nodes[:0]
+	for _, n := range c.Nodes {
+		if n.AdvisoryKey == key {
+			continue
+		}
+		kept = append(kept, n)
+	}
+	c.Nodes = kept
+}
+
 // nodeByID returns the planted node with stable ID nodeID on the craft
 // with stable ID craftID, and ok=false when either no longer resolves —
 // the craft was removed, the node was deleted or re-planted, or an id is

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -464,6 +464,13 @@ func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
 
 	leadBuffer := w.rendezvousLeadBuffer(c, advisory.AxisUnit)
 
+	// #293: a second K press replaces its own previous unfired nudge
+	// node instead of stacking a stale duplicate behind it — every
+	// advisory is computed from the craft's CURRENT orbit, so a node
+	// queued behind an earlier one would fire against an orbit it was
+	// never computed for. Must run before the append below.
+	w.replaceAdvisoryNode(c, AdvisoryKeyRendezvousNudge)
+
 	mode := axisLabelToBurnMode(advisory.Axis)
 	node := ManeuverNode{
 		Mode:          mode,
@@ -478,6 +485,7 @@ func (w *World) PlanRendezvousNudge() (*planner.RendezvousAdvisory, error) {
 		// node ref resolves against the ghost slate (empty for a local
 		// craft target — w.Target.GhostOwner is "" unless Kind==Ghost).
 		TargetGhostOwner: w.Target.GhostOwner,
+		AdvisoryKey:      AdvisoryKeyRendezvousNudge,
 	}
 	w.PlanNode(node)
 	out := advisory

--- a/internal/sim/rendezvous_test.go
+++ b/internal/sim/rendezvous_test.go
@@ -184,6 +184,50 @@ func TestPlanRendezvousNudge_ArrivalSpeedCarriesThrough(t *testing.T) {
 	}
 }
 
+// TestPlanRendezvousNudge_SecondPressReplacesOwnNode — #293: pressing K
+// twice in a row must not stack a second, now-stale node behind the
+// first. The second plant replaces the craft's own previous unfired K
+// node instead of queuing behind it — verified by the node count
+// staying at 1 and the node's stable ID changing (proof the second
+// plant is a fresh re-plant, not a no-op that happened to leave the
+// original node in place).
+func TestPlanRendezvousNudge_SecondPressReplacesOwnNode(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	_, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not a regression", err)
+		}
+		t.Fatalf("PlanRendezvousNudge (1st press): %v", err)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("after 1st K: expected 1 node, got %d", got)
+	}
+	firstID := c.Nodes[0].ID
+	if firstID == 0 {
+		t.Fatal("first planted node has zero ID")
+	}
+	if c.Nodes[0].AdvisoryKey != AdvisoryKeyRendezvousNudge {
+		t.Errorf("AdvisoryKey = %q, want %q", c.Nodes[0].AdvisoryKey, AdvisoryKeyRendezvousNudge)
+	}
+
+	_, err = w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge on 2nd press (%v); not a regression", err)
+		}
+		t.Fatalf("PlanRendezvousNudge (2nd press): %v", err)
+	}
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("after 2nd K: expected the node count to STAY at 1 (replace, not stack), got %d", got)
+	}
+	if c.Nodes[0].ID == firstID {
+		t.Error("2nd K plant kept the 1st node's stable ID — expected a fresh re-plant with a new ID")
+	}
+}
+
 // TestPlanRendezvousNudge_NoTarget — without a craft target the
 // planter must reject with ErrRendezvousNoTarget and plant nothing.
 func TestPlanRendezvousNudge_NoTarget(t *testing.T) {

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -158,6 +158,20 @@ type ManeuverNode struct {
 	// round-trips it additively, following the CurrentAttitudeDir
 	// schema-v6 precedent — no migration.
 	BurnDirUnit orbital.Vec3 `json:",omitempty"`
+	// AdvisoryKey (#293) tags a node planted by a single-keystroke
+	// advisory planner — "K" (PlanRendezvousNudge) or "C"
+	// (PlanCircularizeAtApoapsis) — with which key planted it. A second
+	// press of the SAME key replaces its own previous unfired node
+	// instead of stacking a stale duplicate behind it (the sim layer's
+	// replaceAdvisoryNode matches on this field before planting); a
+	// different advisory key, or an ordinary multi-step plan (H/I/
+	// porkchop/manual), never touches another key's queued node. Empty
+	// string (the zero-value omitempty default) means "not a
+	// replaceable advisory node" — the common case for every node type
+	// that predates this field. Additive zero-value-omitempty, same
+	// precedent as ID / TargetCraftID / PlaneChangeRad / BurnDirUnit —
+	// no save-schema migration needed.
+	AdvisoryKey string `json:",omitempty"`
 }
 
 // TargetCraftIDValue returns the bound target craft's stable ID and

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -122,10 +122,15 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// NODES (bottom-right) now also carries any in-flight burn as its
 	// firing head (v0.16). A live burn is safety-critical, so when one is
 	// in flight the chip force-shows — bypassing both the ChipNodes
-	// Settings toggle and F2 declutter — so it can never be hidden. With
-	// nothing burning it honours the toggle + declutter like any chip.
+	// Settings toggle and F2 declutter — so it can never be hidden.
+	// #293 extends the same force-show rationale to the staleness
+	// hazard: once more than one node is queued anywhere, every node
+	// behind the first was computed against an orbit that no longer
+	// exists once the first one fires, so the count must be visible
+	// the same way a live burn is. With ≤1 node queued and nothing
+	// burning, the chip honours the toggle + declutter like any chip.
 	if lines := v.buildNodesChip(w); lines != nil {
-		if v.anyActiveBurn(w) || v.chipEnabled(settings.ChipNodes) {
+		if v.anyActiveBurn(w) || totalQueuedNodes(w) > 1 || v.chipEnabled(settings.ChipNodes) {
 			chips = append(chips, builtChip{id: settings.ChipNodes, corner: cornerBottomRight, lines: lines})
 		}
 	}

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -330,6 +330,21 @@ func (v *OrbitView) buildStagesChip(w *sim.World) []string {
 	}
 }
 
+// totalQueuedNodes sums every craft's planted-but-unfired node count.
+// Shared by buildNodesChip (the "(+N more)" overflow count) and
+// assembleChips's #293 force-show gate — more than one node queued
+// anywhere is exactly the staleness hazard the chip exists to surface,
+// so both read the same total.
+func totalQueuedNodes(w *sim.World) int {
+	total := 0
+	for _, c := range w.Crafts {
+		if c != nil {
+			total += len(c.Nodes)
+		}
+	}
+	return total
+}
+
 // buildNodesChip is the bottom-right burn-schedule chip: any in-flight
 // burn(s) as the firing head, then the planted-node chain summarised as
 // the next node plus a "(+N more → [m])" overflow count. The full
@@ -343,12 +358,7 @@ func (v *OrbitView) buildStagesChip(w *sim.World) []string {
 // hidden by the toggle or declutter.
 func (v *OrbitView) buildNodesChip(w *sim.World) []string {
 	burnLines := v.activeBurnLines(w)
-	total := 0
-	for _, c := range w.Crafts {
-		if c != nil {
-			total += len(c.Nodes)
-		}
-	}
+	total := totalQueuedNodes(w)
 	if len(burnLines) == 0 && total == 0 {
 		return nil
 	}

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -443,6 +443,51 @@ func TestOrbitMetricsAlwaysOnAndLiveBurnForceShows(t *testing.T) {
 	}
 }
 
+// TestNodesChipForceShowsWhenMultipleNodesQueued — #293: staleness is
+// exactly "more than one node queued" (every node after the first fires
+// against an orbit it was never computed for), so 2+ queued nodes
+// force-show the NODES chip past the ChipNodes toggle AND F2 declutter —
+// extending the existing live-burn force-show rationale rather than
+// adding a second, differently-gated one. A single queued node must NOT
+// force-show; it still honours the toggle/declutter like any chip.
+func TestNodesChipForceShowsWhenMultipleNodesQueued(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	// Disable every toggleable Chip (incl. ChipNodes) and declutter, same
+	// setup as the live-burn force-show test.
+	s := settings.Default()
+	for _, chipID := range settings.AllChips {
+		s.SetChip(chipID, false)
+	}
+	v.SetSettings(s)
+	v.SetDeclutter(true)
+
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+	c.Nodes = []spacecraft.ManeuverNode{
+		{Mode: spacecraft.BurnPrograde, DV: 42, TriggerTime: w.Clock.SimTime.Add(time.Minute)},
+	}
+	out := v.Render(w, 0, 120, 40)
+	if strings.Contains(out, "NODES") {
+		t.Errorf("a single queued node must not force-show past the toggle/declutter:\n%s", out)
+	}
+
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		Mode: spacecraft.BurnRetrograde, DV: 7, TriggerTime: w.Clock.SimTime.Add(2 * time.Minute),
+	})
+	out = v.Render(w, 0, 120, 40)
+	if !strings.Contains(out, "NODES") {
+		t.Errorf("2+ queued nodes must force-show the NODES chip past the toggle/declutter:\n%s", out)
+	}
+}
+
 // TestOrbitMetricsShowsDirectionIndicator — issue #63: the ORBIT chip
 // carries an explicit prograde/retrograde orbit-direction readout so a
 // genuine reversal is never confused with a projection/shading artifact.


### PR DESCRIPTION
## Summary

Implements the ruling from #293's grill comment ("Grilled with Jason 2026-08-02. Decision: **replace + force-show**"):

- `K` (rendezvous nudge, `PlanRendezvousNudge`) and `C` (circularize, `PlanCircularizeAtApoapsis`) each stamp their planted node with a new `spacecraft.ManeuverNode.AdvisoryKey` tag (`"rendezvous-nudge"` / `"circularize"`). A repeat press of the **same** key now removes its own previous unfired node (`World.replaceAdvisoryNode`) before planting fresh from the craft's current orbit, instead of queuing a second, now-stale node behind it. A different key's queued node is untouched — K and C nodes can coexist.
- The bottom-right NODES chip now force-shows whenever **2+ nodes are queued anywhere** (`totalQueuedNodes`), extending the existing live-burn force-show past the `ChipNodes` Settings toggle and F2 declutter — the same staleness risk the chip already exists to surface.
- Explicitly out of scope per the ruling: plant-time warnings and fire-time re-validation (both rejected in the grill).

## Node-identity mechanism

Every node remaining in `Craft.Nodes` is by definition unfired — `executeDueNodesFor` pops fired nodes out of the slice the tick they fire. So "replace the craft's own previous **unfired** node" reduces to: remove any node in `c.Nodes` whose `AdvisoryKey` matches the key about to plant. `AdvisoryKey` is additive/omitempty on `ManeuverNode`, following the existing `ID` / `TargetCraftID` / `PlaneChangeRad` precedent — ordinary nodes (transfers, plane changes, manual plants) never carry it and are never touched by the replace.

## Save schema

`AdvisoryKey` round-trips through `internal/save` (wire `Node.AdvisoryKey`, additive/omitempty) so a reloaded queued advisory node still replaces correctly on the next press. **No `SchemaVersion` bump** — zero-value-omitempty, same precedent as the fields above; confirmed via a save/load round-trip test.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- New/changed tests:
  - `internal/sim/rendezvous_test.go`: `TestPlanRendezvousNudge_SecondPressReplacesOwnNode` — 2nd K press keeps node count at 1 with a fresh stable ID.
  - `internal/sim/maneuver_test.go`: `TestPlanCircularizeAtApoapsisSecondPressReplacesOwnNode` — same for C.
  - `internal/sim/advisory_node_test.go`: `TestAdvisoryNodeDifferentKeysCoexist` (K then C leaves both queued), `TestReplaceAdvisoryNodeIsNoOpForEmptyKey` (guards ordinary nodes).
  - `internal/tui/screens/orbit_chips_test.go`: `TestNodesChipForceShowsWhenMultipleNodesQueued` — 1 queued node still honours the toggle/declutter, 2+ force-shows.
  - `internal/save/advisory_key_test.go`: `TestRoundtripAdvisoryKey` — tag survives save/load.
- Each new test was run against pre-fix code and observed failing (red) before implementing.