### PR TITLE
feat(#348): descent half of the surface view — impact point, corridor instruments, arc to ground

### DIFF
--- a/internal/render/markers.go
+++ b/internal/render/markers.go
@@ -18,6 +18,12 @@ const (
 	MarkerManeuver // per-node colour exception — see MarkerColor
 	MarkerSOIEntry // SOI Pass arc crosses INTO the pass Body's SOI Ring (ADR 0021 C)
 	MarkerSOIExit  // SOI Pass arc crosses back OUT of the SOI Ring
+	// MarkerImpact is where the live trajectory meets the ground — the
+	// surface view's descent half (ADR 0043 §3 / issue #348). Distinct
+	// from MarkerPeriapsis: a periapsis is the low point of a conic that
+	// may never touch the surface, this is an actual contact point, and
+	// it moves live as a burn reshapes the trajectory.
+	MarkerImpact
 )
 
 // MarkerState modifies a marker's brightness/variant to convey what is
@@ -64,6 +70,8 @@ func MarkerGlyph(t MarkerType) rune {
 		return '▷'
 	case MarkerSOIExit:
 		return '◁'
+	case MarkerImpact:
+		return '⊗'
 	}
 	return '?'
 }
@@ -107,6 +115,8 @@ func markerTypeColor(t MarkerType, base lipgloss.Color) lipgloss.Color {
 		return ColorMarkerSOIEntry
 	case MarkerSOIExit:
 		return ColorMarkerSOIExit
+	case MarkerImpact:
+		return ColorMarkerImpact
 	case MarkerManeuver:
 		// Documented exception (ADR 0020): the maneuver marker's colour is
 		// the post-burn leg colour passed by the caller, not a fixed type

--- a/internal/render/markers_test.go
+++ b/internal/render/markers_test.go
@@ -20,6 +20,7 @@ func TestMarkerGlyph(t *testing.T) {
 		{MarkerManeuver, 'Δ'},
 		{MarkerSOIEntry, '▷'},
 		{MarkerSOIExit, '◁'},
+		{MarkerImpact, '⊗'},
 	}
 	for _, c := range cases {
 		if got := MarkerGlyph(c.t); got != c.want {
@@ -45,6 +46,7 @@ func TestMarkerColorByType(t *testing.T) {
 		{MarkerClosestApproach, ColorMarkerClosestApproach},
 		{MarkerSOIEntry, ColorMarkerSOIEntry},
 		{MarkerSOIExit, ColorMarkerSOIExit},
+		{MarkerImpact, ColorMarkerImpact},
 	}
 	for _, c := range cases {
 		if got := MarkerColor(c.t, MarkerNominal, ""); got != c.want {

--- a/internal/render/palette.go
+++ b/internal/render/palette.go
@@ -71,6 +71,7 @@ var (
 	ColorMarkerClosestApproach = lipgloss.Color("#FF5FAF") // hot pink — craft-to-craft closest approach ✕
 	ColorMarkerSOIEntry        = ColorForeignSOI           // orchid — SOI entry ▷ (shares the foreign-SOI arc hue it brackets, like Perilune shares the apsis amber)
 	ColorMarkerSOIExit         = ColorForeignSOI           // orchid — SOI exit ◁
+	ColorMarkerImpact          = lipgloss.Color("#FF8700") // orange — ground-contact point ⊗ (hotter than the apsis amber it sits near, cooler than the alert red MarkerAlarm promotes it to)
 )
 
 // maneuverSegmentPalette cycles through distinct colors per planted

--- a/internal/sim/descent.go
+++ b/internal/sim/descent.go
@@ -1,0 +1,373 @@
+// Package sim — the descent half of the surface view (issue #348 §3,
+// ADR 0043). Two pure forecasts the launch/surface screen renders:
+// where the current trajectory meets the ground (PredictImpact) and
+// whether the stack can still stop before it gets there
+// (DescentCorridorFor / ComputeBurnMargin).
+//
+// The forecast reuses the predictor's ONE propagator — predictStep,
+// analytic Kepler where the arc is Kepler-eligible and drag-aware Verlet
+// everywhere else — so the drawn descent arc agrees with the orbit map's
+// dashed trajectory AND with the craft's actual flight. No second
+// propagator lives here (the #66 two-drift-sites lesson: when the same
+// curve is integrated at two sites they drift apart and only one of them
+// gets fixed).
+//
+// Both forecasts are ballistic-from-now: they propagate the CURRENT
+// state without assuming any future thrust, exactly like the orbit map's
+// projected orbit. That is what makes the impact marker live under a
+// burn — every tick the burn reshapes the state, and the next frame's
+// forecast is taken from the reshaped state, so the marker slides along
+// the ground as the player thrusts.
+
+package sim
+
+import (
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+const (
+	// DescentPredictHorizon is how far ahead the surface view looks for
+	// ground contact. Past it the forecast reports "no impact" and the
+	// corridor instruments stand down — a craft whose trajectory clears
+	// the surface for the next half hour is not on a descent, whatever
+	// its instantaneous radial rate says (the routine case: an eccentric
+	// parking orbit falling toward periapsis).
+	DescentPredictHorizon = 30 * time.Minute
+
+	// impactSubStepCap bounds the forecast's integrator sub-step in
+	// seconds. predictMaxSubStep alone (period/100, capped at 120 s) is
+	// far too coarse near the ground: an impacting arc is never
+	// Kepler-eligible (canKeplerStepState rejects a sub-surface
+	// periapsis), so every step is Verlet, and a 120 s Verlet step at
+	// descent speeds walks kilometres between surface tests. 2 s keeps a
+	// full-horizon forecast under ~1000 steps — cheap enough to redo
+	// every frame, which is what "live under thrust" requires.
+	impactSubStepCap = 2.0
+
+	// impactMaxSubSteps caps total integrator work per forecast so a
+	// degenerate state (tiny period → tiny sub-step) can't stall the
+	// render loop. Hitting the cap coarsens dt rather than truncating
+	// the horizon, so the forecast still spans DescentPredictHorizon.
+	impactMaxSubSteps = 1024
+
+	// impactPathSamples is the target number of points on the drawn arc.
+	// The arc is inked as a dashed polyline (ClassPlanned), which
+	// interpolates between points, so this only has to be dense enough
+	// that the curve doesn't facet — not one point per pixel.
+	impactPathSamples = 180
+
+	// surfaceRefineIters / surfaceRefineEpsilon bisect the contact time
+	// inside the sub-step that detected it, the same trick
+	// refineCrossingTime uses on an SOI crossing. Without it the impact
+	// point quantizes to wherever a 2 s step happened to land — tens to
+	// hundreds of metres of marker jitter frame to frame.
+	surfaceRefineIters   = 40
+	surfaceRefineEpsilon = 1e-3
+)
+
+// ImpactPrediction is the ballistic-from-now ground-contact forecast:
+// where the current trajectory meets the primary's surface, when, and
+// how fast. Positions are PRIMARY-RELATIVE (body at the origin), the
+// same frame the surface view's canvas draws in and the same frame
+// craft.State.R lives in.
+type ImpactPrediction struct {
+	// Point is the contact position, projected exactly onto the
+	// primary's mean radius so the marker lands on the drawn ground
+	// line rather than a metre under it.
+	Point orbital.Vec3
+	// Path is the sampled trajectory from the craft's current position
+	// (Path[0]) to Point (the last element) — the raw material for the
+	// dashed arc to ground.
+	Path []orbital.Vec3
+	// TimeToImpact is the flight time from now to contact.
+	TimeToImpact time.Duration
+	// SpeedMps is the SURFACE-relative speed at contact (v − ω×r via
+	// physics.AirRelativeVelocity — the same quantity the surface-arrival
+	// classifier and the chute gate measure), not the inertial speed.
+	SpeedMps float64
+}
+
+// PredictImpact forward-propagates the craft's current state until it
+// meets the primary's surface, returning ok=false when the trajectory
+// clears the ground for the whole horizon (or the inputs are
+// degenerate). Thrust is deliberately NOT modelled: the forecast answers
+// "where do I land if I stop flying now", which is the question a
+// descent instrument exists to answer, and it re-derives from the live
+// state every frame so an active burn visibly walks the answer.
+func PredictImpact(c *spacecraft.Spacecraft, horizon time.Duration) (ImpactPrediction, bool) {
+	if c == nil {
+		return ImpactPrediction{}, false
+	}
+	primary := c.Primary
+	radius := primary.RadiusMeters()
+	mu := primary.GravitationalParameter()
+	total := horizon.Seconds()
+	if radius <= 0 || mu <= 0 || total <= 0 {
+		return ImpactPrediction{}, false
+	}
+	state := c.State
+	if r := state.R.Norm(); r <= radius || math.IsNaN(r) {
+		return ImpactPrediction{}, false
+	}
+	bc := c.EffectiveBallisticCoefficient()
+
+	dt := predictMaxSubStep(orbitalPeriod(state, mu))
+	if dt > impactSubStepCap {
+		dt = impactSubStepCap
+	}
+	steps := int(math.Ceil(total / dt))
+	if steps > impactMaxSubSteps {
+		steps = impactMaxSubSteps
+		dt = total / float64(steps)
+	}
+	if steps < 1 {
+		return ImpactPrediction{}, false
+	}
+	sampleEvery := steps / impactPathSamples
+	if sampleEvery < 1 {
+		sampleEvery = 1
+	}
+
+	path := make([]orbital.Vec3, 0, impactPathSamples+2)
+	path = append(path, state.R)
+	elapsed := 0.0
+	for i := 0; i < steps; i++ {
+		pre := state
+		state = predictStep(state, mu, dt, primary, bc)
+		if state.R.Norm() < radius {
+			hit, tau := refineSurfaceCrossing(pre, mu, dt, primary, bc, radius)
+			elapsed += tau
+			point := hit.R
+			if n := point.Norm(); n > 0 {
+				point = point.Scale(radius / n)
+			}
+			path = append(path, point)
+			return ImpactPrediction{
+				Point:        point,
+				Path:         path,
+				TimeToImpact: time.Duration(elapsed * float64(time.Second)),
+				SpeedMps:     physics.AirRelativeVelocity(hit.R, hit.V, primary).Norm(),
+			}, true
+		}
+		elapsed += dt
+		if (i+1)%sampleEvery == 0 {
+			path = append(path, state.R)
+		}
+	}
+	return ImpactPrediction{}, false
+}
+
+// refineSurfaceCrossing bisects surface contact inside (0, dt]: pre is
+// the state at the start of the detecting sub-step (known above the
+// surface) and propagating it by dt is known to land below. Returns the
+// state at the earliest detected contact and the offset tau ∈ (0, dt]
+// that produced it. Each probe re-integrates from pre by the trial
+// offset — one propagator call, never a partial re-walk — so the refined
+// state is on the same curve the sub-step loop drew.
+func refineSurfaceCrossing(pre physics.StateVector, mu, dt float64, primary bodies.CelestialBody, bc, radius float64) (physics.StateVector, float64) {
+	lo, hi := 0.0, dt
+	state := predictStep(pre, mu, hi, primary, bc)
+	for i := 0; i < surfaceRefineIters && hi-lo > surfaceRefineEpsilon; i++ {
+		mid := (lo + hi) / 2
+		s := predictStep(pre, mu, mid, primary, bc)
+		if s.R.Norm() < radius {
+			hi, state = mid, s
+		} else {
+			lo = mid
+		}
+	}
+	return state, hi
+}
+
+// MarginState is the burn-margin alarm ladder. The surface view renders
+// it as a label AND a colour swap on the MARGIN row, never as a subtle
+// shade alone — a silent state reads as broken.
+type MarginState int
+
+const (
+	// MarginNone means the margin is undefined for this state (not
+	// descending, on the ground, no mass). Rendered as an em dash.
+	MarginNone MarginState = iota
+	// MarginOK: comfortably more stopping capability than needed.
+	MarginOK
+	// MarginTight: enough to stop, but with little to spare — the
+	// suicide-burn window is closing.
+	MarginTight
+	// MarginInsufficient: the stack CANNOT null this descent rate in the
+	// altitude left. The alarm state.
+	MarginInsufficient
+)
+
+// marginTightBelow is the ratio under which a survivable margin still
+// warrants a warning. 1.5× is one and a half times the deceleration the
+// stop needs — below that, a few seconds of hesitation (or the mass the
+// burn itself has yet to shed) eats the whole reserve.
+const marginTightBelow = 1.5
+
+// MarginLimiter names which of the two capabilities binds the margin:
+// the thrust available to decelerate, or the propellant left to spend on
+// it. Reported so the alarm says what to fix, not just that something is
+// wrong.
+type MarginLimiter int
+
+const (
+	LimitNone MarginLimiter = iota
+	LimitThrust
+	LimitFuel
+)
+
+func (l MarginLimiter) String() string {
+	switch l {
+	case LimitThrust:
+		return "thrust"
+	case LimitFuel:
+		return "fuel"
+	}
+	return ""
+}
+
+// BurnMargin answers the descent question "can the remaining thrust kill
+// this velocity in the altitude left", as a ratio of capability to
+// requirement (≥ 1 means yes).
+//
+// Two independent capabilities have to hold, so the reported Ratio is
+// the smaller of the two and Limiter says which one bound it:
+//
+//   - Acceleration. Nulling a descent rate v within altitude h needs a
+//     net deceleration of at least v²/2h. The stack's net deceleration
+//     at full thrust is a_net = F/m − g_local (gravity keeps pulling
+//     through the burn), so the acceleration ratio is a_net / (v²/2h).
+//     A stack that can't out-thrust local gravity (a_net ≤ 0) has ratio
+//     0 — it cannot stop at any altitude.
+//   - Propellant. The stop takes t = v/a_net seconds at full thrust, and
+//     the engine spends Δv at F/m per second the whole time, so it costs
+//     v·(F/m)/a_net m/s of the budget — strictly more than v, because
+//     part of every second is spent holding the vehicle up. The
+//     propellant ratio is RemainingDeltaV over that.
+//
+// Both are the idealised constant-mass, straight-down bound: no attitude
+// error, no throttle ramp, no mass shed mid-burn. That is deliberate —
+// an instrument that flatters the pilot is worse than none, and this one
+// errs optimistic only in the mass term (a real burn gets lighter, so a
+// little easier), which the TIGHT band exists to cover.
+type BurnMargin struct {
+	Ratio        float64
+	State        MarginState
+	Limiter      MarginLimiter
+	NetAccelMps2 float64 // F/m − g_local, the deceleration actually available
+	ReqAccelMps2 float64 // v²/2h, the deceleration the stop requires
+	ReqDVMps     float64 // the stop burn's Δv cost (+Inf when it can't be flown)
+	AvailDVMps   float64 // the stack's remaining Δv
+}
+
+// ComputeBurnMargin evaluates the margin from SI scalars. Pure, so the
+// arithmetic can be pinned exactly by tests without seeding a World.
+func ComputeBurnMargin(thrustN, massKg, gLocalMps2, descentRateMps, altitudeM, availDVMps float64) BurnMargin {
+	if massKg <= 0 || altitudeM <= 0 || descentRateMps <= 0 {
+		return BurnMargin{AvailDVMps: availDVMps}
+	}
+	aAvail := thrustN / massKg
+	aNet := aAvail - gLocalMps2
+	reqAccel := descentRateMps * descentRateMps / (2 * altitudeM)
+	m := BurnMargin{
+		NetAccelMps2: aNet,
+		ReqAccelMps2: reqAccel,
+		ReqDVMps:     math.Inf(1),
+		AvailDVMps:   availDVMps,
+	}
+	if aNet <= 0 || reqAccel <= 0 {
+		// Can't out-thrust gravity: no altitude and no propellant makes
+		// this stop flyable, so the thrust side binds at zero.
+		m.Ratio = 0
+		m.State = MarginInsufficient
+		m.Limiter = LimitThrust
+		return m
+	}
+	accelRatio := aNet / reqAccel
+	m.ReqDVMps = descentRateMps * aAvail / aNet
+	dvRatio := math.Inf(1)
+	if m.ReqDVMps > 0 {
+		dvRatio = availDVMps / m.ReqDVMps
+	}
+	m.Ratio, m.Limiter = accelRatio, LimitThrust
+	if dvRatio < accelRatio {
+		m.Ratio, m.Limiter = dvRatio, LimitFuel
+	}
+	switch {
+	case m.Ratio < 1:
+		m.State = MarginInsufficient
+	case m.Ratio < marginTightBelow:
+		m.State = MarginTight
+	default:
+		m.State = MarginOK
+	}
+	return m
+}
+
+// descentRateFloorMps is the surface-relative descent rate below which
+// the corridor stands down. Above zero so a craft parked on a pad, or
+// one the pilot has already brought to a hover, doesn't flicker the
+// instruments on numerical dust.
+const descentRateFloorMps = 0.1
+
+// DescentCorridor is the surface view's descent instrument block:
+// altitude, descent rate, time to impact, and the burn margin, plus the
+// impact forecast the arc and the ground marker are drawn from.
+type DescentCorridor struct {
+	AltitudeM      float64
+	DescentRateMps float64 // surface-relative, positive = falling
+	Impact         ImpactPrediction
+	Margin         BurnMargin
+}
+
+// DescentCorridorFor builds the corridor for a craft, or reports
+// ok=false when the craft isn't in a descent worth instrumenting. The
+// gate is deliberately the FORECAST, not the phase: instruments appear
+// exactly when the current trajectory reaches the ground inside the
+// horizon while the craft is falling. That keeps them off an ascent
+// (climbing, so no descent rate) and off a stable parking orbit (falling
+// toward periapsis, but never reaching the surface), with no separate
+// phase predicate to drift out of step with the picture on the canvas.
+func DescentCorridorFor(c *spacecraft.Spacecraft, horizon time.Duration) (DescentCorridor, bool) {
+	if c == nil || c.Landed || c.Crashed {
+		return DescentCorridor{}, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 || c.Primary.RadiusMeters() <= 0 {
+		return DescentCorridor{}, false
+	}
+	rNorm := c.State.R.Norm()
+	alt := c.Altitude()
+	if rNorm <= 0 || alt <= 0 {
+		return DescentCorridor{}, false
+	}
+	rHat := c.State.R.Scale(1 / rNorm)
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	descentRate := -vRel.Dot(rHat)
+	if !(descentRate >= descentRateFloorMps) {
+		return DescentCorridor{}, false
+	}
+	impact, ok := PredictImpact(c, horizon)
+	if !ok {
+		return DescentCorridor{}, false
+	}
+	return DescentCorridor{
+		AltitudeM:      alt,
+		DescentRateMps: descentRate,
+		Impact:         impact,
+		Margin: ComputeBurnMargin(
+			c.Thrust,
+			c.TotalMass(),
+			mu/(rNorm*rNorm),
+			descentRate,
+			alt,
+			c.RemainingDeltaV(),
+		),
+	}, true
+}

--- a/internal/sim/descent_test.go
+++ b/internal/sim/descent_test.go
@@ -1,0 +1,327 @@
+// Package sim — descent-half tests (issue #348 §3 / ADR 0043): the
+// ground-contact forecast, its live response to a burn, and the burn-
+// margin arithmetic the surface view alarms on.
+
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// bodyForTest fetches a catalog body by ID from the world's system.
+func bodyForTest(t *testing.T, w *World, id string) bodies.CelestialBody {
+	t.Helper()
+	for _, b := range w.System().Bodies {
+		if b.ID == id {
+			return b
+		}
+	}
+	t.Fatalf("body %q not in the loaded system", id)
+	return bodies.CelestialBody{}
+}
+
+// dropTestCraft parks the world's active craft `altM` above the Moon's
+// surface at rest in the inertial frame — an airless primary, so drag is
+// out of the picture and the fall is a pure two-body radial free-fall
+// with a closed-form answer.
+func dropTestCraft(t *testing.T, altM float64) (*World, *spacecraft.Spacecraft) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("setup: NewWorld should produce an active craft")
+	}
+	c.Primary = bodyForTest(t, w, "moon")
+	c.Landed = false
+	c.Crashed = false
+	c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + altM}
+	c.State.V = orbital.Vec3{}
+	c.State.M = c.TotalMass()
+	return w, c
+}
+
+// radialFallSeconds is the closed-form two-body radial free-fall time
+// from rest at r0 down to r1 (Kepler's rectilinear ellipse):
+//
+//	t = √(r0³/2μ) · [ arccos√(r1/r0) + √( (r1/r0)(1 − r1/r0) ) ]
+//
+// The reference the integrated forecast is scored against.
+func radialFallSeconds(r0, r1, mu float64) float64 {
+	x := r1 / r0
+	return math.Sqrt(r0*r0*r0/(2*mu)) * (math.Acos(math.Sqrt(x)) + math.Sqrt(x*(1-x)))
+}
+
+// TestPredictImpactBallisticRadialDrop: the analytic case. A vessel
+// dropped from rest 10 km over the Moon must impact straight below
+// where it started (the acceleration is purely radial, so the fall
+// never leaves the r̂ line), exactly on the mean radius, at the
+// closed-form radial free-fall time.
+func TestPredictImpactBallisticRadialDrop(t *testing.T) {
+	const altM = 10_000.0
+	_, c := dropTestCraft(t, altM)
+	radius := c.Primary.RadiusMeters()
+	mu := c.Primary.GravitationalParameter()
+
+	imp, ok := PredictImpact(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictImpact found no ground contact for a vessel dropped from rest")
+	}
+
+	// Straight down: same direction as the start, no lateral component.
+	if math.Abs(imp.Point.Y) > 1 || math.Abs(imp.Point.Z) > 1 {
+		t.Errorf("impact point %v drifted off the radial line (want Y=Z=0)", imp.Point)
+	}
+	if got := imp.Point.Norm(); math.Abs(got-radius) > 1e-6*radius {
+		t.Errorf("impact point |R| = %.3f m, want the mean radius %.3f m", got, radius)
+	}
+
+	want := radialFallSeconds(radius+altM, radius, mu)
+	got := imp.TimeToImpact.Seconds()
+	if math.Abs(got-want) > 0.01*want {
+		t.Errorf("time to impact = %.2f s, want %.2f s (±1%%)", got, want)
+	}
+
+	// Impact speed from energy: v = √(2μ(1/r₁ − 1/r₀)). The Moon's spin
+	// contributes ~4 m/s of co-rotation at the equator, so score the
+	// surface-relative speed loosely against the inertial closed form.
+	wantV := math.Sqrt(2 * mu * (1/radius - 1/(radius+altM)))
+	if math.Abs(imp.SpeedMps-wantV) > 10 {
+		t.Errorf("impact speed = %.1f m/s, want ≈ %.1f m/s", imp.SpeedMps, wantV)
+	}
+
+	// The drawn arc starts where the craft is and ends where it lands.
+	if len(imp.Path) < 2 {
+		t.Fatalf("path has %d points, want a drawable run", len(imp.Path))
+	}
+	if imp.Path[0] != c.State.R {
+		t.Errorf("path[0] = %v, want the craft's current position %v", imp.Path[0], c.State.R)
+	}
+	if imp.Path[len(imp.Path)-1] != imp.Point {
+		t.Errorf("path ends at %v, want the impact point %v", imp.Path[len(imp.Path)-1], imp.Point)
+	}
+}
+
+// TestPredictImpactShiftsUnderThrust: the forecast is taken from the
+// LIVE state, so a burn moves it. A lateral Δv walks the impact point
+// downrange; an upward Δv buys flight time. This is what makes the
+// ground marker track a powered descent instead of standing still.
+func TestPredictImpactShiftsUnderThrust(t *testing.T) {
+	const altM = 10_000.0
+	_, c := dropTestCraft(t, altM)
+	base, ok := PredictImpact(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("baseline drop found no ground contact")
+	}
+
+	// Lateral burn: +Y, orthogonal to the +X radial. The contact point
+	// must slide that way along the surface.
+	c.State.V = orbital.Vec3{Y: 50}
+	lateral, ok := PredictImpact(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("lateral-burn state found no ground contact")
+	}
+	if lateral.Point.Y <= base.Point.Y {
+		t.Errorf("impact point Y %.1f did not move downrange of the ballistic %.1f after a +Y burn",
+			lateral.Point.Y, base.Point.Y)
+	}
+	if lateral.Point.Sub(base.Point).Norm() < 100 {
+		t.Errorf("impact point moved only %.1f m under a 50 m/s lateral burn — marker would look frozen",
+			lateral.Point.Sub(base.Point).Norm())
+	}
+
+	// Retro (upward) burn: same place-ish, but later.
+	c.State.V = orbital.Vec3{X: 40}
+	up, ok := PredictImpact(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("upward-burn state found no ground contact")
+	}
+	if up.TimeToImpact <= base.TimeToImpact {
+		t.Errorf("time to impact %v did not grow past the ballistic %v after an upward burn",
+			up.TimeToImpact, base.TimeToImpact)
+	}
+}
+
+// TestPredictImpactNoneForStableOrbit: a circular parking orbit never
+// reaches the ground, so the forecast reports nothing rather than
+// inventing a contact at the horizon's edge.
+func TestPredictImpactNoneForStableOrbit(t *testing.T) {
+	_, c := dropTestCraft(t, 100_000)
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	if imp, ok := PredictImpact(c, DescentPredictHorizon); ok {
+		t.Errorf("circular orbit reported ground contact at %v (t+%v)", imp.Point, imp.TimeToImpact)
+	}
+}
+
+// TestComputeBurnMarginThrustLimited pins the arithmetic on a seeded
+// scenario with round numbers:
+//
+//	F/m = 2000/1000 = 2 m/s²,  g = 1 m/s²  → a_net = 1 m/s²
+//	v = 20 m/s over h = 100 m  → a_req = 400/200 = 2 m/s²
+//	accel ratio = 1/2 = 0.50
+//	stop Δv     = 20 · 2/1 = 40 m/s, of 100 available → 2.50
+//
+// The thrust side is the smaller, so it binds — and at 0.50 the stack
+// cannot stop: the alarm state.
+func TestComputeBurnMarginThrustLimited(t *testing.T) {
+	m := ComputeBurnMargin(2000, 1000, 1, 20, 100, 100)
+	if m.Ratio != 0.5 {
+		t.Errorf("Ratio = %v, want 0.50", m.Ratio)
+	}
+	if m.Limiter != LimitThrust {
+		t.Errorf("Limiter = %v, want thrust", m.Limiter)
+	}
+	if m.State != MarginInsufficient {
+		t.Errorf("State = %v, want MarginInsufficient (ratio < 1)", m.State)
+	}
+	if m.NetAccelMps2 != 1 || m.ReqAccelMps2 != 2 || m.ReqDVMps != 40 {
+		t.Errorf("net=%v req=%v dv=%v, want 1 / 2 / 40", m.NetAccelMps2, m.ReqAccelMps2, m.ReqDVMps)
+	}
+}
+
+// TestComputeBurnMarginFuelLimited: same stack, half the descent rate,
+// so the acceleration side is comfortable (a_net 1 vs a_req 0.5 → 2.00)
+// but the 30 m/s of propellant left only just covers the 20 m/s stop
+// burn (30/20 = 1.50). The smaller ratio wins and names FUEL, and 1.50
+// sits exactly on the OK/TIGHT boundary — pinned here so the band edge
+// can't drift silently.
+func TestComputeBurnMarginFuelLimited(t *testing.T) {
+	m := ComputeBurnMargin(2000, 1000, 1, 10, 100, 30)
+	if m.Ratio != 1.5 {
+		t.Errorf("Ratio = %v, want 1.50", m.Ratio)
+	}
+	if m.Limiter != LimitFuel {
+		t.Errorf("Limiter = %v, want fuel", m.Limiter)
+	}
+	if m.State != MarginOK {
+		t.Errorf("State = %v, want MarginOK at exactly the 1.5 boundary", m.State)
+	}
+	if m.ReqDVMps != 20 {
+		t.Errorf("ReqDVMps = %v, want 20", m.ReqDVMps)
+	}
+}
+
+// TestComputeBurnMarginTightBand: between 1.0 and 1.5 the stop is
+// flyable but the reserve is thin — the middle rung of the alarm ladder.
+func TestComputeBurnMarginTightBand(t *testing.T) {
+	// a_net = 2 − 1 = 1; a_req = 100/200 = 0.5 → 2.00 on thrust.
+	// Δv: stop costs 10·2/1 = 20 m/s, of 25 available → 1.25 on fuel.
+	m := ComputeBurnMargin(2000, 1000, 1, 10, 100, 25)
+	if m.Ratio != 1.25 {
+		t.Errorf("Ratio = %v, want 1.25", m.Ratio)
+	}
+	if m.State != MarginTight {
+		t.Errorf("State = %v, want MarginTight in [1, 1.5)", m.State)
+	}
+}
+
+// TestComputeBurnMarginCannotHover: a stack that can't out-thrust local
+// gravity has no altitude at which the stop is flyable — ratio 0 and the
+// alarm, never a soothing large number from the propellant side.
+func TestComputeBurnMarginCannotHover(t *testing.T) {
+	m := ComputeBurnMargin(500, 1000, 1.6, 5, 10_000, 5000)
+	if m.Ratio != 0 {
+		t.Errorf("Ratio = %v, want 0 for a sub-hover TWR", m.Ratio)
+	}
+	if m.State != MarginInsufficient || m.Limiter != LimitThrust {
+		t.Errorf("State/Limiter = %v/%v, want insufficient/thrust", m.State, m.Limiter)
+	}
+	if !math.IsInf(m.ReqDVMps, 1) {
+		t.Errorf("ReqDVMps = %v, want +Inf (the stop can't be flown at all)", m.ReqDVMps)
+	}
+}
+
+// TestComputeBurnMarginUndefinedInputs: not descending / no altitude /
+// no mass yields MarginNone, so the readout can print an em dash rather
+// than a fabricated ratio.
+func TestComputeBurnMarginUndefinedInputs(t *testing.T) {
+	for _, c := range []struct {
+		name                                        string
+		thrust, mass, g, descent, altitude, availDV float64
+	}{
+		{"not descending", 2000, 1000, 1, 0, 100, 100},
+		{"on the ground", 2000, 1000, 1, 20, 0, 100},
+		{"no mass", 2000, 0, 1, 20, 100, 100},
+	} {
+		m := ComputeBurnMargin(c.thrust, c.mass, c.g, c.descent, c.altitude, c.availDV)
+		if m.State != MarginNone {
+			t.Errorf("%s: State = %v, want MarginNone", c.name, m.State)
+		}
+	}
+}
+
+// TestDescentCorridorForGating: the corridor is gated on the FORECAST,
+// not on a phase label — it stands up for a falling vessel that reaches
+// the ground inside the horizon, and stands down for one that is
+// climbing, landed, or in a stable orbit.
+func TestDescentCorridorForGating(t *testing.T) {
+	_, c := dropTestCraft(t, 10_000)
+	// Already falling: a vessel exactly at rest in the INERTIAL frame has
+	// no radial rate at all (its air-relative velocity is the pure
+	// horizontal −ω×r), which is the stand-down case, not the descent one.
+	c.State.V = orbital.Vec3{X: -5}
+	dc, ok := DescentCorridorFor(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("falling vessel: corridor stood down, want instruments")
+	}
+	if math.Abs(dc.AltitudeM-10_000) > 1 {
+		t.Errorf("AltitudeM = %.1f, want 10000", dc.AltitudeM)
+	}
+	if dc.DescentRateMps <= 0 {
+		t.Errorf("DescentRateMps = %.3f, want a positive (falling) rate", dc.DescentRateMps)
+	}
+	if dc.Impact.TimeToImpact <= 0 {
+		t.Errorf("TimeToImpact = %v, want positive", dc.Impact.TimeToImpact)
+	}
+
+	// Climbing: the same trajectory run upward.
+	c.State.V = orbital.Vec3{X: 200}
+	if _, ok := DescentCorridorFor(c, DescentPredictHorizon); ok {
+		t.Error("climbing vessel: corridor stood up, want stand-down")
+	}
+
+	// Landed: no descent to instrument.
+	c.State.V = orbital.Vec3{}
+	c.Landed = true
+	if _, ok := DescentCorridorFor(c, DescentPredictHorizon); ok {
+		t.Error("landed vessel: corridor stood up, want stand-down")
+	}
+	c.Landed = false
+
+	// Stable circular orbit: falling nowhere.
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	if _, ok := DescentCorridorFor(c, DescentPredictHorizon); ok {
+		t.Error("circular orbit: corridor stood up, want stand-down")
+	}
+}
+
+// TestDescentCorridorAlarmsWhenItCannotStop: the end-to-end alarm. A
+// vessel falling fast with very little altitude left reports
+// MarginInsufficient — the state the surface view paints red.
+func TestDescentCorridorAlarmsWhenItCannotStop(t *testing.T) {
+	_, c := dropTestCraft(t, 500)
+	c.State.V = orbital.Vec3{X: -300} // 300 m/s straight down, 500 m to go
+	dc, ok := DescentCorridorFor(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("corridor stood down for a 300 m/s descent 500 m up")
+	}
+	if dc.Margin.State != MarginInsufficient {
+		t.Errorf("Margin.State = %v (ratio %.3f), want MarginInsufficient",
+			dc.Margin.State, dc.Margin.Ratio)
+	}
+	if dc.Impact.TimeToImpact > 3*time.Second {
+		t.Errorf("TimeToImpact = %v, want under ~2 s at 300 m/s from 500 m", dc.Impact.TimeToImpact)
+	}
+}

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -156,8 +156,15 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	}
 	title := v.theme.Title.Render(fmt.Sprintf("LAUNCH — %s", craftName))
 
+	// The descent half (ADR 0043 §3): one forecast per frame, shared by
+	// the scene (dashed arc + ground marker) and the corridor chip, so
+	// the picture and the numbers can never disagree about where this
+	// trajectory lands. Ballistic-from-now, so an active burn walks it
+	// live — see sim.PredictImpact.
+	corridor, descending := sim.DescentCorridorFor(craft, sim.DescentPredictHorizon)
+
 	if craft != nil && craft.Primary.MeanRadius > 0 {
-		v.renderScene(w, craft)
+		v.renderScene(w, craft, corridor, descending)
 	} else if craft == nil {
 		// v0.11.4+ (sub-scope 5): the end-flight path can leave the
 		// slate empty mid-session (the player removes the only
@@ -191,7 +198,26 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 		// STAGES / ATTITUDE / BURNS …) onto its own canvas — the side
 		// column is just the slim telemetry block. Canvas content sits 1
 		// col / 2 rows in (border + title), matching the orbit screen.
-		canvasStr = v.hudSource.composeChips(canvasStr, cCols, cRows, nbReserved, 1, 2, v.hudSource.assembleChips(w))
+		chips := v.hudSource.assembleChips(w)
+		// DESCENT CORRIDOR is the surface view's own chip — built here, not
+		// in assembleChips, because it's the launch/surface screen's
+		// instrument block and the orbit map has no ground line to read it
+		// against. Empty id (always-on, F2 declutter still clears it) for
+		// the same reason RENDEZVOUS and TIME LOCK are: it states a
+		// constraint — whether this descent can still be stopped — that
+		// nothing else on screen would say. chipPriorityForced for the
+		// same reason DOCKED carries it (#328): a corner that overflows
+		// must not silently swallow the one readout saying this descent
+		// can no longer be stopped — an overlap is recoverable, a missing
+		// alarm is not.
+		if descending && v.hudSource.chipEnabled("") {
+			chips = append(chips, builtChip{
+				corner:   cornerTopRight,
+				lines:    v.descentCorridorLines(corridor),
+				priority: chipPriorityForced,
+			})
+		}
+		canvasStr = v.hudSource.composeChips(canvasStr, cCols, cRows, nbReserved, 1, 2, chips)
 	}
 	canvasStr = overlayHUDStrip(canvasStr, v.composeHUDLine(w, craft))
 
@@ -329,7 +355,7 @@ func (v *LaunchView) renderNoActiveVesselMessage() {
 // local-up (radial from body centre). Depth axis points laterally —
 // useful for hemisphere culling. ViewTilt.Theta is suppressed inside
 // ViewLaunch per ADR-0002.
-func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft) {
+func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, corridor sim.DescentCorridor, descending bool) {
 	body := craft.Primary
 	// craft.State.R is primary-relative (Earth-centred for a LEO craft,
 	// Moon-centred for a Luna-orbiting craft, etc.). The render layer
@@ -375,6 +401,15 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft) {
 	// the far arc is depth-culled behind it; drawn before the surface
 	// markers + rocket so those layer on top. v0.14+.
 	v.drawOrbitPath(craft, bodyCentre)
+
+	// Descent half (ADR 0043 §3): the dashed arc down to the ground and
+	// the impact point where it lands. Drawn after the orbit ellipse (a
+	// descent arc is the near-term detail of that same orbit and should
+	// win where they overlap) and before the surface markers + rocket, so
+	// the pad, the tower and the vessel still layer on top.
+	if descending {
+		v.drawDescentArc(bodyCentre, camFromBody, corridor)
+	}
 
 	// Pad marker at the active craft's launch site, depth-culled.
 	v.drawPadMarker(w, craft, bodyCentre, camFromBody)
@@ -626,6 +661,89 @@ func (v *LaunchView) drawOrbitPath(craft *spacecraft.Spacecraft, bodyCentre orbi
 	if !v.canvas.IsBehindBody(apo, bodyCentre, primaryPxR) {
 		drawMarker(v.canvas, apo, render.MarkerApoapsis, render.MarkerNominal, "", widgets.CellTag{})
 	}
+}
+
+// drawDescentArc inks the predicted path down to the ground plus the
+// impact point where it lands (ADR 0043 §3 / issue #348).
+//
+// The arc is ClassPlanned — dashed — because it is a PLAN, not a live
+// orbit: the consequence of flying the current state without further
+// input (ADR 0041 §2's line-style vocabulary, PR #353). Colour is the
+// separate, semantic axis: planned-cyan normally, alert-red once the
+// burn margin says this descent can no longer be stopped, so the whole
+// line carries the alarm rather than only the four-character label in
+// the corridor chip.
+//
+// The impact marker is depth-culled by the same near-hemisphere test the
+// pad and tower use — a contact point on the far side of the body would
+// otherwise draw straight through the planet.
+func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim.DescentCorridor) {
+	if len(dc.Impact.Path) < 2 {
+		return
+	}
+	alarm := dc.Margin.State == sim.MarginInsufficient
+	arcColor := render.ColorPlannedNode
+	if alarm {
+		arcColor = render.ColorAlert
+	}
+	pts := make([]orbital.Vec3, len(dc.Impact.Path))
+	for i, p := range dc.Impact.Path {
+		pts[i] = bodyCentre.Add(p)
+	}
+	v.canvas.PlotPolylineClass(pts, arcColor, widgets.ClassPlanned)
+
+	if !isNearHemisphere(dc.Impact.Point, camFromBody) {
+		return
+	}
+	state := render.MarkerNominal
+	if alarm {
+		state = render.MarkerAlarm
+	}
+	drawMarker(v.canvas, bodyCentre.Add(dc.Impact.Point), render.MarkerImpact, state, "", widgets.CellTag{})
+}
+
+// descentCorridorLines renders the DESCENT CORRIDOR instrument block —
+// the four numbers issue #348 §3 asks for: altitude, descent rate, time
+// to impact, and the burn margin.
+//
+// The margin row is the alarm surface. It flips label AND colour
+// together (bare ratio → "TIGHT (thrust)" amber → "CAN'T STOP (thrust)"
+// red) rather than shading a number, because a state a player can miss
+// reads as no state at all. The parenthesised limiter says which
+// capability bound it, so the alarm names the fix instead of only the
+// fault.
+func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
+	return []string{
+		v.theme.Primary.Render("DESCENT CORRIDOR"),
+		fmt.Sprintf("  altitude:   %s", formatAltitude(dc.AltitudeM)),
+		fmt.Sprintf("  descent:    %.0f m/s", dc.DescentRateMps),
+		fmt.Sprintf("  impact in:  %s (%.0f m/s)",
+			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
+		fmt.Sprintf("  margin:     %s", v.marginLabel(dc.Margin)),
+	}
+}
+
+// marginLabel styles the burn-margin readout per its alarm state.
+func (v *LaunchView) marginLabel(m sim.BurnMargin) string {
+	switch m.State {
+	case sim.MarginOK:
+		return v.theme.Primary.Render(fmt.Sprintf("%.2f ×", m.Ratio))
+	case sim.MarginTight:
+		return v.theme.Warning.Render(fmt.Sprintf("%.2f × TIGHT (%s)", m.Ratio, m.Limiter))
+	case sim.MarginInsufficient:
+		return v.theme.Alert.Render(fmt.Sprintf("%.2f × CAN'T STOP (%s)", m.Ratio, m.Limiter))
+	}
+	return v.theme.Dim.Render("—")
+}
+
+// formatAltitude renders metres as m below 1 km and km above, matching
+// the DESCENT chip's existing altitude row so the two readouts agree
+// digit for digit when both are on screen.
+func formatAltitude(m float64) string {
+	if m >= 1000 {
+		return fmt.Sprintf("%.2f km", m/1000)
+	}
+	return fmt.Sprintf("%.0f m", m)
 }
 
 // (launchOrbitSamples retired by ADR 0042 §3.) The chase-cam used to size

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -1,0 +1,235 @@
+// Package screens — descent-half render tests for the surface view
+// (issue #348 §3 / ADR 0043): the corridor instrument block and its
+// alarm ladder, the dashed arc to ground, and the impact marker.
+
+package screens
+
+import (
+	"math/bits"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// countBrailleDots sums the LIT SUB-PIXELS across a rendered canvas, by
+// popcount of each braille glyph's dot bits (U+2800 + an 8-bit pattern).
+// countBraille (orbit_local_arc_test.go) counts glyph CELLS, which can't
+// tell a dashed line from a solid one — at a 3-on/2-off cadence and two
+// pixels per cell, nearly every cell still carries ink. Dots can.
+func countBrailleDots(s string) int {
+	n := 0
+	for _, r := range stripANSI(s) {
+		if r > 0x2800 && r <= 0x28FF {
+			n += bits.OnesCount(uint(r - 0x2800))
+		}
+	}
+	return n
+}
+
+// descendingMoonCraft parks the world's active craft on a powered
+// descent over the Moon: altM up, falling at vDownMps, airless primary.
+func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("setup: NewWorld should produce an active craft")
+	}
+	for _, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			c.Primary = b
+		}
+	}
+	c.Landed = false
+	c.Crashed = false
+	c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + altM}
+	c.State.V = orbital.Vec3{X: -vDownMps}
+	c.State.M = c.TotalMass()
+	return w
+}
+
+// TestDescentCorridorLinesInstruments pins the four instruments issue
+// #348 §3 asks for — altitude, descent rate, time to impact, burn margin
+// — as exact rendered rows, so a formatting change has to be deliberate.
+func TestDescentCorridorLinesInstruments(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	dc := sim.DescentCorridor{
+		AltitudeM:      12_400,
+		DescentRateMps: 182,
+		Impact: sim.ImpactPrediction{
+			TimeToImpact: 64 * time.Second,
+			SpeedMps:     240,
+		},
+		// a_net 1 vs a_req 0.5 → 2.00 on thrust; 30 m/s of Δv against a
+		// 20 m/s stop burn → 1.50 on fuel. Fuel binds, and 1.50 is OK.
+		Margin: sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 30),
+	}
+	want := []string{
+		"DESCENT CORRIDOR",
+		"  altitude:   12.40 km",
+		"  descent:    182 m/s",
+		"  impact in:  1m4s (240 m/s)",
+		"  margin:     1.50 ×",
+	}
+	got := v.descentCorridorLines(dc)
+	if len(got) != len(want) {
+		t.Fatalf("got %d rows, want %d:\n%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d:\n got: %q\nwant: %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDescentCorridorMarginAlarmLadder: the margin row is the alarm
+// surface, so each state must change the LABEL, not only a shade a
+// player can miss. Pins all three rungs plus the undefined case.
+func TestDescentCorridorMarginAlarmLadder(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	cases := []struct {
+		name   string
+		margin sim.BurnMargin
+		want   string
+	}{
+		// a_net 1 vs a_req 2 → 0.50 on thrust: cannot stop.
+		{"insufficient", sim.ComputeBurnMargin(2000, 1000, 1, 20, 100, 100), "0.50 × CAN'T STOP (thrust)"},
+		// 25 m/s of Δv against a 20 m/s stop burn → 1.25 on fuel.
+		{"tight", sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 25), "1.25 × TIGHT (fuel)"},
+		{"ok", sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 100), "2.00 ×"},
+		{"undefined", sim.BurnMargin{}, "—"},
+	}
+	for _, c := range cases {
+		if got := v.marginLabel(c.margin); got != c.want {
+			t.Errorf("%s: margin label %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestDescentArcIsPlannedDashed: the arc to ground is a PLAN, so it must
+// ink at ClassPlanned's dash cadence (ADR 0041 §2 / PR #353), not a
+// solid Real-class line. Measured in lit braille sub-pixels against the
+// same polyline drawn through the primitive at each class — the live
+// canvas must match Planned exactly and undershoot Real.
+func TestDescentArcIsPlannedDashed(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	v.Resize(120, 40)
+	v.canvas.Clear()
+	v.canvas.SetScale(1) // 1 px per metre, so the run is 200 px long
+	v.canvas.Center(orbital.Vec3{})
+
+	pts := []orbital.Vec3{{X: -100}, {X: 100}}
+	dc := sim.DescentCorridor{Impact: sim.ImpactPrediction{Path: pts, Point: pts[1]}}
+	// Put the camera on the far side so the impact glyph is depth-culled
+	// and the only ink on the canvas is the arc itself.
+	v.drawDescentArc(orbital.Vec3{}, pts[1].Scale(-1), dc)
+	live := countBrailleDots(v.canvas.String())
+	if live == 0 {
+		t.Fatal("descent arc inked nothing")
+	}
+
+	measure := func(class widgets.LineClass) int {
+		c := widgets.NewCanvas(v.canvas.Cols(), v.canvas.Rows())
+		c.SetScale(1)
+		c.Center(orbital.Vec3{})
+		c.Clear()
+		c.PlotPolylineClass(pts, render.ColorPlannedNode, class)
+		return countBrailleDots(c.String())
+	}
+	planned, solid := measure(widgets.ClassPlanned), measure(widgets.ClassReal)
+	if live != planned {
+		t.Errorf("arc inked %d dots, want ClassPlanned's %d", live, planned)
+	}
+	if planned >= solid {
+		t.Errorf("ClassPlanned inked %d dots vs ClassReal's %d — the dash pattern is not thinning the line", planned, solid)
+	}
+}
+
+// TestDescentArcAlarmRecolours: colour is the semantic axis (ADR 0041),
+// so an unstoppable descent turns the whole arc alert-red rather than
+// hiding the alarm in the chip's margin row alone. The impact marker
+// promotes to MarkerAlarm with it.
+func TestDescentArcAlarmRecolours(t *testing.T) {
+	pts := []orbital.Vec3{{X: -100}, {X: 100}}
+	draw := func(margin sim.BurnMargin) *widgets.Canvas {
+		v := NewLaunchView(launchThemeForTest(), nil)
+		v.Resize(120, 40)
+		v.canvas.Clear()
+		v.canvas.SetScale(1)
+		v.canvas.Center(orbital.Vec3{})
+		dc := sim.DescentCorridor{
+			Impact: sim.ImpactPrediction{Path: pts, Point: pts[1]},
+			Margin: margin,
+		}
+		v.drawDescentArc(orbital.Vec3{}, pts[1], dc) // camera on the near side
+		return v.canvas
+	}
+
+	okCanvas := draw(sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 100))
+	if n := okCanvas.CountColor(render.ColorPlannedNode); n == 0 {
+		t.Error("nominal descent arc inked no planned-cyan cells")
+	}
+	if n := okCanvas.CountOverlayColor(render.ColorMarkerImpact); n != 1 {
+		t.Errorf("nominal impact marker inked %d cells, want 1", n)
+	}
+
+	alarmCanvas := draw(sim.ComputeBurnMargin(2000, 1000, 1, 20, 100, 100))
+	if n := alarmCanvas.CountColor(render.ColorAlert); n == 0 {
+		t.Error("unstoppable descent arc inked no alert-red cells")
+	}
+	if n := alarmCanvas.CountColor(render.ColorPlannedNode); n != 0 {
+		t.Errorf("unstoppable descent arc still inked %d planned-cyan cells — the alarm did not take the line", n)
+	}
+	if n := alarmCanvas.CountOverlayColor(render.ColorAlert); n != 1 {
+		t.Errorf("alarm impact marker inked %d alert cells, want 1 (MarkerAlarm promotion)", n)
+	}
+}
+
+// TestLaunchViewDescentInstrumentsAt80x24: the whole descent half has to
+// survive the smallest supported terminal — the corridor chip composites
+// onto the canvas and the impact marker lands on the ground line at
+// 80×24, not only at the roomy sizes a dev window happens to be.
+func TestLaunchViewDescentInstrumentsAt80x24(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, 120)
+
+	out := v.Render(w, 80, 24)
+	for _, want := range []string{"DESCENT CORRIDOR", "altitude:", "descent:", "impact in:", "margin:"} {
+		if !strings.Contains(stripANSI(out), want) {
+			t.Errorf("80×24 render is missing %q:\n%s", want, out)
+		}
+	}
+	if rows := len(strings.Split(out, "\n")); rows > 24 {
+		t.Errorf("render is %d rows tall, want ≤ 24", rows)
+	}
+	if n := v.canvas.CountOverlayColor(render.ColorMarkerImpact); n == 0 {
+		t.Error("no impact marker on the ground line during a descent")
+	}
+}
+
+// TestLaunchViewNoDescentInstrumentsOnAscent: the corridor is gated on a
+// forecast ground contact while falling, so a climbing vehicle — the
+// surface view's original job — gets none of it. Guards against the
+// descent half turning into permanent ascent clutter.
+func TestLaunchViewNoDescentInstrumentsOnAscent(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, -400) // climbing at 400 m/s
+
+	out := stripANSI(v.Render(w, 120, 40))
+	if strings.Contains(out, "DESCENT CORRIDOR") {
+		t.Errorf("climbing vehicle rendered the descent corridor:\n%s", out)
+	}
+	if n := v.canvas.CountOverlayColor(render.ColorMarkerImpact); n != 0 {
+		t.Errorf("climbing vehicle drew %d impact markers, want 0", n)
+	}
+}


### PR DESCRIPTION
Part of #348 (§3 descent — ascent cues and view seams follow separately).

## What lands

- **Impact-point marker** — new `render.MarkerImpact` (`⊗`, orange) stamped where the live trajectory meets the ground, depth-culled by the same near-hemisphere test the pad and tower use. Promotes to `MarkerAlarm` red when the burn margin says the descent can't be stopped.
- **DESCENT CORRIDOR chip** — altitude, descent rate, time to impact (with arrival speed), TWR burn margin. Composited on the surface view's top-right corner at `chipPriorityForced`, for the same reason DOCKED carries it (#328): an overflowing corner must not silently swallow the one readout saying this descent can no longer be stopped.
- **Dashed arc to ground** — `PlotPolylineClass(..., ClassPlanned)` per ADR 0041 §2 / PR #353: a predicted path is a PLAN, so it's dashed. Colour stays the separate semantic axis — planned-cyan normally, `ColorAlert` red on an unstoppable descent, so the whole line carries the alarm and not just a four-character label.

## Where the math lives

`internal/sim/descent.go`. It **reuses `predictStep`** — the predictor's one propagator (analytic Kepler where `canKeplerStepState` allows, drag-aware Verlet everywhere else, so an atmosphere is handled by the same drag model the integrator flies) — plus `predictMaxSubStep` for the sub-step cap and a bisection refinement of the contact time, the same trick `refineCrossingTime` uses on an SOI crossing. No second propagator (the #66 two-drift-sites lesson).

The forecast is **ballistic-from-now** and recomputed every frame. That's what makes the marker live under thrust: the burn reshapes the state each tick, and the next frame's forecast is taken from the reshaped state.

## Burn margin

Smaller of two ratios, with the binding one reported:

- **acceleration** — `(F/m − g_local) / (v²/2h)`. A stack that can't out-thrust local gravity is ratio 0 at any altitude.
- **propellant** — `RemainingΔv / (v·(F/m)/a_net)`; the stop takes `v/a_net` seconds at full thrust and spends Δv the whole time, so it costs strictly more than `v`.

Alarm ladder: `< 1` → **CAN'T STOP** (Alert red), `[1, 1.5)` → **TIGHT** (Warning amber), else the bare ratio. Label *and* colour flip together — a state a player can miss reads as no state at all.

The corridor is gated on the **forecast**, not a phase label: instruments stand up exactly when a falling vessel's trajectory reaches the ground inside the 30-minute horizon. That keeps them off an ascent and off a stable parking orbit with no second predicate to drift out of step with the picture.

## Tests

- `internal/sim/descent_test.go` — analytic radial free-fall (impact point on the r̂ line, exactly on the mean radius, time within 1% of the closed-form rectilinear-Kepler answer); impact point shifts downrange under a lateral burn and later under an upward one; no contact reported for a circular orbit; four seeded burn-margin scenarios pinning exact ratios/limiters/bands including the 1.5 boundary; corridor gating (falling / climbing / landed / circular).
- `internal/tui/screens/launch_descent_test.go` — exact instrument rows; the full alarm ladder's labels; the arc's dash cadence measured in **lit braille sub-pixels** against the primitive at ClassPlanned vs ClassReal (cell counts can't tell a 3/2 dash from solid at two pixels per cell); alarm recolours the whole arc and promotes the marker; the whole descent half renders at **80×24**; nothing appears on an ascent.

`go vet ./...` and `go test ./... -race -count=1` green.

## Notes

- Diff deliberately avoids `orbit.go` and `input.go` (concurrent Inspect slice). No keybindings added — the view-seams slice owns keys.
- Known overlap for a later slice: the pre-existing airless-only DESCENT chip also carries an altitude row. The two answer different questions (velocity split + attitude vs. ground contact + stopping capability) and DESCENT doesn't render on atmospheric bodies at all, so they're left as-is rather than reconciled from this branch.