### PR TITLE
fix(dock): bound and scope the re-arm latch, stop swallowing flush errors (#326, #327, #335, #337)

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -514,6 +514,22 @@ func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]Cr
 	var chips []DockChip
 	w.DockGuest = nil // rebuilt below if still a guest in some active dock
 	for id, r := range l.records {
+		// #337: a phase this binary has no case for. DockLink.Phase crosses
+		// the session directory as a bare int, so a rollback past the release
+		// that introduced a phase value seeds records nothing here can
+		// advance: both reconcile arms fall through, no reaper reaches them,
+		// and Claim's engaged-record guard refuses both craft forever. A
+		// record we cannot honour retires instead of bricking the pair —
+		// unless it is holding a payload, which is the ADR 0040 §1 rule: that
+		// craft exists in no World and no save, and an immortal record is
+		// recoverable by running a binary that understands the phase again,
+		// while a deleted vessel is not.
+		if r.Phase != DockPending && r.Phase != DockActive && r.Phase != DockCooldown {
+			if !r.hasParkedPayload() {
+				delete(l.records, id)
+			}
+			continue
+		}
 		// ADR 0038 §5: a Cooldown record is the re-arm-by-leaving latch, not
 		// a live dock — neither reconcileOwner nor reconcileGuest touches it.
 		// Either side of the pair can notice the separation and clear it, so

--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -36,12 +37,13 @@ const (
 	DockActive
 	// DockCooldown: the pair just undocked (a live handback, not a Parcel)
 	// and the record is held open purely as the ADR 0038 §5 re-arm-by-
-	// leaving latch — Claim()'s existing craft-ID dedup keeps refusing a
-	// fresh dock between this SAME pair of craft until reconcileCooldown
-	// observes them past ReArmDistM and drops the record. Nothing else reads
-	// a Cooldown record: RequestUndock/RequestRelease/RequestTransfer/
-	// ReclaimTarget all gate on DockActive, so a cooling-down pair is
-	// invisible to every other verb.
+	// leaving latch — Claim refuses a fresh dock between this SAME pair of
+	// craft (isPair, both endpoints — never a third party, #326) until
+	// reconcileCooldown observes them past ReArmDistM, or sim.ReArmCeiling of
+	// sim-time passes with the range unreadable, and drops the record.
+	// Nothing else reads a Cooldown record: RequestUndock/RequestRelease/
+	// RequestTransfer/ReclaimTarget all gate on DockActive, so a cooling-down
+	// pair is invisible to every other verb.
 	DockCooldown
 )
 
@@ -101,6 +103,16 @@ type DockRecord struct {
 	// their empty seat while they were gone (ADR 0040 §4). Delivered on
 	// their next connect — otherwise their vehicle is simply missing.
 	reclaimNotice bool
+	// reArmNoticed / reArmNoticeTo are the ADR 0038 §5 latch's evidence
+	// (#326). DetectGuestContact fires every tick, so a latched pair sitting
+	// inside the docking gates refuses a Claim every tick; reArmNoticed makes
+	// that ONE chip for the life of the latch, and reArmNoticeTo names the
+	// fingerprint owed it until their own next reconcile can raise it (chips
+	// are addressed to the session whose reconcile returns them). Deliberately
+	// NOT durable — there is no room on the persisted DockLink for them, and a
+	// restart re-telling a pilot once is not spam.
+	reArmNoticed  bool
+	reArmNoticeTo string
 	// reclaimAtNano is the absent owner's sim-time at the moment their stack
 	// was lifted out of their persisted payload (review finding on ADR 0040
 	// §4): the payload can be hours stale by the time the reclaimer's own
@@ -127,6 +139,9 @@ func (r *DockRecord) hasParkedPayload() bool {
 type DockChip struct {
 	Kind   sim.SessionEventKind
 	Handle string
+	// Detail is the reason, in the player's words, for the kinds that render
+	// one verbatim (the refusal chips). Empty on every other moment.
+	Detail string
 }
 
 // DockLedger is the shared, in-process ledger of live cross-player docks.
@@ -147,11 +162,36 @@ func NewDockLedger() *DockLedger {
 // has closed on. Refused (ok=false) when either craft is already engaged in a
 // dock — the guard that keeps a simultaneous mutual approach from opening two
 // crossed records (the ledger mutex serialises, so the first writer wins; the
-// passive-station MVP posture means only one side is actively claiming).
+// passive-station MVP posture means only one side is actively claiming) — or
+// when this exact PAIR is still holding an ADR 0038 §5 re-arm latch.
+//
+// The two guards are deliberately different widths (#326). An engaged record
+// (Pending/Active) means a craft is party to a live dock, and it must refuse on
+// EITHER endpoint: a craft already fused into someone's stack cannot also be
+// claimed by a third player. A Cooldown record is not a dock at all — it is a
+// statement about ONE pair ("you two backed apart yet?") — so it may only ever
+// refuse that same pair. Refusing on either endpoint made one couple's latch
+// disable docking for both of their craft against everybody, which is how a
+// vessel ended up permanently un-dockable.
 func (l *DockLedger) Claim(owner, ownerHandle string, dockerCraftID uint64, guestOwner, guestHandle string, guestCraftID uint64) (*DockRecord, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, r := range l.records {
+		if r.Phase == DockCooldown {
+			if r.isPair(owner, dockerCraftID, guestOwner, guestCraftID) {
+				// Leave evidence, once per latch: the detector re-claims every
+				// tick for as long as the pair drift inside the gates, so the
+				// notice is armed once and delivered on the claimer's own next
+				// reconcile (#326). Silence here is #308 at the one verb with
+				// no key to press.
+				if !r.reArmNoticed {
+					r.reArmNoticed = true
+					r.reArmNoticeTo = owner
+				}
+				return nil, false
+			}
+			continue
+		}
 		if r.involvesCraft(owner, dockerCraftID) || r.involvesCraft(guestOwner, guestCraftID) {
 			return nil, false
 		}
@@ -175,6 +215,15 @@ func (l *DockLedger) Claim(owner, ownerHandle string, dockerCraftID uint64, gues
 func (r *DockRecord) involvesCraft(fp string, craftID uint64) bool {
 	return (r.Owner == fp && r.DockerCraftID == craftID) ||
 		(r.GuestOwner == fp && r.GuestCraftID == craftID)
+}
+
+// isPair reports whether r's two endpoints are exactly these two craft, in
+// either orientation — the same pair, not merely a record one of them is in.
+// Orientation-blind because roles flip: a control transfer swaps owner and
+// guest, so the pair a latch names can be written either way round.
+func (r *DockRecord) isPair(fp1 string, id1 uint64, fp2 string, id2 uint64) bool {
+	return (r.Owner == fp1 && r.DockerCraftID == id1 && r.GuestOwner == fp2 && r.GuestCraftID == id2) ||
+		(r.Owner == fp2 && r.DockerCraftID == id2 && r.GuestOwner == fp1 && r.GuestCraftID == id1)
 }
 
 // RequestUndock flags the guest's active dock for a split (guest-initiated,
@@ -419,6 +468,17 @@ func (l *DockLedger) Records() []DockRecord {
 	return out
 }
 
+// RecordCount is how many docks the ledger currently holds. The serve layer
+// samples it either side of a Reconcile to notice a record ENDING (#326): a
+// re-arm latch clearing, or any other teardown, produces no chip, no craft
+// movement and no successful Claim, so without this the flush that persists it
+// never fires and the record comes back from disk on the next restart.
+func (l *DockLedger) RecordCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.records)
+}
+
 // Seed installs durable records (from the session directory on server start)
 // so a dock that outlived a restart resumes. Only the durable fields are
 // carried; the in-flight payload handoffs were transient and are gone.
@@ -459,8 +519,11 @@ func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]Cr
 		// Either side of the pair can notice the separation and clear it, so
 		// check both regardless of which one owner is.
 		if r.Phase == DockCooldown {
-			if (r.Owner == owner || r.GuestOwner == owner) && l.reconcileCooldown(w, r, owner, reports) {
-				delete(l.records, id)
+			if r.Owner == owner || r.GuestOwner == owner {
+				r.raiseReArmNotice(owner, &chips)
+				if l.reconcileCooldown(w, r, owner, reports) {
+					delete(l.records, id)
+				}
 			}
 			continue
 		}
@@ -487,6 +550,25 @@ func (l *DockLedger) Reconcile(w *sim.World, owner string, reports map[string]Cr
 // partner isn't reporting yet — an unresolvable range is not evidence of
 // separation.
 func (l *DockLedger) reconcileCooldown(w *sim.World, r *DockRecord, owner string, reports map[string]CraftReport) bool {
+	// Ceiling first (#326): every "can't tell" answer below holds the latch,
+	// and a partner who left — the ordinary reason to undock — is permanently
+	// un-tellable. sim.ReArmCeiling of sim-time since the release stamp ends
+	// it regardless. returnAtNano is the stamp reconcileOwner wrote when it
+	// parked the handback that became this latch; it is already durable
+	// (DockSnapshot.ReturnAtNano), so the ceiling survives the restart that
+	// re-seeds the latch with an empty report store — which is precisely the
+	// state in which nothing else can ever clear it. Nothing reads it once the
+	// return is delivered, so the cooldown phase owns it from here.
+	//
+	// No stamp at all means an origin that predates it (or a record built by
+	// hand): retire rather than latch forever, since an un-ceilinged latch is
+	// the failure this bound exists to prevent.
+	if r.returnAtNano == 0 {
+		return true
+	}
+	if w.Clock.SimTime.Sub(time.Unix(0, r.returnAtNano)) > sim.ReArmCeiling {
+		return true
+	}
 	var localID uint64
 	var remoteOwner string
 	var remoteID uint64
@@ -513,6 +595,33 @@ func (l *DockLedger) reconcileCooldown(w *sim.World, r *DockRecord, owner string
 		return local.State.R.Sub(g.RelPos).Norm() > sim.ReArmDistM
 	}
 	return false // partner's craft not resolvable in this frame — hold
+}
+
+// raiseReArmNotice delivers the once-per-latch explanation for a Claim the
+// re-arm latch refused (#326), if owner is the session owed it. The refusal
+// happens inside Claim, which has no session to chip; this is the first moment
+// the claimer's own reconcile comes round. Rendered as a plain warning row
+// carrying Detail verbatim — the same shape every other cross-player refusal
+// uses (SessionEventTransferRefused is already the ledger's generic "here is
+// why that didn't happen" chip: the reclaim path sends "take control: …"
+// through it too), so no new chip vocabulary is needed to stop being silent.
+func (r *DockRecord) raiseReArmNotice(owner string, chips *[]DockChip) {
+	if r.reArmNoticeTo != owner {
+		return
+	}
+	r.reArmNoticeTo = ""
+	who := r.GuestHandle
+	if r.GuestOwner == owner {
+		who = r.OwnerHandle
+	}
+	if who == "" {
+		who = "them"
+	}
+	*chips = append(*chips, DockChip{
+		Kind:   sim.SessionEventTransferRefused,
+		Handle: who,
+		Detail: fmt.Sprintf("docking held off — back %.0f m clear of %s before docking again", sim.ReArmDistM, who),
+	})
 }
 
 // reconcileOwner runs the stack owner's side of a dock. Returns true when the

--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -753,14 +753,24 @@ func (l *DockLedger) reconcileGuest(w *sim.World, r *DockRecord, reports map[str
 			sim.SafeHandback(r.returnPayload)
 			if r.parcel {
 				kind = sim.SessionEventParcelReturned
-			} else {
+			}
+			w.AdoptCraft(r.returnPayload, true)
+			if !r.parcel {
 				// ADR 0038 §6: I undock already targeting the stack I just
 				// left. Skipped for a Parcel — I only just reconnected, and
 				// "targeting the ghost of a stack I haven't seen in hours" is
 				// a stranger opening move than starting blank.
+				//
+				// Strictly AFTER the adoption (#327). AdoptCraft(_, true) ends
+				// in SetActiveCraftIdx, which checkpoints w.Target onto the
+				// OUTGOING craft and then reloads it from the incoming one —
+				// and a restored component is built with a zero Target. Setting
+				// the ghost first therefore stamped it on whatever vessel the
+				// guest happened to be flying and then cleared w.Target, which
+				// only looked correct because a one-vessel guest's outgoing
+				// craft IS the incoming one.
 				w.SetTargetGhost(r.Owner, r.CompositeID)
 			}
-			w.AdoptCraft(r.returnPayload, true)
 			r.returnPayload = nil
 			*chips = append(*chips, DockChip{Kind: kind, Handle: r.OwnerHandle})
 			if r.parcel {

--- a/internal/relay/dock_cooldown_test.go
+++ b/internal/relay/dock_cooldown_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
@@ -146,5 +147,57 @@ func TestCooldownRefusalTellsThePilotOnce(t *testing.T) {
 	}
 	if again := ledger.Reconcile(wA, fpA, none); len(again) != 0 {
 		t.Errorf("the latch refusal chipped a second time: %+v", again)
+	}
+}
+
+// TestUnknownDockPhaseSelfRetires is #337. DockLink.Phase crosses session.json
+// as a bare int, so a binary rolled back past the release that introduced a
+// phase value gets seeded with a number it has no case for: reconcileOwner and
+// reconcileGuest both fall through, nothing ever ends the record, and Claim's
+// engaged-record guard refuses BOTH craft forever — an immortal record no
+// reaper can reach. A phase this binary cannot advance is a record it cannot
+// honour, so it retires rather than bricking the pair.
+func TestUnknownDockPhaseSelfRetires(t *testing.T) {
+	ledger := NewDockLedger()
+	w := newWorld(t)
+	const dockerID = 4001
+	w.ActiveCraft().ID = dockerID
+
+	ledger.SeedFull([]DockSnapshot{{
+		ID: 5, Owner: fpA, OwnerHandle: "alice", DockerCraftID: dockerID,
+		CompositeID: dockerID, GuestOwner: fpB, GuestHandle: "bob",
+		GuestCraftID: 4002, Phase: DockPhase(99),
+	}}, loadedSystems(t))
+
+	ledger.Reconcile(w, fpA, map[string]CraftReport{})
+	if recs := ledger.Records(); len(recs) != 0 {
+		t.Fatalf("a record in an unhandled phase outlived a reconcile: %+v", recs)
+	}
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", 4002); !ok {
+		t.Errorf("the pair is still un-dockable after the unhandled record retired")
+	}
+}
+
+// TestUnknownDockPhaseHoldingACraftIsKept is the ADR 0040 §1 exception to the
+// retirement above: a record parking a payload is holding the ONLY copy of a
+// craft. Retiring it would destroy the vessel that durability exists to save,
+// and an immortal record is recoverable by running a binary that understands
+// the phase again — a deleted craft is not.
+func TestUnknownDockPhaseHoldingACraftIsKept(t *testing.T) {
+	ledger := NewDockLedger()
+	w := newWorld(t)
+	const dockerID = 4003
+	w.ActiveCraft().ID = dockerID
+	wire := save.CraftToWire(w.ActiveCraft())
+
+	ledger.SeedFull([]DockSnapshot{{
+		ID: 6, Owner: fpA, OwnerHandle: "alice", DockerCraftID: dockerID,
+		CompositeID: dockerID, GuestOwner: fpB, GuestHandle: "bob",
+		GuestCraftID: 4004, Phase: DockPhase(99), ReturnPayload: &wire,
+	}}, loadedSystems(t))
+
+	ledger.Reconcile(w, fpA, map[string]CraftReport{})
+	if recs := ledger.Records(); len(recs) != 1 {
+		t.Errorf("an unhandled record holding the only copy of a craft was reaped: %+v", recs)
 	}
 }

--- a/internal/relay/dock_cooldown_test.go
+++ b/internal/relay/dock_cooldown_test.go
@@ -1,0 +1,150 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// The ADR 0038 §5 re-arm latch, hardened (#326). The latch itself is pinned by
+// TestReArmLatchBlocksImmediateReclaimUntilSeparation; what these cover is the
+// four ways a latch could outlive its purpose and brick a vessel — the #312
+// shape ADR 0040 was written to close.
+
+const fpC = "SHA256:carol"
+
+// cooledPair runs a full dock + undock between A and B and returns the two
+// Worlds with a standing Cooldown latch in the ledger, plus the docker's craft
+// ID. Every test below starts from exactly the state a live undock leaves.
+func cooledPair(t *testing.T, ledger *DockLedger, store *Store, guestID uint64) (wA, wB *sim.World, dockerID uint64) {
+	t.Helper()
+	wA, wB = alignedPair(t, guestID)
+	dockerID = wA.ActiveCraft().ID
+	now := time.Now()
+
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); !ok {
+		t.Fatalf("test setup: Claim refused")
+	}
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("test setup: RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	recs := ledger.Records()
+	if len(recs) != 1 || recs[0].Phase != DockCooldown {
+		t.Fatalf("test setup: ledger after undock = %+v, want one Cooldown latch", recs)
+	}
+	return wA, wB, dockerID
+}
+
+// TestCooldownLatchDoesNotBlockAThirdParty is #326 defect 1. Claim refused when
+// EITHER endpoint of any record matched, and that guard now also sees Cooldown
+// records — so one pair's re-arm latch disabled docking for both of their craft
+// against ANYONE. ADR 0038 §5 disarms auto-dock "with that partner"; a latch
+// must never be a third player's problem.
+func TestCooldownLatchDoesNotBlockAThirdParty(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1101
+	_, _, dockerID := cooledPair(t, ledger, store, guestID)
+
+	// The latch still holds against the pair it names.
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); ok {
+		t.Fatalf("the latch let its own pair re-claim immediately")
+	}
+
+	// Carol, who was never part of that dock, closes on A's craft.
+	const carolCraftID = 9001
+	if _, ok := ledger.Claim(fpC, "carol", carolCraftID, fpA, "alice", dockerID); !ok {
+		t.Errorf("a third player's dock on A was refused by A and B's re-arm latch")
+	}
+}
+
+// TestCooldownLatchExpiresAtItsCeiling is #326 defect 3. reconcileCooldown only
+// clears on a POSITIVE range reading, and every unresolvable case — the partner
+// landed, in another system, in another SOI, or simply absent from the report
+// set — holds the latch. So the ordinary reason to undock (one of you leaves)
+// is exactly the case that can never clear it. Measured production shape: B
+// does a TLI after the undock and A's craft is un-dockable until --reset-fleet.
+func TestCooldownLatchExpiresAtItsCeiling(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1102
+	wA, _, dockerID := cooledPair(t, ledger, store, guestID)
+
+	// The partner is unresolvable from here — no report at all, the same
+	// answer a craft in another SOI or another system produces.
+	none := map[string]CraftReport{}
+	ledger.Reconcile(wA, fpA, none)
+	if len(ledger.Records()) != 1 {
+		t.Fatalf("the latch cleared against an unresolvable partner — it should hold until the ceiling")
+	}
+
+	// Well past the ceiling of sim-time later, it must let go regardless.
+	wA.Clock.SimTime = wA.Clock.SimTime.Add(sim.ReArmCeiling + time.Minute)
+	ledger.Reconcile(wA, fpA, none)
+	if recs := ledger.Records(); len(recs) != 0 {
+		t.Fatalf("the latch outlived its ceiling with an unresolvable partner: %+v", recs)
+	}
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); !ok {
+		t.Errorf("re-claim still refused after the latch's ceiling expired")
+	}
+}
+
+// TestCooldownCeilingSurvivesARestart is the durability half of defect 3: the
+// record is durable, so the ceiling has to be too. A restart re-seeds the latch
+// from disk with an empty in-memory report store, which is the very state that
+// holds the latch forever — if the ceiling stamp doesn't round-trip, the
+// restart resets the clock on an already-doomed latch every hour.
+func TestCooldownCeilingSurvivesARestart(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1103
+	wA, _, _ := cooledPair(t, ledger, store, guestID)
+
+	fresh := restart(t, ledger)
+	if len(fresh.Records()) != 1 {
+		t.Fatalf("the latch did not survive the restart at all")
+	}
+	wA.Clock.SimTime = wA.Clock.SimTime.Add(sim.ReArmCeiling + time.Minute)
+	fresh.Reconcile(wA, fpA, map[string]CraftReport{})
+	if recs := fresh.Records(); len(recs) != 0 {
+		t.Errorf("the latch's ceiling did not survive the restart: %+v", recs)
+	}
+}
+
+// TestCooldownRefusalTellsThePilotOnce is #326 defect 4. DetectGuestContact
+// fires every tick, so a latched pair sitting inside the gates refuses a Claim
+// every tick with nothing on screen — "a refused action tells you nothing", at
+// the one verb with no key to press. The pilot gets told, and told once: a
+// chip per tick would be its own kind of broken.
+func TestCooldownRefusalTellsThePilotOnce(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1104
+	wA, _, dockerID := cooledPair(t, ledger, store, guestID)
+	none := map[string]CraftReport{}
+
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); ok {
+		t.Fatalf("test setup: the latch did not refuse")
+	}
+	chips := ledger.Reconcile(wA, fpA, none)
+	if len(chips) != 1 || chips[0].Detail == "" {
+		t.Fatalf("a latch refusal produced no explanation: %+v", chips)
+	}
+
+	// Still drifting inside the gates: the detector claims again every tick,
+	// and the pilot must not get the same chip again every tick.
+	if _, ok := ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID); ok {
+		t.Fatalf("the latch stopped refusing")
+	}
+	if again := ledger.Reconcile(wA, fpA, none); len(again) != 0 {
+		t.Errorf("the latch refusal chipped a second time: %+v", again)
+	}
+}

--- a/internal/relay/dock_lifecycle_test.go
+++ b/internal/relay/dock_lifecycle_test.go
@@ -126,6 +126,61 @@ func TestUndockSetsMutualTargets(t *testing.T) {
 	}
 }
 
+// TestUndockTargetsTheStackWithAMultiVesselGuest is #327: ADR 0038 §6 on the
+// guest side worked only by accident. SetTargetGhost ran BEFORE AdoptCraft,
+// and AdoptCraft(_, true) ends in SetActiveCraftIdx, whose last act is to
+// reload w.Target from the INCOMING craft — a restored component with a zero
+// Target. With a one-vessel guest the outgoing craft IS the incoming one, so
+// the ghost target is checkpointed and read straight back; with two vessels
+// the ghost target lands on the guest's OTHER vessel (silently replacing
+// whatever it was aimed at) and the guest undocks blind. Very reachable:
+// DetectGuestContact scans every ghost a guest owns, so a docker can claim a
+// vessel the guest isn't even flying.
+func TestUndockTargetsTheStackWithAMultiVesselGuest(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 1009
+	wA, wB := alignedPair(t, guestID)
+	now := time.Now()
+
+	// B owns a second vessel and is flying it while the first rides in A's
+	// stack. It is aimed at a body of its own, which the undock must not touch.
+	second := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	second.Primary = wB.ActiveCraft().Primary
+	second.State = wB.ActiveCraft().State
+	wB.AdoptCraft(second, false)
+	secondTarget := spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: 1}
+	second.Target = secondTarget
+	secondID := second.ID
+
+	ledger.Claim(fpA, "alice", wA.ActiveCraft().ID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports) // B hands craft 1 over
+	ledger.Reconcile(wA, fpA, reports) // A fuses
+	compositeID := wA.Crafts[0].ID
+
+	// B flies its second vessel while docked-as-guest.
+	_, idx, ok := wB.CraftByID(secondID)
+	if !ok {
+		t.Fatalf("B lost its second vessel on handover")
+	}
+	wB.SetActiveCraftIdx(idx)
+
+	if !ledger.RequestUndock(fpB, guestID) {
+		t.Fatalf("RequestUndock refused")
+	}
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wA, fpA, reports)
+	ledger.Reconcile(wB, fpB, reports)
+
+	if wB.Target.Kind != sim.TargetGhost || wB.Target.GhostOwner != fpA || wB.Target.CraftID != compositeID {
+		t.Errorf("guest target = %+v, want a ghost target at (%s, %d) — the returned vessel undocked blind", wB.Target, fpA, compositeID)
+	}
+	if second.Target != secondTarget {
+		t.Errorf("the guest's OTHER vessel had its target overwritten: %+v, want %+v", second.Target, secondTarget)
+	}
+}
+
 // TestReturnAtNanoSurvivesRestart (#304, durability): the release-time stamp
 // a live undock's subspace-gap placement reads at delivery must round-trip
 // the same way, or a restart between the split and the guest's own tick

--- a/internal/relay/dock_range_test.go
+++ b/internal/relay/dock_range_test.go
@@ -1,0 +1,96 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// #336: ADR 0038 §4 promised a check of "the ghost-side range reading
+// immediately after a slate change", on the theory that the kilometre reads
+// measured live were weighted toward display-layer lag. Nothing in the release
+// touched the ghost path and no test covered the moment, so the question was
+// left open. This is that check, kept as a regression pin rather than a
+// finding: the reads were real unpropagated placement error, and the §4
+// placement fix (SeparationPush + PlaceAcrossSubspaceGap) removed them.
+//
+// The invariant, from both seats and with and without a subspace skew: across
+// the tick a cross-player undock lands on, a ghost range reading is either
+// TRUTHFUL or ABSENT — never a plausible wrong number. Absence is structural
+// and lasts one frame: the serve tick builds w.Ghosts from the report store
+// BEFORE reconcileDocking mutates the slate, so on the frame of the split the
+// partner's last report still predates it. ResolveTargetGhost /
+// TargetStateRelativeToActivePrimary both return ok=false for a ghost that
+// isn't in the slate — nothing caches a last-known position — so the readout
+// goes blank for that frame and resolves on the next.
+func TestGhostRangeIsTruthfulAcrossASlateChange(t *testing.T) {
+	// The pair's true separation the instant they part: SeparationPush, the
+	// only thing that moves them apart, and independent of the ghost path.
+	const wantSep = sim.DockingDistM * 1.5 // 75 m
+	const tolM = 2.0                       // a couple of metres of Kepler/report slack
+
+	for _, skew := range []time.Duration{0, 5 * time.Second} {
+		t.Run(skew.String(), func(t *testing.T) {
+			store := NewStore()
+			ledger := NewDockLedger()
+			const guestID = 1200
+			wA, wB := alignedPair(t, guestID)
+			dockerID := wA.ActiveCraft().ID
+			now := time.Now()
+
+			ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+			reports := reportMap(store, wA, wB, now)
+			ledger.Reconcile(wB, fpB, reports)
+			ledger.Reconcile(wA, fpA, reports)
+			compositeID := wA.Crafts[0].ID
+			if !ledger.RequestUndock(fpB, guestID) {
+				t.Fatalf("RequestUndock refused")
+			}
+			// The guest's subspace clock sits ahead of the docker's — the
+			// ordinary case, and the one that produced the kilometre reads.
+			wB.Clock.SimTime = wA.Clock.SimTime.Add(skew)
+
+			// The tick the split lands on, in the serve layer's order:
+			// report, build ghosts, THEN reconcile. Both sessions.
+			t1 := now.Add(time.Second)
+			reports = reportMap(store, wA, wB, t1)
+			ghostsA := GhostsFor(wA, store.Snapshot(fpA), nil)
+			ledger.Reconcile(wA, fpA, reports) // A splits the guest out
+			ghostsB := GhostsFor(wB, store.Snapshot(fpB), nil)
+			ledger.Reconcile(wB, fpB, reports) // B adopts it
+
+			check := func(label string, ghosts []sim.Ghost, from *sim.World, localID uint64, owner string, id uint64) (found bool) {
+				t.Helper()
+				local, _, ok := from.CraftByID(localID)
+				if !ok {
+					t.Fatalf("%s: local craft %d is not in the slate", label, localID)
+				}
+				for _, g := range ghosts {
+					if g.Owner != owner || g.CraftID != id {
+						continue
+					}
+					if d := local.State.R.Sub(g.RelPos).Norm(); d < wantSep-tolM || d > wantSep+tolM {
+						t.Errorf("%s: ghost range reads %.1f m, want the %.0f m separation — a plausible wrong number is worse than none", label, d, wantSep)
+					}
+					return true
+				}
+				return false
+			}
+
+			// Same frame as the split: truthful if present at all.
+			check("docker→returned craft, same frame", ghostsA, wA, dockerID, fpB, guestID)
+			check("guest→stack, same frame", ghostsB, wB, guestID, fpA, compositeID)
+
+			// Next frame, once both sides have reported their new slates: both
+			// readings must be there AND right, subspace skew and all.
+			reportMap(store, wA, wB, t1.Add(50*time.Millisecond))
+			if !check("docker→returned craft, next frame", GhostsFor(wA, store.Snapshot(fpA), nil), wA, dockerID, fpB, guestID) {
+				t.Errorf("the docker still had no ghost of the craft it just released a frame later")
+			}
+			if !check("guest→stack, next frame", GhostsFor(wB, store.Snapshot(fpB), nil), wB, guestID, fpA, compositeID) {
+				t.Errorf("the guest still had no ghost of the stack it just left a frame later")
+			}
+		})
+	}
+}

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"log"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -93,10 +94,40 @@ func (m *reportingModel) reconcileDocking(w *sim.World, coupled map[string]bool,
 	}
 
 	// Persist the durable cross-ref on any transition so a reconnecting guest
-	// resumes.
-	if changed {
-		_ = m.srv.persistDocks()
+	// resumes — or on a tick after one failed, until one lands (#335).
+	if changed || m.srv.dockFlushOwed() {
+		if err := m.srv.persistDocks(); err != nil {
+			// Not swallowed. reclaimFromEmptySeat treats this exact failure as
+			// fatal and undoes its migration, because the parked payload is the
+			// only copy of a craft; the handback here is in the same position —
+			// w.UndockGuest has already shrunk the owner's composite in place —
+			// but its undo is not available from this side of the seam. What is
+			// available is refusing to forget: say so once, and keep re-flushing
+			// every tick until the ledger reaches disk, so the window a restart
+			// could fall into is one tick rather than open-ended.
+			m.srv.markDockFlushFailed(err)
+		}
 	}
+}
+
+// dockFlushOwed reports whether a previous dock-ledger flush failed and has
+// not since succeeded (#335).
+func (s *Server) dockFlushOwed() bool {
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+	return s.dockPersistFailed
+}
+
+// markDockFlushFailed records a failed flush and logs the first one of a run.
+// Logged once per run rather than per tick: the tick loop retries ~20×/s, and
+// a full disk would otherwise bury the operator's own logs while they fix it.
+func (s *Server) markDockFlushFailed(err error) {
+	s.persistMu.Lock()
+	defer s.persistMu.Unlock()
+	if !s.dockPersistFailed {
+		log.Printf("dock ledger: could not be written (%v) — a craft handed between players is parked on the ledger and exists nowhere else; retrying every tick", err)
+	}
+	s.dockPersistFailed = true
 }
 
 // dockedWith reports whether this session and partner share a FUSED
@@ -178,7 +209,13 @@ func (m reportingModel) releaseGuest() (tea.Model, tea.Cmd) {
 func (s *Server) persistDocks() error {
 	s.persistMu.Lock()
 	defer s.persistMu.Unlock()
-	return s.store.SetDocks(snapshotsToDockLinks(s.dock.FullRecords()))
+	err := s.store.SetDocks(snapshotsToDockLinks(s.dock.FullRecords()))
+	if err == nil {
+		// Whatever a previous flush failed to carry out is on disk now — this
+		// writes the whole ledger, not a delta (#335).
+		s.dockPersistFailed = false
+	}
+	return err
 }
 
 // dockLinksToSnapshots adapts the persisted cross-ref into live ledger

--- a/internal/serve/dock.go
+++ b/internal/serve/dock.go
@@ -40,9 +40,21 @@ func (m *reportingModel) reconcileDocking(w *sim.World, coupled map[string]bool,
 
 	// Advance every dock touching this session against its World.
 	craftsBefore := len(w.Crafts)
+	recordsBefore := m.srv.dock.RecordCount()
 	chips := m.srv.dock.Reconcile(w, m.owner, reports)
 	for _, c := range chips {
-		m.localEvents = append(m.localEvents, sim.SessionEvent{Kind: c.Kind, Handle: c.Handle, At: now})
+		m.localEvents = append(m.localEvents, sim.SessionEvent{
+			Kind: c.Kind, Handle: c.Handle, Detail: c.Detail, At: now,
+		})
+		changed = true
+	}
+	// A record ENDING is a durable transition with none of the three traces
+	// above (#326). The ADR 0038 §5 re-arm latch clearing is the case that
+	// bit: entering cooldown persisted (it rides the undocked chip), leaving
+	// it did not, so the delete lived in memory and the next restart re-seeded
+	// a latch that by then had no way left to clear — a vessel permanently
+	// un-dockable. The record count is the observable trace of any teardown.
+	if m.srv.dock.RecordCount() != recordsBefore {
 		changed = true
 	}
 	// The guest side of a DockPending record parks its craft on the record

--- a/internal/serve/dock_cooldown_test.go
+++ b/internal/serve/dock_cooldown_test.go
@@ -1,0 +1,64 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// TestClearedCooldownLatchDoesNotResurrectAfterRestart is #326 defect 2, driven
+// through the real serve seam. reconcileDocking decides whether to flush from a
+// successful Claim, an emitted chip, or a changed craft count — and a re-arm
+// latch CLEARING produces none of the three, so the delete lands in memory
+// only. Entering cooldown persists (it rides the undocked chip); leaving it did
+// not. On the production host the hourly auto-adopt restart then re-seeded the
+// latch from disk, in the one state (empty report store, partner long gone)
+// where nothing can ever clear it again.
+func TestClearedCooldownLatchDoesNotResurrectAfterRestart(t *testing.T) {
+	const guestFP = "SHA256:gern"
+	dir := t.TempDir()
+	srv := serverOver(t, dir)
+	enrollDirect(t, srv, guestFP, "gern")
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// A latch whose local craft is no longer in this World — the guest staged
+	// it, or ended the flight. Nothing left of theirs to guard, so the next
+	// reconcile clears the latch.
+	srv.dock.SeedFull([]relay.DockSnapshot{{
+		ID: 77, Owner: sessiondir.HostFingerprint, OwnerHandle: "host",
+		DockerCraftID: 1, CompositeID: 90,
+		GuestOwner: guestFP, GuestHandle: "gern", GuestCraftID: 9999,
+		Phase:        relay.DockCooldown,
+		ReturnAtNano: w.Clock.SimTime.UnixNano(),
+	}}, nil)
+	if err := srv.persistDocks(); err != nil {
+		t.Fatalf("test setup: persistDocks: %v", err)
+	}
+
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	model := srv.withReporting(app, guestFP)
+	rm, ok := model.(reportingModel)
+	if !ok {
+		t.Fatalf("wrapper model = %T", model)
+	}
+	rm.reconcileDocking(w, map[string]bool{}, map[string]relay.CraftReport{}, map[string]string{}, time.Now())
+
+	if recs := srv.dock.Records(); len(recs) != 0 {
+		t.Fatalf("test setup: the latch did not clear in memory: %+v", recs)
+	}
+
+	restarted := serverOver(t, dir)
+	if recs := restarted.dock.FullRecords(); len(recs) != 0 {
+		t.Errorf("a cleared re-arm latch came back from disk after a restart: %+v", recs)
+	}
+}

--- a/internal/serve/dock_persist_retry_test.go
+++ b/internal/serve/dock_persist_retry_test.go
@@ -1,0 +1,92 @@
+package serve
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// TestFailedDockFlushIsRetriedNotSwallowed is #335. reconcileDocking's flush
+// was `_ = m.srv.persistDocks()`, while reclaimFromEmptySeat treats the
+// IDENTICAL failure as fatal — undoing both halves of its migration because
+// the parked payload is the only copy of a craft. ADR 0038 §4 widened the
+// undock handback from the Parcel-only path to every live undock, so the
+// handback is now the common path through that same window: w.UndockGuest has
+// already shrunken the owner's composite in place and the restored craft
+// exists only on the record. Drop the error and the owner's world later saves
+// without it, while disk still holds the pre-undock record — the guest's [U]
+// then finds nothing of theirs in the composite and refuses forever.
+//
+// The flush is only ever driven by a transition, so a swallowed failure has no
+// second chance: this drives one failing flush, restores the disk, and then
+// ticks a reconcile with nothing whatsoever changed. Pre-fix that tick does
+// nothing and the stale record survives the restart.
+func TestFailedDockFlushIsRetriedNotSwallowed(t *testing.T) {
+	const guestFP = "SHA256:gern"
+	dir := t.TempDir()
+	srv := serverOver(t, dir)
+	enrollDirect(t, srv, guestFP, "gern")
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	srv.dock.SeedFull([]relay.DockSnapshot{{
+		ID: 78, Owner: sessiondir.HostFingerprint, OwnerHandle: "host",
+		DockerCraftID: 1, CompositeID: 91,
+		GuestOwner: guestFP, GuestHandle: "gern", GuestCraftID: 9999,
+		Phase:        relay.DockCooldown,
+		ReturnAtNano: w.Clock.SimTime.UnixNano(),
+	}}, nil)
+	if err := srv.persistDocks(); err != nil {
+		t.Fatalf("test setup: persistDocks: %v", err)
+	}
+
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	model := srv.withReporting(app, guestFP)
+	rm, ok := model.(reportingModel)
+	if !ok {
+		t.Fatalf("wrapper model = %T", model)
+	}
+
+	// The disk goes away underneath the transition (full volume, EIO, a
+	// read-only mount): the atomic tmpfile+rename cannot land.
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat session dir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod session dir: %v", err)
+	}
+	if err := srv.persistDocks(); err == nil {
+		t.Skip("this filesystem still writes to a read-only directory — cannot inject the failure")
+	}
+
+	// The transition: the latch clears (the guest's craft is not in this
+	// World), and the flush that should carry it to disk fails.
+	rm.reconcileDocking(w, map[string]bool{}, map[string]relay.CraftReport{}, map[string]string{}, time.Now())
+	if recs := srv.dock.Records(); len(recs) != 0 {
+		t.Fatalf("test setup: the latch did not clear in memory: %+v", recs)
+	}
+
+	// The disk comes back. The next tick has no transition of its own — no
+	// claim, no chip, no craft moved, no record ended — so the only thing that
+	// can still save the ledger is the failure not having been swallowed.
+	if err := os.Chmod(dir, info.Mode().Perm()); err != nil {
+		t.Fatalf("restoring session dir mode: %v", err)
+	}
+	rm.reconcileDocking(w, map[string]bool{}, map[string]relay.CraftReport{}, map[string]string{}, time.Now())
+
+	restarted := serverOver(t, dir)
+	if recs := restarted.dock.FullRecords(); len(recs) != 0 {
+		t.Errorf("a failed dock flush was swallowed — disk still holds the pre-transition ledger: %+v", recs)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -143,6 +143,17 @@ type Server struct {
 	// re-snapshotting dock.Records() makes the last writer persist the truly-
 	// current full ledger (ledger mutations are already ledger-mutex serial).
 	persistMu sync.Mutex
+
+	// dockPersistFailed is set when a dock-ledger flush errors and cleared
+	// when one lands (#335). The undock handback shrinks the owner's
+	// composite in place and leaves the guest's craft on the record as its
+	// only copy, so a dropped flush leaves disk holding a pre-undock record
+	// that a restart would restore over a world that has already moved on —
+	// the identical window reclaimFromEmptySeat treats as fatal. The next
+	// tick re-flushes on the strength of this flag rather than waiting for
+	// some later, unrelated transition to happen to carry the state out.
+	// Guarded by persistMu, which every flush already takes.
+	dockPersistFailed bool
 }
 
 // DefaultHostKeyPath returns the per-host SSH identity path, sibling

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -1,6 +1,8 @@
 package sim
 
 import (
+	"time"
+
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
@@ -345,6 +347,23 @@ const (
 // "~100 m, just outside the gate band") so re-arming isn't a coin-flip right
 // at the boundary the 75 m SeparationPush lands just inside of.
 const ReArmDistM = DockingDistM * 2 // 100 m
+
+// ReArmCeiling bounds how long a re-arm latch may hold when the distance it
+// waits on can never be read (#326). The latch clears on a POSITIVE range
+// reading, and a partner who is landed, in another system, in another SOI, or
+// simply not reporting yields no reading at all — so the ordinary reason to
+// undock (one of you leaves) is exactly the case that holds the latch open
+// forever, and a restart re-seeds it from disk with an empty report store.
+//
+// Measured in SIM-time against the release stamp the record already carries,
+// not wall time: the latch is a statement about the pair's flight ("back away
+// first"), and sim-time is the clock that flight happens on — under warp a
+// pair who have not separated in ten minutes of flying are not about to. It
+// costs nothing durable, since the stamp is a field the record already
+// persists. Far beyond ADR 0038 §5's "silent instant re-fuse" worry, so it
+// cannot expire a latch that is still doing its job; short enough that a
+// vessel is never un-dockable for a session.
+const ReArmCeiling = 10 * time.Minute
 
 // checkDocking scans every craft pair in the same primary frame
 // for a docking-eligible encounter (proximity + relative velocity


### PR DESCRIPTION
Four dock-ledger defects from the v0.35.0 batch review, plus the #336
investigation. One commit per issue, TDD throughout — every test was run red
against the pre-fix code first.

No schema version bumped anywhere: these are patch fixes against a live server
holding real durable state.

## #326 — the re-arm latch could permanently brick a vessel

Four compounding defects in the ADR 0038 §5 latch, all four fixed in `245472d`.

1. **Scope.** `Claim` refused on *either* endpoint of any record, and that guard
   now also sees `DockCooldown` records — so one pair's latch disabled docking
   for both of their craft against *anybody*. A cooldown record refuses only its
   own pair now (`isPair`, both endpoints, orientation-blind because a control
   transfer flips roles). The engaged-record guard (`DockPending`/`DockActive`)
   is untouched and still refuses on either endpoint, which is correct: a craft
   fused into someone's stack cannot also be claimed by a third player.
2. **Persistence.** `reconcileDocking` derived its flush from a successful
   `Claim`, an emitted chip, or a changed craft count. A latch *clearing*
   produces none of the three, so the delete never reached disk while entering
   cooldown did. `DockLedger.RecordCount()` is now sampled either side of the
   reconcile, which catches any record teardown, not just this one.
3. **Ceiling.** The latch cleared only on a *positive* range reading, and every
   unresolvable case (partner landed, in another system, in another SOI, absent
   from the report set) held it open — so leaving, the ordinary reason to
   undock, was exactly the case that could never clear it. `sim.ReArmCeiling`
   (10 minutes of **sim**-time) now ends it regardless. It is measured against
   `returnAtNano`, the release stamp the record **already persists** as
   `DockSnapshot.ReturnAtNano`, so the ceiling survives the restart that
   re-seeds the latch into an empty report store — the state in which nothing
   else can ever clear it. Sim-time rather than wall-time because the latch is a
   statement about the pair's flight. A cooldown record with no stamp at all
   retires immediately rather than latching forever.
4. **Silence.** `DetectGuestContact` fires every tick, so a latched pair inside
   the gates refused a `Claim` every tick with nothing on screen. The refusal now
   arms **one chip for the life of the latch** (`reArmNoticed`), delivered on the
   claimer's own next reconcile and carrying the way out in words: *"docking held
   off — back 100 m clear of bob before docking again"*. It rides
   `SessionEventTransferRefused`, which is already the ledger's generic
   "here is why that didn't happen" chip (the reclaim path sends
   `take control: …` through it too), so no new chip vocabulary and no change to
   the tui. `DockChip` gained a `Detail` field to carry it.

## #327 — mutual post-undock targeting with a multi-vessel guest (`ca0207d`)

`SetTargetGhost` moved after `AdoptCraft`. `AdoptCraft(_, true)` ends in
`SetActiveCraftIdx`, whose last act reloads `w.Target` from the incoming craft —
a restored component with a zero `Target`. With one vessel the outgoing craft
*is* the incoming one, so it worked by coincidence; with two, the ghost target
landed on the guest's *other* vessel and `w.Target` was cleared.

## #335 — swallowed handback `persistDocks` error (`196aacb`)

`_ = m.srv.persistDocks()` no longer. `reclaimFromEmptySeat`'s undo is not
available from this side of the seam (`w.UndockGuest` has already shrunk the
composite in place), so the flush instead refuses to forget: the error is logged
once per run of failures — the tick loop retries ~20×/s and a full disk would
bury the operator's own logs — and every subsequent tick re-flushes until one
lands. The window a restart can fall into becomes one tick instead of
open-ended. One field added to `Server` (`dockPersistFailed`, guarded by the
`persistMu` every flush already takes).

## #337 — durable `DockPhase` values inert to an older binary (`be020b0`)

Per the ruling: unknown phases **self-retire**, no session meta bump. A record
this binary cannot advance is dropped on the first reconcile that sees it rather
than bricking the pair via `Claim`'s engaged-record guard. The exception is ADR
0040 §1 — a record holding a parked payload holds the only copy of a craft, and
an immortal record is recoverable by running a binary that understands the phase
again, while a deleted vessel is not.

## #336 — investigation: **clean, no defect** (`cb32d8f`, test only)

There is no measurable ghost-range error after a slate change. The kilometre
reads were real unpropagated placement error, and the §4 placement fix removed
them entirely.

Evidence, from an instrumented reproduction of the serve tick order
(`reporter.Tick` → `GhostsFor` → `reconcileDocking`), with and without a 5 s
subspace skew:

- **Both seats, next frame: 75.0 m, error < 0.1 m** — the true separation, which
  is `SeparationPush` and comes from nowhere near the ghost path.
- **Docker's seat, same frame as the split: no ghost at all.** Structural and
  one frame long: the tick builds `w.Ghosts` from the report store *before*
  `reconcileDocking` mutates the slate, so the partner's last report predates
  the change. `ResolveTargetGhost` and `TargetStateRelativeToActivePrimary` both
  fail closed for a ghost that is not in the slate — nothing caches a last-known
  position — so the readout **blanks** for ~50 ms rather than going stale. An
  absence, never a wrong number.
- **Mutation check** confirming the test is not vacuous: deleting
  `PlaceAcrossSubspaceGap` from the handback makes it report **38 km** across a
  5 s skew — the exact #304 shape.

Kept as `TestGhostRangeIsTruthfulAcrossASlateChange`, which pins the invariant
so the question cannot come back as "investigated, no record". Recommend
closing #336 as no-defect.

## Tests

| Test | Pins |
| --- | --- |
| `relay.TestUndockTargetsTheStackWithAMultiVesselGuest` | #327 — guest with 2+ vessels undocks *targeting the stack*, and the other vessel's own target is untouched |
| `relay.TestCooldownLatchDoesNotBlockAThirdParty` | #326.1 — the latch still refuses its own pair, and Carol's unrelated dock on A succeeds |
| `relay.TestCooldownLatchExpiresAtItsCeiling` | #326.3 — holds against an unresolvable partner, lets go past `ReArmCeiling` |
| `relay.TestCooldownCeilingSurvivesARestart` | #326.3 — the ceiling stamp round-trips, so a restart cannot reset the clock on a doomed latch |
| `relay.TestCooldownRefusalTellsThePilotOnce` | #326.4 — a refusal explains itself, and exactly once however many ticks re-claim |
| `serve.TestClearedCooldownLatchDoesNotResurrectAfterRestart` | #326.2 — a cleared latch does not come back from disk (through the real serve seam) |
| `serve.TestFailedDockFlushIsRetriedNotSwallowed` | #335 — disk fails mid-transition, comes back, and a tick with *no* transition of its own still gets the ledger out |
| `relay.TestUnknownDockPhaseSelfRetires` | #337 — a phase this binary has no case for retires, and the pair is dockable again |
| `relay.TestUnknownDockPhaseHoldingACraftIsKept` | #337 — ADR 0040 §1 exception: never reap a record holding the only copy of a craft |
| `relay.TestGhostRangeIsTruthfulAcrossASlateChange` | #336 — truthful-or-absent, both seats, 0 s and 5 s skew |

`go vet ./...` and `go test ./... -race -count=1` both green.

Closes #326, closes #327, closes #335, closes #337. Resolves #336 (no defect).
