### PR TITLE
fix(sim): rider camera follow no longer defeats player Focus changes

### DIFF
--- a/internal/sim/dock_guest_rider_test.go
+++ b/internal/sim/dock_guest_rider_test.go
@@ -78,6 +78,11 @@ func TestFollowDockGuestStackNoopWhenNotDocked(t *testing.T) {
 // equality, but the method must not, say, needlessly re-derive a
 // different-looking Focus value that would upset a consumer comparing by
 // equality for the Framing Event gate.
+//
+// NOTE: this restates the implementation (two calls, nothing else changes
+// in between) rather than pinning the interesting case — see #331 and the
+// tests below, which change Focus *between* calls the way a player
+// actually would.
 func TestFollowDockGuestStackIdempotent(t *testing.T) {
 	w := riderTestWorld(t)
 	g := dockGuestGhost(w)
@@ -87,6 +92,110 @@ func TestFollowDockGuestStackIdempotent(t *testing.T) {
 	w.FollowDockGuestStack()
 	if w.Focus != first {
 		t.Errorf("FollowDockGuestStack changed an already-tracking Focus: %+v -> %+v", first, w.Focus)
+	}
+}
+
+// TestFollowDockGuestStackReleasesOnPlayerFocusChange (#331 case 1): f/g
+// are documented CAMERA & VIEW keys. Pressing one while riding a stack
+// exits FocusGhost via CycleFocus's Spectate-exit clause. The very next
+// tick's FollowDockGuestStack call (unconditional every tick from
+// reporting.go's refreshSession) must not stamp the ghost focus straight
+// back — that silently defeats the key.
+func TestFollowDockGuestStackReleasesOnPlayerFocusChange(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	w.FollowDockGuestStack()
+	if w.Focus.Kind != FocusGhost {
+		t.Fatalf("setup: expected the follow-stack camera to engage, got %+v", w.Focus)
+	}
+
+	// Player presses f/g: CycleFocus's Spectate-exit clause returns to
+	// own-craft (or system) framing.
+	w.CycleFocus(true)
+	afterKey := w.Focus
+	if afterKey.Kind == FocusGhost {
+		t.Fatalf("setup: CycleFocus did not leave FocusGhost: %+v", afterKey)
+	}
+
+	w.FollowDockGuestStack()
+	if w.Focus != afterKey {
+		t.Errorf("FollowDockGuestStack overrode a player-initiated f/g focus change: got %+v, want %+v", w.Focus, afterKey)
+	}
+}
+
+// TestFollowDockGuestStackReleasesOnSpectate (#331 case 2): a rider
+// Spectating a third player (the Session screen's [v] row action, app.go's
+// SessionCmdSpectate handler calling SpectateGhost) must not have the very
+// next tick snap the camera back to the stack they're riding — the toast
+// promises "spectating carol — [f] to return" and the camera must
+// actually move there.
+func TestFollowDockGuestStackReleasesOnSpectate(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	w.FollowDockGuestStack()
+
+	third := Ghost{
+		Owner: "SHA256:carol", CraftID: 7, Handle: "carol", Name: "carol's ship",
+		PrimaryID: g.PrimaryID, Pos: g.Pos, RelPos: g.RelPos, Vel: g.Vel,
+	}
+	w.Ghosts = append(w.Ghosts, third)
+	w.SpectateGhost(third.Owner, third.CraftID)
+
+	w.FollowDockGuestStack()
+
+	if w.Focus.Kind != FocusGhost || w.Focus.GhostOwner != third.Owner || w.Focus.GhostCraftID != third.CraftID {
+		t.Errorf("FollowDockGuestStack overrode a Spectate: got %+v, want ghost ref %s/%d", w.Focus, third.Owner, third.CraftID)
+	}
+}
+
+// TestFollowDockGuestStackReleasesOnSpawnFocus (#331 case 3): a rider who
+// spawns a second vessel while still docked gets focusNewCraft (spawn.go)
+// pointing Focus at the new craft. The next tick must not force the
+// camera back onto the owner's stack — that split-brain (panels on the
+// new craft, camera locked on the stack) was unrecoverable by f/g.
+func TestFollowDockGuestStackReleasesOnSpawnFocus(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	w.FollowDockGuestStack()
+
+	w.focusNewCraft()
+	if w.Focus.Kind != FocusCraft {
+		t.Fatalf("setup: focusNewCraft did not set FocusCraft: %+v", w.Focus)
+	}
+
+	w.FollowDockGuestStack()
+	if w.Focus.Kind != FocusCraft {
+		t.Errorf("FollowDockGuestStack overrode a post-spawn focus: got %+v", w.Focus)
+	}
+}
+
+// TestFollowDockGuestStackReassertsWhenRideChanges pins the other half of
+// the #331 ruling: the rider camera is a convenience, not a permanent
+// lock — once the ridden stack itself changes (the owner switches active
+// craft underneath the rider), the follow may re-assert even though the
+// player had released it.
+func TestFollowDockGuestStackReassertsWhenRideChanges(t *testing.T) {
+	w := riderTestWorld(t)
+	g := dockGuestGhost(w)
+	w.DockGuest = &DockGuestLink{OwnerFP: g.Owner, OwnerHandle: g.Handle, OwnerActiveCraftID: g.CraftID}
+	w.FollowDockGuestStack()
+
+	w.CycleFocus(true) // player releases the follow (f/g)
+	if w.Focus.Kind == FocusGhost {
+		t.Fatal("setup: expected the player's focus change to leave FocusGhost")
+	}
+
+	// The owner moves to a different active craft (e.g. Transfer Control,
+	// or switching stacks) — the ride itself changed, so it re-fits.
+	newCraftID := g.CraftID + 1
+	w.DockGuest.OwnerActiveCraftID = newCraftID
+	w.FollowDockGuestStack()
+
+	if w.Focus.Kind != FocusGhost || w.Focus.GhostCraftID != newCraftID {
+		t.Errorf("FollowDockGuestStack did not re-assert on a ride change: %+v", w.Focus)
 	}
 }
 

--- a/internal/sim/docking_guest.go
+++ b/internal/sim/docking_guest.go
@@ -343,22 +343,45 @@ type DockGuestLink struct {
 // slate goes empty at the fuse (#301), so FocusCraft has nothing left to
 // track; rather than invent a new Focus kind, this reuses Spectate's
 // FocusGhost (v0.28 S6) — "watch a remote craft" is exactly the rider's
-// situation. Safe to call every tick: assigning the identical Focus value
-// is a no-op by struct equality (the same idiom CycleFocus and
-// SetActiveCraftIdx already rely on), so a genuine Framing Event — a real
-// re-fit — only happens on the tick the tracked ref actually changes:
-// entering the ride, or the owner moving to a different active craft.
-// Manual pan/zoom the player applies afterward composes over that fit and
-// persists across ticks exactly as it does for a manually-entered
-// Spectate. No-op while not docked as a guest.
+// situation. Called unconditionally every tick from the serve layer's
+// refreshSession, so it must not fight the player: the rider camera is a
+// convenience, not a lock (#331). The follow is a Framing Event only when
+// the *tracked ref* itself changes — entering the ride, or the owner
+// switching to a different active craft — never merely because w.Focus
+// currently disagrees with it. That disagreement is exactly what a
+// player-initiated Focus write (f/g's CycleFocus Spectate-exit, Spectate
+// on a third player, focusNewCraft after a mid-ride spawn) looks like, and
+// it must stick until the ride itself moves.
+//
+// dockGuestFollowedRef (on World) records the last ref this function
+// itself wrote — not the last Focus value, which the player is free to
+// overwrite. Comparing the desired ref against that latch, rather than
+// against the live w.Focus, is what tells "the ref changed, re-fit" apart
+// from "the player changed Focus away from a ref that hasn't moved, leave
+// it be". Once released this way the follow re-engages automatically the
+// moment the ref does change (owner switches craft), per the ADR 0038 §2
+// ruling: convenience, not a permanent lock.
 func (w *World) FollowDockGuestStack() {
 	if w.DockGuest == nil {
+		// Not riding: clear the latch so a *future* dock always treats
+		// entry as a fresh Framing Event, rather than possibly matching a
+		// stale ref left over from a previous ride.
+		w.dockGuestFollowedRef = Focus{}
 		return
 	}
 	want := Focus{Kind: FocusGhost, GhostOwner: w.DockGuest.OwnerFP, GhostCraftID: w.DockGuest.OwnerActiveCraftID}
-	if w.Focus != want {
-		w.Focus = want
+	if want == w.dockGuestFollowedRef {
+		// The ride hasn't changed since this function last wrote it, so
+		// whatever w.Focus holds now was set afterward by the player (or
+		// is still this same ref — the idempotent case). Either way,
+		// leave it alone.
+		return
 	}
+	// A genuine Framing Event: entering the ride, or the owner moved to a
+	// different active craft underneath the rider. Re-fit regardless of
+	// whatever Focus currently holds.
+	w.Focus = want
+	w.dockGuestFollowedRef = want
 }
 
 // DockGuestStackGhost resolves the stack this player rides in to its live

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -299,6 +299,15 @@ type World struct {
 	// Undock.
 	DockGuest *DockGuestLink
 
+	// dockGuestFollowedRef is the last FocusGhost ref FollowDockGuestStack
+	// itself force-wrote (#331). Comparing the desired ref against THIS —
+	// not against the live w.Focus — is what lets a player-initiated Focus
+	// change (f/g, Spectate, a fresh spawn) release the rider's follow
+	// camera until the ridden stack itself changes: see
+	// FollowDockGuestStack in docking_guest.go. Transient camera
+	// bookkeeping, never persisted.
+	dockGuestFollowedRef Focus
+
 	// LastSyncArrival is set when a Sync warp reaches its target time
 	// (v0.27 S7) and cleared by the serve wrapper after firing the
 	// arrival chips. Transient, like LastDockEvent.


### PR DESCRIPTION
## Summary

Fixes #331. `FollowDockGuestStack` (`internal/sim/docking_guest.go`) is
called unconditionally on every tick from `internal/serve/reporting.go`'s
`refreshSession`. It reassigned `Focus` whenever it differed from the
tracked ghost ref, so three player-initiated Focus writes were silently
reverted on the very next tick:

- `f` / `g` (documented CAMERA & VIEW keys)
- Spectate (`app.go` `SessionCmdSpectate` → `SpectateGhost`)
- `focusNewCraft` after a mid-ride spawn (`sim/spawn.go`)

## Fix

Added `World.dockGuestFollowedRef` — the last ghost ref
`FollowDockGuestStack` itself wrote. The function now re-fits (a genuine
Framing Event, ADR 0021) only when the **tracked ref itself changes**
(entering the ride, or the owner switching to a different active craft) —
never merely because `Focus` currently disagrees with what was last
written. Any player-initiated Focus change now sticks until the ridden
stack itself changes, at which point the follow re-asserts automatically.
This matches the issue's ruling: the rider camera is a convenience, not a
lock.

The fix is entirely contained in `internal/sim/` (`docking_guest.go` +
one new field in `world.go`) — `reporting.go`, `app.go`, and `spawn.go`
needed no changes, since the bug was entirely in how the one function
decided whether to reassert.

## Test plan

- [x] `TestFollowDockGuestStackReleasesOnPlayerFocusChange` — pins case 1
      (f/g): observed **red** against pre-fix code, now green.
- [x] `TestFollowDockGuestStackReleasesOnSpectate` — pins case 2
      (Spectate a third player mid-ride): observed red, now green.
- [x] `TestFollowDockGuestStackReleasesOnSpawnFocus` — pins case 3
      (`focusNewCraft` after a mid-ride spawn): observed red, now green.
- [x] `TestFollowDockGuestStackReassertsWhenRideChanges` — pins the other
      half of the ruling: once the owner switches active craft, the
      follow re-engages even after being released.
- [x] Existing `TestFollowDockGuestStackIdempotent` kept (annotated as
      insufficient alone) plus all pre-existing dock/rider/save tests
      still pass, including `TestAdoptCraftReturnsCameraFromGhostFocus`
      which independently pins the undock camera snap-back (relies on
      `w.DockGuest` being nil, untouched by this change).
- [x] `go vet ./...` clean.
- [x] `go test ./... -race -count=1` full suite green.

No schema version bump — this is transient camera state, never persisted.