### PR TITLE
feat(#348): ascent cues — nose-vs-prograde, predicted arc, Q band

### DIFF
--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -1,0 +1,235 @@
+// Package sim — the ascent half of the surface view (issue #348 §3, ADR
+// 0043), the mirror image of descent.go's descent half (PR #354). Three
+// pure forecasts the launch/surface screen renders while a vessel is
+// climbing:
+//
+//   - AttitudeVectorsFor: the nose-vs-prograde pair a gravity turn pulls
+//     apart, then brings back together near MECO.
+//   - PredictAscentPath: the ballistic-from-now path ahead of the sprite,
+//     sharing forwardBallisticPath (descent.go) with the descent arc so
+//     the two halves never integrate the same curve twice (the #66
+//     two-drift-sites lesson).
+//   - AscentQBandFor: the atmosphere depth / dynamic-pressure band, with
+//     the peak Q actually measured so far this session (World.LaunchMaxQ)
+//     marked on it — see AscentQBand's doc comment for why "measured so
+//     far" rather than a forecast eventual peak.
+//
+// AscentCueFor gates all three behind one climbing predicate — the
+// mirror image of DescentCorridorFor's falling gate — so the surface
+// view can never show the ascent cues and the descent corridor at once.
+package sim
+
+import (
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// AscentPredictHorizon bounds how far ahead the ascent arc forecasts.
+// Shorter than DescentPredictHorizon (30 min): the ascent arc's job is
+// "what does the immediate flight path look like from here", drawn close
+// enough to the sprite to stay legible on the chase-cam canvas — not a
+// full orbital-period lookahead. A craft still governed by atmosphere or
+// gravity typically resolves (apoapsis, or a fall back to ground) well
+// inside 10 minutes; one that reaches a stable orbit inside the horizon
+// just draws a partial arc of it (PredictAscentPath's no-impact branch).
+const AscentPredictHorizon = 10 * time.Minute
+
+// climbRateFloorMps is the ascent mirror of descentRateFloorMps
+// (descent.go): the surface-relative climb rate below which the ascent
+// cues stand down, so a vessel at zero net vertical rate (coasting near
+// apoapsis, sitting on the pad before liftoff) doesn't flicker the cues
+// on numerical dust. Same magnitude as its descent counterpart — there
+// is no physical reason the two floors should differ.
+const climbRateFloorMps = 0.1
+
+// AttitudeVectors is the nose-vs-prograde pair the ascent cues plot as
+// vector stubs on the sprite (issue #348 §3): the vessel's commanded
+// pointing direction and its current direction of travel through the
+// air. A gravity turn is exactly the story of these two vectors drifting
+// apart and then converging again near MECO — showing both anchored to
+// the vessel, rather than only on the corner navball, makes that story
+// readable at a glance.
+type AttitudeVectors struct {
+	// NoseDir is the vessel's physical pointing direction
+	// (Spacecraft.CurrentAttitudeDir), unit length, in the same
+	// primary-relative frame State.R lives in.
+	NoseDir orbital.Vec3
+	// ProgradeDir is the surface-relative velocity direction
+	// (physics.AirRelativeVelocity, unit length) — the vector a gravity
+	// turn actually tracks. Air-relative rather than inertial keeps a
+	// launchpad-co-rotating vessel's prograde undefined-at-rest instead
+	// of pointing along the planet's spin, matching every other surface
+	// view instrument (Q, the descent corridor's descent rate).
+	ProgradeDir orbital.Vec3
+}
+
+// AttitudeVectorsFor resolves a craft's current nose and prograde unit
+// vectors, or ok=false when either is undefined: no commanded attitude
+// yet (pre-first-tick), or zero air-relative velocity (sitting still on
+// the pad — surface-relative prograde has no direction until the vessel
+// actually moves relative to the ground it's leaving).
+func AttitudeVectorsFor(c *spacecraft.Spacecraft) (AttitudeVectors, bool) {
+	if c == nil {
+		return AttitudeVectors{}, false
+	}
+	nose := c.CurrentAttitudeDir
+	noseN := nose.Norm()
+	if noseN == 0 {
+		return AttitudeVectors{}, false
+	}
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	vN := vRel.Norm()
+	if vN == 0 {
+		return AttitudeVectors{}, false
+	}
+	return AttitudeVectors{
+		NoseDir:     nose.Scale(1 / noseN),
+		ProgradeDir: vRel.Scale(1 / vN),
+	}, true
+}
+
+// AscentPath is the sampled forward-ballistic trajectory the ascent arc
+// draws ahead of the sprite (issue #348 §3). Unlike ImpactPrediction it
+// is populated even when the horizon never finds ground contact — a
+// climbing vessel, or one that has already reached a stable-enough orbit,
+// still has a path worth drawing; it just doesn't end at an impact
+// marker.
+type AscentPath struct {
+	// Path is the sampled trajectory from the craft's current position
+	// (Path[0]) forward. Ends at ground contact when the forecast finds
+	// one inside the horizon, otherwise ends wherever the horizon ran
+	// out (or the vessel settled into an orbit that never dips back to
+	// the surface).
+	Path []orbital.Vec3
+	// Impact is the ground-contact point; meaningful only when
+	// ImpactFound is true (a lofted or suborbital ascent can still arc
+	// back down inside the horizon).
+	Impact      orbital.Vec3
+	ImpactFound bool
+}
+
+// PredictAscentPath forward-propagates the craft's current state exactly
+// like PredictImpact — same forwardBallisticPath loop, same sub-step
+// policy — but always returns the sampled path. PredictImpact discards
+// its path on the "no impact inside the horizon" branch, which is
+// exactly the common ascent case (still climbing, or already in an orbit
+// stable enough that the ballistic-from-now forecast never touches
+// ground). ok is false only for the same degenerate-input cases
+// PredictImpact refuses.
+func PredictAscentPath(c *spacecraft.Spacecraft, horizon time.Duration) (AscentPath, bool) {
+	fc, setupOK := forwardBallisticPath(c, horizon)
+	if !setupOK {
+		return AscentPath{}, false
+	}
+	return AscentPath{Path: fc.Path, Impact: fc.Impact, ImpactFound: fc.ImpactFound}, true
+}
+
+// AscentQBand is the atmosphere/Q instrument the ascent cues draw as a
+// vertical scale (issue #348 §3): where the vessel currently sits
+// against the atmosphere's depth, its current dynamic pressure, and the
+// altitude of the peak Q observed so far this session.
+//
+// Design note on "max Q": the ascent forecast (PredictAscentPath) is
+// deliberately ballistic-from-now, exactly like PredictImpact — it has
+// no modelled future thrust or pitch program to integrate forward, so a
+// genuine FORECAST of the eventual max-Q altitude isn't something this
+// physics can honestly produce; it would have to assume a throttle and
+// attitude program the player hasn't committed to yet. What the sim DOES
+// know honestly is the peak Q actually measured so far: World.LaunchMaxQ
+// / LaunchMaxQAltM, ratcheted every session tick since v0.11
+// (updateLaunchMaxQ, view_launch.go). So the band marks THAT — the
+// altitude of the peak already passed, updating live as a new peak is
+// measured — rather than a predicted peak that doesn't exist yet on a
+// fresh climb.
+type AscentQBand struct {
+	AtmosphereDepthM float64
+	CurrentAltM      float64
+	CurrentQPa       float64
+	MaxQPa           float64
+	MaxQAltM         float64
+	// HasMaxQ is false until the session has actually measured a
+	// positive Q — before that there is no peak to mark, and drawing one
+	// at altitude 0 would read as "max Q happened at the pad".
+	HasMaxQ bool
+}
+
+// AscentQBandFor builds the Q-band instrument for a craft, or ok=false
+// when the primary has no atmosphere at all — issue #348 §3's gate ("Q
+// band only on bodies WITH atmosphere"). Independent of whether the
+// vessel is CURRENTLY inside the atmosphere: a vessel that has already
+// climbed clear of the cutoff still has a meaningful band (it reads
+// "past the top", clamped by qBandRowIndex) carrying the max-Q mark from
+// the climb through it.
+func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
+	if w == nil || c == nil || c.Primary.Atmosphere == nil {
+		return AscentQBand{}, false
+	}
+	atm := c.Primary.Atmosphere
+	return AscentQBand{
+		AtmosphereDepthM: atm.CutoffAltitude,
+		CurrentAltM:      c.Altitude(),
+		CurrentQPa:       physics.DynamicPressure(c.State.R, c.State.V, c.Primary),
+		MaxQPa:           w.LaunchMaxQ,
+		MaxQAltM:         w.LaunchMaxQAltM,
+		HasMaxQ:          w.LaunchMaxQ > 0,
+	}, true
+}
+
+// AscentCue bundles the three ascent-half instruments issue #348 §3 asks
+// for — nose-vs-prograde attitude, the predicted path ahead, and the
+// atmosphere/Q band — behind ONE gate, mirroring DescentCorridor's shape
+// so the surface view composes them the same way.
+type AscentCue struct {
+	ClimbRateMps float64
+	Attitude     AttitudeVectors
+	HasAttitude  bool
+	Arc          AscentPath
+	QBand        AscentQBand
+	HasQBand     bool
+}
+
+// AscentCueFor gates the ascent cues on CLIMBING — the mirror image of
+// DescentCorridorFor's falling gate (issue #348 §3 / ADR 0043). Climbing
+// and falling are opposite signs of the same surface-relative radial
+// rate (climbRateFloorMps / descentRateFloorMps share both magnitude and
+// meaning), so the two instrument sets are naturally mutually exclusive
+// by construction — climbRate ≥ floor forces the descent gate's
+// descentRate (= −climbRate) below its own floor, and vice versa.
+// Nothing here needs to consult DescentCorridorFor's result to avoid
+// stacking on top of it.
+func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (AscentCue, bool) {
+	if c == nil || c.Landed || c.Crashed {
+		return AscentCue{}, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 || c.Primary.RadiusMeters() <= 0 {
+		return AscentCue{}, false
+	}
+	rNorm := c.State.R.Norm()
+	alt := c.Altitude()
+	if rNorm <= 0 || alt <= 0 {
+		return AscentCue{}, false
+	}
+	rHat := c.State.R.Scale(1 / rNorm)
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	climbRate := vRel.Dot(rHat)
+	if !(climbRate >= climbRateFloorMps) {
+		return AscentCue{}, false
+	}
+
+	attitude, hasAttitude := AttitudeVectorsFor(c)
+	arc, _ := PredictAscentPath(c, horizon)
+	qband, hasQBand := AscentQBandFor(w, c)
+
+	return AscentCue{
+		ClimbRateMps: climbRate,
+		Attitude:     attitude,
+		HasAttitude:  hasAttitude,
+		Arc:          arc,
+		QBand:        qband,
+		HasQBand:     hasQBand,
+	}, true
+}

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -1,0 +1,291 @@
+// Package sim — ascent-half tests (issue #348 §3 / ADR 0043): the
+// nose-vs-prograde geometry, the forward path a climbing vessel draws
+// ahead of itself, the Q-band arithmetic, and the gating that keeps the
+// ascent cues off a descending or coasting vessel.
+
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// ascendTestCraft parks the world's active craft `altM` above `bodyID`'s
+// surface with a purely radial (+X) inertial velocity of `climbMps` PLUS
+// the body's own co-rotation term at that point — so a vessel built this
+// way has an air-relative velocity that is EXACTLY climbMps along +X
+// (physics.AirRelativeVelocity cancels the co-rotation term out again),
+// which is what makes the "vertical ascent" tests below exact rather
+// than approximate.
+func ascendTestCraft(t *testing.T, bodyID string, altM, climbMps float64) (*World, *spacecraft.Spacecraft) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("setup: NewWorld should produce an active craft")
+	}
+	c.Primary = bodyForTest(t, w, bodyID)
+	c.Landed = false
+	c.Crashed = false
+	rHat := orbital.Vec3{X: 1}
+	c.State.R = rHat.Scale(c.Primary.RadiusMeters() + altM)
+	corotate := physics.AtmosphereOmega(c.Primary).Cross(c.State.R)
+	c.State.V = corotate.Add(rHat.Scale(climbMps))
+	c.State.M = c.TotalMass()
+	return w, c
+}
+
+// TestAttitudeVectorsForVerticalAscentCoincide: a vessel climbing
+// straight up (nose along local-up, no co-rotation-relative crosstrack
+// drift) has a surface-relative prograde that is ALSO exactly local-up
+// — the classic "no gravity turn yet" moment right off the pad. Nose and
+// prograde must read as the same direction.
+func TestAttitudeVectorsForVerticalAscentCoincide(t *testing.T) {
+	_, c := ascendTestCraft(t, "earth", 1_000, 50)
+	rHat := orbital.Vec3{X: 1}
+	c.CurrentAttitudeDir = rHat
+
+	vec, ok := AttitudeVectorsFor(c)
+	if !ok {
+		t.Fatal("AttitudeVectorsFor: ok=false for a vessel with defined nose + velocity")
+	}
+	if d := vec.NoseDir.Dot(vec.ProgradeDir); d < 1-1e-9 {
+		t.Errorf("vertical ascent: nose·prograde = %.9f, want ~1 (coincident)", d)
+	}
+}
+
+// TestAttitudeVectorsForPitchedOverDiverge: the same climb, but the nose
+// is pitched 45° off the (still-vertical) velocity vector — the gravity
+// turn in progress. Nose and prograde must read as clearly distinct
+// directions, not a numerically-negligible wobble.
+func TestAttitudeVectorsForPitchedOverDiverge(t *testing.T) {
+	_, c := ascendTestCraft(t, "earth", 1_000, 50)
+	// 45° off +X (local-up) toward +Y.
+	c.CurrentAttitudeDir = orbital.Vec3{X: math.Cos(math.Pi / 4), Y: math.Sin(math.Pi / 4)}
+
+	vec, ok := AttitudeVectorsFor(c)
+	if !ok {
+		t.Fatal("AttitudeVectorsFor: ok=false for a vessel with defined nose + velocity")
+	}
+	if d := vec.NoseDir.Dot(vec.ProgradeDir); d > math.Cos(math.Pi/8) {
+		t.Errorf("45° pitched-over ascent: nose·prograde = %.4f, want clearly below cos(22.5°) (%.4f)",
+			d, math.Cos(math.Pi/8))
+	}
+}
+
+// TestAttitudeVectorsForUndefinedCases: no commanded nose yet, or sitting
+// dead still relative to the ground (zero air-relative velocity) — both
+// report ok=false rather than a fabricated direction.
+func TestAttitudeVectorsForUndefinedCases(t *testing.T) {
+	_, c := ascendTestCraft(t, "earth", 1_000, 50)
+	c.CurrentAttitudeDir = orbital.Vec3{}
+	if _, ok := AttitudeVectorsFor(c); ok {
+		t.Error("zero CurrentAttitudeDir: want ok=false")
+	}
+
+	_, c2 := ascendTestCraft(t, "earth", 1_000, 0) // climbMps=0 → air-relative V is zero
+	c2.CurrentAttitudeDir = orbital.Vec3{X: 1}
+	if _, ok := AttitudeVectorsFor(c2); ok {
+		t.Error("zero air-relative velocity: want ok=false")
+	}
+}
+
+// TestPredictAscentPathNoImpactForStableOrbit: an ascent that has already
+// reached a stable circular orbit never touches ground inside the
+// horizon — PredictImpact would report nothing at all (ok=false, no
+// path), but the ascent arc still has a real path worth drawing.
+func TestPredictAscentPathNoImpactForStableOrbit(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Primary = bodyForTest(t, w, "earth")
+	c.Landed = false
+	c.Crashed = false
+	mu := c.Primary.GravitationalParameter()
+	r := c.Primary.RadiusMeters() + 300_000
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	c.State.M = c.TotalMass()
+
+	path, ok := PredictAscentPath(c, AscentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictAscentPath: ok=false for a valid orbital state")
+	}
+	if path.ImpactFound {
+		t.Error("stable circular orbit reported ground contact")
+	}
+	if len(path.Path) < 2 {
+		t.Fatalf("path has %d points, want a drawable run", len(path.Path))
+	}
+	if path.Path[0] != c.State.R {
+		t.Errorf("path[0] = %v, want the craft's current position %v", path.Path[0], c.State.R)
+	}
+}
+
+// TestPredictAscentPathFindsImpactForLoftedHop: a suborbital hop (well
+// under escape velocity, zero angular momentum) arcs up and falls
+// straight back down — the ascent arc must find that contact just like
+// PredictImpact would once the vessel starts actually falling.
+func TestPredictAscentPathFindsImpactForLoftedHop(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Primary = bodyForTest(t, w, "moon")
+	c.Landed = false
+	c.Crashed = false
+	const altM = 10_000.0
+	c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + altM}
+	c.State.V = orbital.Vec3{X: 50} // well under lunar escape velocity
+	c.State.M = c.TotalMass()
+
+	path, ok := PredictAscentPath(c, AscentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictAscentPath: ok=false for a valid ballistic state")
+	}
+	if !path.ImpactFound {
+		t.Fatal("lofted hop should fall back to the surface inside the horizon")
+	}
+	if path.Path[0] != c.State.R {
+		t.Errorf("path[0] = %v, want the craft's current position %v", path.Path[0], c.State.R)
+	}
+	if path.Path[len(path.Path)-1] != path.Impact {
+		t.Errorf("path ends at %v, want the impact point %v", path.Path[len(path.Path)-1], path.Impact)
+	}
+}
+
+// TestAscentQBandForGatesOnAtmosphere: the Q-band instrument only exists
+// on a body with an atmosphere at all (issue #348 §3) — an airless body
+// (the Moon) reports ok=false regardless of how the vessel is flying.
+func TestAscentQBandForGatesOnAtmosphere(t *testing.T) {
+	w, c := ascendTestCraft(t, "moon", 1_000, 50)
+	if _, ok := AscentQBandFor(w, c); ok {
+		t.Error("airless body: AscentQBandFor ok=true, want false")
+	}
+}
+
+// TestAscentQBandForSeededAnalyticQ pins AscentQBandFor's current-Q
+// arithmetic against Earth's catalog atmosphere constants by hand:
+// ρ(alt) = ρ₀·exp(-alt/H), Q = ½·ρ·v². ascendTestCraft's construction
+// makes the air-relative speed exactly climbMps, so this is a genuine
+// closed-form check of the wiring, not a re-statement of
+// physics.DynamicPressure's own formula.
+func TestAscentQBandForSeededAnalyticQ(t *testing.T) {
+	const altM = 5_000.0
+	const climbMps = 100.0
+	w, c := ascendTestCraft(t, "earth", altM, climbMps)
+	atm := c.Primary.Atmosphere
+	if atm == nil {
+		t.Fatal("setup: earth should carry catalog atmosphere data")
+	}
+
+	qb, ok := AscentQBandFor(w, c)
+	if !ok {
+		t.Fatal("AscentQBandFor: ok=false for a body with an atmosphere")
+	}
+	if qb.AtmosphereDepthM != atm.CutoffAltitude {
+		t.Errorf("AtmosphereDepthM = %v, want the catalog cutoff %v", qb.AtmosphereDepthM, atm.CutoffAltitude)
+	}
+	if math.Abs(qb.CurrentAltM-altM) > 1 {
+		t.Errorf("CurrentAltM = %v, want %v", qb.CurrentAltM, altM)
+	}
+
+	rho := atm.SurfaceDensity * math.Exp(-altM/atm.ScaleHeight)
+	wantQ := 0.5 * rho * climbMps * climbMps
+	if math.Abs(qb.CurrentQPa-wantQ) > 1e-6*wantQ {
+		t.Errorf("CurrentQPa = %.6f, want %.6f (analytic ρ·v² formula)", qb.CurrentQPa, wantQ)
+	}
+
+	if qb.HasMaxQ {
+		t.Error("HasMaxQ = true before any session has ratcheted LaunchMaxQ")
+	}
+	w.LaunchMaxQ = 12_345
+	w.LaunchMaxQAltM = 8_000
+	qb2, ok := AscentQBandFor(w, c)
+	if !ok {
+		t.Fatal("AscentQBandFor: ok=false on second call")
+	}
+	if !qb2.HasMaxQ || qb2.MaxQPa != 12_345 || qb2.MaxQAltM != 8_000 {
+		t.Errorf("MaxQ fields = (%v, %v, has=%v), want (12345, 8000, true)", qb2.MaxQPa, qb2.MaxQAltM, qb2.HasMaxQ)
+	}
+}
+
+// TestAscentCueForGatingMatrix is the ascent mirror of
+// TestDescentCorridorForGating: it stands up for a climbing vessel and
+// stands down for a falling, coasting, or landed one — and, critically,
+// AscentCueFor and DescentCorridorFor are never both true for the same
+// state, so the surface view can't stack the two instrument blocks.
+func TestAscentCueForGatingMatrix(t *testing.T) {
+	w, c := ascendTestCraft(t, "earth", 1_000, 50)
+	c.CurrentAttitudeDir = orbital.Vec3{X: 1}
+
+	assertGates := func(name string, wantAscent, wantDescent bool) {
+		t.Helper()
+		_, ascOK := AscentCueFor(w, c, AscentPredictHorizon)
+		_, descOK := DescentCorridorFor(c, DescentPredictHorizon)
+		if ascOK != wantAscent {
+			t.Errorf("%s: AscentCueFor ok=%v, want %v", name, ascOK, wantAscent)
+		}
+		if descOK != wantDescent {
+			t.Errorf("%s: DescentCorridorFor ok=%v, want %v", name, descOK, wantDescent)
+		}
+		if ascOK && descOK {
+			t.Errorf("%s: ascent AND descent both stood up — the gates must be mutually exclusive", name)
+		}
+	}
+
+	// Climbing: ascent up, descent down.
+	assertGates("climbing", true, false)
+
+	// Falling: mirror the velocity's radial component negative.
+	rHat := c.State.R.Scale(1 / c.State.R.Norm())
+	corotate := physics.AtmosphereOmega(c.Primary).Cross(c.State.R)
+	c.State.V = corotate.Add(rHat.Scale(-50))
+	assertGates("falling", false, true)
+
+	// Coasting in a stable circular orbit: falling nowhere, climbing
+	// nowhere — both stand down.
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	assertGates("circular orbit", false, false)
+
+	// Landed: neither instrument applies.
+	c.State.V = corotate.Add(rHat.Scale(50))
+	c.Landed = true
+	assertGates("landed", false, false)
+	c.Landed = false
+}
+
+// TestAscentCueForAirlessBodyHasCuesButNoQBand: the nose/prograde markers
+// and the predicted arc don't depend on an atmosphere existing at all —
+// only the Q band does (issue #348 §3's explicit gate). A climbing
+// vessel over the airless Moon gets the first two but not the third.
+func TestAscentCueForAirlessBodyHasCuesButNoQBand(t *testing.T) {
+	w, c := ascendTestCraft(t, "moon", 1_000, 50)
+	c.CurrentAttitudeDir = orbital.Vec3{X: 1}
+
+	cue, ok := AscentCueFor(w, c, AscentPredictHorizon)
+	if !ok {
+		t.Fatal("AscentCueFor: ok=false for a climbing vessel over an airless body")
+	}
+	if !cue.HasAttitude {
+		t.Error("HasAttitude = false, want true (nose + velocity both defined)")
+	}
+	if len(cue.Arc.Path) < 2 {
+		t.Error("Arc.Path too short — the predicted path should still draw over an airless body")
+	}
+	if cue.HasQBand {
+		t.Error("HasQBand = true over an airless body, want false")
+	}
+}

--- a/internal/sim/descent.go
+++ b/internal/sim/descent.go
@@ -101,19 +101,62 @@ type ImpactPrediction struct {
 // descent instrument exists to answer, and it re-derives from the live
 // state every frame so an active burn visibly walks the answer.
 func PredictImpact(c *spacecraft.Spacecraft, horizon time.Duration) (ImpactPrediction, bool) {
-	if c == nil {
+	fc, setupOK := forwardBallisticPath(c, horizon)
+	if !setupOK || !fc.ImpactFound {
 		return ImpactPrediction{}, false
+	}
+	return ImpactPrediction{
+		Point:        fc.Impact,
+		Path:         fc.Path,
+		TimeToImpact: fc.TimeToImpact,
+		SpeedMps:     fc.SpeedMps,
+	}, true
+}
+
+// ballisticForecast is forwardBallisticPath's result: the sampled path
+// plus, when the horizon actually finds one, ground contact. Shared by
+// PredictImpact (descent, ADR 0043 §3 first half) and PredictAscentPath
+// (ascent, §3 second half / issue #348, internal/sim/ascent.go) — see
+// forwardBallisticPath's doc comment for why the loop itself lives in
+// exactly one place.
+type ballisticForecast struct {
+	Path         []orbital.Vec3
+	Impact       orbital.Vec3
+	ImpactFound  bool
+	TimeToImpact time.Duration
+	SpeedMps     float64
+}
+
+// forwardBallisticPath is the one forward-propagation loop behind both
+// the descent and ascent halves of the surface view (ADR 0043 §3 / issue
+// #348): it walks the craft's current state forward via predictStep —
+// the repo's single propagator — until either ground contact or the
+// horizon runs out, and returns the full sampled path either way.
+// PredictImpact discards the path when no contact is found inside the
+// horizon; PredictAscentPath needs exactly that path (a climbing vessel,
+// or one that has already reached a stable-enough orbit, is the common
+// case where no contact is ever found) — this is what makes both
+// instrument sets agree on where this trajectory goes, instead of a
+// second propagator drifting apart from this one (the #66 lesson
+// documented at the top of this file).
+//
+// setupOK is false only for the degenerate-input cases PredictImpact has
+// always refused: a nil craft, missing primary radius/mu, a non-positive
+// horizon, or a craft state already at/under the surface.
+func forwardBallisticPath(c *spacecraft.Spacecraft, horizon time.Duration) (ballisticForecast, bool) {
+	if c == nil {
+		return ballisticForecast{}, false
 	}
 	primary := c.Primary
 	radius := primary.RadiusMeters()
 	mu := primary.GravitationalParameter()
 	total := horizon.Seconds()
 	if radius <= 0 || mu <= 0 || total <= 0 {
-		return ImpactPrediction{}, false
+		return ballisticForecast{}, false
 	}
 	state := c.State
 	if r := state.R.Norm(); r <= radius || math.IsNaN(r) {
-		return ImpactPrediction{}, false
+		return ballisticForecast{}, false
 	}
 	bc := c.EffectiveBallisticCoefficient()
 
@@ -127,7 +170,7 @@ func PredictImpact(c *spacecraft.Spacecraft, horizon time.Duration) (ImpactPredi
 		dt = total / float64(steps)
 	}
 	if steps < 1 {
-		return ImpactPrediction{}, false
+		return ballisticForecast{}, false
 	}
 	sampleEvery := steps / impactPathSamples
 	if sampleEvery < 1 {
@@ -148,9 +191,10 @@ func PredictImpact(c *spacecraft.Spacecraft, horizon time.Duration) (ImpactPredi
 				point = point.Scale(radius / n)
 			}
 			path = append(path, point)
-			return ImpactPrediction{
-				Point:        point,
+			return ballisticForecast{
 				Path:         path,
+				Impact:       point,
+				ImpactFound:  true,
 				TimeToImpact: time.Duration(elapsed * float64(time.Second)),
 				SpeedMps:     physics.AirRelativeVelocity(hit.R, hit.V, primary).Norm(),
 			}, true
@@ -160,7 +204,7 @@ func PredictImpact(c *spacecraft.Spacecraft, horizon time.Duration) (ImpactPredi
 			path = append(path, state.R)
 		}
 	}
-	return ImpactPrediction{}, false
+	return ballisticForecast{Path: path}, true
 }
 
 // refineSurfaceCrossing bisects surface contact inside (0, dt]: pre is

--- a/internal/sim/view_launch.go
+++ b/internal/sim/view_launch.go
@@ -118,6 +118,7 @@ func (w *World) handleActiveCraftSwitch(newActive *spacecraft.Spacecraft) {
 		// new vessel's launch.
 		w.LaunchT0 = w.Clock.SimTime
 		w.LaunchMaxQ = 0
+		w.LaunchMaxQAltM = 0
 		w.LaunchTrail = w.LaunchTrail[:0]
 		w.LaunchZoom = 0
 	case inSession && !newLanded:
@@ -164,6 +165,7 @@ func (w *World) releaseLaunchSession() {
 	w.LaunchSessionActive = false
 	w.LaunchT0 = time.Time{}
 	w.LaunchMaxQ = 0
+	w.LaunchMaxQAltM = 0
 	w.LaunchTrail = w.LaunchTrail[:0]
 	w.LaunchZoom = 0
 }
@@ -190,6 +192,7 @@ func (w *World) updateLaunchMaxQ() {
 	q := 0.5 * rho * vMag * vMag
 	if q > w.LaunchMaxQ {
 		w.LaunchMaxQ = q
+		w.LaunchMaxQAltM = alt
 	}
 }
 
@@ -247,6 +250,7 @@ func (w *World) routeToLaunchView() {
 	w.ViewMode = ViewLaunch
 	w.LaunchT0 = w.Clock.SimTime
 	w.LaunchMaxQ = 0
+	w.LaunchMaxQAltM = 0
 	w.LaunchTrail = w.LaunchTrail[:0]
 	w.LaunchZoom = 0
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -142,6 +142,15 @@ type World struct {
 	// handler at session open. Not persisted.
 	LaunchMaxQ float64
 
+	// LaunchMaxQAltM is the altitude (m) at which LaunchMaxQ was
+	// measured — the mark the ascent Q-band chip (issue #348 §3 / ADR
+	// 0043) draws on its vertical scale. Ratcheted alongside LaunchMaxQ
+	// in updateLaunchMaxQ; cleared everywhere LaunchMaxQ is. Zero is
+	// ambiguous with "measured at the pad", so callers gate on LaunchMaxQ
+	// > 0 (AscentQBand.HasMaxQ) rather than testing this field directly.
+	// Not persisted.
+	LaunchMaxQAltM float64
+
 	// LaunchTrail is the breadcrumb buffer of body-fixed (lat, lon,
 	// alt) samples the chase-cam scene re-projects each render so the
 	// trace visibly rotates with the body. FIFO cap 256, sampled at

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -162,9 +162,17 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	// trajectory lands. Ballistic-from-now, so an active burn walks it
 	// live — see sim.PredictImpact.
 	corridor, descending := sim.DescentCorridorFor(craft, sim.DescentPredictHorizon)
+	// The ascent half (ADR 0043 §3 / issue #348): the mirror-image gate —
+	// climbing, not falling — so exactly one of the two instrument sets is
+	// ever live for a given state (sim.AscentCueFor's doc comment; pinned
+	// by TestAscentCueForGatingMatrix). Bundles the nose/prograde vectors,
+	// the predicted path ahead, and the atmosphere/Q band behind one call
+	// for the same reason the descent corridor is one call: the scene and
+	// the chip must never disagree.
+	ascent, ascending := sim.AscentCueFor(w, craft, sim.AscentPredictHorizon)
 
 	if craft != nil && craft.Primary.MeanRadius > 0 {
-		v.renderScene(w, craft, corridor, descending)
+		v.renderScene(w, craft, corridor, descending, ascent, ascending)
 	} else if craft == nil {
 		// v0.11.4+ (sub-scope 5): the end-flight path can leave the
 		// slate empty mid-session (the player removes the only
@@ -215,6 +223,21 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 				corner:   cornerTopRight,
 				lines:    v.descentCorridorLines(corridor),
 				priority: chipPriorityForced,
+			})
+		}
+		// ATMOSPHERE is the ascent half's own chip (issue #348 §3),
+		// mirroring DESCENT CORRIDOR's placement and empty-id treatment —
+		// same corner, same "always-on while the gate holds, F2 still
+		// clears it" rule. Unlike the corridor's stop-margin alarm, nothing
+		// here is safety-critical (there's no "can this still be stopped"
+		// question during an ascent), so it competes for space at normal
+		// priority instead of chipPriorityForced. Gated additionally on
+		// HasQBand — an airless-body ascent gets the nose/prograde markers
+		// and the arc but has no atmosphere to chart.
+		if ascending && ascent.HasQBand && v.hudSource.chipEnabled("") {
+			chips = append(chips, builtChip{
+				corner: cornerTopRight,
+				lines:  v.ascentQBandLines(ascent.QBand),
 			})
 		}
 		canvasStr = v.hudSource.composeChips(canvasStr, cCols, cRows, nbReserved, 1, 2, chips)
@@ -355,7 +378,7 @@ func (v *LaunchView) renderNoActiveVesselMessage() {
 // local-up (radial from body centre). Depth axis points laterally —
 // useful for hemisphere culling. ViewTilt.Theta is suppressed inside
 // ViewLaunch per ADR-0002.
-func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, corridor sim.DescentCorridor, descending bool) {
+func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, corridor sim.DescentCorridor, descending bool, ascent sim.AscentCue, ascending bool) {
 	body := craft.Primary
 	// craft.State.R is primary-relative (Earth-centred for a LEO craft,
 	// Moon-centred for a Luna-orbiting craft, etc.). The render layer
@@ -407,8 +430,15 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, cor
 	// descent arc is the near-term detail of that same orbit and should
 	// win where they overlap) and before the surface markers + rocket, so
 	// the pad, the tower and the vessel still layer on top.
+	//
+	// Ascent half (ADR 0043 §3 / issue #348): the dashed path ahead of a
+	// climbing vessel, same layering rule. descending/ascending are
+	// mutually exclusive (sim.AscentCueFor's doc comment), so at most one
+	// of these ever draws.
 	if descending {
 		v.drawDescentArc(bodyCentre, camFromBody, corridor)
+	} else if ascending {
+		v.drawAscentArc(bodyCentre, ascent.Arc)
 	}
 
 	// Pad marker at the active craft's launch site, depth-culled.
@@ -441,6 +471,15 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, cor
 			}
 		}
 		v.canvas.SetCellOverlay(camWorld, glyph)
+	}
+
+	// Ascent half (ADR 0043 §3 / issue #348): nose-vs-prograde vector
+	// stubs anchored right on the sprite, drawn after the rocket so they
+	// read against it rather than under it. Only meaningful while
+	// ascending — HasAttitude is additionally false pre-first-tick or
+	// while sitting dead still on the pad (AttitudeVectorsFor).
+	if ascending && ascent.HasAttitude {
+		v.drawAscentAttitudeMarkers(ascent.Attitude, camWorld, scale)
 	}
 
 	// RCS puffs (v0.11.5 sub-scope 5): visible in the chase-cam so
@@ -744,6 +783,134 @@ func formatAltitude(m float64) string {
 		return fmt.Sprintf("%.2f km", m/1000)
 	}
 	return fmt.Sprintf("%.0f m", m)
+}
+
+// drawAscentArc inks the predicted path ahead of a climbing vessel (ADR
+// 0043 §3 / issue #348) — the ascent mirror of drawDescentArc. ClassPlanned
+// (dashed): a PLAN, not a live orbit (ADR 0041 §2, PR #353), same
+// treatment as the descent arc. Unlike the descent arc there's no
+// alarm/margin state to promote the colour with — an ascent has nothing
+// analogous to "can this stop in time" — so the arc is always the plain
+// planned-cyan.
+//
+// Nothing here needs to detect "the path exits the view" or "the vessel
+// reaches orbit" explicitly: the canvas's own segment clipping
+// (walkPixelDashSegment / clipSegmentToCanvas) already bounds the drawn
+// run to what's on-screen, and sim.PredictAscentPath already returns a
+// path capped to the ascent horizon whether or not it ever finds ground
+// contact.
+func (v *LaunchView) drawAscentArc(bodyCentre orbital.Vec3, arc sim.AscentPath) {
+	if len(arc.Path) < 2 {
+		return
+	}
+	pts := make([]orbital.Vec3, len(arc.Path))
+	for i, p := range arc.Path {
+		pts[i] = bodyCentre.Add(p)
+	}
+	v.canvas.PlotPolylineClass(pts, render.ColorPlannedNode, widgets.ClassPlanned)
+}
+
+// ascentMarkerStubPx is the stub length, in canvas sub-pixels, each
+// attitude vector extends from the sprite (issue #348 §3). In the same
+// units drawRCSPuffs uses for its own short direction indicators
+// (puffStep = 5 sub-pixels) — bumped slightly so the nose/prograde
+// divergence during a gravity turn reads as two separated stubs rather
+// than overlapping dots at small pitch angles.
+const ascentMarkerStubPx = 6.0
+
+// drawAscentAttitudeMarkers plots the nose and prograde vector stubs from
+// the active vessel's screen position (ADR 0043 §3 / issue #348): a
+// gravity turn is exactly the story of these two directions drifting
+// apart and then converging again near MECO, and putting them right on
+// the sprite makes that story readable without reading the corner
+// navball. Colors reuse the navball's own vocabulary
+// (render.ColorNavballMarkerNoseFront / ColorNavballMarkerPrograde) so
+// "nose" and "prograde" mean the same hue everywhere in the UI.
+func (v *LaunchView) drawAscentAttitudeMarkers(vec sim.AttitudeVectors, anchorWorld orbital.Vec3, scaleMPerPx float64) {
+	if scaleMPerPx <= 0 || vec.NoseDir.Norm() == 0 || vec.ProgradeDir.Norm() == 0 {
+		return
+	}
+	step := ascentMarkerStubPx * scaleMPerPx
+	v.canvas.PlotDenseLineColored(anchorWorld, anchorWorld.Add(vec.NoseDir.Scale(step)), render.ColorNavballMarkerNoseFront, 1)
+	v.canvas.PlotDenseLineColored(anchorWorld, anchorWorld.Add(vec.ProgradeDir.Scale(step)), render.ColorNavballMarkerPrograde, 1)
+}
+
+// ascentQBandRows is the number of altitude bands the ATMOSPHERE chip's
+// vertical scale divides the atmosphere into — top row is the cutoff
+// altitude (the top of the modelled atmosphere), bottom row is the
+// ground. Six is enough to place the current-altitude and max-Q marks
+// distinctly without making the chip taller than the DESCENT CORRIDOR
+// chip it never coexists with.
+const ascentQBandRows = 6
+
+// Glyphs for the ATMOSPHERE chip's vertical scale: the vessel's current
+// band, the band the peak-Q-so-far was measured in, and a bare tick for
+// every other band. Single-cell, no wide/combining runes — the chip's
+// padChipBlock right-pads by rune count, and a double-width glyph here
+// would throw that off (the same "no %-Ns padding" trap the launch HUD
+// strip already documents for byte-vs-rune widths).
+const (
+	ascentQBandCraftGlyph = "▶"
+	ascentQBandMaxQGlyph  = "✕"
+	ascentQBandTickGlyph  = "│"
+)
+
+// qBandRowIndex maps an altitude within [0, cutoffM] onto one of `rows`
+// bands, top row 0 = cutoffM (the atmosphere's outer edge), bottom row
+// rows-1 = the ground. Altitudes outside the range clamp to the nearest
+// edge — a vessel already well clear of the atmosphere still reads at
+// the top row rather than an undefined or out-of-range index.
+func qBandRowIndex(altM, cutoffM float64, rows int) int {
+	if cutoffM <= 0 || rows <= 0 {
+		return 0
+	}
+	frac := altM / cutoffM
+	if frac < 0 {
+		frac = 0
+	} else if frac > 1 {
+		frac = 1
+	}
+	idx := int((1 - frac) * float64(rows))
+	if idx >= rows {
+		idx = rows - 1
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	return idx
+}
+
+// ascentQBandLines renders the ATMOSPHERE chip: a vertical scale from the
+// atmosphere's outer edge down to the ground, the vessel's current
+// position on it, and the altitude of the peak dynamic pressure measured
+// so far this session. See sim.AscentQBand's doc comment for why the mark
+// is "the peak measured so far" rather than a forecast eventual peak —
+// the ballistic-from-now ascent arc has no future thrust program to
+// integrate a real forecast from.
+func (v *LaunchView) ascentQBandLines(qb sim.AscentQBand) []string {
+	curRow := qBandRowIndex(qb.CurrentAltM, qb.AtmosphereDepthM, ascentQBandRows)
+	maxRow := -1
+	if qb.HasMaxQ {
+		maxRow = qBandRowIndex(qb.MaxQAltM, qb.AtmosphereDepthM, ascentQBandRows)
+	}
+	lines := []string{v.theme.Primary.Render("ATMOSPHERE")}
+	for i := 0; i < ascentQBandRows; i++ {
+		switch {
+		case i == curRow && i == maxRow:
+			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandCraftGlyph, formatAltitude(qb.CurrentAltM)))
+		case i == curRow:
+			lines = append(lines, fmt.Sprintf("  %s %s", ascentQBandCraftGlyph, formatAltitude(qb.CurrentAltM)))
+		case i == maxRow:
+			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandMaxQGlyph, formatAltitude(qb.MaxQAltM)))
+		default:
+			lines = append(lines, "  "+ascentQBandTickGlyph)
+		}
+	}
+	lines = append(lines, fmt.Sprintf("  Q:     %.1f kPa", qb.CurrentQPa/1000))
+	if qb.HasMaxQ {
+		lines = append(lines, fmt.Sprintf("  max Q: %.1f kPa", qb.MaxQPa/1000))
+	}
+	return lines
 }
 
 // (launchOrbitSamples retired by ADR 0042 §3.) The chase-cam used to size

--- a/internal/tui/screens/launch_ascent_test.go
+++ b/internal/tui/screens/launch_ascent_test.go
@@ -1,0 +1,286 @@
+// Package screens — ascent-half render tests for the surface view (issue
+// #348 §3 / ADR 0043): the nose-vs-prograde vector stubs, the dashed
+// path ahead of a climbing vessel, and the ATMOSPHERE chip's vertical
+// Q-band scale. Mirrors launch_descent_test.go's structure for the
+// descent half (PR #354).
+
+package screens
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// ascendingCraftWorld parks the world's active craft `altM` above
+// `bodyID`'s surface, climbing straight up (+X, radial) at `climbMps`,
+// nose pointed in `nose`. A simplified (non-co-rotating) construction —
+// good enough for render smoke tests; the exact coincide/diverge
+// geometry is already pinned at the sim layer
+// (internal/sim/ascent_test.go).
+func ascendingCraftWorld(t *testing.T, bodyID string, altM, climbMps float64, nose orbital.Vec3) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("setup: NewWorld should produce an active craft")
+	}
+	for _, b := range w.System().Bodies {
+		if b.ID == bodyID {
+			c.Primary = b
+		}
+	}
+	c.Landed = false
+	c.Crashed = false
+	rHat := orbital.Vec3{X: 1}
+	c.State.R = rHat.Scale(c.Primary.RadiusMeters() + altM)
+	c.State.V = rHat.Scale(climbMps)
+	c.State.M = c.TotalMass()
+	c.CurrentAttitudeDir = nose
+	return w
+}
+
+// TestAscentArcIsPlannedDashed: the predicted path ahead of a climbing
+// vessel is a PLAN, so it must ink at ClassPlanned's dash cadence (ADR
+// 0041 §2 / PR #353), matching the descent arc's own test
+// (TestDescentArcIsPlannedDashed).
+func TestAscentArcIsPlannedDashed(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	v.Resize(120, 40)
+	v.canvas.Clear()
+	v.canvas.SetScale(1) // 1 px per metre
+	v.canvas.Center(orbital.Vec3{})
+
+	pts := []orbital.Vec3{{X: -100}, {X: 100}}
+	arc := sim.AscentPath{Path: pts}
+	v.drawAscentArc(orbital.Vec3{}, arc)
+	live := countBrailleDots(v.canvas.String())
+	if live == 0 {
+		t.Fatal("ascent arc inked nothing")
+	}
+
+	measure := func(class widgets.LineClass) int {
+		c := widgets.NewCanvas(v.canvas.Cols(), v.canvas.Rows())
+		c.SetScale(1)
+		c.Center(orbital.Vec3{})
+		c.Clear()
+		c.PlotPolylineClass(pts, render.ColorPlannedNode, class)
+		return countBrailleDots(c.String())
+	}
+	planned, solid := measure(widgets.ClassPlanned), measure(widgets.ClassReal)
+	if live != planned {
+		t.Errorf("arc inked %d dots, want ClassPlanned's %d", live, planned)
+	}
+	if planned >= solid {
+		t.Errorf("ClassPlanned inked %d dots vs ClassReal's %d — the dash pattern is not thinning the line", planned, solid)
+	}
+}
+
+// TestAscentArcClipsAtViewEdge: a predicted path running far past the
+// visible canvas (e.g. an ascent still climbing toward a distant
+// apoapsis) must not panic and must still ink the portion that's
+// actually on-screen — the canvas's own segment clipping
+// (clipSegmentToCanvas) is what issue #348 §3 relies on for "clip
+// gracefully" rather than any special-case logic in drawAscentArc.
+func TestAscentArcClipsAtViewEdge(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	v.Resize(120, 40)
+	v.canvas.Clear()
+	v.canvas.SetScale(1)
+	v.canvas.Center(orbital.Vec3{})
+
+	// The canvas is a few hundred pixels wide at scale 1; this run goes
+	// four orders of magnitude past that.
+	pts := []orbital.Vec3{{X: 0}, {X: 50}, {X: 1_000_000}}
+	arc := sim.AscentPath{Path: pts}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("drawAscentArc panicked on an off-canvas path: %v", r)
+		}
+	}()
+	v.drawAscentArc(orbital.Vec3{}, arc)
+	if n := countBrailleDots(v.canvas.String()); n == 0 {
+		t.Error("off-canvas-bound arc inked nothing near the sprite, want the on-screen portion drawn")
+	}
+}
+
+// TestAscentAttitudeMarkersDrawBothColors: the nose and prograde stubs
+// use the navball's own hues (ColorNavballMarkerNoseFront /
+// ColorNavballMarkerPrograde) — when the two directions are distinct,
+// both colors must land on the canvas.
+func TestAscentAttitudeMarkersDrawBothColors(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	v.Resize(120, 40)
+	v.canvas.Clear()
+	v.canvas.SetScale(1)
+	v.canvas.Center(orbital.Vec3{})
+
+	vec := sim.AttitudeVectors{
+		NoseDir:     orbital.Vec3{X: 1},
+		ProgradeDir: orbital.Vec3{Y: 1},
+	}
+	v.drawAscentAttitudeMarkers(vec, orbital.Vec3{}, 1.0)
+	if n := v.canvas.CountColor(render.ColorNavballMarkerNoseFront); n == 0 {
+		t.Error("nose stub inked no ColorNavballMarkerNoseFront cells")
+	}
+	if n := v.canvas.CountColor(render.ColorNavballMarkerPrograde); n == 0 {
+		t.Error("prograde stub inked no ColorNavballMarkerPrograde cells")
+	}
+}
+
+// TestAscentAttitudeMarkersSkipUndefinedVectors: a zero-value
+// AttitudeVectors (the AttitudeVectorsFor ok=false case) must not paint
+// anything — there's no fabricated direction to draw a stub toward.
+func TestAscentAttitudeMarkersSkipUndefinedVectors(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	v.Resize(120, 40)
+	v.canvas.Clear()
+	v.canvas.SetScale(1)
+	v.canvas.Center(orbital.Vec3{})
+
+	v.drawAscentAttitudeMarkers(sim.AttitudeVectors{}, orbital.Vec3{}, 1.0)
+	if n := countBrailleDots(v.canvas.String()); n != 0 {
+		t.Errorf("undefined attitude vectors inked %d dots, want 0", n)
+	}
+}
+
+// TestQBandRowIndexEdgesAndClamp pins qBandRowIndex's mapping: the
+// atmosphere's outer edge is row 0, the ground is the last row, and
+// altitudes outside [0, cutoff] clamp rather than going out of range.
+func TestQBandRowIndexEdgesAndClamp(t *testing.T) {
+	const cutoff = 150_000.0
+	const rows = 6
+	cases := []struct {
+		name string
+		altM float64
+		want int
+	}{
+		{"ground", 0, rows - 1},
+		{"top of atmosphere", cutoff, 0},
+		{"above the cutoff", cutoff * 2, 0},
+		{"below ground", -1000, rows - 1},
+		{"midpoint", cutoff / 2, rows / 2},
+	}
+	for _, c := range cases {
+		if got := qBandRowIndex(c.altM, cutoff, rows); got != c.want {
+			t.Errorf("%s: qBandRowIndex(%.0f, %.0f, %d) = %d, want %d", c.name, c.altM, cutoff, rows, got, c.want)
+		}
+	}
+}
+
+// TestAscentQBandLinesMarksCurrentAndMaxQ pins the ATMOSPHERE chip's
+// rendered rows: the vessel's current band carries the craft glyph, the
+// peak-Q band carries the max-Q glyph, and every other row is a bare
+// tick — so a formatting change has to be deliberate, matching the
+// descent corridor's own instrument-lines test.
+func TestAscentQBandLinesMarksCurrentAndMaxQ(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	qb := sim.AscentQBand{
+		AtmosphereDepthM: 150_000,
+		CurrentAltM:      125_000, // row 1 of 6 (top-adjacent band)
+		CurrentQPa:       1234.5,
+		MaxQAltM:         25_000, // row 4 of 6
+		MaxQPa:           45_678,
+		HasMaxQ:          true,
+	}
+	got := v.ascentQBandLines(qb)
+	if len(got) != ascentQBandRows+3 { // header + rows + Q + max Q
+		t.Fatalf("got %d lines, want %d:\n%v", len(got), ascentQBandRows+3, got)
+	}
+	if !strings.Contains(got[0], "ATMOSPHERE") {
+		t.Errorf("line 0 = %q, want the ATMOSPHERE header", got[0])
+	}
+	curRow := qBandRowIndex(qb.CurrentAltM, qb.AtmosphereDepthM, ascentQBandRows)
+	maxRow := qBandRowIndex(qb.MaxQAltM, qb.AtmosphereDepthM, ascentQBandRows)
+	if !strings.Contains(got[1+curRow], ascentQBandCraftGlyph) {
+		t.Errorf("current-altitude row %d = %q, want the craft glyph %q", curRow, got[1+curRow], ascentQBandCraftGlyph)
+	}
+	if !strings.Contains(got[1+maxRow], ascentQBandMaxQGlyph) {
+		t.Errorf("max-Q row %d = %q, want the max-Q glyph %q", maxRow, got[1+maxRow], ascentQBandMaxQGlyph)
+	}
+	if !strings.Contains(got[len(got)-2], "1.2") {
+		// 1234.5 Pa → 1.2 kPa
+		t.Errorf("Q row = %q, want the current Q value in kPa", got[len(got)-2])
+	}
+	if !strings.Contains(got[len(got)-1], "45.7") {
+		// 45678 Pa → 45.7 kPa
+		t.Errorf("max Q row = %q, want the max Q value in kPa", got[len(got)-1])
+	}
+}
+
+// TestAscentQBandLinesOmitsMaxQBeforeMeasured: a fresh session that
+// hasn't ratcheted a peak yet must not fabricate one at the ground.
+func TestAscentQBandLinesOmitsMaxQBeforeMeasured(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	qb := sim.AscentQBand{AtmosphereDepthM: 150_000, CurrentAltM: 1_000, CurrentQPa: 10, HasMaxQ: false}
+	got := v.ascentQBandLines(qb)
+	for _, line := range got {
+		if strings.Contains(line, ascentQBandMaxQGlyph) || strings.Contains(line, "max Q") {
+			t.Errorf("line %q mentions max Q before any peak was measured", line)
+		}
+	}
+}
+
+// TestLaunchViewAscentInstrumentsAt80x24: the ascent half has to survive
+// the smallest supported terminal — the ATMOSPHERE chip composites onto
+// the canvas and the attitude stubs land near the sprite at 80×24, not
+// only at roomy dev-window sizes.
+func TestLaunchViewAscentInstrumentsAt80x24(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := ascendingCraftWorld(t, "earth", 20_000, 300, orbital.Vec3{X: 1})
+
+	out := v.Render(w, 80, 24)
+	if !strings.Contains(stripANSI(out), "ATMOSPHERE") {
+		t.Errorf("80×24 ascending render is missing the ATMOSPHERE chip:\n%s", out)
+	}
+	if rows := len(strings.Split(out, "\n")); rows > 24 {
+		t.Errorf("render is %d rows tall, want ≤ 24", rows)
+	}
+	if n := v.canvas.CountColor(render.ColorNavballMarkerNoseFront); n == 0 {
+		t.Error("no nose-direction marker drawn during ascent")
+	}
+	if n := v.canvas.CountColor(render.ColorNavballMarkerPrograde); n == 0 {
+		t.Error("no prograde marker drawn during ascent")
+	}
+}
+
+// TestLaunchViewNoAscentInstrumentsOnDescentOrCoast: the ATMOSPHERE chip
+// is gated on climbing, mirroring TestLaunchViewNoDescentInstrumentsOnAscent
+// — a falling vessel or one coasting in a stable orbit gets none of the
+// ascent cues, so the surface view never stacks both instrument sets.
+func TestLaunchViewNoAscentInstrumentsOnDescentOrCoast(t *testing.T) {
+	th := launchThemeForTest()
+
+	// Falling: mirrors descendingMoonCraft's own falling case.
+	fallingV := NewLaunchView(th, NewOrbitView(th))
+	falling := descendingMoonCraft(t, 20_000, 120)
+	fallingOut := stripANSI(fallingV.Render(falling, 120, 40))
+	if strings.Contains(fallingOut, "ATMOSPHERE") {
+		t.Errorf("falling vehicle rendered the ATMOSPHERE chip:\n%s", fallingOut)
+	}
+
+	// Coasting in a stable circular orbit: neither climbing nor falling.
+	coastV := NewLaunchView(th, NewOrbitView(th))
+	coast := ascendingCraftWorld(t, "earth", 300_000, 0, orbital.Vec3{X: 1})
+	c := coast.ActiveCraft()
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	coastOut := stripANSI(coastV.Render(coast, 120, 40))
+	if strings.Contains(coastOut, "ATMOSPHERE") {
+		t.Errorf("coasting vehicle rendered the ATMOSPHERE chip:\n%s", coastOut)
+	}
+	if strings.Contains(coastOut, "DESCENT CORRIDOR") {
+		t.Errorf("coasting vehicle rendered the DESCENT CORRIDOR chip:\n%s", coastOut)
+	}
+}


### PR DESCRIPTION
Part of #348 (§3 ascent — view seams follow separately).

## What this adds

Ascent half of the surface view (ADR 0043 §3), mirroring the descent
half from PR #354, all in `internal/tui/screens/launch.go` plus a new
`internal/sim/ascent.go`:

1. **Nose-vs-prograde markers** — short vector stubs plotted right on
   the launch sprite: the vessel's commanded nose direction
   (`Spacecraft.CurrentAttitudeDir`) and its surface-relative prograde
   (`physics.AirRelativeVelocity`). Colors reuse the navball's own
   vocabulary (`ColorNavballMarkerNoseFront` / `ColorNavballMarkerPrograde`)
   so "nose" and "prograde" mean the same hue everywhere.
2. **Predicted ascent arc** — `sim.PredictAscentPath` forward-propagates
   the current state exactly like `PredictImpact` (same `predictStep`
   propagator, same sub-step policy), but always returns the sampled
   path — `PredictImpact` discards its path on the "no impact inside the
   horizon" branch, which is exactly the common ascent case (still
   climbing, or already in a stable orbit). Both now share a
   `forwardBallisticPath` loop in `descent.go` so the two halves can't
   drift apart (the #66 two-drift-sites lesson the file already
   documents). Drawn `ClassPlanned` (dashed); clipping at the view edge
   is the canvas's existing segment clipping (`clipSegmentToCanvas`) —
   nothing ascent-specific was needed for that.
3. **ATMOSPHERE chip** — a vertical Q-band scale (6 bands, top =
   atmosphere cutoff, bottom = ground) showing the vessel's current
   position and dynamic pressure, with the altitude of the peak Q
   marked.

## Max-Q design choice

The ascent arc is deliberately ballistic-from-now (no future thrust/pitch
program modelled — same restraint `PredictImpact` already documents), so
there's no honest way to *forecast* the eventual max-Q altitude; that
would require assuming a throttle/attitude program the player hasn't
committed to. What the sim already tracks honestly is the peak Q
*measured so far* this session (`World.LaunchMaxQ`, ratcheted every tick
since v0.11). This PR adds `LaunchMaxQAltM` alongside it (same ratchet,
same three reset sites) and the chip marks that — the altitude of the
already-passed peak, updating live as a new peak is measured — rather
than a predicted one that doesn't exist yet on a fresh climb.

## Gating

`sim.AscentCueFor` gates all three cues on climbing (surface-relative
radial rate ≥ a small floor) — the mirror image of
`DescentCorridorFor`'s falling gate. Climbing and falling are opposite
signs of the same rate, so the two instrument sets are mutually
exclusive by construction; `TestAscentCueForGatingMatrix` pins ascent
vs. descent vs. coasting-orbit vs. landed, and
`TestLaunchViewNoAscentInstrumentsOnDescentOrCoast` /
`TestLaunchViewNoDescentInstrumentsOnAscent` cover it at the render
layer. The Q band additionally requires the primary to have an
atmosphere at all (`TestAscentCueForAirlessBodyHasCuesButNoQBand`) — the
nose/prograde markers and the arc work over airless bodies too.

## Not in scope

View seams (per the issue), stage-event theater, auto-reframing, chase
cam — all explicitly rejected in the ADR/issue.

## Testing

- `go vet ./...` clean
- `go test ./... -race -count=1` green
- New tests: `internal/sim/ascent_test.go` (geometry coincide/diverge,
  path with/without impact, seeded analytic Q, gating matrix, airless
  body) and `internal/tui/screens/launch_ascent_test.go` (dash-class
  arc, clip-at-edge, marker colors, Q-band row pinning, 80×24 render,
  gating at the render layer)