### PR TITLE
feat(#347): adaptive arc-length sampling + clipped chord bridging

### DIFF
--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -613,8 +613,7 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	}
 	canvasReach := v.canvas.Cols()*2 + v.canvas.Rows()*4
 	primaryPxR := BodyPixelRadius(craft.Primary, false, scale, canvasReach)
-	samples := launchOrbitSamples(el.Apoapsis() * scale)
-	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, samples, 3, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
+	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, 360, 2, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
 	peri := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, 0))
 	apo := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 	// Unified single-glyph apsis markers (ADR 0020) — same ▼/▲ as the
@@ -627,35 +626,14 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	}
 }
 
-// launchOrbitSamples returns how many true-anomaly samples to walk when
-// drawing the current-orbit ellipse in the chase-cam scene. The orbit
-// map screens use a fixed 360 because the whole ellipse is on-canvas;
-// the launch / landing view centres on the craft and magnifies only a
-// few degrees of the orbit, so 360 samples scatter at most a handful of
-// dots onto the visible arc (an empirical 5 cells for a 200 km LEO) —
-// the orbit reads as just the apoapsis marker, not a line. Scale the
-// count to the projected orbit circumference (≈ 2π·apoapsisPx) at a
-// sub-pixel target spacing so the visible arc fills in, clamped to
-// [360, maxLaunchOrbitSamples] so a tiny orbit still gets the map's
-// density and a huge (off-canvas-apoapsis) transfer ellipse can't blow
-// up the per-frame sample loop. apoapsisPx is the apoapsis radius in
-// canvas pixels (el.Apoapsis() · canvas.Scale()).
-func launchOrbitSamples(apoapsisPx float64) int {
-	const (
-		arcSpacingPx          = 0.6 // sub-pixel: fully populate the visible arc
-		maxLaunchOrbitSamples = 8000
-	)
-	samples := 360
-	if apoapsisPx > 0 {
-		if n := int(2 * math.Pi * apoapsisPx / arcSpacingPx); n > samples {
-			samples = n
-		}
-	}
-	if samples > maxLaunchOrbitSamples {
-		samples = maxLaunchOrbitSamples
-	}
-	return samples
-}
+// (launchOrbitSamples retired by ADR 0042 §3.) The chase-cam used to size
+// its own ellipse sample count from the projected orbit circumference,
+// because the orbit map's fixed 360 samples scattered at most a handful of
+// dots onto the magnified visible arc. That was a second sampling policy
+// living beside the map's; the canvas now flattens every ellipse adaptively
+// and inks it at a constant on-screen dot spacing, so the magnified view
+// fills in from the shared path and drawOrbitPath just passes the map's own
+// arguments.
 
 // drawPadMarker plots the launch site as a `+` glyph in ColorAccent
 // when the pad is on the camera-facing hemisphere.

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -666,32 +666,11 @@ func TestLaunchViewLandedOrbitNotDrawn(t *testing.T) {
 	}
 }
 
-// launchOrbitSamples must scale the ellipse sample count up for the
-// magnified chase-cam view. The orbit map's fixed 360 leaves only ~5
-// dots on the visible arc of a low orbit (the orbit reads as just the
-// apoapsis marker); the count must grow with the projected orbit size
-// so the visible arc fills in, while clamping at both ends.
-func TestLaunchOrbitSamplesScalesWithProjectedSize(t *testing.T) {
-	// A tiny projected orbit keeps the map's baseline density.
-	if got := launchOrbitSamples(10); got != 360 {
-		t.Errorf("tiny orbit: got %d samples, want 360 baseline", got)
-	}
-	// A 200 km LEO at launch zoom projects apoapsis to ~790 px; the
-	// shipped 360 produced ~5 on-canvas cells. The count must be far
-	// higher so the arc reads as a line.
-	if got := launchOrbitSamples(790); got <= 360 {
-		t.Errorf("LEO apoapsis 790px: got %d samples, want >> 360", got)
-	}
-	// A huge (off-canvas-apoapsis) transfer ellipse must clamp so the
-	// per-frame sample loop can't blow up.
-	if got := launchOrbitSamples(5e5); got != 8000 {
-		t.Errorf("transfer apoapsis 500k px: got %d samples, want 8000 cap", got)
-	}
-	// Monotonic non-decreasing in projected size.
-	if launchOrbitSamples(2000) < launchOrbitSamples(790) {
-		t.Error("sample count should not decrease as projected orbit grows")
-	}
-}
+// (TestLaunchOrbitSamplesScalesWithProjectedSize retired with
+// launchOrbitSamples — ADR 0042 §3 folded the chase-cam's private sample
+// budget into the canvas's shared adaptive flattening. The behaviour it
+// guarded is now covered by TestLaunchViewOrbitRendersAsLine below plus
+// the widgets-level density tests in arc_test.go.)
 
 // End-to-end: the magnified chase-cam must paint a current-orbit ellipse
 // that reads as a dotted line, not just the apo/peri markers. Render a

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -517,7 +517,7 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 
 	// Current orbit. Empty colour → uses Plot for back-compat with
 	// the existing white-on-default rendering of this canvas.
-	m.canvas.DrawEllipseOffsetOccluded(currentEl, orbital.Vec3{}, 360, 4, orbital.Vec3{}, primaryPxR, "")
+	m.canvas.DrawEllipseOffsetOccluded(currentEl, orbital.Vec3{}, 360, 3, orbital.Vec3{}, primaryPxR, "")
 
 	// v0.9.3 polish: target craft's orbit + current position when it
 	// shares the active craft's primary. The maneuver canvas centers

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -481,7 +481,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			continue
 		}
 		el := orbital.ElementsFromBody(b)
-		v.canvas.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 6, orbital.Vec3{}, 0, render.ColorBodyOrbit)
+		v.canvas.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 5, orbital.Vec3{}, 0, render.ColorBodyOrbit)
 	}
 
 	// Plot each body at its perceived-size disk. System primary (index 0)
@@ -780,12 +780,12 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				gPrimaryPos := w.BodyPosition(gp)
 				gPxR := BodyPixelRadius(gp, false, scale, canvasReach)
 				orbitColor := lipgloss.Color(render.ColorDim)
-				stride := 5
+				spacingPx := 4
 				if isTarget {
 					orbitColor = render.ColorTarget
-					stride = 3
+					spacingPx = 3
 				}
-				v.canvas.DrawEllipseOffsetFarSideDashed(el, gPrimaryPos, 180, stride, gPrimaryPos, gPxR, orbitColor)
+				v.canvas.DrawEllipseOffsetFarSideDashed(el, gPrimaryPos, 180, spacingPx, gPrimaryPos, gPxR, orbitColor)
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted
 					// ghost's own apsides, dimmed via MarkerCounterfactual
@@ -836,7 +836,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// same check.
 		primaryPxR := BodyPixelRadius(c.Primary, false, scale, canvasReach)
 		if orbitVisible {
-			v.canvas.DrawEllipseOffsetFarSideDashed(el, primaryPos, 360, 3, primaryPos, primaryPxR, render.ColorCurrentOrbit)
+			v.canvas.DrawEllipseOffsetFarSideDashed(el, primaryPos, 360, 2, primaryPos, primaryPxR, render.ColorCurrentOrbit)
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 			// Unified single-glyph markers (ADR 0020): ▼ periapsis / ▲
@@ -938,14 +938,14 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				otherColor = render.ColorTarget
 			}
 			if otherOrbitVisible {
-				// Target gets denser sampling (every 3rd vs every 5th
-				// for plain non-active craft) so its track reads as
-				// brighter / more prominent than peers.
-				stride := 5
+				// Target gets denser sampling (a dot every 3 px vs
+				// every 4 for plain non-active craft) so its track
+				// reads as brighter / more prominent than peers.
+				spacingPx := 4
 				if isTarget {
-					stride = 3
+					spacingPx = 3
 				}
-				v.canvas.DrawEllipseOffsetFarSideDashed(otherEl, otherPrimaryPos, 180, stride, otherPrimaryPos, otherPxR, otherColor)
+				v.canvas.DrawEllipseOffsetFarSideDashed(otherEl, otherPrimaryPos, 180, spacingPx, otherPrimaryPos, otherPxR, otherColor)
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted
 					// craft's own apsides, dimmed via MarkerCounterfactual
@@ -1768,30 +1768,18 @@ func (v *OrbitView) plotPredictedLegs(w *sim.World, legs []predictLegDraw) {
 			continue
 		}
 		for _, seg := range leg.segs {
-			pts := w.SegmentDrawPoints(seg, homeID)
-			if seg.PrimaryID == homeID {
-				// Home transfer leg: plain stride-2 scattered dots, NOT a
-				// gap-filled line. It's drawn in the primary's inertial frame
-				// and aims at the encounter's FUTURE position, while the
-				// encounter arc is rebased to the body's current position
-				// (ADR 0021) — connecting it into a line reads as a stray line
-				// shooting past the encounter. Densify only the encounter arcs.
-				for i, p := range pts {
-					if i%2 == 0 {
-						continue
-					}
-					v.canvas.PlotColored(p, leg.color)
-				}
-				continue
-			}
-			// Foreign-SOI segment — zoom-constant gap-fill so the encounter
-			// stays a dense readable arc when zoomed in (ADR 0023 C).
-			if len(pts) == 1 {
-				v.canvas.PlotColored(pts[0], leg.color)
-			}
-			for i := 0; i+1 < len(pts); i++ {
-				v.canvas.PlotDenseLineColored(pts[i], pts[i+1], leg.color, 2)
-			}
+			// Every segment — home and foreign alike — inks as one
+			// phase-continuous polyline at a constant on-screen dot cadence
+			// (ADR 0023 C, generalised by ADR 0042 §3). The home transfer leg
+			// used to be scattered stride-2 dots on the theory that joining it
+			// up read as a stray line shooting past the encounter; that
+			// disconnect is really the inertial-leg-vs-rebased-arc gap at the
+			// SOI boundary (the leg aims at the body's FUTURE position, the
+			// encounter arc is rebased to its CURRENT one), and dotting the
+			// leg only hid it by making the leg unreadable when zoomed in.
+			// Fill stays within a segment, so an SOI transition is still never
+			// bridged.
+			v.canvas.PlotDensePolylineColored(w.SegmentDrawPoints(seg, homeID), leg.color, 2)
 		}
 	}
 }
@@ -1829,13 +1817,7 @@ func (v *OrbitView) plotArcLine(w *sim.World, line frozenArcLine) {
 		// — fill stays within a segment, so an SOI-transition boundary isn't
 		// bridged by a chord. step=2 matches the foreign-SOI leg cadence
 		// after the playtest density trim.
-		pts := w.SegmentDrawPoints(seg, line.anchor)
-		if len(pts) == 1 {
-			v.canvas.PlotColored(pts[0], line.color)
-		}
-		for i := 0; i+1 < len(pts); i++ {
-			v.canvas.PlotDenseLineColored(pts[i], pts[i+1], line.color, 2)
-		}
+		v.canvas.PlotDensePolylineColored(w.SegmentDrawPoints(seg, line.anchor), line.color, 2)
 	}
 }
 

--- a/internal/tui/screens/orbit_ghost_orbit_test.go
+++ b/internal/tui/screens/orbit_ghost_orbit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
@@ -188,7 +189,7 @@ func TestSubPixelGhostOrbitGated(t *testing.T) {
 	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / rOwn)}
 	c.State.M = c.TotalMass()
 
-	base := countBraille(v.Render(w, 0, 200, 60))
+	v.Render(w, 0, 200, 60)
 	scale := v.canvas.Scale()
 	if scale <= 0 {
 		t.Fatal("non-positive canvas scale")
@@ -198,21 +199,30 @@ func TestSubPixelGhostOrbitGated(t *testing.T) {
 		t.Skipf("frame not zoomed out enough (gate radius %.2g < 4×body %.2g)", gateR, 4*bodyR)
 	}
 
+	// Measure the ghost's OWN ink (its dim colour) rather than a whole-frame
+	// braille delta: since ADR 0042 §3 the body-orbit ellipses fill in their
+	// visible arcs properly instead of scattering a couple of dots, so a
+	// small ring landing on that busier backdrop adds few *new* lit cells
+	// while still drawing its full track.
+	ghostInk := func() int {
+		v.Render(w, 0, 200, 60)
+		return v.canvas.CountColor(lipgloss.Color(render.ColorDim))
+	}
+
 	// Above the primary's surface (so not occluded) yet well below the pixel
-	// gate → no ellipse.
+	// gate → no ellipse, just the marker.
 	tinyR := 2 * bodyR // apoapsis*scale < gate/2 < 6 px
 	w.Ghosts = []sim.Ghost{circularGhost(w, tinyR)}
-	gated := countBraille(v.Render(w, 0, 200, 60))
-	if gated-base > 6 {
-		t.Errorf("sub-pixel ghost orbit drew %d cells past baseline — gate not applied", gated-base)
+	gated := ghostInk()
+	if gated > 4 {
+		t.Errorf("sub-pixel ghost orbit inked %d cells — gate not applied (marker only expected)", gated)
 	}
 
 	// Same ghost, orbit comfortably above the gate → ellipse appears.
 	bigR := 4 * gateR // apoapsis*scale ≈ 24 px
 	w.Ghosts = []sim.Ghost{circularGhost(w, bigR)}
-	shown := countBraille(v.Render(w, 0, 200, 60))
-	if shown-base < 20 {
-		t.Errorf("above-gate ghost orbit drew only %d cells past baseline — gate mis-firing", shown-base)
+	if shown := ghostInk(); shown < 15 {
+		t.Errorf("above-gate ghost orbit inked only %d cells — gate mis-firing", shown)
 	}
 }
 

--- a/internal/tui/widgets/arc.go
+++ b/internal/tui/widgets/arc.go
@@ -1,0 +1,314 @@
+package widgets
+
+// Adaptive arc-length sampling for trajectory curves (ADR 0042 §3).
+//
+// Every curve the orbit map draws — the active vessel's ellipse, other
+// vessels' and ghosts' ellipses, body orbits, node legs, encounter arcs,
+// the SOI ring — now goes through one sampling policy:
+//
+//  1. FLATTEN. The curve is subdivided into chords that, once projected,
+//     are straight to within arcFlatTolerancePx. A chord that passes that
+//     test IS the curve on screen at the current zoom, so nothing is lost
+//     by inking it as a straight run. Subdivision is adaptive and
+//     view-pruned: a sub-span whose projected bounding box misses the
+//     canvas is dropped in O(1), so a curve that is mostly (or entirely)
+//     off-screen costs almost nothing, and the work that IS done lands on
+//     the visible arc.
+//
+//  2. INK. Each surviving chord is walked in PIXELS, one dot every
+//     `spacingPx`, with the dash phase carried ACROSS chord boundaries.
+//     The cadence is therefore an arc-length parameter measured on screen,
+//     not a sample-index stride — constant dot spacing at any zoom (ADR
+//     0023 C, generalised from foreign-SOI legs to every curve), and the
+//     parameter a future dashed / dotted line vocabulary needs is already
+//     the one being counted.
+//
+// Before this, ellipses were fixed 360-sample stride-dot loops: zoom in and
+// consecutive samples spread apart until the ellipse read as scattered dust
+// rather than a line.
+
+import (
+	"math"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+const (
+	// arcFlatTolerancePx is how far (canvas pixels) a chord may depart
+	// from the arc it stands in for. Half a braille pixel is below what
+	// the renderer can express, so a chord inside it is visually exact.
+	arcFlatTolerancePx = 0.5
+
+	// arcCoarseSpans is the first-pass division of a closed curve. Each
+	// span is then flattened adaptively (or pruned). It has to be fine
+	// enough that a span's arc can't sneak across the canvas while its
+	// endpoints and midpoint all sit outside the pruning box — see
+	// arcPruneChordFrac.
+	arcCoarseSpans = 256
+
+	// arcMaxSpans caps the coarse pass so a caller-supplied minimum can't
+	// blow up the per-frame loop.
+	arcMaxSpans = 2048
+
+	// arcMaxDepth bounds the subdivision of one coarse span. Chord
+	// deviation falls ~4× per level, so 12 levels absorb a 16-million-fold
+	// zoom-in past the point where the coarse span was already flat.
+	arcMaxDepth = 12
+
+	// arcPruneMarginPx / arcPruneChordFrac inflate the pruning box around a
+	// span's {start, mid, end} projected points. Stepping in ECCENTRIC
+	// anomaly bounds the tangent turn over a span at ΔE·(a/b), so the arc
+	// bulges past the box by at most ~ΔE·(a/b)/8 of the chord — under 3 %
+	// for e ≤ 0.995 at arcCoarseSpans, and the midpoint is already in the
+	// box. A quarter-chord margin is an order of magnitude of headroom;
+	// over-accepting only costs one extra flatness test.
+	arcPruneMarginPx  = 2.0
+	arcPruneChordFrac = 0.25
+)
+
+// projectPx is Project without the integer rounding or the on-canvas
+// verdict: the raw pixel coordinate of a world point. Adaptive flattening
+// works in floats so a span far off-canvas is measured and pruned before
+// anything is rounded into an int.
+func (c *Canvas) projectPx(w orbital.Vec3) (float64, float64) {
+	rel := w.Sub(c.centerW)
+	relX := rel.X*c.basis.X.X + rel.Y*c.basis.X.Y + rel.Z*c.basis.X.Z
+	relY := rel.X*c.basis.Y.X + rel.Y*c.basis.Y.Y + rel.Z*c.basis.Y.Z
+	return relX*c.scale + float64(c.pxW/2), float64(c.pxH/2) - relY*c.scale
+}
+
+// arcChord is one flattened piece of a curve: the world endpoints plus the
+// projected pixel coordinates the flattener already computed for them.
+type arcChord struct {
+	a, b   orbital.Vec3
+	ax, ay float64
+	bx, by float64
+}
+
+// flattenEllipse walks an ellipse and hands `emit` a run of chords whose
+// projected form is flat to within arcFlatTolerancePx, skipping spans that
+// can't reach the canvas. Sampling steps in eccentric anomaly, not true
+// anomaly: uniform ν crowds an eccentric orbit's samples at periapsis and
+// starves apoapsis (where the tangent turns 1/(1−e) times faster), while
+// uniform E spreads them by arc length within a factor of a/b. It is the
+// same parameterisation orbital.SampleConicArc uses for the ADR 0023
+// foreign-SOI redraw — this is that idea generalised to every curve.
+//
+// minSpans lets a caller keep a floor on the coarse pass (the historical
+// fixed sample counts); the adaptive subdivision supplies everything above.
+func (c *Canvas) flattenEllipse(el orbital.Elements, offset orbital.Vec3, minSpans int, emit func(arcChord)) {
+	if !(el.A > 0) || math.IsNaN(el.A) || math.IsInf(el.A, 0) ||
+		el.E < 0 || el.E >= 1 || math.IsNaN(el.E) {
+		return
+	}
+	spans := arcCoarseSpans
+	if minSpans > spans {
+		spans = minSpans
+	}
+	if spans > arcMaxSpans {
+		spans = arcMaxSpans
+	}
+	at := func(ea float64) orbital.Vec3 {
+		return offset.Add(orbital.PositionAtTrueAnomaly(el, orbital.TrueAnomaly(ea, el.E)))
+	}
+	p0 := at(0)
+	x0, y0 := c.projectPx(p0)
+	for i := 0; i < spans; i++ {
+		ea1 := 2 * math.Pi * float64(i+1) / float64(spans)
+		p1 := at(ea1)
+		x1, y1 := c.projectPx(p1)
+		ea0 := 2 * math.Pi * float64(i) / float64(spans)
+		c.flattenSpan(at, ea0, ea1, p0, x0, y0, p1, x1, y1, 0, emit)
+		p0, x0, y0 = p1, x1, y1
+	}
+}
+
+// flattenSpan is the recursive half of flattenEllipse: prune, test for
+// flatness, else split at the midpoint. The midpoint is projected once and
+// serves both the pruning box and the flatness test.
+func (c *Canvas) flattenSpan(
+	at func(float64) orbital.Vec3,
+	u0, u1 float64,
+	p0 orbital.Vec3, x0, y0 float64,
+	p1 orbital.Vec3, x1, y1 float64,
+	depth int,
+	emit func(arcChord),
+) {
+	um := 0.5 * (u0 + u1)
+	pm := at(um)
+	xm, ym := c.projectPx(pm)
+	if !c.spanReachesCanvas(x0, y0, x1, y1, xm, ym) {
+		return
+	}
+	if depth >= arcMaxDepth || pointSegDistSq(xm, ym, x0, y0, x1, y1) <= arcFlatTolerancePx*arcFlatTolerancePx {
+		emit(arcChord{a: p0, b: p1, ax: x0, ay: y0, bx: x1, by: y1})
+		return
+	}
+	c.flattenSpan(at, u0, um, p0, x0, y0, pm, xm, ym, depth+1, emit)
+	c.flattenSpan(at, um, u1, pm, xm, ym, p1, x1, y1, depth+1, emit)
+}
+
+// spanReachesCanvas reports whether the arc through the three projected
+// points could touch the canvas. The box around the points is inflated by
+// arcPruneMarginPx + arcPruneChordFrac × chord so a span that bulges toward
+// the view isn't dropped; see the constants' doc comment for the bound.
+func (c *Canvas) spanReachesCanvas(x0, y0, x1, y1, xm, ym float64) bool {
+	minX, maxX := minMax3(x0, x1, xm)
+	minY, maxY := minMax3(y0, y1, ym)
+	margin := arcPruneMarginPx + arcPruneChordFrac*math.Hypot(x1-x0, y1-y0)
+	return maxX+margin >= 0 && minX-margin <= float64(c.pxW-1) &&
+		maxY+margin >= 0 && minY-margin <= float64(c.pxH-1)
+}
+
+func minMax3(a, b, m float64) (float64, float64) {
+	lo, hi := a, a
+	if b < lo {
+		lo = b
+	}
+	if b > hi {
+		hi = b
+	}
+	if m < lo {
+		lo = m
+	}
+	if m > hi {
+		hi = m
+	}
+	return lo, hi
+}
+
+// pointSegDistSq is the squared distance from (px, py) to the segment
+// (ax, ay)–(bx, by) — the flatness measure (the arc's sagitta, sampled at
+// its midpoint).
+func pointSegDistSq(px, py, ax, ay, bx, by float64) float64 {
+	dx, dy := bx-ax, by-ay
+	den := dx*dx + dy*dy
+	if den == 0 {
+		return (px-ax)*(px-ax) + (py-ay)*(py-ay)
+	}
+	t := ((px-ax)*dx + (py-ay)*dy) / den
+	if t < 0 {
+		t = 0
+	} else if t > 1 {
+		t = 1
+	}
+	ex, ey := px-(ax+t*dx), py-(ay+t*dy)
+	return ex*ex + ey*ey
+}
+
+// drawEllipseAdaptive is the shared body of the ellipse draw helpers.
+// Chords on the far side of the basis plane through bodyPos ink at
+// farSpacingPx (the same-hue depth stipple documented in
+// internal/render/palette.go); near-side chords ink at nearSpacingPx.
+// bodyPxR > 0 additionally cuts far-side pixels that land inside the
+// body's projected disk, so the disk reads as opaque and the orbit visibly
+// passes behind it. The cut is per-PIXEL rather than per-sample, so the
+// occlusion gap tracks the disk edge exactly however long the chords get.
+func (c *Canvas) drawEllipseAdaptive(
+	el orbital.Elements,
+	offset orbital.Vec3,
+	minSpans int,
+	nearSpacingPx, farSpacingPx int,
+	bodyPos orbital.Vec3,
+	bodyPxR int,
+	color lipgloss.Color,
+) {
+	if nearSpacingPx < 1 {
+		nearSpacingPx = 1
+	}
+	if farSpacingPx < 1 {
+		farSpacingPx = 1
+	}
+	depthAxis := c.basis.DepthAxis()
+	bodyX, bodyY := c.projectPx(bodyPos)
+	// "Behind" needs a floor: an orbit lying IN the basis plane (any
+	// coplanar view — an equatorial orbit under the perifocal basis, the
+	// commonest case there is) has depth ≈ 0, and floating-point noise then
+	// flips chords between the near and far cadence at random, thinning the
+	// curve to roughly the average of the two. Anything less than half a
+	// pixel behind the plane is not behind it.
+	behindThreshold := 0.0
+	if c.scale > 0 {
+		behindThreshold = -0.5 / c.scale
+	}
+	tag := CellTag{Color: color}
+	// One dash phase for the whole curve: the cadence has to survive chord
+	// boundaries or a finely flattened curve inks solid (every chord would
+	// restart at phase 0).
+	nearPhase, farPhase := 0.0, 0.0
+	c.flattenEllipse(el, offset, minSpans, func(ch arcChord) {
+		mid := ch.a.Add(ch.b).Scale(0.5).Sub(bodyPos)
+		depth := mid.X*depthAxis.X + mid.Y*depthAxis.Y + mid.Z*depthAxis.Z
+		if depth < behindThreshold {
+			farPhase = c.walkPixelSegment(ch.ax, ch.ay, ch.bx, ch.by, tag, farSpacingPx, farPhase,
+				bodyX, bodyY, float64(bodyPxR))
+			return
+		}
+		nearPhase = c.walkPixelSegment(ch.ax, ch.ay, ch.bx, ch.by, tag, nearSpacingPx, nearPhase, 0, 0, 0)
+	})
+}
+
+// visibleAngleWindow returns the angular window (radians, measured from the
+// +x pixel axis, y down) outside which no point of the circle of radius
+// pxRadius centred at (cx, cy) can land on the canvas. ok=false means the
+// circle misses the canvas entirely.
+//
+// This is what keeps a screen-space ring honest at extreme zoom: sampling
+// the whole circle at a fixed dot spacing costs O(radius), so the shipped
+// primitives capped the sample count instead and the visible arc went
+// sparse — the ring dissolved exactly when zoomed in. Restricting the sweep
+// to the wedge the canvas subtends makes the cost O(visible arc) instead,
+// and the dots stay at their commanded spacing at any radius.
+func visibleAngleWindow(cx, cy float64, pxRadius float64, w, h int) (start, span float64, ok bool) {
+	maxX, maxY := float64(w-1), float64(h-1)
+	if cx >= 0 && cx <= maxX && cy >= 0 && cy <= maxY {
+		// Centre inside the canvas: every direction can matter, but a
+		// radius past the far corner puts the whole circle outside.
+		far := math.Max(math.Hypot(cx, cy), math.Hypot(maxX-cx, maxY-cy))
+		far = math.Max(far, math.Max(math.Hypot(maxX-cx, cy), math.Hypot(cx, maxY-cy)))
+		if pxRadius > far {
+			return 0, 0, false
+		}
+		return 0, 2 * math.Pi, true
+	}
+	// Centre outside: the canvas rectangle subtends less than π, so the
+	// corner angles unwrapped around the rectangle's centre bound it.
+	ref := math.Atan2((maxY/2)-cy, (maxX/2)-cx)
+	lo, hi := 0.0, 0.0
+	corners := [4][2]float64{{0, 0}, {maxX, 0}, {0, maxY}, {maxX, maxY}}
+	farthest := 0.0
+	for i, p := range corners {
+		d := math.Hypot(p[0]-cx, p[1]-cy)
+		if d > farthest {
+			farthest = d
+		}
+		a := wrapToRef(math.Atan2(p[1]-cy, p[0]-cx), ref)
+		if i == 0 || a < lo {
+			lo = a
+		}
+		if i == 0 || a > hi {
+			hi = a
+		}
+	}
+	// Nearest point of the rectangle to the centre (clamped projection).
+	nx := math.Min(math.Max(cx, 0), maxX)
+	ny := math.Min(math.Max(cy, 0), maxY)
+	near := math.Hypot(nx-cx, ny-cy)
+	if pxRadius < near || pxRadius > farthest {
+		return 0, 0, false
+	}
+	return lo, hi - lo, true
+}
+
+// wrapToRef shifts angle a by whole turns until it lies within π of ref.
+func wrapToRef(a, ref float64) float64 {
+	for a-ref > math.Pi {
+		a -= 2 * math.Pi
+	}
+	for ref-a > math.Pi {
+		a += 2 * math.Pi
+	}
+	return a
+}

--- a/internal/tui/widgets/arc_test.go
+++ b/internal/tui/widgets/arc_test.go
@@ -1,0 +1,283 @@
+package widgets
+
+import (
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// arcColor is the tag colour the adaptive-sampling tests draw with, so
+// taggedPixels can pull exactly the curve's ink back out.
+const arcColor = lipgloss.Color("#33AAFF")
+
+// litRows / litPixels are the row coverage and pixel set of a drawn curve.
+func litRows(c *Canvas, color lipgloss.Color) int {
+	rows := map[int]bool{}
+	for _, p := range taggedPixels(c, color) {
+		rows[p[1]] = true
+	}
+	return len(rows)
+}
+
+// zoomedCanvas frames a circular orbit of radius R, then multiplies the fit
+// scale by `zoom` — the same baseScale × userZoom composition the orbit
+// screen applies. The canvas centre sits ON the orbit (its periapsis), which
+// is where the vessel would be, so zooming in magnifies a real piece of the
+// track rather than empty space.
+func zoomedCanvas(cols, rows int, r, zoom float64) *Canvas {
+	c := NewCanvas(cols, rows)
+	c.Center(orbital.Vec3{X: r})
+	c.FitTo(r)
+	c.ZoomBy(zoom)
+	c.Clear()
+	return c
+}
+
+// TestEllipseStaysConnectedWhenZoomedIn is the headline of ADR 0042 §3: a
+// trajectory must read as a curve at any zoom. The shipped fixed-360-sample
+// stride loop spread its samples further apart the further the player zoomed
+// in, until the ellipse was a scatter of dots ("zoom-in turns to dust"). With
+// arc-length sampling the visible arc stays a connected line — asserted as
+// "the curve reaches nearly every pixel row it crosses" — at 1×, 40× and
+// 1000× the framing scale, on an 80×24 terminal.
+func TestEllipseStaysConnectedWhenZoomedIn(t *testing.T) {
+	const r = 1e7
+	el := orbital.Elements{A: r}
+	for _, zoom := range []float64{1, 40, 1000, 100000} {
+		c := zoomedCanvas(80, 24, r, zoom) // 160 × 96 px
+		c.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 1, orbital.Vec3{}, 0, arcColor)
+		if got := litRows(c, arcColor); got < 80 {
+			t.Errorf("zoom %.0f×: arc lit %d of 96 pixel rows — the curve broke up into dots", zoom, got)
+		}
+	}
+}
+
+// TestEllipseDotSpacingIsZoomInvariant: the spacing argument is a distance in
+// canvas pixels along the arc, so the same ellipse at wildly different zooms
+// inks at the same on-screen cadence. At high zoom the visible arc is a
+// near-vertical line through the canvas centre, so consecutive dots ordered
+// by row are consecutive along the arc.
+func TestEllipseDotSpacingIsZoomInvariant(t *testing.T) {
+	const (
+		r       = 1e7
+		spacing = 4
+	)
+	el := orbital.Elements{A: r}
+	for _, zoom := range []float64{200, 5000, 250000} {
+		c := zoomedCanvas(80, 24, r, zoom)
+		c.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, spacing, orbital.Vec3{}, 0, arcColor)
+		ys := make([]int, 0, 64)
+		for _, p := range taggedPixels(c, arcColor) {
+			ys = append(ys, p[1])
+		}
+		if len(ys) < 10 {
+			t.Fatalf("zoom %.0f×: only %d dots on the visible arc", zoom, len(ys))
+		}
+		sort.Ints(ys)
+		for i := 1; i < len(ys); i++ {
+			if gap := ys[i] - ys[i-1]; gap > spacing+2 {
+				t.Errorf("zoom %.0f×: %d px gap between dots at y=%d and y=%d, want ≈%d",
+					zoom, gap, ys[i-1], ys[i], spacing)
+				break
+			}
+		}
+		// And not solid: a finely flattened curve must still honour the
+		// cadence across chord boundaries rather than plotting every chord's
+		// own start pixel.
+		if len(ys) > 96/spacing*2 {
+			t.Errorf("zoom %.0f×: %d dots over ~96 px of arc at spacing %d — cadence lost between chords",
+				zoom, len(ys), spacing)
+		}
+	}
+}
+
+// TestEllipseSpacingArgumentScalesInk: doubling the spacing roughly halves
+// the ink, at a fixed zoom — the depth stipple (far side = 2× spacing) and
+// the per-line-role density levers both rest on this.
+func TestEllipseSpacingArgumentScalesInk(t *testing.T) {
+	const r = 1e7
+	el := orbital.Elements{A: r}
+	count := func(spacing int) int {
+		c := zoomedCanvas(200, 60, r, 1)
+		c.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, spacing, orbital.Vec3{}, 0, arcColor)
+		return len(taggedPixels(c, arcColor))
+	}
+	dense, sparse := count(2), count(4)
+	if dense == 0 || sparse == 0 {
+		t.Fatalf("no ink: spacing2=%d spacing4=%d", dense, sparse)
+	}
+	if ratio := float64(dense) / float64(sparse); ratio < 1.6 || ratio > 2.4 {
+		t.Errorf("spacing 2 vs 4 inked %d vs %d pixels (ratio %.2f), want ≈2", dense, sparse, ratio)
+	}
+}
+
+// TestEllipseOffCanvasCostsNothing: a curve that can't reach the viewport is
+// pruned rather than sampled — the perf side of the adaptive policy. An
+// orbit far off-screen must set no pixels at all.
+func TestEllipseOffCanvasDrawsNothing(t *testing.T) {
+	c := NewCanvas(80, 24)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{X: 1e9}) // a gigapixel away from the orbit
+	c.Clear()
+	c.DrawEllipseOffsetFarSideDashed(orbital.Elements{A: 1e4}, orbital.Vec3{}, 360, 2, orbital.Vec3{}, 0, arcColor)
+	if n := len(taggedPixels(c, arcColor)); n != 0 {
+		t.Errorf("off-canvas ellipse set %d pixels, want 0", n)
+	}
+}
+
+// TestEllipseEccentricSamplingCoversApoapsis: sampling steps in eccentric
+// anomaly, not true anomaly. Uniform ν starves the apoapsis half of an
+// eccentric orbit (where the tangent turns 1/(1−e) times faster per radian
+// of ν), which is exactly where a transfer ellipse spends its time. Frame the
+// apoapsis of an e=0.9 orbit and require the arc to read as a curve there.
+func TestEllipseEccentricSamplingCoversApoapsis(t *testing.T) {
+	el := orbital.Elements{A: 1e7, E: 0.9}
+	apo := orbital.PositionAtTrueAnomaly(el, math.Pi)
+	c := NewCanvas(80, 24)
+	c.Center(apo)
+	c.SetScale(96 * 0.45 / (0.2 * el.A)) // zoomed well inside the orbit
+	c.Clear()
+	c.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 1, orbital.Vec3{}, 0, arcColor)
+	if got := litRows(c, arcColor); got < 40 {
+		t.Errorf("apoapsis arc of an e=0.9 orbit lit %d pixel rows — sampling starves the slow half", got)
+	}
+}
+
+// TestClipSegmentToCanvas covers the three cases the chord bridging depends
+// on: wholly inside (unchanged), crossing the viewport with both endpoints
+// outside (clipped to the visible run), and wholly outside (rejected).
+func TestClipSegmentToCanvas(t *testing.T) {
+	const w, h = 160, 96
+	tests := []struct {
+		name               string
+		ax, ay, bx, by     float64
+		wantOK             bool
+		wx0, wy0, wx1, wy1 float64
+	}{
+		{"inside", 10, 10, 100, 50, true, 10, 10, 100, 50},
+		{"crossing", -500, 48, 900, 48, true, 0, 48, 159, 48},
+		{"half in", 80, 48, 1e6, 48, true, 80, 48, 159, 48},
+		{"outside right", 500, 10, 900, 50, false, 0, 0, 0, 0},
+		{"outside above", 10, -900, 100, -500, false, 0, 0, 0, 0},
+	}
+	for _, tc := range tests {
+		x0, y0, x1, y1, ok := clipSegmentToCanvas(tc.ax, tc.ay, tc.bx, tc.by, w, h)
+		if ok != tc.wantOK {
+			t.Errorf("%s: ok=%v, want %v", tc.name, ok, tc.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if math.Abs(x0-tc.wx0) > 0.5 || math.Abs(y0-tc.wy0) > 0.5 ||
+			math.Abs(x1-tc.wx1) > 0.5 || math.Abs(y1-tc.wy1) > 0.5 {
+			t.Errorf("%s: clipped to (%.1f,%.1f)→(%.1f,%.1f), want (%.1f,%.1f)→(%.1f,%.1f)",
+				tc.name, x0, y0, x1, y1, tc.wx0, tc.wy0, tc.wx1, tc.wy1)
+		}
+	}
+}
+
+// TestPlotDensePolylineCarriesDashPhase: the dot cadence is measured along
+// the whole polyline, not restarted at every sample. A run of points one
+// pixel apart at step 4 must ink about a quarter of them — restarting the
+// phase per segment would ink every one and the "dashed" leg would come out
+// solid.
+func TestPlotDensePolylineCarriesDashPhase(t *testing.T) {
+	c := NewCanvas(60, 30) // 120 × 120 px
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	pts := make([]orbital.Vec3, 0, 81)
+	for i := -40; i <= 40; i++ {
+		pts = append(pts, orbital.Vec3{X: float64(i)})
+	}
+	c.PlotDensePolylineColored(pts, arcColor, 4)
+
+	n := len(taggedPixels(c, arcColor))
+	if n < 15 || n > 26 {
+		t.Errorf("81-point polyline at step 4 inked %d pixels, want ≈21 (the phase must survive the joins)", n)
+	}
+}
+
+// TestPlotDensePolylineSinglePoint: a one-sample segment still plots its dot
+// (the degenerate case the leg draw path hands over at extreme zoom).
+func TestPlotDensePolylineSinglePoint(t *testing.T) {
+	c := NewCanvas(60, 30)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	c.PlotDensePolylineColored([]orbital.Vec3{{}}, arcColor, 2)
+	if n := len(taggedPixels(c, arcColor)); n != 1 {
+		t.Errorf("single-point polyline set %d pixels, want 1", n)
+	}
+}
+
+// TestRingDottedKeepsSpacingAtExtremeRadius: the SOI ring is a screen-space
+// circle, and the shipped primitive sampled the WHOLE circumference under a
+// 4×(pxW+pxH) cap — so at a zoomed-in radius the samples fell hundreds of
+// pixels apart and the visible arc vanished. Restricting the sweep to the
+// window the canvas subtends keeps the commanded dot spacing at any radius.
+func TestRingDottedKeepsSpacingAtExtremeRadius(t *testing.T) {
+	const pxRadius = 200000
+	c := NewCanvas(80, 24) // 160 × 96 px
+	c.SetScale(1)
+	// Put the ring's centre far to the left so the circle sweeps through the
+	// canvas: centre x = 80 − pxRadius, radius pxRadius → the ring crosses
+	// x ≈ 80.
+	c.Center(orbital.Vec3{X: pxRadius})
+	c.Clear()
+	c.RingDottedColored(orbital.Vec3{}, pxRadius, arcColor)
+
+	dots := taggedPixels(c, arcColor)
+	if len(dots) < 15 {
+		t.Fatalf("ring at radius %d px inked %d dots on canvas — the visible arc went sparse", pxRadius, len(dots))
+	}
+	ys := make([]int, 0, len(dots))
+	for _, d := range dots {
+		ys = append(ys, d[1])
+	}
+	sort.Ints(ys)
+	for i := 1; i < len(ys); i++ {
+		if gap := ys[i] - ys[i-1]; gap > ringDotSpacingPx+2 {
+			t.Errorf("%d px gap between ring dots at y=%d and y=%d, want ≈%d", gap, ys[i-1], ys[i], ringDotSpacingPx)
+			break
+		}
+	}
+}
+
+// TestRingDottedWhollyOffCanvas: a circle that can't reach the viewport is
+// rejected by the angular window rather than swept.
+func TestRingDottedWhollyOffCanvas(t *testing.T) {
+	c := NewCanvas(80, 24)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	// Centre on canvas, radius far beyond the far corner.
+	c.RingDottedColored(orbital.Vec3{}, 900_000, arcColor)
+	if n := len(taggedPixels(c, arcColor)); n != 0 {
+		t.Errorf("ring wholly outside the canvas set %d pixels, want 0", n)
+	}
+}
+
+// TestVisibleAngleWindowBoundsTheSweep: the window a canvas subtends from a
+// distant centre is narrow, which is what makes the ring cost O(visible arc)
+// instead of O(circumference).
+func TestVisibleAngleWindowBoundsTheSweep(t *testing.T) {
+	// Centre far to the left of a 160 × 96 canvas.
+	_, span, ok := visibleAngleWindow(-100000, 48, 100000, 160, 96)
+	if !ok {
+		t.Fatal("window rejected a circle that crosses the canvas")
+	}
+	if span > 0.01 {
+		t.Errorf("span %.4f rad from 100 000 px away — the sweep is not being bounded", span)
+	}
+	// Centre inside the canvas: every direction can matter.
+	if _, span, ok := visibleAngleWindow(80, 48, 40, 160, 96); !ok || math.Abs(span-2*math.Pi) > 1e-9 {
+		t.Errorf("centre inside canvas: span=%.4f ok=%v, want 2π", span, ok)
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -465,15 +465,25 @@ const ringDotSpacingPx = 4
 // orthographic projection is the same circle under every view basis, so
 // like RingColoredOutline the ring draws in screen space rather than as
 // a tilted world-plane ellipse. Dots are spaced ~ringDotSpacingPx of
-// circumference apart; the sample count carries the same
-// 4×(pxW+pxH) cap as the other ring primitives so an extreme-zoom
-// radius can't lock the render loop (the visible arc just goes sparse).
+// circumference apart.
+//
+// ADR 0042 §3: the sweep is restricted to the angular window the canvas
+// subtends from the ring's centre (visibleAngleWindow), so the cost is
+// O(the visible arc) rather than O(the circumference). Previously the
+// full circle was sampled and the count capped at 4×(pxW+pxH), which
+// meant the dots thinned out as the player zoomed in — the ring
+// dissolved exactly when it mattered most. Now the commanded spacing
+// holds at any radius.
 func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipgloss.Color) {
 	if pxRadius < 1 {
 		return
 	}
-	cx, cy, _ := c.Project(center)
-	samples := int(math.Round(2 * math.Pi * float64(pxRadius) / ringDotSpacingPx))
+	cxF, cyF := c.projectPx(center)
+	start, span, ok := visibleAngleWindow(cxF, cyF, float64(pxRadius), c.pxW, c.pxH)
+	if !ok {
+		return
+	}
+	samples := int(math.Round(span * float64(pxRadius) / ringDotSpacingPx))
 	if samples < 8 {
 		samples = 8
 	}
@@ -486,9 +496,9 @@ func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipg
 	}
 	tag := CellTag{Color: color}
 	for i := 0; i < samples; i++ {
-		theta := 2 * math.Pi * float64(i) / float64(samples)
-		px := cx + int(math.Round(float64(pxRadius)*math.Cos(theta)))
-		py := cy + int(math.Round(float64(pxRadius)*math.Sin(theta)))
+		theta := start + span*float64(i)/float64(samples)
+		px := int(math.Round(cxF + float64(pxRadius)*math.Cos(theta)))
+		py := int(math.Round(cyF + float64(pxRadius)*math.Sin(theta)))
 		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
 			continue
 		}
@@ -616,130 +626,152 @@ func (c *Canvas) PlotColoredTagged(w orbital.Vec3, tag CellTag) {
 // The chord is exact under the affine projection, so no curve fidelity is
 // lost beyond the sampling already present.
 //
-// A chord longer than the canvas's shorter dimension is NOT bridged — those
-// samples straddle a fast periapsis arc or one sits well off-canvas (a
-// Hohmann transfer's off-screen apoapsis), where a straight fill would shoot
-// a line across the view. Such a pair falls back to the pre-gap-fill
-// behaviour: just the on-canvas endpoint dots, no connecting line.
+// ADR 0042 §3: a long chord is now CLIPPED AND BRIDGED, not refused. The old
+// rule dropped any chord longer than the canvas's shorter dimension back to
+// endpoint dots, on the theory that such a chord straddles a fast periapsis
+// arc and a straight fill would shoot a line across the view. That theory
+// held only because the curve upstream was sampled at a fixed count: once the
+// caller flattens adaptively (see arc.go), a long chord is long because the
+// view is zoomed in, and it IS the curve — refusing it is precisely what made
+// zooming in dissolve a trajectory into dust. Clipping keeps the cost O(the
+// visible run) however far off-canvas the far endpoint sits.
 func (c *Canvas) PlotDenseLineColored(a, b orbital.Vec3, color lipgloss.Color, step int) {
-	if step < 1 {
-		step = 1
-	}
-	ax, ay, aOK := c.Project(a)
-	bx, by, bOK := c.Project(b)
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
-	plotPx := func(px, py int) {
-		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
-			return
-		}
-		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = CellTag{Color: color}
-	}
-	if !aOK && !bOK {
-		// Both off-canvas and sharing an off-edge — the whole chord is
-		// off-screen. A pair straddling the canvas still draws its visible run.
-		if (ax < 0 && bx < 0) || (ax >= c.pxW && bx >= c.pxW) ||
-			(ay < 0 && by < 0) || (ay >= c.pxH && by >= c.pxH) {
-			return
-		}
-	}
-	dx, dy := bx-ax, by-ay
-	n := dx
-	if n < 0 {
-		n = -n
-	}
-	if ady := dy; ady < 0 {
-		if -ady > n {
-			n = -ady
-		}
-	} else if ady > n {
-		n = ady
-	}
-	maxFill := c.pxW
-	if c.pxH < maxFill {
-		maxFill = c.pxH
-	}
-	if n > maxFill {
-		// Too long to bridge — endpoint dots only, no shooting line.
-		plotPx(ax, ay)
-		plotPx(bx, by)
+	ax, ay := c.projectPx(a)
+	bx, by := c.projectPx(b)
+	c.walkPixelSegment(ax, ay, bx, by, CellTag{Color: color}, step, 0, 0, 0, 0)
+}
+
+// PlotDenseLineForcedColored draws a dotted line between world points a and b.
+// Kept as a distinct name for the CommNet relay sightline (C2-7), where the
+// chord IS the real straight path and must draw all the way toward its (often
+// off-screen) far endpoint — a Moon→Earth relay hop spans far more than the
+// canvas. Since ADR 0042 §3 replaced PlotDenseLineColored's long-chord refusal
+// with the same clipped bridging, the two behave identically; the separate
+// entry point survives so the call site keeps stating its intent.
+func (c *Canvas) PlotDenseLineForcedColored(a, b orbital.Vec3, color lipgloss.Color, step int) {
+	c.PlotDenseLineColored(a, b, color, step)
+}
+
+// PlotDensePolylineColored inks a run of world points as one connected dotted
+// curve: every consecutive pair is bridged like PlotDenseLineColored, but the
+// dash phase carries ACROSS the joins, so the dot cadence is measured along
+// the whole polyline's on-screen arc length rather than restarting at each
+// sample. Without that, a densely sampled leg (or a finely flattened ellipse)
+// inks solid regardless of `step`, because every segment re-plots its own
+// start pixel. A single point plots as a dot.
+func (c *Canvas) PlotDensePolylineColored(pts []orbital.Vec3, color lipgloss.Color, step int) {
+	if len(pts) == 0 {
 		return
 	}
-	for i := 0; i <= n; i += step {
-		if n == 0 {
-			plotPx(ax, ay)
-			break
-		}
-		plotPx(
-			ax+int(math.Round(float64(dx)*float64(i)/float64(n))),
-			ay+int(math.Round(float64(dy)*float64(i)/float64(n))),
-		)
+	if len(pts) == 1 {
+		c.PlotColored(pts[0], color)
+		return
+	}
+	tag := CellTag{Color: color}
+	phase := 0.0
+	ax, ay := c.projectPx(pts[0])
+	for i := 1; i < len(pts); i++ {
+		bx, by := c.projectPx(pts[i])
+		phase = c.walkPixelSegment(ax, ay, bx, by, tag, step, phase, 0, 0, 0)
+		ax, ay = bx, by
 	}
 }
 
-// PlotDenseLineForcedColored draws a dotted line between world points a and b
-// like PlotDenseLineColored, but WITHOUT the "too long to bridge" guard: it
-// always connects the two points, clipping the segment to the canvas so a link
-// to a far off-screen endpoint draws its visible run with O(canvas) iteration
-// rather than O(projected distance). Use for a genuine straight sightline — a
-// CommNet relay link (C2-7) — where the chord IS the real path and must draw
-// all the way toward its (possibly off-screen) far endpoint, e.g. a Moon→Earth
-// relay hop. Orbit-arc chords keep the guarded variant, which refuses to bridge
-// a long chord because that chord is NOT a real straight path across the view.
-func (c *Canvas) PlotDenseLineForcedColored(a, b orbital.Vec3, color lipgloss.Color, step int) {
+// walkPixelSegment inks the pixel segment (ax,ay)→(bx,by), clipped to the
+// canvas, placing a dot every `step` pixels of ON-SCREEN ARC LENGTH and
+// returning the phase to hand to the next segment of the same curve.
+// `phase` is how far past the last dot the curve already is, so a caller
+// that walks a flattened arc chord by chord gets one continuous cadence.
+// Arc length is therefore the parameter — which is both why the dot spacing
+// is zoom-invariant and what a future dashed / dotted line vocabulary needs.
+//
+// The phase is a float and advances by the FULL segment length, including
+// the part clipped away: sub-pixel chords (a finely flattened curve) still
+// accumulate toward the next dot instead of each plotting their own start
+// pixel and inking solid, and the pattern stays put as the view pans.
+//
+// exR > 0 excludes pixels within exR of (exCx, exCy) — the body-disk cut that
+// makes an occluded far-side arc read as passing behind the body. A zero-value
+// tag sets pixels without recording a colour (the untagged Plot path).
+func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int, phase float64, exCx, exCy, exR float64) float64 {
 	if step < 1 {
 		step = 1
 	}
-	ax, ay, _ := c.Project(a)
-	bx, by, _ := c.Project(b)
+	stepF := float64(step)
+	if !(phase >= 0) { // NaN-safe
+		phase = 0
+	}
+	full := segLenPx(ax, ay, bx, by)
+	advanced := math.Mod(phase+full, stepF)
 	cax, cay, cbx, cby, ok := clipSegmentToCanvas(ax, ay, bx, by, c.pxW, c.pxH)
 	if !ok {
-		return // segment lies wholly off the canvas
+		return advanced
 	}
-	if c.pixelTags == nil {
+	tagged := tag != (CellTag{})
+	if tagged && c.pixelTags == nil {
 		c.pixelTags = make(map[[2]int]CellTag)
 	}
+	exR2 := exR * exR
 	plotPx := func(px, py int) {
 		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
 			return
 		}
+		if exR > 0 {
+			dx, dy := float64(px)-exCx, float64(py)-exCy
+			if dx*dx+dy*dy <= exR2 {
+				return
+			}
+		}
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = CellTag{Color: color}
+		if tagged {
+			c.pixelTags[[2]int{px, py}] = tag
+		}
+	}
+	// Length clipped off the a-end still counts toward the cadence, so the
+	// dot positions don't slide when the visible run changes.
+	lead := phase + segLenPx(ax, ay, cax, cay)
+	clipLen := segLenPx(cax, cay, cbx, cby)
+	if clipLen == 0 {
+		if math.Mod(lead, stepF) == 0 {
+			plotPx(int(math.Round(cax)), int(math.Round(cay)))
+		}
+		return advanced
 	}
 	dx, dy := cbx-cax, cby-cay
-	n := dx
-	if n < 0 {
-		n = -n
-	}
-	if ady := dy; ady < 0 {
-		if -ady > n {
-			n = -ady
+	for k := math.Ceil(lead / stepF); ; k++ {
+		s := k*stepF - lead
+		if s > clipLen {
+			break
 		}
-	} else if ady > n {
-		n = ady
+		f := s / clipLen
+		plotPx(int(math.Round(cax+dx*f)), int(math.Round(cay+dy*f)))
 	}
-	if n == 0 {
-		plotPx(cax, cay)
-		return
+	return advanced
+}
+
+// segLenPx is the on-screen length of a pixel segment — the arc-length unit
+// the dense-line cadence counts in, so a dot every `step` means every `step`
+// pixels of curve however the curve is oriented. Clamped so an
+// astronomically distant (or NaN) projected endpoint can't run away with the
+// loop.
+func segLenPx(ax, ay, bx, by float64) float64 {
+	d := math.Hypot(bx-ax, by-ay)
+	if !(d < 1e9) { // NaN-safe
+		return 1e9
 	}
-	for i := 0; i <= n; i += step {
-		plotPx(
-			cax+int(math.Round(float64(dx)*float64(i)/float64(n))),
-			cay+int(math.Round(float64(dy)*float64(i)/float64(n))),
-		)
-	}
+	return d
 }
 
 // clipSegmentToCanvas clips the pixel segment [(ax,ay),(bx,by)] to the canvas
-// rectangle [0,w-1]×[0,h-1] via Liang-Barsky, returning the clipped integer
-// endpoints and ok=false when the segment lies wholly outside. Bounds the
-// forced dense-line iteration so a link to a far off-screen endpoint costs
-// O(canvas), not O(projected distance).
-func clipSegmentToCanvas(ax, ay, bx, by, w, h int) (int, int, int, int, bool) {
-	x0, y0 := float64(ax), float64(ay)
-	dx, dy := float64(bx-ax), float64(by-ay)
+// rectangle [0,w-1]×[0,h-1] via Liang-Barsky, returning the clipped endpoints
+// and ok=false when the segment lies wholly outside. Bounds the dense-line
+// iteration so a chord toward a far off-screen endpoint costs O(canvas), not
+// O(projected distance). Works in floats: an adaptively flattened arc hands
+// over raw projected coordinates, which are only rounded once inside the
+// canvas rectangle.
+func clipSegmentToCanvas(ax, ay, bx, by float64, w, h int) (float64, float64, float64, float64, bool) {
+	x0, y0 := ax, ay
+	dx, dy := bx-ax, by-ay
 	maxX, maxY := float64(w-1), float64(h-1)
 	p := [4]float64{-dx, dx, -dy, dy}
 	q := [4]float64{x0, maxX - x0, y0, maxY - y0}
@@ -768,8 +800,7 @@ func clipSegmentToCanvas(ax, ay, bx, by, w, h int) (int, int, int, int, bool) {
 			}
 		}
 	}
-	return int(math.Round(x0 + u0*dx)), int(math.Round(y0 + u0*dy)),
-		int(math.Round(x0 + u1*dx)), int(math.Round(y0 + u1*dy)), true
+	return x0 + u0*dx, y0 + u0*dy, x0 + u1*dx, y0 + u1*dy, true
 }
 
 // Cols / Rows expose the configured terminal cell dimensions.
@@ -951,10 +982,10 @@ func (c *Canvas) IsBehindBody(samplePos, bodyPos orbital.Vec3, bodyPxR int) bool
 }
 
 // DrawEllipseOffsetFarSideDashed plots an ellipse with near-side
-// pixels rendered at nearStride (solid stride) and far-side pixels
-// rendered at nearStride*2 (visually dashed) in the same colour.
-// Pixels truly occluded by the body disk — far side AND inside the
-// body's projected pixel radius — are skipped entirely. v0.10.6+.
+// pixels rendered at nearSpacingPx and far-side pixels rendered at
+// nearSpacingPx*2 (visually dashed) in the same colour. Pixels truly
+// occluded by the body disk — far side AND inside the body's projected
+// pixel radius — are cut entirely. v0.10.6+.
 //
 // "Far side" is decided by the sign of (p − bodyPos) · DepthAxis()
 // against the canvas's active basis: negative depth is behind the
@@ -962,102 +993,56 @@ func (c *Canvas) IsBehindBody(samplePos, bodyPos orbital.Vec3, bodyPxR int) bool
 //
 // Same-hue stippling is the lossless equivalent of KSP's
 // dim-the-back-arc rendering — a terminal canvas can't do alpha,
-// so per-sample stride flips do the depth read instead. The
-// convention is documented in internal/render/palette.go; see
-// ColorBodyOrbit's doc comment for the standard.
+// so spacing flips do the depth read instead. The convention is
+// documented in internal/render/palette.go; see ColorBodyOrbit's doc
+// comment for the standard.
 //
 // Pass bodyPxR = 0 to skip the disk-occlusion check (suitable for
 // heliocentric body orbits, where the system primary's disk doesn't
 // meaningfully occlude at default zoom).
+//
+// ADR 0042 §3 changed what the two count arguments mean. The ellipse is
+// no longer a fixed loop of `samples` true-anomalies plotted every
+// `nearStride`th index — that scattered into dust the moment the player
+// zoomed in, because index stride is not a screen-space quantity. It is
+// now flattened adaptively (arc.go) and inked at a constant on-screen dot
+// spacing: `minSamples` is only a floor on the coarse pass, and
+// `nearSpacingPx` is the near-side dot spacing in canvas pixels.
 func (c *Canvas) DrawEllipseOffsetFarSideDashed(
 	el orbital.Elements,
 	offset orbital.Vec3,
-	samples int,
-	nearStride int,
+	minSamples int,
+	nearSpacingPx int,
 	bodyPos orbital.Vec3,
 	bodyPxR int,
 	color lipgloss.Color,
 ) {
-	if samples < 16 {
-		samples = 16
+	if nearSpacingPx < 1 {
+		nearSpacingPx = 1
 	}
-	if nearStride < 1 {
-		nearStride = 1
-	}
-	farStride := nearStride * 2
-	depthAxis := c.basis.DepthAxis()
-	for i := 0; i < samples; i++ {
-		nu := 2 * math.Pi * float64(i) / float64(samples)
-		p := offset.Add(orbital.PositionAtTrueAnomaly(el, nu))
-		rel := p.Sub(bodyPos)
-		depth := rel.X*depthAxis.X + rel.Y*depthAxis.Y + rel.Z*depthAxis.Z
-		if depth < 0 {
-			if bodyPxR > 0 {
-				spx, spy, ok := c.Project(p)
-				if ok {
-					bpx, bpy, _ := c.Project(bodyPos)
-					dx := spx - bpx
-					dy := spy - bpy
-					if dx*dx+dy*dy <= bodyPxR*bodyPxR {
-						continue
-					}
-				}
-			}
-			if i%farStride != 0 {
-				continue
-			}
-		} else {
-			if i%nearStride != 0 {
-				continue
-			}
-		}
-		if color == "" {
-			c.Plot(p)
-		} else {
-			c.PlotColored(p, color)
-		}
-	}
+	c.drawEllipseAdaptive(el, offset, minSamples, nearSpacingPx, nearSpacingPx*2, bodyPos, bodyPxR, color)
 }
 
-// DrawEllipseOffsetOccluded plots a dotted ellipse but skips any
-// sample IsBehindBody-occluded by the supplied (bodyPos, bodyPxR).
-// Same shape as DrawEllipseOffsetDotted; v0.6.4+ side-view variant.
-// Pass an untagged stride to keep the existing colour helpers; this
-// helper writes through PlotColored when `color` is non-empty,
-// otherwise plain Plot. v0.10.6 supersedes this on the orbit-trace
-// draw path with DrawEllipseOffsetFarSideDashed (renders the back
-// arc dashed instead of skipping); this helper is retained for
-// callers that want strict occlusion without far-side dashing.
+// DrawEllipseOffsetOccluded plots a dotted ellipse but cuts anything
+// IsBehindBody-occluded by the supplied (bodyPos, bodyPxR) — strict
+// occlusion with no far-side dashing, unlike
+// DrawEllipseOffsetFarSideDashed. v0.6.4+ side-view variant; writes
+// through the colour path when `color` is non-empty, otherwise plain
+// untagged pixels.
+//
+// As with its sibling, ADR 0042 §3 reinterprets the count arguments:
+// `minSamples` is a floor on the adaptive coarse pass and `spacingPx` is
+// the dot spacing in canvas pixels.
 func (c *Canvas) DrawEllipseOffsetOccluded(
 	el orbital.Elements,
 	offset orbital.Vec3,
-	samples int,
-	stride int,
+	minSamples int,
+	spacingPx int,
 	bodyPos orbital.Vec3,
 	bodyPxR int,
 	color lipgloss.Color,
 ) {
-	if samples < 16 {
-		samples = 16
-	}
-	if stride < 1 {
-		stride = 1
-	}
-	for i := 0; i < samples; i++ {
-		if i%stride != 0 {
-			continue
-		}
-		nu := 2 * math.Pi * float64(i) / float64(samples)
-		p := offset.Add(orbital.PositionAtTrueAnomaly(el, nu))
-		if c.IsBehindBody(p, bodyPos, bodyPxR) {
-			continue
-		}
-		if color == "" {
-			c.Plot(p)
-		} else {
-			c.PlotColored(p, color)
-		}
-	}
+	c.drawEllipseAdaptive(el, offset, minSamples, spacingPx, spacingPx, bodyPos, bodyPxR, color)
 }
 
 // Plot sets the pixel at the given world coord. No-op if off-canvas.
@@ -1185,6 +1170,12 @@ func (c *Canvas) PlotArrowTagged(center, velocity orbital.Vec3, size int, tag Ce
 
 // DrawEllipseDotted traces an ellipse defined by orbital elements. Dotted:
 // every `stride`th sample is plotted. stride=1 gives a solid curve.
+//
+// This and DrawEllipseOffsetDotted[Colored] keep the pre-ADR-0042 fixed-count
+// index-stride sampling and are no longer on any screen's draw path — the
+// trajectory renderers all go through the adaptive helpers above. Reach for
+// DrawEllipseOffsetFarSideDashed / DrawEllipseOffsetOccluded for anything the
+// player zooms.
 // Points are assumed to live in the system primary's inertial frame
 // (PositionAtTrueAnomaly output), which is correct for heliocentric
 // body orbits. For spacecraft orbiting a non-primary body, use

--- a/internal/tui/widgets/dense_line_test.go
+++ b/internal/tui/widgets/dense_line_test.go
@@ -100,11 +100,13 @@ func TestPlotDenseLineStepDashes(t *testing.T) {
 	}
 }
 
-// TestPlotDenseLineLongChordNotBridged: a chord longer than the canvas's
-// shorter dimension (here an on-canvas point to one far off-canvas — a
-// Hohmann transfer's off-screen apoapsis) is NOT bridged. Only the on-canvas
-// endpoint is dotted; no straight line shoots across the view (ADR 0023 C).
-func TestPlotDenseLineLongChordNotBridged(t *testing.T) {
+// TestPlotDenseLineLongChordClippedAndBridged: a chord longer than the
+// canvas (here an on-canvas point to one far off-canvas) is CLIPPED to the
+// viewport and its visible run drawn — ADR 0042 §3 replacing ADR 0023's
+// long-chord refusal, which used to drop such a pair back to endpoint dots
+// and so dissolved a zoomed-in trajectory into dust. Iteration stays bounded
+// by the canvas, not by the projected distance.
+func TestPlotDenseLineLongChordClippedAndBridged(t *testing.T) {
 	c := NewCanvas(60, 30) // pixel grid 120 × 120
 	c.SetScale(1)
 	c.Center(orbital.Vec3{})
@@ -116,12 +118,17 @@ func TestPlotDenseLineLongChordNotBridged(t *testing.T) {
 	c.PlotDenseLineColored(a, b, color, 1)
 
 	dots := taggedPixels(c, color)
-	if len(dots) != 1 {
-		t.Fatalf("long chord set %d pixels, want 1 (the on-canvas endpoint only — no shooting line)", len(dots))
-	}
 	cx, cy, _ := c.Project(a)
-	if dots[0][0] != cx || dots[0][1] != cy {
-		t.Errorf("plotted pixel %v, want the on-canvas endpoint (%d,%d)", dots[0], cx, cy)
+	if len(dots) < 50 {
+		t.Fatalf("long chord set %d pixels, want the visible run (~%d, centre→right edge)", len(dots), 120-cx)
+	}
+	for _, d := range dots {
+		if d[1] != cy {
+			t.Errorf("pixel %v off the y=%d line", d, cy)
+		}
+		if d[0] < cx || d[0] >= 120 {
+			t.Errorf("pixel %v outside the visible run [%d,119]", d, cx)
+		}
 	}
 }
 


### PR DESCRIPTION
Part of #347 (adaptive arc sampling — foundation slice).

Implements ADR 0042 §3. One sampling policy replaces the fixed-360-sample stride-dot loops, applied to every trajectory curve the map draws.

## Policy

**Flatten** (`internal/tui/widgets/arc.go`) — a curve is subdivided until each chord is straight to within half a braille pixel *once projected*. Stepping is in **eccentric anomaly**, not true anomaly: uniform ν starves the apoapsis half of an eccentric orbit, where the tangent turns 1/(1−e) times faster per radian. This is the same parameterisation `orbital.SampleConicArc` already used for ADR 0023's foreign-SOI redraw, generalised rather than duplicated. Sub-spans whose projected bounding box (endpoints + midpoint, inflated) misses the canvas are pruned in O(1), so a curve that is mostly or entirely off-screen costs almost nothing and the subdivision work lands on the visible arc.

**Ink** — each surviving chord is walked in *pixels* at a constant on-screen dot spacing, with the dash phase carried **across** chord boundaries (`walkPixelSegment` takes and returns a float phase). Arc length on screen is therefore the parameter: the cadence is zoom-invariant, and the parameter a dashed/dotted line vocabulary will need is already the one being counted. Without the carried phase a finely flattened curve inks solid, because every chord re-plots its own start pixel.

## What changed

- `PlotDenseLineColored`'s long-chord refusal (chords longer than `min(pxW,pxH)` degraded to endpoint dots) is replaced by Liang-Barsky clipping — the refusal is what turned a zoomed-in trajectory into dust. `PlotDenseLineForcedColored` survives as a name for the CommNet sightline's intent and now delegates.
- New `PlotDensePolylineColored` inks a run of samples as one phase-continuous curve. ADR 0023's gap fill, previously applied *only* to foreign-SOI encounter legs, now covers every ellipse and leg: own orbit, other vessels, ghosts, body orbits, and home-SOI node legs. Fill still stays within a segment, so an SOI transition is never bridged.
- Far-side occlusion is now a per-**pixel** cut against the body's projected disk instead of a per-sample skip, so the occlusion gap tracks the disk edge exactly however long the chords get. "Behind" gained a half-pixel floor — a coplanar orbit sat at depth ≈ 0 and float noise flipped chords between the near and far cadence at random.
- `RingDottedColored` (the SOI ring) sweeps only the angular window the canvas subtends from its centre. The old code sampled the whole circumference under a 4×(pxW+pxH) cap, so the dots fell hundreds of pixels apart at high zoom and the ring dissolved.
- The chase-cam's private `launchOrbitSamples` budget is retired — it was a second sampling policy beside the map's.
- The two count arguments on `DrawEllipseOffsetFarSideDashed` / `DrawEllipseOffsetOccluded` are reinterpreted: `minSamples` is a floor on the coarse pass, and the former stride is now **dot spacing in canvas pixels**. Call-site values are retuned (own orbit 3→2, body orbits 6→5, other vessels/ghosts 5→4, maneuver current 4→3) to hold the shipped density at the reference framing, since the old effective spacing depended on how big the ellipse happened to be.

## Tests

New `internal/tui/widgets/arc_test.go`, mostly at 80×24:
- curve stays connected at 1× / 40× / 1000× / 100000× the framing scale (row coverage);
- dot spacing is zoom-invariant, and *not* solid (cadence survives chord joins);
- spacing argument scales ink ~2:1;
- an off-canvas ellipse sets zero pixels;
- eccentric (e=0.9) apoapsis arc reads as a curve;
- `clipSegmentToCanvas` inside / crossing / half-in / two off-canvas cases;
- polyline dash-phase continuity and the single-point degenerate case;
- SOI ring keeps its spacing at radius 200 000 px, rejects a wholly off-canvas circle, and `visibleAngleWindow` bounds the sweep.

Updated: `TestPlotDenseLineLongChordNotBridged` → `...ClippedAndBridged` (it pinned the behaviour this slice deliberately replaces); `TestSubPixelGhostOrbitGated` now measures the ghost's own ink rather than a whole-frame braille delta, because body orbits now fill their visible arcs and a small ring lands on a busier backdrop. Removed `TestLaunchOrbitSamplesScalesWithProjectedSize` with the function it pinned.

`go vet ./...` and `go test ./... -race -count=1` green.

## Not in scope

Zoom memory, pan, line styles, markers, Proximity View, zoom floors, keybindings, save schema. The predictor's own sample budget is untouched (it is sim-layer state behind the predict-on-change cache) — leg samples are bridged rather than re-sampled, so the inertial-leg vs rebased-arc disconnect at an SOI boundary remains its own known issue.