### PR TITLE
Add signed lead angle to the craft target panel (#287)

### DIFF
--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -1,6 +1,8 @@
 package sim
 
 import (
+	"math"
+
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -340,6 +342,75 @@ func (w *World) TargetStateRelativeToActivePrimary() (rT, vT orbital.Vec3, ok bo
 	activePrimaryR := w.BodyPosition(active.Primary)
 	activePrimaryV := w.bodyInertialVelocity(active.Primary)
 	return targetInertialR.Sub(activePrimaryR), targetInertialV.Sub(activePrimaryV), true
+}
+
+// TargetLeadAngleDeg answers the phase-order question a rendezvous
+// planning step needs first (#287): is the active craft ahead of or
+// behind its craft/ghost target along the shared orbit? Returns the
+// signed along-track angle from the active craft to the target, in
+// degrees, range (-180, 180]. Positive means the target is AHEAD of the
+// active craft along its direction of orbital motion — i.e. the active
+// craft is trailing and must lower its orbit to catch up; negative means
+// the target is behind.
+//
+// The angle is measured about the active craft's own specific angular
+// momentum axis (h = r x v, unit vector), which is exactly "signed by
+// the direction of the craft's motion" — the sign is intrinsic to how
+// the active craft is actually flying, not an assumption about which
+// way orbits in this system usually go. The target's position is used
+// as-is (not first forced coplanar): projecting a vector onto the plane
+// perpendicular to h and then taking the signed angle from the active
+// craft's radius vector is exactly what
+// atan2(hHat . (r_active x r_target), r_active . r_target) computes (the
+// out-of-plane component of r_target cancels in both the numerator and
+// denominator), so a non-coplanar target still yields a usable
+// along-track answer via that projection rather than refusing outright.
+//
+// ok=false when there is no craft/ghost target, the target doesn't
+// resolve, or the target orbits a different primary than the active
+// craft — a phase angle spanning two different SOIs has no shared
+// reference orbit to measure it in, so the caller should render "—"
+// rather than a misleading number (issue #287 decision: craft targets
+// only, and only when both craft share a primary).
+func (w *World) TargetLeadAngleDeg() (float64, bool) {
+	if w.Target.Kind != TargetCraft && w.Target.Kind != TargetGhost {
+		return 0, false
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		return 0, false
+	}
+	var targetPrimary bodies.CelestialBody
+	switch w.Target.Kind {
+	case TargetCraft:
+		t, _, ok := w.craftByID(w.Target.CraftID)
+		if !ok {
+			return 0, false
+		}
+		targetPrimary = t.Primary
+	case TargetGhost:
+		_, primary, ok := w.ResolveTargetGhost()
+		if !ok {
+			return 0, false
+		}
+		targetPrimary = primary
+	}
+	if targetPrimary.ID != c.Primary.ID {
+		return 0, false
+	}
+	rT, _, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return 0, false
+	}
+	a := c.State.R
+	h := a.Cross(c.State.V)
+	hNorm := h.Norm()
+	if hNorm == 0 || a.Norm() == 0 {
+		return 0, false // degenerate orbit (e.g. radial fall) — no defined plane
+	}
+	hHat := h.Scale(1 / hNorm)
+	theta := math.Atan2(hHat.Dot(a.Cross(rT)), a.Dot(rT))
+	return theta * 180 / math.Pi, true
 }
 
 // TargetName returns a short human label for the current target,

--- a/internal/sim/target_lead_test.go
+++ b/internal/sim/target_lead_test.go
@@ -1,0 +1,199 @@
+package sim
+
+import (
+	"math"
+	"testing"
+)
+
+// leadAngleWorld builds a two-craft world sharing the active craft's
+// primary, with the sister craft placed at a signed along-track offset
+// `deltaDeg` from the active craft on the SAME circular orbital plane
+// (no inclination). Positive deltaDeg means the sister sits ahead of the
+// active craft in the direction of its own motion (mirrors
+// rendezvousSmallLagWorld's rotateAboutAxis pattern, generalized to an
+// arbitrary signed angle rather than a fixed small lag). Target is bound
+// to the sister craft (idx 1); active stays at idx 0.
+func leadAngleWorld(t *testing.T, deltaDeg float64) *World {
+	t.Helper()
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	sister := w.Crafts[1]
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := deltaDeg * math.Pi / 180
+	sister.State.R = rotateAboutAxis(active.State.R, axis, angle)
+	sister.State.V = rotateAboutAxis(active.State.V, axis, angle)
+	sister.Primary = active.Primary
+	return w
+}
+
+// TestTargetLeadAngleDeg_IssueRepro is the issue's own reproduction: two
+// craft on the same 500 km circular 0deg-inclination orbit, separated
+// along-track. Asserts the sign reads correctly for both directions and
+// that the two craft's readings of each other are opposite in sign
+// (issue #287, decisions section: "positive means the target is ahead of
+// you along-track").
+func TestTargetLeadAngleDeg_IssueRepro(t *testing.T) {
+	const lead = 82.0
+	w := leadAngleWorld(t, lead)
+
+	// From the active craft's (idx 0) point of view, the sister (idx 1)
+	// sits `lead` degrees ahead along-track.
+	got, ok := w.TargetLeadAngleDeg()
+	if !ok {
+		t.Fatal("expected ok=true for a same-primary craft target")
+	}
+	if math.Abs(got-lead) > 0.5 {
+		t.Errorf("active-craft view: lead angle = %.2f, want ~%.1f (target ahead)", got, lead)
+	}
+
+	// Flip perspective: make the sister active and target the original
+	// craft. From the sister's point of view, the original craft is
+	// `lead` degrees BEHIND it along-track, so the reading must be the
+	// opposite sign of the first reading.
+	w.ActiveCraftIdx = 1
+	w.SetTargetCraft(0)
+	flipped, ok := w.TargetLeadAngleDeg()
+	if !ok {
+		t.Fatal("expected ok=true for the flipped perspective")
+	}
+	if math.Abs(flipped-(-lead)) > 0.5 {
+		t.Errorf("sister-craft view: lead angle = %.2f, want ~%.1f (target behind)", flipped, -lead)
+	}
+	if (got > 0) == (flipped > 0) {
+		t.Errorf("the two craft's readings must be opposite in sign: got=%.2f flipped=%.2f", got, flipped)
+	}
+}
+
+// TestTargetLeadAngleDeg_Wrap180 checks the +/-180 deg wrap boundary: a
+// target placed just past +180 deg of lead (i.e., actually trailing by
+// just under 180 deg from the other side) must read as a small negative
+// number, not wrap around to a bogus large positive one, and vice versa.
+func TestTargetLeadAngleDeg_Wrap180(t *testing.T) {
+	cases := []struct {
+		name     string
+		deltaDeg float64
+		wantDeg  float64
+	}{
+		{"just_under_positive_180", 179.5, 179.5},
+		{"just_under_negative_180", -179.5, -179.5},
+		{"just_past_positive_180_wraps_negative", 190, -170},
+		{"just_past_negative_180_wraps_positive", -190, 170},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := leadAngleWorld(t, c.deltaDeg)
+			got, ok := w.TargetLeadAngleDeg()
+			if !ok {
+				t.Fatal("expected ok=true")
+			}
+			if got > 180 || got <= -180 {
+				t.Errorf("lead angle %.2f outside (-180, 180] range", got)
+			}
+			if math.Abs(got-c.wantDeg) > 0.5 {
+				t.Errorf("lead angle = %.2f, want ~%.1f", got, c.wantDeg)
+			}
+		})
+	}
+}
+
+// TestTargetLeadAngleDeg_NonCoplanar checks a non-coplanar target still
+// yields a sensible along-track answer via projection into the active
+// craft's orbital plane, rather than refusing or returning garbage. The
+// expected value is derived independently of the production formula:
+// for a target displaced by along-track angle `delta` on a plane tilted
+// by inclination `incl` from the active craft's plane (about the line of
+// nodes = the active craft's own radius vector), the projected along-
+// track angle is atan2(sin(delta)*cos(incl), cos(delta)) — a standard
+// projected-angle identity, not a restatement of the vector cross/dot
+// form the implementation uses.
+func TestTargetLeadAngleDeg_NonCoplanar(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	sister := w.Crafts[1]
+
+	aHat := active.State.R.Unit()
+	nHat := active.State.R.Cross(active.State.V).Unit()
+	pHat := nHat.Cross(aHat).Unit() // in-plane, perpendicular to aHat, aligned with motion
+
+	deltaDeg := 60.0
+	inclDeg := 30.0
+	delta := deltaDeg * math.Pi / 180
+	incl := inclDeg * math.Pi / 180
+
+	r := active.State.R.Norm()
+	sister.State.R = aHat.Scale(r * math.Cos(delta)).
+		Add(pHat.Scale(r * math.Sin(delta) * math.Cos(incl))).
+		Add(nHat.Scale(r * math.Sin(delta) * math.Sin(incl)))
+	// Velocity is irrelevant to the along-track angle computation (only
+	// positions are used) but give the sister a state consistent enough
+	// to resolve as a normal craft target; reuse the active craft's speed
+	// tangent to its own new radius direction as a stand-in.
+	sister.State.V = pHat.Scale(active.State.V.Norm())
+	sister.Primary = active.Primary
+
+	want := math.Atan2(math.Sin(delta)*math.Cos(incl), math.Cos(delta)) * 180 / math.Pi
+
+	got, ok := w.TargetLeadAngleDeg()
+	if !ok {
+		t.Fatal("expected ok=true for a non-coplanar same-primary target")
+	}
+	if math.Abs(got-want) > 0.5 {
+		t.Errorf("non-coplanar lead angle = %.2f, want ~%.2f (projected)", got, want)
+	}
+}
+
+// TestTargetLeadAngleDeg_DifferentPrimaries_NotMeaningful verifies the
+// cross-SOI refusal path: when the target craft orbits a different
+// primary than the active craft, the phase angle is not meaningful (no
+// shared reference frame to measure it in), so the function must report
+// ok=false rather than invent a number.
+func TestTargetLeadAngleDeg_DifferentPrimaries_NotMeaningful(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	sister := w.Crafts[1]
+	other := otherBody(t, w)
+	sister.Primary = other
+	_ = active
+
+	if _, ok := w.TargetLeadAngleDeg(); ok {
+		t.Error("expected ok=false when the target craft orbits a different primary")
+	}
+}
+
+// TestTargetLeadAngleDeg_BodyTarget_NotMeaningful verifies the field is
+// craft-target-only: a body target (not a craft) must never produce a
+// lead angle.
+func TestTargetLeadAngleDeg_BodyTarget_NotMeaningful(t *testing.T) {
+	w := mustWorld(t)
+	w.SetTargetBody(1)
+	if _, ok := w.TargetLeadAngleDeg(); ok {
+		t.Error("expected ok=false for a body target")
+	}
+}
+
+// TestTargetLeadAngleDeg_GhostTarget mirrors the craft-target repro but
+// through the ghost path (a remote player's craft, ADR 0034), which the
+// TARGET chip renders through the same field.
+func TestTargetLeadAngleDeg_GhostTarget(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	const lead = 45.0
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := lead * math.Pi / 180
+	ghostR := rotateAboutAxis(active.State.R, axis, angle)
+	ghostV := rotateAboutAxis(active.State.V, axis, angle)
+
+	g := ghostShapedLike(w, active.Primary, ghostR, ghostV, "SHA256:gern", "gern", 99)
+	w.Ghosts = []Ghost{g}
+	w.SetTargetGhost(g.Owner, g.CraftID)
+
+	got, ok := w.TargetLeadAngleDeg()
+	if !ok {
+		t.Fatal("expected ok=true for a same-primary ghost target")
+	}
+	if math.Abs(got-lead) > 0.5 {
+		t.Errorf("ghost target lead angle = %.2f, want ~%.1f", got, lead)
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1505,10 +1505,12 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		if rangeM > 0 {
 			closing = -rRel.Dot(vRelVec) / rangeM
 		}
+		leadDeg, leadOK := w.TargetLeadAngleDeg()
 		lines = append(lines,
 			chipRow("range:", formatRangeM(rangeM)),
 			chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", vRel)),
 			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
+			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
 		if tc.Primary.ID == c.Primary.ID {
 			lines = append(lines, v.closestApproachRows(w, c)...)
@@ -1552,10 +1554,12 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		if rangeM > 0 {
 			closing = -rRel.Dot(vRelVec) / rangeM
 		}
+		leadDeg, leadOK := w.TargetLeadAngleDeg()
 		lines = append(lines,
 			chipRow("range:", formatRangeM(rangeM)),
 			chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", vRel)),
 			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
+			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
 		if gPrimary.ID == c.Primary.ID {
 			lines = append(lines, v.closestApproachRows(w, c)...)
@@ -1563,6 +1567,28 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		return lines
 	}
 	return nil
+}
+
+// targetLeadLabel renders World.TargetLeadAngleDeg's reading as a chip
+// value (#287): phasing direction is the first decision of any
+// rendezvous, and a bare signed number is exactly the kind of thing
+// that's ambiguous in the seat at the moment it matters — so the sign
+// is always paired with a plain "ahead"/"behind" word rather than left
+// for the pilot to decode a convention. "—" when the reading isn't
+// meaningful (different primary / no shared SOI, or a degenerate orbit)
+// rather than a misleading number.
+func targetLeadLabel(angleDeg float64, ok bool) string {
+	if !ok {
+		return "—"
+	}
+	switch {
+	case angleDeg > 0:
+		return fmt.Sprintf("%+.0f° (ahead)", angleDeg)
+	case angleDeg < 0:
+		return fmt.Sprintf("%+.0f° (behind)", angleDeg)
+	default:
+		return "0° (aligned)"
+	}
 }
 
 // closestApproachRows computes the TCA/CA rows against the current

--- a/internal/tui/screens/orbit_target_lead_chip_test.go
+++ b/internal/tui/screens/orbit_target_lead_chip_test.go
@@ -1,0 +1,215 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestTargetLeadLabel is the pure content selector's unit test (issue
+// #287): a signed angle is always paired with a plain "ahead"/"behind"
+// word, never a bare +/- number a pilot has to decode under pressure,
+// and "—" stands in when the reading isn't meaningful.
+func TestTargetLeadLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		angle float64
+		ok    bool
+		want  string
+	}{
+		{"ahead", 82, true, "+82° (ahead)"},
+		{"behind", -82, true, "-82° (behind)"},
+		{"aligned", 0, true, "0° (aligned)"},
+		{"not_meaningful", 0, false, "—"},
+		{"not_meaningful_nonzero_angle_ignored", 999, false, "—"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := targetLeadLabel(c.angle, c.ok); got != c.want {
+				t.Errorf("targetLeadLabel(%v, %v) = %q, want %q", c.angle, c.ok, got, c.want)
+			}
+		})
+	}
+}
+
+// leadTestWorld builds a two-craft world (mirrors the sim package's own
+// rendezvousTwoCraftWorld) with the sister craft offset along-track by
+// deltaDeg on the active craft's own circular orbital plane, and targets
+// the sister from the active craft.
+func leadTestWorld(t *testing.T, deltaDeg float64) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	active := w.Crafts[0]
+	sister := w.Crafts[1]
+
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	angle := deltaDeg * math.Pi / 180
+	cos, sin := math.Cos(angle), math.Sin(angle)
+	rotate := func(v orbital.Vec3) orbital.Vec3 {
+		return v.Scale(cos).Add(axis.Cross(v).Scale(sin)).Add(axis.Scale(axis.Dot(v) * (1 - cos)))
+	}
+	sister.State.R = rotate(active.State.R)
+	sister.State.V = rotate(active.State.V)
+	sister.Primary = active.Primary
+
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestBuildTargetChipShowsLeadAhead/Behind exercise the issue's own
+// reproduction through the render path: the TARGET chip must carry a
+// "lead:" row reading the direction in plain words, both ways.
+func TestBuildTargetChipShowsLeadAhead(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := leadTestWorld(t, 82)
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "lead:") {
+		t.Fatalf("TARGET chip missing lead: row:\n%s", joined)
+	}
+	if !strings.Contains(joined, "+82° (ahead)") {
+		t.Errorf("TARGET chip lead row = %q, want a line containing \"+82° (ahead)\"", joined)
+	}
+}
+
+func TestBuildTargetChipShowsLeadBehind(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := leadTestWorld(t, -82)
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "-82° (behind)") {
+		t.Errorf("TARGET chip lead row = %q, want a line containing \"-82° (behind)\"", joined)
+	}
+}
+
+// TestBuildTargetChipLeadDashesAcrossPrimaries: a craft target orbiting a
+// different primary than the active craft has no shared reference orbit
+// to measure a phase angle in — the row must render "—", not a number
+// that looks meaningful but isn't (issue #287 decision).
+func TestBuildTargetChipLeadDashesAcrossPrimaries(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := leadTestWorld(t, 82)
+	sister := w.Crafts[1]
+	// Move the sister to any other body in the system so its Primary no
+	// longer matches the active craft's.
+	for _, b := range w.System().Bodies {
+		if b.ID != sister.Primary.ID {
+			sister.Primary = b
+			break
+		}
+	}
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "lead:") {
+		t.Fatalf("TARGET chip missing lead: row:\n%s", joined)
+	}
+	if !strings.Contains(joined, "lead:") || !strings.Contains(joined, "—") {
+		t.Errorf("cross-primary target's lead row should read —, got:\n%s", joined)
+	}
+}
+
+// TestBuildTargetChipBodyTargetHasNoLeadRow: the field is craft-target
+// only (issue #287 decision) — a body target must never grow a lead row.
+func TestBuildTargetChipBodyTargetHasNoLeadRow(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.SetTargetBody(1)
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "lead:") {
+		t.Errorf("body TARGET chip should not have a lead: row:\n%s", joined)
+	}
+}
+
+// TestTargetChipLeadRowFitsNarrowTerminal renders the full HUD at 80x24 —
+// the project's minimum-viable terminal, not a generous one — with a
+// craft target set (so the TARGET chip carries the new lead: row) and
+// asserts the frame never grows past the terminal height. Two clipping
+// defects shipped in this project because every prior chip-growth test
+// used 120x40 or 200x60; this one deliberately doesn't.
+//
+// Note: at 80x24 the always-on ORBIT chip alone already fills the
+// top-right corner's chip budget (admitChipsByBudget, chipPriorityNormal
+// for TARGET) — a pre-existing space constraint independent of this
+// change, reproducible on main without the lead row. So this test does
+// not assert TARGET itself is visible in the composed frame; that would
+// be testing the corner-budget allocator, out of scope for #287. It
+// asserts the one thing in scope: the frame never overflows regardless.
+func TestTargetChipLeadRowFitsNarrowTerminal(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	const cols, rows = 80, 24
+	v.Resize(cols, rows)
+	w := leadTestWorld(t, 82)
+	// Plant a node too — the layout this row actually ships into, not
+	// TARGET alone in isolation.
+	c := w.ActiveCraft()
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		DV:          50,
+		TriggerTime: w.Clock.SimTime.Add(10 * time.Minute),
+	})
+
+	out := v.Render(w, 0, cols, rows)
+	if h := strings.Count(out, "\n") + 1; h > rows {
+		t.Errorf("frame height = %d rows, want <= %d at 80x24 with a craft target set", h, rows)
+	}
+}
+
+// TestTargetChipLeadRowComposesAtNarrowWidth exercises the actual
+// composition path (composeChips, the same corner-placement/clipping
+// logic Render uses) with the real TARGET chip content — lead row
+// included — at an 80-column canvas, isolated from the unrelated
+// ORBIT-vs-TARGET corner-budget competition covered by the note above.
+// Confirms the new row: composes without panic, is glyph-width-consistent
+// (assertChipCellWidthConsistent — the em dash / degree sign / +- glyphs
+// this row introduces must measure the same in lipgloss cells as in
+// splitStyledCells, the ☾-class trap noted throughout this file), and
+// its rendered column stays within the 80-col canvas.
+func TestTargetChipLeadRowComposesAtNarrowWidth(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := leadTestWorld(t, 82)
+	lines := v.buildTargetChip(w)
+	assertChipCellWidthConsistent(t, "TARGET (ahead)", lines)
+
+	const cols, rows = 80, 24
+	chips := []builtChip{
+		{id: "TARGET", corner: cornerTopRight, lines: lines},
+	}
+	out := v.composeChips(blankCanvas(cols, rows), cols, rows, 0, 0, 0, chips)
+	if !strings.Contains(out, "lead:") {
+		t.Fatalf("composed frame missing the lead: row:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if width := lipgloss.Width(line); width > cols {
+			t.Errorf("composed line exceeds %d cols (%d): %q", cols, width, line)
+		}
+	}
+
+	// The dashed (cross-primary) form must also stay glyph-width-consistent.
+	sister := w.Crafts[1]
+	for _, b := range w.System().Bodies {
+		if b.ID != sister.Primary.ID {
+			sister.Primary = b
+			break
+		}
+	}
+	dashLines := v.buildTargetChip(w)
+	assertChipCellWidthConsistent(t, "TARGET (dashed)", dashLines)
+}


### PR DESCRIPTION
## Summary

- Two coplanar circular craft used to read `closing 0.00 m/s` with no field answering "am I ahead of or behind my target?" — the first decision of any rendezvous. Adds `World.TargetLeadAngleDeg()` (`internal/sim/target.go`): the signed along-track angle from the active craft to its craft/ghost target, measured about the active craft's own specific angular momentum axis (`h = r × v`) so a non-coplanar target still projects to a sensible along-track answer, rather than refusing outright.
- The TARGET chip (`internal/tui/screens/orbit_chip_builders.go`) gets a new `lead:` row: `+82° (ahead)` / `-82° (behind)` — always paired with a plain word, never a bare signed number. Reads `—` when the target craft orbits a different primary (no shared reference orbit to measure a phase angle in) or for a body target (the field is craft-target only, per the issue's decisions).
- Display-only: no physics/integrator change, no save-schema bump, no catalog-hash change.

Closes #287.

## Method (TDD)

- Red observed first: wrote `internal/sim/target_lead_test.go` against `TargetLeadAngleDeg`, which didn't exist yet — confirmed compile failure, then implemented.
- Coverage: the issue's own repro (two craft, same 500 km circular 0° orbit, along-track separation — opposite-sign readings from each craft's perspective), the ±180° wrap boundary, a non-coplanar pair (checked against an independently-derived `atan2(sin δ·cos i, cos δ)` projection formula, not a restatement of the implementation), the different-primaries → not-meaningful path, a body-target → no lead row path, and the ghost-target path (remote player's craft).
- Render-level tests in `internal/tui/screens/orbit_target_lead_chip_test.go`: the pure `targetLeadLabel` formatter, the TARGET chip content for ahead/behind/cross-primary, and an 80×24 (not a generous terminal) composition test that checks the new row is glyph-width-consistent (`assertChipCellWidthConsistent`) and fits the canvas via `composeChips` directly.

## Note on 80×24

At 80×24 the always-on ORBIT chip alone already fills the top-right corner's chip budget (`admitChipsByBudget`, TARGET is `chipPriorityNormal`) — reproducible on `main` today, independent of this change (verified by temporarily removing the new row and re-rendering: TARGET was already absent). So the narrow-terminal test doesn't assert TARGET is visible in the full composed HUD at 80×24 (that would be testing the corner-budget allocator, out of scope for #287); it asserts the frame never overflows, plus a direct `composeChips`-level check of the new row's own content/width.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] Red observed before implementing (`TargetLeadAngleDeg undefined` compile failure)