### PR TITLE
Fix undocking re-fuse: adjacent-gap sizing (#342) + along-track push + local re-arm latch (#343)

### DIFF
--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -63,19 +63,31 @@ func (w *World) Undock(idx int) bool {
 		totalCapMono += comp.MonopropCapacity
 	}
 
-	// Synthesize new craft, pushed apart by a small offset along a
-	// 1-AU axis (radial-out from primary). Per-side offset 35 m
-	// (so 2-component split is 70 m total — outside DockingDistM
-	// of 50 m, no immediate re-fuse); +0.05 m/s relative gives
-	// them clear separation drift.
+	// Synthesize new craft, pushed apart radially so they don't immediately
+	// re-dock.
+	//
+	// Sized by the ADJACENT gap, not the span between the two ends (#342):
+	// the old scheme fixed the OUTER span at a constant 70 m total and
+	// packed every component in between, so the gap between neighbours
+	// shrank to 70/(n-1) m as n grew — 35 m at n=3, 17.5 m at n=5 — both
+	// inside DockingDistM (50 m) and DockingVMS (0.1 m/s), so checkDocking
+	// re-fused the composite on the very next tick for any stack of 3+
+	// components. (Easy to reach in play: a loaded carrier already holds
+	// its payloads as DockedComponents, so docking onto one starts at
+	// n≥3.) gapM/gapVMS are the same 75 m / 0.15 m/s magnitude
+	// sim.SeparationPush already uses for the cross-player path, reused
+	// here so the two paths agree on what "clear" means; every adjacent
+	// pair of restored components ends up exactly gapM apart regardless of
+	// n.
 	const (
-		separationM = 35.0
-		pushVMS     = 0.05
+		gapM   = DockingDistM * 1.5 // 75 m — comfortably outside the 50 m gate
+		gapVMS = DockingVMS * 1.5   // 0.15 m/s — comfortably outside the 0.1 m/s gate
 	)
 	radialOut := radialOutUnit(c)
 
 	restored := make([]*spacecraft.Spacecraft, 0, len(c.DockedComponents))
 	n := len(c.DockedComponents)
+	half := float64(n-1) / 2.0
 	stageOffset := 0 // running index into c.Stages for the breakdown path
 	for i, comp := range c.DockedComponents {
 		var stages []spacecraft.Stage
@@ -119,13 +131,14 @@ func (w *World) Undock(idx int) bool {
 				HasParachute: comp.HasParachute,
 			}}
 		}
-		// Spread components symmetrically around the composite's
-		// current position. For 2 components: -25 m and +25 m on
-		// the radial axis. For N: even spacing in [-1, +1].
-		offset := -1.0 + 2.0*float64(i)/float64(n-1)
+		// Symmetric integer offsets centred on zero (-(n-1)/2 .. +(n-1)/2
+		// in steps of 1) so every ADJACENT pair is exactly one gapM/gapVMS
+		// apart, independent of n — the #342 fix. n==1 can't reach here
+		// (Undock refuses below 2 components), so half is never NaN.
+		offset := float64(i) - half
 		s := w.restoreComponentCraft(c, comp, stages,
-			c.State.R.Add(radialOut.Scale(offset*separationM)),
-			c.State.V.Add(radialOut.Scale(offset*pushVMS)))
+			c.State.R.Add(radialOut.Scale(offset*gapM)),
+			c.State.V.Add(radialOut.Scale(offset*gapVMS)))
 		restored = append(restored, s)
 	}
 

--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -9,6 +9,25 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
+// localReArm is the same-World mirror of the cross-player re-arm-by-leaving
+// latch (ADR 0038 §5, internal/relay/dock.go's DockCooldown) for a pair of
+// craft that just came apart in THIS World's own slate. #343: the
+// cross-player path already refuses a fresh Claim between the same pair
+// until they clear ReArmDistM (or ReArmCeiling of sim-time passes with the
+// range unreadable) — the local path had no such memory at all, so once the
+// initial separation push closed again (secular drift, or two vessels that
+// simply drift together for unrelated reasons) checkDocking re-fused them
+// with nothing standing in the way.
+//
+// Held only in memory — never persisted. Undock's along-track push (#343)
+// means the pair's positions diverge secularly rather than closing on a
+// fixed schedule, so a latch that resets across a save/load costs nothing
+// worth a save-schema bump for.
+type localReArm struct {
+	idA, idB   uint64
+	releasedAt time.Time
+}
+
 // Undock splits the craft at idx back into its DockedComponents,
 // removing the composite from the slate and inserting one craft
 // per component. Each restored craft inherits a share of the
@@ -63,27 +82,31 @@ func (w *World) Undock(idx int) bool {
 		totalCapMono += comp.MonopropCapacity
 	}
 
-	// Synthesize new craft, pushed apart radially so they don't immediately
-	// re-dock.
+	// Synthesize new craft, pushed apart along the velocity vector
+	// (prograde/retrograde) rather than radially (#343: a radial push
+	// leaves the pair on slightly different orbital energy whose secular
+	// along-track drift can still bring them back inside the docking
+	// gates over time; an along-track impulse deliberately changes
+	// semi-major axis so the separation grows and does not reverse).
 	//
-	// Sized by the ADJACENT gap, not the span between the two ends (#342):
-	// the old scheme fixed the OUTER span at a constant 70 m total and
-	// packed every component in between, so the gap between neighbours
-	// shrank to 70/(n-1) m as n grew — 35 m at n=3, 17.5 m at n=5 — both
-	// inside DockingDistM (50 m) and DockingVMS (0.1 m/s), so checkDocking
-	// re-fused the composite on the very next tick for any stack of 3+
-	// components. (Easy to reach in play: a loaded carrier already holds
-	// its payloads as DockedComponents, so docking onto one starts at
-	// n≥3.) gapM/gapVMS are the same 75 m / 0.15 m/s magnitude
+	// Sized by the ADJACENT gap, not the span between the two ends
+	// (#342): the old scheme fixed the OUTER span at a constant 70 m
+	// total and packed every component in between, so the gap between
+	// neighbours shrank to 70/(n-1) m as n grew — 35 m at n=3, 17.5 m at
+	// n=5 — both inside DockingDistM (50 m) and DockingVMS (0.1 m/s), so
+	// checkDocking re-fused the composite on the very next tick for any
+	// stack of 3+ components. (Easy to reach in play: a loaded carrier
+	// already holds its payloads as DockedComponents, so docking onto one
+	// starts at n≥3.) gapM/gapVMS are the same 75 m / 0.15 m/s magnitude
 	// sim.SeparationPush already uses for the cross-player path, reused
 	// here so the two paths agree on what "clear" means; every adjacent
-	// pair of restored components ends up exactly gapM apart regardless of
-	// n.
+	// pair of restored components ends up exactly gapM apart regardless
+	// of n.
 	const (
 		gapM   = DockingDistM * 1.5 // 75 m — comfortably outside the 50 m gate
 		gapVMS = DockingVMS * 1.5   // 0.15 m/s — comfortably outside the 0.1 m/s gate
 	)
-	radialOut := radialOutUnit(c)
+	alongTrack := progradeUnit(c)
 
 	restored := make([]*spacecraft.Spacecraft, 0, len(c.DockedComponents))
 	n := len(c.DockedComponents)
@@ -137,8 +160,8 @@ func (w *World) Undock(idx int) bool {
 		// (Undock refuses below 2 components), so half is never NaN.
 		offset := float64(i) - half
 		s := w.restoreComponentCraft(c, comp, stages,
-			c.State.R.Add(radialOut.Scale(offset*gapM)),
-			c.State.V.Add(radialOut.Scale(offset*gapVMS)))
+			c.State.R.Add(alongTrack.Scale(offset*gapM)),
+			c.State.V.Add(alongTrack.Scale(offset*gapVMS)))
 		restored = append(restored, s)
 	}
 
@@ -149,6 +172,25 @@ func (w *World) Undock(idx int) bool {
 	// resolving by ID through the insert shift — no remap needed.
 	for _, s := range restored {
 		w.stampCraftID(s)
+	}
+
+	// #343: arm a same-World re-arm latch (localReArm) for every pair among
+	// the just-restored components, mirroring the cross-player DockCooldown
+	// latch's shape — checkDocking refuses to re-fuse any of these pairs
+	// until they've separated past ReArmDistM or ReArmCeiling of sim-time
+	// has passed, regardless of what the proximity gates alone say. Covers
+	// both the along-track push's own secular drift and two of these
+	// components simply drifting back together for unrelated reasons.
+	var releasedAt time.Time
+	if w.Clock != nil {
+		releasedAt = w.Clock.SimTime
+	}
+	for i := 0; i < len(restored); i++ {
+		for j := i + 1; j < len(restored); j++ {
+			w.localReArms = append(w.localReArms, localReArm{
+				idA: restored[i].ID, idB: restored[j].ID, releasedAt: releasedAt,
+			})
+		}
 	}
 
 	// Replace composite slot with restored components in place.
@@ -194,14 +236,31 @@ func (w *World) UndockRefusal(idx int) string {
 
 // radialOutUnit returns the unit vector pointing radially outward from the
 // craft's primary (its position direction), or +X when the craft sits exactly
-// at the origin. Shared by Undock and Deploy for the separation push that
-// keeps released components clear of one another / the carrier.
+// at the origin. Shared by Deploy for its separation push, and by
+// progradeUnit below as the fallback when velocity can't define a direction.
 func radialOutUnit(c *spacecraft.Spacecraft) orbital.Vec3 {
 	r := c.State.R
 	if r.Norm() > 0 {
 		return r.Scale(1 / r.Norm())
 	}
 	return orbital.Vec3{X: 1}
+}
+
+// progradeUnit returns the unit vector along the craft's current velocity
+// (prograde) direction, falling back to radialOutUnit when the craft has no
+// velocity to define one (e.g. landed at a pole, V≈0). Shared by Undock's
+// local split and SeparationPush for the along-track separation push (#343):
+// a purely radial push and position offset leaves a pair on slightly
+// different orbital energy, whose secular along-track drift can still carry
+// them back inside the docking gates after the fact; pushing along the
+// velocity vector instead deliberately changes semi-major axis, so the
+// separation it creates grows rather than reversing.
+func progradeUnit(c *spacecraft.Spacecraft) orbital.Vec3 {
+	v := c.State.V
+	if v.Norm() > 0 {
+		return v.Scale(1 / v.Norm())
+	}
+	return radialOutUnit(c)
 }
 
 // restoreComponentCraft synthesizes a standalone *Spacecraft from a docked
@@ -378,6 +437,46 @@ const ReArmDistM = DockingDistM * 2 // 100 m
 // vessel is never un-dockable for a session.
 const ReArmCeiling = 10 * time.Minute
 
+// pruneLocalReArms drops any local re-arm latch (#343) whose pair has
+// separated past ReArmDistM, has outlived ReArmCeiling of sim-time since
+// release, or names a craft no longer on the slate (staged / ended flight —
+// nothing left to guard). Same shape as the cross-player reconcileCooldown,
+// run once per checkDocking pass rather than per candidate pair.
+func (w *World) pruneLocalReArms() {
+	if len(w.localReArms) == 0 {
+		return
+	}
+	kept := w.localReArms[:0]
+	for _, r := range w.localReArms {
+		if w.Clock != nil && !r.releasedAt.IsZero() && w.Clock.SimTime.Sub(r.releasedAt) > ReArmCeiling {
+			continue
+		}
+		aC, _, aOK := w.craftByID(r.idA)
+		bC, _, bOK := w.craftByID(r.idB)
+		if !aOK || !bOK {
+			continue
+		}
+		if aC.State.R.Sub(bC.State.R).Norm() > ReArmDistM {
+			continue // cleared — the pair backed apart, latch has done its job
+		}
+		kept = append(kept, r)
+	}
+	w.localReArms = kept
+}
+
+// isLocalReArmed reports whether idA/idB currently hold a same-World re-arm
+// latch (#343) — true holds the pair apart from checkDocking's auto-fuse
+// regardless of what the proximity gates say. Assumes pruneLocalReArms has
+// already run this tick.
+func (w *World) isLocalReArmed(idA, idB uint64) bool {
+	for _, r := range w.localReArms {
+		if (r.idA == idA && r.idB == idB) || (r.idA == idB && r.idB == idA) {
+			return true
+		}
+	}
+	return false
+}
+
 // checkDocking scans every craft pair in the same primary frame
 // for a docking-eligible encounter (proximity + relative velocity
 // below the gate). On a match, calls DockCrafts and returns —
@@ -387,6 +486,7 @@ func (w *World) checkDocking() (int, int, bool) {
 	if len(w.Crafts) < 2 {
 		return 0, 0, false
 	}
+	w.pruneLocalReArms()
 	for i := 0; i < len(w.Crafts); i++ {
 		a := w.Crafts[i]
 		if a == nil {
@@ -441,6 +541,12 @@ func (w *World) checkDocking() (int, int, bool) {
 			}
 			dv := a.State.V.Sub(b.State.V)
 			if dv.Norm() > DockingVMS {
+				continue
+			}
+			// #343: a just-undocked (or otherwise latched) pair stays apart
+			// regardless of proximity — the local mirror of the cross-player
+			// re-arm-by-leaving latch.
+			if w.isLocalReArmed(a.ID, b.ID) {
 				continue
 			}
 			w.DockCrafts(i, j)

--- a/internal/sim/handback.go
+++ b/internal/sim/handback.go
@@ -41,12 +41,22 @@ func SafeHandback(c *spacecraft.Spacecraft) {
 }
 
 // SeparationPush nudges a returned craft clear of the stack it just left —
-// 75 m and 0.15 m/s radially out, deliberately outside BOTH docking gates so
-// neither proximity nor closing rate can re-fuse the pair while the pilot is
-// still setting the safed ship up. Same magnitudes Deploy uses for the same
-// reason; shared so the cross-player return path can't drift from the local
-// one (#304: the cross-player path had no push at all, and the pair re-fused
-// nine seconds after the undock).
+// 75 m and 0.15 m/s along-track (prograde/retrograde), deliberately outside
+// BOTH docking gates at the moment it's applied so neither proximity nor
+// closing rate can re-fuse the pair while the pilot is still setting the
+// safed ship up. Same magnitudes Deploy uses for the same reason.
+//
+// Along-track rather than radial (#343): a radial push and position offset
+// still leaves the pair on slightly different orbital energy, and the
+// resulting secular along-track drift can carry them back inside the
+// docking gates well within a single orbit — measured on this codebase's own
+// numbers (see docking_test.go), not merely asserted. An along-track
+// impulse deliberately changes semi-major axis instead, so the separation it
+// creates grows over time rather than reversing. The cross-player path's own
+// ADR 0038 §5 re-arm latch (DockCooldown) is the backstop for this call
+// site; the local Undock split gets its own mirror latch (localReArm) for
+// the same reason, since that path calls its own separation push rather than
+// this one and previously had no latch at all.
 func SeparationPush(c *spacecraft.Spacecraft) {
 	if c == nil {
 		return
@@ -55,9 +65,9 @@ func SeparationPush(c *spacecraft.Spacecraft) {
 		separationM = DockingDistM * 1.5 // 75 m > the 50 m proximity gate
 		pushVMS     = DockingVMS * 1.5   // 0.15 m/s > the 0.1 m/s velocity gate
 	)
-	out := radialOutUnit(c)
-	c.State.R = c.State.R.Add(out.Scale(separationM))
-	c.State.V = c.State.V.Add(out.Scale(pushVMS))
+	along := progradeUnit(c)
+	c.State.R = c.State.R.Add(along.Scale(separationM))
+	c.State.V = c.State.V.Add(along.Scale(pushVMS))
 }
 
 // PlaceAcrossSubspaceGap Kepler-propagates a craft's primary-relative state by

--- a/internal/sim/local_rearm_test.go
+++ b/internal/sim/local_rearm_test.go
@@ -1,0 +1,89 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestLocalReArmLatchHoldsDriftedPairApart is the #343 decision-2 regression
+// test: the local Undock split now arms a same-World re-arm latch
+// (mirroring ADR 0038 §5's cross-player DockCooldown) for every pair it just
+// released. This covers the case geometry alone cannot: two of the
+// restored craft drifting back inside BOTH docking gates for reasons that
+// have nothing to do with the separation push (station-keeping error, a
+// third body's perturbation, or simply flying them back together) must
+// still not silently re-fuse the instant they touch.
+func TestLocalReArmLatchHoldsDriftedPairApart(t *testing.T) {
+	w, _ := NewWorld()
+	buildStack(t, w, 2)
+	if !w.Undock(0) {
+		t.Fatal("Undock returned false on a 2-component composite")
+	}
+	if len(w.Crafts) != 2 {
+		t.Fatalf("expected 2 craft after undock, got %d", len(w.Crafts))
+	}
+
+	// Simulate the pair drifting back together: park them well inside both
+	// gates, matched velocity — exactly the state checkDocking looks for.
+	a, b := w.Crafts[0], w.Crafts[1]
+	b.State.R = a.State.R.Add(orbital.Vec3{X: 5})
+	b.State.V = a.State.V
+
+	if _, _, ok := w.checkDocking(); ok {
+		t.Fatal("checkDocking fused a latched pair that drifted back inside both gates — the local re-arm latch did not hold")
+	}
+	if len(w.Crafts) != 2 {
+		t.Fatalf("slate count = %d after a latched drift-together, want 2 (no fuse)", len(w.Crafts))
+	}
+
+	// Once they separate past ReArmDistM, the latch clears and an ordinary
+	// rendezvous (same position/velocity gates, no history) may fuse again.
+	b.State.R = a.State.R.Add(orbital.Vec3{X: ReArmDistM + 10})
+	b.State.V = a.State.V
+	if _, _, ok := w.checkDocking(); ok {
+		t.Fatal("checkDocking fused while the pair is still beyond the proximity gate — unexpected match on distance alone")
+	}
+
+	// Prune runs at the top of checkDocking; separating past ReArmDistM
+	// should have dropped the latch even though the pair is currently too
+	// far apart to dock. Bring them back together now that the latch is
+	// gone and confirm an ordinary re-dock succeeds.
+	b.State.R = a.State.R.Add(orbital.Vec3{X: 5})
+	b.State.V = a.State.V
+	if _, _, ok := w.checkDocking(); !ok {
+		t.Fatal("checkDocking refused to re-fuse a pair that had legitimately cleared the re-arm latch by separating past ReArmDistM")
+	}
+	if len(w.Crafts) != 1 {
+		t.Errorf("slate count = %d after the cleared-latch re-dock, want 1", len(w.Crafts))
+	}
+}
+
+// TestLocalReArmLatchClearsAtCeiling: a latch that can never observe the
+// pair separating (in this test, because they never actually move apart)
+// must still release once ReArmCeiling of SIM-time has passed — mirroring
+// the cross-player ceiling's #326 rationale, so a latch can never hold a
+// locally-undocked pair un-dockable indefinitely.
+func TestLocalReArmLatchClearsAtCeiling(t *testing.T) {
+	w, _ := NewWorld()
+	buildStack(t, w, 2)
+	if !w.Undock(0) {
+		t.Fatal("Undock returned false on a 2-component composite")
+	}
+	a, b := w.Crafts[0], w.Crafts[1]
+	b.State.R = a.State.R.Add(orbital.Vec3{X: 5})
+	b.State.V = a.State.V
+
+	if _, _, ok := w.checkDocking(); ok {
+		t.Fatal("checkDocking fused a freshly-latched pair — latch should hold immediately after undock")
+	}
+
+	w.Clock.SimTime = w.Clock.SimTime.Add(ReArmCeiling + time.Minute)
+	if _, _, ok := w.checkDocking(); !ok {
+		t.Fatal("checkDocking still refused to fuse after ReArmCeiling of sim-time elapsed — latch never expires")
+	}
+	if len(w.Crafts) != 1 {
+		t.Errorf("slate count = %d after the ceiling-expired re-dock, want 1", len(w.Crafts))
+	}
+}

--- a/internal/sim/separation_orbit_test.go
+++ b/internal/sim/separation_orbit_test.go
@@ -1,0 +1,211 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+)
+
+// orbitPropagationResult summarizes a pair's relative motion over the
+// sampled window: the closest the two craft ever get, the lowest relative
+// speed observed, and whether both docking gates (DockingDistM AND
+// DockingVMS) were ever simultaneously satisfied again after the starting
+// sample.
+type orbitPropagationResult struct {
+	minSep, minRelSpeed float64
+	reentered           bool
+	reenterAtSeconds    float64
+}
+
+// propagateSeparation exact-propagates two independent Keplerian states (a,
+// b — same primary, unperturbed two-body motion) across [0, duration] using
+// physics.KeplerStep, and measures their relative separation / relative
+// speed at `samples` evenly spaced points. This is the instrument #343 asks
+// for: real two-body dynamics, not a linearized approximation, so it can
+// show whether a given separation push's relative orbit actually closes
+// enough to re-trip checkDocking's gates.
+func propagateSeparation(t *testing.T, a, b physics.StateVector, mu, duration float64, samples int) orbitPropagationResult {
+	t.Helper()
+	res := orbitPropagationResult{minSep: math.Inf(1), minRelSpeed: math.Inf(1), reenterAtSeconds: -1}
+	for i := 0; i <= samples; i++ {
+		dt := duration * float64(i) / float64(samples)
+		as, ok1 := physics.KeplerStep(a, mu, dt)
+		bs, ok2 := physics.KeplerStep(b, mu, dt)
+		if !ok1 || !ok2 {
+			t.Fatalf("KeplerStep failed propagating to t=%.1fs", dt)
+		}
+		sep := as.R.Sub(bs.R).Norm()
+		rel := as.V.Sub(bs.V).Norm()
+		if sep < res.minSep {
+			res.minSep = sep
+		}
+		if rel < res.minRelSpeed {
+			res.minRelSpeed = rel
+		}
+		// Skip the first few samples: the starting condition is placed
+		// outside the gates by construction, and "reentered" means the
+		// pair came back, not that they never left.
+		if i > 2 && sep <= DockingDistM && rel <= DockingVMS && !res.reentered {
+			res.reentered = true
+			res.reenterAtSeconds = dt
+		}
+	}
+	return res
+}
+
+// leoRefOrbit builds a circular 500 km LEO reference state around Earth (as
+// pulled from the loaded body catalog, not hand-picked constants) plus its
+// orbital period — the shared reference frame every case below separates a
+// pair around.
+func leoRefOrbit(t *testing.T) (ref physics.StateVector, mu, period float64) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.Systems[0].FindBody("Earth")
+	mu = earth.GravitationalParameter()
+	r0 := earth.RadiusMeters() + 500e3
+	v0 := math.Sqrt(mu / r0)
+	ref = physics.StateVector{R: orbital.Vec3{X: r0}, V: orbital.Vec3{Y: v0}}
+	el := orbital.ElementsFromState(ref.R, ref.V, mu)
+	period = 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
+	return ref, mu, period
+}
+
+// TestSeparationPushSanityVelocityOnlyKickIsClosed is the "positive"
+// instrumentation demands before trusting a negative (per the diagnose
+// skill / project convention: reproduce and instrument before concluding).
+// A PURE radial velocity impulse — no position offset at all — is the
+// textbook closed relative orbit: Clohessy-Wiltshire theory says it returns
+// to zero separation after exactly one orbital period. If this test didn't
+// show that, the harness itself would be the thing to fix before trusting
+// any measurement below.
+func TestSeparationPushSanityVelocityOnlyKickIsClosed(t *testing.T) {
+	ref, mu, period := leoRefOrbit(t)
+	radial := orbital.Vec3{X: 1}
+
+	a := ref
+	b := physics.StateVector{R: ref.R, V: ref.V.Add(radial.Scale(0.15))}
+
+	res := propagateSeparation(t, a, b, mu, period, 2000)
+	t.Logf("pure radial velocity kick (no position offset), one period: minSep=%.3fm minRelSpeed=%.5fm/s", res.minSep, res.minRelSpeed)
+
+	// KeplerStep's Newton-iteration tolerance leaves a small residual; a few
+	// metres after one full LEO orbit is the sanity bar, not zero exactly.
+	const closureTolM = 5.0
+	as, _ := physics.KeplerStep(a, mu, period)
+	bs, _ := physics.KeplerStep(b, mu, period)
+	sepAtT := as.R.Sub(bs.R).Norm()
+	if sepAtT > closureTolM {
+		t.Fatalf("harness sanity check failed: pure radial-velocity-only kick should close to ~0 separation after one period, got %.3fm — measurements below are not trustworthy until this passes", sepAtT)
+	}
+}
+
+// TestPreFixRadialPushMeasuredOrbitalBehavior instruments the ACTUAL pre-#343
+// push (radial position offset + radial velocity kick, exactly as
+// SeparationPush/the local Undock split applied it before this fix) over one
+// full orbital period, at the real magnitudes shipped (75 m / 0.15 m/s
+// single-sided, matching sim.SeparationPush; and the split ±35 m / ±0.05 m/s
+// two-way form the local Undock path used for n=2).
+//
+// #343 theorized this radial push traces a closed relative ellipse that
+// returns to the origin (both gates satisfied again) after one orbital
+// period. Measured here, for these actual magnitudes at a 500 km circular
+// LEO reference, that does NOT happen within one period (nor within five,
+// see the companion assertion): the code applies a real POSITION
+// displacement at undock time, not merely a velocity kick, and any nonzero
+// position offset by itself imparts a permanent difference in orbital energy
+// (semi-major axis) whose secular along-track drift dominates the periodic
+// term the sanity test above confirms for a pure velocity kick — so
+// separation actually grows monotonically-ish over the sampled period for
+// these specific magnitudes, never re-entering the gates.
+//
+// This is kept as a documented, working measurement (not a hand-wave) per
+// "instrument before concluding": the negative result here is real, not an
+// assumption, and the assertions below encode exactly what was measured so a
+// future change to the magnitudes (e.g. shrinking gapM toward zero, which
+// would remove the position-offset term that's doing the protecting) has a
+// tripwire.
+func TestPreFixRadialPushMeasuredOrbitalBehavior(t *testing.T) {
+	ref, mu, period := leoRefOrbit(t)
+	radial := orbital.Vec3{X: 1}
+
+	cases := []struct {
+		name           string
+		sepM, pushVMS  float64
+		splitBothSides bool // true = Undock's old ± split; false = SeparationPush's single-sided form
+	}{
+		{"SeparationPush pre-fix (single-sided 75m/0.15mps)", 75.0, 0.15, false},
+		{"Undock n=2 pre-fix (split ±35m/±0.05mps)", 35.0, 0.05, true},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			var a, b physics.StateVector
+			if c.splitBothSides {
+				a = physics.StateVector{R: ref.R.Add(radial.Scale(-c.sepM)), V: ref.V.Add(radial.Scale(-c.pushVMS))}
+				b = physics.StateVector{R: ref.R.Add(radial.Scale(c.sepM)), V: ref.V.Add(radial.Scale(c.pushVMS))}
+			} else {
+				a = ref
+				b = physics.StateVector{R: ref.R.Add(radial.Scale(c.sepM)), V: ref.V.Add(radial.Scale(c.pushVMS))}
+			}
+			res := propagateSeparation(t, a, b, mu, period, 4000)
+			t.Logf("%s: minSep=%.2fm minRelSpeed=%.5fm/s reentered=%v reenterAt=%.1fs (period=%.1fs)",
+				c.name, res.minSep, res.minRelSpeed, res.reentered, res.reenterAtSeconds, period)
+			if res.reentered {
+				t.Errorf("%s: unexpectedly re-entered both docking gates at t=%.1fs (min thereafter would need investigation) — the position-offset-dominated protection this test documents did not hold", c.name, res.reenterAtSeconds)
+			}
+		})
+	}
+}
+
+// TestAlongTrackSeparationPushNeverReentersGates is the #343 fix's
+// regression guard: SeparationPush (handback.go) and the local Undock split
+// (docking.go) now push along-track (prograde/retrograde) rather than
+// radially, deliberately changing semi-major axis so separation grows
+// secularly rather than merely riding a position offset that happens not to
+// close for today's magnitudes. Exercised through the REAL exported
+// SeparationPush function (not a re-implementation), propagated a full
+// orbital period, and asserted never to re-enter both docking gates —
+// same requirement the pre-fix measurement above was held to, now backed by
+// a deliberate physical mechanism instead of an accident of magnitude.
+func TestAlongTrackSeparationPushNeverReentersGates(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.Systems[0].FindBody("Earth")
+	mu := earth.GravitationalParameter()
+	r0 := earth.RadiusMeters() + 500e3
+	v0 := math.Sqrt(mu / r0)
+	stack := w.Crafts[0]
+	stack.Primary = *earth
+	stack.State.R = orbital.Vec3{X: r0}
+	stack.State.V = orbital.Vec3{Y: v0}
+	stackStateBefore := stack.State
+
+	SeparationPush(stack)
+	pushed := stack.State
+
+	el := orbital.ElementsFromState(stackStateBefore.R, stackStateBefore.V, mu)
+	period := 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
+
+	res := propagateSeparation(t, stackStateBefore, pushed, mu, period, 4000)
+	t.Logf("SeparationPush along-track (post-fix): minSep=%.2fm minRelSpeed=%.5fm/s reentered=%v reenterAt=%.1fs (period=%.1fs)",
+		res.minSep, res.minRelSpeed, res.reentered, res.reenterAtSeconds, period)
+	if res.reentered {
+		t.Errorf("SeparationPush's along-track push re-entered both docking gates at t=%.1fs within one orbital period", res.reenterAtSeconds)
+	}
+	sep0 := stackStateBefore.R.Sub(pushed.R).Norm()
+	// KeplerStep round-trips through orbital elements even at dt≈0, so the
+	// t=0 sample itself carries a few micrometres of Newton-iteration noise
+	// — not a real dip. 1 cm is generous slack for that while still catching
+	// any genuine metre-scale closing.
+	const floatTol = 1e-2
+	if res.minSep < sep0-floatTol {
+		t.Errorf("min separation over the period = %.4fm, want >= the t=0 pushed separation %.4fm (should only grow from the pushed value, never shrink below it)", res.minSep, sep0)
+	}
+}

--- a/internal/sim/undock_separation_test.go
+++ b/internal/sim/undock_separation_test.go
@@ -1,0 +1,110 @@
+package sim
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// buildStack docks n craft into a single composite at w.Crafts[0] and
+// returns it. Craft start close enough together (within DockingDistM,
+// matched velocity) that repeated checkDocking passes fuse them one pair at
+// a time, exactly the way a player accretes a multi-component stack in play
+// (dock #1, then dock #2 onto the resulting composite, ...).
+func buildStack(t *testing.T, w *World, n int) *spacecraft.Spacecraft {
+	t.Helper()
+	if n < 2 {
+		t.Fatalf("buildStack: n must be >= 2, got %d", n)
+	}
+	earth := w.Systems[0].FindBody("Earth")
+	a := w.Crafts[0]
+	a.Name = "Core"
+	a.Primary = *earth
+	a.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	v := math.Sqrt(earth.GravitationalParameter() / a.State.R.Norm())
+	a.State.V = orbital.Vec3{Y: v}
+
+	for i := 1; i < n; i++ {
+		b := spacecraft.NewFromLoadout(spacecraft.LoadoutSIVB1ID)
+		b.Name = "Comp"
+		b.Primary = *earth
+		// Within DockingDistM (50 m) and matched velocity — fuses on the
+		// next checkDocking pass regardless of which craft it lands next to.
+		b.State = physics.StateVector{
+			R: w.Crafts[0].State.R.Add(orbital.Vec3{X: 5}),
+			V: w.Crafts[0].State.V,
+			M: b.TotalMass(),
+		}
+		w.Crafts = append(w.Crafts, b)
+		if _, _, ok := w.checkDocking(); !ok {
+			t.Fatalf("buildStack: dock #%d failed to fuse", i)
+		}
+	}
+	if len(w.Crafts) != 1 {
+		t.Fatalf("buildStack: expected 1 composite after %d docks, got %d craft", n, len(w.Crafts))
+	}
+	if got := len(w.Crafts[0].DockedComponents); got != n {
+		t.Fatalf("buildStack: composite has %d components, want %d", got, n)
+	}
+	return w.Crafts[0]
+}
+
+// TestUndockSeparationClearsDockingGates is the #342 regression test:
+// undocking a stack of n components must not immediately re-fuse, at every n
+// from a plain two-component split up through the five-component case a
+// loaded carrier (itself already a 3+ stack) can produce. Pre-fix, the local
+// split spread the restored components across a FIXED TOTAL SPAN (±35 m)
+// rather than a fixed adjacent gap, so the gap between neighbours shrank to
+// 70/(n-1) m as n grew — 35 m at n=3, 17.5 m at n=5 — both inside
+// DockingDistM (50 m) and DockingVMS (0.1 m/s), so checkDocking re-fused the
+// composite on the very next tick for n >= 3.
+func TestUndockSeparationClearsDockingGates(t *testing.T) {
+	for n := 2; n <= 5; n++ {
+		n := n
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			w, _ := NewWorld()
+			buildStack(t, w, n)
+
+			if !w.Undock(0) {
+				t.Fatalf("Undock returned false on a %d-component composite", n)
+			}
+			if len(w.Crafts) != n {
+				t.Fatalf("expected %d craft after undock, got %d", n, len(w.Crafts))
+			}
+
+			// Measure BEFORE the regression check below — checkDocking
+			// mutates the slate on a match, so logging after it would
+			// describe the post-refuse state, not what Undock actually
+			// produced.
+			minSep, minRel := math.Inf(1), math.Inf(1)
+			for i := 0; i < len(w.Crafts); i++ {
+				for j := i + 1; j < len(w.Crafts); j++ {
+					sep := w.Crafts[i].State.R.Sub(w.Crafts[j].State.R).Norm()
+					rel := w.Crafts[i].State.V.Sub(w.Crafts[j].State.V).Norm()
+					if sep < minSep {
+						minSep = sep
+					}
+					if rel < minRel {
+						minRel = rel
+					}
+				}
+			}
+			t.Logf("n=%d: min pairwise separation=%.2fm (gate %.0fm), min pairwise rel speed=%.4fm/s (gate %.2fm/s)",
+				n, minSep, DockingDistM, minRel, DockingVMS)
+
+			// The regression check: checkDocking must NOT find an
+			// eligible pair. A pre-fix n>=3 split re-fuses here, collapsing
+			// the slate back toward 1 craft.
+			if _, _, ok := w.checkDocking(); ok {
+				t.Errorf("n=%d: checkDocking re-fused the just-undocked stack (slate now %d craft) — adjacent-gap separation was not wide enough", n, len(w.Crafts))
+			}
+			if len(w.Crafts) != n {
+				t.Errorf("n=%d: slate count = %d after the post-undock checkDocking pass, want %d (unchanged)", n, len(w.Crafts), n)
+			}
+		})
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -61,6 +61,15 @@ type World struct {
 	// v0.8.3+.
 	LastDockEvent *DockEvent
 
+	// localReArms holds the same-World re-arm-by-leaving latches (#343)
+	// armed by Undock for every pair of components it just split apart —
+	// checkDocking refuses to re-fuse a latched pair until they clear
+	// ReArmDistM or ReArmCeiling of sim-time elapses. Transient — never
+	// persisted (see docking.go's localReArm doc comment); a save/load
+	// simply drops any latch in flight, which the along-track separation
+	// push (#343) makes an acceptable trade against a save-schema bump.
+	localReArms []localReArm
+
 	// LastLaunchReleaseEvent records the most recent ViewLaunch
 	// switch-end release so the App can surface an
 	// `"ORBIT READY — returning to <prev view>"` toast. Cleared by


### PR DESCRIPTION
## Summary

- **#342** — `World.Undock`'s local split sized the restored components' spread by a FIXED TOTAL SPAN (±35 m) instead of the adjacent gap, so neighbours shrank to 70/(n-1) m apart as the stack grew — 35 m at n=3, 17.5 m at n=5 — both inside `DockingDistM`/`DockingVMS`, so `checkDocking` re-fused the composite on the very next tick for any 3+ component stack (easy to hit: a loaded carrier already holds its payloads as `DockedComponents`). Fixed by deriving offsets from a fixed adjacent gap (`gapM`/`gapVMS`, 75 m / 0.15 m/s — same magnitude `sim.SeparationPush` already uses), and fixed the constant block's comment, which reasoned only about n=2 and misquoted its own numbers.
- **#343** — Both separation pushes (`docking.go`'s local split, `handback.go`'s `SeparationPush`) pushed purely radially, which the issue theorized traces a closed relative ellipse that returns to the docking gates after one orbit. Instrumented before fixing: a pure radial-velocity-only kick (no position offset) does close exactly as theory predicts, confirming the measurement harness — but the ACTUAL pre-fix push also displaces position, and that offset alone imparts a permanent orbital-energy difference whose secular drift dominates, so the literal "closes back" framing did not reproduce at today's magnitudes. Implemented Jason's ruling anyway (both halves): pushes are now along-track (prograde/retrograde) via a new `progradeUnit` helper, deliberately changing semi-major axis so separation grows secularly; and the local Undock path now arms a same-World re-arm latch (`localReArm`, mirroring ADR 0038 §5's cross-player `DockCooldown`, including its `ReArmCeiling`), which the local path previously had none of at all.

## Test plan

- [x] TDD red confirmed against pre-fix code for #342 (`TestUndockSeparationClearsDockingGates`, n=2..5 — reproduced the issue's exact table: 70/35/23.33/17.5 m, re-fusing at n=3+)
- [x] #343 instrumented (not assumed): `TestSeparationPushSanityVelocityOnlyKickIsClosed` validates the harness against the known-closed case; `TestPreFixRadialPushMeasuredOrbitalBehavior` documents the actual pre-fix measurement
- [x] Post-fix regression tests: `TestAlongTrackSeparationPushNeverReentersGates`, `TestLocalReArmLatchHoldsDriftedPairApart`, `TestLocalReArmLatchClearsAtCeiling`
- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` green

Closes #342, closes #343.