### PR TITLE
feat(#348): Proximity View hull sprites at true relative scale

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -103,6 +103,20 @@ type OrbitView struct {
 	mapPanOffset orbital.Vec3
 	mapPanSaved  bool
 
+	// proxOwnSpriteShown / proxTargetSpriteShown latch the Proximity
+	// View glyph→hull-sprite transition (issue #348 §1) per vessel, so
+	// the picture doesn't flicker between the two right at the switch
+	// point: entering the sprite state takes a taller silhouette than
+	// leaving it holds onto (see proximitySpriteVisible's hysteresis
+	// band, orbit_proximity.go). Kept separate per vessel because a
+	// small ghost/craft and a large stack at different ranges don't
+	// cross the band together. Session-only render state, reset
+	// alongside v.fitted/burnFrozenCenter at every Framing Event so a
+	// newly targeted vessel starts from its own measured height rather
+	// than inheriting the previous target's latch.
+	proxOwnSpriteShown    bool
+	proxTargetSpriteShown bool
+
 	// panOffset (ADR 0042, CONTEXT.md "Pan") is the player's ↑↓←→ view
 	// offset from the tracked Focus, in world units. Render adds it to
 	// FocusPosition() every frame — so the camera keeps tracking a moving

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
@@ -24,9 +25,10 @@ import (
 // key and every readout behaves exactly as it does on the map — the
 // picture changes, the cockpit does not.
 //
-// This slice draws deliberately little: two glyphs, the V-bar / R-bar
+// The core slice drew deliberately little: two glyphs, the V-bar / R-bar
 // cross, and a readout chip. The drift path, range rings and dock gate
-// are the follow-up cue slice; hull sprites the one after.
+// followed as the cue slice; hull sprites at true relative scale are this
+// slice. View seams (jump-key polish) are the one after.
 
 // proximityFitMarginFrac is how much room past the current range the
 // entry fit leaves. Canvas.FitTo frames a circle of the given radius at
@@ -105,6 +107,8 @@ func (v *OrbitView) renderProximity(w *sim.World, totalCols, totalRows int) stri
 			v.InspectClear()
 		}
 		v.burnFrozenCenter = nil
+		v.proxOwnSpriteShown = false
+		v.proxTargetSpriteShown = false
 	}
 
 	v.canvas.Clear()
@@ -233,7 +237,7 @@ func proximityPrimaryName(w *sim.World) string {
 
 // Cue slice (issue #348 §1, follow-up to the Proximity View core in PR
 // #357): the drift path, range rings, dock gate, and v_rel vector stub.
-// Hull sprites at true scale are the slice after this one.
+// Hull sprites at true scale (also #348 §1) follow further down this file.
 
 // proximityDriftHorizonFloorMps floors the relative speed
 // proximityDriftHorizonFor divides by. A pair sitting almost exactly
@@ -488,29 +492,194 @@ func (v *OrbitView) drawProximityVelocityVector(st sim.ProximityState) {
 	v.canvas.PlotDenseLineColored(st.CraftWorld, end, render.ColorNavballMarkerPrograde, 1)
 }
 
-// drawProximityVessels stamps the two hulls-for-now: the target dead
-// centre and the active vessel wherever the relative state puts it. Hull
-// sprites at true scale are the follow-up slice; a glyph at the true
-// POSITION is what this slice owes.
+// Hull-sprite slice (issue #348 §1, follow-up to the cue slice above):
+// inside a few hundred meters both craft render as their real
+// composed-from-stages silhouettes — the Launch-Sprite machinery
+// launch.go / launch_sprite.go already own — at true relative scale and
+// position; a glyph the rest of the time. View seams are the slice
+// after this one.
+
+// proximitySpriteEnterCells / proximitySpriteExitCells are the
+// glyph→hull-sprite transition's hysteresis band, stated in terminal
+// CELLS rather than metres — the metres a given cell count corresponds
+// to fall out of the current zoom (ADR 0043 §1: "true relative scale
+// and position"), not a fixed distance the picture has to chase. Below
+// proximitySpriteExitCells tall the composed silhouette has collapsed
+// to a smear a cell or two high — the same illegible-past-this-point
+// failure vesselSpriteBelowCellFloor guards on the launch screen, just
+// with headroom instead of a bare single-cell floor, so the switch
+// happens while there's still a recognisable shape to switch to.
+//
+// EnterCells > ExitCells opens the same arm-high/release-low band
+// proximityHintRangeM/proximityHintReleaseM already use for the CLOSE
+// RANGE chip: growing UP through 3 cells tall switches a glyph to its
+// sprite; shrinking back down, the sprite holds until it drops below 2.
+// Without the gap, a vessel sitting (or drifting slowly) right at the
+// switch point would repaint every frame.
+const (
+	proximitySpriteEnterCells = 3.0
+	proximitySpriteExitCells  = 2.0
+)
+
+// proximitySpriteVisible applies the hysteresis band above to one
+// vessel's measured sprite height. shown is that vessel's OWN latch
+// from the previous frame — OrbitView.proxOwnSpriteShown /
+// proxTargetSpriteShown are kept as two separate bools rather than one
+// shared flag precisely so a small ghost/craft and a large stack at
+// different ranges can cross the band independently.
+func proximitySpriteVisible(shown bool, heightCells float64) bool {
+	if shown {
+		return heightCells >= proximitySpriteExitCells
+	}
+	return heightCells >= proximitySpriteEnterCells
+}
+
+// proximitySpriteHeightCells is the composed launch sprite's on-screen
+// height in terminal CELLS at the Proximity canvas's current scale
+// (pixels-per-metre): the same real-world stride (vesselSubPixelM) and
+// row count (composedStackRows, launch_sprite.go) the launch screen's
+// own cell floor already uses, converted against canvasCellPxH instead
+// of launch's bare single-cell test (vesselSpriteBelowCellFloor). 0 for
+// a stack with no composed rows (no LaunchSprite-catalogued stage) or a
+// non-positive scale — both read as "no sprite, use the glyph."
+func proximitySpriteHeightCells(stages []spacecraft.Stage, scale float64) float64 {
+	rows := composedStackRows(stages)
+	if rows <= 0 || scale <= 0 {
+		return 0
+	}
+	heightPx := float64(rows) * vesselSubPixelM * scale
+	return heightPx / canvasCellPxH
+}
+
+// proximityTargetHullInputs resolves what the TARGET side of the
+// hull-sprite draw has to work with. A local vessel target carries its
+// own Stages + CurrentAttitudeDir, exactly like any other craft the
+// launch screen already composes (drawSOICraft's own precedent — a
+// sibling vessel in view gets its own sprite, not a shared one). A
+// multiplayer ghost carries neither: Ghost (ghost.go) is a name, a
+// glyph and a Kepler-propagated state — nothing about how the vessel is
+// built — so it falls back to the diamond-glyph path below rather than
+// invent a class-default silhouette this slice has no data to justify
+// (see the PR body for the explicit call).
+func proximityTargetHullInputs(w *sim.World) ([]spacecraft.Stage, orbital.Vec3) {
+	c, _, ok := w.ResolveTargetCraft()
+	if !ok || c == nil {
+		return nil, orbital.Vec3{}
+	}
+	return c.Stages, c.CurrentAttitudeDir
+}
+
+// drawProximityHull attempts the composed-from-stages silhouette at
+// anchorWorld, in the target-centred LVLH basis (screen-right =
+// AlongTrack, screen-down = −RadialOut) that renderProximity already
+// pinned as the canvas basis for this frame.
+//
+// True relative scale: ComposeLaunchSprite's per-dot stride is the
+// FIXED real-world vesselSubPixelM (launch_sprite.go's own precedent —
+// "the composed geometry is real metres, and it is the canvas's zoom
+// that turns those metres into screen pixels"). Proximity's canvas
+// already carries the LVLH pixels-per-metre scale the Framing Event
+// fitted (renderProximity / proximityFitRadius), so reusing the launch
+// composers here needs no scale translation of its own: a true 10 m
+// vessel composes to true 10 m of canvas real-estate, whatever that
+// happens to project to at the current zoom.
+//
+// Orientation: attitudeDir is projected into the screen plane exactly
+// as the launch screen's gravity-turn lean already does
+// (stackDirScreen, inside the Compose* functions) — a genuine
+// continuous lean within the LVLH plane, not a snap to a fixed pose.
+// What it can NOT do is rotate out of that plane: any attitude
+// component along the frame's CrossTrack axis (toward/away from the
+// camera) has no representation in a flat sprite, so a hull banking on
+// that axis renders at its in-plane projection — the nearest pose the
+// machinery supports, the same limitation the launch screen already
+// lives with. Full 3-D rotation is deferred, not built here (ADR 0043
+// §2: port-alignment gameplay, the feature that would actually need
+// it, is visibility-only for now).
+//
+// shown is the caller's per-vessel hysteresis latch (proximitySpriteVisible);
+// this updates it in place. Returns false — *shown left cleared —
+// whenever there's nothing to compose or it doesn't clear the
+// hysteresis band, so the caller's existing glyph fallback runs
+// unchanged.
+func (v *OrbitView) drawProximityHull(shown *bool, stages []spacecraft.Stage, attitudeDir orbital.Vec3, anchorWorld orbital.Vec3, frame orbital.LVLHFrame) bool {
+	heightCells := proximitySpriteHeightCells(stages, v.canvas.Scale())
+	*shown = proximitySpriteVisible(*shown, heightCells)
+	if !*shown {
+		return false
+	}
+	basis := widgets.Basis{X: frame.AlongTrack, Y: frame.RadialOut}
+	sprite := ComposeLaunchSprite(stages, attitudeDir, basis, vesselSubPixelM)
+	if sprite == nil {
+		// Defensive: composedStackRows and ComposeLaunchSprite agree on
+		// what counts as "no sprite" (taperRowBetween is their shared
+		// source of truth), so heightCells should already have been 0
+		// and *shown false above — this only guards a future drift
+		// between the two.
+		*shown = false
+		return false
+	}
+	bell := ComposeEngineBell(stages, attitudeDir, basis, vesselSubPixelM)
+	legs := ComposeLegs(stages, attitudeDir, basis, vesselSubPixelM)
+	// No flame / canopy: both are transient equipment state (an active
+	// burn, a deployed chute) rather than hull geometry, and issue #348
+	// §1 asks for the SILHOUETTE at scale — the bell and legs are
+	// static stage-stack geometry the same way the body rectangles are,
+	// so they stay; exhaust and canopies are a different visual claim
+	// this slice doesn't make.
+	for _, pixels := range [][]SpritePixel{sprite, bell, legs} {
+		for _, p := range pixels {
+			// Tagged IsVessel (not plain PlotColored, unlike the launch
+			// screen's drawComposedRocket): Proximity's click routing
+			// resolves a vessel hit through HitAt/IsVessel
+			// (app.go), and the sprite should be clickable across its
+			// whole silhouette, not just the single anchor pixel the
+			// disk-glyph fallback tags.
+			v.canvas.PlotColoredTagged(anchorWorld.Add(p.OffsetWorld),
+				widgets.CellTag{Color: p.Color, IsVessel: true})
+		}
+	}
+	return true
+}
+
+// drawProximityVessels stamps the two vessels: the target dead centre
+// and the active vessel wherever the relative state puts it. Each side
+// tries the true-scale hull sprite first (drawProximityHull) and falls
+// back to the pre-existing disk-and-glyph marker exactly as before
+// whenever there's no composable stack or the silhouette hasn't cleared
+// the hysteresis band yet — "glyphs beyond" the ADR's own words for the
+// far side of this same rule.
 func (v *OrbitView) drawProximityVessels(w *sim.World, st sim.ProximityState) {
-	v.canvas.FillColoredDiskTagged(st.TargetWorld, 1,
-		widgets.CellTag{Color: render.ColorTarget, IsVessel: true})
-	v.canvas.SetCellOverlayColored(st.TargetWorld, '◆', render.ColorTarget)
+	targetStages, targetAttitude := proximityTargetHullInputs(w)
+	if !v.drawProximityHull(&v.proxTargetSpriteShown, targetStages, targetAttitude, st.TargetWorld, st.Frame) {
+		v.canvas.FillColoredDiskTagged(st.TargetWorld, 1,
+			widgets.CellTag{Color: render.ColorTarget, IsVessel: true})
+		v.canvas.SetCellOverlayColored(st.TargetWorld, '◆', render.ColorTarget)
+	}
 
 	activeColor := render.ColorCraftMarker
 	glyph := '▲'
-	if c := w.ActiveCraft(); c != nil {
-		if c.Color != "" {
-			activeColor = lipgloss.Color(c.Color)
+	active := w.ActiveCraft()
+	if active != nil {
+		if active.Color != "" {
+			activeColor = lipgloss.Color(active.Color)
 		}
-		if g := []rune(c.Glyph); len(g) > 0 {
+		if g := []rune(active.Glyph); len(g) > 0 {
 			glyph = g[0]
 		}
 	}
 	if _, _, onCanvas := v.canvasCell(st.CraftWorld); onCanvas {
-		v.canvas.FillColoredDiskTagged(st.CraftWorld, 1,
-			widgets.CellTag{Color: activeColor, IsVessel: true})
-		v.canvas.SetCellOverlayColored(st.CraftWorld, glyph, activeColor)
+		var ownStages []spacecraft.Stage
+		var ownAttitude orbital.Vec3
+		if active != nil {
+			ownStages = active.Stages
+			ownAttitude = active.CurrentAttitudeDir
+		}
+		if !v.drawProximityHull(&v.proxOwnSpriteShown, ownStages, ownAttitude, st.CraftWorld, st.Frame) {
+			v.canvas.FillColoredDiskTagged(st.CraftWorld, 1,
+				widgets.CellTag{Color: activeColor, IsVessel: true})
+			v.canvas.SetCellOverlayColored(st.CraftWorld, glyph, activeColor)
+		}
 		return
 	}
 	// Zoomed past your own vessel. The entry fit can't produce this, but a

--- a/internal/tui/screens/orbit_proximity_test.go
+++ b/internal/tui/screens/orbit_proximity_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
 // newProximityTestView is newSOIPassTestView sized to a real terminal
@@ -524,6 +526,325 @@ func TestProximityCuesRenderAt80x24(t *testing.T) {
 	for i, l := range lines[1:] {
 		if width := lipgloss.Width(l); width > 80 {
 			t.Errorf("row %d is %d cols wide, want ≤ 80", i+1, width)
+		}
+	}
+}
+
+// --- Hull-sprite slice tests (issue #348 §1) ---
+
+// TestProximitySpriteHysteresis pins proximitySpriteVisible's arm-high /
+// release-low band directly: growing UP through proximitySpriteEnterCells
+// switches a glyph to its sprite; shrinking back DOWN, the sprite survives
+// until it drops below proximitySpriteExitCells. Both directions, plus the
+// dead zone in between where whichever state was already active holds.
+func TestProximitySpriteHysteresis(t *testing.T) {
+	cases := []struct {
+		name        string
+		shown       bool
+		heightCells float64
+		want        bool
+	}{
+		{"glyph, well below enter, stays glyph", false, 1.0, false},
+		{"glyph, just below enter, stays glyph", false, proximitySpriteEnterCells - 0.01, false},
+		{"glyph, exactly at enter, switches to sprite", false, proximitySpriteEnterCells, true},
+		{"glyph, above enter, switches to sprite", false, 10.0, true},
+		{"sprite, still well above exit, stays sprite", true, 10.0, true},
+		{"sprite, exactly at exit, stays sprite (>=)", true, proximitySpriteExitCells, true},
+		{"sprite, just below exit, falls back to glyph", true, proximitySpriteExitCells - 0.01, false},
+		{"sprite, in the hysteresis band, stays sprite", true, (proximitySpriteEnterCells + proximitySpriteExitCells) / 2, true},
+		{"glyph, in the hysteresis band, stays glyph", false, (proximitySpriteEnterCells + proximitySpriteExitCells) / 2, false},
+		{"sprite, height collapsed to zero, falls back to glyph", true, 0, false},
+	}
+	for _, c := range cases {
+		if got := proximitySpriteVisible(c.shown, c.heightCells); got != c.want {
+			t.Errorf("%s: proximitySpriteVisible(shown=%v, %.3f) = %v, want %v",
+				c.name, c.shown, c.heightCells, got, c.want)
+		}
+	}
+}
+
+// TestProximitySpriteHeightCellsNoSpriteOrScale pins the two "no sprite"
+// guard cases proximitySpriteHeightCells owes: a stack with no
+// LaunchSprite-catalogued stage, and a non-positive scale — both must
+// read as 0 cells (glyph), never panic on the division.
+func TestProximitySpriteHeightCellsNoSpriteOrScale(t *testing.T) {
+	spriteless := []spacecraft.Stage{{LaunchSpriteRowsPx: 0}}
+	if got := proximitySpriteHeightCells(spriteless, 1.0); got != 0 {
+		t.Errorf("spriteless stack: got %v cells, want 0", got)
+	}
+	tall := []spacecraft.Stage{{LaunchSpriteRowsPx: 10, LaunchSpriteWidthPx: 2, Color: "#FFFFFF"}}
+	if got := proximitySpriteHeightCells(tall, 0); got != 0 {
+		t.Errorf("zero scale: got %v cells, want 0", got)
+	}
+	if got := proximitySpriteHeightCells(tall, -1); got != 0 {
+		t.Errorf("negative scale: got %v cells, want 0", got)
+	}
+}
+
+// TestProximityHullSpriteSpansExpectedCellsAtEntryFit is the "seeded
+// range" quality-bar test: at a 20 m separation — inside
+// proximityFitFloorM (50 m), so the entry fit pins to the game's own
+// DOCK READY floor rather than scaling with range — a 24 m-tall stack
+// (16 sub-pixel rows × vesselSubPixelM) spans the height
+// proximityFitRadius's own documented entry-fit math (Canvas.FitTo:
+// scale = 0.45 × shorter-pixel-axis / radius) predicts, derived here
+// independently of the production code under test rather than by
+// re-calling it, so a scale-formula regression can't silently agree
+// with itself.
+func TestProximityHullSpriteSpansExpectedCellsAtEntryFit(t *testing.T) {
+	const rangeM = 20.0
+	const rows = 16
+	stages := []spacecraft.Stage{{LaunchSpriteRowsPx: rows, LaunchSpriteWidthPx: 2, Color: "#ABCDEF"}}
+
+	w := proximityWorld(t, orbital.Vec3{X: rangeM})
+	w.Crafts[0].Stages = stages
+	w.Crafts[1].Stages = stages
+	v := newProximityTestView(t, 104, 24)
+	w.ViewMode = sim.ViewProximity
+	v.Render(w, 0, 104, 24)
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused")
+	}
+	fitRadius := proximityFitRadius(st)
+	shorterPx := float64(v.canvas.Cols() * 2)
+	if h := float64(v.canvas.Rows() * 4); h < shorterPx {
+		shorterPx = h
+	}
+	wantScale := 0.45 * shorterPx / fitRadius
+	if got := v.canvas.Scale(); math.Abs(got-wantScale)/wantScale > 1e-9 {
+		t.Fatalf("canvas scale = %.6f, want %.6f (FitTo's own documented formula)", got, wantScale)
+	}
+
+	wantCells := float64(rows) * vesselSubPixelM * wantScale / canvasCellPxH
+	if wantCells < proximitySpriteEnterCells {
+		t.Fatalf("test setup: stack only spans %.2f cells at entry fit, need >= %v to exercise the sprite path",
+			wantCells, proximitySpriteEnterCells)
+	}
+	if got := proximitySpriteHeightCells(stages, v.canvas.Scale()); math.Abs(got-wantCells) > 1e-6 {
+		t.Errorf("sprite height = %.3f cells, want %.3f", got, wantCells)
+	}
+
+	// And the hull actually reached the canvas in the stage's own colour
+	// — the end-to-end check that drawProximityVessels wired the height
+	// math through to real ink, not just that the formula agrees with
+	// itself.
+	if n := v.canvas.CountColor(lipgloss.Color("#ABCDEF")); n == 0 {
+		t.Error("no hull-sprite ink found on canvas at entry-fit scale")
+	}
+}
+
+// TestProximityHullPositionsMatchLVLHAnchors extends
+// TestProximityFrameOrientation's own construction (trailing +
+// below-primary) to the hull-sprite path: with both vessels' Stages
+// enlarged enough to guarantee the sprite threshold at this range, the
+// composed silhouette must still land AT each vessel's true LVLH anchor
+// — own vessel's hull registers a vessel-hit at its own screen cell,
+// target's hull at its own, and the trailing/below relationship the
+// glyph-only test already pins survives unchanged (the sprite's anchor
+// point is the same world position the old glyph used; only what's
+// painted around it changed).
+func TestProximityHullPositionsMatchLVLHAnchors(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	active := w.ActiveCraft()
+	frame, ok := orbital.LVLHBasis(active.State.R, active.State.V)
+	if !ok {
+		t.Fatal("precondition: no LVLH frame for the spawned orbit")
+	}
+	tgtR, tgtV := active.State.R, active.State.V
+	w.Crafts[1].Primary = active.Primary
+	w.Crafts[1].State.R = tgtR
+	w.Crafts[1].State.V = tgtV
+	active.State.R = tgtR.
+		Add(frame.AlongTrack.Scale(-600)).
+		Add(frame.RadialOut.Scale(-300))
+	w.SetTargetCraft(1)
+	w.ViewMode = sim.ViewProximity
+
+	// Deliberately (and unrealistically) oversized for the ~670 m
+	// separation — this test is about WHERE the hull lands, not the
+	// realism of its size, and a big stack removes any doubt that both
+	// crossed the sprite threshold at whatever scale the entry fit
+	// (proportional to range, not floored at this distance) lands on.
+	big := []spacecraft.Stage{{LaunchSpriteRowsPx: 400, LaunchSpriteWidthPx: 4, Color: "#112233"}}
+	active.Stages = big
+	w.Crafts[1].Stages = big
+
+	v := newProximityTestView(t, 104, 24)
+	v.Render(w, 0, 104, 24)
+
+	if !v.proxOwnSpriteShown {
+		t.Fatal("own vessel did not switch to the hull sprite — test setup too small")
+	}
+	if !v.proxTargetSpriteShown {
+		t.Fatal("target did not switch to the hull sprite — test setup too small")
+	}
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused")
+	}
+	tx, ty, _ := v.canvas.Project(st.TargetWorld)
+	cx, cy, onCanvas := v.canvas.Project(st.CraftWorld)
+	if !onCanvas {
+		t.Fatal("own vessel off canvas at the entry fit")
+	}
+	if cx >= tx {
+		t.Errorf("trailing vessel anchor at px %d, target at %d — behind must still render LEFT of the target with the sprite path", cx, tx)
+	}
+	if cy <= ty {
+		t.Errorf("below vessel anchor at py %d, target at %d — below must still render BELOW the target with the sprite path", cy, ty)
+	}
+
+	ownCol, ownRow, onCanvas := v.canvasCell(st.CraftWorld)
+	if !onCanvas {
+		t.Fatal("own vessel cell off canvas")
+	}
+	if hit := v.canvas.HitAt(ownCol, ownRow); !hit.IsVessel {
+		t.Error("own vessel's anchor cell doesn't read as a vessel hit with the hull sprite drawn")
+	}
+	tgtCol, tgtRow, onCanvas := v.canvasCell(st.TargetWorld)
+	if !onCanvas {
+		t.Fatal("target cell off canvas")
+	}
+	if hit := v.canvas.HitAt(tgtCol, tgtRow); !hit.IsVessel {
+		t.Error("target's anchor cell doesn't read as a vessel hit with the hull sprite drawn")
+	}
+}
+
+// TestProximityGhostTargetFallsBackToGlyph: a multiplayer ghost target
+// carries a name, a glyph and a Kepler-propagated state — never a stage
+// stack — so no range should ever switch it to a hull sprite; it stays
+// the diamond glyph regardless of how close the pair gets.
+func TestProximityGhostTargetFallsBackToGlyph(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	active := w.ActiveCraft()
+	primary := active.Primary
+	primaryPos := w.BodyPosition(primary)
+	// 40 m away — well inside the range a real vessel with any
+	// catalog-sized stack would already be rendering as a sprite.
+	ghostWorldPos := primaryPos.Add(active.State.R).Add(orbital.Vec3{X: 40})
+	w.Ghosts = []sim.Ghost{{
+		Owner: "SHA256:ghosttest", CraftID: 99, Handle: "remote",
+		Name: "Remote Craft", PrimaryID: primary.ID,
+		Pos: ghostWorldPos, Vel: active.State.V,
+	}}
+	w.SetTargetGhost("SHA256:ghosttest", 99)
+	w.ViewMode = sim.ViewProximity
+
+	v := newProximityTestView(t, 104, 24)
+	v.Render(w, 0, 104, 24)
+
+	st, ok := w.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused for a ghost target")
+	}
+	if v.proxTargetSpriteShown {
+		t.Error("ghost target latched a hull sprite — ghosts carry no composition data")
+	}
+	col, row, onCanvas := v.canvasCell(st.TargetWorld)
+	if !onCanvas {
+		t.Fatal("ghost target off canvas")
+	}
+	if hit := v.canvas.HitAt(col, row); !hit.IsVessel {
+		t.Error("ghost target's glyph fallback did not tag IsVessel")
+	}
+}
+
+// TestProximityHullWinsRingOverlapSamePixel pins the draw-order
+// requirement directly at the canvas level: when a ring (or any other
+// backdrop cue) happens to ink the exact same braille sub-pixel the
+// hull sprite also occupies, the sprite — drawn after, per
+// renderProximity's call order — must win the pixel outright, not just
+// tie a per-cell majority vote.
+func TestProximityHullWinsRingOverlapSamePixel(t *testing.T) {
+	v := newProximityTestView(t, 104, 24)
+	frame := orbital.LVLHFrame{
+		AlongTrack: orbital.Vec3{X: 1},
+		RadialOut:  orbital.Vec3{Y: 1},
+		CrossTrack: orbital.Vec3{Z: 1},
+	}
+	v.canvas.SetBasis(widgets.Basis{X: frame.AlongTrack, Y: frame.RadialOut})
+	v.canvas.SetScale(1.0) // 1 px per metre
+	v.canvas.Center(orbital.Vec3{})
+	target := orbital.Vec3{}
+
+	// Tall enough (20 rows * 1.5 m stride = 30 m, well past the 3-cell
+	// enter threshold at 1 px/m) that the hysteresis gate isn't what's
+	// under test here — the overlap is.
+	stages := []spacecraft.Stage{{LaunchSpriteRowsPx: 20, LaunchSpriteWidthPx: 2, Color: "#123456"}}
+	sprite := ComposeLaunchSprite(stages, orbital.Vec3{}, v.canvas.Basis(), vesselSubPixelM)
+	if len(sprite) == 0 {
+		t.Fatal("setup: no composed sprite")
+	}
+	overlapWorld := target.Add(sprite[0].OffsetWorld)
+
+	// Paint a ring pixel at the EXACT same world point first — standing
+	// in for a range ring or dock gate that happens to cross the
+	// sprite's footprint (drawProximityRangeRings / drawProximityDockGate
+	// both run before drawProximityVessels in renderProximity).
+	v.canvas.PlotColored(overlapWorld, render.ColorDim)
+
+	shown := false
+	if !v.drawProximityHull(&shown, stages, orbital.Vec3{}, target, frame) {
+		t.Fatal("drawProximityHull refused a tall stack at 1 px/m")
+	}
+
+	if n := v.canvas.CountColor(render.ColorDim); n != 0 {
+		t.Errorf("ring colour still present after the hull overwrote the shared pixel: %d cells", n)
+	}
+	if n := v.canvas.CountColor(lipgloss.Color("#123456")); n == 0 {
+		t.Error("hull stage colour did not become the cell's colour over the ring ink")
+	}
+	col, row, onCanvas := v.canvasCell(overlapWorld)
+	if !onCanvas {
+		t.Fatal("overlap point off canvas")
+	}
+	if hit := v.canvas.HitAt(col, row); !hit.IsVessel {
+		t.Error("the shared cell doesn't read as a vessel hit — the ring pixel's tag is winning the overlap")
+	}
+}
+
+// TestProximityHullsRenderAt104x24 re-runs the layout smoke test at the
+// screen's actual minimum supported terminal size (screens.MinTerminalWidth
+// = 104, not the 80 the rest of this file's tests use for headroom) with
+// both vessels enlarged enough to force the hull-sprite path, so a sprite
+// that overruns a row or corrupts the frame at the real floor fails here.
+func TestProximityHullsRenderAt104x24(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 40})
+	big := []spacecraft.Stage{{LaunchSpriteRowsPx: 20, LaunchSpriteWidthPx: 2, Color: "#445566"}}
+	w.Crafts[0].Stages = big
+	w.Crafts[1].Stages = big
+	v := newProximityTestView(t, MinTerminalWidth, 24)
+	w.ViewMode = sim.ViewProximity
+	out := v.Render(w, 0, MinTerminalWidth, 24)
+
+	if !v.proxOwnSpriteShown || !v.proxTargetSpriteShown {
+		t.Fatal("test setup: hull sprites did not engage for either vessel")
+	}
+
+	lines := strings.Split(out, "\n")
+	if len(lines) != 24 {
+		t.Fatalf("rendered %d rows, want 24", len(lines))
+	}
+	for i, l := range lines[1:] {
+		if width := lipgloss.Width(l); width > MinTerminalWidth {
+			t.Errorf("row %d is %d cols wide, want ≤ %d", i+1, width, MinTerminalWidth)
 		}
 	}
 }


### PR DESCRIPTION
Part of #348 (§1 hull sprites — view seams follow).

## What

Both craft in Proximity View now render as their real composed-from-stages silhouettes (reusing `ComposeLaunchSprite` / `ComposeEngineBell` / `ComposeLegs` from `launch_sprite.go`) once close enough, falling back to the existing disk-and-glyph marker otherwise ("glyphs beyond," per ADR 0043 §1).

## Threshold + hysteresis

Stated in terminal **cells**, not metres (the metres follow from the current zoom):

- glyph → sprite at **≥ 3 cells** tall (`proximitySpriteEnterCells`)
- sprite → glyph at **< 2 cells** tall (`proximitySpriteExitCells`)

Latched independently per vessel (`OrbitView.proxOwnSpriteShown` / `proxTargetSpriteShown`, reset on the next Framing Event) so a vessel sitting or drifting slowly right at the boundary doesn't repaint every frame, and a small/large pair at different ranges can cross the band independently. Same arm-high/release-low shape the existing `CLOSE RANGE` chip hysteresis already uses.

## Scale / position

No new scale math needed: `ComposeLaunchSprite`'s per-dot stride is the fixed real-world `vesselSubPixelM`, and Proximity's canvas already carries the LVLH pixels-per-metre scale the entry fit computed. A true 10 m vessel composes to true 10 m of canvas real estate, whatever that projects to at the current zoom — "visibly small but real" at range, growing toward the 50 m gate, exactly as described.

## Orientation

`attitudeDir` is projected into the LVLH screen plane exactly like the launch screen's gravity-turn lean (`stackDirScreen`) — a genuine continuous lean *within* the screen plane. **Limitation, not half-built:** it cannot rotate *out* of that plane — any attitude component along the frame's CrossTrack axis (toward/away from the camera) has no representation in a flat sprite, so a hull banking on that axis renders at its in-plane projection, the nearest pose the machinery supports. Same limitation the launch screen already lives with. Full 3-D rotation is deferred, not built — port-alignment gameplay (the feature that would actually need it) stays visibility-only per ADR 0043 §2.

## Ghosts

A multiplayer `Ghost` carries a name, a glyph, and a Kepler-propagated state — no `Stages`, no build data. Ghosts **always fall back to the diamond glyph**, regardless of range; inventing a class-default silhouette wasn't justified by anything a `Ghost` actually carries.

## Draw order

Sprite pixels are plotted after rings / dock gate / drift path (unchanged call order in `renderProximity`) and tagged `IsVessel: true` via `PlotColoredTagged`, so:
- they win exact-pixel and per-cell-majority overlaps against ring ink (pinned directly at the canvas level in `TestProximityHullWinsRingOverlapSamePixel`)
- the whole silhouette is mouse-clickable as the vessel, not just a single anchor pixel (an improvement over the old disk fallback, which only tagged 1 px radius)

## Scope decisions (not in this slice)

- **No flame/canopy.** Both are transient equipment state (an active burn, a deployed chute), not hull geometry. The engine bell and landing legs *are* included — they're static stage-stack geometry, same footing as the body rectangles.
- **No port-alignment indicators.** Deferred per ADR 0043 §2, visibility-only.
- **No relative-motion trails.** Rejected in the ADR.

## Tests

- `TestProximitySpriteHysteresis` — both hysteresis directions + the dead band, pure function
- `TestProximitySpriteHeightCellsNoSpriteOrScale` — spriteless stack / non-positive scale guards
- `TestProximityHullSpriteSpansExpectedCellsAtEntryFit` — a seeded 24 m-tall stack at 20 m range spans the cell count independently derived from `Canvas.FitTo`'s own documented formula (not by re-calling production code)
- `TestProximityHullPositionsMatchLVLHAnchors` — both vessels' hulls land at their true LVLH anchors (extends the existing frame-orientation test)
- `TestProximityGhostTargetFallsBackToGlyph` — ghost target never sprites
- `TestProximityHullWinsRingOverlapSamePixel` — draw-order pin at the canvas level
- `TestProximityHullsRenderAt104x24` — layout smoke test at the screen's real minimum (`screens.MinTerminalWidth`), not the roomier 80×24 used elsewhere in this file

`go vet ./...` and `go test ./... -race -count=1` both green.