### PR TITLE
fix: chip-layout batch — DOCKED/NODES clipping, undock hint, per-craft node hazard

### DIFF
--- a/internal/tui/screens/dock_guest_rider_render_test.go
+++ b/internal/tui/screens/dock_guest_rider_render_test.go
@@ -59,7 +59,7 @@ func TestDockGuestRenderLooksRight(t *testing.T) {
 				}
 			}
 			if tc.online {
-				if !strings.Contains(out, "[J] request control") || !strings.Contains(out, "[u] ask to undock") {
+				if !strings.Contains(out, "[J] request control") || !strings.Contains(out, "[U] ask to undock") {
 					t.Errorf("%s render missing the live-owner exits", tc.name)
 				}
 			} else {

--- a/internal/tui/screens/dock_guest_rider_render_test.go
+++ b/internal/tui/screens/dock_guest_rider_render_test.go
@@ -3,6 +3,7 @@ package screens
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -74,5 +75,45 @@ func TestDockGuestRenderLooksRight(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestDockGuestRenderAt80x24IncludesDockedBlock (#328): the standing
+// DOCKED block was silently clipped entirely off-canvas at 80x24 — the
+// most common terminal size. composeChips had no height bound on the
+// top-left stack at all: topLeftRow grew past cRows with nothing to
+// stop it, and overlayStyledBlock silently drops any row outside
+// [0, cRows). DOCKED is appended late in assembleChips' top-left order,
+// so it absorbed all the accumulated overflow from VESSEL/MISSION/
+// SESSION/TIME LOCK ahead of it and rendered nowhere. It is the rider's
+// only surviving route to [J] request control / [U] undock, so unlike
+// most chips it must never be silently lost to overflow.
+func TestDockGuestRenderAt80x24IncludesDockedBlock(t *testing.T) {
+	v := NewOrbitView(riderViewTheme())
+	v.Resize(80, 24)
+
+	w := dockGuestStackGhostWorld(t)
+	w.Session = &sim.SessionInfo{Players: []sim.SessionPlayer{
+		{Fingerprint: w.DockGuest.OwnerFP, Handle: w.DockGuest.OwnerHandle, Online: true},
+	}}
+	// Reproduce the #328 report's exact top-left stack: VESSEL (badged,
+	// grown to 6 lines by the ghost report) + MISSION + SESSION + TIME
+	// LOCK ahead of DOCKED — the combination that pushed DOCKED's block
+	// to rows 21-26 on a 21-row canvas, entirely past the edge. (The dock
+	// coupling also drives buildTimeLockChip's own #328 fix — see the
+	// TIME LOCK suppression test — but this render-level test stands on
+	// the structural composeChips budget alone, independent of that.)
+	w.SessionEvents = []sim.SessionEvent{
+		{Kind: sim.SessionEventJoin, Handle: "bob", At: time.Now()},
+	}
+	w.CoWarp = sim.CoWarpState{Coupled: true, MinWarp: 10, Partners: []string{"bob"}}
+
+	out := v.Render(w, 0, 80, 24)
+	t.Logf("=== DockGuest render at 80x24 ===\n%s", out)
+
+	for _, want := range []string{"DOCKED", "riding in bob's stack", "[J] request control", "[U] ask to undock"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("80x24 render missing %q — the rider's only route to [J]/[U] was clipped off-canvas", want)
+		}
 	}
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -41,13 +41,22 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// must not be able to hide fuel/Δv mid-burn. v0.13 playtest move:
 	// VESSEL/PROPELLANT left the right-hand column to live on the canvas.
 	if lines := v.buildVesselChip(w); lines != nil {
-		chips = append(chips, builtChip{corner: cornerTopLeft, lines: lines})
+		chips = append(chips, builtChip{corner: cornerTopLeft, lines: lines, priority: chipPriorityCore})
 	}
 	add := func(id settings.Chip, corner chipCorner, lines []string) {
 		if lines == nil || !v.chipEnabled(id) {
 			return
 		}
 		chips = append(chips, builtChip{id: id, corner: corner, lines: lines})
+	}
+	// addPriority is add's twin for the handful of chips that must never
+	// be silently dropped by admitChipsByBudget when a corner overflows
+	// (#328/#334) — see the chipPriority* doc comment in orbit_chips.go.
+	addPriority := func(id settings.Chip, corner chipCorner, lines []string, priority int) {
+		if lines == nil || !v.chipEnabled(id) {
+			return
+		}
+		chips = append(chips, builtChip{id: id, corner: corner, lines: lines, priority: priority})
 	}
 	// The current goal sits directly under the pinned VESSEL chip — "who I am"
 	// then "what I'm doing" in the top-left status corner (ADR 0025 / Slice 5).
@@ -83,8 +92,12 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// while one of this player's craft rides in another player's stack
 	// (names the ride + the exits), with #253's owner-away line folded in
 	// as an extra row rather than a second surface. Always-on like
-	// RENDEZVOUS (empty id); F2 declutter still clears it.
-	add("", cornerTopLeft, v.buildDockGuestChip(w))
+	// RENDEZVOUS (empty id); F2 declutter still clears it. #328: this is
+	// the rider's only surviving route to [J] request control / [U]
+	// undock once absorbed into another player's stack, so it carries
+	// chipPriorityForced — admitChipsByBudget must never silently drop it
+	// for space the way it dropped every ordinary chip ahead of it.
+	addPriority("", cornerTopLeft, v.buildDockGuestChip(w), chipPriorityForced)
 	// COMMS link status for the active probe (ADR 0027 / C2-7), beneath the
 	// vessel-state readouts. Force-shown while a just-blocked command is
 	// flashing (CommBlockedFlash) — bypassing the toggle + declutter — so the
@@ -100,7 +113,7 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// the current orbit (apo/peri/incl) is never user-hideable from the
 	// Settings screen, mirroring the always-on ● BURNS readout — both are
 	// too load-bearing to toggle off. F2 declutter still clears them.
-	add("", cornerTopRight, v.buildOrbitMetricsChip(w))
+	addPriority("", cornerTopRight, v.buildOrbitMetricsChip(w), chipPriorityCore)
 	// PROJECTED ORBIT sits to the LEFT of the always-on ORBIT readout (issue
 	// #63 follow-up) so current + projected show together during a burn
 	// without growing the top-right column's height — leaving vertical room
@@ -139,7 +152,17 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	if lines := v.buildNodesChip(w); lines != nil {
 		forced := v.anyActiveBurn(w) || activeCraftQueuedNodes(w) > 1
 		if forced || v.chipEnabled(settings.ChipNodes) {
-			chips = append(chips, builtChip{id: settings.ChipNodes, corner: cornerBottomRight, lines: lines})
+			// #334: only a genuinely FORCED render (bypassing the toggle)
+			// gets chipPriorityForced's "never drop for space, clamp
+			// instead" guarantee. A merely toggle-enabled NODES chip is a
+			// normal-priority chip like any other — if it can't fit, the
+			// player's own toggle choice is what loses, not a silent
+			// safety-critical readout.
+			priority := chipPriorityNormal
+			if forced {
+				priority = chipPriorityForced
+			}
+			chips = append(chips, builtChip{id: settings.ChipNodes, corner: cornerBottomRight, lines: lines, priority: priority})
 		}
 	}
 	return chips
@@ -555,12 +578,17 @@ func rendezvousHoldLabel(h sim.RendezvousRateHolder, handle string) string {
 // slow, proximity co-warp coupled them, and min-wins is quietly setting
 // the player's rate. Who, and what the clock is doing — the RENDEZVOUS
 // chip carries the same facts with far more context inside an agreement,
-// so this stays out of its way there.
+// so this stays out of its way there. #328 review: a docked rider's
+// coupling comes from WithDockCoupling, not an agreement either — the
+// standing DOCKED block already says "riding in X's stack", which is
+// the same fact ("your clock isn't yours right now, X's is") stated in
+// flight terms, so this stays out of ITS way too rather than stacking a
+// second "warp locked with X" line directly above it.
 //
 // The v0.30 lesson (a silent no-op reads as broken) applied to warp: a
-// lock on the player's time is always explained on screen.
+// lock on the player's time is always explained on screen — somewhere.
 func (v *OrbitView) buildTimeLockChip(w *sim.World) []string {
-	if !w.CoWarp.Coupled || v.rendezvousExplainsCoupledLock(w) {
+	if !w.CoWarp.Coupled || v.rendezvousExplainsCoupledLock(w) || v.dockGuestExplainsCoupledLock(w) {
 		return nil
 	}
 	partners := strings.Join(w.CoWarp.Partners, ", ")
@@ -571,6 +599,27 @@ func (v *OrbitView) buildTimeLockChip(w *sim.World) []string {
 		v.theme.Primary.Render("TIME LOCK"),
 		v.theme.Dim.Render("  warp locked with " + partners + " — " + WarpLabel(w.EffectiveWarp())),
 	}
+}
+
+// dockGuestExplainsCoupledLock reports whether the standing DOCKED block
+// (buildDockGuestChip) already explains the exact co-warp lock
+// buildTimeLockChip would otherwise state (#328 review, mirroring
+// rendezvousExplainsCoupledLock's specificity discipline). True only
+// when this player is riding as a DockGuest AND the CoWarp coupling
+// actually names that same stack owner — a rider coincidentally also
+// proximity-coupled to a third, unrelated player still needs TIME LOCK
+// to explain THAT lock, since DOCKED never mentions them.
+func (v *OrbitView) dockGuestExplainsCoupledLock(w *sim.World) bool {
+	dg := w.DockGuest
+	if dg == nil {
+		return false
+	}
+	for _, p := range w.CoWarp.Partners {
+		if p == dg.OwnerHandle {
+			return true
+		}
+	}
+	return false
 }
 
 // rendezvousExplainsCoupledLock reports whether the RENDEZVOUS chip is

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -126,13 +126,19 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	// in flight the chip force-shows — bypassing both the ChipNodes
 	// Settings toggle and F2 declutter — so it can never be hidden.
 	// #293 extends the same force-show rationale to the staleness
-	// hazard: once more than one node is queued anywhere, every node
-	// behind the first was computed against an orbit that no longer
-	// exists once the first one fires, so the count must be visible
-	// the same way a live burn is. With ≤1 node queued and nothing
-	// burning, the chip honours the toggle + declutter like any chip.
+	// hazard: once more than one node is queued on the ACTIVE craft,
+	// every node behind the first was computed against an orbit that no
+	// longer exists once the first one fires, so the count must be
+	// visible the same way a live burn is. #333: this is strictly
+	// per-craft (activeCraftQueuedNodes), not the old fleet-wide sum — a
+	// different craft's queue firing doesn't stale the one this player
+	// is watching, so a small constellation with one node per vessel no
+	// longer force-shows a chip the player explicitly decluttered. With
+	// ≤1 node queued on the active craft and nothing burning, the chip
+	// honours the toggle + declutter like any chip.
 	if lines := v.buildNodesChip(w); lines != nil {
-		if v.anyActiveBurn(w) || totalQueuedNodes(w) > 1 || v.chipEnabled(settings.ChipNodes) {
+		forced := v.anyActiveBurn(w) || activeCraftQueuedNodes(w) > 1
+		if forced || v.chipEnabled(settings.ChipNodes) {
 			chips = append(chips, builtChip{id: settings.ChipNodes, corner: cornerBottomRight, lines: lines})
 		}
 	}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -647,7 +647,12 @@ func (v *OrbitView) buildDockGuestChip(w *sim.World) []string {
 	if w.DockOwnerOnline() {
 		lines = append(lines,
 			v.theme.Dim.Render("  [J] request control"),
-			v.theme.Dim.Render("  [u] ask to undock"),
+			// #330: relabel to [U] — Undock is bound uppercase
+			// (input.go, key.NewBinding(key.WithKeys("U"))) and there is
+			// no lowercase u binding anywhere in internal/tui. A rider
+			// following the lowercase advertisement pressed a dead key.
+			// docs/controls.md and the F1 overlay both already say U.
+			v.theme.Dim.Render("  [U] ask to undock"),
 		)
 	} else {
 		lines = append(lines, v.theme.Warning.Render("  [J] take the stick (pilot's gone)"))

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -54,7 +55,46 @@ type builtChip struct {
 	// for cornerTopRight; ignored (normal stacking) when there's no prior
 	// top-right chip to sit beside.
 	leftOfPrev bool
+	// priority controls which chips survive when a corner's stack would
+	// otherwise overflow the canvas (#328/#334 — see admitChipsByBudget).
+	// Defaults to chipPriorityNormal; the shared "add" helper in
+	// assembleChips never sets it, so every ordinary toggleable chip
+	// competes on equal footing and only chipPriorityCore/chipPriorityForced
+	// chips are called out explicitly.
+	priority int
 }
+
+// Priority tiers for admitChipsByBudget (#328/#334). Highest first:
+//
+//   - chipPriorityCore (100): unconditionally pinned core telemetry that
+//     predates chip toggles entirely — VESSEL and the top-right ORBIT
+//     metrics chip. Never gated by Settings or declutter, so it must
+//     never be silently dropped for space either.
+//   - chipPriorityForced (90): chips a game-state rule force-shows past
+//     the Settings toggle AND F2 declutter, because losing them
+//     silently would hide a safety/continuity fact the player has no
+//     other way to see: DOCKED (ADR 0038 S4 — the rider's only
+//     surviving route to [J]/[U] once absorbed into another player's
+//     stack, #328) and NODES while force-shown (a live burn, or more
+//     than one queued node on the active craft, #333/#334).
+//   - chipPriorityNormal (0, the zero value): every ordinary toggleable/
+//     contextual chip. Competes for whatever budget chipPriorityCore
+//     and chipPriorityForced chips leave behind; the first class
+//     dropped when a corner would overflow.
+//
+// chipPriorityForced and up are "critical": admitChipsByBudget never
+// drops them for space, and composeChips clamps their placement onto
+// the canvas as a last resort (accepting an overlap with whatever's
+// beneath) rather than let them run off-canvas and be silently clipped
+// by overlayStyledBlock. Everything below that line is dropped whole
+// rather than partially rendered — a corner that doesn't fit shows a
+// clean, shorter stack, never a lone border fragment.
+const (
+	chipPriorityCore     = 100
+	chipPriorityForced   = 90
+	chipPriorityNormal   = 0
+	chipPriorityCritical = chipPriorityForced // admission threshold
+)
 
 // chipRect is the absolute screen-cell rectangle a composited Chip
 // occupied this frame, used by the orbit screen's mouse dispatch to route
@@ -93,6 +133,72 @@ func padChipBlock(lines []string) ([]string, int) {
 	return out, width
 }
 
+// admitChipsByBudget decides, independently per corner, which of chips
+// survive this frame without that corner's stack running off the canvas
+// (#328/#334). composeChips used to have no height bound at all:
+// topLeftRow / bottomRightRow could walk past the canvas edge with
+// nothing to stop them, and overlayStyledBlock silently drops any row
+// outside [0, cRows) — so an always-on chip late in a corner's stack
+// (DOCKED, appended after VESSEL/MISSION/SESSION/TIME LOCK, #328) or one
+// squeezed against the navball reservation (NODES, #334) could vanish
+// with no signal anything was lost.
+//
+// Each corner gets a real budget: the number of rows it can stack into
+// before hitting the opposite edge of the canvas (or the navball, for
+// bottom-right). Candidates are considered highest builtChip.priority
+// first — ties keep their original relative order (a stable sort), so a
+// corner that fits comfortably within budget is admitted in full and
+// composeChips lays it out identically to a flat, unconditional append.
+// A chip that would push the running total past budget is dropped
+// (not admitted) rather than placed and clipped; a smaller, later chip
+// in priority order can still land in whatever budget remains. Chips at
+// chipPriorityForced or above ("critical") are always admitted
+// regardless of budget — composeChips clamps their placement onto the
+// canvas as a last resort instead of dropping them, since losing DOCKED
+// or a force-shown NODES chip silently is worse than an overlap.
+// leftOfPrev chips don't grow their corner's column (they share a row
+// band with the chip beside them), so they bypass the budget check
+// entirely and are always admitted.
+func admitChipsByBudget(chips []builtChip, cRows, navballReserved int) []bool {
+	budget := map[chipCorner]int{
+		cornerTopLeft:     cRows,
+		cornerTopRight:    cRows,
+		cornerBottomLeft:  cRows - 1,
+		cornerBottomRight: cRows - navballReserved,
+	}
+	admitted := make([]bool, len(chips))
+	type candidate struct {
+		idx      int
+		priority int
+		bh       int
+	}
+	byCorner := make(map[chipCorner][]candidate)
+	for i, c := range chips {
+		if c.leftOfPrev {
+			admitted[i] = true
+			continue
+		}
+		if len(c.lines) == 0 {
+			admitted[i] = true // no footprint; the render loop skips it too
+			continue
+		}
+		bh := len(c.lines) + 2 // + the chip's own border
+		byCorner[c.corner] = append(byCorner[c.corner], candidate{idx: i, priority: c.priority, bh: bh})
+	}
+	for _, cands := range byCorner {
+		sort.SliceStable(cands, func(a, b int) bool { return cands[a].priority > cands[b].priority })
+		used := 0
+		for _, c := range cands {
+			critical := c.priority >= chipPriorityCritical
+			if critical || used+c.bh <= budget[chips[c.idx].corner] {
+				admitted[c.idx] = true
+				used += c.bh
+			}
+		}
+	}
+	return admitted
+}
+
 // composeChips paints each chip onto canvasStr at its corner, stacking
 // multiple chips in a corner with a one-row gap, and records each chip's
 // screen rectangle in v.chipRects for mouse routing. navballReserved is
@@ -104,10 +210,15 @@ func padChipBlock(lines []string) ([]string, int) {
 //
 // Top-left chips start one row down so they clear the canvas's "focus:"
 // label at (0,0); bottom-left chips stop one row up so they clear the
-// "view:" label on the last row.
+// "view:" label on the last row. admitChipsByBudget decides which chips
+// survive an overflowing corner before this loop ever runs; chips it
+// drops are skipped here, and chips it keeps despite exceeding budget
+// (chipPriorityCritical and up) are clamped onto the canvas rather than
+// let overlayStyledBlock silently clip them off an edge.
 func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved, screenColOffset, screenRowOffset int, chips []builtChip) string {
 	v.chipRects = v.chipRects[:0]
 	lines := strings.Split(canvasStr, "\n")
+	admitted := admitChipsByBudget(chips, cRows, navballReserved)
 
 	// Per-corner stacking cursors. Top corners grow downward from their
 	// start row; bottom corners grow upward from their start row. v0.13:
@@ -122,7 +233,10 @@ func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved
 	// can sit beside it (same top row, immediately to its left).
 	lastTRStartRow, lastTRCol, haveTR := 0, 0, false
 
-	for _, chip := range chips {
+	for i, chip := range chips {
+		if !admitted[i] {
+			continue
+		}
 		padded, w := padChipBlock(chip.lines)
 		if len(padded) == 0 || w == 0 {
 			continue
@@ -159,6 +273,26 @@ func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved
 		}
 		if atCol < 0 {
 			atCol = 0
+		}
+		// Last-resort clamp (#328/#334): a critical chip is always
+		// admitted above even when it overruns its corner's budget (two
+		// critical chips together can still exceed cRows). Rather than
+		// let it run off the canvas edge and have overlayStyledBlock
+		// silently drop those rows, pull it back on-canvas — accepting
+		// an overlap with whatever's beneath rather than losing it.
+		// Non-critical chips never need this: admitChipsByBudget only
+		// admits them when they already fit.
+		if chip.priority >= chipPriorityCritical {
+			switch chip.corner {
+			case cornerTopLeft, cornerTopRight:
+				if atRow+bh > cRows {
+					atRow = cRows - bh
+				}
+			case cornerBottomLeft, cornerBottomRight:
+				if atRow < 0 {
+					atRow = 0
+				}
+			}
 		}
 		lines = overlayStyledBlock(lines, block, atRow, atCol, cCols)
 		v.chipRects = append(v.chipRects, chipRect{

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -277,7 +277,10 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 					fmt.Sprintf("  velocity:  %.2f km/s", g.Vel.Norm()/1000),
 				)
 			}
-			lines = append(lines, v.theme.Dim.Render("  [u] release it"))
+			// #330: [U], matching the actual uppercase Undock binding —
+			// see the sibling comment on the DOCKED block's "ask to
+			// undock" row in orbit_chip_builders.go.
+			lines = append(lines, v.theme.Dim.Render("  [U] release it"))
 			return lines
 		}
 		return []string{

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -354,10 +354,13 @@ func (v *OrbitView) buildStagesChip(w *sim.World) []string {
 }
 
 // totalQueuedNodes sums every craft's planted-but-unfired node count.
-// Shared by buildNodesChip (the "(+N more)" overflow count) and
-// assembleChips's #293 force-show gate — more than one node queued
-// anywhere is exactly the staleness hazard the chip exists to surface,
-// so both read the same total.
+// Used only to decide whether the NODES chip has anything to show at
+// all (buildNodesChip's top-of-function relevance check) — a fleet
+// with a node planted on ANY craft is a fleet where the chip belongs on
+// screen, even if the active craft itself is currently node-free.
+//
+// #333: this total is deliberately NOT used for the force-show gate or
+// the "(+N more)" overflow count anymore — see activeCraftQueuedNodes.
 func totalQueuedNodes(w *sim.World) int {
 	total := 0
 	for _, c := range w.Crafts {
@@ -366,6 +369,24 @@ func totalQueuedNodes(w *sim.World) int {
 		}
 	}
 	return total
+}
+
+// activeCraftQueuedNodes reports the ACTIVE craft's own planted-but-
+// unfired node count (#333). The staleness hazard the NODES chip
+// force-show exists to surface is per-vessel: every node behind the
+// first ON THE SAME CRAFT was computed against an orbit that no longer
+// exists once the first one fires. A different craft's queue doesn't
+// stale this one, so summing across the fleet (the old totalQueuedNodes
+// use here) force-showed the chip — bypassing a declutter + disabled
+// toggle the player explicitly chose — for constellations where no
+// single vessel actually carried the hazard. Returns 0 with no active
+// craft.
+func activeCraftQueuedNodes(w *sim.World) int {
+	ac := w.ActiveCraft()
+	if ac == nil {
+		return 0
+	}
+	return len(ac.Nodes)
 }
 
 // buildNodesChip is the bottom-right burn-schedule chip: any in-flight
@@ -426,9 +447,13 @@ func (v *OrbitView) buildNodesChip(w *sim.World) []string {
 				hudNodeMarker, label, dt, n.Mode.String(), n.DV)
 		}
 		lines = append(lines, line, "  "+kind)
-	}
-	if total > 1 {
-		lines = append(lines, v.theme.Dim.Render(fmt.Sprintf("  (+%d more → [m])", total-1)))
+		// #333: the overflow count is nc's OWN remaining queue, not the
+		// fleet-wide total — mixing in another craft's nodes here would
+		// describe a different vessel's queue as if it were stale on
+		// THIS one.
+		if craftTotal := len(nc.Nodes); craftTotal > 1 {
+			lines = append(lines, v.theme.Dim.Render(fmt.Sprintf("  (+%d more → [m])", craftTotal-1)))
+		}
 	}
 	return lines
 }

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -718,7 +718,7 @@ func TestEmptySlateSaysSo(t *testing.T) {
 	// new flight" would be the wrong advice.
 	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:bob", OwnerHandle: "bob"}
 	out = strings.Join(v.buildVesselChip(w), "\n")
-	if !strings.Contains(out, "bob") || !strings.Contains(out, "[u]") {
+	if !strings.Contains(out, "bob") || !strings.Contains(out, "[U]") {
 		t.Errorf("docked-as-guest empty slate does not name the stack or the release key:\n%s", out)
 	}
 	if strings.Contains(out, "[n]") {

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -490,6 +490,89 @@ func TestNodesChipForceShowsWhenMultipleNodesQueued(t *testing.T) {
 	}
 }
 
+// TestNodesChipForceShowIsPerCraftNotFleetWide (#333): the staleness
+// hazard the force-show gate exists for is per-vessel — every node
+// behind the first ON THE SAME CRAFT was computed against an orbit that
+// no longer exists once the first one fires. Two different craft each
+// carrying exactly one node have no such hazard on either vessel, so
+// summing across the fleet must not force the chip past a declutter +
+// disabled toggle the player explicitly chose.
+func TestNodesChipForceShowIsPerCraftNotFleetWide(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	s := settings.Default()
+	for _, chipID := range settings.AllChips {
+		s.SetChip(chipID, false)
+	}
+	v.SetSettings(s)
+	v.SetDeclutter(true)
+
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("expected an active craft")
+	}
+	active.Nodes = []spacecraft.ManeuverNode{
+		{Mode: spacecraft.BurnPrograde, DV: 42, TriggerTime: w.Clock.SimTime.Add(time.Minute)},
+	}
+	second := &spacecraft.Spacecraft{
+		Name:    "relay",
+		Primary: active.Primary,
+		State:   active.State,
+		Stages:  []spacecraft.Stage{{DryMass: 1000}},
+		Nodes: []spacecraft.ManeuverNode{
+			{Mode: spacecraft.BurnPrograde, DV: 10, TriggerTime: w.Clock.SimTime.Add(time.Minute)},
+		},
+	}
+	second.SyncFields()
+	w.Crafts = append(w.Crafts, second)
+
+	out := v.Render(w, 0, 120, 40)
+	if strings.Contains(out, "NODES") {
+		t.Errorf("one node each on two different craft force-showed NODES past the toggle/declutter — the hazard is per-craft, not fleet-wide:\n%s", out)
+	}
+}
+
+// TestNodesChipOverflowCountIsPerCraft (#333): the "(+N more)" overflow
+// annotation must count the SAME craft's own remaining queue that the
+// "next" node line above it names — folding in another craft's
+// unrelated nodes misdescribes whose queue is actually stale.
+func TestNodesChipOverflowCountIsPerCraft(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("expected an active craft")
+	}
+	active.Nodes = []spacecraft.ManeuverNode{
+		{DV: 10, TriggerTime: w.Clock.SimTime.Add(time.Minute)},
+	}
+	other := &spacecraft.Spacecraft{
+		Name:    "relay",
+		Primary: active.Primary,
+		State:   active.State,
+		Stages:  []spacecraft.Stage{{DryMass: 1000}},
+		Nodes: []spacecraft.ManeuverNode{
+			{DV: 5, TriggerTime: w.Clock.SimTime.Add(time.Minute)},
+			{DV: 6, TriggerTime: w.Clock.SimTime.Add(2 * time.Minute)},
+			{DV: 7, TriggerTime: w.Clock.SimTime.Add(3 * time.Minute)},
+		},
+	}
+	other.SyncFields()
+	w.Crafts = append(w.Crafts, other)
+
+	joined := strings.Join(v.buildNodesChip(w), "\n")
+	if strings.Contains(joined, "more") {
+		t.Errorf("active craft has a single node; overflow count leaked another craft's queue:\n%s", joined)
+	}
+}
+
 // TestOrbitMetricsShowsDirectionIndicator — issue #63: the ORBIT chip
 // carries an explicit prograde/retrograde orbit-direction readout so a
 // genuine reversal is never confused with a projection/shading artifact.

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -146,6 +146,99 @@ func TestComposeChipsClipsOversizeChipWithoutPanic(t *testing.T) {
 	}
 }
 
+// TestComposeChipsBudgetProtectsCriticalChipFromOverflow (#328/#334):
+// composeChips had NO height bound on the top-left stack at all —
+// topLeftRow grew past cRows with nothing to stop it, and
+// overlayStyledBlock silently drops any row outside [0, cRows). A
+// high-priority chip appended late (the real DOCKED block, in
+// assembleChips' order) absorbed all the accumulated overflow from the
+// filler chips ahead of it and vanished with no signal anything was
+// lost — TestComposeChipsClipsOversizeChipWithoutPanic above only
+// checks the row COUNT survives, which passes even on total content
+// loss. Reproduces the #328 report's numbers: an 80x24 terminal's
+// canvas is 21 rows; three filler chips (mirroring VESSEL/MISSION/
+// SESSION/TIME LOCK) consume all 21 rows between them, and a critical
+// chip appended after them must still render in full rather than being
+// silently dropped or clipped.
+func TestComposeChipsBudgetProtectsCriticalChipFromOverflow(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	const cCols, cRows = 78, 21 // an 80x24 terminal's canvas (totalRows-3)
+
+	filler := func(n int) []string {
+		lines := make([]string, n)
+		for i := range lines {
+			lines[i] = "row"
+		}
+		return lines
+	}
+	chips := []builtChip{
+		{corner: cornerTopLeft, lines: filler(6), priority: chipPriorityCore},   // VESSEL-sized
+		{corner: cornerTopLeft, lines: filler(3)},                               // MISSION-sized filler
+		{corner: cornerTopLeft, lines: filler(2)},                               // SESSION-sized filler
+		{corner: cornerTopLeft, lines: filler(2)},                               // TIME LOCK-sized filler
+		{corner: cornerTopLeft, lines: []string{
+			"DOCKED", "  riding in bob's stack", "  [J] request control", "  [U] ask to undock",
+		}, priority: chipPriorityForced},
+	}
+	out := v.composeChips(blankCanvas(cCols, cRows), cCols, cRows, 0, 0, 0, chips)
+	if !strings.Contains(out, "DOCKED") {
+		t.Fatalf("critical chip (DOCKED) silently lost to top-left overflow:\n%s", out)
+	}
+	if !strings.Contains(out, "riding in bob's stack") || !strings.Contains(out, "[U] ask to undock") {
+		t.Errorf("critical chip rendered but truncated — its own content was clipped:\n%s", out)
+	}
+}
+
+// TestComposeChipsBudgetClampsBottomRightAgainstNavball (#334): at
+// 80x24, navballReservedRows(w, cCols, 21) returns navballPanelH+1 = 20,
+// so bottomRightRow = cRows-1-navballReserved = 0 — a force-shown NODES
+// chip (4 content lines, block height 6) placed there lands at
+// atRow = 0-6+1 = -5, and overlayStyledBlock drops every row outside
+// [0, cRows), leaving only the block's bottom border on canvas row 0.
+// A force-shown (critical-priority) chip that cannot fit above the
+// navball must still render in full rather than vanish upward off the
+// canvas.
+func TestComposeChipsBudgetClampsBottomRightAgainstNavball(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	const cCols, cRows = 78, 21
+	const navballReserved = navballPanelH + 1 // == 20, matches navballReservedRows at this size
+
+	chips := []builtChip{
+		{id: settings.ChipNodes, corner: cornerBottomRight, lines: []string{
+			"NODES", "  ▸ #1 prograde 42 m/s", "  imp", "  (+1 more → [m])",
+		}, priority: chipPriorityForced},
+	}
+	out := v.composeChips(blankCanvas(cCols, cRows), cCols, cRows, navballReserved, 0, 0, chips)
+	if !strings.Contains(out, "NODES") || !strings.Contains(out, "▸ #1 prograde 42 m/s") {
+		t.Fatalf("force-shown NODES chip lost above the navball reservation:\n%s", out)
+	}
+}
+
+// TestComposeChipsClampsTwoCriticalChipsThatTogetherOverflow exercises the
+// last-resort clamp directly (admitChipsByBudget's drop-lower-priority
+// pass never runs here — both chips are chipPriorityForced, so both are
+// admitted unconditionally, and their combined height exceeds the
+// corner's entire budget). composeChips must still keep the SECOND
+// critical chip fully on-canvas by pulling it back up to overlap the
+// first, rather than let it run off the bottom edge and have
+// overlayStyledBlock silently drop the overflow rows.
+func TestComposeChipsClampsTwoCriticalChipsThatTogetherOverflow(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	const cCols, cRows = 40, 10 // small on purpose: two 8-row blocks won't both fit
+
+	chips := []builtChip{
+		{corner: cornerTopLeft, lines: []string{"FIRST", "a", "b", "c", "d", "e"}, priority: chipPriorityCore},
+		{corner: cornerTopLeft, lines: []string{"SECOND", "f", "g", "h", "i", "j"}, priority: chipPriorityForced},
+	}
+	out := v.composeChips(blankCanvas(cCols, cRows), cCols, cRows, 0, 0, 0, chips)
+	if got := strings.Count(out, "\n") + 1; got != cRows {
+		t.Fatalf("output row count = %d, want %d (canvas height preserved)", got, cRows)
+	}
+	if !strings.Contains(out, "SECOND") || !strings.Contains(out, "j") {
+		t.Errorf("second critical chip lost/truncated when it couldn't fit below the first:\n%s", out)
+	}
+}
+
 func TestChipEnabledRespectsSettingsAndDeclutter(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	if !v.chipEnabled(settings.ChipStages) {

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -336,7 +336,7 @@ func TestDockGuestChipStandingBlock(t *testing.T) {
 		{Fingerprint: "SHA256:host", Handle: "vex", Online: true},
 	}}
 	joined := strings.Join(v.buildDockGuestChip(w), "\n")
-	for _, want := range []string{"DOCKED", "riding in vex's stack", "[J] request control", "[u] ask to undock"} {
+	for _, want := range []string{"DOCKED", "riding in vex's stack", "[J] request control", "[U] ask to undock"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("live-owner standing block missing %q:\n%s", want, joined)
 		}
@@ -352,7 +352,7 @@ func TestDockGuestChipStandingBlock(t *testing.T) {
 	if !strings.Contains(joined, "vex is away — their session is still flying") {
 		t.Errorf("no standing away line while the stack owner is away:\n%s", joined)
 	}
-	if !strings.Contains(joined, "[u] ask to undock") {
+	if !strings.Contains(joined, "[U] ask to undock") {
 		t.Errorf("away row replaced the exits instead of joining them:\n%s", joined)
 	}
 	w.DockGuest.OwnerAway = false

--- a/internal/tui/screens/orbit_time_lock_chip_test.go
+++ b/internal/tui/screens/orbit_time_lock_chip_test.go
@@ -164,6 +164,39 @@ func TestTimeLockChipShowsWhenCoupledToADifferentPlayerThanTheArm(t *testing.T) 
 	}
 }
 
+// ADR 0038 S4 review (#328): a docked rider's CoWarp coupling comes from
+// WithDockCoupling (internal/serve/dock.go), not a RENDEZVOUS agreement —
+// there is no seat, no rate negotiation, just "you're riding in their
+// stack, so you share their clock." The standing DOCKED block already
+// says exactly that ("riding in X's stack"), so TIME LOCK repeating
+// "warp locked with X" directly above it is two surfaces for one fact
+// (S4's own stated goal was "one surface, not two"). Mirrors
+// rendezvousExplainsCoupledLock: suppress only when the DockGuest's
+// owner is the SAME partner the co-warp coupling names, the same
+// specificity discipline as the rendezvous case.
+func TestTimeLockChipSuppressedForDockGuest(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.DockGuest = &sim.DockGuestLink{OwnerFP: "SHA256:bob", OwnerHandle: "bob"}
+	w.CoWarp = sim.CoWarpState{Coupled: true, MinWarp: 10, Partners: []string{"bob"}}
+
+	if chip := v.buildTimeLockChip(w); chip != nil {
+		t.Errorf("TIME LOCK duplicated the DOCKED block's own lock explanation:\n%s", strings.Join(chip, "\n"))
+	}
+
+	// Coupled to a DIFFERENT player than the one the rider is docked
+	// with: the DOCKED block never mentions that player, so the lock
+	// must still be explained somewhere.
+	w.CoWarp = sim.CoWarpState{Coupled: true, MinWarp: 10, Partners: []string{"someone-else"}}
+	chip := v.buildTimeLockChip(w)
+	if chip == nil {
+		t.Fatalf("TIME LOCK suppressed while coupled to a player DOCKED doesn't name")
+	}
+	if joined := strings.Join(chip, "\n"); !strings.Contains(joined, "someone-else") {
+		t.Errorf("TIME LOCK line missing the actual partner:\n%s", joined)
+	}
+}
+
 // #280 / ADR 0037 §4: the SESSION chip gets CHAT's depth cap so any burst
 // stays bounded. Before it, every moment inside the 6 s TTL rendered —
 // 852 coupled/released moments in one live session grew a block tall


### PR DESCRIPTION
## Summary

Four TUI chip-layout defects from the v0.35.0 batch review, all confined to `internal/tui/screens/`.

- **#328** — the rider's standing DOCKED block was silently clipped entirely off-canvas at 80x24 (the most common terminal size), reintroducing #301. Two parts, both fixed:
  - `composeChips` had no height budget at all; a late-appended chip absorbed all the overflow with no signal anything was lost.
  - TIME LOCK was force-on for every docked rider, rendering "warp locked with X" directly above DOCKED's own "riding in X's stack" — two surfaces for one fact.
- **#334** — the force-shown NODES chip rendered as a single row of border at 80x24 (bottom-right corner, squeezed against the navball reservation).
- **#330** — DOCKED block and VESSEL chip advertised `[u]` for Undock, but the binding is uppercase `U` and there's no lowercase binding. Relabeled both to `[U]` (docs/controls.md and the F1 overlay already said `U`).
- **#333** — the NODES force-show gate summed queued nodes fleet-wide, though the staleness hazard it exists to surface is strictly per-craft.

## Fix shape

- `builtChip` gets a `priority` field and a `chipPriorityCore` (100) / `chipPriorityForced` (90) / `chipPriorityNormal` (0) tier. `admitChipsByBudget` runs per corner: highest priority first (stable sort — a corner that fits within budget renders identically to today), dropping lower-priority chips that would overflow. `chipPriorityForced`+ ("critical") is never dropped for space; `composeChips` clamps a critical chip's placement onto the canvas as a last resort rather than let it silently run off an edge.
- VESSEL and the top-right ORBIT metrics chip are `chipPriorityCore`; DOCKED is `chipPriorityForced`; NODES is `chipPriorityForced` only while its force-show condition (live burn, or >1 node on the **active craft**) actually fires — a merely toggle-enabled NODES chip competes as a normal chip.
- `buildTimeLockChip` gains `dockGuestExplainsCoupledLock`, mirroring the existing `rendezvousExplainsCoupledLock` specificity discipline: suppressed only when the CoWarp partner named is the same stack owner DOCKED already names.
- `activeCraftQueuedNodes` replaces the fleet-wide sum for the #293 force-show gate; `buildNodesChip`'s "(+N more)" overflow count now reflects the displayed craft's own remaining queue instead of leaking another vessel's count into it.

## Commits

1. `419b92b` — #330: relabel `[u]` → `[U]`
2. `268c21c` — #333: per-craft NODES force-show + overflow count
3. `a6fa3ac` — #328/#334: composeChips height budget + priority tiers + TIME LOCK dedupe

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- New/updated tests render at 80x24 and assert actual content survives (not just row count) — `TestComposeChipsClipsOversizeChipWithoutPanic` was noted in the issues as passing on total content loss, so it wasn't sufficient coverage on its own.
- `TestDockGuestRenderAt80x24IncludesDockedBlock` reproduces the exact #328 report (VESSEL+MISSION+SESSION+TIME LOCK ahead of DOCKED on a 21-row canvas) and was confirmed red against pre-fix code before the fix landed.