### PR TITLE
feat(dock): rider view — follow-stack camera, standing DOCKED block, badged panels (ADR 0038 S4)

### DIFF
--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -428,6 +428,21 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	// current. Mutates w (fuses/splits craft) — same goroutine as the tick.
 	m.reconcileDocking(w, cw.CoupledOwners, reports, handles, now)
 
+	// Rider view (ADR 0038 S4): while riding in another player's stack,
+	// name which of the owner's reported craft IS that stack (their
+	// ActiveCraftID — DockGuestCraft always fuses onto the docker's
+	// existing craft in place, so it keeps naming the composite for as
+	// long as the owner flies it) and point the camera at it. Read here
+	// rather than inside reconcileDocking/setDockGuest because both those
+	// live in the relay ledger, which only knows dock records — not which
+	// of a report's crafts the owner is actually flying.
+	if w.DockGuest != nil {
+		if rep, ok := reports[w.DockGuest.OwnerFP]; ok {
+			w.DockGuest.OwnerActiveCraftID = rep.ActiveCraftID
+		}
+		w.FollowDockGuestStack()
+	}
+
 	info := &sim.SessionInfo{
 		IsHost:        m.owner == sessiondir.HostFingerprint,
 		CanAdminister: m.srv.store.MayAdminister(m.owner),

--- a/internal/serve/rider_view_test.go
+++ b/internal/serve/rider_view_test.go
@@ -1,0 +1,84 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// TestDockGuestFollowsStackCamera drives a real cross-player dock through
+// the reporting seam (the same harness as
+// TestCrossPlayerDockThroughReportingModels) and asserts the ADR 0038 S4
+// follow-through: once absorbed, the guest's camera is repointed at the
+// stack's ghost — not left on FocusCraft with nothing to show (#301) — and
+// that ghost ref actually resolves (DockGuestStackGhost), so the rider-view
+// camera and badged panels have real data to render, not a dangling ref.
+func TestDockGuestFollowsStackCamera(t *testing.T) {
+	const guestFP = "SHA256:gern-rider"
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, guestFP, "gern")
+
+	hostApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New host: %v", err)
+	}
+	guestApp, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New guest: %v", err)
+	}
+	var host tea.Model = srv.HostModel(hostApp)
+	var guest tea.Model = srv.withReporting(guestApp, guestFP)
+
+	hw, gw := hostApp.World(), guestApp.World()
+	gw.Clock.SimTime = hw.Clock.SimTime
+	gw.ActiveCraft().ID = 778
+	gw.ActiveCraft().State = hw.ActiveCraft().State
+	// The guest was flying normally before the dock (FocusCraft) — the
+	// baseline #301 regressed from.
+	gw.Focus = sim.Focus{Kind: sim.FocusCraft}
+
+	guest = tick(guest)
+	host = tick(host)
+
+	for i := 0; i < 6 && !hostStackHasGuest(hw); i++ {
+		gw.Clock.SimTime = hw.Clock.SimTime
+		if gc, hc := gw.ActiveCraft(), hw.ActiveCraft(); gc != nil && hc != nil && !hostStackHasGuest(hw) {
+			gc.State = hc.State
+		}
+		host, _ = host.Update(sim.TickMsg(time.Now()))
+		guest, _ = guest.Update(sim.TickMsg(time.Now()))
+	}
+	if !hostStackHasGuest(hw) {
+		t.Fatalf("host never fused a cross-player stack (crafts=%d, coupled=%v)", len(hw.Crafts), hw.CoWarp.Coupled)
+	}
+	if gw.DockGuest == nil {
+		t.Fatalf("guest world not docked-as-guest")
+	}
+
+	// A few more rounds: the guest's own report of "my craft is gone" and the
+	// host's report of its now-fused ActiveCraftID both need to round-trip
+	// through the store before the guest's tick can resolve a ghost for it.
+	for i := 0; i < 4; i++ {
+		gw.Clock.SimTime = hw.Clock.SimTime
+		host, _ = host.Update(sim.TickMsg(time.Now()))
+		guest, _ = guest.Update(sim.TickMsg(time.Now()))
+	}
+
+	if gw.Focus.Kind != sim.FocusGhost {
+		t.Fatalf("guest camera not following the stack: Focus = %+v", gw.Focus)
+	}
+	if gw.Focus.GhostOwner != sessiondir.HostFingerprint {
+		t.Errorf("guest camera following the wrong owner: %+v", gw.Focus)
+	}
+	if _, _, ok := gw.DockGuestStackGhost(); !ok {
+		t.Errorf("guest camera points at a ghost ref that does not resolve: Focus=%+v Ghosts=%+v", gw.Focus, gw.Ghosts)
+	}
+	if len(gw.Crafts) != 0 {
+		t.Errorf("guest slate not empty as expected post-fuse: %d crafts", len(gw.Crafts))
+	}
+}

--- a/internal/sim/dock_guest_rider_test.go
+++ b/internal/sim/dock_guest_rider_test.go
@@ -1,0 +1,168 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// Rider view (ADR 0038 S4): while one of this player's craft rides in
+// another player's stack, the guest's own Crafts slate is empty (#301) —
+// there is nothing local left for FocusCraft to track. FollowDockGuestStack
+// repoints the camera at the stack's ghost, reusing the existing Spectate
+// mechanism (FocusGhost, v0.28 S6) rather than inventing a new Focus kind.
+
+func riderTestWorld(t *testing.T) *World {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	return w
+}
+
+// dockGuestGhost builds a Ghost representing the stack owner's active craft
+// plus registers it on the world, mirroring what GhostsFor would produce
+// from the owner's reported state.
+func dockGuestGhost(w *World) Ghost {
+	c := w.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 400e3
+	rel := orbital.Vec3{X: r}
+	vel := orbital.Vec3{Y: math.Sqrt(mu / r)}
+	g := Ghost{
+		Owner: "SHA256:host", CraftID: 99, Handle: "jason", Name: "jason's stack",
+		PrimaryID: c.Primary.ID,
+		Pos:       w.BodyPosition(c.Primary).Add(rel), RelPos: rel, Vel: vel,
+	}
+	w.Ghosts = []Ghost{g}
+	return g
+}
+
+// TestFollowDockGuestStackEntersSpectate: entering DockGuest state points
+// the camera at the stack's ghost via FocusGhost — the follow-stack camera,
+// ADR 0038 §2.
+func TestFollowDockGuestStackEntersSpectate(t *testing.T) {
+	w := riderTestWorld(t)
+	w.Focus = Focus{Kind: FocusCraft}
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+
+	w.FollowDockGuestStack()
+
+	if w.Focus.Kind != FocusGhost || w.Focus.GhostOwner != g.Owner || w.Focus.GhostCraftID != g.CraftID {
+		t.Fatalf("FollowDockGuestStack focus = %+v, want ghost ref %s/%d", w.Focus, g.Owner, g.CraftID)
+	}
+	if got := w.FocusPosition(); got.Sub(g.Pos).Norm() > 1e-6 {
+		t.Errorf("follow-stack camera position = %+v, want ghost Pos %+v", got, g.Pos)
+	}
+}
+
+// TestFollowDockGuestStackNoopWhenNotDocked: no DockGuest link means no
+// camera change at all — solo/live-flying players are unaffected.
+func TestFollowDockGuestStackNoopWhenNotDocked(t *testing.T) {
+	w := riderTestWorld(t)
+	w.Focus = Focus{Kind: FocusCraft}
+	w.FollowDockGuestStack()
+	if w.Focus.Kind != FocusCraft {
+		t.Errorf("Focus changed with no DockGuest: %+v", w.Focus)
+	}
+}
+
+// TestFollowDockGuestStackIdempotent: calling it again once already
+// tracking the same ghost must not reassign Focus — this is what keeps
+// player pan/zoom composed over the fit (Camera Contract, ADR 0021): a
+// literal reassignment to an unchanged value is harmless by struct
+// equality, but the method must not, say, needlessly re-derive a
+// different-looking Focus value that would upset a consumer comparing by
+// equality for the Framing Event gate.
+func TestFollowDockGuestStackIdempotent(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	w.FollowDockGuestStack()
+	first := w.Focus
+	w.FollowDockGuestStack()
+	if w.Focus != first {
+		t.Errorf("FollowDockGuestStack changed an already-tracking Focus: %+v -> %+v", first, w.Focus)
+	}
+}
+
+// TestDockGuestStackGhostResolves: the helper both screens (VESSEL/ORBIT
+// badged panels) and the camera use to find the stack's live state.
+func TestDockGuestStackGhostResolves(t *testing.T) {
+	w := riderTestWorld(t)
+	if _, _, ok := w.DockGuestStackGhost(); ok {
+		t.Fatal("resolved a ghost with no DockGuest set")
+	}
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	got, primary, ok := w.DockGuestStackGhost()
+	if !ok {
+		t.Fatal("DockGuestStackGhost refused with a valid DockGuest + matching ghost")
+	}
+	if got.CraftID != g.CraftID || got.Owner != g.Owner {
+		t.Errorf("resolved ghost = %+v, want %+v", got, g)
+	}
+	if primary == nil || primary.ID != g.PrimaryID {
+		t.Errorf("resolved primary = %+v, want ID %s", primary, g.PrimaryID)
+	}
+
+	// Stale ref (ghost gone — owner's report hasn't arrived yet, or they
+	// left the system): degrades to ok=false rather than a dangling ref.
+	w.Ghosts = nil
+	if _, _, ok := w.DockGuestStackGhost(); ok {
+		t.Error("DockGuestStackGhost resolved a vanished ghost")
+	}
+}
+
+// TestDockOwnerOnlineReusesPresenceGate: the rider-view standing block's
+// empty-seat fork (ADR 0038 amendment 3) reads the SAME presence gate
+// ADR 0040 §4's reclaim already reuses (SessionInfo.Players[].Online, itself
+// Server.presence.isOnline) rather than inventing new plumbing — a roster
+// already carrying this per player.
+func TestDockOwnerOnlineReusesPresenceGate(t *testing.T) {
+	w := riderTestWorld(t)
+	if w.DockOwnerOnline() {
+		t.Error("DockOwnerOnline true with no DockGuest at all")
+	}
+	w.DockGuest = &DockGuestLink{OwnerFP: "SHA256:host", OwnerHandle: "jason"}
+	if w.DockOwnerOnline() {
+		t.Error("DockOwnerOnline true with no Session roster to consult")
+	}
+	w.Session = &SessionInfo{Players: []SessionPlayer{
+		{Fingerprint: "SHA256:host", Handle: "jason", Online: false},
+	}}
+	if w.DockOwnerOnline() {
+		t.Error("DockOwnerOnline true while the roster says the owner is offline")
+	}
+	w.Session.Players[0].Online = true
+	if !w.DockOwnerOnline() {
+		t.Error("DockOwnerOnline false while the roster says the owner is online")
+	}
+}
+
+// TestAdoptCraftReturnsCameraFromGhostFocus: getting a real, controllable
+// craft back (undock handback) while the camera was spectating a ghost
+// must return the camera to it — otherwise the safe handback lands the
+// player on a live, flyable ship while the view keeps showing the stack
+// they just left (ADR 0038 §2 follow-through).
+func TestAdoptCraftReturnsCameraFromGhostFocus(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.Focus = Focus{Kind: FocusGhost, GhostOwner: g.Owner, GhostCraftID: g.CraftID}
+	w.Crafts = nil
+	w.ActiveCraftIdx = 0
+
+	if w.ActiveCraft() != nil {
+		t.Fatal("test setup: slate should be empty pre-adopt")
+	}
+	c := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	w.AdoptCraft(c, true)
+
+	if w.Focus.Kind == FocusGhost {
+		t.Errorf("Focus still spectating a ghost after a craft was adopted active: %+v", w.Focus)
+	}
+}

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -256,6 +257,16 @@ func (w *World) AdoptCraft(c *spacecraft.Spacecraft, makeActive bool) int {
 	idx := len(w.Crafts) - 1
 	if makeActive {
 		w.SetActiveCraftIdx(idx)
+		// A real, flyable craft just landed on the active slot. If the
+		// camera was spectating a ghost (rider view, ADR 0038 §2 — most
+		// commonly the guest's own stack while docked) it must return to
+		// the player's own craft: a safe handback that leaves the view
+		// parked on the stack you just left reads as though nothing
+		// happened. SetActiveCraftIdx only resets Focus on a cross-system
+		// switch, so a same-system handback needs this explicit check.
+		if w.Focus.Kind == FocusGhost {
+			w.Focus = w.ownCraftFocus()
+		}
 	}
 	return idx
 }
@@ -314,6 +325,65 @@ type DockGuestLink struct {
 	// liveness to consult); the flight view renders it as a standing line,
 	// the docked-as-guest sibling of RendezvousPartnerAway.
 	OwnerAway bool
+
+	// OwnerActiveCraftID is the stack owner's currently-reported active
+	// craft ID — the ghost that IS the stack this player rides in (ADR
+	// 0038 S4). DockGuestCraft always fuses onto the docker's existing
+	// craft in place (the composite keeps the docker's identity, §"Cross-
+	// player docking" above), so the owner's own reported ActiveCraftID
+	// names the fused composite for as long as they keep flying it. Zero
+	// until the owner's first report lands; the rider-view camera and
+	// badged panels both degrade gracefully (ok=false) rather than
+	// tracking craft ID 0.
+	OwnerActiveCraftID uint64
+}
+
+// FollowDockGuestStack keeps the rider's camera on the stack they are
+// riding (ADR 0038 §2 — the follow-stack camera). The guest's own Crafts
+// slate goes empty at the fuse (#301), so FocusCraft has nothing left to
+// track; rather than invent a new Focus kind, this reuses Spectate's
+// FocusGhost (v0.28 S6) — "watch a remote craft" is exactly the rider's
+// situation. Safe to call every tick: assigning the identical Focus value
+// is a no-op by struct equality (the same idiom CycleFocus and
+// SetActiveCraftIdx already rely on), so a genuine Framing Event — a real
+// re-fit — only happens on the tick the tracked ref actually changes:
+// entering the ride, or the owner moving to a different active craft.
+// Manual pan/zoom the player applies afterward composes over that fit and
+// persists across ticks exactly as it does for a manually-entered
+// Spectate. No-op while not docked as a guest.
+func (w *World) FollowDockGuestStack() {
+	if w.DockGuest == nil {
+		return
+	}
+	want := Focus{Kind: FocusGhost, GhostOwner: w.DockGuest.OwnerFP, GhostCraftID: w.DockGuest.OwnerActiveCraftID}
+	if w.Focus != want {
+		w.Focus = want
+	}
+}
+
+// DockGuestStackGhost resolves the stack this player rides in to its live
+// ghost + SOI primary (ADR 0038 §2 "badged panels"): the VESSEL/ORBIT
+// chips read this to show the stack's real flight data — badged with the
+// owner's handle — instead of the bare "why is this empty" placeholder.
+// ok is false with no DockGuest, no ghost report yet (owner hasn't
+// reported since the fuse), or the ghost's primary not resolving in the
+// viewer's current system (owner in a different system/body) — every
+// case degrades to the caller's existing empty-slate fallback rather than
+// a dangling reference.
+func (w *World) DockGuestStackGhost() (Ghost, *bodies.CelestialBody, bool) {
+	if w.DockGuest == nil {
+		return Ghost{}, nil, false
+	}
+	g, ok := w.ghostByRef(w.DockGuest.OwnerFP, w.DockGuest.OwnerActiveCraftID)
+	if !ok {
+		return Ghost{}, nil, false
+	}
+	sys := w.System()
+	primary := sys.FindBody(g.PrimaryID)
+	if primary == nil {
+		return Ghost{}, nil, false
+	}
+	return g, primary, true
 }
 
 // WithDockCoupling folds a docked-as-guest coupling into the co-warp state

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -184,3 +184,27 @@ type SessionEvent struct {
 	// that accounts for it. Zero on every other kind.
 	Elapsed time.Duration
 }
+
+// DockOwnerOnline reports whether the stack owner named by DockGuest has a
+// live Session right now (ADR 0038 amendment 3 / ADR 0040 §4's empty-seat
+// gate). This is the SAME presence gate the reclaim flow already uses —
+// Server.presence.isOnline — reused here via the roster the reporting
+// layer already fills in each tick (SessionInfo.Players[].Online) rather
+// than plumbing a second copy through the docking ledger. Distinct from
+// DockGuest.OwnerAway, which is true for an idle-but-still-connected owner
+// (ADR 0036): an Away owner still holds their seat, so [u] stays theirs to
+// grant; only a Session that is not live at all is an empty seat. False
+// (renders as empty-seat) with no DockGuest, or no matching roster row —
+// conservative by design, since an unconfirmed owner should not offer the
+// "ask them" flow.
+func (w *World) DockOwnerOnline() bool {
+	if w.DockGuest == nil || w.Session == nil {
+		return false
+	}
+	for _, p := range w.Session.Players {
+		if p.Fingerprint == w.DockGuest.OwnerFP {
+			return p.Online
+		}
+	}
+	return false
+}

--- a/internal/tui/screens/dock_guest_rider_render_test.go
+++ b/internal/tui/screens/dock_guest_rider_render_test.go
@@ -1,0 +1,78 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// riderViewTheme mirrors chipTestTheme but is exported-local to this file
+// (kept separate from the other render smoke tests so it's obvious this
+// one is meant to be read, not just asserted against).
+func riderViewTheme() Theme {
+	return Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+}
+
+// TestDockGuestRenderLooksRight is a "render and actually look at it" check
+// (ADR 0038 S4): a real full-frame Render call with a DockGuest + ghost
+// fixture, live and empty-seat, printed via -v so a mangled column (a
+// width-2 glyph, a broken border, an overlapping chip) is visible to a
+// human reviewer rather than only passing a substring assertion. Also
+// pins the structural invariants a substring check could miss: the DOCKED
+// block and the VESSEL/ORBIT panels must all appear, and the canvas must
+// not blow past its requested width (padChipBlock/overlayStyledBlock
+// mismatches show up as a wildly long line).
+func TestDockGuestRenderLooksRight(t *testing.T) {
+	v := NewOrbitView(riderViewTheme())
+	v.Resize(200, 60)
+
+	for _, tc := range []struct {
+		name   string
+		online bool
+	}{
+		{"live-owner", true},
+		{"empty-seat", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := dockGuestStackGhostWorld(t)
+			w.Session = &sim.SessionInfo{Players: []sim.SessionPlayer{
+				{Fingerprint: w.DockGuest.OwnerFP, Handle: w.DockGuest.OwnerHandle, Online: tc.online},
+			}}
+
+			out := v.Render(w, 0, 200, 60)
+			t.Logf("=== DockGuest render (%s) ===\n%s", tc.name, out)
+
+			for _, want := range []string{"DOCKED", "riding in bob's stack", "VESSEL", "bob's stack"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s render missing %q", tc.name, want)
+				}
+			}
+			if tc.online {
+				if !strings.Contains(out, "[J] request control") || !strings.Contains(out, "[u] ask to undock") {
+					t.Errorf("%s render missing the live-owner exits", tc.name)
+				}
+			} else {
+				if !strings.Contains(out, "take the stick") {
+					t.Errorf("%s render missing the empty-seat exit", tc.name)
+				}
+			}
+
+			for i, line := range strings.Split(out, "\n") {
+				if width := lipgloss.Width(line); width > 220 {
+					t.Errorf("%s render line %d is %d cells wide (canvas requested at 200) — a chip likely overran: %q", tc.name, i, width, line)
+				}
+			}
+		})
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -79,9 +79,11 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// RENDEZVOUS is: it explains a constraint the player can't otherwise
 	// see. Nil inside an agreement, where the chip above says it better.
 	add("", cornerTopLeft, v.buildTimeLockChip(w))
-	// DOCKED (#253): the standing away line for the other Commitment kind
-	// — renders only while docked-as-guest with the stack owner away.
-	// Always-on like RENDEZVOUS (empty id); F2 declutter still clears it.
+	// DOCKED (ADR 0038 S4): the rider-view standing block — unconditional
+	// while one of this player's craft rides in another player's stack
+	// (names the ride + the exits), with #253's owner-away line folded in
+	// as an extra row rather than a second surface. Always-on like
+	// RENDEZVOUS (empty id); F2 declutter still clears it.
 	add("", cornerTopLeft, v.buildDockGuestChip(w))
 	// COMMS link status for the active probe (ADR 0027 / C2-7), beneath the
 	// vessel-state readouts. Force-shown while a just-blocked command is
@@ -603,25 +605,54 @@ func CraftTag(name string) string {
 	return " (" + name + ")"
 }
 
-// buildDockGuestChip is the docked-as-guest standing away surface (#253):
-// while one of this player's craft rides in another player's stack, the
-// stack owner going Away — session still flying under the Commitment
-// Reprieve, nobody at the controls — needs an on-screen representation
-// that outlives the 6 s went-quiet SESSION chip. The dock itself has no
-// persistent flight-view chip (couple/dock moments are TTL'd SESSION
-// events), so this renders only while the owner is actually away and
-// stays nil otherwise.
+// buildDockGuestChip is the rider-view standing DOCKED block (ADR 0038
+// S4): while one of this player's craft rides in another player's stack,
+// this renders on EVERY frame — not only while the owner is away, which
+// was #253's older and narrower treatment — naming the ride and the way
+// out. Half of every dock used to be experienced as a crash (#301, the
+// absorbed seat's whole flight UI blanking with no explanation); this is
+// the standing surface that replaces the silence.
+//
+// The exit list forks on whether the stack owner has a live Session right
+// now (w.DockOwnerOnline, the same presence gate ADR 0040 §4's empty-seat
+// reclaim already uses): a connected owner — even an idle/Away one — gets
+// the ask-first phrasing, since undocking is theirs to grant; an owner
+// with no live Session at all is the empty-seat case, where [J] grants
+// instantly (ADR 0040 §4), so the row says so and the now-meaningless
+// "ask to undock" drops — there is nobody to ask.
+//
+// #253's away line survives as an EXTRA row on this same block rather
+// than a second, competing one — "one surface, not two" (ADR 0038
+// consequences). An away owner is by definition still connected
+// (Server.isAway is false for an offline fingerprint), so the away row
+// and the empty-seat exit fork never both fire.
 func (v *OrbitView) buildDockGuestChip(w *sim.World) []string {
 	dg := w.DockGuest
-	if dg == nil || !dg.OwnerAway {
+	if dg == nil {
 		return nil
 	}
-	return []string{
+	handle := dg.OwnerHandle
+	if handle == "" {
+		handle = "their"
+	}
+	lines := []string{
 		v.theme.Primary.Render("DOCKED"),
+		"  " + v.theme.Dim.Render("◇ riding in "+handle+"'s stack"),
+	}
+	if w.DockOwnerOnline() {
+		lines = append(lines,
+			v.theme.Dim.Render("  [J] request control"),
+			v.theme.Dim.Render("  [u] ask to undock"),
+		)
+	} else {
+		lines = append(lines, v.theme.Warning.Render("  [J] take the stick (pilot's gone)"))
+	}
+	if dg.OwnerAway {
 		// "z" not 💤 — chip glyphs must be width-1 (see the away line in
 		// buildRendezvousChip for why).
-		"  " + v.theme.Warning.Render("z "+dg.OwnerHandle+" is away — their session is still flying"),
+		lines = append(lines, "  "+v.theme.Warning.Render("z "+handle+" is away — their session is still flying"))
 	}
+	return lines
 }
 
 // anyActiveBurn reports whether any craft in the slate has an in-flight
@@ -1148,7 +1179,13 @@ func (v *OrbitView) buildChuteChip(w *sim.World) []string {
 // instead of the live orbit being replaced by the projection.
 func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	if !w.CraftVisibleHere() {
-		return nil
+		// ADR 0038 S4 part 3 ("badged panels"): riding in another player's
+		// stack is the commonest reason CraftVisibleHere is false with no
+		// active craft — and it's exactly when there IS a live orbit to
+		// show, the stack's. buildDockGuestOrbitChip returns nil for every
+		// other !CraftVisibleHere case (no DockGuest, or no ghost report
+		// yet), so the ORBIT chip's existing silence is unchanged there.
+		return v.buildDockGuestOrbitChip(w)
 	}
 	c := w.ActiveCraft()
 	if c == nil {
@@ -1203,6 +1240,47 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	lines = append(lines, chipRow("period:", formatPeriod(period)))
 	lines = append(lines, chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)))
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
+	if periAlt < 0 {
+		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
+	}
+	return lines
+}
+
+// buildDockGuestOrbitChip is the ORBIT chip's badged rider-view sibling
+// (ADR 0038 S4 part 3): while riding in another player's stack, the
+// guest's own Crafts slate is empty, so the live-craft ORBIT readout above
+// has nothing to draw — exactly when there IS an orbit worth showing, the
+// stack's. Mirrors buildOrbitMetricsChip's own-craft element derivation
+// (same ElementsFromStateInFrame call) but reads the ghost's
+// primary-relative state instead of a local craft's, and headers with the
+// owner's handle so the numbers are never mistaken for the player's own
+// ship. Returns nil with no DockGuest, no ghost report yet, or a
+// degenerate/hyperbolic resolved orbit — the caller (buildOrbitMetricsChip)
+// falls through to its existing silent nil in all of those.
+func (v *OrbitView) buildDockGuestOrbitChip(w *sim.World) []string {
+	g, primary, ok := w.DockGuestStackGhost()
+	if !ok {
+		return nil
+	}
+	mu := primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(*primary)
+	el := orbital.ElementsFromStateInFrame(g.RelPos, g.Vel, mu, frame)
+	if math.IsNaN(el.A) || math.IsInf(el.A, 0) || el.A <= 0 || el.E >= 1 {
+		return nil
+	}
+	primaryR := primary.RadiusMeters()
+	apoAlt := el.Apoapsis() - primaryR
+	periAlt := el.Periapsis() - primaryR
+	header := "ORBIT"
+	if w.DockGuest.OwnerHandle != "" {
+		header = "ORBIT — " + w.DockGuest.OwnerHandle + "'s stack"
+	}
+	lines := []string{
+		v.theme.Primary.Render(header),
+		chipRow("Ap:", fmt.Sprintf("%.1f km", apoAlt/1000)),
+		chipRow("Pe:", fmt.Sprintf("%.1f km", periAlt/1000)),
+		chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)),
+	}
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
 	}

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -254,11 +254,31 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 		// riding in another player's stack is not the same situation as having
 		// no craft, and offering "launch a new flight" there would be wrong.
 		if dg := w.DockGuest; dg != nil {
-			return []string{
+			lines := []string{
 				v.theme.Primary.Render("VESSEL"),
 				"  " + v.theme.Warning.Render("docked in "+dg.OwnerHandle+"'s stack"),
-				v.theme.Dim.Render("  [u] release it"),
 			}
+			// ADR 0038 S4 part 3 ("badged panels"): once the stack's ghost
+			// report has landed, upgrade from the bare "why is this empty"
+			// placeholder to its real flight data — badged with the owner's
+			// handle so the numbers are never mistaken for this player's own
+			// ship. Ghosts don't carry fuel/mass/Δv (never reported over the
+			// wire, ADR 0034), so this shows what IS available: identity,
+			// primary, and velocity — the same fields the ORBIT chip's
+			// badged sibling (buildDockGuestOrbitChip) also draws from.
+			if g, primary, ok := w.DockGuestStackGhost(); ok {
+				name := g.Name
+				if name == "" {
+					name = "(unnamed)"
+				}
+				lines = append(lines,
+					"  "+name,
+					"  primary:   "+primary.EnglishName,
+					fmt.Sprintf("  velocity:  %.2f km/s", g.Vel.Norm()/1000),
+				)
+			}
+			lines = append(lines, v.theme.Dim.Render("  [u] release it"))
+			return lines
 		}
 		return []string{
 			v.theme.Primary.Render("NO VESSEL"),

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -2,12 +2,14 @@ package screens
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -676,6 +678,81 @@ func TestEmptySlateSaysSo(t *testing.T) {
 	}
 	if strings.Contains(out, "[n]") {
 		t.Errorf("docked-as-guest chip offers a new launch as if the craft were gone:\n%s", out)
+	}
+}
+
+// dockGuestStackGhostWorld builds a World with no local craft, docked as a
+// guest in "bob"'s stack, whose ghost carries a real 500 km circular orbit
+// around Earth — the fixture both badged-panel tests (VESSEL and ORBIT)
+// share (ADR 0038 S4 part 3).
+func dockGuestStackGhostWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.Systems[0].FindBody("Earth")
+	w.Crafts = nil
+	w.ActiveCraftIdx = 0
+	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:bob", OwnerHandle: "bob", OwnerActiveCraftID: 42}
+
+	mu := earth.GravitationalParameter()
+	r := earth.RadiusMeters() + 500e3
+	rel := orbital.Vec3{X: r}
+	vel := orbital.Vec3{Y: math.Sqrt(mu / r)}
+	w.Ghosts = []sim.Ghost{{
+		Owner: "SHA256:bob", CraftID: 42, Handle: "bob", Name: "bob's stack",
+		PrimaryID: earth.ID,
+		Pos:       w.BodyPosition(*earth).Add(rel), RelPos: rel, Vel: vel,
+	}}
+	return w
+}
+
+// TestDockGuestVesselChipShowsBadgedFlightData (ADR 0038 S4 part 3): once
+// the stack's ghost report has landed, the VESSEL chip upgrades from the
+// bare #310 "why is this empty" placeholder to the stack's real flight
+// data — name, primary, velocity — badged as the owner's rather than the
+// player's own, so the numbers never read as this player's ship.
+func TestDockGuestVesselChipShowsBadgedFlightData(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := dockGuestStackGhostWorld(t)
+
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	for _, want := range []string{"bob", "bob's stack", "Earth", "velocity:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("badged VESSEL chip missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDockGuestOrbitChipShowsBadgedShape (ADR 0038 S4 part 3): the
+// always-on ORBIT chip goes dark whenever !CraftVisibleHere (today,
+// riding as a guest) — exactly when there IS a live orbit to show, the
+// stack's. It must render the ghost's orbit shape, badged with the
+// owner's handle.
+func TestDockGuestOrbitChipShowsBadgedShape(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := dockGuestStackGhostWorld(t)
+
+	out := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if out == "" {
+		t.Fatal("ORBIT chip renders nothing while docked as a guest with a live ghost")
+	}
+	for _, want := range []string{"bob", "Ap:", "Pe:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("badged ORBIT chip missing %q:\n%s", want, out)
+		}
+	}
+
+	// Solo, no craft at all, no DockGuest: still nil — no stack to badge.
+	w2, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w2.Crafts = nil
+	w2.ActiveCraftIdx = 0
+	if got := v.buildOrbitMetricsChip(w2); got != nil {
+		t.Errorf("ORBIT chip rendered with no craft and no DockGuest:\n%s", strings.Join(got, "\n"))
 	}
 }
 

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -317,28 +317,58 @@ func TestRendezvousChipPartnerAway(t *testing.T) {
 	}
 }
 
-// The other Commitment kind gets the same treatment (#253): while docked
-// as guest, the stack owner going away surfaces as a standing line driven
-// by the DockGuest slate. There is no persistent dock chip otherwise, so
-// the builder renders only while the owner is away.
-func TestDockGuestChipOwnerAway(t *testing.T) {
+// The standing DOCKED block (ADR 0038 S4) is unconditional while riding in
+// another player's stack — a strictly wider surface than #253's original
+// away-only line. The exit list forks on whether the stack owner has a
+// live Session right now (ADR 0040 §4's empty-seat presence gate, reused
+// via the roster rather than reinvented); #253's away line survives as an
+// extra row on this SAME block, never a second competing one (ADR 0038
+// consequences: "one surface, not two").
+func TestDockGuestChipStandingBlock(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	w := rendezvousChipWorld(t)
 	if chip := v.buildDockGuestChip(w); chip != nil {
 		t.Errorf("dock chip rendered while not docked as guest:\n%s", strings.Join(chip, "\n"))
 	}
+
 	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:host", OwnerHandle: "vex"}
-	if chip := v.buildDockGuestChip(w); chip != nil {
-		t.Errorf("dock chip rendered while the stack owner is at the controls:\n%s", strings.Join(chip, "\n"))
-	}
-	w.DockGuest.OwnerAway = true
+	w.Session = &sim.SessionInfo{Players: []sim.SessionPlayer{
+		{Fingerprint: "SHA256:host", Handle: "vex", Online: true},
+	}}
 	joined := strings.Join(v.buildDockGuestChip(w), "\n")
+	for _, want := range []string{"DOCKED", "riding in vex's stack", "[J] request control", "[u] ask to undock"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("live-owner standing block missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "take the stick") {
+		t.Errorf("live-owner block offers the empty-seat exit:\n%s", joined)
+	}
+
+	// Owner away but still connected (#253): an extra row on the SAME
+	// block, not a second one, and the live-owner exits stay put.
+	w.DockGuest.OwnerAway = true
+	joined = strings.Join(v.buildDockGuestChip(w), "\n")
 	if !strings.Contains(joined, "vex is away — their session is still flying") {
 		t.Errorf("no standing away line while the stack owner is away:\n%s", joined)
 	}
+	if !strings.Contains(joined, "[u] ask to undock") {
+		t.Errorf("away row replaced the exits instead of joining them:\n%s", joined)
+	}
 	w.DockGuest.OwnerAway = false
-	if chip := v.buildDockGuestChip(w); chip != nil {
-		t.Errorf("away line still shown after the owner returned:\n%s", strings.Join(chip, "\n"))
+
+	// Empty seat (ADR 0040 §4 / amendment 3): the owner has no live Session
+	// at all. The exit list changes and [u] drops — there is nobody to ask.
+	w.Session.Players[0].Online = false
+	joined = strings.Join(v.buildDockGuestChip(w), "\n")
+	if !strings.Contains(joined, "[J] take the stick (pilot's gone)") {
+		t.Errorf("empty-seat block missing the reclaim exit:\n%s", joined)
+	}
+	if strings.Contains(joined, "ask to undock") {
+		t.Errorf("empty-seat block still offers 'ask to undock' — nobody to ask:\n%s", joined)
+	}
+	if strings.Contains(joined, "request control") {
+		t.Errorf("empty-seat block still offers the ask-first phrasing:\n%s", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements S4 of ADR 0038 (`0038-dock-lifecycle-rider-view-safe-handback.md`), amended 2026-08-03 by the ADR 0040 grill. A guest whose only craft is absorbed into another player's stack now keeps a **live flight view following the stack they're riding in**, instead of the empty system-wide view that made half of every dock read as a crash (#301).

- **Follow-stack camera** — `World.FollowDockGuestStack` repoints the camera at the stack's ghost via the existing Spectate/`FocusGhost` mechanism (v0.28 S6) rather than inventing a new Focus kind. Idempotent (Focus-equality no-op) so a genuine re-fit only happens when the tracked ref actually changes. `AdoptCraft` now returns the camera to the player's own craft on handback if it was left spectating a ghost.
- **Unconditional standing DOCKED block** — `buildDockGuestChip` now renders on every frame while docked-as-guest (not only while the owner is away, #253's older/narrower treatment):
  ```
  DOCKED
    ◇ riding in jason's stack
    [J] request control
    [u] ask to undock
  ```
  Per **amendment 3**: when the stack owner's Session is not live, the exits fork to `[J] take the stick (pilot's gone)` and `[u] ask to undock` drops (nobody to ask). #253's away line survives as an *extra row on the same block* — one surface, not two, per the ADR's consequences section.
- **Badged panels** — `buildVesselChip` / `buildOrbitMetricsChip` show the stack's real flight data (name, primary, velocity, orbit shape) badged with the owner's handle once the ghost report lands, replacing the bare "why is this empty" placeholder from the earlier #310 stopgap.

### Empty-seat detection

Reuses ADR 0040 §4's presence gate exactly — no new plumbing. `World.DockOwnerOnline()` reads `SessionInfo.Players[].Online`, which is already `Server.presence.isOnline(fp)` (the same predicate `ReclaimTarget`/`RequestTransfer` use). This is distinct from `DockGuest.OwnerAway` (idle-but-connected, ADR 0036) — an Away owner still owns their seat, only a Session that's *not live at all* is the empty-seat case.

### Scope discipline

Per the task's constraints, stayed out of `internal/relay/dock.go`, `internal/relay/dock_persist.go`, `internal/serve/dock.go`, `internal/sessiondir/sessiondir.go`, `internal/sim/docking.go` (S1-S3, PR #324) and kept edits to `orbit_chips.go`/`orbit_chip_builders.go` additive-only (another branch is mid-edit on the NODES gate there). The one new tick-path touch is in `internal/serve/reporting.go` (not on either off-limits/careful list): stamps `DockGuest.OwnerActiveCraftID` from the owner's report and calls `FollowDockGuestStack` once per tick.

No save-break: rider view is TUI/world-transient state, exactly as ADR 0038's consequences section expects.

## Test plan

TDD throughout — each test observed red against pre-fix code before implementing:
- `internal/sim/dock_guest_rider_test.go` — `FollowDockGuestStack` (enters spectate, no-op when undocked, idempotent), `DockGuestStackGhost` (resolves / degrades on stale ref), `DockOwnerOnline` (reuses the presence gate), `AdoptCraft` returning the camera from a ghost focus.
- `internal/serve/rider_view_test.go` — `TestDockGuestFollowsStackCamera` drives a real cross-player dock through the full reporting seam (host + guest reportingModels) and asserts the guest's camera ends up following the stack's resolvable ghost — confirmed red without the `reporting.go` wiring.
- `internal/tui/screens/orbit_rendezvous_chip_test.go` — `TestDockGuestChipStandingBlock` replaces the narrower `TestDockGuestChipOwnerAway`, covering live-owner / away-extra-row / empty-seat.
- `internal/tui/screens/orbit_chips_test.go` — `TestDockGuestVesselChipShowsBadgedFlightData`, `TestDockGuestOrbitChipShowsBadgedShape`.
- `internal/tui/screens/dock_guest_rider_render_test.go` — `TestDockGuestRenderLooksRight` does a full `Render` call in both live-owner and empty-seat states and logs the actual composited frame (visually inspected — clean borders, correct column widths, no ANSI-padding mangling) plus a canvas-width sanity assertion.

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] `go build ./cmd/terminal-space-program`