### PR TITLE
fix(sessiondir): case-insensitive handle collisions — refuse at boundary, auto-suffix legacy (#274)

### DIFF
--- a/internal/serve/handle_collision_test.go
+++ b/internal/serve/handle_collision_test.go
@@ -1,0 +1,79 @@
+package serve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+)
+
+// #274: a legacy roster collision repaired at load (sessiondir's
+// dedupeRosterHandles, pinned at that layer's own tests) must actually
+// reach the affected players, not just rewrite session.json quietly.
+// Both the renamed player and the collision counterpart who kept
+// their name get a toast on their next connect.
+func TestLegacyHandleRenameNoteReachesConnectingPlayers(t *testing.T) {
+	sessionDir := t.TempDir()
+	// Seed a pre-#274 session.json: two guest rows sharing "gern",
+	// exactly the shape a roster written before this fix would have.
+	seed := sessiondir.Meta{
+		Version:         sessiondir.MetaVersion,
+		BodyCatalogHash: "irrelevant-to-this-test",
+		Roster: []sessiondir.Player{
+			{Fingerprint: sessiondir.HostFingerprint, Handle: "jason", Role: sessiondir.RoleHost},
+			{Fingerprint: "SHA256:first", Handle: "gern", Role: sessiondir.RoleGuest},
+			{Fingerprint: "SHA256:second", Handle: "gern", Role: sessiondir.RoleGuest},
+		},
+	}
+	data, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(sessionDir, "players"), 0o755); err != nil {
+		t.Fatalf("mkdir players: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionDir, "session.json"), data, 0o644); err != nil {
+		t.Fatalf("seed session.json: %v", err)
+	}
+
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	srv, err := New(Config{
+		Addr:        "127.0.0.1:0",
+		HostKeyPath: filepath.Join(t.TempDir(), "hostkey"),
+		SessionDir:  sessionDir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.ln.Close() })
+
+	// The repair ran during New (via sessiondir.Open): the later
+	// enrollee is renamed.
+	p, err := srv.store.FindPlayer("SHA256:second")
+	if err != nil || p.Handle != "gern2" {
+		t.Fatalf("legacy roster not repaired by New/Open: %+v, %v", p, err)
+	}
+
+	renamedApp, err := srv.newGuestApp("SHA256:second")
+	if err != nil {
+		t.Fatalf("newGuestApp (renamed): %v", err)
+	}
+	renamed := tick(srv.withReporting(renamedApp, "SHA256:second"))
+	out := stripANSI(renamed.View())
+	if !strings.Contains(out, "gern2") {
+		t.Errorf("renamed player's connect toast missing the new handle: %q", out)
+	}
+
+	keptApp, err := srv.newGuestApp("SHA256:first")
+	if err != nil {
+		t.Fatalf("newGuestApp (kept name): %v", err)
+	}
+	kept := tick(srv.withReporting(keptApp, "SHA256:first"))
+	koutt := stripANSI(kept.View())
+	if !strings.Contains(koutt, "gern2") {
+		t.Errorf("collision counterpart's connect toast missing the new handle: %q", koutt)
+	}
+}

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -90,7 +90,16 @@ var (
 const metaRefresh = 5 * time.Second
 
 // withReporting wraps app so its world reports to the store as owner.
+// Called once per new session (ssh connect/reconnect, or the host
+// starting to host), so it's also the single place that delivers a
+// player's pending session note (#274) — today only the legacy
+// handle-collision auto-rename produces one, surfaced as a toast on
+// the owner's own screen the moment their session comes up, then
+// cleared so it fires exactly once.
 func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
+	if note, err := s.store.ConsumePendingNote(owner); err == nil && note != "" {
+		app.Toast(note)
+	}
 	return reportingModel{
 		inner: app, app: app,
 		rep: relay.NewReporter(s.relay, owner),
@@ -200,7 +209,14 @@ func (m reportingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch admin.Cmd.Kind {
 		case screens.SessionCmdMint:
-			_, _ = m.srv.store.MintInvite(admin.Cmd.Handle)
+			// #274: MintInvite refuses a handle that case-insensitively
+			// collides with the roster or another outstanding invite —
+			// this used to be silently discarded (`_, _ = ...`), so the
+			// host never learned a mint failed and could hand out a code
+			// bound to a handle that could never enroll cleanly.
+			if _, err := m.srv.store.MintInvite(admin.Cmd.Handle); err != nil {
+				m.app.Toast(err.Error())
+			}
 		case screens.SessionCmdRevoke:
 			_ = m.srv.store.RevokeInvite(admin.Cmd.Code)
 		case screens.SessionCmdRemove:

--- a/internal/serve/session_slate_test.go
+++ b/internal/serve/session_slate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +180,35 @@ func TestSessionAdminCommands(t *testing.T) {
 	}})
 	if _, err := srv.store.FindPlayer("SHA256:gern"); !errors.Is(err, sessiondir.ErrNotEnrolled) {
 		t.Errorf("remove via admin msg: %v", err)
+	}
+}
+
+// A colliding mint (#274) is refused, and the reason reaches the
+// admin's own screen as a toast. Previously the admin handler
+// discarded MintInvite's error entirely (`_, _ =
+// m.srv.store.MintInvite(...)`), so a doomed invite — bound to a
+// handle that could never land as a distinct roster identity — was
+// minted silently, with nothing telling the host why the code they
+// handed out couldn't be redeemed cleanly.
+func TestSessionAdminMintCollisionSurfacesRefusal(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	m := tick(srv.HostModel(hostApp))
+
+	m, _ = m.Update(screens.SessionAdminMsg{Cmd: screens.SessionCommand{
+		Kind: screens.SessionCmdMint, Handle: "GERN",
+	}})
+	if meta, _ := srv.store.Meta(); len(meta.Invites) != 0 {
+		t.Fatalf("colliding mint was not refused: invites = %+v", meta.Invites)
+	}
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "collide") {
+		t.Errorf("mint refusal not surfaced to the admin: %q", out)
 	}
 }
 

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,12 @@ var (
 	ErrNotEnrolled   = errors.New("sessiondir: fingerprint not in roster")
 )
 
+// foldHandle normalises a handle for case-insensitive comparison
+// (#274): "Gern" and "gern" must be treated as the same identity when
+// checking uniqueness, even though the stored Handle preserves the
+// player's chosen case.
+func foldHandle(h string) string { return strings.ToLower(strings.TrimSpace(h)) }
+
 // Player is one roster entry. Fingerprint is the ssh public-key
 // SHA256 fingerprint (the stable identity — handles are editable).
 type Player struct {
@@ -78,6 +85,17 @@ type Player struct {
 	Role        string    `json:"role"`
 	EnrolledAt  time.Time `json:"enrolled_at"`
 	Calibrated  bool      `json:"calibrated"`
+
+	// PendingNote is a durable, deliver-once session note (#274):
+	// surfaced to the player as a toast the next time they connect,
+	// then cleared via ConsumePendingNote. Additive field — an
+	// existing roster row without it deserialises to "", a no-op, so
+	// no MetaVersion bump is needed (same additive precedent as Role
+	// gaining RoleAdmin). Used today for the legacy handle-collision
+	// auto-rename: both the renamed player and the collision
+	// counterpart who kept their name get one, so both learn a
+	// previously-ambiguous pair is now distinct.
+	PendingNote string `json:"pending_note,omitempty"`
 }
 
 // Invite is one outstanding (unredeemed) invite code. The handle is
@@ -171,7 +189,13 @@ func DefaultDir() (string, error) {
 }
 
 // Open creates the directory if needed and initialises session.json
-// on first use, stamping the current body-catalog hash.
+// on first use, stamping the current body-catalog hash. Opening an
+// EXISTING session also repairs any legacy roster handle collision
+// (#274, see dedupeRosterHandles) — a one-shot fix-up run at load,
+// mirroring the versioned migration ladder but keyed on content
+// rather than a version number, since case-insensitive uniqueness
+// wasn't the persisted shape changing, just a rule that used to be
+// unenforced.
 func Open(dir string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Join(dir, "players"), 0o755); err != nil {
 		return nil, fmt.Errorf("sessiondir: %w", err)
@@ -187,8 +211,115 @@ func Open(dir string) (*Store, error) {
 		if err := s.writeMeta(Meta{Version: MetaVersion, BodyCatalogHash: hash}); err != nil {
 			return nil, err
 		}
+		return s, nil
+	}
+	m, err := s.readMeta()
+	if err != nil {
+		return nil, err
+	}
+	if repairLegacyHandleCollisions(&m) {
+		if err := s.writeMeta(m); err != nil {
+			return nil, err
+		}
 	}
 	return s, nil
+}
+
+// repairLegacyHandleCollisions runs dedupeRosterHandles over m.Roster
+// and, for each rename it makes, logs a server-log line and stamps a
+// PendingNote on both the renamed player and the collision
+// counterpart who kept their name (#274). Reports whether it changed
+// anything, so the caller only persists when there was something to
+// persist.
+func repairLegacyHandleCollisions(m *Meta) bool {
+	renames := dedupeRosterHandles(m.Roster)
+	for _, r := range renames {
+		log.Printf("sessiondir: legacy roster handle collision at load — renamed %q to %q (fingerprint %s) to keep handles case-insensitively unique (#274)", r.From, r.To, r.Fingerprint)
+		for i := range m.Roster {
+			switch {
+			case m.Roster[i].Fingerprint == r.Fingerprint:
+				m.Roster[i].PendingNote = fmt.Sprintf(
+					"your handle collided with another player's (case-insensitively) — you've been renamed to %q so you can both be DMed unambiguously", r.To)
+			case foldHandle(m.Roster[i].Handle) == foldHandle(r.From) && m.Roster[i].Fingerprint != r.Fingerprint:
+				m.Roster[i].PendingNote = fmt.Sprintf(
+					"a roster handle collision with your name was resolved — the other player is now %q", r.To)
+			}
+		}
+	}
+	return len(renames) > 0
+}
+
+// handleRename is one deterministic legacy-collision fix dedupeRosterHandles made.
+type handleRename struct {
+	Fingerprint string
+	From        string
+	To          string
+}
+
+// dedupeRosterHandles walks roster in enrollment order (its natural
+// append order — the host first, guests in the order they enrolled)
+// and renames any entry whose handle case-insensitively collides with
+// an EARLIER entry: the Nth colliding handle becomes "<handle>2",
+// "<handle>3", ... skipping any candidate suffix that would itself
+// collide. It mutates roster in place and returns the renames made.
+//
+// This is a pure function of roster order and handles, so calling it
+// again on an already-fixed roster (or, if the caller never persists,
+// on the same still-colliding input) always reproduces the same
+// result — "gern2", never "gern22" — which is what makes the legacy
+// fix at Open safe to run on every load rather than exactly once
+// (#274).
+func dedupeRosterHandles(roster []Player) []handleRename {
+	seen := make(map[string]bool, len(roster))
+	var renames []handleRename
+	for i := range roster {
+		folded := foldHandle(roster[i].Handle)
+		if !seen[folded] {
+			seen[folded] = true
+			continue
+		}
+		orig := roster[i].Handle
+		suffix := 2
+		var next, foldedNext string
+		for {
+			next = fmt.Sprintf("%s%d", orig, suffix)
+			foldedNext = foldHandle(next)
+			if !seen[foldedNext] {
+				break
+			}
+			suffix++
+		}
+		seen[foldedNext] = true
+		roster[i].Handle = next
+		renames = append(renames, handleRename{
+			Fingerprint: roster[i].Fingerprint,
+			From:        orig,
+			To:          next,
+		})
+	}
+	return renames
+}
+
+// ConsumePendingNote returns and clears fingerprint's pending session
+// note (#274), if any — empty string and no error when there is none.
+// Clearing is persisted immediately so the note is delivered exactly
+// once, even if the process restarts between the read and the next
+// mutation.
+func (s *Store) ConsumePendingNote(fingerprint string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m, err := s.readMeta()
+	if err != nil {
+		return "", err
+	}
+	for i := range m.Roster {
+		if m.Roster[i].Fingerprint == fingerprint && m.Roster[i].PendingNote != "" {
+			note := m.Roster[i].PendingNote
+			m.Roster[i].PendingNote = ""
+			return note, s.writeMeta(m)
+		}
+	}
+	return "", nil
 }
 
 func (s *Store) metaPath() string { return filepath.Join(s.dir, "session.json") }
@@ -324,7 +455,11 @@ func (s *Store) EnsureHost(handle string) (Player, error) {
 	return host, s.writeMeta(m)
 }
 
-// MintInvite creates a one-time code pre-bound to handle.
+// MintInvite creates a one-time code pre-bound to handle. The handle
+// must be case-insensitively unique against both the roster and any
+// other outstanding invite (#274) — refused here rather than left to
+// surface only once the guest tries to enroll, so the host learns
+// about a collision before ever handing out a code that can't land.
 func (s *Store) MintInvite(handle string) (Invite, error) {
 	handle = strings.TrimSpace(handle)
 	if handle == "" {
@@ -336,6 +471,9 @@ func (s *Store) MintInvite(handle string) (Invite, error) {
 	if err != nil {
 		return Invite{}, err
 	}
+	if p, ok := findHandleCollision(handle, m.Roster, m.Invites); ok {
+		return Invite{}, fmt.Errorf("sessiondir: handle %q collides with %q (case-insensitive) — pick a different handle", handle, p)
+	}
 	code, err := mintCode()
 	if err != nil {
 		return Invite{}, err
@@ -343,6 +481,24 @@ func (s *Store) MintInvite(handle string) (Invite, error) {
 	inv := Invite{Code: code, Handle: handle, CreatedAt: time.Now().UTC()}
 	m.Invites = append(m.Invites, inv)
 	return inv, s.writeMeta(m)
+}
+
+// findHandleCollision reports the first existing roster handle or
+// outstanding invite handle that case-insensitively matches handle,
+// if any.
+func findHandleCollision(handle string, roster []Player, invites []Invite) (string, bool) {
+	folded := foldHandle(handle)
+	for _, p := range roster {
+		if foldHandle(p.Handle) == folded {
+			return p.Handle, true
+		}
+	}
+	for _, inv := range invites {
+		if foldHandle(inv.Handle) == folded {
+			return inv.Handle, true
+		}
+	}
+	return "", false
 }
 
 // mintCode returns a short read-out-loud code ("AB2C-DE3F"): 40 bits
@@ -407,6 +563,15 @@ func (s *Store) Enroll(code, fingerprint, handle string) (Player, error) {
 	}
 	if idx < 0 {
 		return Player{}, ErrUnknownInvite
+	}
+	// Case-insensitive uniqueness against the roster (#274) — checked
+	// here, not just at mint, because the handle is editable at this
+	// step (ADR 0034 addendum) and could be hand-edited into a
+	// collision even when the pre-bound handle was clean. Checked
+	// BEFORE consuming the invite, so a refusal leaves the code intact
+	// for a retry with a different handle.
+	if collidesWith, ok := findHandleCollision(handle, m.Roster, nil); ok {
+		return Player{}, fmt.Errorf("sessiondir: handle %q collides with %q (case-insensitive) — pick a different handle", handle, collidesWith)
 	}
 	m.Invites = append(m.Invites[:idx], m.Invites[idx+1:]...)
 	p := Player{

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -491,3 +491,209 @@ func TestMigrateV1SessionForward(t *testing.T) {
 		t.Errorf("on-disk version = %d, want %d", probe.Version, MetaVersion)
 	}
 }
+
+// #274: MintInvite refuses a handle that collides case-insensitively
+// with an existing roster entry, and the store is left untouched.
+func TestMintInviteRefusesCaseInsensitiveRosterCollision(t *testing.T) {
+	s := openStore(t)
+	inv1, err := s.MintInvite("gern")
+	if err != nil {
+		t.Fatalf("MintInvite gern: %v", err)
+	}
+	if _, err := s.Enroll(inv1.Code, "SHA256:gern", "gern"); err != nil {
+		t.Fatalf("Enroll gern: %v", err)
+	}
+	if _, err := s.MintInvite("Gern"); err == nil {
+		t.Fatal("MintInvite accepted a case-different collision with an enrolled handle")
+	}
+	m, _ := s.Meta()
+	if len(m.Invites) != 0 {
+		t.Errorf("a refused mint left an invite behind: %+v", m.Invites)
+	}
+}
+
+// #274: MintInvite also refuses a collision against another
+// outstanding (unredeemed) invite's pre-bound handle — catching the
+// clash at the host's mint step, before a second player is ever
+// handed a code that can't enroll.
+func TestMintInviteRefusesCaseInsensitiveInviteCollision(t *testing.T) {
+	s := openStore(t)
+	if _, err := s.MintInvite("dave"); err != nil {
+		t.Fatalf("first MintInvite: %v", err)
+	}
+	if _, err := s.MintInvite("DAVE"); err == nil {
+		t.Fatal("MintInvite accepted a case-different collision with an outstanding invite")
+	}
+	m, _ := s.Meta()
+	if len(m.Invites) != 1 {
+		t.Errorf("a refused mint left a second invite behind: %+v", m.Invites)
+	}
+}
+
+// #274: Enroll refuses a (possibly hand-edited) handle that collides
+// case-insensitively with an already-enrolled roster entry, and the
+// invite code is NOT spent — the player can retry with a different
+// handle using the same code.
+func TestEnrollRefusesCaseInsensitiveRosterCollision(t *testing.T) {
+	s := openStore(t)
+	inv1, err := s.MintInvite("gern")
+	if err != nil {
+		t.Fatalf("MintInvite gern: %v", err)
+	}
+	if _, err := s.Enroll(inv1.Code, "SHA256:gern", "gern"); err != nil {
+		t.Fatalf("Enroll gern: %v", err)
+	}
+	inv2, err := s.MintInvite("someone-new")
+	if err != nil {
+		t.Fatalf("MintInvite someone-new: %v", err)
+	}
+	if _, err := s.Enroll(inv2.Code, "SHA256:other", "GERN"); err == nil {
+		t.Fatal("Enroll accepted a case-different collision with an enrolled handle")
+	}
+	m, _ := s.Meta()
+	if len(m.Roster) != 1 {
+		t.Fatalf("a refused enroll added a roster row: %+v", m.Roster)
+	}
+	// The code survives the refusal — Peek still finds it.
+	if _, err := s.Peek(inv2.Code); err != nil {
+		t.Errorf("refused enroll spent the invite code: %v", err)
+	}
+}
+
+// #274: a pre-fix roster already carrying a case-insensitive
+// collision (planted directly, bypassing the now-guarded Enroll, to
+// simulate data written before this fix shipped) is deterministically
+// repaired at Open: the later enrollee (by roster/enrollment order)
+// is renamed with a numeric suffix, and both the renamed player and
+// the collision counterpart who kept their name get a pending session
+// note.
+func TestOpenDedupesLegacyRosterHandleCollision(t *testing.T) {
+	dir := t.TempDir()
+	seed, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	m, err := seed.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	m.Roster = []Player{
+		{Fingerprint: HostFingerprint, Handle: "jason", Role: RoleHost},
+		{Fingerprint: "SHA256:first", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:second", Handle: "gern", Role: RoleGuest},
+	}
+	if err := seed.writeMeta(m); err != nil {
+		t.Fatalf("seed writeMeta: %v", err)
+	}
+
+	// Re-open: this is the "load" that must repair the legacy collision.
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (repair): %v", err)
+	}
+	m2, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta after repair: %v", err)
+	}
+	if len(m2.Roster) != 3 {
+		t.Fatalf("roster rows = %d, want 3", len(m2.Roster))
+	}
+	byFP := map[string]Player{}
+	for _, p := range m2.Roster {
+		byFP[p.Fingerprint] = p
+	}
+	if byFP["SHA256:first"].Handle != "gern" {
+		t.Errorf("first (earlier) enrollee's handle changed: %+v", byFP["SHA256:first"])
+	}
+	if byFP["SHA256:second"].Handle != "gern2" {
+		t.Errorf("later enrollee not renamed to gern2: %+v", byFP["SHA256:second"])
+	}
+	if byFP["SHA256:first"].PendingNote == "" {
+		t.Error("collision counterpart (kept name) has no pending session note")
+	}
+	if byFP["SHA256:second"].PendingNote == "" {
+		t.Error("renamed player has no pending session note")
+	}
+
+	// Idempotent across repeated loads: reopening again must not
+	// compound the suffix (gern2 -> gern22).
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (second load): %v", err)
+	}
+	m3, err := s2.Meta()
+	if err != nil {
+		t.Fatalf("Meta after second load: %v", err)
+	}
+	byFP3 := map[string]Player{}
+	for _, p := range m3.Roster {
+		byFP3[p.Fingerprint] = p
+	}
+	if byFP3["SHA256:second"].Handle != "gern2" {
+		t.Errorf("second load compounded the rename: %+v", byFP3["SHA256:second"])
+	}
+}
+
+// A legacy collision that differs only by case ("gern" vs "Gern")
+// keeps the later entrant's OWN typed case in the rename — only a
+// disambiguating numeric suffix is added, the case they chose is
+// never silently rewritten.
+func TestOpenDedupePreservesLaterEntrantCase(t *testing.T) {
+	dir := t.TempDir()
+	seed, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	m, err := seed.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	m.Roster = []Player{
+		{Fingerprint: HostFingerprint, Handle: "jason", Role: RoleHost},
+		{Fingerprint: "SHA256:first", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:second", Handle: "Gern", Role: RoleGuest},
+	}
+	if err := seed.writeMeta(m); err != nil {
+		t.Fatalf("seed writeMeta: %v", err)
+	}
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (repair): %v", err)
+	}
+	m2, _ := s.Meta()
+	for _, p := range m2.Roster {
+		if p.Fingerprint == "SHA256:second" && p.Handle != "Gern2" {
+			t.Errorf("later entrant's case not preserved: got %q, want %q", p.Handle, "Gern2")
+		}
+	}
+}
+
+// ConsumePendingNote returns a player's pending note exactly once,
+// then clears it — a second consume is silent (empty, no error).
+func TestConsumePendingNoteFiresOnce(t *testing.T) {
+	s := openStore(t)
+	inv, err := s.MintInvite("dave")
+	if err != nil {
+		t.Fatalf("MintInvite: %v", err)
+	}
+	if _, err := s.Enroll(inv.Code, "SHA256:dave", "dave"); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	m, _ := s.Meta()
+	for i := range m.Roster {
+		if m.Roster[i].Fingerprint == "SHA256:dave" {
+			m.Roster[i].PendingNote = "test note"
+		}
+	}
+	if err := s.writeMeta(m); err != nil {
+		t.Fatalf("writeMeta: %v", err)
+	}
+	note, err := s.ConsumePendingNote("SHA256:dave")
+	if err != nil || note != "test note" {
+		t.Fatalf("first consume = %q, %v; want %q, nil", note, err, "test note")
+	}
+	note2, err := s.ConsumePendingNote("SHA256:dave")
+	if err != nil || note2 != "" {
+		t.Fatalf("second consume = %q, %v; want empty, nil", note2, err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the grilled decision on #274: **refuse at the boundary, auto-suffix legacy at load.**

- `MintInvite` and `Enroll` now validate **case-insensitive** handle uniqueness and refuse with a surfaced reason (`"sessiondir: handle %q collides with %q (case-insensitive) — pick a different handle"`).
  - `MintInvite` checks against the roster **and** other outstanding invites, so the host learns about a collision before ever handing out a code that can't land.
  - `Enroll` checks against the roster (the handle is editable at enroll, ADR 0034 addendum, so it's re-checked even when the pre-bound handle was clean) — checked **before** the invite code is consumed, so a refusal leaves the code intact for a retry with a different handle.
  - Fixed the admin handler in `internal/serve/reporting.go` (`SessionCmdMint`), which previously discarded `MintInvite`'s error entirely (`_, _ = m.srv.store.MintInvite(...)`). It now surfaces the refusal as a toast on the admin's screen.
- A pre-fix roster already carrying a collision is repaired at `sessiondir.Open`: `dedupeRosterHandles` walks the roster in enrollment order and renames the later colliding entry with a numeric suffix (`gern` → `gern2`), preserving whatever case the player originally typed. This is logged server-side (`log.Printf`) and stamps a one-shot `PendingNote` on both the renamed player and the collision counterpart who kept their name — delivered as a toast the next time each connects (via `withReporting`, consumed once through `ConsumePendingNote`).

## Persisted shape

`Player` gains an additive `PendingNote string` field (`omitempty`). This mirrors the existing `RoleAdmin` precedent documented in the `MetaVersion` doc comment ("adding admin is additive: no MetaVersion bump, no migration") — an existing roster row without it deserialises to `""`, a no-op. **No `MetaVersion` bump, no migration needed.**

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`

New tests (all written first and observed red against pre-fix code):
- `TestMintInviteRefusesCaseInsensitiveRosterCollision` / `...InviteCollision` — mint refusal pins both collision sources.
- `TestEnrollRefusesCaseInsensitiveRosterCollision` — enroll refusal, and pins the invite code surviving the refusal (not spent).
- `TestOpenDedupesLegacyRosterHandleCollision` — pins the rename, the `PendingNote` on both parties, **and idempotency across two `Open` calls on the same directory** (`gern2`, never `gern22`).
- `TestOpenDedupePreservesLaterEntrantCase` — a case-different collision (`gern`/`Gern`) keeps the later entrant's own typed case in the suffix (`Gern2`), not a silently-normalized case.
- `TestConsumePendingNoteFiresOnce` — the note is delivered once, then empty.
- `TestSessionAdminMintCollisionSurfacesRefusal` — pins the previously-discarded admin mint error now reaching the admin's screen.
- `TestLegacyHandleRenameNoteReachesConnectingPlayers` — end-to-end: seeds a pre-#274 `session.json` on disk, boots a `Server` against it, and confirms **both** the renamed player and the collision counterpart see the new handle in their own screen's toast on connect.

## Idempotency of the legacy rename

`dedupeRosterHandles` is a pure function of roster order/handles. `Open` persists the fix immediately via `writeMeta`, so a real restart never re-triggers it (the log line fires exactly once). Even without that persistence, re-running the function on the same still-colliding input always reproduces the same result (`gern2`, never `gern22`) — pinned explicitly by `TestOpenDedupesLegacyRosterHandleCollision`'s second `Open` call.

## Where the refusal reaches the player

- Guest enroll flow: `internal/serve/flow.go`'s existing `errMsg` mechanism (unchanged) already surfaces `Enroll`'s error text back to the guest at the handle-entry prompt.
- Admin mint: `internal/serve/reporting.go`'s `SessionCmdMint` case now calls `m.app.Toast(err.Error())` on refusal (previously discarded).
- Legacy rename note: `internal/serve/reporting.go`'s `withReporting` (called once per new session — ssh connect/reconnect or host-starts-hosting) drains `ConsumePendingNote` and toasts it.