### PR TITLE
fix: deterministic Inspect click-owner resolution (cross-platform)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -512,7 +512,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// stage a burn there — because that is a place, not an
 			// identity question: you already know whose line it is. Any
 			// other line stops the click at identity.
-			ownOrbitLine := ownerHit && ownerRef.Kind == screens.InspectVessel &&
+			//
+			// hit.OwnerTied vetoes it: where your line and someone
+			// else's ink the cell equally, the click is genuinely
+			// ambiguous, and the two readings do not cost the same. The
+			// identity reading paints a name chip you can dismiss; the
+			// own-line reading pauses the clock and swaps to the
+			// maneuver screen. On a coin toss, take the reversible one —
+			// the ADR 0041 §3 contract is identity ON DEMAND, and a
+			// question that sometimes answers with a mode change reads
+			// as a misfire. Zoom in and the tie resolves itself.
+			ownOrbitLine := ownerHit && !hit.OwnerTied &&
+				ownerRef.Kind == screens.InspectVessel &&
 				a.world.ActiveCraft() != nil && ownerRef.CraftID == a.world.ActiveCraft().ID
 			switch {
 			case hit.IsVessel:

--- a/internal/tui/app_inspect_test.go
+++ b/internal/tui/app_inspect_test.go
@@ -1,12 +1,14 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
@@ -272,25 +274,23 @@ func TestBodyClickStillMovesTheCursorAndAlsoInspects(t *testing.T) {
 // both wrong and destructive when the line belongs to someone else. Now it
 // answers whose line it is and stops there.
 func TestClickingAnotherVesselsOrbitLineInspectsInsteadOfPlanting(t *testing.T) {
-	a := inspectApp(t)
-	active := a.world.ActiveCraft()
-	if active == nil {
-		t.Skip("no active vessel in the default world")
+	// Both a roomy terminal and the supported floor: the two ellipses land
+	// on far fewer cells at the floor size, so the cell the fixture picks
+	// there is a tighter constraint on the click router than the wide case
+	// — and the floor is where two lines are most likely to share one.
+	for _, size := range []struct{ w, h int }{
+		{200, 60},
+		{screens.MinTerminalWidth, screens.MinTerminalHeight},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.w, size.h), func(t *testing.T) {
+			clickSistersOrbitLine(t, size.w, size.h)
+		})
 	}
-	// A sister vessel on a clearly larger orbit, so its ellipse has pixels
-	// nowhere near the active vessel's.
-	sister := *active
-	sister.Name = "Sister"
-	sister.ID = 0
-	sister.State.R = active.State.R.Scale(1.6)
-	sister.State.V = active.State.V.Scale(1 / 1.6)
-	a.world.Crafts = append(a.world.Crafts, &sister)
-	a.world.EnsureCraftIDs()
-	a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
-	a.orbitView.ZoomOut()
-	a.orbitView.ZoomOut()
-	a.View()
+}
 
+func clickSistersOrbitLine(t *testing.T, width, height int) {
+	t.Helper()
+	a, sister := sisterApp(t, width, height)
 	want := screens.InspectRef{Kind: screens.InspectVessel, CraftID: sister.ID}
 	col, row, ok := findOwnerCell(a, want.OwnerKey())
 	if !ok {
@@ -313,13 +313,137 @@ func TestClickingAnotherVesselsOrbitLineInspectsInsteadOfPlanting(t *testing.T) 
 	}
 }
 
+// sisterApp is the two-vessels-on-the-map fixture: the default world plus
+// a copy of the active vessel on a clearly larger orbit, framed and
+// rendered at the requested terminal size so the canvas has both ellipses
+// on it. Returns the app and the sister (whose ID is assigned by
+// EnsureCraftIDs, so read it back off the pointer, never assume 2).
+func sisterApp(t *testing.T, width, height int) (*App, *spacecraft.Spacecraft) {
+	t.Helper()
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	a.View()
+
+	active := a.world.ActiveCraft()
+	if active == nil {
+		t.Skip("no active vessel in the default world")
+	}
+	sister := *active
+	sister.Name = "Sister"
+	sister.ID = 0
+	sister.State.R = active.State.R.Scale(1.6)
+	sister.State.V = active.State.V.Scale(1 / 1.6)
+	a.world.Crafts = append(a.world.Crafts, &sister)
+	a.world.EnsureCraftIDs()
+	a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
+	a.orbitView.ZoomOut()
+	a.orbitView.ZoomOut()
+	a.View()
+	return a, &sister
+}
+
+// TestClickingTheSameOrbitCellAlwaysAnswersTheSame is the cross-platform
+// regression for the flake this fixture shipped with: the sister's orbit
+// line resolved through a randomized map iteration inside HitAt, so a cell
+// where the two ellipses inked equally answered "the sister" on one call
+// and "you" on the next — roughly a one-in-ten failure on arm64 AND
+// amd64, which read as a commit- and platform-sensitive break because CI
+// only ever draws one sample per push.
+//
+// Asserting stability rather than a specific owner keeps the test honest
+// about geometry it does not control: which vessel wins any given cell is
+// the renderer's business, but it must be the SAME answer every time.
+func TestClickingTheSameOrbitCellAlwaysAnswersTheSame(t *testing.T) {
+	a, sister := sisterApp(t, 200, 60)
+	key := screens.InspectRef{Kind: screens.InspectVessel, CraftID: sister.ID}.OwnerKey()
+
+	checked := 0
+	for r := 2; r < a.height-1; r++ {
+		for c := 1; c < a.width-1; c++ {
+			first := a.orbitView.HitAt(c, r)
+			if first.Owner == "" {
+				continue
+			}
+			for i := 0; i < 25; i++ {
+				got := a.orbitView.HitAt(c, r)
+				if got.Owner != first.Owner || got.OwnerTied != first.OwnerTied {
+					t.Fatalf("cell (%d,%d) resolved to %q (tied=%v) then %q (tied=%v) — the hit-test is not deterministic",
+						c, r, first.Owner, first.OwnerTied, got.Owner, got.OwnerTied)
+				}
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Skip("no owner-tagged cells on the canvas")
+	}
+	t.Logf("checked %d owner-tagged cells (sister key %q)", checked, key)
+}
+
+// TestClickingAnAmbiguousOrbitCellNeverOpensThePlanner: where your line
+// and someone else's ink a cell equally, the click has no single right
+// answer — but the two candidate answers cost very different things. The
+// identity reading paints a chip; the own-line reading pauses the clock,
+// swaps to the maneuver screen and stages a burn. ADR 0041 §3 makes
+// Inspect identity ON DEMAND, so an ambiguous point-and-ask must never
+// cash out as a mode change.
+func TestClickingAnAmbiguousOrbitCellNeverOpensThePlanner(t *testing.T) {
+	a, _ := sisterApp(t, 200, 60)
+
+	col, row, ok := findTiedOwnerCell(a)
+	if !ok {
+		t.Skip("the two ellipses did not share a cell evenly on this canvas")
+	}
+
+	nodesBefore := len(a.world.ActiveCraft().Nodes)
+	orbit := a.active
+	a.Update(tea.MouseMsg{X: col, Y: row, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+
+	if a.active != orbit {
+		t.Errorf("clicking an ambiguous orbit cell left the map for %v", a.active)
+	}
+	if n := len(a.world.ActiveCraft().Nodes); n != nodesBefore {
+		t.Errorf("clicking an ambiguous orbit cell planted a node (%d -> %d)", nodesBefore, n)
+	}
+	if _, _, inspecting := a.orbitView.InspectedRef(); !inspecting {
+		t.Error("clicking an ambiguous orbit cell inspected nothing — it should still answer with one of the two")
+	}
+}
+
+// findTiedOwnerCell scans for an orbit-line cell whose owners split the
+// pixel count evenly — the ambiguous case, deliberately sought here
+// rather than avoided.
+func findTiedOwnerCell(a *App) (col, row int, ok bool) {
+	for r := 2; r < a.height-1; r++ {
+		for c := 1; c < a.width-1; c++ {
+			hit := a.orbitView.HitAt(c, r)
+			if hit.OwnerTied && hit.BodyID == "" && !hit.IsVessel && hit.NodeIdx == 0 {
+				return c, r, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
 // findOwnerCell scans the orbit canvas for a cell whose hit-test resolves
 // to the given Inspect owner key, returning its SCREEN coordinates.
+//
+// Tied cells are skipped. The two ellipses in this fixture pass close
+// enough to share a handful of cells one pixel each, and such a cell is
+// not the subject of any test here — clicking one asks the tie-break a
+// question, not the click router. Picking one by accident is what made
+// this scan's first hit a coin toss: the caller would find a cell only
+// while the wanted owner won the tie, then click it and get the other
+// owner on the next roll.
 func findOwnerCell(a *App, owner string) (col, row int, ok bool) {
 	for r := 2; r < a.height-1; r++ {
 		for c := 1; c < a.width-1; c++ {
 			hit := a.orbitView.HitAt(c, r)
-			if hit.Owner == owner && hit.BodyID == "" && !hit.IsVessel && hit.NodeIdx == 0 {
+			if hit.Owner == owner && !hit.OwnerTied &&
+				hit.BodyID == "" && !hit.IsVessel && hit.NodeIdx == 0 {
 				return c, r, true
 			}
 		}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -3,6 +3,7 @@
 package widgets
 
 import (
+	"cmp"
 	"math"
 	"strings"
 
@@ -57,6 +58,18 @@ type CellTag struct {
 	// (focus, open the node form, move the body Cursor) that Inspect does
 	// not change.
 	Owner string
+	// OwnerTied is a HitAt OUTPUT only — never set by a drawer, and
+	// ignored on any tag passed into a draw helper. It reports that two
+	// or more owners inked the same number of the cell's pixels, so the
+	// Owner above is the tie-break's answer rather than a majority's.
+	//
+	// It exists because the click paths are not symmetric: resolving an
+	// ambiguous cell to ANOTHER vessel costs a name chip, while resolving
+	// it to your OWN vessel's orbit line falls through to "stage a burn
+	// here" and changes screen. A coin-toss that sometimes opens the
+	// planner reads as a broken click, so the App gates that fallthrough
+	// on the cell being unambiguous.
+	OwnerTied bool
 }
 
 // DefaultBasis is the top-down projection: world X axis maps to
@@ -997,14 +1010,51 @@ func (c *Canvas) Unproject(px, py int) orbital.Vec3 {
 		Add(c.basis.Y.Scale(relY))
 }
 
+// cellCentreDist2 is the squared pixel distance from a cell-local braille
+// pixel (dx ∈ [0,2), dy ∈ [0,4)) to the geometric centre of its terminal
+// cell, in HALF-pixel units so the arithmetic stays integral: the centre
+// sits at (0.5, 1.5), which doubles to (1, 3).
+//
+// A braille pixel is cellW/2 wide and cellH/4 tall, and a terminal cell is
+// roughly twice as tall as it is wide, so the two axes are close enough to
+// square that an unweighted metric is honest here.
+func cellCentreDist2(dx, dy int) int {
+	x, y := 2*dx-1, 2*dy-3
+	return x*x + y*y
+}
+
+// hitCandidates accumulates, per tag value, how many of a cell's pixels
+// carry it and how close its closest pixel got to the cell centre. Both
+// are needed to resolve a hit deterministically: count is the primary
+// rule, distance is the tie-break.
+type hitCandidates[K comparable] struct {
+	count map[K]int
+	dist  map[K]int
+}
+
+func newHitCandidates[K comparable]() hitCandidates[K] {
+	return hitCandidates[K]{count: map[K]int{}, dist: map[K]int{}}
+}
+
+func (h hitCandidates[K]) add(k K, dist2 int) {
+	if nearest, seen := h.dist[k]; !seen || dist2 < nearest {
+		h.dist[k] = dist2
+	}
+	h.count[k]++
+}
+
 // HitAt aggregates the CellTag fields recorded on the 2×4 pixels
 // of the terminal cell at (col, row). Returns the most-common
-// non-empty BodyID among those pixels (with first-seen as the tie-
-// breaker). NodeIdx and IsVessel resolve the same way (most common
-// non-zero / true wins). Color falls out of the existing String()
-// aggregation and is not returned here. v0.6.4+: paired with the
-// app's MouseMsg dispatch so a click resolves to "what sim object
-// is this cell rendering?"
+// non-empty BodyID among those pixels; NodeIdx and IsVessel resolve
+// the same way (most common non-zero / true wins). Color falls out
+// of the existing String() aggregation and is not returned here.
+// v0.6.4+: paired with the app's MouseMsg dispatch so a click
+// resolves to "what sim object is this cell rendering?"
+//
+// Resolution is DETERMINISTIC, on every platform and every call: see
+// pickHit for the tie-break ladder. It has to be — the caller turns a
+// hit into a mode change, and a click that answers differently on two
+// consecutive presses reads as a broken input, not as an ambiguity.
 //
 // (col, row) outside the canvas → zero-value CellTag (no hit).
 // Cells whose pixel set is entirely untagged also return zero —
@@ -1017,9 +1067,9 @@ func (c *Canvas) HitAt(col, row int) CellTag {
 	if len(c.pixelTags) == 0 {
 		return CellTag{}
 	}
-	bodyCounts := map[string]int{}
-	nodeCounts := map[int]int{}
-	ownerCounts := map[string]int{}
+	bodies := newHitCandidates[string]()
+	nodes := newHitCandidates[int]()
+	owners := newHitCandidates[string]()
 	vesselCount := 0
 	pxStart, pyStart := col*2, row*4
 	for dx := 0; dx < 2; dx++ {
@@ -1028,14 +1078,15 @@ func (c *Canvas) HitAt(col, row int) CellTag {
 			if !ok {
 				continue
 			}
+			d2 := cellCentreDist2(dx, dy)
 			if tag.BodyID != "" {
-				bodyCounts[tag.BodyID]++
+				bodies.add(tag.BodyID, d2)
 			}
 			if tag.NodeIdx != 0 {
-				nodeCounts[tag.NodeIdx]++
+				nodes.add(tag.NodeIdx, d2)
 			}
 			if tag.Owner != "" {
-				ownerCounts[tag.Owner]++
+				owners.add(tag.Owner, d2)
 			}
 			if tag.IsVessel {
 				vesselCount++
@@ -1046,43 +1097,68 @@ func (c *Canvas) HitAt(col, row int) CellTag {
 	if vesselCount > 0 {
 		hit.IsVessel = true
 	}
-	if best, n := mostCommonString(bodyCounts); n > 0 {
+	if best, n, _ := pickHit(bodies); n > 0 {
 		hit.BodyID = best
 	}
-	if best, n := mostCommonInt(nodeCounts); n > 0 {
+	if best, n, _ := pickHit(nodes); n > 0 {
 		hit.NodeIdx = best
 	}
 	// Owner resolves the same most-common-wins way (ADR 0041 §3): a cell
 	// straddling two orbit lines answers with whichever owns more of its
 	// eight pixels, which is also the one the player can see more of.
-	if best, n := mostCommonString(ownerCounts); n > 0 {
+	// When neither owns more, OwnerTied says so, and the caller is
+	// expected to pick its LEAST destructive reading of the click.
+	if best, n, tied := pickHit(owners); n > 0 {
 		hit.Owner = best
+		hit.OwnerTied = tied
 	}
 	return hit
 }
 
-func mostCommonString(counts map[string]int) (string, int) {
-	var best string
-	bestN := 0
-	for k, n := range counts {
-		if n > bestN {
-			bestN = n
-			best = k
+// pickHit resolves one cell's candidates to a single winner, plus whether
+// the win was a genuine tie.
+//
+// The ladder, in order:
+//
+//  1. Most pixels in the cell wins — the ADR 0041 §3 rule, and the one
+//     the player can see: whichever entity inked more of the cell.
+//  2. Exact count tie → the candidate whose closest pixel is nearest the
+//     cell centre, i.e. nearest to where the click landed. A cell is all
+//     the sub-cell resolution a terminal mouse report gives us, so its
+//     centre is the best available stand-in for the click point.
+//  3. Still tied → the ordered key, purely so the answer is a function of
+//     the pixels and nothing else.
+//
+// Rung 3 exists only as a backstop and is deliberately LAST: on its own
+// it would systematically hand ties to the lowest-sorting key, which for
+// Inspect owner keys ("v:1", "v:2", …) means the lowest craft ID —
+// usually the active vessel, whose orbit line is the one click path with
+// a destructive fallthrough (stage a burn). Rungs 1 and 2 are grounded in
+// what is on screen; rung 3 is grounded in nothing, so it decides least.
+//
+// This used to be a bare `for k, n := range counts` keeping the first key
+// that beat the running max, with no tie-break at all — which meant Go's
+// per-range randomized map iteration picked the winner of every tie. It is
+// the same latent class of bug pickDominantColor was fixed for in
+// v0.7.2.1, missed here when hit-testing arrived in v0.6.4 and unreachable
+// in practice until ADR 0041 §3 put a SECOND owner's ink on the map beside
+// your own.
+func pickHit[K cmp.Ordered](h hitCandidates[K]) (best K, bestN int, tied bool) {
+	bestDist, atBest := 0, 0
+	for k, n := range h.count {
+		d := h.dist[k]
+		switch {
+		case n > bestN:
+			best, bestN, bestDist, atBest = k, n, d, 1
+		case n < bestN:
+		default:
+			atBest++
+			if d < bestDist || (d == bestDist && k < best) {
+				best, bestDist = k, d
+			}
 		}
 	}
-	return best, bestN
-}
-
-func mostCommonInt(counts map[int]int) (int, int) {
-	var best int
-	bestN := 0
-	for k, n := range counts {
-		if n > bestN {
-			bestN = n
-			best = k
-		}
-	}
-	return best, bestN
+	return best, bestN, atBest > 1
 }
 
 // IsBehindBody reports whether a world point `samplePos` is occluded

--- a/internal/tui/widgets/canvas_hit_determinism_test.go
+++ b/internal/tui/widgets/canvas_hit_determinism_test.go
@@ -1,0 +1,155 @@
+package widgets
+
+import (
+	"testing"
+)
+
+// HitAt has to answer the same way every time it is asked about the same
+// pixels. It resolves a mouse click into an ACTION — focus a vessel, open
+// the node form, move the body Cursor, inspect a line, or stage a burn —
+// so a cell that answers "your orbit" on one press and "their orbit" on
+// the next is not an ambiguity the player can reason about, it is a
+// broken button.
+//
+// The aggregation used to be a bare `for k, n := range counts` keeping the
+// first key that beat the running max, which meant Go's per-range
+// randomized map iteration decided every exact tie. It stayed invisible
+// while the map only ever tagged one owner per cell; ADR 0041 §3 put a
+// second vessel's orbit line on the canvas and made ties reachable, at
+// which point the Inspect click test started failing a tenth of the time
+// on both arm64 and amd64.
+//
+// setCellPixels writes tags straight into the per-pixel map so a test can
+// construct an exact pixel distribution without solving for world coords
+// that project onto the cell it wants.
+
+// setCellPixels tags `n` pixels of the terminal cell at (col, row),
+// starting at cell-local pixel index `from` in (dy-major) order, with the
+// supplied tag. Cell-local index i maps to (dx, dy) = (i/4, i%4).
+func setCellPixels(c *Canvas, col, row, from, n int, tag CellTag) {
+	if c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	for i := from; i < from+n && i < 8; i++ {
+		dx, dy := i/4, i%4
+		px, py := col*2+dx, row*4+dy
+		c.dc.Set(px, py)
+		c.pixelTags[[2]int{px, py}] = tag
+	}
+}
+
+// TestHitAtOwnerMajorityWins pins the ADR 0041 §3 rule itself: with an
+// unequal split the owner holding more of the cell's ink wins, which is
+// also the one the player can see more of.
+func TestHitAtOwnerMajorityWins(t *testing.T) {
+	c := NewCanvas(40, 20)
+	setCellPixels(c, 10, 5, 0, 3, CellTag{Owner: "v:2"})
+	setCellPixels(c, 10, 5, 3, 1, CellTag{Owner: "v:1"})
+
+	hit := c.HitAt(10, 5)
+	if hit.Owner != "v:2" {
+		t.Errorf("3-vs-1 split resolved to %q, want %q", hit.Owner, "v:2")
+	}
+	if hit.OwnerTied {
+		t.Error("a 3-vs-1 split reported OwnerTied — it has a clear majority")
+	}
+}
+
+// TestHitAtOwnerTieIsDeterministic is the regression proper: an exact
+// pixel-count tie must resolve to the SAME owner on every call, in every
+// process, on every platform.
+func TestHitAtOwnerTieIsDeterministic(t *testing.T) {
+	c := NewCanvas(40, 20)
+	// Cell-local pixels 0..3 are column dx=0, 4..7 are dx=1 — an even
+	// four-and-four straddle, the shape two orbit lines crossing a cell
+	// actually make.
+	setCellPixels(c, 10, 5, 0, 4, CellTag{Owner: "v:1"})
+	setCellPixels(c, 10, 5, 4, 4, CellTag{Owner: "v:2"})
+
+	first := c.HitAt(10, 5)
+	if first.Owner == "" {
+		t.Fatal("a fully-inked cell resolved to no owner")
+	}
+	if !first.OwnerTied {
+		t.Error("a 4-vs-4 split did not report OwnerTied")
+	}
+	// 500 calls is far past the point where a randomized map-iteration
+	// tie-break would have shown both answers.
+	for i := 0; i < 500; i++ {
+		if got := c.HitAt(10, 5); got.Owner != first.Owner {
+			t.Fatalf("call %d resolved the same cell to %q, first call said %q — HitAt is not deterministic", i, got.Owner, first.Owner)
+		}
+	}
+}
+
+// TestHitAtTieBreaksOnTheNearestPixel: with the counts equal, the owner
+// whose ink lies closest to the cell centre wins. That is the only
+// tie-break rung grounded in what the player pointed at — the cell is all
+// the sub-cell resolution a terminal mouse report carries, so its centre
+// stands in for the click point.
+func TestHitAtTieBreaksOnTheNearestPixel(t *testing.T) {
+	// Cell-local (dx, dy) distances² from the centre (see cellCentreDist2):
+	// dy 0 and 3 are the far rows (9+1=10), dy 1 and 2 the near ones (1+1=2).
+	c := NewCanvas(40, 20)
+	setCellPixels(c, 10, 5, 0, 1, CellTag{Owner: "v:1"}) // (0,0) — far row
+	setCellPixels(c, 10, 5, 1, 1, CellTag{Owner: "v:2"}) // (0,1) — near row
+
+	hit := c.HitAt(10, 5)
+	if hit.Owner != "v:2" {
+		t.Errorf("1-vs-1 tie resolved to %q, want %q (its pixel is nearer the cell centre)", hit.Owner, "v:2")
+	}
+	if !hit.OwnerTied {
+		t.Error("a 1-vs-1 split did not report OwnerTied")
+	}
+
+	// Mirror it: the same two owners, near/far swapped, must swap the
+	// winner. If it does not, something other than the geometry is
+	// deciding (e.g. the key order backstop).
+	c2 := NewCanvas(40, 20)
+	setCellPixels(c2, 10, 5, 1, 1, CellTag{Owner: "v:1"}) // (0,1) — near row
+	setCellPixels(c2, 10, 5, 0, 1, CellTag{Owner: "v:2"}) // (0,0) — far row
+	if hit2 := c2.HitAt(10, 5); hit2.Owner != "v:1" {
+		t.Errorf("mirrored tie resolved to %q, want %q — the tie-break is not reading the geometry", hit2.Owner, "v:1")
+	}
+}
+
+// TestHitAtBodyAndNodeTiesAreDeterministic: BodyID and NodeIdx go through
+// the same ladder as Owner and had the same latent bug. Two body disks
+// overlapping a cell, or two node markers, must not answer differently
+// per click either.
+func TestHitAtBodyAndNodeTiesAreDeterministic(t *testing.T) {
+	c := NewCanvas(40, 20)
+	setCellPixels(c, 10, 5, 0, 4, CellTag{BodyID: "earth", NodeIdx: 1})
+	setCellPixels(c, 10, 5, 4, 4, CellTag{BodyID: "luna", NodeIdx: 2})
+
+	first := c.HitAt(10, 5)
+	if first.BodyID == "" || first.NodeIdx == 0 {
+		t.Fatalf("fully-inked cell resolved to %+v", first)
+	}
+	for i := 0; i < 500; i++ {
+		got := c.HitAt(10, 5)
+		if got.BodyID != first.BodyID {
+			t.Fatalf("call %d resolved BodyID to %q, first call said %q", i, got.BodyID, first.BodyID)
+		}
+		if got.NodeIdx != first.NodeIdx {
+			t.Fatalf("call %d resolved NodeIdx to %d, first call said %d", i, got.NodeIdx, first.NodeIdx)
+		}
+	}
+}
+
+// TestHitAtSingleOwnerIsNeverTied: the overwhelmingly common case — one
+// entity's ink in the cell — must not trip the ambiguity flag, or the App
+// would refuse the own-orbit-line burn placement everywhere.
+func TestHitAtSingleOwnerIsNeverTied(t *testing.T) {
+	for n := 1; n <= 8; n++ {
+		c := NewCanvas(40, 20)
+		setCellPixels(c, 10, 5, 0, n, CellTag{Owner: "v:1"})
+		hit := c.HitAt(10, 5)
+		if hit.Owner != "v:1" {
+			t.Errorf("%d pixels of one owner resolved to %q", n, hit.Owner)
+		}
+		if hit.OwnerTied {
+			t.Errorf("%d pixels of a SINGLE owner reported OwnerTied", n)
+		}
+	}
+}


### PR DESCRIPTION
## What was actually wrong

`Canvas.HitAt` aggregates the eight braille pixels of a terminal cell into one answer. It did that by walking a Go map and keeping the first key that beat the running max:

```go
for k, n := range counts {
    if n > bestN { bestN, best = n, k }
}
```

There is no tie-break. On an exact tie the winner is whichever key **Go's randomized map iteration** happens to visit first — a fresh roll on every call, in the same process, on every platform. The doc comment claimed "with first-seen as the tie-breaker", which is not a thing a map has.

This was unreachable in practice from v0.6.4 (when hit-testing landed) until #355: at most one owner ever inked a given cell. ADR 0041 §3 tagged **orbit-line** pixels with an owner, so two vessels' ellipses crossing a single cell became routine, and the tie went live.

Note the same class of bug was already found and fixed in this very file for **colours** — `pickDominantColor` carries a comment about exactly this ("Go's map iteration order is randomized per range, which used to cause visible flicker"). The hit-test aggregators added later never got the memo.

## Pixel-level mechanism

Instrumenting the fixture in `TestClickingAnotherVesselsOrbitLineInspectsInsteadOfPlanting` at 200×60, the first cell `findOwnerCell` accepts in scan order is:

```
cell(110,24) counts = {v:1: 1, v:2: 1}   <- exact tie, one pixel each
cell( 89,25) counts = {v:1: 1, v:2: 3}   <- clean majority for the sister
```

`findOwnerCell` calls `HitAt` and returns the first cell resolving to the sister. When `v:2` wins the roll at (110,24) it returns (110,24) — a cell that is a coin toss. The test then clicks it, `HitAt` re-rolls, and roughly one time in ten the click resolves to `v:1`, the **active** vessel. That branch is not inert: it is the v0.6.4 "click a point on your own trajectory to stage a burn there" path, so it pauses the clock and swaps to the maneuver screen. Hence both assertion failures in one shot — wrong `CraftID`, and the planner opening.

Over 200 consecutive `findOwnerCell` calls in one process: 174 returned (110,24), 26 returned (89,25). The distribution is not 50/50 because Go's map iterator picks a random *start slot* and walks, so the odds are set by the gap between the two keys' slots.

## Why the commit table was misleading

The reported bisect (`38d732d` pass, `37eb518`/`9d2f9ad` fail on arm64, amd64 green until #358) does not hold up. Dumping the exact per-pixel owner tags at **all four** commits, on **both** architectures:

| | 38d732d (#355) | 37eb518 (#356) | 9d2f9ad (#357) | 14c6c3f (#358) |
|---|---|---|---|---|
| first candidate cell | (110,24) | (110,24) | (110,24) | (110,24) |
| its owner counts | v:1=1, v:2=1 | v:1=1, v:2=1 | v:1=1, v:2=1 | v:1=1, v:2=1 |
| ambiguous cells | 3 | 3 | 3 | 3 |
| cleanly sister-owned cells | 39 | 39 | 39 | 39 |

Byte-identical geometry, arm64 and amd64 (checked via a `GOARCH=amd64` build under Rosetta, which gives x86-64 FP semantics including no FMA contraction). So it is **not** floating-point divergence and **not** anything #356 or #357 changed on the draw path. It is a ~10% flake **born in #355 with the test itself**.

Measured failure rate over independent processes, before any fix:

- `38d732d` arm64: **7/60**
- main HEAD arm64: 2/40, amd64: **6/60**

`go test -count=5` passing at 38d732d has probability ≈ 0.9^5 ≈ 0.59 — an unremarkable draw, not evidence of a good commit.

## Why CI missed it

Seven CI runs happened between #355 merging and #358 opening (three branch pushes, three main merges, one PR run). At ~10% per run, P(all seven green) ≈ 0.48. A coin flip. CI did not "stay green until #358" for any structural reason — it drew green, and #358 happened to be where somebody looked. PR #358's current run is in fact green, which is the tell.

Nothing about linux/amd64 protected it. The flake is architecture-independent because the nondeterminism is in the Go runtime's map iterator, not in the arithmetic.

## The fix

Three levels, because the marginal fixture and the nondeterministic source are both real and fixing only one just moves the margin.

**1. Source — `HitAt` resolves through an explicit ladder** (`internal/tui/widgets/canvas.go`):

1. **Most pixels wins.** The ADR 0041 §3 rule, unchanged — "whichever owns more of its eight pixels, which is also the one the player can see more of."
2. **Exact tie → nearest the cell centre.** A cell is all the sub-cell resolution a terminal mouse report carries, so its centre stands in for the click point. "The ink you pointed closest at" is a rule a player can feel.
3. **Still tied → the ordered key**, purely so the answer is a function of the pixels and nothing else.

Rung 3 is deliberately last. On its own it would systematically hand every tie to the lowest-sorting key, which for owner keys (`v:1`, `v:2`, …) is the lowest craft ID — usually the active vessel, i.e. the one reading with a destructive fallthrough. Rungs 1 and 2 are grounded in what is on screen; rung 3 is grounded in nothing, so it decides least.

Applied to `BodyID` and `NodeIdx` too — same bug, same ladder, and two overlapping body disks or node markers were equally exposed.

**2. Behaviour — an ambiguous click never opens the planner** (`internal/tui/app.go`). `HitAt` now reports `CellTag.OwnerTied` when two or more owners inked the same number of pixels, and the `ownOrbitLine` fallthrough is gated on `!hit.OwnerTied`.

The two readings of an ambiguous click do not cost the same. Resolving to another vessel paints a name chip you can dismiss. Resolving to your own line pauses the clock, swaps screen and stages a burn. ADR 0041's contract is identity **on demand** — a question that sometimes answers with a mode change reads as a misfire, so on a genuine tie take the reversible reading. Zooming in resolves the tie for real.

**3. Fixture — `findOwnerCell` skips tied cells** (`internal/tui/app_inspect_test.go`). Clicking a tied cell asks the tie-break a question, not the click router; it was never the subject of this test. There are 39 cleanly sister-owned cells on that canvas and the scan now lands on one.

## Tests

- `internal/tui/widgets/canvas_hit_determinism_test.go` (new, 5 cases): majority still wins and is not flagged tied; a 4-vs-4 tie resolves identically 500× running; the tie-break demonstrably reads the geometry (mirroring near/far swaps the winner); `BodyID`/`NodeIdx` ties are deterministic; a single owner is never flagged tied. The tie case **fails at call 2** against the pre-fix aggregation — verified.
- `TestClickingTheSameOrbitCellAlwaysAnswersTheSame` (new): scans every owner-tagged cell on the rendered fixture (256 of them) and asserts each answers identically 25× running. Asserts *stability*, not a specific owner, so it does not pin geometry the test does not control.
- `TestClickingAnAmbiguousOrbitCellNeverOpensThePlanner` (new): deliberately seeks a tied cell, clicks it, asserts the screen did not change, no node was planted, and something was still inspected.
- `TestClickingAnotherVesselsOrbitLineInspectsInsteadOfPlanting` now runs as subtests at 200×60 **and** at the supported floor (`screens.MinTerminalWidth`×`MinTerminalHeight` = 104×24), where the ellipses land on far fewer cells and sharing one is likeliest.

## Results

```
go vet ./...                                        clean
go test ./... -race -count=1                        all packages ok
go test ./internal/tui -run TestClicking -race -count=20        ok
go test ./internal/tui/widgets -run TestHitAt -race -count=20   ok
GOARCH=amd64 go test ./internal/tui/... -count=3                ok
```

Independent-process flake rate for `TestClicking*`:

| | before | after |
|---|---|---|
| arm64 | 7/60 | **0/100** |
| amd64 | 6/60 | **0/100** |

## Blocking

This is what CI will keep intermittently tripping over on **#358** (and on every future PR) until it lands. #358 needs no change of its own — its red run was a draw of this flake, not a defect in the Proximity cues work.
