### PR TITLE
fix(sessiondir): enrollment/roster defects from v0.35.0 batch review (#329, #332)

### DIFF
--- a/internal/serve/flow.go
+++ b/internal/serve/flow.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"errors"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -119,11 +120,22 @@ func (m guestFlow) updateHandle(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyEnter:
 		p, err := m.store.Enroll(m.code, m.fp, string(m.input))
 		if err != nil {
-			// The code was spent between Peek and commit (or the handle
-			// is empty) — back to the code prompt with the reason.
 			m.errMsg = err.Error()
-			m.phase = phaseCode
-			m.input = nil
+			if errors.Is(err, sessiondir.ErrUnknownInvite) {
+				// The code itself was spent (or revoked) between Peek
+				// and commit — there's no code left to retry a handle
+				// against, so back to the code prompt.
+				m.phase = phaseCode
+				m.input = nil
+			} else {
+				// A handle problem (empty, or a case-insensitive
+				// collision, #332) — the code is still valid and
+				// unconsumed. Stay on the handle prompt so the player
+				// can just edit the handle they typed and retry with
+				// the same code, instead of being bounced back to
+				// re-enter a code that was never the issue.
+				m.phase = phaseHandle
+			}
 			return m, nil
 		}
 		if m.onEnroll != nil {
@@ -183,14 +195,18 @@ func (m guestFlow) View() string {
 		lines = append(lines, "  (enter to submit, esc to disconnect)")
 		return strings.Join(lines, "\n")
 	case phaseHandle:
-		return strings.Join([]string{
+		lines := []string{
 			"",
 			"  TERMINAL SPACE PROGRAM — join session",
 			"",
 			"  your handle: " + string(m.input) + "▌",
 			"",
-			"  (edit if you like — enter to join, esc to disconnect)",
-		}, "\n")
+		}
+		if m.errMsg != "" {
+			lines = append(lines, "  "+m.errMsg, "")
+		}
+		lines = append(lines, "  (edit if you like — enter to join, esc to disconnect)")
+		return strings.Join(lines, "\n")
 	}
 	// phaseCard — the terminal capability check (v0.27 S2): braille
 	// and color support are undetectable server-side, so we ask.

--- a/internal/serve/flow_test.go
+++ b/internal/serve/flow_test.go
@@ -115,6 +115,75 @@ func TestFlowBadCode(t *testing.T) {
 	}
 }
 
+// #332: a handle collision at the commit step must bounce the guest
+// back to the HANDLE prompt (with the invite still unconsumed), not
+// the invite-code prompt carrying a message about their handle. The
+// player can then just edit the handle and retry with the same code.
+func TestFlowHandleCollisionReturnsToHandlePrompt(t *testing.T) {
+	store, m := newFlowFixture(t)
+	// Seed a roster row occupying "gern" directly (an already-enrolled
+	// player), then hand our guest an unrelated invite so their
+	// pre-bound handle doesn't itself collide.
+	seedInv, err := store.MintInvite("gern")
+	if err != nil {
+		t.Fatalf("MintInvite gern: %v", err)
+	}
+	if _, err := store.Enroll(seedInv.Code, "SHA256:seed", "gern"); err != nil {
+		t.Fatalf("seed Enroll: %v", err)
+	}
+	inv, err := store.MintInvite("dave")
+	if err != nil {
+		t.Fatalf("MintInvite dave: %v", err)
+	}
+
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 45})
+	m = typeString(m, "y")
+	m = typeString(m, inv.Code)
+	m = pressEnter(m)
+	if out := stripANSI(m.View()); !strings.Contains(out, "your handle:") {
+		t.Fatalf("expected the prefilled handle prompt, got:\n%s", out)
+	}
+
+	// Clear the prefilled "dave" and type a handle that collides
+	// (case-insensitively) with the already-enrolled "gern".
+	for i := 0; i < 10; i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	m = typeString(m, "GERN")
+	m = pressEnter(m)
+
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "your handle:") {
+		t.Fatalf("expected to stay on the HANDLE prompt after a handle collision, got:\n%s", out)
+	}
+	if strings.Contains(out, "invite code:") {
+		t.Fatalf("bounced back to the CODE prompt instead of the handle prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "collides") {
+		t.Fatalf("expected the collision error on the handle prompt, got:\n%s", out)
+	}
+
+	// The invite must still be unconsumed — a retry with a different
+	// handle on the SAME code must succeed.
+	if _, err := store.Peek(inv.Code); err != nil {
+		t.Fatalf("invite was consumed despite the collision refusal: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	m = typeString(m, "davey")
+	m = pressEnter(m)
+	m, _ = m.Update(sim.TickMsg(time.Now()))
+	if out := stripANSI(m.View()); !strings.Contains(out, "warp 1x") {
+		t.Fatalf("expected the game after a corrected retry, got:\n%s", firstLines(out, 3))
+	}
+	p, err := store.FindPlayer(testFP)
+	if err != nil || p.Handle != "davey" {
+		t.Errorf("FindPlayer = %+v, %v; want handle davey", p, err)
+	}
+}
+
 // The shared size gate holds behind the flow too: enrolling on an
 // undersized pty lands on the gate, not a broken frame.
 func TestFlowEnrollIntoSizeGate(t *testing.T) {

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -614,13 +614,27 @@ func (s *Store) Enroll(code, fingerprint, handle string) (Player, error) {
 	if idx < 0 {
 		return Player{}, ErrUnknownInvite
 	}
-	// Case-insensitive uniqueness against the roster (#274) — checked
-	// here, not just at mint, because the handle is editable at this
-	// step (ADR 0034 addendum) and could be hand-edited into a
-	// collision even when the pre-bound handle was clean. Checked
-	// BEFORE consuming the invite, so a refusal leaves the code intact
-	// for a retry with a different handle.
-	if collidesWith, ok := findHandleCollision(handle, m.Roster, nil); ok {
+	// Case-insensitive uniqueness against the roster AND any OTHER
+	// outstanding invite (#274, #332) — checked here, not just at
+	// mint, because the handle is editable at this step (ADR 0034
+	// addendum) and could be hand-edited into a collision even when
+	// the pre-bound handle was clean. Matches MintInvite's own
+	// comparison set: without the invite check, a handle minted for
+	// one player but not yet redeemed could be claimed by a second
+	// player enrolling first, permanently orphaning the first player's
+	// code. otherInvites excludes the invite being redeemed itself —
+	// the overwhelmingly common path is accepting the pre-bound
+	// handle unedited, which must not "collide" with its own
+	// still-outstanding invite. Checked BEFORE consuming the invite,
+	// so a refusal leaves the code intact for a retry with a
+	// different handle.
+	otherInvites := make([]Invite, 0, len(m.Invites))
+	for i, inv := range m.Invites {
+		if i != idx {
+			otherInvites = append(otherInvites, inv)
+		}
+	}
+	if collidesWith, ok := findHandleCollision(handle, m.Roster, otherInvites); ok {
 		return Player{}, fmt.Errorf("sessiondir: handle %q collides with %q (case-insensitive) — pick a different handle", handle, collidesWith)
 	}
 	m.Invites = append(m.Invites[:idx], m.Invites[idx+1:]...)

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -234,27 +234,44 @@ func Open(dir string) (*Store, error) {
 }
 
 // repairLegacyHandleCollisions runs dedupeRosterHandles over m.Roster
-// and, for each rename it makes, logs a server-log line and stamps a
-// PendingNote on both the renamed player and the collision
-// counterpart who kept their name (#274). Reports whether it changed
-// anything, so the caller only persists when there was something to
-// persist.
+// (seeded against m.Invites too, #329) and, for each rename it makes,
+// logs a server-log line and stamps a PendingNote on both the renamed
+// player and the collision counterpart who kept their name (#274).
+// Reports whether it changed anything, so the caller only persists
+// when there was something to persist.
 func repairLegacyHandleCollisions(m *Meta) bool {
-	renames := dedupeRosterHandles(m.Roster)
+	renames := dedupeRosterHandles(m.Roster, m.Invites)
 	for _, r := range renames {
 		log.Printf("sessiondir: legacy roster handle collision at load — renamed %q to %q (fingerprint %s) to keep handles case-insensitively unique (#274)", r.From, r.To, r.Fingerprint)
 		for i := range m.Roster {
 			switch {
 			case m.Roster[i].Fingerprint == r.Fingerprint:
-				m.Roster[i].PendingNote = fmt.Sprintf(
-					"your handle collided with another player's (case-insensitively) — you've been renamed to %q so you can both be DMed unambiguously", r.To)
+				m.Roster[i].PendingNote = appendPendingNote(m.Roster[i].PendingNote, fmt.Sprintf(
+					"your handle collided with another player's (case-insensitively) — you've been renamed to %q so you can both be DMed unambiguously", r.To))
 			case foldHandle(m.Roster[i].Handle) == foldHandle(r.From) && m.Roster[i].Fingerprint != r.Fingerprint:
-				m.Roster[i].PendingNote = fmt.Sprintf(
-					"a roster handle collision with your name was resolved — the other player is now %q", r.To)
+				m.Roster[i].PendingNote = appendPendingNote(m.Roster[i].PendingNote, fmt.Sprintf(
+					"a roster handle collision with your name was resolved — the other player is now %q", r.To))
 			}
 		}
 	}
 	return len(renames) > 0
+}
+
+// appendPendingNote adds a newly-learned fact to a player's pending
+// session note (#329) instead of overwriting it. A player can
+// accumulate more than one unconsumed fact across separate repair
+// passes (renamed in one pass, then a collision counterpart in a
+// later one, or vice versa) — ConsumePendingNote still delivers and
+// clears the combined string exactly once, so nothing here changes
+// the deliver-once contract, it just means the single delivery can
+// carry more than one sentence. toast display is one line (App.Toast
+// / a.toast — see tui/app.go), so facts are joined with "; " rather
+// than a newline.
+func appendPendingNote(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	return existing + "; " + add
 }
 
 // handleRename is one deterministic legacy-collision fix dedupeRosterHandles made.
@@ -268,22 +285,46 @@ type handleRename struct {
 // append order — the host first, guests in the order they enrolled)
 // and renames any entry whose handle case-insensitively collides with
 // an EARLIER entry: the Nth colliding handle becomes "<handle>2",
-// "<handle>3", ... skipping any candidate suffix that would itself
-// collide. It mutates roster in place and returns the renames made.
+// "<handle>3", ... skipping any candidate suffix that is already
+// TAKEN — by any roster handle, any outstanding invite's pre-bound
+// handle, or a rename target already chosen earlier in this same
+// pass. It mutates roster in place and returns the renames made.
 //
-// This is a pure function of roster order and handles, so calling it
-// again on an already-fixed roster (or, if the caller never persists,
-// on the same still-colliding input) always reproduces the same
-// result — "gern2", never "gern22" — which is what makes the legacy
-// fix at Open safe to run on every load rather than exactly once
-// (#274).
-func dedupeRosterHandles(roster []Player) []handleRename {
-	seen := make(map[string]bool, len(roster))
+// `reserved` is seeded from EVERY roster handle and EVERY invite
+// handle up front, before any renaming happens (#329) — not built up
+// incrementally as the loop goes. The earlier incremental version let
+// a rename target land on a handle belonging to an entry not yet
+// visited (e.g. roster [gern(A), gern(B), gern2(C)]: B's first free
+// candidate "gern2" wasn't "seen" yet at B's turn, so B took C's own
+// handle, and C — who never collided with anyone — got displaced by
+// C's own turn exposing the manufactured collision). Seeding
+// up front closes that: a candidate can never take a handle that
+// exists ANYWHERE, roster or invite, at the time the repair runs.
+//
+// `firstSeen` is the separate, still-incremental set that decides
+// whether THIS entry is itself a duplicate needing a rename — the
+// canonical (first-seen) holder of a handle is never renamed.
+//
+// This is a pure function of roster order, handles, and invites, so
+// calling it again on an already-fixed roster (or, if the caller
+// never persists, on the same still-colliding input) always
+// reproduces the same result — "gern2", never "gern22" — which is
+// what makes the legacy fix at Open safe to run on every load rather
+// than exactly once (#274).
+func dedupeRosterHandles(roster []Player, invites []Invite) []handleRename {
+	reserved := make(map[string]bool, len(roster)+len(invites))
+	for i := range roster {
+		reserved[foldHandle(roster[i].Handle)] = true
+	}
+	for _, inv := range invites {
+		reserved[foldHandle(inv.Handle)] = true
+	}
+	firstSeen := make(map[string]bool, len(roster))
 	var renames []handleRename
 	for i := range roster {
 		folded := foldHandle(roster[i].Handle)
-		if !seen[folded] {
-			seen[folded] = true
+		if !firstSeen[folded] {
+			firstSeen[folded] = true
 			continue
 		}
 		orig := roster[i].Handle
@@ -292,12 +333,13 @@ func dedupeRosterHandles(roster []Player) []handleRename {
 		for {
 			next = fmt.Sprintf("%s%d", orig, suffix)
 			foldedNext = foldHandle(next)
-			if !seen[foldedNext] {
+			if !reserved[foldedNext] {
 				break
 			}
 			suffix++
 		}
-		seen[foldedNext] = true
+		reserved[foldedNext] = true
+		firstSeen[foldedNext] = true
 		roster[i].Handle = next
 		renames = append(renames, handleRename{
 			Fingerprint: roster[i].Fingerprint,

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -916,3 +916,55 @@ func TestPendingNoteAppendsAcrossRepeatedRepairs(t *testing.T) {
 		}
 	}
 }
+
+// #332: Enroll must refuse a handle that case-insensitively collides
+// with an OUTSTANDING INVITE, not just the roster — matching
+// MintInvite's own check. Without this, a host mints "gern" for Bob;
+// before Bob redeems it, Alice enrolls (on an unrelated code) as
+// "Gern"; Bob's code is now permanently dead — the exact failure the
+// mint-side check exists to prevent, arriving through the enroll
+// door instead.
+func TestEnrollRefusesCaseInsensitiveInviteCollision(t *testing.T) {
+	s := openStore(t)
+	bobInvite, err := s.MintInvite("gern")
+	if err != nil {
+		t.Fatalf("MintInvite gern (bob): %v", err)
+	}
+	aliceInvite, err := s.MintInvite("someone-else")
+	if err != nil {
+		t.Fatalf("MintInvite someone-else (alice): %v", err)
+	}
+	if _, err := s.Enroll(aliceInvite.Code, "SHA256:alice", "GERN"); err == nil {
+		t.Fatal("Enroll accepted a handle colliding with another outstanding invite")
+	}
+	// Both invites must survive the refusal: Alice's because a refused
+	// enroll never spends the code, Bob's because it was never
+	// touched.
+	if _, err := s.Peek(aliceInvite.Code); err != nil {
+		t.Errorf("refused enroll spent alice's invite code: %v", err)
+	}
+	if _, err := s.Peek(bobInvite.Code); err != nil {
+		t.Errorf("bob's invite code was disturbed by alice's refused enroll: %v", err)
+	}
+	// Bob can still redeem his own code for "gern" cleanly afterward.
+	if _, err := s.Enroll(bobInvite.Code, "SHA256:bob", "gern"); err != nil {
+		t.Fatalf("bob's own enroll for his own pre-bound handle failed: %v", err)
+	}
+}
+
+// #332 regression guard: Enroll must NOT refuse a player redeeming
+// their OWN invite with its own pre-bound handle (the ordinary,
+// overwhelmingly common path) just because that invite is still
+// sitting in m.Invites at the moment of the check — the collision
+// check must exclude the invite being redeemed from the invite set it
+// compares against.
+func TestEnrollAcceptsOwnPreboundHandle(t *testing.T) {
+	s := openStore(t)
+	inv, err := s.MintInvite("dave")
+	if err != nil {
+		t.Fatalf("MintInvite: %v", err)
+	}
+	if _, err := s.Enroll(inv.Code, "SHA256:dave", "dave"); err != nil {
+		t.Fatalf("Enroll with own pre-bound handle refused: %v", err)
+	}
+}

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -697,3 +697,222 @@ func TestConsumePendingNoteFiresOnce(t *testing.T) {
 		t.Fatalf("second consume = %q, %v; want empty, nil", note2, err)
 	}
 }
+
+// #329: dedupeRosterHandles must not displace an innocent third party.
+// Roster [gern(A), gern(B), gern2(C)] processed in enrollment order:
+// B collides with A and must NOT be handed C's already-taken "gern2" —
+// C never collided with anyone and must keep their own handle. The
+// old (buggy) algorithm seeded `seen` incrementally, so it let B take
+// "gern2" (not yet "seen" at B's turn) and then renamed C out of their
+// own handle when C's turn exposed the manufactured collision.
+func TestOpenDedupeDoesNotDisplaceThirdParty(t *testing.T) {
+	dir := t.TempDir()
+	seed, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	m, err := seed.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	m.Roster = []Player{
+		{Fingerprint: HostFingerprint, Handle: "jason", Role: RoleHost},
+		{Fingerprint: "SHA256:A", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:B", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:C", Handle: "gern2", Role: RoleGuest},
+	}
+	if err := seed.writeMeta(m); err != nil {
+		t.Fatalf("seed writeMeta: %v", err)
+	}
+
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (repair): %v", err)
+	}
+	m2, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta after repair: %v", err)
+	}
+	byFP := map[string]Player{}
+	for _, p := range m2.Roster {
+		byFP[p.Fingerprint] = p
+	}
+	if byFP["SHA256:C"].Handle != "gern2" {
+		t.Fatalf("innocent third party displaced: %+v", byFP["SHA256:C"])
+	}
+	if byFP["SHA256:A"].Handle != "gern" {
+		t.Errorf("earlier entrant's handle changed: %+v", byFP["SHA256:A"])
+	}
+	if byFP["SHA256:B"].Handle == "gern" || byFP["SHA256:B"].Handle == "gern2" {
+		t.Errorf("later colliding entrant not disambiguated away from a taken handle: %+v", byFP["SHA256:B"])
+	}
+	if byFP["SHA256:C"].PendingNote != "" {
+		t.Errorf("innocent third party got a pending note it shouldn't have: %+v", byFP["SHA256:C"])
+	}
+
+	// Idempotent across a second load: no further renames, no
+	// suffix compounding (e.g. never "gern22").
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (second load): %v", err)
+	}
+	m3, err := s2.Meta()
+	if err != nil {
+		t.Fatalf("Meta after second load: %v", err)
+	}
+	byFP3 := map[string]Player{}
+	for _, p := range m3.Roster {
+		byFP3[p.Fingerprint] = p
+	}
+	if byFP3["SHA256:B"].Handle != byFP["SHA256:B"].Handle {
+		t.Errorf("second load changed B's handle again: %q -> %q", byFP["SHA256:B"].Handle, byFP3["SHA256:B"].Handle)
+	}
+	if byFP3["SHA256:C"].Handle != "gern2" {
+		t.Errorf("second load displaced C: %+v", byFP3["SHA256:C"])
+	}
+}
+
+// #329: the repair must also seed `seen` from outstanding invites, not
+// just the roster — otherwise it can mint a roster rename directly
+// onto a handle a live invite is already pre-bound to, permanently
+// orphaning that invite (EnrollWithInvite's roster-collision guard
+// would then refuse it forever).
+func TestOpenDedupeAvoidsOutstandingInviteCollision(t *testing.T) {
+	dir := t.TempDir()
+	seed, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	m, err := seed.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	m.Roster = []Player{
+		{Fingerprint: HostFingerprint, Handle: "jason", Role: RoleHost},
+		{Fingerprint: "SHA256:A", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:B", Handle: "gern", Role: RoleGuest},
+	}
+	m.Invites = []Invite{
+		{Code: "AAAA-BBBB", Handle: "gern2"},
+	}
+	if err := seed.writeMeta(m); err != nil {
+		t.Fatalf("seed writeMeta: %v", err)
+	}
+
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (repair): %v", err)
+	}
+	m2, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta after repair: %v", err)
+	}
+	for _, p := range m2.Roster {
+		if p.Fingerprint == "SHA256:B" && foldHandle(p.Handle) == "gern2" {
+			t.Fatalf("rename landed on a handle an outstanding invite is pre-bound to: %+v", p)
+		}
+	}
+}
+
+// #329: PendingNote must APPEND rather than assign, so a player who
+// accumulates two separate facts across two separate repair passes
+// (an unconsumed "you were renamed" note from one pass, then a
+// "someone else collided with your name" note from a later pass, once
+// more legacy junk data collides with the handle they were renamed
+// to) learns both — not just the last one written.
+func TestPendingNoteAppendsAcrossRepeatedRepairs(t *testing.T) {
+	dir := t.TempDir()
+	seed, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (seed): %v", err)
+	}
+	m, err := seed.Meta()
+	if err != nil {
+		t.Fatalf("Meta: %v", err)
+	}
+	// Round 1: a plain two-way legacy collision. "second" gets renamed
+	// to "gern2" and gets a PendingNote; "first" (kept name) gets a
+	// counterpart PendingNote.
+	m.Roster = []Player{
+		{Fingerprint: HostFingerprint, Handle: "jason", Role: RoleHost},
+		{Fingerprint: "SHA256:first", Handle: "gern", Role: RoleGuest},
+		{Fingerprint: "SHA256:second", Handle: "gern", Role: RoleGuest},
+	}
+	if err := seed.writeMeta(m); err != nil {
+		t.Fatalf("seed writeMeta: %v", err)
+	}
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (round 1 repair): %v", err)
+	}
+	m1, err := s.Meta()
+	if err != nil {
+		t.Fatalf("Meta after round 1: %v", err)
+	}
+	var secondNoteRound1 string
+	for _, p := range m1.Roster {
+		if p.Fingerprint == "SHA256:second" {
+			if p.Handle != "gern2" {
+				t.Fatalf("round 1: second not renamed to gern2: %+v", p)
+			}
+			secondNoteRound1 = p.PendingNote
+			if secondNoteRound1 == "" {
+				t.Fatal("round 1: second has no pending note")
+			}
+		}
+	}
+
+	// Round 2: without "second" ever consuming their note, more legacy
+	// junk data (simulating an out-of-band edit / further pre-existing
+	// data) introduces a THIRD entry that collides with "second"'s new
+	// handle "gern2". "second" is the earlier entrant this round, so
+	// it keeps "gern2" and becomes the collision COUNTERPART for the
+	// new entry's rename — while still holding its round-1 unconsumed
+	// note.
+	m1.Roster = append(m1.Roster, Player{Fingerprint: "SHA256:third", Handle: "gern2", Role: RoleGuest})
+	if err := s.writeMeta(m1); err != nil {
+		t.Fatalf("seed round 2 writeMeta: %v", err)
+	}
+	s2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (round 2 repair): %v", err)
+	}
+	m2, err := s2.Meta()
+	if err != nil {
+		t.Fatalf("Meta after round 2: %v", err)
+	}
+	var secondNoteRound2 string
+	for _, p := range m2.Roster {
+		if p.Fingerprint == "SHA256:second" {
+			if p.Handle != "gern2" {
+				t.Fatalf("round 2: second's handle changed unexpectedly: %+v", p)
+			}
+			secondNoteRound2 = p.PendingNote
+		}
+		if p.Fingerprint == "SHA256:third" && p.Handle == "gern2" {
+			t.Fatalf("round 2: third not disambiguated away from second's handle: %+v", p)
+		}
+	}
+	if !strings.Contains(secondNoteRound2, secondNoteRound1) {
+		t.Errorf("round 2 note lost the round 1 fact: round1=%q round2=%q", secondNoteRound1, secondNoteRound2)
+	}
+	if secondNoteRound2 == secondNoteRound1 {
+		t.Errorf("round 2 note didn't append the new counterpart fact: %q", secondNoteRound2)
+	}
+
+	// A third load with nothing new to repair must not touch the note
+	// again (idempotent).
+	s3, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open (round 3, no-op): %v", err)
+	}
+	m3, err := s3.Meta()
+	if err != nil {
+		t.Fatalf("Meta after round 3: %v", err)
+	}
+	for _, p := range m3.Roster {
+		if p.Fingerprint == "SHA256:second" && p.PendingNote != secondNoteRound2 {
+			t.Errorf("a no-op load changed second's note: %q -> %q", secondNoteRound2, p.PendingNote)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two enrollment/roster defects found by the v0.35.0 batch review.

- **#329** — the legacy handle auto-rename displaced an innocent third party, overwrote its own notice, and orphaned outstanding invites.
- **#332** — `Enroll` validated handle uniqueness against the roster but not against outstanding invites, unlike `MintInvite`; plus a related flow bug where a handle collision bounced the guest to the invite-code prompt with a message about their handle.

### #329 fix

`dedupeRosterHandles` seeded its `seen` set incrementally as it walked the roster, so a rename target could land on a handle belonging to an entry not yet visited. Roster `[gern(A), gern(B), gern2(C)]`: B's first free candidate `gern2` wasn't "seen" yet at B's turn, so B took C's own handle, and C — who never collided with anyone — was displaced when C's own turn exposed the manufactured collision.

Fix: seed a `reserved` set from every roster handle **and** every outstanding invite handle up front, before renaming anything, and pick rename candidates against that. A separate `firstSeen` set still decides (incrementally, in roster order) whether an entry is itself a duplicate needing a rename. This also closes the invite-orphaning defect: a rename can no longer land on a handle a live invite is already pre-bound to.

`PendingNote` now appends instead of assigning, via `appendPendingNote` (joined with `"; "` — the toast display is one line). `ConsumePendingNote`'s deliver-exactly-once contract is unchanged; it just now clears a string that may carry more than one sentence.

### #332 fix

`Enroll` now checks `findHandleCollision` against `m.Roster` and the *other* outstanding invites (excluding the invite being redeemed itself, so accepting your own pre-bound handle unedited — the common path — never "collides" with your own still-outstanding invite).

`guestFlow.updateHandle` (`internal/serve/flow.go`) previously reset `phase = phaseCode` on any Enroll error, so a handle-collision error was shown on the invite-code prompt. It now distinguishes: `ErrUnknownInvite` (the code itself went bad) still bounces to `phaseCode`; anything else (empty or colliding handle) stays on `phaseHandle`, letting the player edit the handle and retry with the same still-unconsumed code. `phaseHandle`'s `View` now renders `errMsg`, which it previously dropped silently.

## Out of scope

The stale `DockLink.OwnerHandle`/`GuestHandle` noted at the end of #329 is cosmetic and untouched — owned by another agent's in-flight dock ledger work.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- New tests in `internal/sessiondir/sessiondir_test.go`:
  - `TestOpenDedupeDoesNotDisplaceThirdParty` — pins roster `[gern, gern, gern2]` must not take C's handle
  - `TestOpenDedupeAvoidsOutstandingInviteCollision` — a rename must not collide with an outstanding invite
  - `TestPendingNoteAppendsAcrossRepeatedRepairs` — a player renamed in one repair pass and made a counterpart in a later pass learns both facts; idempotent on a third no-op load
  - `TestEnrollRefusesCaseInsensitiveInviteCollision` — Enroll refuses a handle bound to an outstanding invite
  - `TestEnrollAcceptsOwnPreboundHandle` — regression guard: redeeming your own invite with its own handle still works
- New test in `internal/serve/flow_test.go`:
  - `TestFlowHandleCollisionReturnsToHandlePrompt` — collision bounces to the handle prompt (not code), code stays unconsumed, retry succeeds
- Existing idempotency tests (`TestOpenDedupesLegacyRosterHandleCollision`, `TestOpenDedupePreservesLaterEntrantCase`) stay green.

No `session.json` meta version bump — `MetaVersion` stays at 3.

Refs #329, #332.