### PR TITLE
feat(#348): Proximity View cues — drift path, range rings, dock gate, v_rel vector

### DIFF
--- a/internal/sim/proximity.go
+++ b/internal/sim/proximity.go
@@ -1,7 +1,11 @@
 package sim
 
 import (
+	"math"
+	"time"
+
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 )
 
 // Proximity View (ADR 0043) — the sim half. This file owns three things:
@@ -211,4 +215,165 @@ func (w *World) ProximityHintActive() bool {
 		return false
 	}
 	return w.ProximityAvailable()
+}
+
+// ProximityDockGateReady reports whether the pair sits inside BOTH
+// docking gates right now — exactly checkDocking's own auto-fuse
+// predicate (DockingDistM / DockingVMS), reused rather than
+// re-thresholded so the dock-gate ring's green state and the game's
+// actual "you are about to dock" moment can never drift apart (issue
+// #348 §1: "DOCK READY becomes a place on screen").
+func (w *World) ProximityDockGateReady(st ProximityState) bool {
+	return st.RangeM < DockingDistM && st.VRelMS < DockingVMS
+}
+
+// ProximityDriftHorizonMin / ProximityDriftHorizonMax bound the no-burn
+// drift forecast (issue #348 §1): "a few minutes to tens of minutes" in
+// the issue's own words. The screen picks a horizon inside this band
+// from the current zoom (see orbit_proximity.go's
+// proximityDriftHorizonFor) and hands it to ProximityDriftPath — the sim
+// owns the physics of walking the horizon forward, the screen owns how
+// far ahead is worth looking at the player's current scale.
+const (
+	ProximityDriftHorizonMin = 2 * time.Minute
+	ProximityDriftHorizonMax = 30 * time.Minute
+)
+
+// proximityDriftSamples is the target number of points on the drawn
+// drift curve — plenty for a dashed polyline over a few-minutes-to-tens-
+// of-minutes horizon at docking-relevant relative speeds (impactPathSamples
+// uses 180 for a full 30-minute descent arc that can pass through
+// atmosphere; this curve is always vacuum two-body, so it needs far less
+// density to read smoothly).
+const proximityDriftSamples = 60
+
+// proximityDriftSubStepCap bounds the drift forecast's integrator
+// sub-step, seconds. predictMaxSubStep alone can return up to
+// predictMaxSubStepCap (120 s) for a long-period orbit, which is far
+// coarser than the whole drift horizon can afford to lose to a single
+// step's dt² truncation on the Verlet fallback path (reached only for a
+// non-Kepler-eligible state — an atmosphere-skimming or hyperbolic
+// craft). 5 s keeps a full 30-minute horizon under proximityDriftMaxSubSteps.
+const proximityDriftSubStepCap = 5.0
+
+// proximityDriftMaxSubSteps caps total integrator work per forecast so a
+// degenerate state (tiny period → tiny sub-step) can't stall the render
+// loop — same role as impactMaxSubSteps.
+const proximityDriftMaxSubSteps = 1024
+
+// ProximityDriftPoint is one sample of the no-burn relative-drift
+// forecast: the active vessel's position relative to the target,
+// expressed in the LVLH frame the TARGET'S OWN STATE defines AT THAT
+// FUTURE INSTANT — not today's frame. orbital.LVLHBasis's doc comment
+// explains why the basis has to rotate with the target; a caller that
+// reused today's frame for every future sample would draw a curve that
+// lies (a target-and-chaser pair sitting still relative to each other in
+// the CO-ROTATING frame — e.g. two craft on the same circular orbit at a
+// fixed phase offset — would instead sweep around like an inertial
+// orbit, because the frozen frame keeps rotating relative to the actual
+// physics while the physics itself doesn't).
+//
+// Local follows LVLHFrame.ToFrame's axis order: X = along-track,
+// Y = radial-out, Z = cross-track, all metres.
+type ProximityDriftPoint struct {
+	T     time.Duration
+	Local orbital.Vec3
+}
+
+// ProximityDriftPath forward-propagates BOTH the active vessel and the
+// target — using predictStep, the repo's one propagator, exactly like
+// forwardBallisticPath's established reuse pattern (descent.go) — and
+// differences their states at each sample instant, expressed in the
+// target's LVLH frame resolved fresh at that instant. No CW
+// linearization: this is the exact two-body difference, sampled.
+//
+// The target's own drag coefficient isn't generally available (a ghost
+// target has no Spacecraft at all; even a local craft target's bc is a
+// simplifying stand-in for whatever the OTHER player is actually flying)
+// so it propagates with bc=0 — a reasonable default since proximity ops
+// are, by construction, well clear of any atmosphere dense enough for
+// the choice to matter over a few-to-tens-of-minutes horizon.
+//
+// Both states propagate under the ACTIVE vessel's primary/mu — the same
+// simplification TargetStateRelativeToActivePrimary already makes for
+// every other relative-vector readout this view draws from (range,
+// |v_rel|, closing): Proximity View exists for two craft sharing a
+// neighbourhood, which in practice means sharing a primary.
+//
+// ok is false only for the same degenerate-input cases the rest of this
+// file already refuses (no active craft, no resolvable vessel/ghost
+// target, no defined LVLH frame at the current or a future instant) or a
+// non-positive horizon.
+func (w *World) ProximityDriftPath(horizon time.Duration) ([]ProximityDriftPoint, bool) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return nil, false
+	}
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return nil, false
+	}
+	frame0, ok := orbital.LVLHBasis(rT, vT)
+	if !ok {
+		return nil, false
+	}
+	primary := c.Primary
+	mu := primary.GravitationalParameter()
+	total := horizon.Seconds()
+	if mu <= 0 || total <= 0 {
+		return nil, false
+	}
+
+	craftState := c.State
+	targetState := physics.StateVector{R: rT, V: vT}
+	craftBC := c.EffectiveBallisticCoefficient()
+	const targetBC = 0.0
+
+	dt := predictMaxSubStep(orbitalPeriod(craftState, mu))
+	if td := predictMaxSubStep(orbitalPeriod(targetState, mu)); td < dt {
+		dt = td
+	}
+	if dt > proximityDriftSubStepCap {
+		dt = proximityDriftSubStepCap
+	}
+	steps := int(math.Ceil(total / dt))
+	if steps < 1 {
+		steps = 1
+	}
+	if steps > proximityDriftMaxSubSteps {
+		steps = proximityDriftMaxSubSteps
+		dt = total / float64(steps)
+	}
+	sampleEvery := steps / proximityDriftSamples
+	if sampleEvery < 1 {
+		sampleEvery = 1
+	}
+
+	points := make([]ProximityDriftPoint, 0, proximityDriftSamples+2)
+	points = append(points, ProximityDriftPoint{Local: frame0.ToFrame(craftState.R.Sub(rT))})
+
+	elapsed := 0.0
+	for i := 0; i < steps; i++ {
+		craftState = predictStep(craftState, mu, dt, primary, craftBC)
+		targetState = predictStep(targetState, mu, dt, primary, targetBC)
+		elapsed += dt
+		if (i+1)%sampleEvery != 0 && i != steps-1 {
+			continue
+		}
+		frame, ok := orbital.LVLHBasis(targetState.R, targetState.V)
+		if !ok {
+			// Degenerate future frame (radial fall / zero speed) — stop
+			// extending the curve rather than draw a bogus point; every
+			// sample taken so far is still valid.
+			break
+		}
+		points = append(points, ProximityDriftPoint{
+			T:     time.Duration(elapsed * float64(time.Second)),
+			Local: frame.ToFrame(craftState.R.Sub(targetState.R)),
+		})
+	}
+	if len(points) < 2 {
+		return nil, false
+	}
+	return points, true
 }

--- a/internal/sim/proximity_test.go
+++ b/internal/sim/proximity_test.go
@@ -3,6 +3,7 @@ package sim
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
@@ -324,6 +325,205 @@ func TestProximityHintResetsOnRetarget(t *testing.T) {
 	w.updateProximityHint()
 	if w.ProximityHintActive() {
 		t.Error("hint survived losing the target")
+	}
+}
+
+// coCircularProximityWorld builds two vessels on the SAME circular orbit
+// (idx 1 = target, unchanged from the spawn; idx 0 = active, rotated by
+// deltaTheta about the orbit normal so it sits deltaTheta further along
+// the same circle) — the formation-flying configuration
+// TestProximityDriftPathMatchesAnalyticCoCircular checks against a
+// closed-form result. Returns the world and the shared orbital radius.
+func coCircularProximityWorld(t *testing.T, deltaTheta float64) (*World, float64) {
+	t.Helper()
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 vessels after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	active := w.ActiveCraft()
+	tgtR, tgtV := active.State.R, active.State.V
+	w.Crafts[1].Primary = active.Primary
+	w.Crafts[1].State.R = tgtR
+	w.Crafts[1].State.V = tgtV
+
+	frame, ok := orbital.LVLHBasis(tgtR, tgtV)
+	if !ok {
+		t.Fatal("precondition: no LVLH frame for the spawned circular orbit")
+	}
+	n := frame.CrossTrack
+	active.State.R = rotateAboutAxis(tgtR, n, deltaTheta)
+	active.State.V = rotateAboutAxis(tgtV, n, deltaTheta)
+	w.SetTargetCraft(1)
+	return w, tgtR.Norm()
+}
+
+// TestProximityDriftPathMatchesAnalyticCoCircular checks
+// ProximityDriftPath against a closed-form result that is entirely
+// independent of predictStep/KeplerStep: two craft on the SAME circular
+// orbit at a fixed angular phase offset Δθ have an EXACTLY constant
+// separation in the LVLH frame for all time — elementary circular-motion
+// geometry, since both craft's angle advances by the identical ω·t, so
+// their angular difference (and therefore the r̂/v̂-frame decomposition
+// of their separation) never changes:
+//
+//	local_along  = r·sin(Δθ)
+//	local_radial = r·(cos(Δθ) − 1)
+//	local_cross  = 0
+//
+// This single scenario does double duty as the frozen-frame regression
+// guard the issue calls for: a caller that reused TODAY's frame for
+// every future sample (instead of resolving each sample's frame from
+// the target's OWN state at that instant) would show these two craft
+// sweeping around each other as the real physics rotates out from under
+// the frozen axes — exactly the bug orbital.LVLHBasis's doc comment
+// warns about. Holding constant across the WHOLE returned path is what
+// this test actually checks, not just at t=0.
+func TestProximityDriftPathMatchesAnalyticCoCircular(t *testing.T) {
+	const deltaTheta = 0.05 // rad — a few km of arc at LEO altitude
+	w, r := coCircularProximityWorld(t, deltaTheta)
+
+	points, ok := w.ProximityDriftPath(10 * time.Minute)
+	if !ok {
+		t.Fatal("ProximityDriftPath refused a resolvable co-circular pair")
+	}
+	if len(points) < 2 {
+		t.Fatalf("got %d points, want at least 2", len(points))
+	}
+
+	want := orbital.Vec3{
+		X: r * math.Sin(deltaTheta),
+		Y: r * (math.Cos(deltaTheta) - 1),
+	}
+	const tol = 0.05 // metres — exact Kepler propagation, FP roundoff only
+	for i, p := range points {
+		if d := p.Local.Sub(want).Norm(); d > tol {
+			t.Errorf("point %d (t=%s): Local = %+v, want %+v (off by %.4f m) — co-circular formation should show near-zero drift", i, p.T, p.Local, want, d)
+		}
+	}
+}
+
+// TestProximityDriftPathMatchesAnalyticDifferentRadii is the
+// non-degenerate companion to the co-circular test above: two craft on
+// DIFFERENT circular orbits (r1 = target, r2 = active), sharing a plane,
+// so their separation genuinely changes shape over the horizon. Closed
+// form (elementary circular-motion geometry, independent of
+// predictStep): with target angle θ1(t) = ω1·t (reference zero) and
+// craft angle θ2(t) = θ0 + ω2·t,
+//
+//	local_along(t)  = r2·sin(θ0 + (ω2 − ω1)·t)
+//	local_radial(t) = r2·cos(θ0 + (ω2 − ω1)·t) − r1
+//
+// checked at every sample's OWN elapsed time (ProximityDriftPoint.T),
+// not just at the end of the horizon.
+func TestProximityDriftPathMatchesAnalyticDifferentRadii(t *testing.T) {
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 vessels after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	active := w.ActiveCraft()
+	tgtR, tgtV := active.State.R, active.State.V
+	w.Crafts[1].Primary = active.Primary
+	w.Crafts[1].State.R = tgtR
+	w.Crafts[1].State.V = tgtV
+
+	frame, ok := orbital.LVLHBasis(tgtR, tgtV)
+	if !ok {
+		t.Fatal("precondition: no LVLH frame for the spawned circular orbit")
+	}
+	mu := active.Primary.GravitationalParameter()
+	r1 := tgtR.Norm()
+	const theta0 = 0.3 // rad — craft starts ahead of the target
+	r2Val := r1 + 50e3 // 50 km higher than the target's circular radius
+	v2 := math.Sqrt(mu / r2Val)
+
+	n := frame.CrossTrack
+	rHat0 := rotateAboutAxis(tgtR.Scale(1/r1), n, theta0)
+	vHat0 := rotateAboutAxis(frame.AlongTrack, n, theta0)
+	active.State.R = rHat0.Scale(r2Val)
+	active.State.V = vHat0.Scale(v2)
+	w.SetTargetCraft(1)
+
+	omega1 := math.Sqrt(mu / (r1 * r1 * r1))
+	omega2 := math.Sqrt(mu / (r2Val * r2Val * r2Val))
+
+	points, ok := w.ProximityDriftPath(10 * time.Minute)
+	if !ok {
+		t.Fatal("ProximityDriftPath refused a resolvable pair")
+	}
+	if len(points) < 2 {
+		t.Fatalf("got %d points, want at least 2", len(points))
+	}
+
+	const tol = 0.5 // metres — exact Kepler propagation, FP roundoff only
+	for i, p := range points {
+		secs := p.T.Seconds()
+		phase := theta0 + (omega2-omega1)*secs
+		want := orbital.Vec3{
+			X: r2Val * math.Sin(phase),
+			Y: r2Val*math.Cos(phase) - r1,
+		}
+		if d := p.Local.Sub(want).Norm(); d > tol {
+			t.Errorf("point %d (t=%s): Local = %+v, want %+v (off by %.4f m)", i, p.T, p.Local, want, d)
+		}
+	}
+}
+
+// TestProximityDriftPathRefusalPaths: the same degenerate-input cases
+// the rest of Proximity View already refuses (no active craft, no
+// resolvable target) must refuse here too, plus a non-positive horizon —
+// ProximityDriftPath's own new guard.
+func TestProximityDriftPathRefusalPaths(t *testing.T) {
+	w := proximityPairWorld(t, orbital.Vec3{X: 1000}, orbital.Vec3{})
+	if _, ok := w.ProximityDriftPath(10 * time.Minute); !ok {
+		t.Fatal("refused a resolvable vessel target")
+	}
+	if _, ok := w.ProximityDriftPath(0); ok {
+		t.Error("accepted a zero horizon")
+	}
+	if _, ok := w.ProximityDriftPath(-time.Minute); ok {
+		t.Error("accepted a negative horizon")
+	}
+
+	w.ClearTarget()
+	if _, ok := w.ProximityDriftPath(10 * time.Minute); ok {
+		t.Error("accepted a world with no target")
+	}
+}
+
+// TestProximityDockGateReady checks all four quadrants around the
+// DockingDistM / DockingVMS thresholds — ready iff BOTH gates are
+// satisfied, using the exact same constants checkDocking's auto-fuse
+// reads, so the ring and the actual dock event can never disagree.
+func TestProximityDockGateReady(t *testing.T) {
+	w := mustWorld(t)
+	tests := []struct {
+		name      string
+		rangeM    float64
+		vRelMS    float64
+		wantReady bool
+	}{
+		{"inside both gates", DockingDistM - 1, DockingVMS - 0.01, true},
+		{"outside range, inside velocity", DockingDistM + 1, DockingVMS - 0.01, false},
+		{"inside range, outside velocity", DockingDistM - 1, DockingVMS + 0.01, false},
+		{"outside both gates", DockingDistM + 1, DockingVMS + 0.01, false},
+		{"exactly at range threshold (not <)", DockingDistM, DockingVMS - 0.01, false},
+		{"exactly at velocity threshold (not <)", DockingDistM - 1, DockingVMS, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := ProximityState{RangeM: tc.rangeM, VRelMS: tc.vRelMS}
+			if got := w.ProximityDockGateReady(st); got != tc.wantReady {
+				t.Errorf("range=%.1f vRel=%.3f: ready=%v, want %v", tc.rangeM, tc.vRelMS, got, tc.wantReady)
+			}
+		})
 	}
 }
 

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -2,6 +2,8 @@ package screens
 
 import (
 	"fmt"
+	"math"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -119,7 +121,11 @@ func (v *OrbitView) renderProximity(w *sim.World, totalCols, totalRows int) stri
 		// does on the map — the centre keeps tracking, just offset.
 		v.canvas.Center(st.TargetWorld.Add(v.panOffset))
 		v.drawProximityAxes(w, st)
+		v.drawProximityRangeRings(w, st)
+		v.drawProximityDockGate(w, st)
+		v.drawProximityDriftPath(w, st)
 		v.drawProximityVessels(w, st)
+		v.drawProximityVelocityVector(st)
 	}
 	// The no-target case draws nothing on the canvas on purpose: the
 	// explanation and both ways out ride the PROXIMITY chip, which paints
@@ -223,6 +229,263 @@ func proximityPrimaryName(w *sim.World) string {
 		return c.Primary.EnglishName
 	}
 	return "primary"
+}
+
+// Cue slice (issue #348 §1, follow-up to the Proximity View core in PR
+// #357): the drift path, range rings, dock gate, and v_rel vector stub.
+// Hull sprites at true scale are the slice after this one.
+
+// proximityDriftHorizonFloorMps floors the relative speed
+// proximityDriftHorizonFor divides by. A pair sitting almost exactly
+// matched in velocity (the stable end-state of a good approach) would
+// otherwise make "time to cross the framed radius" blow up toward +Inf;
+// the floor just means that case takes the horizon ceiling instead of a
+// division that has to be special-cased.
+const proximityDriftHorizonFloorMps = 0.01
+
+// proximityDriftHorizonFor picks how far ahead the no-burn drift path
+// looks: enough time, at the CURRENT |v_rel|, to cross roughly the
+// radius the Framing Event fitted — so a tight zoom (close range, small
+// frame) gets a proportionally short forecast and a wide one gets a
+// longer one, instead of a fixed window that either vanishes into a dot
+// at wide zoom or rockets off-canvas at close range. Clamped to
+// [ProximityDriftHorizonMin, ProximityDriftHorizonMax] (issue #348 §1's
+// own words: "a few minutes to tens of minutes"). Stated here, not
+// re-derived per call site, so the PR has exactly one place to point at
+// for "why this horizon."
+func proximityDriftHorizonFor(v *OrbitView, st sim.ProximityState) time.Duration {
+	scale := v.canvas.Scale()
+	if scale <= 0 {
+		return sim.ProximityDriftHorizonMin
+	}
+	halfSpanPx := float64(v.canvas.Cols() * 2)
+	if h := float64(v.canvas.Rows() * 4); h < halfSpanPx {
+		halfSpanPx = h
+	}
+	halfSpanPx /= 2
+	halfSpanM := halfSpanPx / scale
+
+	speed := st.VRelMS
+	if speed < proximityDriftHorizonFloorMps {
+		speed = proximityDriftHorizonFloorMps
+	}
+	horizon := time.Duration(halfSpanM / speed * float64(time.Second))
+	if horizon < sim.ProximityDriftHorizonMin {
+		return sim.ProximityDriftHorizonMin
+	}
+	if horizon > sim.ProximityDriftHorizonMax {
+		return sim.ProximityDriftHorizonMax
+	}
+	return horizon
+}
+
+// drawProximityDriftPath draws the no-burn forecast: where the active
+// vessel drifts relative to the target over the next few minutes if
+// nobody touches the throttle. ClassPlanned (dashed) — a plan, not a
+// live orbit (ADR 0041 §2), the same vocabulary the ascent/descent arcs
+// use for "what happens if flight continues exactly as it is now."
+//
+// sim.ProximityDriftPath hands back LVLH-LOCAL coordinates, each
+// resolved in the TARGET's frame at that future instant (see its doc
+// comment for why that matters). Re-anchoring every point at TODAY's
+// target position using TODAY's frame axes is what turns "a series of
+// co-rotating-frame offsets" into a single curve on the canvas Camera
+// Contract holds fixed for this render — it's the same picture a pilot
+// re-entering this view at each future instant would see, drawn as one
+// continuous line from where they are now.
+func (v *OrbitView) drawProximityDriftPath(w *sim.World, st sim.ProximityState) {
+	horizon := proximityDriftHorizonFor(v, st)
+	samples, ok := w.ProximityDriftPath(horizon)
+	if !ok || len(samples) < 2 {
+		return
+	}
+	pts := make([]orbital.Vec3, len(samples))
+	for i, s := range samples {
+		pts[i] = st.TargetWorld.
+			Add(st.Frame.AlongTrack.Scale(s.Local.X)).
+			Add(st.Frame.RadialOut.Scale(s.Local.Y)).
+			Add(st.Frame.CrossTrack.Scale(s.Local.Z))
+	}
+	v.canvas.PlotPolylineClass(pts, render.ColorPlannedNode, widgets.ClassPlanned)
+}
+
+// proximityRingRadii are the log-spaced range rings issue #348 §1 asks
+// for: 10 km, 1 km, 100 m — a coarse decade ladder a pilot can eyeball
+// distance against without reading the range chip. The 50 m dock gate
+// (sim.DockingDistM) is drawn separately by drawProximityDockGate: it
+// isn't a fourth entry here because its colour is gated on |v_rel| too,
+// not radius alone.
+var proximityRingRadii = []float64{10_000, 1_000, 100}
+
+// proximityRingSegments is how many straight edges approximate each
+// ring. The braille canvas's own pixel grid (cols*2 × rows*4) is coarse
+// enough at any terminal size this game actually supports that this many
+// segments is indistinguishable from a true circle — unlike
+// DrawEllipseClass's adaptive flattening, this never needs to scale with
+// projected radius because a range ring is always a perfect circle in
+// the LVLH plane, never foreshortened by a tilted orbit.
+const proximityRingSegments = 96
+
+// proximityRingMinPixels is the same floor drawSOIRing already uses
+// (soiRingMinPixels, internal/tui/screens/orbit.go): below this a ring's
+// outline degenerates into scattered noise rather than a readable
+// circle, so it's skipped entirely rather than drawn wrong.
+const proximityRingMinPixels = 4
+
+// proximityRingPoints samples a closed circle of radiusM around center,
+// in the plane spanned by e1/e2 (both unit length, mutually orthogonal)
+// — the raw material PlotPolylineClass turns into a dotted or dashed
+// ring via its own arc-length-stable dash machinery. Closed by repeating
+// the first point.
+func proximityRingPoints(center, e1, e2 orbital.Vec3, radiusM float64) []orbital.Vec3 {
+	pts := make([]orbital.Vec3, 0, proximityRingSegments+1)
+	for i := 0; i <= proximityRingSegments; i++ {
+		theta := 2 * math.Pi * float64(i) / float64(proximityRingSegments)
+		pts = append(pts, center.
+			Add(e1.Scale(radiusM*math.Cos(theta))).
+			Add(e2.Scale(radiusM*math.Sin(theta))))
+	}
+	return pts
+}
+
+// proximityRingVisible reports whether a ring of radiusM around
+// st.TargetWorld would show at least a readable arc on the current
+// canvas: O(1) on the projected radius against the viewport rectangle,
+// so a ring far outside the current zoom never reaches the O(segments)
+// polyline walk at all (the same budget-before-you-draw discipline
+// drawSOIRing already uses for the SOI Ring).
+//
+// A ring is visible exactly when its CIRCUMFERENCE crosses the canvas
+// rectangle — not merely when its bounding box overlaps it, which would
+// wrongly call a ring "visible" when it has zoomed in so far past the
+// canvas that the whole screen sits deep inside it and the drawn line
+// never comes near a single pixel (the log rings are exactly the case
+// this matters for: at close range the 10 km/1 km rings dwarf the framed
+// view). The standard circle-vs-rectangle test: the circle crosses the
+// rect iff the rect's NEAREST point to the centre is inside-or-on the
+// circle and its FARTHEST point (always a corner) is outside-or-on it.
+func (v *OrbitView) proximityRingVisible(st sim.ProximityState, radiusM float64) bool {
+	scale := v.canvas.Scale()
+	if scale <= 0 {
+		return false
+	}
+	pxR := radiusM * scale
+	if pxR < proximityRingMinPixels {
+		return false
+	}
+	cx, cy, _ := v.canvas.Project(st.TargetWorld)
+	fcx, fcy := float64(cx), float64(cy)
+	pxW, pxH := float64(v.canvas.Cols()*2), float64(v.canvas.Rows()*4)
+
+	nearX := math.Max(0, math.Min(fcx, pxW))
+	nearY := math.Max(0, math.Min(fcy, pxH))
+	if math.Hypot(nearX-fcx, nearY-fcy) > pxR {
+		return false // the whole canvas lies outside the ring
+	}
+	farX := math.Max(fcx, pxW-fcx)
+	farY := math.Max(fcy, pxH-fcy)
+	if math.Hypot(farX, farY) < pxR {
+		return false // the whole canvas lies inside the ring; the line never crosses it
+	}
+	return true
+}
+
+// drawProximityRangeRings draws the log-spaced range rings around the
+// target, skipping any ring that doesn't clear proximityRingMinPixels or
+// falls entirely outside the canvas at the current zoom. ClassScenery
+// (dotted, faint) — backdrop distance cues, never the thing being flown.
+// Each ring carries a narrow label at its +V-bar crossing so the faint
+// ink still reads as a specific distance rather than an unlabeled
+// decoration; on-canvas gated the same way the axis end labels are.
+func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState) {
+	dim := v.theme.Dim.GetForeground()
+	for _, r := range proximityRingRadii {
+		if !v.proximityRingVisible(st, r) {
+			continue
+		}
+		pts := proximityRingPoints(st.TargetWorld, st.Frame.AlongTrack, st.Frame.RadialOut, r)
+		v.canvas.PlotPolylineClass(pts, render.ColorDim, widgets.ClassScenery)
+		labelPt := st.TargetWorld.Add(st.Frame.AlongTrack.Scale(r))
+		if col, row, onCanvas := v.canvasCell(labelPt); onCanvas {
+			v.canvas.SetCellLabelColored(col, row, formatRangeM(r), dim)
+		}
+	}
+}
+
+// drawProximityDockGate draws the 50 m dock-gate ring (sim.DockingDistM)
+// — the one ring whose COLOR carries state rather than just its
+// presence: dim while outside either gate, ColorTarget green exactly
+// when the pair sits inside BOTH DockingDistM and DockingVMS
+// (sim.ProximityDockGateReady — the same predicate checkDocking's
+// auto-fuse uses, so the ring's green threshold and the game's actual
+// "you are about to dock" threshold can never drift apart). This is
+// issue #348 §1's "DOCK READY becomes a place on screen."
+//
+// No separate DOCK READY text callout is added alongside it: the ready
+// state is inherently momentary (checkDocking auto-fuses the pair the
+// very next tick it holds true), so a chip would flicker on and off
+// faster than a player could read it — exactly the failure the hint
+// chip's hysteresis band exists to prevent elsewhere in this file. A
+// ring doesn't need that guard because it's a place, not a popup: it's
+// already there, faint, before the moment arrives, and it simply changes
+// colour when the moment does.
+func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
+	const gateRadius = sim.DockingDistM
+	if !v.proximityRingVisible(st, gateRadius) {
+		return
+	}
+	color := render.ColorDim
+	if w.ProximityDockGateReady(st) {
+		color = render.ColorTarget
+	}
+	pts := proximityRingPoints(st.TargetWorld, st.Frame.AlongTrack, st.Frame.RadialOut, gateRadius)
+	v.canvas.PlotPolylineClass(pts, color, widgets.ClassScenery)
+}
+
+// proximityVelocityStubPx is the v_rel vector stub's length in canvas
+// sub-pixels — the same order of magnitude as the ascent view's
+// nose/prograde stubs (ascentMarkerStubPx), long enough to read a
+// direction at a glance without swamping the vessel glyph it's anchored
+// to.
+const proximityVelocityStubPx = 8.0
+
+// proximityVelocityVectorEndpoint computes the world point the v_rel stub
+// reaches from st.CraftWorld: the active vessel's velocity relative to
+// the target (st.RelVel, world axes), unit-scaled to
+// proximityVelocityStubPx worth of canvas pixels at the given
+// pixels-per-metre scale. Split out from drawProximityVelocityVector as
+// a pure function so the DIRECTION math — the part issue #348 §1's third
+// cue is actually about — can be checked by a test without inspecting
+// canvas pixels. ok is false for the two cases nothing sensible can be
+// drawn: no relative motion (RelVel = 0, nothing to point at) or a
+// non-positive scale.
+func proximityVelocityVectorEndpoint(st sim.ProximityState, scale float64) (orbital.Vec3, bool) {
+	n := st.RelVel.Norm()
+	if n == 0 || scale <= 0 {
+		return orbital.Vec3{}, false
+	}
+	dir := st.RelVel.Scale(1 / n)
+	step := proximityVelocityStubPx / scale
+	return st.CraftWorld.Add(dir.Scale(step)), true
+}
+
+// drawProximityVelocityVector draws a short stub from the active vessel
+// in the direction of v_rel — issue #348 §1's third cue.
+// render.ColorNavballMarkerPrograde: this is a "which way am I moving"
+// marker, the same semantic role that colour already carries on the
+// navball and the ascent attitude stubs (ADR 0041: colour is semantic,
+// never identity, so it is NOT the active vessel's own marker colour
+// here).
+//
+// A direction stub rather than a magnitude-scaled arrow: the range chip
+// already gives the number, and at docking-relevant speeds (cm/s to a
+// few m/s) a to-scale vector would be sub-pixel most of the time anyway.
+func (v *OrbitView) drawProximityVelocityVector(st sim.ProximityState) {
+	end, ok := proximityVelocityVectorEndpoint(st, v.canvas.Scale())
+	if !ok {
+		return
+	}
+	v.canvas.PlotDenseLineColored(st.CraftWorld, end, render.ColorNavballMarkerPrograde, 1)
 }
 
 // drawProximityVessels stamps the two hulls-for-now: the target dead

--- a/internal/tui/screens/orbit_proximity_test.go
+++ b/internal/tui/screens/orbit_proximity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
@@ -337,5 +338,192 @@ func TestProximityHintAbsentFarAway(t *testing.T) {
 	w.Tick()
 	if out := v.Render(w, 0, 80, 24); strings.Contains(out, "CLOSE RANGE") {
 		t.Errorf("hint chip at 500 km\n%s", out)
+	}
+}
+
+// --- Cue slice tests (issue #348 §1) ---
+
+// TestProximityRangeRingsVisibleByZoom pins drawProximityRangeRings'
+// "only draw what fits at the current zoom" rule directly against
+// proximityRingVisible, the O(1) gate every ring call goes through
+// before the O(segments) polyline walk. At a 20 km separation, the
+// entry fit frames roughly 45 km — comfortably wide enough for the
+// 10 km ring to clear proximityRingMinPixels, but the 1 km and 100 m
+// rings project to under a pixel and must be skipped rather than drawn
+// as noise.
+func TestProximityRangeRingsVisibleByZoom(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 20_000})
+	v := newProximityTestView(t, 80, 24)
+	w.ViewMode = sim.ViewProximity
+	v.Render(w, 0, 80, 24)
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused")
+	}
+	if !v.proximityRingVisible(st, 10_000) {
+		t.Error("10 km ring not visible at a 20 km separation — should clear the pixel floor")
+	}
+	if v.proximityRingVisible(st, 1_000) {
+		t.Error("1 km ring visible at a 20 km separation — should be sub-pixel and skipped")
+	}
+	if v.proximityRingVisible(st, 100) {
+		t.Error("100 m ring visible at a 20 km separation — should be sub-pixel and skipped")
+	}
+}
+
+// TestProximityRangeRingsSkippedWhenEngulfed is the other half of "only
+// draw what fits at the current zoom": once the view is fitted tight
+// enough (a ~10 m separation, so the fit floor takes over), the 10 km
+// and 1 km rings are so much larger than the framed view that the whole
+// canvas sits deep inside them — the circle itself never crosses a
+// single pixel, which the naive "is the bounding box on screen" check
+// would miss (a huge ring's bounding box always overlaps a small
+// canvas). The 50 m dock gate, by contrast, is close enough to the fit
+// radius to still cross the canvas and must stay visible.
+func TestProximityRangeRingsSkippedWhenEngulfed(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 10})
+	v := newProximityTestView(t, 80, 24)
+	w.ViewMode = sim.ViewProximity
+	v.Render(w, 0, 80, 24)
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused")
+	}
+	if v.proximityRingVisible(st, 10_000) {
+		t.Error("10 km ring reported visible at a 10 m separation — the canvas is entirely inside it")
+	}
+	if v.proximityRingVisible(st, 1_000) {
+		t.Error("1 km ring reported visible at a 10 m separation — the canvas is entirely inside it")
+	}
+	if !v.proximityRingVisible(st, sim.DockingDistM) {
+		t.Error("50 m dock gate not visible at a 10 m separation — it should still cross the framed view")
+	}
+}
+
+// TestProximityDockGateColorReady: the gate ring renders ColorTarget
+// green exactly when the pair is inside BOTH DockingDistM and
+// DockingVMS — the same predicate table TestProximityDockGateReady
+// exercises at the sim layer, here confirmed to actually reach the
+// canvas in the right colour. Compared as a DELTA rather than an
+// absolute count, because the target vessel's own glyph is always drawn
+// ColorTarget (drawProximityVessels) regardless of gate state — the
+// ready scene must show MORE ColorTarget cells than the not-ready scene
+// (the gate ring's own ~dozens of dotted cells switching from dim to
+// green), not merely "some."
+func TestProximityDockGateColorReady(t *testing.T) {
+	readyW := proximityWorld(t, orbital.Vec3{X: 30}) // inside DockingDistM, matched v (v_rel = 0)
+	readyV := newProximityTestView(t, 80, 24)
+	readyW.ViewMode = sim.ViewProximity
+	readyV.Render(readyW, 0, 80, 24)
+	readySt, ok := readyW.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused (ready case)")
+	}
+	if !readyW.ProximityDockGateReady(readySt) {
+		t.Fatal("precondition: ready case is not actually ready")
+	}
+
+	notReadyW := proximityWorld(t, orbital.Vec3{X: 100}) // outside DockingDistM, matched v
+	notReadyV := newProximityTestView(t, 80, 24)
+	notReadyW.ViewMode = sim.ViewProximity
+	notReadyV.Render(notReadyW, 0, 80, 24)
+	notReadySt, ok := notReadyW.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused (not-ready case)")
+	}
+	if notReadyW.ProximityDockGateReady(notReadySt) {
+		t.Fatal("precondition: not-ready case is actually ready")
+	}
+	if !readyV.proximityRingVisible(readySt, sim.DockingDistM) {
+		t.Fatal("precondition: gate ring not visible in the ready scene")
+	}
+	if !notReadyV.proximityRingVisible(notReadySt, sim.DockingDistM) {
+		t.Fatal("precondition: gate ring not visible in the not-ready scene")
+	}
+
+	readyGreen := readyV.canvas.CountColor(render.ColorTarget)
+	notReadyGreen := notReadyV.canvas.CountColor(render.ColorTarget)
+	if readyGreen <= notReadyGreen {
+		t.Errorf("ColorTarget cells: ready=%d, not-ready=%d — the gate ring should add green cells the not-ready scene doesn't have", readyGreen, notReadyGreen)
+	}
+}
+
+// TestProximityDriftPathDrawsPlannedClass: the drift path reaches the
+// canvas as ClassPlanned (dashed) ink in render.ColorPlannedNode — the
+// end-to-end wiring check that drawProximityDriftPath actually calls
+// sim.ProximityDriftPath and plots what comes back, not just that the
+// sim math is right (already covered at the sim layer).
+func TestProximityDriftPathDrawsPlannedClass(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 2_000})
+	v := newProximityTestView(t, 80, 24)
+	w.ViewMode = sim.ViewProximity
+	v.Render(w, 0, 80, 24)
+
+	if n := v.canvas.CountColor(render.ColorPlannedNode); n == 0 {
+		t.Error("no ColorPlannedNode ink found on canvas — drift path did not draw")
+	}
+}
+
+// TestProximityVelocityVectorOrientation checks
+// proximityVelocityVectorEndpoint — the pure direction math behind the
+// v_rel stub — for a known relative velocity: purely along the target's
+// +AlongTrack, the endpoint must decompose to a POSITIVE along-track
+// offset from the craft (the +V-bar side), zero radial.
+func TestProximityVelocityVectorOrientation(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 800})
+	// Own vessel closes along the target's +AlongTrack direction — set
+	// directly via the same LVLH frame the scene resolves, so the
+	// expectation is stated in the frame's own vocabulary.
+	active := w.ActiveCraft()
+	tc := w.Crafts[1]
+	frame, ok := orbital.LVLHBasis(tc.State.R, tc.State.V)
+	if !ok {
+		t.Fatal("precondition: no LVLH frame")
+	}
+	active.State.V = tc.State.V.Add(frame.AlongTrack.Scale(3))
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused")
+	}
+	if st.RelVel.Norm() == 0 {
+		t.Fatal("precondition: RelVel is zero")
+	}
+
+	const scale = 0.01 // pixels-per-metre; only the DIRECTION is under test
+	end, ok := proximityVelocityVectorEndpoint(st, scale)
+	if !ok {
+		t.Fatal("proximityVelocityVectorEndpoint refused a nonzero RelVel")
+	}
+	local := st.Frame.ToFrame(end.Sub(st.CraftWorld))
+	if local.X <= 0 {
+		t.Errorf("along-track = %g, want > 0 (stub should point toward +V-bar)", local.X)
+	}
+	if math.Abs(local.Y) > 1e-6 {
+		t.Errorf("radial = %g, want ~0 (relative velocity is pure along-track)", local.Y)
+	}
+}
+
+// TestProximityCuesRenderAt80x24 re-runs the core's layout smoke test
+// (TestProximityRendersAt80x24) at a range that actually exercises every
+// cue this slice adds — rings, dock gate, drift path, v_rel stub — so a
+// cue that overruns a row or corrupts the frame at the minimum supported
+// terminal size fails here rather than shipping unnoticed.
+func TestProximityCuesRenderAt80x24(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 5_000})
+	v := newProximityTestView(t, 80, 24)
+	w.ViewMode = sim.ViewProximity
+	out := v.Render(w, 0, 80, 24)
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 24 {
+		t.Fatalf("rendered %d rows, want 24", len(lines))
+	}
+	for i, l := range lines[1:] {
+		if width := lipgloss.Width(l); width > 80 {
+			t.Errorf("row %d is %d cols wide, want ≤ 80", i+1, width)
+		}
 	}
 }


### PR DESCRIPTION
Part of #348 (§1 cues — hull sprites follow).

## Summary

Builds on the Proximity View core (PR #357) with the four cues issue #348 §1 calls for:

- **Predicted relative drift path** — both craft propagated forward via `predictStep` (the repo's single propagator; reuses `forwardBallisticPath`'s established pattern from `descent.go`), differenced, and each sample expressed in the **target's LVLH frame resolved fresh at that future instant** — not today's frame — so a co-rotating formation draws as a near-point rather than lying about an inertial spiral. Lives in `internal/sim/proximity.go` (`ProximityDriftPath`); the screen only draws (`drawProximityDriftPath`). Drawn `ClassPlanned` (dashed, `render.ColorPlannedNode`).
- **Range rings + dock gate** — faint `ClassScenery` rings at 10 km / 1 km / 100 m, narrowly labeled, plus the 50 m dock-gate ring which turns `render.ColorTarget` green exactly when `sim.ProximityDockGateReady` (reuses `sim.DockingDistM` / `sim.DockingVMS` from `docking.go` — never re-thresholded, so the ring and the actual auto-dock event can't drift apart). Ring visibility is an O(1) circle-vs-viewport rectangle test (`proximityRingVisible`) so an off-scale ring never reaches the O(segments) polyline walk — this also fixes the naive-bounding-box false positive where a ring much larger than the framed view would otherwise be reported "visible" while never actually crossing a canvas pixel.
- **v_rel vector stub** — a short direction stub from the active vessel along `RelVel`, in `render.ColorNavballMarkerPrograde` (a semantic "which way am I moving" marker per ADR 0041 — never craft-identity color). Direction math is split into a pure function (`proximityVelocityVectorEndpoint`) so it's testable without inspecting canvas pixels.

**Deviation from the ADR's literal wording:** no separate "DOCK READY" text chip is added — the ring itself is issue #348's "DOCK READY becomes a place on screen," and since `checkDocking` auto-fuses the pair the very next tick the gate holds true, a text callout would flicker on/off faster than a player could read it (the same failure the hint chip's hysteresis exists to prevent elsewhere). A ring doesn't need that guard because it's already there, faint, before the moment arrives.

**Drift-path horizon:** scales with the current framed radius and `|v_rel|` (`proximityDriftHorizonFor`), clamped to `[2 min, 30 min]` (`sim.ProximityDriftHorizonMin/Max`) — a tight zoom gets a proportionally short forecast, a wide one a longer one, instead of a fixed window that vanishes into a dot or rockets off-canvas.

Hull sprites at true scale remain the deferred follow-up slice, out of scope here.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./... -race -count=1` green
- New sim tests (`internal/sim/proximity_test.go`): drift path matches closed-form analytic differencing for a co-circular formation (`TestProximityDriftPathMatchesAnalyticCoCircular` — doubles as the frozen-frame regression guard: verified it fails if the frame is reused instead of resolved per-sample) and for two different-radius circular orbits (`TestProximityDriftPathMatchesAnalyticDifferentRadii`); refusal paths; dock-gate-ready predicate across all four quadrants of the threshold.
- New screen tests (`internal/tui/screens/orbit_proximity_test.go`): ring visibility by zoom (both "too small" and "canvas engulfed" cases); dock-gate color flips green iff ready (verified the test fails if the color-flip logic is removed); v_rel vector orientation for a known relative-velocity state (verified the test fails on a sign flip); drift path reaches the canvas as planned-class ink; 80×24 render stays within budget with every cue active.