### PR TITLE
feat(#346): draw the missing marks — CA ✕, target Ap/Pe, AN/DN on map

### DIFF
--- a/internal/planner/rendezvous.go
+++ b/internal/planner/rendezvous.go
@@ -49,11 +49,52 @@ func NextClosestApproach(
 	mu, horizon float64,
 ) (t, dist float64, vRel orbital.Vec3, err error) {
 	_ = primary // captured in the signature for future cross-frame work
+	res, err := closestApproach(stateA, stateB, mu, horizon)
+	if err != nil {
+		return 0, 0, orbital.Vec3{}, err
+	}
+	return res.t, res.dist, res.vRel, nil
+}
+
+// NextClosestApproachPositions is NextClosestApproach plus the two
+// craft's positions at the refined closest-approach time — the map's ✕
+// marker (ADR 0020 / #346) plots both ends of the encounter there. The
+// positions come from the exact same re-propagation that produces
+// `dist`, so a marker at posA/posB is always exactly `dist` apart —
+// there is no separate position pass to drift out of sync with the
+// scalar HUD readout.
+func NextClosestApproachPositions(
+	stateA, stateB orbital.Vec3State,
+	mu, horizon float64,
+) (t, dist float64, posA, posB orbital.Vec3, err error) {
+	res, err := closestApproach(stateA, stateB, mu, horizon)
+	if err != nil {
+		return 0, 0, orbital.Vec3{}, orbital.Vec3{}, err
+	}
+	return res.t, res.dist, res.posA, res.posB, nil
+}
+
+// closestApproachResult is the shared outcome of the sampling +
+// parabolic-refinement pipeline both NextClosestApproach and
+// NextClosestApproachPositions expose slices of.
+type closestApproachResult struct {
+	t    float64
+	dist float64
+	vRel orbital.Vec3
+	posA orbital.Vec3
+	posB orbital.Vec3
+}
+
+// closestApproach is NextClosestApproach's algorithm body, extracted so
+// the position-carrying variant can share it exactly rather than
+// re-deriving the sampling/refinement math. See NextClosestApproach's
+// doc comment for the algorithm description.
+func closestApproach(stateA, stateB orbital.Vec3State, mu, horizon float64) (closestApproachResult, error) {
 	if horizon <= 0 {
-		return 0, 0, orbital.Vec3{}, errors.New("rendezvous: non-positive horizon")
+		return closestApproachResult{}, errors.New("rendezvous: non-positive horizon")
 	}
 	if mu <= 0 {
-		return 0, 0, orbital.Vec3{}, errors.New("rendezvous: non-positive mu")
+		return closestApproachResult{}, errors.New("rendezvous: non-positive mu")
 	}
 
 	sA := physics.StateVector{R: stateA.R, V: stateA.V}
@@ -146,5 +187,11 @@ func NextClosestApproach(
 		rB = physics.StepVerlet(rB, mu, step)
 		remaining -= step
 	}
-	return tStar, rA.R.Sub(rB.R).Norm(), rA.V.Sub(rB.V), nil
+	return closestApproachResult{
+		t:    tStar,
+		dist: rA.R.Sub(rB.R).Norm(),
+		vRel: rA.V.Sub(rB.V),
+		posA: rA.R,
+		posB: rB.R,
+	}, nil
 }

--- a/internal/planner/rendezvous_test.go
+++ b/internal/planner/rendezvous_test.go
@@ -171,3 +171,68 @@ func TestNextClosestApproachInvalidMu(t *testing.T) {
 		t.Error("zero mu: expected err")
 	}
 }
+
+// TestNextClosestApproachPositionsAgreesWithScalarDist — the ✕ marker's
+// two positions (#346) must be exactly `dist` apart, since the map plots
+// posA/posB directly as the encounter's two ends. Cross-checks
+// NextClosestApproachPositions against NextClosestApproach on the same
+// inputs: same t and dist (shared closestApproach core), and
+// |posA-posB| == dist to float precision.
+func TestNextClosestApproachPositionsAgreesWithScalarDist(t *testing.T) {
+	r := 6.771e6
+	a := circularState(r, 0, muEarth)
+	b := circularState(r, math.Pi/2, muEarth)
+	const horizon = 6000.0
+
+	tCA, dist, _, err := NextClosestApproach(a, b, bodies.CelestialBody{}, muEarth, horizon)
+	if err != nil {
+		t.Fatalf("NextClosestApproach err: %v", err)
+	}
+	tCA2, dist2, posA, posB, err := NextClosestApproachPositions(a, b, muEarth, horizon)
+	if err != nil {
+		t.Fatalf("NextClosestApproachPositions err: %v", err)
+	}
+	if tCA2 != tCA {
+		t.Errorf("t mismatch: scalar=%v positions=%v", tCA, tCA2)
+	}
+	if dist2 != dist {
+		t.Errorf("dist mismatch: scalar=%v positions=%v", dist, dist2)
+	}
+	if gotSep := posA.Sub(posB).Norm(); math.Abs(gotSep-dist) > 1e-6 {
+		t.Errorf("|posA-posB|=%v, want == dist (%v)", gotSep, dist)
+	}
+}
+
+// TestNextClosestApproachPositionsIdenticalStatesCoincide — same state
+// for both craft: closest approach is "now" at distance 0, so both
+// reported positions should coincide with that shared state.
+func TestNextClosestApproachPositionsIdenticalStatesCoincide(t *testing.T) {
+	r := 6.771e6
+	s := circularState(r, 0, muEarth)
+	_, dist, posA, posB, err := NextClosestApproachPositions(s, s, muEarth, 3600)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if dist > 1.0 {
+		t.Errorf("identical states: dist=%v, want ≈0", dist)
+	}
+	if got := posA.Sub(posB).Norm(); got > 1.0 {
+		t.Errorf("identical states: |posA-posB|=%v, want ≈0", got)
+	}
+	if got := posA.Sub(s.R).Norm(); got > 1.0 {
+		t.Errorf("posA=%v, want ≈ initial state %v", posA, s.R)
+	}
+}
+
+// TestNextClosestApproachPositionsInvalidInputs — non-positive horizon
+// / mu propagate the same errors as NextClosestApproach.
+func TestNextClosestApproachPositionsInvalidInputs(t *testing.T) {
+	r := 6.771e6
+	s := circularState(r, 0, muEarth)
+	if _, _, _, _, err := NextClosestApproachPositions(s, s, muEarth, 0); err == nil {
+		t.Error("zero horizon: expected err")
+	}
+	if _, _, _, _, err := NextClosestApproachPositions(s, s, 0, 3600); err == nil {
+		t.Error("zero mu: expected err")
+	}
+}

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -413,6 +413,90 @@ func (w *World) TargetLeadAngleDeg() (float64, bool) {
 	return theta * 180 / math.Pi, true
 }
 
+// TargetSharesActivePrimary reports whether the active craft's bound
+// craft/ghost target orbits the SAME primary as the active craft — the
+// gate every same-primary-only piece of rendezvous-adjacent tooling
+// built on TargetStateRelativeToActivePrimary needs (TargetPlaneNodePositions,
+// the map's Closest-Approach marker, #346): cross-SOI rendezvous is
+// already out of scope for the rendezvous tooling (see CONTEXT.md's
+// Rendezvous entry), and a target re-expressed in the active craft's
+// frame across two different primaries doesn't correspond to a point on
+// that target's own drawn orbit. False for a body/site target or no
+// target at all.
+func (w *World) TargetSharesActivePrimary() bool {
+	c := w.ActiveCraft()
+	if c == nil {
+		return false
+	}
+	switch w.Target.Kind {
+	case TargetCraft:
+		t, _, ok := w.craftByID(w.Target.CraftID)
+		return ok && t.Primary.ID == c.Primary.ID
+	case TargetGhost:
+		_, primary, ok := w.ResolveTargetGhost()
+		return ok && primary.ID == c.Primary.ID
+	default:
+		return false
+	}
+}
+
+// TargetPlaneNodePositions locates the active craft's crossings of its
+// bound target's orbital plane — an Ascending / Descending Node pair
+// measured against the TARGET's plane, unlike orbital.TimeToNodeCrossing's
+// usual reference-plane sense (the primary's equator / the ecliptic; see
+// the Ascending Node / Descending Node glossary entries). The map's ◇ / ◆
+// markers (ADR 0020 §3 / #346) plot these two points on the active
+// craft's own orbit.
+//
+// Reuses TimeToNodeCrossing exactly rather than re-deriving node-crossing
+// math: PlanPlaneMatch already solves "coplanar with X" by re-expressing
+// the craft's state in a frame whose Z axis is X's orbit normal
+// (orbital.FrameFromNormal) and asking the ordinary reference-plane
+// helper for its crossings in that frame — this does the same thing with
+// the target CRAFT/ghost's relative angular momentum (rT × vT) standing
+// in for a body's catalog-derived orbit normal.
+//
+// ok (hasAN / hasDN) is false when: there's no active craft, no bound
+// craft/ghost target, the target orbits a different primary (see
+// TargetSharesActivePrimary), the target's relative state is degenerate
+// (coincident position, zero relative angular momentum), or the two
+// planes are within TimeToNodeCrossing's own equatorial tolerance of
+// coincident (no defined line of nodes). hasAN and hasDN are reported
+// independently in case only one resolves.
+func (w *World) TargetPlaneNodePositions() (anPos, dnPos orbital.Vec3, hasAN, hasDN bool) {
+	c := w.ActiveCraft()
+	if c == nil || !w.TargetSharesActivePrimary() {
+		return orbital.Vec3{}, orbital.Vec3{}, false, false
+	}
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return orbital.Vec3{}, orbital.Vec3{}, false, false
+	}
+	nTarget := rT.Cross(vT)
+	if nTarget.Norm() == 0 {
+		return orbital.Vec3{}, orbital.Vec3{}, false, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	planeFrame := orbital.FrameFromNormal(nTarget)
+	stateTF := orbital.Vec3State{
+		R: planeFrame.FromWorld(c.State.R),
+		V: planeFrame.FromWorld(c.State.V),
+	}
+	tAN := orbital.TimeToNodeCrossing(stateTF, mu, true)
+	tDN := orbital.TimeToNodeCrossing(stateTF, mu, false)
+	if tAN >= 0 {
+		post, postPrimary := w.propagateCraftWithPrimary(tAN)
+		anPos = w.BodyPosition(postPrimary).Add(post.R)
+		hasAN = true
+	}
+	if tDN >= 0 {
+		post, postPrimary := w.propagateCraftWithPrimary(tDN)
+		dnPos = w.BodyPosition(postPrimary).Add(post.R)
+		hasDN = true
+	}
+	return anPos, dnPos, hasAN, hasDN
+}
+
 // TargetName returns a short human label for the current target,
 // suitable for the TARGET HUD block. Empty string when no target is
 // set or the index is stale.

--- a/internal/sim/target_plane_nodes_test.go
+++ b/internal/sim/target_plane_nodes_test.go
@@ -1,0 +1,150 @@
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestTargetPlaneNodePositions_TiltedAboutXAxis sets up a hand-computable
+// geometry: the target orbits a circle of radius r in the primary's
+// XY-plane (orbit normal = +Z), and the active craft orbits the SAME
+// circle tilted 30 degrees about the +X axis. Rotating a circle about an
+// axis leaves the two points that already sit ON that axis fixed, so the
+// active orbit's crossings of the target's XY-plane (its Ascending /
+// Descending Node pair against the TARGET's plane) are exactly (+r, 0, 0)
+// and (-r, 0, 0) in the primary's frame — independent of TimeToNodeCrossing's
+// own internals, so this checks the map-facing wiring (frame-from-normal +
+// propagate-to-crossing) rather than re-asserting the node-crossing math
+// TimeToNodeCrossing already owns.
+func TestTargetPlaneNodePositions_TiltedAboutXAxis(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	mu := active.Primary.GravitationalParameter()
+	const r = 6.771e6 // 400 km LEO
+	baseV := math.Sqrt(mu / r)
+
+	// Target: circular, in the primary's XY-plane (h ∥ +Z).
+	target.State.R = orbital.Vec3{X: r}
+	target.State.V = orbital.Vec3{Y: baseV}
+	target.Primary = active.Primary
+
+	// Active: the same circle, started 90° around it, then the whole
+	// state tilted 30° about +X — the line of nodes with the target's
+	// plane is exactly the X-axis.
+	preR := orbital.Vec3{Y: r}
+	preV := orbital.Vec3{X: -baseV}
+	theta := 30 * math.Pi / 180
+	axis := orbital.Vec3{X: 1}
+	active.State.R = rotateAboutAxis(preR, axis, theta)
+	active.State.V = rotateAboutAxis(preV, axis, theta)
+
+	anPos, dnPos, hasAN, hasDN := w.TargetPlaneNodePositions()
+	if !hasAN || !hasDN {
+		t.Fatalf("expected both nodes resolvable, hasAN=%v hasDN=%v", hasAN, hasDN)
+	}
+
+	primaryPos := w.BodyPosition(active.Primary)
+	wantA := primaryPos.Add(orbital.Vec3{X: r})
+	wantB := primaryPos.Add(orbital.Vec3{X: -r})
+
+	const tol = 50.0 // metres — analytic Kepler propagation, not sample-grid
+	matches := func(got, want orbital.Vec3) bool { return got.Sub(want).Norm() < tol }
+	okSet := (matches(anPos, wantA) && matches(dnPos, wantB)) ||
+		(matches(anPos, wantB) && matches(dnPos, wantA))
+	if !okSet {
+		t.Errorf("node positions = {%v, %v}, want the pair {%v, %v} (line of nodes = ±X at radius %.0f)",
+			anPos, dnPos, wantA, wantB, r)
+	}
+}
+
+// TestTargetPlaneNodePositions_Coplanar verifies the degenerate case: an
+// active craft coplanar with its target has no defined line of nodes, so
+// TimeToNodeCrossing's own equatorial-tolerance gate returns -1 for both
+// crossings and TargetPlaneNodePositions must report hasAN=hasDN=false
+// rather than fabricating a point.
+func TestTargetPlaneNodePositions_Coplanar(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	// rendezvousTwoCraftWorld's default spawn already puts both craft in
+	// the same equatorial plane; make it explicit / robust to spawn
+	// defaults changing by forcing both onto the primary's XY-plane.
+	mu := active.Primary.GravitationalParameter()
+	const r1, r2 = 6.771e6, 6.971e6
+	target.State.R = orbital.Vec3{X: r1}
+	target.State.V = orbital.Vec3{Y: math.Sqrt(mu / r1)}
+	target.Primary = active.Primary
+	active.State.R = orbital.Vec3{Y: r2}
+	active.State.V = orbital.Vec3{X: -math.Sqrt(mu / r2)}
+
+	_, _, hasAN, hasDN := w.TargetPlaneNodePositions()
+	if hasAN || hasDN {
+		t.Errorf("coplanar craft: expected no defined nodes, got hasAN=%v hasDN=%v", hasAN, hasDN)
+	}
+}
+
+// TestTargetPlaneNodePositions_DifferentPrimaries_NotMeaningful mirrors
+// TargetLeadAngleDeg's cross-SOI refusal: a target orbiting a different
+// primary has no shared plane to measure a line of nodes against.
+func TestTargetPlaneNodePositions_DifferentPrimaries_NotMeaningful(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	sister := w.Crafts[1]
+	other := otherBody(t, w)
+	sister.Primary = other
+
+	if _, _, hasAN, hasDN := w.TargetPlaneNodePositions(); hasAN || hasDN {
+		t.Error("expected no nodes when the target craft orbits a different primary")
+	}
+}
+
+// TestTargetPlaneNodePositions_BodyTarget_NotMeaningful: a body target
+// (not a craft/ghost) must never produce plane-node markers.
+func TestTargetPlaneNodePositions_BodyTarget_NotMeaningful(t *testing.T) {
+	w := mustWorld(t)
+	w.SetTargetBody(1)
+	if _, _, hasAN, hasDN := w.TargetPlaneNodePositions(); hasAN || hasDN {
+		t.Error("expected no nodes for a body target")
+	}
+}
+
+// TestTargetPlaneNodePositions_GhostTarget mirrors the craft-target
+// tilted-orbit case through the ghost path (ADR 0034), which the map
+// draws through the same Ghosts slate as a local craft target.
+func TestTargetPlaneNodePositions_GhostTarget(t *testing.T) {
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	mu := active.Primary.GravitationalParameter()
+	const r = 6.771e6
+	baseV := math.Sqrt(mu / r)
+
+	ghostR := orbital.Vec3{X: r}
+	ghostV := orbital.Vec3{Y: baseV}
+	g := ghostShapedLike(w, active.Primary, ghostR, ghostV, "SHA256:gern", "gern", 99)
+	w.Ghosts = []Ghost{g}
+	w.SetTargetGhost(g.Owner, g.CraftID)
+
+	preR := orbital.Vec3{Y: r}
+	preV := orbital.Vec3{X: -baseV}
+	theta := 30 * math.Pi / 180
+	axis := orbital.Vec3{X: 1}
+	active.State.R = rotateAboutAxis(preR, axis, theta)
+	active.State.V = rotateAboutAxis(preV, axis, theta)
+
+	anPos, dnPos, hasAN, hasDN := w.TargetPlaneNodePositions()
+	if !hasAN || !hasDN {
+		t.Fatalf("expected both nodes resolvable for a ghost target, hasAN=%v hasDN=%v", hasAN, hasDN)
+	}
+	primaryPos := w.BodyPosition(active.Primary)
+	wantA := primaryPos.Add(orbital.Vec3{X: r})
+	wantB := primaryPos.Add(orbital.Vec3{X: -r})
+	const tol = 50.0
+	matches := func(got, want orbital.Vec3) bool { return got.Sub(want).Norm() < tol }
+	okSet := (matches(anPos, wantA) && matches(dnPos, wantB)) ||
+		(matches(anPos, wantB) && matches(dnPos, wantA))
+	if !okSet {
+		t.Errorf("ghost-target node positions = {%v, %v}, want the pair {%v, %v}", anPos, dnPos, wantA, wantB)
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -786,6 +786,23 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 					stride = 3
 				}
 				v.canvas.DrawEllipseOffsetFarSideDashed(el, gPrimaryPos, 180, stride, gPrimaryPos, gPxR, orbitColor)
+				if isTarget {
+					// Target's Ap/Pe (ADR 0020 / #346): the targeted
+					// ghost's own apsides, dimmed via MarkerCounterfactual
+					// — the same brightness convention the SOI Pass
+					// counterfactual arc uses (nominal = "yours", dim =
+					// "someone/something else's") — so the active craft's
+					// own Ap/Pe (drawn nominal below) stay the visually
+					// dominant pair.
+					peri := gPrimaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
+					apo := gPrimaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
+					if !v.canvas.IsBehindBody(peri, gPrimaryPos, gPxR) {
+						drawMarker(v.canvas, peri, render.MarkerPeriapsis, render.MarkerCounterfactual, "", widgets.CellTag{})
+					}
+					if !v.canvas.IsBehindBody(apo, gPrimaryPos, gPxR) {
+						drawMarker(v.canvas, apo, render.MarkerApoapsis, render.MarkerCounterfactual, "", widgets.CellTag{})
+					}
+				}
 			}
 		}
 		if isTarget {
@@ -929,6 +946,22 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 					stride = 3
 				}
 				v.canvas.DrawEllipseOffsetFarSideDashed(otherEl, otherPrimaryPos, 180, stride, otherPrimaryPos, otherPxR, otherColor)
+				if isTarget {
+					// Target's Ap/Pe (ADR 0020 / #346): the targeted
+					// craft's own apsides, dimmed via MarkerCounterfactual
+					// — same brightness convention as the ghost target
+					// above and the SOI Pass counterfactual arc (nominal
+					// = "yours", dim = "someone else's") — so the active
+					// craft's own Ap/Pe stay the visually dominant pair.
+					peri := otherPrimaryPos.Add(orbital.PositionAtTrueAnomaly(otherEl, 0))
+					apo := otherPrimaryPos.Add(orbital.PositionAtTrueAnomaly(otherEl, math.Pi))
+					if !v.canvas.IsBehindBody(peri, otherPrimaryPos, otherPxR) {
+						drawMarker(v.canvas, peri, render.MarkerPeriapsis, render.MarkerCounterfactual, "", widgets.CellTag{})
+					}
+					if !v.canvas.IsBehindBody(apo, otherPrimaryPos, otherPxR) {
+						drawMarker(v.canvas, apo, render.MarkerApoapsis, render.MarkerCounterfactual, "", widgets.CellTag{})
+					}
+				}
 			}
 			if !v.canvas.IsBehindBody(otherInertial, otherPrimaryPos, otherPxR) {
 				v.canvas.PlotColored(otherInertial, otherColor)
@@ -979,6 +1012,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// the node trajectory — drawn regardless of declutter (only the COMMS
 		// chip declutters); no-op for a manned or disconnected craft.
 		v.drawCommPath(w)
+		// Closest-Approach ✕ + target-plane ◇/◆ nodes (ADR 0020 / #346):
+		// both are no-ops without a bound craft/ghost target sharing the
+		// active craft's primary.
+		v.drawClosestApproachMarker(w)
+		v.drawTargetPlaneNodes(w)
 	}
 
 	// Stamp the active projection in the canvas's bottom-left corner

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1602,8 +1602,10 @@ func (v *OrbitView) closestApproachRows(w *sim.World, c *spacecraft.Spacecraft) 
 	active := orbital.Vec3State{R: c.State.R, V: c.State.V}
 	target := orbital.Vec3State{R: rT, V: vT}
 	mu := c.Primary.GravitationalParameter()
-	const horizon = 4 * 3600.0
-	tCA, distCA, _, err := planner.NextClosestApproach(active, target, c.Primary, mu, horizon)
+	// closestApproachHorizonSec (orbit_target_markers.go) — shared with
+	// the map's ✕ marker so the chip's numbers and the marker's position
+	// always describe the same encounter.
+	tCA, distCA, _, err := planner.NextClosestApproach(active, target, c.Primary, mu, closestApproachHorizonSec)
 	if err != nil {
 		return nil
 	}

--- a/internal/tui/screens/orbit_target_markers.go
+++ b/internal/tui/screens/orbit_target_markers.go
@@ -1,0 +1,76 @@
+package screens
+
+import (
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// closestApproachHorizonSec is the forward-prediction window
+// NextClosestApproach(Positions) searches for the encounter, matching
+// closestApproachRows' (orbit_chip_builders.go) TARGET-chip CA/TCA rows
+// exactly — the map's ✕ marker and the chip's numbers must never
+// disagree about which encounter they're describing.
+const closestApproachHorizonSec = 4 * 3600.0
+
+// drawClosestApproachMarker plots the map's ✕ Closest-Approach marker
+// (ADR 0020 / #346) at both ends of the predicted encounter: the active
+// craft's own point on its orbit, and its twin at the bound target's
+// position on ITS orbit, at the instant NextClosestApproachPositions
+// reports for the current geometry. The two positions come from the same
+// re-propagation that produces the TARGET chip's CA distance, so the
+// marker separation always agrees with the chip's number — there is no
+// separate, potentially-drifting position computation.
+//
+// No-op without a craft/ghost target sharing the active craft's primary
+// (see World.TargetSharesActivePrimary) — cross-SOI rendezvous is
+// already out of scope for the rendezvous tooling (CONTEXT.md's
+// Rendezvous entry), same restriction NextClosestApproach itself
+// documents.
+//
+// Not occlusion-culled against the primary disk, matching drawNodes' and
+// drawSOIPass's marker convention (a maneuver marker or Perilune marker
+// behind the body still shows) — overlap between markers resolves by
+// deterministic draw order (ADR 0020 D), not a per-marker occlusion
+// test.
+func (v *OrbitView) drawClosestApproachMarker(w *sim.World) {
+	c := w.ActiveCraft()
+	if c == nil || !w.TargetSharesActivePrimary() {
+		return
+	}
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return
+	}
+	mu := c.Primary.GravitationalParameter()
+	active := orbital.Vec3State{R: c.State.R, V: c.State.V}
+	target := orbital.Vec3State{R: rT, V: vT}
+	_, _, posA, posB, err := planner.NextClosestApproachPositions(active, target, mu, closestApproachHorizonSec)
+	if err != nil {
+		return
+	}
+	primaryPos := w.BodyPosition(c.Primary)
+	drawMarker(v.canvas, primaryPos.Add(posA), render.MarkerClosestApproach, render.MarkerNominal, "", widgets.CellTag{})
+	drawMarker(v.canvas, primaryPos.Add(posB), render.MarkerClosestApproach, render.MarkerNominal, "", widgets.CellTag{})
+}
+
+// drawTargetPlaneNodes plots the map's ◇ Ascending / ◆ Descending Node
+// markers (ADR 0020 / #346) where the active craft's orbit crosses its
+// bound target's orbital plane — reusing World.TargetPlaneNodePositions,
+// which itself reuses the navball / PlanPlaneMatch node-crossing
+// primitives (orbital.FrameFromNormal + orbital.TimeToNodeCrossing)
+// against the target craft/ghost's plane instead of the primary's usual
+// reference plane. No-op when neither crossing resolves (no target,
+// cross-primary target, or the two orbits are already coplanar — see
+// TargetPlaneNodePositions for the full list of refusal cases).
+func (v *OrbitView) drawTargetPlaneNodes(w *sim.World) {
+	anPos, dnPos, hasAN, hasDN := w.TargetPlaneNodePositions()
+	if hasAN {
+		drawMarker(v.canvas, anPos, render.MarkerAscendingNode, render.MarkerNominal, "", widgets.CellTag{})
+	}
+	if hasDN {
+		drawMarker(v.canvas, dnPos, render.MarkerDescendingNode, render.MarkerNominal, "", widgets.CellTag{})
+	}
+}

--- a/internal/tui/screens/orbit_target_markers_test.go
+++ b/internal/tui/screens/orbit_target_markers_test.go
@@ -1,0 +1,352 @@
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// eccentricStateAtNu90 returns the (R, V) state of an eccentric orbit
+// (periapsis rPeri, apoapsis rApo, gravitational parameter mu) at true
+// anomaly 90°, given the orbit's periapsis direction pHat and its
+// in-plane perpendicular qHat (= orbitNormal × pHat) — the standard
+// perifocal parametrization R = r·Q̂, V = √(μ/p)·(−P̂ + e·Q̂) at ν=90°.
+// Test-only helper so the two fixtures below don't hand-derive the same
+// arithmetic twice.
+func eccentricStateAtNu90(mu, rPeri, rApo float64, pHat, qHat orbital.Vec3) (r, v orbital.Vec3) {
+	e := (rApo - rPeri) / (rApo + rPeri)
+	p := rPeri * (1 + e) // semi-latus rectum
+	vScale := math.Sqrt(mu / p)
+	r = qHat.Scale(p)
+	v = pHat.Scale(-vScale).Add(qHat.Scale(vScale * e))
+	return r, v
+}
+
+// targetMarkerWorld builds a two-craft world (active idx0, target idx1)
+// on distinct eccentric orbits around the same primary, each large
+// enough to clear the minOrbitPixels zoom-skip. The two orbits differ in
+// BOTH size and orientation (not just a 90° rotation of the same shape)
+// so their Ap/Pe points and the ✕ closest-approach point don't land in
+// the same rendered cell by geometric coincidence — mirrors
+// TestApsisMarkersRenderAsUnifiedGlyphs' single-craft eccentric-orbit
+// construction (orbit_markers_test.go), doubled for a craft target.
+func targetMarkerWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	active.Landed = false
+	mu := active.Primary.GravitationalParameter()
+	primaryR := active.Primary.RadiusMeters()
+
+	// Active: line of apsides along ±X.
+	active.State.R, active.State.V = eccentricStateAtNu90(
+		mu, primaryR+400e3, primaryR+4000e3,
+		orbital.Vec3{X: 1}, orbital.Vec3{Y: 1},
+	)
+
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	target := w.Crafts[1]
+	target.Landed = false
+	target.Primary = active.Primary
+	// Target: a differently-sized eccentric orbit, line of apsides along
+	// ±Y (rotated 90° from the active craft's — qHat = orbitNormal(+Z) ×
+	// pHat(0,1,0) = (-1,0,0)).
+	target.State.R, target.State.V = eccentricStateAtNu90(
+		mu, primaryR+900e3, primaryR+7000e3,
+		orbital.Vec3{Y: 1}, orbital.Vec3{X: -1},
+	)
+
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestTargetApsisMarkersDimmerThanOwnApsis is the deliverable's brightness
+// requirement (#346 §1.2): the targeted craft's Ap/Pe render dimmed
+// (MarkerCounterfactual) while the active craft's own Ap/Pe stay bright
+// (MarkerNominal) — both present, distinctly colored, via the same
+// ADR 0020 state-encodes-brightness convention the SOI Pass
+// counterfactual arc already uses (not a new styling invention).
+func TestTargetApsisMarkersDimmerThanOwnApsis(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w := targetMarkerWorld(t)
+
+	v.Render(w, 0, 200, 60)
+
+	ownApo := render.MarkerColor(render.MarkerApoapsis, render.MarkerNominal, "")
+	ownPeri := render.MarkerColor(render.MarkerPeriapsis, render.MarkerNominal, "")
+	targetApo := render.MarkerColor(render.MarkerApoapsis, render.MarkerCounterfactual, "")
+	targetPeri := render.MarkerColor(render.MarkerPeriapsis, render.MarkerCounterfactual, "")
+
+	if ownApo == targetApo || ownPeri == targetPeri {
+		t.Fatalf("nominal and counterfactual marker colors must differ: apo %v vs %v, peri %v vs %v",
+			ownApo, targetApo, ownPeri, targetPeri)
+	}
+	if got := v.canvas.CountOverlayColor(ownApo); got == 0 {
+		t.Error("own craft's apoapsis did not render in the bright/nominal color")
+	}
+	if got := v.canvas.CountOverlayColor(ownPeri); got == 0 {
+		t.Error("own craft's periapsis did not render in the bright/nominal color")
+	}
+	if got := v.canvas.CountOverlayColor(targetApo); got == 0 {
+		t.Error("target's apoapsis did not render in the dimmed/counterfactual color")
+	}
+	if got := v.canvas.CountOverlayColor(targetPeri); got == 0 {
+		t.Error("target's periapsis did not render in the dimmed/counterfactual color")
+	}
+}
+
+// closestApproachTestWorld builds a two-craft world (active idx0, target
+// idx1) on different-altitude circular LEO orbits sharing the active
+// craft's primary — the default spawn geometry the sim package's own
+// rendezvousTwoCraftWorld fixture uses for closest-approach tests. Unlike
+// targetMarkerWorld's eccentric pair (tuned for well-separated Ap/Pe
+// cells), this fixture's two craft pass close enough over the 4h horizon
+// that the ✕ marker's two ends land several canvas cells apart at typical
+// zoom — verified to hold at both 200×60 and 80×24 canvases.
+func closestApproachTestWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestClosestApproachMarkerRendersOnBothOrbits is deliverable #346 §1.1:
+// the ✕ glyph must appear at least twice — once on the active craft's
+// own orbit, once as its twin on the target's — when a craft target
+// shares the active craft's primary.
+func TestClosestApproachMarkerRendersOnBothOrbits(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w := closestApproachTestWorld(t)
+
+	out := v.Render(w, 0, 200, 60)
+	glyph := render.MarkerGlyph(render.MarkerClosestApproach)
+	if got := strings.Count(out, string(glyph)); got < 2 {
+		t.Errorf("expected the ✕ marker at both ends of the encounter (>=2 occurrences), got %d in:\n%s", got, out)
+	}
+}
+
+// TestClosestApproachMarkerAbsentWithoutTarget: no bound target means no
+// defined encounter, so the ✕ marker must not appear at all — it's not a
+// property of the active craft's own orbit alone.
+func TestClosestApproachMarkerAbsentWithoutTarget(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	out := v.Render(w, 0, 200, 60)
+	glyph := render.MarkerGlyph(render.MarkerClosestApproach)
+	if strings.ContainsRune(out, glyph) {
+		t.Errorf("✕ marker rendered with no target bound:\n%s", out)
+	}
+}
+
+// TestClosestApproachMarkerAbsentCrossPrimary: a target on a different
+// primary has no well-defined encounter in the active craft's frame
+// (cross-SOI rendezvous is out of scope — CONTEXT.md's Rendezvous
+// entry), so the ✕ marker must not appear.
+func TestClosestApproachMarkerAbsentCrossPrimary(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w := closestApproachTestWorld(t)
+	sys := w.System()
+	// Re-primary the target craft to any body that isn't the active
+	// craft's primary.
+	activePrimaryID := w.ActiveCraft().Primary.ID
+	for _, b := range sys.Bodies {
+		if b.ID != activePrimaryID {
+			w.Crafts[1].Primary = b
+			break
+		}
+	}
+
+	out := v.Render(w, 0, 200, 60)
+	glyph := render.MarkerGlyph(render.MarkerClosestApproach)
+	if strings.ContainsRune(out, glyph) {
+		t.Errorf("✕ marker rendered for a cross-primary target:\n%s", out)
+	}
+}
+
+// tiltedPlaneWorld builds a two-craft world where the target orbits
+// circularly in the primary's XY-plane and the active craft orbits the
+// same circle tilted 30° about the +X axis — the line of nodes with the
+// target's plane is exactly the X-axis (see the sim package's
+// TestTargetPlaneNodePositions_TiltedAboutXAxis for the full derivation
+// this mirrors at the screen level).
+func tiltedPlaneWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	active.Landed = false
+	mu := active.Primary.GravitationalParameter()
+	const r = 6.771e6
+	baseV := math.Sqrt(mu / r)
+
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: r - active.Primary.RadiusMeters()}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	target := w.Crafts[1]
+	target.Landed = false
+	target.Primary = active.Primary
+	target.State.R = orbital.Vec3{X: r}
+	target.State.V = orbital.Vec3{Y: baseV}
+
+	preR := orbital.Vec3{Y: r}
+	preV := orbital.Vec3{X: -baseV}
+	theta := 30 * math.Pi / 180
+	axis := orbital.Vec3{X: 1}
+	rotate := func(v orbital.Vec3) orbital.Vec3 {
+		cos, sin := math.Cos(theta), math.Sin(theta)
+		return v.Scale(cos).Add(axis.Cross(v).Scale(sin)).Add(axis.Scale(axis.Dot(v) * (1 - cos)))
+	}
+	active.State.R = rotate(preR)
+	active.State.V = rotate(preV)
+
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestTargetPlaneNodesRenderDiamonds is deliverable #346 §1.3: the ◇/◆
+// Ascending/Descending Node markers against the TARGET's plane must
+// appear on the map when the two orbits are inclined relative to each
+// other.
+//
+// Asserted via CountOverlayColor rather than a raw glyph search: '◇' is
+// also used as a plain-text bullet for unrelated session-event chip rows
+// (orbit_chip_builders.go — "joined" / "left" / "docked with" etc.), so a
+// bare strings.ContainsRune check can pass for the wrong reason. The
+// marker's pinned color (render.ColorMarkerAscendingNode /
+// ColorMarkerDescendingNode via SetCellOverlayColored) is unique to the
+// canvas glyph.
+func TestTargetPlaneNodesRenderDiamonds(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w := tiltedPlaneWorld(t)
+
+	v.Render(w, 0, 200, 60)
+	anColor := render.MarkerColor(render.MarkerAscendingNode, render.MarkerNominal, "")
+	dnColor := render.MarkerColor(render.MarkerDescendingNode, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(anColor); got == 0 {
+		t.Error("ascending-node marker did not render")
+	}
+	if got := v.canvas.CountOverlayColor(dnColor); got == 0 {
+		t.Error("descending-node marker did not render")
+	}
+}
+
+// TestTargetPlaneNodesAbsentWhenCoplanar: two craft on the SAME orbital
+// plane have no defined line of nodes, so neither ◇ nor ◆ should render.
+func TestTargetPlaneNodesAbsentWhenCoplanar(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(200, 60)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	target := w.Crafts[1]
+	// Same orbital plane as the active craft (its own h axis), phase-
+	// shifted 90° — coplanar, not identical, so it's still a distinct
+	// craft target.
+	h := active.State.R.Cross(active.State.V).Unit()
+	angle := math.Pi / 2
+	cos, sin := math.Cos(angle), math.Sin(angle)
+	rotate := func(v orbital.Vec3) orbital.Vec3 {
+		return v.Scale(cos).Add(h.Cross(v).Scale(sin)).Add(h.Scale(h.Dot(v) * (1 - cos)))
+	}
+	target.State.R = rotate(active.State.R)
+	target.State.V = rotate(active.State.V)
+	target.Primary = active.Primary
+
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+
+	v.Render(w, 0, 200, 60)
+	anColor := render.MarkerColor(render.MarkerAscendingNode, render.MarkerNominal, "")
+	dnColor := render.MarkerColor(render.MarkerDescendingNode, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(anColor); got != 0 {
+		t.Errorf("ascending-node marker rendered for a coplanar target (no defined line of nodes), count=%d", got)
+	}
+	if got := v.canvas.CountOverlayColor(dnColor); got != 0 {
+		t.Errorf("descending-node marker rendered for a coplanar target (no defined line of nodes), count=%d", got)
+	}
+}
+
+// TestClosestApproachMarkerRendersAtNarrowCanvas and
+// TestApsisMarkersRenderDimmedAtNarrowCanvas exercise the new marker
+// kinds (✕, target Ap/Pe) at 80×24 — the terminal-minimum size a past
+// lesson (project_v030/rendezvous fix cluster) flagged for narrow-glyph
+// rendering — rather than only the roomy 200×60 canvas the other tests in
+// this file use, so a cramped canvas / stride skip doesn't silently drop
+// a marker kind at the sizes players actually run in.
+func TestClosestApproachMarkerRendersAtNarrowCanvas(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w := closestApproachTestWorld(t)
+
+	out := v.Render(w, 0, 80, 24)
+	caGlyph := render.MarkerGlyph(render.MarkerClosestApproach)
+	if strings.Count(out, string(caGlyph)) < 2 {
+		t.Errorf("expected both ✕ marker ends at 80x24, got render:\n%s", out)
+	}
+}
+
+func TestApsisMarkersRenderDimmedAtNarrowCanvas(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w := targetMarkerWorld(t)
+
+	v.Render(w, 0, 80, 24)
+	targetApo := render.MarkerColor(render.MarkerApoapsis, render.MarkerCounterfactual, "")
+	if got := v.canvas.CountOverlayColor(targetApo); got == 0 {
+		t.Error("target apoapsis did not render dimmed at 80x24")
+	}
+}
+
+// TestTargetPlaneNodesRenderAtNarrowCanvas mirrors the above for the
+// ◇/◆ node markers, which need a different (tilted-plane) world fixture.
+func TestTargetPlaneNodesRenderAtNarrowCanvas(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w := tiltedPlaneWorld(t)
+
+	v.Render(w, 0, 80, 24)
+	anColor := render.MarkerColor(render.MarkerAscendingNode, render.MarkerNominal, "")
+	dnColor := render.MarkerColor(render.MarkerDescendingNode, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(anColor); got == 0 {
+		t.Error("ascending-node marker missing at 80x24")
+	}
+	if got := v.canvas.CountOverlayColor(dnColor); got == 0 {
+		t.Error("descending-node marker missing at 80x24")
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -1340,6 +1340,25 @@ func (c *Canvas) CountColor(color lipgloss.Color) int {
 	return n
 }
 
+// CountOverlayColor reports how many cells carry the given pinned overlay
+// color (SetCellOverlayColored / SetCellLabelColored) — the sibling of
+// CountColor for the overlay-glyph channel, which paints independently of
+// the pixelTag majority (see SetCellOverlayColored's doc comment). An
+// untagged marker glyph (drawMarker called with an empty CellTag — the
+// apsis / node / closest-approach markers) never touches pixelTags, so
+// CountColor can't see it; this is the assertion callers need instead to
+// distinguish e.g. a dimmed MarkerCounterfactual glyph from its bright
+// MarkerNominal counterpart.
+func (c *Canvas) CountOverlayColor(color lipgloss.Color) int {
+	n := 0
+	for _, oc := range c.cellOverlayColors {
+		if oc == color {
+			n++
+		}
+	}
+	return n
+}
+
 // joinRows is the uncolored fast path used when no color regions are
 // registered.
 func (c *Canvas) joinRows(rows []string) string {

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -224,6 +224,35 @@ func TestSetCellOverlayColoredWinsOverBodyColor(t *testing.T) {
 	}
 }
 
+// TestCountOverlayColor verifies the overlay-color counting sibling of
+// CountColor (#346): SetCellOverlayColored pins a glyph's color on the
+// separate cellOverlayColors channel, which CountColor's pixelTag-majority
+// scan never sees (an untagged marker — an empty CellTag — never writes to
+// pixelTags at all), so a distinct counting path is needed to assert
+// glyph-level color distinctions in tests.
+func TestCountOverlayColor(t *testing.T) {
+	c := NewCanvas(20, 10)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	bright := lipgloss.Color("#5FD75F")
+	dim := lipgloss.Color("#2F6B2F")
+	c.SetCellOverlayColored(orbital.Vec3{X: 0, Y: 0}, '▲', bright)
+	c.SetCellOverlayColored(orbital.Vec3{X: 4, Y: 0}, '▼', dim)
+	c.SetCellOverlayColored(orbital.Vec3{X: -4, Y: 0}, '▼', dim)
+
+	if got := c.CountOverlayColor(bright); got != 1 {
+		t.Errorf("CountOverlayColor(bright) = %d, want 1", got)
+	}
+	if got := c.CountOverlayColor(dim); got != 2 {
+		t.Errorf("CountOverlayColor(dim) = %d, want 2", got)
+	}
+	if got := c.CountOverlayColor(lipgloss.Color("#000000")); got != 0 {
+		t.Errorf("CountOverlayColor(unused color) = %d, want 0", got)
+	}
+}
+
 // TestRingOutlineHugeRadiusDoesNotHang: v0.5.15 regression — pre-fix
 // a ring with pxRadius in the millions (Saturn rings projected at
 // extreme zoom) looped pxRadius*8 ≈ billions of times, locking the


### PR DESCRIPTION
Part of #346 (section 1 — marker batch)

## Summary

The map's marker vocabulary (ADR 0020) was incompletely delivered: the `✕` closest-approach glyph was defined but never drawn, `◇`/`◆` AN/DN existed only via the navball's node-crossing math, and Ap/Pe markers existed only for the own craft. This lands section 1:

- **✕ Closest Approach** — drawn on both the active craft's own orbit and its twin on the target's orbit, at the exact positions `planner.NextClosestApproachPositions` reports (a new function sharing the identical re-propagation `NextClosestApproach`'s scalar `Dist` already uses, so the marker and the TARGET chip's CA number never disagree).
- **Target Ap/Pe** — the targeted craft/ghost's own apoapsis/periapsis now render, dimmed via the existing `MarkerCounterfactual` state (same brightness convention the SOI Pass counterfactual arc already uses — no new styling invented).
- **◇/◆ AN/DN vs target plane** — a new `sim.TargetPlaneNodePositions` locates where the active craft's orbit crosses its bound target's orbital plane, reusing `orbital.FrameFromNormal` + `orbital.TimeToNodeCrossing` (the same trick `PlanPlaneMatch` already uses against a body's plane) rather than re-deriving node-crossing math.
- Overlap resolves by existing deterministic draw order (no leader lines, no label arbitration, per scope).

All three are gated on `World.TargetSharesActivePrimary` (new helper) — cross-SOI rendezvous stays out of scope, consistent with the existing `NextClosestApproach` and `TargetLeadAngleDeg` restrictions.

## Out of scope (deferred to later #346 phases)

Line-style vocabulary (solid/dashed/dotted), Inspect/hit-testing, any camera/zoom/pan work, Proximity View, keybinding changes, save-schema changes.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- New unit tests: `internal/planner/rendezvous_test.go` (`NextClosestApproachPositions` agreement/degenerate/error cases), `internal/sim/target_plane_nodes_test.go` (tilted/coplanar/cross-primary/body-target/ghost-target), `internal/tui/screens/orbit_target_markers_test.go` (renders + brightness + narrow 80×24 canvas), `internal/tui/widgets/canvas_test.go` (`CountOverlayColor`).