### PR TITLE
feat(#346): three-class line-style vocabulary (solid/dashed/dotted)

### DIFF
--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -370,7 +370,7 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft) {
 	v.drawHorizonAndFill(body, bodyCentre)
 
 	// Current-orbit ellipse, rendered exactly as the orbit-map screens
-	// do (same DrawEllipseOffsetFarSideDashed path + apo/peri markers).
+	// do (same DrawEllipseClass Real-class path + apo/peri markers).
 	// Drawn after the body fill so the near arc paints over the disk and
 	// the far arc is depth-culled behind it; drawn before the surface
 	// markers + rocket so those layer on top. v0.14+.
@@ -613,7 +613,9 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	}
 	canvasReach := v.canvas.Cols()*2 + v.canvas.Rows()*4
 	primaryPxR := BodyPixelRadius(craft.Primary, false, scale, canvasReach)
-	v.canvas.DrawEllipseOffsetFarSideDashed(el, bodyCentre, 360, 2, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
+	// Real class, bright (ADR 0041 §2) — same treatment as the orbit map's
+	// own-craft ellipse.
+	v.canvas.DrawEllipseClass(el, bodyCentre, 360, widgets.ClassReal, bodyCentre, primaryPxR, render.ColorCurrentOrbit)
 	peri := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, 0))
 	apo := bodyCentre.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 	// Unified single-glyph apsis markers (ADR 0020) — same ▼/▲ as the

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -595,7 +595,7 @@ func TestLaunchViewRendersRCSPuffs(t *testing.T) {
 
 // The launch / landing chase-cam must draw the active craft's
 // current-orbit ellipse the same way the orbit-map screens do
-// (drawOrbitPath → DrawEllipseOffsetFarSideDashed). The view is built
+// (drawOrbitPath → DrawEllipseClass, Real class). The view is built
 // with a nil hudSource so the side chips (which echo velocity /
 // apoapsis / inclination and would differ on V alone) are suppressed —
 // the orbit ellipse on the canvas becomes the only V-dependent output

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -515,9 +515,10 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	}
 	m.canvas.FillColoredDisk(orbital.Vec3{}, primaryPxR, primaryColor)
 
-	// Current orbit. Empty colour → uses Plot for back-compat with
-	// the existing white-on-default rendering of this canvas.
-	m.canvas.DrawEllipseOffsetOccluded(currentEl, orbital.Vec3{}, 360, 3, orbital.Vec3{}, primaryPxR, "")
+	// Current orbit — Real class, solid (ADR 0041 §2). Empty colour →
+	// uses Plot for back-compat with the existing white-on-default
+	// rendering of this canvas.
+	m.canvas.DrawEllipseClass(currentEl, orbital.Vec3{}, 360, widgets.ClassReal, orbital.Vec3{}, primaryPxR, "")
 
 	// v0.9.3 polish: target craft's orbit + current position when it
 	// shares the active craft's primary. The maneuver canvas centers
@@ -530,7 +531,9 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 			tEl := orbital.ElementsFromState(tc.State.R, tc.State.V, mu)
 			tOrbitVisible := tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0)
 			if tOrbitVisible {
-				m.canvas.DrawEllipseOffsetOccluded(tEl, orbital.Vec3{}, 360, 3, orbital.Vec3{}, primaryPxR, render.ColorTarget)
+				// Still Real class — the TARGET green is a colour swap,
+				// not a different line style (ADR 0041 §2).
+				m.canvas.DrawEllipseClass(tEl, orbital.Vec3{}, 360, widgets.ClassReal, orbital.Vec3{}, primaryPxR, render.ColorTarget)
 			}
 			if !m.canvas.IsBehindBody(tc.State.R, orbital.Vec3{}, primaryPxR) {
 				m.canvas.PlotColored(tc.State.R, render.ColorTarget)
@@ -568,13 +571,30 @@ func (m *Maneuver) Render(w *sim.World, cols, rows int) string {
 	shadowPeriod := orbitalPeriodOrFallback(shadowState, shadowMu)
 	pts := planner.Predict(shadowState, shadowMu, shadowPeriod, 256)
 	primaryGap := w.BodyPosition(shadowPrimary).Sub(w.BodyPosition(c.Primary))
+	// Planned class, dashed (ADR 0041 §2): this is a predicted trajectory
+	// — the orbit the burn WOULD produce, not a real one. Previously every
+	// sample plotted its own untagged dot regardless of its neighbours,
+	// which at 256 fixed samples read as solid rather than the "plans are
+	// dashed" vocabulary calls for. Runs are broken at each occluded
+	// (behind-primary) point exactly as before, so a run never bridges a
+	// gap the body actually occludes; each surviving run gets a fresh
+	// phase-continuous dash, same as node legs.
+	var visibleRun []orbital.Vec3
+	flushShadowRun := func() {
+		if len(visibleRun) > 0 {
+			m.canvas.PlotPolylineClass(visibleRun, "", widgets.ClassPlanned)
+			visibleRun = visibleRun[:0]
+		}
+	}
 	for _, p := range pts {
 		pp := p.Add(primaryGap)
 		if m.canvas.IsBehindBody(pp, orbital.Vec3{}, primaryPxR) {
+			flushShadowRun()
 			continue
 		}
-		m.canvas.Plot(pp)
+		visibleRun = append(visibleRun, pp)
 	}
+	flushShadowRun()
 
 	// Craft cluster — skip if behind primary in the active view.
 	if !m.canvas.IsBehindBody(c.State.R, orbital.Vec3{}, primaryPxR) {

--- a/internal/tui/screens/maneuver_lineclass_test.go
+++ b/internal/tui/screens/maneuver_lineclass_test.go
@@ -1,0 +1,63 @@
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestManeuverShadowTrajectoryDrawsWithPlannedClass: the maneuver planner's
+// post-burn preview (ADR 0041 §2 — a predicted trajectory, Planned class)
+// used to plot every one of its 256 fixed samples via a raw untagged Plot
+// call, one dot per sample, with no dash/gap pattern at all. This pins the
+// call site itself: raising the planned Δv (which raises the shadow orbit,
+// separating it from the current-orbit ellipse already on the canvas) must
+// add new ink to the render — proving the Render method's shadow-
+// trajectory loop's PlotPolylineClass(..., ClassPlanned) call actually
+// fires rather than silently no-op'ing.
+// The pixel-level dash-vs-solid distinction itself (contiguous run vs
+// dash/gap cadence) is pinned directly against the primitive in
+// internal/tui/widgets/lineclass_test.go, which is a cleaner place to
+// assert exact pixel geometry than through this screen's ANSI-free
+// headless render.
+func TestManeuverShadowTrajectoryDrawsWithPlannedClass(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Landed = false
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 400e3
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+
+	m := NewManeuver(Theme{})
+	m.dvInput.SetValue("0")
+	before := countBraille(m.Render(w, 120, 40))
+
+	m.dvInput.SetValue("400") // a clear raise, separating the shadow from the current orbit
+	after := countBraille(m.Render(w, 120, 40))
+
+	if after <= before {
+		t.Errorf("raising the planned Δv added no shadow-trajectory ink (%d→%d) — Planned-class call site not firing", before, after)
+	}
+}
+
+// TestManeuverTargetOrbitStaysGreenRealClass: the maneuver canvas's target-
+// craft orbit is Real class (ADR 0041 §2) same as the active craft's — the
+// TARGET treatment is a colour swap via DrawEllipseClass(..., ClassReal,
+// ..., render.ColorTarget), not a different pattern. This is the maneuver-
+// screen sibling of TestTargetedGhostOrbitPromoted (orbit_ghost_orbit_test.go).
+func TestManeuverTargetOrbitStaysGreenRealClass(t *testing.T) {
+	w := targetMarkerWorld(t)
+	m := NewManeuver(Theme{})
+	m.Render(w, 120, 40)
+
+	if n := m.canvas.CountColor(render.ColorTarget); n == 0 {
+		t.Error("target craft's orbit inked no TARGET-colour cells on the maneuver canvas")
+	}
+}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -602,20 +602,18 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	v.canvas.SetScale(v.baseScale * v.userZoom)
 	v.canvas.Center(center)
 
-	// Dotted orbit ellipses for each body with a nonzero semimajor axis.
-	// v0.10.6+: far-side arc renders at stride*2 (visually dashed) in
-	// the dedicated dim-grey ColorBodyOrbit — KSP-aligned quiet
-	// backdrop. bodyPxR=0 skips disk occlusion; the system primary at
-	// origin doesn't meaningfully occlude body orbits at heliocentric
-	// zoom. Pre-v0.10.6 this was a flat DrawEllipseDotted with no
-	// depth read.
+	// Dotted (Scenery-class, ADR 0041 §2) orbit ellipses for each body
+	// with a nonzero semimajor axis — KSP-aligned quiet backdrop in the
+	// dedicated dim-grey ColorBodyOrbit. bodyPxR=0 skips disk occlusion;
+	// the system primary at origin doesn't meaningfully occlude body
+	// orbits at heliocentric zoom.
 	for i := range sys.Bodies {
 		b := sys.Bodies[i]
 		if b.SemimajorAxis == 0 {
 			continue
 		}
 		el := orbital.ElementsFromBody(b)
-		v.canvas.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, 5, orbital.Vec3{}, 0, render.ColorBodyOrbit)
+		v.canvas.DrawEllipseClass(el, orbital.Vec3{}, 360, widgets.ClassScenery, orbital.Vec3{}, 0, render.ColorBodyOrbit)
 	}
 
 	// Plot each body at its perceived-size disk. System primary (index 0)
@@ -913,13 +911,14 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			if orbitVisible {
 				gPrimaryPos := w.BodyPosition(gp)
 				gPxR := BodyPixelRadius(gp, false, scale, canvasReach)
+				// Real class (ADR 0041 §2): a ghost's orbit is solid dim
+				// like any other real craft's, promoted to TARGET green —
+				// same pattern, not a denser one — when targeted.
 				orbitColor := lipgloss.Color(render.ColorDim)
-				spacingPx := 4
 				if isTarget {
 					orbitColor = render.ColorTarget
-					spacingPx = 3
 				}
-				v.canvas.DrawEllipseOffsetFarSideDashed(el, gPrimaryPos, 180, spacingPx, gPrimaryPos, gPxR, orbitColor)
+				v.canvas.DrawEllipseClass(el, gPrimaryPos, 180, widgets.ClassReal, gPrimaryPos, gPxR, orbitColor)
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted
 					// ghost's own apsides, dimmed via MarkerCounterfactual
@@ -970,7 +969,9 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// same check.
 		primaryPxR := BodyPixelRadius(c.Primary, false, scale, canvasReach)
 		if orbitVisible {
-			v.canvas.DrawEllipseOffsetFarSideDashed(el, primaryPos, 360, 2, primaryPos, primaryPxR, render.ColorCurrentOrbit)
+			// Real class, bright (ADR 0041 §2): the active vessel's live
+			// orbit — solid, contiguous ink.
+			v.canvas.DrawEllipseClass(el, primaryPos, 360, widgets.ClassReal, primaryPos, primaryPxR, render.ColorCurrentOrbit)
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
 			// Unified single-glyph markers (ADR 0020): ▼ periapsis / ▲
@@ -1072,14 +1073,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				otherColor = render.ColorTarget
 			}
 			if otherOrbitVisible {
-				// Target gets denser sampling (a dot every 3 px vs
-				// every 4 for plain non-active craft) so its track
-				// reads as brighter / more prominent than peers.
-				spacingPx := 4
-				if isTarget {
-					spacingPx = 3
-				}
-				v.canvas.DrawEllipseOffsetFarSideDashed(otherEl, otherPrimaryPos, 180, spacingPx, otherPrimaryPos, otherPxR, otherColor)
+				// Real class (ADR 0041 §2): another craft's orbit is solid
+				// like the active vessel's — the TARGET promotion above is
+				// a color change, not a denser pattern.
+				v.canvas.DrawEllipseClass(otherEl, otherPrimaryPos, 180, widgets.ClassReal, otherPrimaryPos, otherPxR, otherColor)
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted
 					// craft's own apsides, dimmed via MarkerCounterfactual
@@ -1903,17 +1900,18 @@ func (v *OrbitView) plotPredictedLegs(w *sim.World, legs []predictLegDraw) {
 		}
 		for _, seg := range leg.segs {
 			// Every segment — home and foreign alike — inks as one
-			// phase-continuous polyline at a constant on-screen dot cadence
-			// (ADR 0023 C, generalised by ADR 0042 §3). The home transfer leg
-			// used to be scattered stride-2 dots on the theory that joining it
-			// up read as a stray line shooting past the encounter; that
-			// disconnect is really the inertial-leg-vs-rebased-arc gap at the
-			// SOI boundary (the leg aims at the body's FUTURE position, the
-			// encounter arc is rebased to its CURRENT one), and dotting the
-			// leg only hid it by making the leg unreadable when zoomed in.
-			// Fill stays within a segment, so an SOI transition is still never
+			// phase-continuous DASHED polyline (Planned class, ADR 0041
+			// §2): a plan's before-it-fires consequence. The home transfer
+			// leg used to be scattered stride-2 dots on the theory that
+			// joining it up read as a stray line shooting past the
+			// encounter; that disconnect is really the
+			// inertial-leg-vs-rebased-arc gap at the SOI boundary (the leg
+			// aims at the body's FUTURE position, the encounter arc is
+			// rebased to its CURRENT one), and dotting the leg only hid it
+			// by making the leg unreadable when zoomed in. Fill stays
+			// within a segment, so an SOI transition is still never
 			// bridged.
-			v.canvas.PlotDensePolylineColored(w.SegmentDrawPoints(seg, homeID), leg.color, 2)
+			v.canvas.PlotPolylineClass(w.SegmentDrawPoints(seg, homeID), leg.color, widgets.ClassPlanned)
 		}
 	}
 }
@@ -1947,11 +1945,11 @@ func (v *OrbitView) drawCommPath(w *sim.World) {
 // coasting path and the frozen burn-time replay.
 func (v *OrbitView) plotArcLine(w *sim.World, line frozenArcLine) {
 	for _, seg := range line.segs {
-		// Zoom-constant dot cadence along the connected samples (ADR 0023 C)
-		// — fill stays within a segment, so an SOI-transition boundary isn't
-		// bridged by a chord. step=2 matches the foreign-SOI leg cadence
-		// after the playtest density trim.
-		v.canvas.PlotDensePolylineColored(w.SegmentDrawPoints(seg, line.anchor), line.color, 2)
+		// Planned class (ADR 0041 §2): an encounter arc is a predicted
+		// consequence like a node leg, so it dashes the same way. Fill
+		// stays within a segment, so an SOI-transition boundary isn't
+		// bridged by a chord.
+		v.canvas.PlotPolylineClass(w.SegmentDrawPoints(seg, line.anchor), line.color, widgets.ClassPlanned)
 	}
 }
 

--- a/internal/tui/screens/orbit_ghost_orbit_test.go
+++ b/internal/tui/screens/orbit_ghost_orbit_test.go
@@ -226,27 +226,30 @@ func TestSubPixelGhostOrbitGated(t *testing.T) {
 	}
 }
 
-// Targeting a ghost promotes its ellipse to the TARGET treatment: denser
-// sampling (stride 3 vs 5), mirroring a targeted local craft. With no color in
-// the headless frame, the promotion is observed as more ellipse ink.
+// Targeting a ghost promotes its ellipse to the TARGET treatment. Pre-ADR
+// 0041 this was denser sampling (stride 3 vs 5); under the LineClass
+// vocabulary (issue #346) a ghost's orbit is Real class either way — solid
+// dim, promoted to solid TARGET green — so color, not density, is the
+// promoted signal, checked the same way TestSubPixelGhostOrbitGated checks
+// ColorDim ink: CountColor reads the per-pixel tag regardless of the
+// headless renderer's lack of ANSI.
 func TestTargetedGhostOrbitPromoted(t *testing.T) {
 	v := NewOrbitView(ghostTestTheme())
 	v.Resize(200, 60)
 
 	w, ownR, _ := leoWorld(t)
-	base := countBraille(v.Render(w, 0, 200, 60))
 	g := circularGhost(w, ownR.Norm()*1.6)
 	w.Ghosts = []sim.Ghost{g}
 
-	untarg := countBraille(v.Render(w, 0, 200, 60))
-	if untarg-base < 20 {
-		t.Fatalf("untargeted ghost drew only %d cells past baseline — no ellipse to promote", untarg-base)
+	v.Render(w, 0, 200, 60)
+	if untarg := v.canvas.CountColor(lipgloss.Color(render.ColorTarget)); untarg != 0 {
+		t.Fatalf("untargeted ghost already inked %d TARGET-colour cells", untarg)
 	}
 
 	w.SetTargetGhost(g.Owner, g.CraftID)
-	targ := countBraille(v.Render(w, 0, 200, 60))
-	if targ <= untarg {
-		t.Errorf("targeting a ghost did not densify its ellipse (%d→%d) — not promoted", untarg, targ)
+	v.Render(w, 0, 200, 60)
+	if targ := v.canvas.CountColor(lipgloss.Color(render.ColorTarget)); targ < 15 {
+		t.Errorf("targeting a ghost inked only %d TARGET-colour cells — ellipse not promoted", targ)
 	}
 }
 

--- a/internal/tui/screens/orbit_lineclass_test.go
+++ b/internal/tui/screens/orbit_lineclass_test.go
@@ -1,0 +1,52 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestOwnOrbitAndNodeLegDrawDistinctClassesInSameFrame is the call-site half
+// of ADR 0041 §2's line-style vocabulary audit: the active vessel's live
+// orbit (Real class, bright render.ColorCurrentOrbit, via DrawEllipseClass)
+// and a planted transfer's leg (Planned class, its per-leg colour, via
+// PlotPolylineClass) must both ink in the SAME render — proving the two
+// call sites are wired and don't clobber each other. The two patterns'
+// pixel-level distinctness (contiguous run vs dash/gap cadence) is pinned
+// directly in internal/tui/widgets/lineclass_test.go; this test is the
+// screens-level proof that both call sites fire together on one frame.
+//
+// Uses the Kern→Cursor transfer fixture (shared with
+// TestPredictedLegsPersistDuringActiveBurn) focused on the CRAFT rather
+// than the destination body, and zoomed out from the default craft-orbit
+// fit: at the tight default fit the leg's home-frame samples (anchored at
+// their own future clock, when Kern has moved along its own orbit — see
+// CONTEXT.md / the "inertial leg vs rebased arc" note) fall outside the
+// tiny window fit to the parking orbit alone. Zooming out is exactly what
+// a player would do to see both at once; it isn't a workaround for
+// anything this PR changed.
+func TestOwnOrbitAndNodeLegDrawDistinctClassesInSameFrame(t *testing.T) {
+	v := newSOIPassTestView()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	setupKernCursorTransfer(t, w)
+	w.ViewMode = sim.ViewTilted
+	w.Focus = sim.Focus{Kind: sim.FocusCraft}
+
+	v.Render(w, 0, 200, 60) // establishes baseScale before zooming out
+	for i := 0; i < 5; i++ {
+		v.ZoomOut()
+	}
+	v.Render(w, 0, 200, 60)
+
+	if n := v.canvas.CountColor(render.ColorCurrentOrbit); n < 5 {
+		t.Errorf("own craft's live orbit (Real class, bright) inked only %d cells alongside a planted leg", n)
+	}
+	legColor := render.ManeuverSegmentColor(0)
+	if n := v.canvas.CountColor(legColor); n < 5 {
+		t.Errorf("planted transfer leg (Planned class, dashed) inked only %d cells alongside the live orbit", n)
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -457,8 +457,12 @@ func (c *Canvas) RingColoredOutlineTagged(center orbital.Vec3, pxRadius int, tag
 
 // ringDotSpacingPx is the circumference distance (pixels) between
 // successive dots of RingDottedColored — sparse enough that the ring
-// reads as a quiet dotted boundary cue rather than solid ink.
-const ringDotSpacingPx = 4
+// reads as a quiet dotted boundary cue rather than solid ink. ADR 0041
+// §2: the SOI Ring is Scenery (dotted, faint) alongside body orbits, so
+// this shares body orbits' classSceneryNearSpacingPx cadence exactly
+// (folded from its own previously-separate value of 4) rather than a
+// second, incidentally-close number.
+const ringDotSpacingPx = classSceneryNearSpacingPx
 
 // RingDottedColored draws a dotted screen-space circle of pxRadius
 // pixels around center — the SOI Ring (ADR 0021 C). A sphere's
@@ -675,6 +679,98 @@ func (c *Canvas) PlotDensePolylineColored(pts []orbital.Vec3, color lipgloss.Col
 		phase = c.walkPixelSegment(ax, ay, bx, by, tag, step, phase, 0, 0, 0)
 		ax, ay = bx, by
 	}
+}
+
+// plotDensePolylineDashedColored is PlotDensePolylineColored's dashed
+// sibling (ADR 0041 §2 / issue #346's LineClass vocabulary): instead of a
+// single lit pixel every `step` px, it inks a contiguous run of `onPx`
+// pixels followed by a gap of `offPx` pixels, repeating — a genuine dash
+// pattern rather than sparse dots. Phase carries across the whole
+// polyline exactly like PlotDensePolylineColored, so the dash/gap cadence
+// holds across joins instead of restarting (and therefore looking solid)
+// at every sample.
+func (c *Canvas) plotDensePolylineDashedColored(pts []orbital.Vec3, color lipgloss.Color, onPx, offPx int) {
+	if len(pts) == 0 {
+		return
+	}
+	if len(pts) == 1 {
+		c.PlotColored(pts[0], color)
+		return
+	}
+	tag := CellTag{Color: color}
+	phase := 0.0
+	ax, ay := c.projectPx(pts[0])
+	for i := 1; i < len(pts); i++ {
+		bx, by := c.projectPx(pts[i])
+		phase = c.walkPixelDashSegment(ax, ay, bx, by, tag, onPx, offPx, phase)
+		ax, ay = bx, by
+	}
+}
+
+// walkPixelDashSegment is walkPixelSegment's dashed sibling: it inks every
+// integer pixel of ON-SCREEN ARC LENGTH that falls in the "on" part of a
+// repeating onPx-on / offPx-off cycle, instead of a single dot per `step`.
+// Walking pixel-by-pixel (rather than jumping straight to each mark, as
+// walkPixelSegment does) is what makes a dash a CONTIGUOUS run instead of
+// a lone point; the cost is still bounded by the canvas-clipped run
+// length, so it stays cheap. `phase` is the position within the cycle the
+// curve already occupies, carried across chords/segments the same way
+// walkPixelSegment carries its dot phase, so a dash never restarts (and
+// therefore never reads as solid) at a chord or polyline join.
+func (c *Canvas) walkPixelDashSegment(ax, ay, bx, by float64, tag CellTag, onPx, offPx int, phase float64) float64 {
+	if onPx < 1 {
+		onPx = 1
+	}
+	if offPx < 0 {
+		offPx = 0
+	}
+	cycle := float64(onPx + offPx)
+	if !(phase >= 0) { // NaN-safe
+		phase = 0
+	}
+	full := segLenPx(ax, ay, bx, by)
+	newPhase := math.Mod(phase+full, cycle)
+	cax, cay, cbx, cby, ok := clipSegmentToCanvas(ax, ay, bx, by, c.pxW, c.pxH)
+	if !ok {
+		return newPhase
+	}
+	tagged := tag != (CellTag{})
+	if tagged && c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	plotPx := func(px, py int) {
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			return
+		}
+		c.dc.Set(px, py)
+		if tagged {
+			c.pixelTags[[2]int{px, py}] = tag
+		}
+	}
+	// Length clipped off the a-end still counts toward the cycle position,
+	// matching walkPixelSegment's `lead` so the dash pattern doesn't slide
+	// when the visible run changes.
+	lead := phase + segLenPx(ax, ay, cax, cay)
+	clipLen := segLenPx(cax, cay, cbx, cby)
+	if clipLen == 0 {
+		if math.Mod(lead, cycle) < float64(onPx) {
+			plotPx(int(math.Round(cax)), int(math.Round(cay)))
+		}
+		return newPhase
+	}
+	dx, dy := cbx-cax, cby-cay
+	steps := int(math.Ceil(clipLen))
+	for s := 0; s <= steps; s++ {
+		d := float64(s)
+		if d > clipLen {
+			d = clipLen
+		}
+		if math.Mod(lead+d, cycle) < float64(onPx) {
+			f := d / clipLen
+			plotPx(int(math.Round(cax+dx*f)), int(math.Round(cay+dy*f)))
+		}
+	}
+	return newPhase
 }
 
 // walkPixelSegment inks the pixel segment (ax,ay)→(bx,by), clipped to the
@@ -1021,28 +1117,6 @@ func (c *Canvas) DrawEllipseOffsetFarSideDashed(
 		nearSpacingPx = 1
 	}
 	c.drawEllipseAdaptive(el, offset, minSamples, nearSpacingPx, nearSpacingPx*2, bodyPos, bodyPxR, color)
-}
-
-// DrawEllipseOffsetOccluded plots a dotted ellipse but cuts anything
-// IsBehindBody-occluded by the supplied (bodyPos, bodyPxR) — strict
-// occlusion with no far-side dashing, unlike
-// DrawEllipseOffsetFarSideDashed. v0.6.4+ side-view variant; writes
-// through the colour path when `color` is non-empty, otherwise plain
-// untagged pixels.
-//
-// As with its sibling, ADR 0042 §3 reinterprets the count arguments:
-// `minSamples` is a floor on the adaptive coarse pass and `spacingPx` is
-// the dot spacing in canvas pixels.
-func (c *Canvas) DrawEllipseOffsetOccluded(
-	el orbital.Elements,
-	offset orbital.Vec3,
-	minSamples int,
-	spacingPx int,
-	bodyPos orbital.Vec3,
-	bodyPxR int,
-	color lipgloss.Color,
-) {
-	c.drawEllipseAdaptive(el, offset, minSamples, spacingPx, spacingPx, bodyPos, bodyPxR, color)
 }
 
 // Plot sets the pixel at the given world coord. No-op if off-canvas.

--- a/internal/tui/widgets/lineclass.go
+++ b/internal/tui/widgets/lineclass.go
@@ -1,0 +1,113 @@
+package widgets
+
+// Line-style vocabulary (ADR 0041 §2 / issue #346, CONTEXT.md "Line
+// Class"): every trajectory the orbit map draws belongs to exactly one of
+// three learnable classes, carried entirely by ink PATTERN. Color stays a
+// separate axis — semantic (targeting, alarm state), never identity — and
+// composes with the class pattern rather than replacing it: a targeted
+// entity keeps its class's pattern and gains the TARGET green tint, and
+// the pre-existing far-side depth cue (drawEllipseAdaptive's near/far
+// spacing split) still thins the ink behind a body regardless of class.
+//
+// Before this, six orbit layers (own craft, other local craft, ghosts,
+// targeted entities, body backdrop, predicted legs) differed only by
+// color plus an ad hoc dot stride chosen per call site — no genuine dash
+// pattern existed anywhere, so "solid-ish but sparser" and "actually
+// dashed" were indistinguishable. This file is the ONE place that states
+// what solid / dashed / dotted mean, in canvas pixels.
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// LineClass is the three-way vocabulary a drawn trajectory's line STYLE
+// carries. Never used to encode identity or targeting — see the package
+// doc comment above.
+type LineClass int
+
+const (
+	// ClassReal is a live orbit: solid, contiguous ink. Bright
+	// (render.ColorCurrentOrbit) for the active vessel, dim
+	// (render.ColorDim / a craft's own Color) for any other real
+	// craft/player, including multiplayer Kepler ghosts. Promoted to
+	// render.ColorTarget — same pattern, different color — when the
+	// entity is targeted.
+	ClassReal LineClass = iota
+	// ClassPlanned is a burn's before-it-fires consequence: dashed.
+	// Node legs, predicted trajectories (including the maneuver
+	// planner's post-burn shadow), and SOI-pass encounter arcs.
+	ClassPlanned
+	// ClassScenery is backdrop: dotted, faint. Body orbits and the SOI
+	// Ring — never the thing the player is flying or planning around.
+	ClassScenery
+)
+
+// Ink-pattern pixel constants. Real's near-side spacing of 1 is genuinely
+// contiguous ink ("solid") — before this fold, the own-craft orbit drew at
+// a 2px stride and other craft/ghosts at 3-4px, dense enough to read as a
+// line but not actually solid, which is exactly why two Real lines at
+// different call sites looked like different KINDS instead of the same
+// kind at different brightness (ADR 0041's "whose line is whose"
+// diagnosis). Real's far side keeps the pre-existing depth-cue halving
+// (see drawEllipseAdaptive's doc comment) so the "passes behind the body"
+// read survives the fold into one class.
+//
+// Scenery's spacing is carried over verbatim from the body-orbit call
+// site, which already matched "dotted, faint" before this PR — folded
+// here so the SOI Ring (previously its own ringDotSpacingPx = 4) shares
+// the identical cadence instead of an incidentally-close second number.
+//
+// Planned's dash/gap replaces the sparse single-pixel-per-N-px dotting
+// every "dashed" call site actually used (ADR 0041's measured fact: "no
+// dash patterns exist"). The on:off ratio keeps a similar overall ink
+// density to the old default so overall clutter is unchanged, but the
+// pattern is now a literal dash run rather than one lit pixel in N.
+const (
+	classRealNearSpacingPx = 1
+	classRealFarSpacingPx  = 2
+
+	classSceneryNearSpacingPx = 5
+	classSceneryFarSpacingPx  = 10
+
+	classPlannedDashPx = 3
+	classPlannedGapPx  = 2
+)
+
+// DrawEllipseClass draws an offset ellipse at the LineClass's ink pattern,
+// through the same adaptive flattening + near/far body-occlusion split
+// DrawEllipseOffsetFarSideDashed established — the class only chooses the
+// two spacings, never the flattening or occlusion behaviour.
+//
+// class must be ClassReal or ClassScenery: every ellipse call site in this
+// codebase is a real orbit or a body/scenery orbit. Planned trajectories
+// are legs and arcs, not single ellipses — see PlotPolylineClass. Passing
+// ClassPlanned here draws with Real's spacing (documented fallback, not a
+// panic, since a caller passing it is a mistake to fix, not a state worth
+// crashing the render loop over).
+func (c *Canvas) DrawEllipseClass(el orbital.Elements, offset orbital.Vec3, minSpans int, class LineClass, bodyPos orbital.Vec3, bodyPxR int, color lipgloss.Color) {
+	near, far := classRealNearSpacingPx, classRealFarSpacingPx
+	if class == ClassScenery {
+		near, far = classSceneryNearSpacingPx, classSceneryFarSpacingPx
+	}
+	c.drawEllipseAdaptive(el, offset, minSpans, near, far, bodyPos, bodyPxR, color)
+}
+
+// PlotPolylineClass draws a run of world points as one connected curve at
+// the LineClass's ink pattern — the polyline sibling of DrawEllipseClass,
+// for trajectories that aren't a single ellipse: node legs, predicted
+// legs, encounter arcs, and the maneuver planner's post-burn shadow. Dash
+// phase carries across points exactly like PlotDensePolylineColored (and,
+// for ClassPlanned, across separate calls sharing the same curve is NOT
+// supported — each call restarts its own phase at 0, matching how every
+// current Planned call site already draws one call per connected run).
+func (c *Canvas) PlotPolylineClass(pts []orbital.Vec3, color lipgloss.Color, class LineClass) {
+	switch class {
+	case ClassPlanned:
+		c.plotDensePolylineDashedColored(pts, color, classPlannedDashPx, classPlannedGapPx)
+	case ClassScenery:
+		c.PlotDensePolylineColored(pts, color, classSceneryNearSpacingPx)
+	default: // ClassReal
+		c.PlotDensePolylineColored(pts, color, classRealNearSpacingPx)
+	}
+}

--- a/internal/tui/widgets/lineclass_test.go
+++ b/internal/tui/widgets/lineclass_test.go
@@ -1,0 +1,225 @@
+package widgets
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// runsAndGaps takes the x-coordinates of tagged pixels along a single
+// horizontal row (sorted ascending, no duplicates) and returns the length of
+// each contiguous run of set pixels and each gap between runs — the shape a
+// dash pattern (contiguous "on" pixels separated by "off" pixels) leaves
+// behind, as opposed to dotted's isolated single-pixel runs or solid's one
+// single run covering everything.
+func runsAndGaps(xs []int) (runs, gaps []int) {
+	if len(xs) == 0 {
+		return nil, nil
+	}
+	xs = append([]int(nil), xs...)
+	sort.Ints(xs)
+	runStart := xs[0]
+	prev := xs[0]
+	for i := 1; i < len(xs); i++ {
+		if xs[i] == prev+1 {
+			prev = xs[i]
+			continue
+		}
+		runs = append(runs, prev-runStart+1)
+		gaps = append(gaps, xs[i]-prev-1)
+		runStart = xs[i]
+		prev = xs[i]
+	}
+	runs = append(runs, prev-runStart+1)
+	return runs, gaps
+}
+
+// classChordXs draws a long horizontal world-space chord through a class's
+// polyline path and returns the tagged x-coordinates on the row it lands on
+// — the fixture every pattern-per-class test below measures.
+func classChordXs(t *testing.T, class LineClass, scale float64) (xs []int, row int) {
+	t.Helper()
+	color := lipgloss.Color("#33AAFF")
+	c := NewCanvas(200, 60) // 400 x 240 px
+	c.SetScale(scale)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+	half := 150.0 / scale
+	c.PlotPolylineClass([]orbital.Vec3{{X: -half}, {X: half}}, color, class)
+	px := taggedPixels(c, color)
+	if len(px) == 0 {
+		t.Fatalf("class %d chord inked nothing at scale %v", class, scale)
+	}
+	row = px[0][1]
+	for _, p := range px {
+		if p[1] != row {
+			t.Fatalf("chord ink spans more than one row (%d and %d) — not a straight horizontal test chord", row, p[1])
+		}
+		xs = append(xs, p[0])
+	}
+	return xs, row
+}
+
+// TestClassRealIsContiguous: ClassReal (a live orbit — "SOLID bright" /
+// "SOLID dim") inks every pixel along its run, i.e. exactly one run with no
+// internal gaps — the "contiguous pixel run" ADR 0041 §2 describes.
+func TestClassRealIsContiguous(t *testing.T) {
+	xs, _ := classChordXs(t, ClassReal, 1)
+	runs, gaps := runsAndGaps(xs)
+	if len(runs) != 1 {
+		t.Fatalf("ClassReal chord has %d runs (%v) with gaps %v — want one contiguous run", len(runs), runs, gaps)
+	}
+	if want := len(xs); runs[0] != want {
+		t.Errorf("ClassReal run length %d, want %d (every pixel of the chord)", runs[0], want)
+	}
+}
+
+// TestClassPlannedHasDashPattern: ClassPlanned (a plan's before-it-fires
+// consequence — node legs, predictions, encounter arcs) inks a genuine dash:
+// repeated runs of classPlannedDashPx pixels separated by gaps of
+// classPlannedGapPx pixels. This is the pattern that didn't exist anywhere
+// in the codebase before ADR 0041 — every "dashed" call site was really
+// sparse single-pixel dotting.
+func TestClassPlannedHasDashPattern(t *testing.T) {
+	xs, _ := classChordXs(t, ClassPlanned, 1)
+	runs, gaps := runsAndGaps(xs)
+	if len(runs) < 5 {
+		t.Fatalf("ClassPlanned chord has only %d runs — want a repeated dash pattern", len(runs))
+	}
+	// Endpoints can clip a run short; check the interior only.
+	for i := 1; i < len(runs)-1; i++ {
+		if runs[i] != classPlannedDashPx {
+			t.Errorf("dash run %d has length %d, want %d", i, runs[i], classPlannedDashPx)
+		}
+	}
+	for i, g := range gaps {
+		if g != classPlannedGapPx {
+			t.Errorf("gap %d has length %d, want %d", i, g, classPlannedGapPx)
+		}
+	}
+}
+
+// TestClassSceneryIsSparseDots: ClassScenery (backdrop — body orbits, the
+// SOI Ring) inks isolated single-pixel dots, sparser than a dash: every run
+// has length 1, separated by classSceneryNearSpacingPx-1 px gaps.
+func TestClassSceneryIsSparseDots(t *testing.T) {
+	xs, _ := classChordXs(t, ClassScenery, 1)
+	runs, gaps := runsAndGaps(xs)
+	if len(runs) < 5 {
+		t.Fatalf("ClassScenery chord has only %d runs — want repeated sparse dots", len(runs))
+	}
+	for i, r := range runs {
+		if r != 1 {
+			t.Errorf("scenery run %d has length %d, want 1 (a lone dot)", i, r)
+		}
+	}
+	wantGap := classSceneryNearSpacingPx - 1
+	for i, g := range gaps {
+		if g != wantGap {
+			t.Errorf("scenery gap %d has length %d, want %d", i, g, wantGap)
+		}
+	}
+}
+
+// TestClassInkDensityOrdering: the three classes' ink density over an
+// identical chord orders SOLID > DASHED > DOTTED — the class vocabulary's
+// whole premise is that this ordering is learnable at a glance regardless of
+// color.
+func TestClassInkDensityOrdering(t *testing.T) {
+	real, _ := classChordXs(t, ClassReal, 1)
+	planned, _ := classChordXs(t, ClassPlanned, 1)
+	scenery, _ := classChordXs(t, ClassScenery, 1)
+	if !(len(real) > len(planned) && len(planned) > len(scenery)) {
+		t.Errorf("ink counts real=%d planned=%d scenery=%d — want real > planned > scenery",
+			len(real), len(planned), len(scenery))
+	}
+}
+
+// TestDashCadenceZoomInvariant: the dash on/off run lengths are a canvas-
+// pixel quantity, not a world-space or sample-index one, so the same class
+// chord dashes identically at 1x, 40x and 1000x zoom (mirroring
+// TestEllipseDotSpacingIsZoomInvariant for the new dash pattern).
+func TestDashCadenceZoomInvariant(t *testing.T) {
+	for _, scale := range []float64{1, 40, 1000} {
+		xs, _ := classChordXs(t, ClassPlanned, scale)
+		runs, gaps := runsAndGaps(xs)
+		if len(runs) < 5 {
+			t.Fatalf("scale %v: only %d dash runs — cadence not holding at this zoom", scale, len(runs))
+		}
+		for i := 1; i < len(runs)-1; i++ {
+			if runs[i] != classPlannedDashPx {
+				t.Errorf("scale %v: dash run %d has length %d, want %d", scale, i, runs[i], classPlannedDashPx)
+			}
+		}
+		for i, g := range gaps {
+			if g != classPlannedGapPx {
+				t.Errorf("scale %v: gap %d has length %d, want %d", scale, i, g, classPlannedGapPx)
+			}
+		}
+	}
+}
+
+// TestPlotPolylineClassCarriesPhaseAcrossPoints: a many-point polyline (the
+// realistic shape of a node leg or encounter arc, sampled at sub-dash
+// spacing) must still show the dash cadence rather than restarting the
+// on/off cycle — and therefore reading solid — at every sample, mirroring
+// TestPlotDensePolylineCarriesDashPhase for the new dash primitive.
+func TestPlotPolylineClassCarriesPhaseAcrossPoints(t *testing.T) {
+	color := lipgloss.Color("#33AAFF")
+	c := NewCanvas(60, 30) // 120 x 120 px
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	c.Clear()
+
+	pts := make([]orbital.Vec3, 0, 81)
+	for i := -40; i <= 40; i++ {
+		pts = append(pts, orbital.Vec3{X: float64(i)})
+	}
+	c.PlotPolylineClass(pts, color, ClassPlanned)
+
+	xs := []int{}
+	for _, p := range taggedPixels(c, color) {
+		xs = append(xs, p[0])
+	}
+	runs, _ := runsAndGaps(xs)
+	if len(runs) < 5 {
+		t.Fatalf("only %d dash runs over an 81-sample polyline — phase not carrying across points", len(runs))
+	}
+	for i := 1; i < len(runs)-1; i++ {
+		if runs[i] != classPlannedDashPx {
+			t.Errorf("dash run %d has length %d, want %d — a per-sample phase restart would read solid", i, runs[i], classPlannedDashPx)
+		}
+	}
+}
+
+// TestDrawEllipseClassRealMatchesFarSideDashedAtSpacingOne: DrawEllipseClass
+// is a thin dispatcher over the already-tested drawEllipseAdaptive engine —
+// this pins the dispatch itself: ClassReal must draw identically to calling
+// DrawEllipseOffsetFarSideDashed at the documented Real near-spacing (1px,
+// genuinely contiguous), not merely "close to it."
+func TestDrawEllipseClassRealMatchesFarSideDashedAtSpacingOne(t *testing.T) {
+	el := orbital.Elements{A: 5e6, E: 0.2}
+	color := lipgloss.Color("#33AAFF")
+
+	viaClass := NewCanvas(80, 24)
+	viaClass.FitTo(el.A * 1.3)
+	viaClass.Clear()
+	viaClass.DrawEllipseClass(el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, color)
+
+	viaSpacing := NewCanvas(80, 24)
+	viaSpacing.FitTo(el.A * 1.3)
+	viaSpacing.Clear()
+	viaSpacing.DrawEllipseOffsetFarSideDashed(el, orbital.Vec3{}, 360, classRealNearSpacingPx, orbital.Vec3{}, 0, color)
+
+	a, b := taggedPixels(viaClass, color), taggedPixels(viaSpacing, color)
+	if len(a) == 0 || len(b) == 0 {
+		t.Fatalf("no ink drawn: DrawEllipseClass=%d DrawEllipseOffsetFarSideDashed=%d", len(a), len(b))
+	}
+	if len(a) != len(b) {
+		t.Errorf("DrawEllipseClass(ClassReal) inked %d pixels, DrawEllipseOffsetFarSideDashed(spacing=%d) inked %d — dispatch drifted from its documented mapping",
+			len(a), classRealNearSpacingPx, len(b))
+	}
+}


### PR DESCRIPTION
Part of #346 (section 2 — line classes). Inspect (§3) follows separately.

## What

Implements ADR 0041 §2's line-style vocabulary: three learnable classes,
carried entirely by ink pattern (color stays semantic — targeting/state —
and never identity).

    SOLID bright   ────────  your live orbit               (ClassReal)
    SOLID dim      ────────  any other real craft/ghost     (ClassReal)
    DASHED         ─ ─ ─ ─   plans: legs / predictions / arcs (ClassPlanned)
    DOTTED faint   · · · ·   scenery: body orbits, SOI ring   (ClassScenery)
    GREEN stays    (same pattern) whatever's targeted — color swap only

## Where it lives

`internal/tui/widgets/lineclass.go` is the one place stating what each
class means in canvas pixels:

| Class | Ellipse (near/far spacing) | Polyline (on/off) |
|---|---|---|
| `ClassReal` | 1px / 2px | 1px dot every 1px (contiguous) |
| `ClassScenery` | 5px / 10px | 1px dot every 5px |
| `ClassPlanned` | (falls back to Real; no ellipse call site needs it) | 3px on / 2px off |

`DrawEllipseClass` dispatches to the existing (`#352`) adaptive
near/far-spacing engine (`drawEllipseAdaptive`) for Real/Scenery.
`PlotPolylineClass` dispatches to `PlotDensePolylineColored` for
Real/Scenery and a **new** `walkPixelDashSegment` (canvas.go) for Planned —
the genuinely new piece, since no dash-run primitive existed before this
(every "dashed" call site was really sparse single-pixel dotting; see
ADR 0041's "measured code facts").

## Call sites (audited every one)

| Call site | File | Class |
|---|---|---|
| Own craft live orbit | orbit.go | Real, bright |
| Other local craft orbit | orbit.go | Real, dim/target-green |
| Multiplayer Kepler ghost orbit | orbit.go | Real, dim/target-green |
| Body orbits | orbit.go | Scenery |
| SOI Ring | orbit.go (`RingDottedColored`) | Scenery (shares the spacing constant) |
| Node legs | orbit.go (`plotPredictedLegs`) | Planned |
| SOI-pass encounter arc | orbit.go (`plotArcLine`) | Planned |
| Maneuver planner current + target orbit | maneuver.go | Real |
| Maneuver planner shadow (post-burn preview) | maneuver.go | Planned |
| Launch/landing chase-cam current orbit | launch.go | Real, bright |
| CommNet relay sightline | orbit.go (`drawCommPath`) | **not a class** — a comms line, not a trajectory; left untouched |

## Deviations (value changes, called out per the task's quality bar)

- **Own-craft near spacing 2px → 1px, other-craft/ghost 3-4px → 1px.**
  Both are `ClassReal`; the vocabulary's whole point is that TARGET
  promotion is a color change, not a denser pattern, so these fold to the
  same genuinely-contiguous spacing. `TestTargetedGhostOrbitPromoted` was
  rewritten to check the TARGET color tag (`CountColor`) instead of ink
  density, since density is no longer the promoted signal.
- **SOI Ring spacing 4px → 5px** (`ringDotSpacingPx` now equals
  `classSceneryNearSpacingPx`), so the Ring and body orbits — both
  Scenery — share one number instead of two incidentally-close ones.
- **Node legs / encounter arc: sparse dot-every-2px → genuine 3px-on/2px-off
  dash.** This is the vocabulary's core deliverable (ADR 0041: "no dash
  patterns exist" before this PR).
- **Maneuver planner's shadow trajectory: raw per-sample `Plot()` (256
  discrete dots, no color, no dash) → `PlotPolylineClass(..., ClassPlanned)`
  runs.** This was the one call site that predates the `PlotDensePolyline*`
  architecture entirely; converted to connected dashed runs, broken at each
  occluded (behind-primary) point exactly like before so a run never
  bridges a body-occlusion gap. Still uncolored (`""`) — no palette change.
- **`DrawEllipseOffsetOccluded` retired.** Its only two callers
  (maneuver.go's current + target orbit) now go through `DrawEllipseClass`,
  which gives them the same Real-class near/far depth cue the orbit map's
  craft orbits already have (previously maneuver.go used a stricter,
  no-depth-cue variant — an inconsistency the class fold naturally
  resolves). `DrawEllipseOffsetFarSideDashed` stays: it's the tested
  low-level engine `DrawEllipseClass` calls internally, and `arc_test.go` /
  `canvas_test.go` exercise it directly at explicit spacings.

## Tests

- `internal/tui/widgets/lineclass_test.go` (new): pattern-per-class
  (`TestClassRealIsContiguous`, `TestClassPlannedHasDashPattern`,
  `TestClassSceneryIsSparseDots`), density ordering
  (`TestClassInkDensityOrdering`), zoom invariance of the dash cadence at
  1×/40×/1000× (`TestDashCadenceZoomInvariant`), phase-carry across a
  many-point polyline (`TestPlotPolylineClassCarriesPhaseAcrossPoints`),
  and a pin that `DrawEllipseClass(ClassReal)` matches
  `DrawEllipseOffsetFarSideDashed` at the documented spacing exactly.
- `internal/tui/screens/orbit_lineclass_test.go` (new): own orbit (Real)
  and a planted transfer leg (Planned) both ink in the same frame.
- `internal/tui/screens/maneuver_lineclass_test.go` (new): the shadow
  trajectory's Planned-class call site fires; the maneuver canvas's
  target orbit stays Real class with the TARGET color.
- `internal/tui/screens/orbit_ghost_orbit_test.go`: `TestTargetedGhostOrbitPromoted`
  rewritten (see deviations above) — same intent, different signal.

Tested at 80×24 (via the existing `zoomedCanvas`/`NewCanvas(80,24)`
fixtures already in `arc_test.go`) as well as larger sizes.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./... -race -count=1` green (full suite)
- `gofmt -l` clean on every file this PR touches

## Out of scope

Inspect / hit-testing / name chips (§3, next slice), markers/glyphs,
camera work, Proximity View, keybindings, save schema — untouched.