### PR TITLE
feat(#347): per-focus zoom memory

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -40,6 +40,12 @@ type OrbitView struct {
 	// move the camera. Per-frame center *tracking* of the focused object
 	// continues below — that is what Focus means — but the fit is written
 	// exactly once per event, then owned by the player.
+	//
+	// Render also diffs these against the incoming World state to tell a
+	// real Framing Event (one of these fields actually changed) apart from
+	// a bare resize (none of them changed, only !fitted is true) — Zoom
+	// Memory (ADR 0042) only restores/resets userZoom on the former; a
+	// resize refits baseScale but always keeps the multiplier.
 	lastSystemIdx int
 	lastFocus     sim.Focus
 	lastViewMode  sim.ViewMode
@@ -60,10 +66,25 @@ type OrbitView struct {
 	// `+`/`-` multiplier on top of it: the on-screen scale is
 	// baseScale × userZoom, re-applied every frame (v0.18.2 mechanism).
 	// baseScale only changes at a Framing Event, so on a steady focus
-	// manual zoom persists indefinitely; userZoom resets to 1.0 at the
-	// next Framing Event (fresh framing context, fresh zoom).
+	// manual zoom persists indefinitely. Per Zoom Memory (ADR 0042,
+	// amending ADR 0021's original "userZoom resets to 1.0 at every
+	// Framing Event" rule): a real Framing Event restores the multiplier
+	// this focus target last used (or 1.0 on a first visit), and a bare
+	// resize never touches userZoom at all — see zoomMemory below and the
+	// contextChanged guard in Render.
 	baseScale float64
 	userZoom  float64
+
+	// zoomMemory persists the manual zoom multiplier the player last set
+	// at each focus target visited this session (ADR 0042). Keyed by
+	// zoomMemoryKey — sim.Focus is already the comparable identity the
+	// Framing-Event guard above uses (lastFocus), extended with SystemIdx
+	// because Focus.BodyIdx is only unique within one system's Bodies
+	// slice (index 3 in Sol and index 3 in Lumen are different bodies).
+	// Session-only: never persisted to the save file, never bumps the
+	// save schema. Written by setUserZoom, read at each real Framing
+	// Event (not a bare resize) in Render.
+	zoomMemory map[zoomMemoryKey]float64
 
 	// burnFrozenCenter pins the canvas center for the duration of an
 	// active burn. Captured when ActiveBurn becomes non-nil, cleared
@@ -301,11 +322,36 @@ func (v *OrbitView) Resize(totalCols, totalRows int) {
 // ZoomIn / ZoomOut are thin wrappers for App to call on +/-. They nudge the
 // manual-zoom multiplier (applied over the Framing-Event base scale in
 // Render): scale = baseScale × userZoom, so the player's zoom persists
-// indefinitely on a steady focus and resets only at the next Framing Event
-// (ADR 0021 A). Clamped to a wide but finite range so a held key can't drive
-// the scale to a degenerate value.
+// indefinitely on a steady focus and, per Zoom Memory (ADR 0042), is
+// restored rather than reset the next time the player returns to this
+// focus target. Clamped to a wide but finite range so a held key can't
+// drive the scale to a degenerate value.
 func (v *OrbitView) ZoomIn()  { v.setUserZoom(v.userZoom * 1.25) }
 func (v *OrbitView) ZoomOut() { v.setUserZoom(v.userZoom / 1.25) }
+
+// zoomMemoryKey identifies a focus target for Zoom Memory (ADR 0042).
+// sim.Focus is already the comparable identity Render's Framing-Event
+// guard uses (lastFocus) — bodies by index, the active craft by kind
+// alone (there is no per-craft field on Focus, so a dock/undock that
+// swaps which craft is active shares the one FocusCraft slot, same as
+// the Framing-Event guard already treats it), ghosts by owner+craft ID.
+// SystemIdx is added because Focus.BodyIdx is only unique within one
+// system's Bodies slice — body index 3 in Sol and body index 3 in Lumen
+// are different bodies and must not share a remembered zoom.
+type zoomMemoryKey struct {
+	systemIdx int
+	focus     sim.Focus
+}
+
+// zoomMemoryFor returns the multiplier the player last set at the given
+// focus target, or 1 (fresh fit) when the target has no recorded visit
+// this session — ADR 0042 "first visit fits fresh."
+func (v *OrbitView) zoomMemoryFor(systemIdx int, focus sim.Focus) float64 {
+	if z, ok := v.zoomMemory[zoomMemoryKey{systemIdx, focus}]; ok {
+		return z
+	}
+	return 1
+}
 
 func (v *OrbitView) setUserZoom(z float64) {
 	const minZoom, maxZoom = 1e-4, 1e4
@@ -316,6 +362,15 @@ func (v *OrbitView) setUserZoom(z float64) {
 		z = maxZoom
 	}
 	v.userZoom = z
+	// Zoom Memory (ADR 0042): record against the focus target Render most
+	// recently fit to, so returning to it later restores this value
+	// instead of the ADR 0021-era reset to 1×. lastSystemIdx/lastFocus are
+	// only written by Render's Framing-Event block, so this always keys
+	// against the currently-displayed target.
+	if v.zoomMemory == nil {
+		v.zoomMemory = make(map[zoomMemoryKey]float64)
+	}
+	v.zoomMemory[zoomMemoryKey{v.lastSystemIdx, v.lastFocus}] = z
 }
 
 // HitAt translates a screen-space mouse coordinate (col, row) into a
@@ -411,9 +466,16 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// target (body or craft) we still re-center every frame below; this
 	// path only fires when the framing *context* changes, not when the
 	// target moves.
+	//
+	// contextChanged distinguishes a real Framing Event from a bare
+	// resize: a resize leaves SystemIdx/Focus/ViewMode/craftHere all
+	// unchanged and only clears v.fitted. Zoom Memory (ADR 0042) restores
+	// or resets userZoom solely on contextChanged — a resize refits
+	// baseScale below but always keeps the player's current multiplier.
 	craftHere := w.CraftVisibleHere()
-	if v.lastSystemIdx != w.SystemIdx || v.lastFocus != w.Focus ||
-		v.lastViewMode != w.ViewMode || v.lastCraftHere != craftHere || !v.fitted {
+	contextChanged := v.lastSystemIdx != w.SystemIdx || v.lastFocus != w.Focus ||
+		v.lastViewMode != w.ViewMode || v.lastCraftHere != craftHere
+	if contextChanged || !v.fitted {
 		v.lastSystemIdx = w.SystemIdx
 		v.lastFocus = w.Focus
 		v.lastViewMode = w.ViewMode
@@ -435,7 +497,15 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			}
 		}
 		v.baseScale = v.canvas.Scale()
-		v.userZoom = 1 // fresh framing context — drop any manual zoom
+		if contextChanged {
+			// Zoom Memory (ADR 0042): a real Framing Event restores the
+			// multiplier this focus target last used, or starts fresh at
+			// 1× on a first visit — amending ADR 0021's unconditional
+			// reset. A bare resize (contextChanged false) falls through
+			// this branch and leaves userZoom exactly as the player left
+			// it.
+			v.userZoom = v.zoomMemoryFor(w.SystemIdx, w.Focus)
+		}
 		// A Framing Event mid-burn re-frames once, then re-freezes: drop
 		// the frozen-center snapshot so the burn guard below re-captures
 		// it at the new focus center (ADR 0021 watch-point).

--- a/internal/tui/screens/orbit_camera_contract_test.go
+++ b/internal/tui/screens/orbit_camera_contract_test.go
@@ -94,10 +94,14 @@ func TestManualZoomPersistsOnSteadyFocus(t *testing.T) {
 	}
 }
 
-// TestFramingEventResetsZoom: userZoom resets at the next Framing Event — a
-// Focus change and a ViewMode change each re-fit once and drop the manual
-// multiplier (ADR 0021 A: fresh framing context, fresh zoom).
-func TestFramingEventResetsZoom(t *testing.T) {
+// TestFramingEventZoomMemory pins the ADR 0042 amendment to the Camera
+// Contract: a Framing Event still fits the canvas exactly once (ADR 0021
+// A unchanged), but userZoom is no longer unconditionally dropped to 1 —
+// it is restored per focus target. A Focus change to a target with no
+// recorded visit fits fresh at 1x; a later Framing Event that returns to
+// an already-zoomed target (here, a ViewMode change with the focus held
+// steady) restores that target's multiplier instead of resetting it.
+func TestFramingEventZoomMemory(t *testing.T) {
 	v := newSOIPassTestView()
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -114,20 +118,27 @@ func TestFramingEventResetsZoom(t *testing.T) {
 		t.Fatal("precondition: userZoom should be off 1 after ZoomIn")
 	}
 
-	// Focus change → Framing Event → zoom reset.
+	// Focus change to a never-visited target → Framing Event → fresh 1x.
 	w.Focus = sim.Focus{Kind: sim.FocusCraft}
 	v.Render(w, 0, 200, 60)
 	if v.userZoom != 1 {
-		t.Errorf("focus change did not reset userZoom: %v", v.userZoom)
+		t.Errorf("focus change to an unvisited target did not fit fresh: userZoom = %v, want 1", v.userZoom)
 	}
 
-	// ViewMode change → Framing Event → zoom reset.
+	// Zoom on this (now-visited) FocusCraft target, then trigger a second
+	// Framing Event — a ViewMode change — with the focus held steady.
+	// Zoom Memory keys on focus, not on (focus, ViewMode), so this must
+	// restore the multiplier just set rather than reset it to 1.
 	v.ZoomIn()
 	v.Render(w, 0, 200, 60)
+	zoomed := v.userZoom
+	if zoomed == 1 {
+		t.Fatal("precondition: userZoom should be off 1 after the second ZoomIn")
+	}
 	w.CycleViewMode()
 	v.Render(w, 0, 200, 60)
-	if v.userZoom != 1 {
-		t.Errorf("view-mode change did not reset userZoom: %v", v.userZoom)
+	if v.userZoom != zoomed {
+		t.Errorf("view-mode change on a steady, already-zoomed focus did not restore the multiplier: got %v, want %v", v.userZoom, zoomed)
 	}
 }
 

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -721,3 +721,147 @@ func TestRCSPuffsRenderWhite(t *testing.T) {
 			string(render.ColorRCSPuffTip), string(render.ColorDim))
 	}
 }
+
+// TestZoomMemoryFirstVisitFitsFresh: ADR 0042 — the first Render at a
+// focus target that has no recorded zoom starts at 1× (the pre-0042
+// behavior), not some stale carry-over from another target.
+func TestZoomMemoryFirstVisitFitsFresh(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w, _ := sim.NewWorld()
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: 1}
+
+	v.Render(w, 0, 80, 24)
+
+	if v.userZoom != 1 {
+		t.Errorf("first visit userZoom = %v, want 1 (fresh fit)", v.userZoom)
+	}
+}
+
+// TestZoomMemoryReturnRestoresMultiplier: ADR 0042's headline behavior —
+// zoom in on a focus, look away at a different focus (which resets to a
+// fresh 1x, per first-visit), then come back: the original focus's
+// multiplier is restored rather than reset again.
+func TestZoomMemoryReturnRestoresMultiplier(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w, _ := sim.NewWorld()
+	bodyA := sim.Focus{Kind: sim.FocusBody, BodyIdx: 1}
+	bodyB := sim.Focus{Kind: sim.FocusBody, BodyIdx: 2}
+
+	w.Focus = bodyA
+	v.Render(w, 0, 80, 24)
+	v.ZoomIn()
+	v.ZoomIn()
+	want := v.userZoom
+	if want == 1 {
+		t.Fatalf("setup: ZoomIn twice left userZoom at 1, test can't distinguish restore from reset")
+	}
+
+	w.Focus = bodyB
+	v.Render(w, 0, 80, 24)
+	if v.userZoom != 1 {
+		t.Fatalf("switching to a never-visited focus: userZoom = %v, want 1 (fresh fit)", v.userZoom)
+	}
+
+	w.Focus = bodyA
+	v.Render(w, 0, 80, 24)
+	if v.userZoom != want {
+		t.Errorf("returning to bodyA: userZoom = %v, want restored %v", v.userZoom, want)
+	}
+}
+
+// TestZoomMemoryResizeKeepsMultiplier: ADR 0042 rule 2 — a terminal
+// resize refits baseScale to the new canvas dimensions but must never
+// reset the player's zoom multiplier, unlike every other Framing Event.
+// Uses FocusSystem rather than a small terminal body: a body focus can
+// hit the ADR 0024 body-texture minScale clamp, which is a pure function
+// of the body's radius and would make baseScale identical across canvas
+// sizes for a reason unrelated to what this test checks.
+func TestZoomMemoryResizeKeepsMultiplier(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w, _ := sim.NewWorld()
+	w.Focus = sim.Focus{Kind: sim.FocusSystem}
+
+	v.Render(w, 0, 80, 24)
+	v.ZoomIn()
+	want := v.userZoom
+	baseBefore := v.baseScale
+
+	v.Resize(160, 48) // same focus context, different canvas
+	v.Render(w, 0, 160, 48)
+
+	if v.userZoom != want {
+		t.Errorf("resize changed userZoom: got %v, want kept %v", v.userZoom, want)
+	}
+	if v.baseScale == baseBefore {
+		t.Errorf("resize did not refit baseScale to the new canvas dimensions")
+	}
+}
+
+// TestZoomMemoryKeyedPerFocus: the multiplier map holds one entry per
+// focus target, not a single scalar — zooming differently on two bodies
+// and bouncing between them must not clobber either entry.
+func TestZoomMemoryKeyedPerFocus(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w, _ := sim.NewWorld()
+	bodyA := sim.Focus{Kind: sim.FocusBody, BodyIdx: 1}
+	bodyB := sim.Focus{Kind: sim.FocusBody, BodyIdx: 2}
+
+	w.Focus = bodyA
+	v.Render(w, 0, 80, 24)
+	v.ZoomIn()
+	zoomA := v.userZoom
+
+	w.Focus = bodyB
+	v.Render(w, 0, 80, 24)
+	v.ZoomOut()
+	zoomB := v.userZoom
+
+	if zoomA == zoomB {
+		t.Fatalf("setup: zoomA (%v) and zoomB (%v) must differ to prove per-key storage", zoomA, zoomB)
+	}
+
+	w.Focus = bodyA
+	v.Render(w, 0, 80, 24)
+	if v.userZoom != zoomA {
+		t.Errorf("bodyA restore after visiting bodyB: got %v, want %v", v.userZoom, zoomA)
+	}
+
+	w.Focus = bodyB
+	v.Render(w, 0, 80, 24)
+	if v.userZoom != zoomB {
+		t.Errorf("bodyB restore after revisiting bodyA: got %v, want %v", v.userZoom, zoomB)
+	}
+}
+
+// TestZoomMemoryDisambiguatesAcrossSystems: sim.Focus.BodyIdx is only
+// unique within one system's Bodies slice, so the same BodyIdx in two
+// different systems (Sol vs. a second system reached via CycleSystem)
+// must not share a remembered zoom — the zoomMemoryKey includes
+// SystemIdx precisely to guard this.
+func TestZoomMemoryDisambiguatesAcrossSystems(t *testing.T) {
+	v := NewOrbitView(Theme{HUDBox: lipgloss.NewStyle()})
+	v.Resize(80, 24)
+	w, _ := sim.NewWorld()
+	if len(w.Systems) < 2 {
+		t.Skip("need at least two systems to test cross-system disambiguation")
+	}
+	body := sim.Focus{Kind: sim.FocusBody, BodyIdx: 1}
+
+	w.Focus = body
+	v.Render(w, 0, 80, 24)
+	v.ZoomIn()
+	zoomSolBody1 := v.userZoom
+
+	w.CycleSystem()
+	v.Render(w, 0, 80, 24) // System switch is a Framing Event: same Focus value, new system
+	if v.userZoom != 1 {
+		t.Errorf("body index 1 in the new system: userZoom = %v, want 1 (fresh fit, not Sol's leftover zoom)", v.userZoom)
+	}
+	if v.userZoom == zoomSolBody1 {
+		t.Errorf("new system's fresh fit accidentally matched Sol's remembered zoom (%v); systems are not disambiguated", zoomSolBody1)
+	}
+}


### PR DESCRIPTION
Part of #347 (zoom memory — amends ADR 0021 reset rule).

## What

Each focus target now remembers the manual zoom multiplier the player last
used on it (ADR 0042). Previously `userZoom` was unconditionally reset to
1x at every Framing Event (focus change, ViewMode change, System switch,
or a resize).

- First visit to a focus: fresh fit at 1x (unchanged).
- Returning to a previously visited focus: restores that focus's last
  multiplier instead of resetting to 1x.
- Resize: refits `baseScale` to the new canvas dimensions but never
  touches `userZoom` — a resize must never reset zoom.
- Other Framing Events (focus change, ViewMode change, System switch)
  still fit the canvas exactly once per the ADR 0021 Camera Contract;
  what changes is that the multiplier is restored/initialized from
  memory instead of hard-reset.

## Focus identity key

Keyed by `(SystemIdx, sim.Focus)`. `sim.Focus` is already the comparable
identity `Render`'s Framing-Event guard uses (`lastFocus`) — bodies by
index, the active craft by kind alone, ghosts by owner+craft ID.
`SystemIdx` is added because `Focus.BodyIdx` is only unique within one
system's `Bodies` slice (body index 3 in Sol and body index 3 in Lumen
are different bodies and must not share a remembered zoom).

Note: `Focus.Kind == FocusCraft` has no per-craft field, so a dock/undock
that swaps which craft is active shares the one `FocusCraft` memory slot
— this mirrors how the existing Framing-Event guard already treats craft
identity (it tracks craft *visibility*, not a craft pointer/ID). No
existing identity scheme carries a stronger per-craft key, so extending
one felt like scope creep for this slice.

## Scope

In-session only — no save-schema change. Diff is scoped to the fit path
and zoom state in `internal/tui/screens/orbit.go`; no changes to plot
primitives, input.go/keybindings, line styles, markers, Proximity View,
or zoom floors.

An existing test (`TestFramingEventResetsZoom`) pinned the old ADR 0021
"always reset" behavior; renamed to `TestFramingEventZoomMemory` and
updated to pin the amended contract (a ViewMode change on an
already-zoomed, steady focus now restores rather than resets).

## Tests added

- `TestZoomMemoryFirstVisitFitsFresh`
- `TestZoomMemoryReturnRestoresMultiplier`
- `TestZoomMemoryResizeKeepsMultiplier`
- `TestZoomMemoryKeyedPerFocus`
- `TestZoomMemoryDisambiguatesAcrossSystems`

`go vet ./...` and `go test ./... -race -count=1` green.