### PR TITLE
Dock lifecycle: absorbed-guest chip, subspace-gap placement, safe handback + re-arm latch (ADR 0038 S1-S3)

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -34,6 +34,15 @@ const (
 	// DockActive: the guest craft is fused into the docker's stack and the
 	// ride is live — the guest is Docked-as-Guest, warp-coupled to the stack.
 	DockActive
+	// DockCooldown: the pair just undocked (a live handback, not a Parcel)
+	// and the record is held open purely as the ADR 0038 §5 re-arm-by-
+	// leaving latch — Claim()'s existing craft-ID dedup keeps refusing a
+	// fresh dock between this SAME pair of craft until reconcileCooldown
+	// observes them past ReArmDistM and drops the record. Nothing else reads
+	// a Cooldown record: RequestUndock/RequestRelease/RequestTransfer/
+	// ReclaimTarget all gate on DockActive, so a cooling-down pair is
+	// invisible to every other verb.
+	DockCooldown
 )
 
 // DockRecord is one cross-player dock. The exported fields are the cross-ref
@@ -445,6 +454,16 @@ func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]Cr
 	var chips []DockChip
 	w.DockGuest = nil // rebuilt below if still a guest in some active dock
 	for id, r := range l.records {
+		// ADR 0038 §5: a Cooldown record is the re-arm-by-leaving latch, not
+		// a live dock — neither reconcileOwner nor reconcileGuest touches it.
+		// Either side of the pair can notice the separation and clear it, so
+		// check both regardless of which one owner is.
+		if r.Phase == DockCooldown {
+			if (r.Owner == owner || r.GuestOwner == owner) && l.reconcileCooldown(w, r, owner, reports) {
+				delete(l.records, id)
+			}
+			continue
+		}
 		switch {
 		case r.Owner == owner:
 			if l.reconcileOwner(w, r, &chips) {
@@ -457,6 +476,43 @@ func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]Cr
 		}
 	}
 	return chips
+}
+
+// reconcileCooldown reports whether a re-arm-by-leaving latch (ADR 0038 §5)
+// has cleared: the pair named by r has separated past ReArmDistM, as seen
+// from whichever side is calling (owner is this session's own fingerprint —
+// either the stack owner or the departed guest). Returns true (clear the
+// latch) when there's nothing left of ours to guard, or the partner's craft
+// has backed off far enough; false holds it open, including when the
+// partner isn't reporting yet — an unresolvable range is not evidence of
+// separation.
+func (l *DockLedger) reconcileCooldown(w *sim.World, r *DockRecord, owner string, reports map[string]CraftReport) bool {
+	var localID uint64
+	var remoteOwner string
+	var remoteID uint64
+	if r.Owner == owner {
+		localID, remoteOwner, remoteID = r.DockerCraftID, r.GuestOwner, r.GuestCraftID
+	} else {
+		localID, remoteOwner, remoteID = r.GuestCraftID, r.Owner, r.DockerCraftID
+	}
+	local, _, ok := w.CraftByID(localID)
+	if !ok {
+		return true // our own craft is gone (staged, ended flight) — nothing to guard
+	}
+	rep, ok := reports[remoteOwner]
+	if !ok {
+		return false // no report from the partner yet — can't tell, hold the latch
+	}
+	// Reuse GhostsFor rather than re-deriving the same Kepler propagation —
+	// the exact substrate the flight HUD's own range reading uses, so the
+	// latch clears at the same moment the pilot sees "clear" on screen.
+	for _, g := range GhostsFor(w, []CraftReport{rep}, nil) {
+		if g.CraftID != remoteID || g.PrimaryID != local.Primary.ID {
+			continue
+		}
+		return local.State.R.Sub(g.RelPos).Norm() > sim.ReArmDistM
+	}
+	return false // partner's craft not resolvable in this frame — hold
 }
 
 // reconcileOwner runs the stack owner's side of a dock. Returns true when the
@@ -687,23 +743,36 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 				dt := w.Clock.SimTime.Sub(time.Unix(0, r.parcelAtNano)).Seconds()
 				sim.PlaceAcrossSubspaceGap(r.returnPayload, dt)
 			}
+			// Safed at DELIVERY, not at release: the throttle and the live
+			// burn state are not part of a craft's persisted form, so safing
+			// at release would be undone by the first restart a Parcel
+			// outlived — and a live handback needs the exact same invariant
+			// regardless (#303: the docker's throttle/engine mode/attitude
+			// hold must never ride home with the guest). Every return leaves
+			// inert now, not just Parcels.
+			sim.SafeHandback(r.returnPayload)
 			if r.parcel {
-				// Safed at DELIVERY, not at release: the throttle and the
-				// live burn state are not part of a craft's persisted form,
-				// so safing at release would be undone by the first restart
-				// the Parcel outlived. Arriving inert is the invariant; where
-				// it is applied has to be the arrival.
-				sim.SafeHandback(r.returnPayload)
 				kind = sim.SessionEventParcelReturned
 			} else {
 				// ADR 0038 §6: I undock already targeting the stack I just
-				// left.
+				// left. Skipped for a Parcel — I only just reconnected, and
+				// "targeting the ghost of a stack I haven't seen in hours" is
+				// a stranger opening move than starting blank.
 				w.SetTargetGhost(r.Owner, r.CompositeID)
 			}
 			w.AdoptCraft(r.returnPayload, true)
 			r.returnPayload = nil
 			*chips = append(*chips, DockChip{Kind: kind, Handle: r.OwnerHandle})
-			return true
+			if r.parcel {
+				// Parcel teardown is unchanged: I wasn't there to re-approach
+				// anything, so there is nothing for a re-arm latch to guard.
+				return true
+			}
+			// ADR 0038 §5: hold the record open as the re-arm-by-leaving
+			// latch rather than tearing it down — reconcileCooldown (either
+			// side) clears it once we've backed off past ReArmDistM.
+			r.Phase = DockCooldown
+			return false
 		}
 		// ADR 0040 §4: my stack was taken back from my empty seat while I was
 		// gone. Say so — a vehicle that is simply missing on reconnect is the

--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -72,6 +72,15 @@ type DockRecord struct {
 	// from a crash. Set the instant the docker's side flips Pending→Active;
 	// consumed (and cleared) on the guest's own next reconcile.
 	dockNotice bool
+	// returnAtNano is the owner's sim-time when ANY returnPayload was parked
+	// — a live handback or a Parcel — so reconcileGuest can Kepler-advance
+	// the craft to the RECEIVING guest's own sim-time before adoption (ADR
+	// 0038 §4 generalises the Parcel-only ADR 0040 stamp to every return: a
+	// live guest's World can sit a few seconds off the docker's too, and at
+	// LEO speed that is kilometres of unpropagated error, #304). parcelAtNano
+	// below is kept for a Parcel already in flight from before this field
+	// existed; reconcileGuest prefers returnAtNano and falls back to it.
+	returnAtNano int64
 	// parcel marks a returnPayload the owner released while the guest was
 	// NOT there to receive it live (ADR 0040 §3). It changes what the guest
 	// is told on delivery — a Parcel arrives with an explanation rather than
@@ -544,7 +553,18 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 				r.undockRefused = true
 				return false
 			}
+			// ADR 0038 §4, generalising the ADR 0040 S3 Parcel-only helpers
+			// to every live undock (#304): clear the stack by the same push
+			// a Parcel gets, computed HERE against the composite's current
+			// state before it changes further, and stamp the release time so
+			// delivery can Kepler-advance to the guest's own sim-time rather
+			// than adopting verbatim.
+			sim.SeparationPush(restored)
 			r.returnPayload = restored
+			r.returnAtNano = w.Clock.SimTime.UnixNano()
+			// ADR 0038 §6: the docker undocks already targeting the guest's
+			// departing craft.
+			w.SetTargetGhost(r.GuestOwner, r.GuestCraftID)
 			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.GuestHandle})
 			return false
 		}
@@ -565,16 +585,21 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 				*chips = append(*chips, DockChip{Kind: sim.SessionEventReleaseRefused, Handle: r.GuestHandle})
 				return false
 			}
-			if asParcel {
-				// Nobody is at the other seat, so the craft has to arrive fit
-				// to be found: clear of the stack it left (here, while the
-				// stack's state is what the push is relative to) and, at
-				// delivery, inert and placed at the guest's own sim-time.
-				sim.SeparationPush(restored)
-				r.parcel = true
-				r.parcelAtNano = w.Clock.SimTime.UnixNano()
-			}
+			// Same push and gap-stamp for BOTH branches below (ADR 0038
+			// generalises this from the Parcel-only path — a single call,
+			// not a second copy of the magnitude): clear of the stack it
+			// left, computed against the composite's current state.
+			sim.SeparationPush(restored)
 			r.returnPayload = restored
+			r.returnAtNano = w.Clock.SimTime.UnixNano()
+			if asParcel {
+				// Nobody is at the other seat: mark it so delivery knows to
+				// explain rather than assume the guest asked for this.
+				r.parcel = true
+				r.parcelAtNano = r.returnAtNano
+			} else {
+				w.SetTargetGhost(r.GuestOwner, r.GuestCraftID)
+			}
 			*chips = append(*chips, DockChip{Kind: sim.SessionEventUndocked, Handle: r.GuestHandle})
 			return false
 		}
@@ -646,15 +671,23 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 		// Undock/abort completion: the docker handed my craft back.
 		if r.returnPayload != nil {
 			kind := sim.SessionEventUndocked
+			// ADR 0038 §4, generalised from the Parcel-only ADR 0040 stamp:
+			// Kepler-advance the craft to MY OWN sim-time before it joins my
+			// slate — a live guest's World can sit a few seconds off the
+			// docker's too (subspace clocks are only guaranteed equal within
+			// co-warp tolerance), and at LEO speed that is kilometres of
+			// error if adopted verbatim (#304). returnAtNano covers every
+			// return; parcelAtNano is the fallback for a Parcel already in
+			// flight from before returnAtNano existed.
+			switch {
+			case r.returnAtNano != 0:
+				dt := w.Clock.SimTime.Sub(time.Unix(0, r.returnAtNano)).Seconds()
+				sim.PlaceAcrossSubspaceGap(r.returnPayload, dt)
+			case r.parcel && r.parcelAtNano != 0:
+				dt := w.Clock.SimTime.Sub(time.Unix(0, r.parcelAtNano)).Seconds()
+				sim.PlaceAcrossSubspaceGap(r.returnPayload, dt)
+			}
 			if r.parcel {
-				// A Parcel: released while I was not there. It has been
-				// coasting on the record ever since, so place it at MY
-				// sim-time before it joins my slate — a craft dropped in at
-				// the owner's hour-old state would be kilometres wrong.
-				if r.parcelAtNano != 0 {
-					dt := w.Clock.SimTime.Sub(time.Unix(0, r.parcelAtNano)).Seconds()
-					sim.PlaceAcrossSubspaceGap(r.returnPayload, dt)
-				}
 				// Safed at DELIVERY, not at release: the throttle and the
 				// live burn state are not part of a craft's persisted form,
 				// so safing at release would be undone by the first restart
@@ -662,6 +695,10 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 				// it is applied has to be the arrival.
 				sim.SafeHandback(r.returnPayload)
 				kind = sim.SessionEventParcelReturned
+			} else {
+				// ADR 0038 §6: I undock already targeting the stack I just
+				// left.
+				w.SetTargetGhost(r.Owner, r.CompositeID)
 			}
 			w.AdoptCraft(r.returnPayload, true)
 			r.returnPayload = nil

--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -65,6 +65,13 @@ type DockRecord struct {
 	aborted         bool                   // docker couldn't fuse / the stack is gone — the dock ends
 	releaseAsk      bool                   // owner→own tick: release the guest's component (ADR 0040 §3)
 	releaseAsParcel bool                   // that release is going to a guest who isn't there
+	// dockNotice is owed to the ABSORBED guest at fuse (ADR 0038 S1, #301):
+	// the docker's own reconcile chips itself the instant it fuses the
+	// stack, but the guest's craft left ITS World on an earlier tick with no
+	// moment at all — from that seat a successful dock was indistinguishable
+	// from a crash. Set the instant the docker's side flips Pending→Active;
+	// consumed (and cleared) on the guest's own next reconcile.
+	dockNotice bool
 	// parcel marks a returnPayload the owner released while the guest was
 	// NOT there to receive it live (ADR 0040 §3). It changes what the guest
 	// is told on delivery — a Parcel arrives with an explanation rather than
@@ -489,6 +496,11 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 		}
 		r.CompositeID = comp.ID
 		r.Phase = DockActive
+		// ADR 0038 S1 (#301): the guest's own chip can't be raised HERE —
+		// this reconcile is running against the OWNER's World, and chips
+		// returned here are addressed to the owner. Flag it for the guest's
+		// own next reconcile to raise instead.
+		r.dockNotice = true
 		*chips = append(*chips, DockChip{Kind: sim.SessionEventDocked, Handle: r.GuestHandle})
 		return false
 
@@ -624,6 +636,13 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 		return false
 
 	case DockActive:
+		// ADR 0038 S1 (#301): the fuse just happened to me on the owner's
+		// tick, which can't chip a moment into MY session's slate — raise it
+		// here, the first chance this side gets.
+		if r.dockNotice {
+			r.dockNotice = false
+			*chips = append(*chips, DockChip{Kind: sim.SessionEventDocked, Handle: r.OwnerHandle})
+		}
 		// Undock/abort completion: the docker handed my craft back.
 		if r.returnPayload != nil {
 			kind := sim.SessionEventUndocked

--- a/internal/relay/dock_lifecycle_test.go
+++ b/internal/relay/dock_lifecycle_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // TestLiveUndockPushesClearOfTheStack (#304, zero subspace skew): a live
@@ -224,5 +226,109 @@ func TestFuseNoticeSurvivesRestart(t *testing.T) {
 	guestChips := fresh.Reconcile(wB, fpB, reports)
 	if !hasChip(guestChips, sim.SessionEventDocked) {
 		t.Errorf("the absorbed guest's fuse notice did not survive a restart: %+v", guestChips)
+	}
+}
+
+// TestLiveUndockAlwaysReturnsASafedCraft (#303) extends the Parcel-only
+// safing (TestOwnerReleasesAnAbsentGuestAsAParcel) to the LIVE cross-player
+// path: the guest's craft comes back inert regardless of what the docker had
+// dialled in while flying the stack. Measured repro: 10% throttle, RCS,
+// Target Retrograde inherited from the docker onto a craft the guest had left
+// at 100%/main/prograde.
+func TestLiveUndockAlwaysReturnsASafedCraft(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1005
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+
+	// The docker flies the fused stack with a different control setup than
+	// the guest ever chose.
+	stack := wA.Crafts[0]
+	stack.Throttle = 0.1
+	stack.EngineMode = spacecraft.EngineRCS
+	stack.AttitudeMode = spacecraft.BurnTargetRetrograde
+	stack.ManualBurn = &spacecraft.ManualBurn{StartTime: wA.Clock.SimTime}
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not get craft %d back", guestID)
+	}
+	if got.Throttle != 0 {
+		t.Errorf("returned craft throttle = %v, want 0", got.Throttle)
+	}
+	if got.EngineMode != spacecraft.EngineMain {
+		t.Errorf("returned craft engine mode = %v, want main", got.EngineMode)
+	}
+	if got.AttitudeMode != spacecraft.BurnPrograde {
+		t.Errorf("returned craft attitude hold = %v, want the neutral default", got.AttitudeMode)
+	}
+	if got.ActiveBurn != nil || got.ManualBurn != nil {
+		t.Errorf("returned craft arrived with a burn running")
+	}
+}
+
+// TestReArmLatchBlocksImmediateReclaimUntilSeparation (ADR 0038 §5): undocking
+// disarms auto-dock with that partner (same craft pair) until they back away
+// past ReArmDistM. Pre-fix there is no latch at all — the ledger record is
+// torn down completely the instant the guest receives its craft, so a fresh
+// Claim on the exact same pair succeeds immediately, which is exactly the
+// silent-instant-re-fuse risk the ADR calls out.
+func TestReArmLatchBlocksImmediateReclaimUntilSeparation(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1006
+	wA, wB := alignedPair(t, guestID)
+	dockerID := wA.ActiveCraft().ID
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	// Immediately drifting back within the gates (the "pilot still setting up
+	// the safed ship" scenario): a fresh claim on the SAME pair must refuse.
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); ok {
+		t.Fatalf("re-claim succeeded before the pair backed away — the re-arm latch did not hold")
+	}
+
+	// Separate for real, well past ReArmDistM, and let the owner's side
+	// notice on its next reconcile.
+	guestIdx := -1
+	for i, c := range wB.Crafts {
+		if c != nil && c.ID == guestID {
+			guestIdx = i
+		}
+	}
+	if guestIdx < 0 {
+		t.Fatalf("guest craft not found in B's slate")
+	}
+	wB.Crafts[guestIdx].State.R = wB.Crafts[guestIdx].State.R.Add(orbital.Vec3{X: 2 * sim.ReArmDistM})
+
+	reports = reportMap(store, wA, wB, now.Add(2*time.Second))
+	ledger.Reconcile(wA, fpA, reports) // owner side notices the separation, clears the latch
+
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); !ok {
+		t.Fatalf("re-claim still refused after backing away past the re-arm distance")
 	}
 }

--- a/internal/relay/dock_lifecycle_test.go
+++ b/internal/relay/dock_lifecycle_test.go
@@ -1,0 +1,71 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// ADR 0038 S1/S2/S3 (#301, #303, #304): the lifecycle around the dock/undock
+// fuse, generalising ADR 0040's Parcel-only safe-handback and subspace-gap
+// helpers to the live cross-player path, plus the re-arm-by-leaving latch.
+
+// TestFuseChipsTheAbsorbedGuestToo is #301, live: the docker's own reconcile
+// already got a "docked" chip when the stack fused (TestCrossPlayerDockHandshakeAndUndock
+// pins that). What was missing is the ABSORBED party's own moment — measured
+// on the 2026-08-02 session as a total UI blank with no chip of any kind on
+// the passive seat. The guest's own next reconcile, once the fuse has
+// happened on the owner's side, must carry its own "docked" chip.
+func TestFuseChipsTheAbsorbedGuestToo(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1001
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	if _, ok := ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID); !ok {
+		t.Fatalf("Claim refused")
+	}
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports) // B hands its craft over — no chip yet, nothing happened to B yet
+
+	ownerChips := ledger.Reconcile(wA, fpA, reports) // A fuses the stack
+	if !hasChip(ownerChips, sim.SessionEventDocked) {
+		t.Fatalf("owner got no docked chip: %+v", ownerChips)
+	}
+
+	// B's own next reconcile must carry the moment that just happened to it:
+	// its craft joined someone else's stack.
+	guestChips := ledger.Reconcile(wB, fpB, reports)
+	if !hasChip(guestChips, sim.SessionEventDocked) {
+		t.Errorf("the absorbed guest got no docked chip at fuse (#301): %+v", guestChips)
+	}
+}
+
+// TestFuseNoticeSurvivesRestart (#301, durability): the absorbed guest's
+// pending "docked" chip is owed at fuse, but the guest might not tick again
+// before a restart. DockNotice has to round-trip through the session
+// directory the same way every other in-flight flag on the record does
+// (ADR 0040 §1), or a restart in that narrow window drops the guest's own
+// moment silently — the exact kind of silence #301 was about.
+func TestFuseNoticeSurvivesRestart(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1007
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports) // B hands its craft over
+	ledger.Reconcile(wA, fpA, reports) // A fuses — dockNotice set for B
+
+	// The server restarts before B's own next tick ever consumes the notice.
+	fresh := restart(t, ledger)
+
+	guestChips := fresh.Reconcile(wB, fpB, reports)
+	if !hasChip(guestChips, sim.SessionEventDocked) {
+		t.Errorf("the absorbed guest's fuse notice did not survive a restart: %+v", guestChips)
+	}
+}

--- a/internal/relay/dock_lifecycle_test.go
+++ b/internal/relay/dock_lifecycle_test.go
@@ -7,6 +7,163 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
+// TestLiveUndockPushesClearOfTheStack (#304, zero subspace skew): a live
+// (both-present) cross-player undock — the guest-ask path — must clear the
+// stack by the same 75 m / 0.15 m/s push the Parcel path already carries.
+// Pre-fix, this path had NO push at all: the returned craft landed at
+// exactly the stack's position.
+func TestLiveUndockPushesClearOfTheStack(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1002
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	stackR := wA.Crafts[0].State.R
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not get craft %d back", guestID)
+	}
+	d := got.State.R.Sub(stackR).Norm()
+	if d <= sim.DockingDistM {
+		t.Errorf("returned craft is %v m from the stack — inside the %v m docking gate, no push applied", d, sim.DockingDistM)
+	}
+	// Bound the OTHER direction too: with zero subspace skew this should be
+	// JUST the push, not a huge propagated jump (that's the next test).
+	if d > 500 {
+		t.Errorf("returned craft is %v m from the stack with zero skew — expected just the separation push", d)
+	}
+}
+
+// TestLiveUndockPlacesAcrossSubspaceGap (#304, nonzero subspace skew): the
+// guest's own World can be a few seconds ahead of or behind the docker's when
+// the split lands — the ordinary case, since subspace clocks are only
+// guaranteed equal within co-warp tolerance. The returned craft must be
+// Kepler-propagated to the GUEST's own sim-time, not adopted verbatim at the
+// docker's. At LEO speed a few seconds of unpropagated skew is kilometres of
+// error (the exact magnitude measured live) — so a large gap should produce
+// a displacement far bigger than the separation push alone.
+func TestLiveUndockPlacesAcrossSubspaceGap(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1003
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	stackR := wA.Crafts[0].State.R
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	// B's subspace clock runs 5s ahead of A's by the time the split lands.
+	wB.Clock.SimTime = wA.Clock.SimTime.Add(5 * time.Second)
+
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports) // A splits the guest out (at A's sim-time)
+	ledger.Reconcile(wB, fpB, reports) // B receives it, placed at B's OWN sim-time
+
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not get craft %d back", guestID)
+	}
+	d := got.State.R.Sub(stackR).Norm()
+	// 5 s at LEO orbital speed (~km/s) is kilometres — far more than the 75 m
+	// push alone could produce. A verbatim (unpropagated) copy would land at
+	// ~75 m, same as the zero-skew case above.
+	if d < 1000 {
+		t.Errorf("returned craft displaced only %v m across a 5s subspace gap — not Kepler-propagated", d)
+	}
+}
+
+// TestUndockSetsMutualTargets (ADR 0038 §6): at handback the docker's target
+// slot holds the returned craft and the guest's holds the stack they just
+// left — range and closure readable from the first frame, rather than
+// starting blind (pre-fix, undock cleared the guest's target selection
+// entirely).
+func TestUndockSetsMutualTargets(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1004
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	compositeID := wA.Crafts[0].ID
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	if wA.Target.Kind != sim.TargetGhost || wA.Target.GhostOwner != fpB || wA.Target.CraftID != guestID {
+		t.Errorf("docker target = %+v, want a ghost target at (%s, %d)", wA.Target, fpB, guestID)
+	}
+	if wB.Target.Kind != sim.TargetGhost || wB.Target.GhostOwner != fpA || wB.Target.CraftID != compositeID {
+		t.Errorf("guest target = %+v, want a ghost target at (%s, %d)", wB.Target, fpA, compositeID)
+	}
+}
+
+// TestReturnAtNanoSurvivesRestart (#304, durability): the release-time stamp
+// a live undock's subspace-gap placement reads at delivery must round-trip
+// the same way, or a restart between the split and the guest's own tick
+// drops the stamp and the returned craft is adopted verbatim again.
+func TestReturnAtNanoSurvivesRestart(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1008
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	stackR := wA.Crafts[0].State.R
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	wB.Clock.SimTime = wA.Clock.SimTime.Add(5 * time.Second)
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports) // A splits the guest out, stamps returnAtNano
+
+	// The server restarts before B's own tick ever delivers the return.
+	fresh := restart(t, ledger)
+
+	guestChips := fresh.Reconcile(wB, fpB, reports)
+	if !hasChip(guestChips, sim.SessionEventUndocked) {
+		t.Fatalf("no undocked chip after restart: %+v", guestChips)
+	}
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not get craft %d back after restart", guestID)
+	}
+	if d := got.State.R.Sub(stackR).Norm(); d < 1000 {
+		t.Errorf("returned craft displaced only %v m across the 5s gap — returnAtNano did not survive the restart", d)
+	}
+}
+
 // ADR 0038 S1/S2/S3 (#301, #303, #304): the lifecycle around the dock/undock
 // fuse, generalising ADR 0040's Parcel-only safe-handback and subspace-gap
 // helpers to the live cross-player path, plus the re-arm-by-leaving latch.

--- a/internal/relay/dock_persist.go
+++ b/internal/relay/dock_persist.go
@@ -56,6 +56,10 @@ type DockSnapshot struct {
 	ParcelAtNano    int64
 	ReclaimNotice   bool
 	ReclaimAtNano   int64
+	// DockNotice (ADR 0038 S1) is the absorbed guest's pending "you just got
+	// docked" chip, owed at fuse — round-tripped so a restart between the
+	// fuse and the guest's next tick doesn't drop it.
+	DockNotice bool
 }
 
 // FullRecords snapshots every live dock in full, converting the parked craft
@@ -85,6 +89,7 @@ func (l *DockLedger) FullRecords() []DockSnapshot {
 			ParcelAtNano:    r.parcelAtNano,
 			ReclaimNotice:   r.reclaimNotice,
 			ReclaimAtNano:   r.reclaimAtNano,
+			DockNotice:      r.dockNotice,
 		})
 	}
 	return out
@@ -118,6 +123,7 @@ func (l *DockLedger) SeedFull(snaps []DockSnapshot, systems []bodies.System) {
 			parcelAtNano:    s.ParcelAtNano,
 			reclaimNotice:   s.ReclaimNotice,
 			reclaimAtNano:   s.ReclaimAtNano,
+			dockNotice:      s.DockNotice,
 		}
 		l.records[rec.ID] = rec
 		if rec.ID >= l.nextID {

--- a/internal/relay/dock_persist.go
+++ b/internal/relay/dock_persist.go
@@ -60,6 +60,10 @@ type DockSnapshot struct {
 	// docked" chip, owed at fuse — round-tripped so a restart between the
 	// fuse and the guest's next tick doesn't drop it.
 	DockNotice bool
+	// ReturnAtNano (ADR 0038 S2) is the release-time stamp a live undock's
+	// subspace-gap placement reads at delivery, generalising ParcelAtNano to
+	// every return, not just Parcels.
+	ReturnAtNano int64
 }
 
 // FullRecords snapshots every live dock in full, converting the parked craft
@@ -90,6 +94,7 @@ func (l *DockLedger) FullRecords() []DockSnapshot {
 			ReclaimNotice:   r.reclaimNotice,
 			ReclaimAtNano:   r.reclaimAtNano,
 			DockNotice:      r.dockNotice,
+			ReturnAtNano:    r.returnAtNano,
 		})
 	}
 	return out
@@ -124,6 +129,7 @@ func (l *DockLedger) SeedFull(snaps []DockSnapshot, systems []bodies.System) {
 			reclaimNotice:   s.ReclaimNotice,
 			reclaimAtNano:   s.ReclaimAtNano,
 			dockNotice:      s.DockNotice,
+			returnAtNano:    s.ReturnAtNano,
 		}
 		l.records[rec.ID] = rec
 		if rec.ID >= l.nextID {

--- a/internal/relay/dock_release_test.go
+++ b/internal/relay/dock_release_test.go
@@ -133,8 +133,12 @@ func TestOwnerReleaseWithTheGuestPresentIsTheNormalUndock(t *testing.T) {
 	if hasChip(gChips, sim.SessionEventParcelReturned) {
 		t.Errorf("a live release arrived as a Parcel: %+v", gChips)
 	}
-	if got.State.R != stackR {
-		t.Errorf("live handback state %v != the seam %v", got.State.R, stackR)
+	// ADR 0038 §4/§5 generalises the Parcel-only separation push to every
+	// live undock (#304): the craft lands clear of the stack, not frozen at
+	// its exact seam — this is what stopped the pair silently re-fusing nine
+	// seconds after undocking.
+	if d := got.State.R.Sub(stackR).Norm(); d <= sim.DockingDistM {
+		t.Errorf("live handback state %v is only %v m from the seam %v — inside the docking gate", got.State.R, d, stackR)
 	}
 }
 

--- a/internal/relay/dock_test.go
+++ b/internal/relay/dock_test.go
@@ -127,9 +127,13 @@ func TestCrossPlayerDockHandshakeAndUndock(t *testing.T) {
 	if len(wA.Crafts) != 1 || sim.StackHasGuest(wA.Crafts[0]) {
 		t.Errorf("A's composite did not revert after undock")
 	}
-	// The dock is fully torn down.
-	if len(ledger.Records()) != 0 {
-		t.Errorf("ledger still holds %d records after undock", len(ledger.Records()))
+	// ADR 0038 §5: the record is held open as the re-arm-by-leaving latch
+	// (Cooldown), not torn down outright — see
+	// TestReArmLatchBlocksImmediateReclaimUntilSeparation for the latch
+	// itself clearing once the pair backs off past ReArmDistM.
+	recs := ledger.Records()
+	if len(recs) != 1 || recs[0].Phase != DockCooldown {
+		t.Errorf("ledger records after undock = %+v, want one Cooldown latch", recs)
 	}
 }
 

--- a/internal/relay/dock_test.go
+++ b/internal/relay/dock_test.go
@@ -109,8 +109,16 @@ func TestCrossPlayerDockHandshakeAndUndock(t *testing.T) {
 	if !ok {
 		t.Fatalf("B did not get craft %d back", guestID)
 	}
-	if got.State.R != stackR || got.State.V != stackV {
-		t.Errorf("returned craft state %v/%v != stack seam %v/%v", got.State.R, got.State.V, stackR, stackV)
+	// ADR 0038 §4/§5: the returned craft clears the seam by the separation
+	// push rather than landing frozen on top of it (was an exact-equality
+	// check pre-0038 — see TestLiveUndockPushesClearOfTheStack for the push
+	// magnitude and TestLiveUndockPlacesAcrossSubspaceGap for the
+	// subspace-gap propagation this generalises from the Parcel-only path).
+	if d := got.State.R.Sub(stackR).Norm(); d <= sim.DockingDistM {
+		t.Errorf("returned craft state %v is only %v m from stack seam %v — inside the docking gate", got.State.R, d, stackR)
+	}
+	if dv := got.State.V.Sub(stackV).Norm(); dv <= sim.DockingVMS {
+		t.Errorf("returned craft closing rate %v is only %v m/s from the seam — inside the docking gate", got.State.V, dv)
 	}
 	if !hasChip(uChips, sim.SessionEventUndocked) {
 		t.Errorf("no undocked chip: %+v", uChips)

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -187,6 +187,7 @@ func dockLinksToSnapshots(links []sessiondir.DockLink) []relay.DockSnapshot {
 			ReleaseAsk: l.ReleaseAsk, ReleaseAsParcel: l.ReleaseAsParcel,
 			Parcel: l.Parcel, ParcelAtNano: l.ParcelAtNano,
 			ReclaimNotice: l.ReclaimNotice, ReclaimAtNano: l.ReclaimAtNano,
+			DockNotice: l.DockNotice,
 		})
 	}
 	return out
@@ -209,6 +210,7 @@ func snapshotsToDockLinks(snaps []relay.DockSnapshot) []sessiondir.DockLink {
 			ReleaseAsk: r.ReleaseAsk, ReleaseAsParcel: r.ReleaseAsParcel,
 			Parcel: r.Parcel, ParcelAtNano: r.ParcelAtNano,
 			ReclaimNotice: r.ReclaimNotice, ReclaimAtNano: r.ReclaimAtNano,
+			DockNotice: r.DockNotice,
 		})
 	}
 	return out

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -187,7 +187,7 @@ func dockLinksToSnapshots(links []sessiondir.DockLink) []relay.DockSnapshot {
 			ReleaseAsk: l.ReleaseAsk, ReleaseAsParcel: l.ReleaseAsParcel,
 			Parcel: l.Parcel, ParcelAtNano: l.ParcelAtNano,
 			ReclaimNotice: l.ReclaimNotice, ReclaimAtNano: l.ReclaimAtNano,
-			DockNotice: l.DockNotice,
+			DockNotice: l.DockNotice, ReturnAtNano: l.ReturnAtNano,
 		})
 	}
 	return out
@@ -210,7 +210,7 @@ func snapshotsToDockLinks(snaps []relay.DockSnapshot) []sessiondir.DockLink {
 			ReleaseAsk: r.ReleaseAsk, ReleaseAsParcel: r.ReleaseAsParcel,
 			Parcel: r.Parcel, ParcelAtNano: r.ParcelAtNano,
 			ReclaimNotice: r.ReclaimNotice, ReclaimAtNano: r.ReclaimAtNano,
-			DockNotice: r.DockNotice,
+			DockNotice: r.DockNotice, ReturnAtNano: r.ReturnAtNano,
 		})
 	}
 	return out

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -135,6 +135,10 @@ type DockLink struct {
 	// and its delivery doesn't lose the stamp the Kepler-advance at
 	// delivery needs.
 	ReclaimAtNano int64 `json:"reclaim_at_unix_nano,omitempty"`
+	// DockNotice (ADR 0038 S1) is the absorbed guest's pending "you just got
+	// docked" chip, owed at fuse — round-tripped so a restart between the
+	// fuse and the guest's next tick doesn't drop it.
+	DockNotice bool `json:"dock_notice,omitempty"`
 }
 
 // Meta is the session.json shape.

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -139,6 +139,10 @@ type DockLink struct {
 	// docked" chip, owed at fuse — round-tripped so a restart between the
 	// fuse and the guest's next tick doesn't drop it.
 	DockNotice bool `json:"dock_notice,omitempty"`
+	// ReturnAtNano (ADR 0038 S2) is the release-time stamp a live undock's
+	// subspace-gap placement reads at delivery, generalising ParcelAtNano to
+	// every return, not just Parcels.
+	ReturnAtNano int64 `json:"return_at_unix_nano,omitempty"`
 }
 
 // Meta is the session.json shape.

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -337,6 +337,15 @@ const (
 	DockingVMS   = 0.1  // m/s — typical proximity-ops null-residual.
 )
 
+// ReArmDistM is the re-arm-by-leaving distance (ADR 0038 §5): once a
+// cross-player pair undocks, a fresh Claim() between the SAME pair of craft
+// is refused until they separate past this distance — "back away first,
+// then you can dock again," a rule with no invisible timer for a drift-back
+// to silently outlast. Deliberately past DockingDistM's 50 m gate (the ADR's
+// "~100 m, just outside the gate band") so re-arming isn't a coin-flip right
+// at the boundary the 75 m SeparationPush lands just inside of.
+const ReArmDistM = DockingDistM * 2 // 100 m
+
 // checkDocking scans every craft pair in the same primary frame
 // for a docking-eligible encounter (proximity + relative velocity
 // below the gate). On a match, calls DockCrafts and returns —


### PR DESCRIPTION
## Summary

Implements ADR 0038 slices S1, S2, S3 (rider view / S4 is out of scope,
being done by another agent). All three root causes were measured live on
the 2026-08-02 two-player dock session (#301, #303, #304), and this
generalises the Parcel-only helpers ADR 0040 S3 already built
(`sim.SafeHandback`, `sim.SeparationPush`, `sim.PlaceAcrossSubspaceGap`) to
the live cross-player path, per the ADR 0038 amendments from the ADR 0040
grill.

- **S1 — emission fix (#301).** The docker's own reconcile already chipped
  itself at fuse; the absorbed guest never got a moment at all — from that
  seat a successful dock was indistinguishable from a crash. Flags the
  transition (`dockNotice`) so the guest's own next reconcile raises its
  own "docked" chip; persisted so a restart in the gap doesn't drop it.
  The other two paths named in the ADR (both ledger reconcile paths, and
  the docker's local split refusing a cross-player stack) were already
  correct as of ADR 0040 — confirmed against existing tests rather than
  re-fixed.
- **S2 — return-path placement (#304).** Cross-player undock computed the
  returned craft's state in the docker's World and adopted it verbatim —
  no subspace-gap propagation, no separation push. Generalises both
  helpers to every live undock (guest-ask and owner-release), and wires
  ADR 0038 §6 mutual post-undock targeting.
- **S3 — safe handback + re-arm latch (#303).** `SafeHandback` now applies
  to every live undock, not just Parcels (throttle zero / main engine / no
  attitude hold). Adds the re-arm-by-leaving latch: undocking holds the
  ledger record open in a new `DockCooldown` phase so a fresh `Claim()`
  between the same pair of craft is refused until they separate past
  `ReArmDistM` (100 m) — durable by construction, per the ADR 0040
  amendment, since it just extends the existing ledger persistence.

## Test plan

- [x] TDD per slice — each new test observed RED against pre-fix code
      before the fix landed (see commit messages / PR description below
      for the exact failure messages recorded during development).
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- New tests: `TestFuseChipsTheAbsorbedGuestToo`, `TestFuseNoticeSurvivesRestart`,
  `TestLiveUndockPushesClearOfTheStack`, `TestLiveUndockPlacesAcrossSubspaceGap`,
  `TestUndockSetsMutualTargets`, `TestReturnAtNanoSurvivesRestart`,
  `TestLiveUndockAlwaysReturnsASafedCraft`,
  `TestReArmLatchBlocksImmediateReclaimUntilSeparation`
- Updated existing tests whose old assertions encoded the pre-fix
  behaviour on purpose: `TestCrossPlayerDockHandshakeAndUndock`,
  `TestOwnerReleaseWithTheGuestPresentIsTheNormalUndock`.

Out of scope: S4 (rider view / follow-stack camera / standing DOCKED
block) — left untouched for the other agent working it.