### PR TITLE
fix: arc review findings — canvas NaN guard, view return addresses, click-owner resolution, chip dedup

### DIFF
--- a/internal/sim/descent.go
+++ b/internal/sim/descent.go
@@ -363,12 +363,41 @@ const descentRateFloorMps = 0.1
 // DescentCorridor is the surface view's descent instrument block:
 // altitude, descent rate, time to impact, and the burn margin, plus the
 // impact forecast the arc and the ground marker are drawn from.
+//
+// HorizontalRateMps / FlightPathAngleDeg are the two readings the older
+// airless-body DESCENT chip carried that the corridor's own four numbers
+// don't imply. They live here so the surface view can show ONE block
+// during a descent instead of two that disagree about sign conventions —
+// the corridor says `descent: 40 m/s` where DESCENT said `v_vert: -40.0
+// m/s`, and having both on screen at once was the duplication this
+// resolves. The chip's other two rows are genuinely redundant and did not
+// come along: `twr` asks "can I stop", which Margin answers better
+// (it accounts for the altitude and speed a bare thrust-to-weight can't),
+// and `sas` is the ATTITUDE chip's own row.
 type DescentCorridor struct {
 	AltitudeM      float64
 	DescentRateMps float64 // surface-relative, positive = falling
-	Impact         ImpactPrediction
-	Margin         BurnMargin
+	// HorizontalRateMps is the surface-relative speed ACROSS the ground —
+	// the component the descent rate says nothing about, and the one that
+	// decides a touchdown from a smear when the vertical rate is already
+	// nulled.
+	HorizontalRateMps float64
+	// FlightPathAngleDeg is the surface-relative velocity's angle out of
+	// the local horizontal: 0 = flying level, −90 = straight down.
+	// HasFPA is false below the speed floor where the angle is numerical
+	// dust rather than a heading.
+	FlightPathAngleDeg float64
+	HasFPA             bool
+	Impact             ImpactPrediction
+	Margin             BurnMargin
 }
+
+// fpaSpeedFloorMps is the surface-relative speed below which the flight
+// path angle stops meaning anything — at a metre per second of total
+// motion the ratio of two near-zero components is noise, not a heading.
+// Carried over verbatim from the DESCENT chip's own threshold so the
+// folded rows read identically to the ones they replace.
+const fpaSpeedFloorMps = 1.0
 
 // DescentCorridorFor builds the corridor for a craft, or reports
 // ok=false when the craft isn't in a descent worth instrumenting. The
@@ -379,22 +408,8 @@ type DescentCorridor struct {
 // toward periapsis, but never reaching the surface), with no separate
 // phase predicate to drift out of step with the picture on the canvas.
 func DescentCorridorFor(c *spacecraft.Spacecraft, horizon time.Duration) (DescentCorridor, bool) {
-	if c == nil || c.Landed || c.Crashed {
-		return DescentCorridor{}, false
-	}
-	mu := c.Primary.GravitationalParameter()
-	if mu <= 0 || c.Primary.RadiusMeters() <= 0 {
-		return DescentCorridor{}, false
-	}
-	rNorm := c.State.R.Norm()
-	alt := c.Altitude()
-	if rNorm <= 0 || alt <= 0 {
-		return DescentCorridor{}, false
-	}
-	rHat := c.State.R.Scale(1 / rNorm)
-	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
-	descentRate := -vRel.Dot(rHat)
-	if !(descentRate >= descentRateFloorMps) {
+	k, ok := descentKinematics(c)
+	if !ok {
 		return DescentCorridor{}, false
 	}
 	impact, ok := PredictImpact(c, horizon)
@@ -402,16 +417,69 @@ func DescentCorridorFor(c *spacecraft.Spacecraft, horizon time.Duration) (Descen
 		return DescentCorridor{}, false
 	}
 	return DescentCorridor{
-		AltitudeM:      alt,
-		DescentRateMps: descentRate,
-		Impact:         impact,
+		AltitudeM:          k.altM,
+		DescentRateMps:     k.descentRate,
+		HorizontalRateMps:  k.horizRate,
+		FlightPathAngleDeg: k.fpaDeg,
+		HasFPA:             k.hasFPA,
+		Impact:             impact,
 		Margin: ComputeBurnMargin(
 			c.Thrust,
 			c.TotalMass(),
-			mu/(rNorm*rNorm),
-			descentRate,
-			alt,
+			k.gLocal,
+			k.descentRate,
+			k.altM,
 			c.RemainingDeltaV(),
 		),
 	}, true
+}
+
+// descentKinematics is DescentCorridorFor's CHEAP half: everything
+// derivable from the craft's current state alone, with no forward
+// propagation. Split out so callers that only need "is this thing
+// falling?" — the DESCENDING hint's crossing state machine — can ask
+// without paying for an impact forecast they'd throw away. ok=false on
+// exactly the states DescentCorridorFor has always refused before it
+// reaches PredictImpact.
+type descentKinematicsResult struct {
+	altM        float64
+	descentRate float64
+	horizRate   float64
+	fpaDeg      float64
+	hasFPA      bool
+	gLocal      float64
+}
+
+func descentKinematics(c *spacecraft.Spacecraft) (descentKinematicsResult, bool) {
+	if c == nil || c.Landed || c.Crashed {
+		return descentKinematicsResult{}, false
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 || c.Primary.RadiusMeters() <= 0 {
+		return descentKinematicsResult{}, false
+	}
+	rNorm := c.State.R.Norm()
+	alt := c.Altitude()
+	if rNorm <= 0 || alt <= 0 {
+		return descentKinematicsResult{}, false
+	}
+	rHat := c.State.R.Scale(1 / rNorm)
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	vVert := vRel.Dot(rHat)
+	descentRate := -vVert
+	if !(descentRate >= descentRateFloorMps) {
+		return descentKinematicsResult{}, false
+	}
+	horiz := vRel.Sub(rHat.Scale(vVert)).Norm()
+	res := descentKinematicsResult{
+		altM:        alt,
+		descentRate: descentRate,
+		horizRate:   horiz,
+		gLocal:      mu / (rNorm * rNorm),
+	}
+	if vRel.Norm() > fpaSpeedFloorMps {
+		res.fpaDeg = math.Atan2(vVert, horiz) * 180 / math.Pi
+		res.hasFPA = true
+	}
+	return res, true
 }

--- a/internal/sim/launch_hint.go
+++ b/internal/sim/launch_hint.go
@@ -18,16 +18,63 @@ type launchHint struct {
 	// entering the launch/surface view. Cleared when the crossing ends,
 	// exactly like proximityHint.dismissed.
 	dismissed bool
+	// sinceForecast counts ticks remaining before the next full
+	// DescentCorridorFor call — see launchHintForecastEveryTicks.
+	sinceForecast int
 }
+
+// launchHintForecastEveryTicks throttles the crossing state machine's
+// forward propagation. DescentCorridorFor's forecast is up to ~1000
+// integrator sub-steps; running it on every 50 ms tick measured at
+// ~70 µs — roughly 87 % of the entire sim tick — to maintain a one-line
+// advisory chip that arms and disarms on a multi-second scale. Ten ticks
+// (half a second at 1×) is still far finer than the thing being observed
+// and cuts the cost by an order of magnitude.
+//
+// It only ever delays the CHIP, never the flight: the surface view's own
+// DESCENT CORRIDOR block calls DescentCorridorFor directly every frame,
+// so the numbers a player actually lands on stay exact and live under
+// thrust. The cheap half of the gate (descentKinematics) still runs every
+// tick, so "stopped falling" — the transition that retires the chip — is
+// noticed immediately.
+const launchHintForecastEveryTicks = 10
 
 // updateLaunchHint steps the crossing state machine. Called once per
 // Tick, after integration (same placement as updateProximityHint), so it
 // reads the DescentCorridorFor forecast off final post-tick positions.
 func (w *World) updateLaunchHint() {
+	// Cheap gate first: not falling at all ⇒ no crossing, and no reason to
+	// propagate anything. This is the common case (on the pad, climbing,
+	// coasting, near-circular) and it now costs a dot product instead of a
+	// full impact forecast.
+	if _, falling := descentKinematics(w.ActiveCraft()); !falling {
+		w.launchHint = launchHint{}
+		return
+	}
+	// Armed and already answered: the chip is not rendering and cannot
+	// render again until this crossing ends, and the cheap gate above is
+	// what ends it. The forecast could only refine exactly WHEN the
+	// impact solution lapses — which nothing reads — so skip it entirely.
+	if w.launchHint.inside && w.launchHint.dismissed {
+		return
+	}
+	if w.launchHint.sinceForecast > 0 {
+		w.launchHint.sinceForecast--
+		return
+	}
+	w.launchHint.sinceForecast = launchHintForecastEveryTicks - 1
+
 	_, descending := DescentCorridorFor(w.ActiveCraft(), DescentPredictHorizon)
 	switch {
 	case descending && !w.launchHint.inside:
-		w.launchHint = launchHint{inside: true}
+		// Arm the crossing WITHOUT clearing `dismissed`. A player who
+		// pressed [V] a moment before the forecast resolved has already
+		// answered this crossing's question, and re-asking it because the
+		// state machine happened to arm afterwards is exactly the re-nudge
+		// the once-per-crossing discipline exists to prevent.
+		// proximityHint behaves this way already — it clears dismissed
+		// only when the crossing genuinely ENDS.
+		w.launchHint.inside = true
 	case !descending:
 		w.launchHint = launchHint{}
 	}

--- a/internal/sim/launch_hint_test.go
+++ b/internal/sim/launch_hint_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // TestLaunchHintArmsWhileDescending: a trajectory DescentCorridorFor
@@ -101,4 +102,141 @@ func TestLaunchHintDismissDiscipline(t *testing.T) {
 	if !w.LaunchHintActive() {
 		t.Error("hint did not re-arm on a fresh descent")
 	}
+}
+
+// TestLaunchHintDismissSurvivesArming is the review regression for
+// finding 6: a dismiss issued BEFORE the crossing arms must still count
+// for that crossing.
+//
+// The state machine used to enter the crossing with a whole-struct
+// reassignment — `w.launchHint = launchHint{inside: true}` — which threw
+// the dismiss away. A player who pressed [V] a moment before the forecast
+// resolved therefore got the chip anyway, on the descent they had already
+// answered. proximityHint never had this: it sets `inside` in place and
+// clears `dismissed` only when the crossing genuinely ENDS.
+func TestLaunchHintDismissSurvivesArming(t *testing.T) {
+	w, c := dropTestCraft(t, 10_000)
+
+	// Not falling yet — the crossing has not started, so there is nothing
+	// to be inside of.
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+	c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)}
+	w.updateLaunchHint()
+	if w.launchHint.inside {
+		t.Fatal("precondition: the crossing armed on a circular orbit")
+	}
+
+	// The player enters the surface view first, THEN the descent starts.
+	if entered, refusal := w.ToggleLaunchView(); !entered || refusal != "" {
+		t.Fatalf("enter: entered=%v refusal=%q", entered, refusal)
+	}
+	w.ToggleLaunchView() // straight back out to the map
+	if !w.launchHint.dismissed {
+		t.Fatal("precondition: entering the view did not record a dismiss")
+	}
+
+	c.State.V = orbital.Vec3{X: -5}
+	w.updateLaunchHint()
+	if !w.launchHint.inside {
+		t.Fatal("the crossing did not arm once the vessel started falling")
+	}
+	if !w.launchHint.dismissed {
+		t.Error("arming the crossing discarded the dismiss recorded a moment earlier")
+	}
+	if w.LaunchHintActive() {
+		t.Error("the chip re-asked a question the player had already answered")
+	}
+
+	// The dismiss is still per-crossing, not permanent: end this one and
+	// the next descent offers the hint again.
+	c.Landed = true
+	w.updateLaunchHint()
+	c.Landed = false
+	c.State.V = orbital.Vec3{X: -5}
+	w.updateLaunchHint()
+	if !w.LaunchHintActive() {
+		t.Error("the dismiss leaked past the crossing it belonged to")
+	}
+}
+
+// TestLaunchHintSkipsTheForecastWhenNotFalling is the review regression
+// for finding 7. The hint's gate used to call DescentCorridorFor — up to
+// ~1000 integrator sub-steps — on EVERY 50 ms tick, measured at ~70 µs
+// against an ~81 µs whole tick. Nearly all of that was spent on states
+// where the cheap half of the gate already knows the answer.
+//
+// Asserted structurally (the cheap predicate agrees with the full one on
+// every non-falling state, so short-circuiting on it cannot change
+// behaviour) rather than by timing, which would be a flaky way to state
+// it. BenchmarkUpdateLaunchHint below is where the cost itself is
+// watched.
+func TestLaunchHintSkipsTheForecastWhenNotFalling(t *testing.T) {
+	w, c := dropTestCraft(t, 10_000)
+	mu := c.Primary.GravitationalParameter()
+	r := c.State.R.Norm()
+
+	for _, tc := range []struct {
+		name string
+		set  func()
+	}{
+		{"circular", func() { c.State.V = orbital.Vec3{Y: math.Sqrt(mu / r)} }},
+		{"climbing", func() { c.State.V = orbital.Vec3{X: 200} }},
+		{"landed", func() { c.Landed = true }},
+		{"crashed", func() { c.Landed = false; c.Crashed = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c.Landed, c.Crashed = false, false
+			tc.set()
+			_, cheap := descentKinematics(c)
+			_, full := DescentCorridorFor(c, DescentPredictHorizon)
+			if cheap {
+				t.Skipf("%s is not a state the cheap gate rejects", tc.name)
+			}
+			if full {
+				t.Errorf("the cheap gate rejected %s but the full gate accepted it — short-circuiting would change behaviour", tc.name)
+			}
+			w.updateLaunchHint()
+			if w.LaunchHintActive() {
+				t.Errorf("hint active on %s", tc.name)
+			}
+		})
+	}
+}
+
+// BenchmarkUpdateLaunchHint watches the per-tick cost the review measured
+// at ~70 µs. The two cases are the ones that matter: a craft that is not
+// falling (the overwhelmingly common state, which must now cost a dot
+// product) and one that is (which pays for the forecast, but only on
+// every launchHintForecastEveryTicks-th tick).
+func BenchmarkUpdateLaunchHint(b *testing.B) {
+	newWorld := func() (*World, *spacecraft.Spacecraft) {
+		w, err := NewWorld()
+		if err != nil {
+			b.Fatal(err)
+		}
+		c := w.ActiveCraft()
+		c.Landed = false
+		c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + 400e3}
+		c.State.M = c.TotalMass()
+		return w, c
+	}
+
+	b.Run("circular", func(b *testing.B) {
+		w, c := newWorld()
+		mu := c.Primary.GravitationalParameter()
+		c.State.V = orbital.Vec3{Y: math.Sqrt(mu / c.State.R.Norm())}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			w.updateLaunchHint()
+		}
+	})
+	b.Run("falling", func(b *testing.B) {
+		w, c := newWorld()
+		c.State.V = orbital.Vec3{X: -50}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			w.updateLaunchHint()
+		}
+	})
 }

--- a/internal/sim/launch_toggle_test.go
+++ b/internal/sim/launch_toggle_test.go
@@ -8,6 +8,7 @@ package sim
 import (
 	"testing"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -177,5 +178,120 @@ func TestToggleLaunchViewReturnsFromAutoRoute(t *testing.T) {
 	}
 	if w.LaunchSessionActive {
 		t.Error("LaunchSessionActive = true after the toggle-out, want false")
+	}
+}
+
+// TestStackedJumpKeysAlwaysReachTheMap is the review regression for the
+// return-address trap the two toggling jump keys shipped with.
+//
+// ViewProximity records where it came from in ProxReturnView, and the two
+// toggles are documented to stack — jumping to Proximity from inside the
+// chase-cam is a supported move. But routeToLaunchView used to stash
+// whatever ViewMode it found into PrevViewMode, so pressing [V] from
+// INSIDE Proximity made the two return addresses point at each other:
+//
+//	tilted --V--> launch(prev=tilted) --o--> proximity(proxRet=launch)
+//	        --V--> launch(prev=PROXIMITY)   ← the corruption
+//	        --V--> proximity --o--> launch --V--> proximity ...
+//
+// From there neither key could reach the map again, and the ViewLaunch
+// half of the loop rendered with LaunchSessionActive=false — chase-cam
+// chrome with T+ frozen at zero and no trail. The fix captures
+// PrevViewMode through baseProjection, so it is always the MAP underneath
+// the stack, never another scene.
+func TestStackedJumpKeysAlwaysReachTheMap(t *testing.T) {
+	w := proximityPairWorld(t, orbital.Vec3{X: 1000}, orbital.Vec3{})
+	w.ViewMode = ViewTilted
+
+	if entered, refusal := w.ToggleLaunchView(); !entered || refusal != "" {
+		t.Fatalf("[V] from the map: entered=%v refusal=%q", entered, refusal)
+	}
+	if entered, refusal := w.ToggleProximityView(); !entered || refusal != "" {
+		t.Fatalf("[o] from the chase-cam: entered=%v refusal=%q", entered, refusal)
+	}
+	if w.ProxReturnView != ViewLaunch {
+		t.Fatalf("precondition: ProxReturnView = %s, want launch (the stack we built)", w.ProxReturnView)
+	}
+
+	// The press that used to corrupt the pair.
+	if entered, refusal := w.ToggleLaunchView(); !entered || refusal != "" {
+		t.Fatalf("[V] from inside proximity: entered=%v refusal=%q", entered, refusal)
+	}
+	if w.PrevViewMode == ViewProximity || w.PrevViewMode == ViewLaunch {
+		t.Fatalf("PrevViewMode = %s — a return address must be a map projection, never a scene", w.PrevViewMode)
+	}
+	if w.PrevViewMode != ViewTilted {
+		t.Errorf("PrevViewMode = %s, want tilted (the map under the whole stack)", w.PrevViewMode)
+	}
+
+	// And the toggle gets all the way out, with coherent session state.
+	if entered, refusal := w.ToggleLaunchView(); entered || refusal != "" {
+		t.Fatalf("[V] to leave: entered=%v refusal=%q", entered, refusal)
+	}
+	if w.ViewMode != ViewTilted {
+		t.Errorf("ViewMode = %s after the round trip, want tilted — the jump keys must always reach the map", w.ViewMode)
+	}
+	if w.LaunchSessionActive {
+		t.Error("LaunchSessionActive = true on the map — a released session must not linger")
+	}
+}
+
+// TestJumpKeysNeverPingPong walks the two keys alternately from a stacked
+// start and asserts the map is reachable at every step — the property the
+// trace above only samples. A press pair that can never leave the two
+// scenes is the failure; six alternating presses is plenty to expose a
+// 2-cycle.
+func TestJumpKeysNeverPingPong(t *testing.T) {
+	w := proximityPairWorld(t, orbital.Vec3{X: 1000}, orbital.Vec3{})
+	w.ViewMode = ViewTop
+	w.ToggleLaunchView()
+	w.ToggleProximityView()
+
+	for i := 0; i < 6; i++ {
+		w.ToggleLaunchView()
+		w.ToggleProximityView()
+		// Whatever scene we are in, the launch toggle's stored return has
+		// to be a projection — that invariant is what guarantees an exit.
+		if w.PrevViewMode == ViewLaunch || w.PrevViewMode == ViewProximity {
+			t.Fatalf("press pair %d left PrevViewMode = %s (a scene, not a map)", i, w.PrevViewMode)
+		}
+	}
+	// Unwind: at most one press per scene we are stacked inside.
+	for i := 0; i < 3 && (w.ViewMode == ViewLaunch || w.ViewMode == ViewProximity); i++ {
+		if w.ViewMode == ViewProximity {
+			w.ToggleProximityView()
+			continue
+		}
+		w.ToggleLaunchView()
+	}
+	if w.ViewMode == ViewLaunch || w.ViewMode == ViewProximity {
+		t.Errorf("still stuck in %s after unwinding — the jump keys ping-pong", w.ViewMode)
+	}
+}
+
+// TestProximityReturnSkipsAReleasedChaseCam: the mirror-image guard. A
+// stacked jump records ProxReturnView=ViewLaunch, but the session behind
+// it can end while the player is still in Proximity (an active-vessel
+// switch onto a flying vessel releases it). Restoring ViewLaunch anyway
+// would drop them into a chase-cam with nothing behind it — T+ frozen at
+// zero, no trail — so the toggle falls through to the map underneath.
+func TestProximityReturnSkipsAReleasedChaseCam(t *testing.T) {
+	w := proximityPairWorld(t, orbital.Vec3{X: 1000}, orbital.Vec3{})
+	w.ViewMode = ViewBottom
+	w.ToggleLaunchView()
+	w.ToggleProximityView()
+	if w.ProxReturnView != ViewLaunch {
+		t.Fatalf("precondition: ProxReturnView = %s, want launch", w.ProxReturnView)
+	}
+
+	// The session ends underneath us.
+	w.LaunchSessionActive = false
+
+	w.ToggleProximityView()
+	if w.ViewMode == ViewLaunch {
+		t.Error("returned into a chase-cam with no live session")
+	}
+	if w.ViewMode != ViewBottom {
+		t.Errorf("ViewMode = %s, want bottom (the map the stack was built on)", w.ViewMode)
 	}
 }

--- a/internal/sim/proximity.go
+++ b/internal/sim/proximity.go
@@ -144,12 +144,28 @@ func (w *World) ToggleProximityView() (entered bool, refusal string) {
 			// Defensive: never toggle out of Proximity into Proximity.
 			back = ViewTilted
 		}
+		if back == ViewLaunch && !w.LaunchSessionActive {
+			// The chase-cam we jumped from has since been released (an
+			// active-vessel switch onto a flying vessel, or a `v` cycle out
+			// of the stack). Restoring ViewLaunch anyway would drop the
+			// player into a scene with no session behind it — T+ frozen at
+			// zero, no trail, no max-Q — which reads as a broken view
+			// rather than a return. Fall through to the map underneath it.
+			back = w.baseProjection(ViewLaunch)
+		}
 		w.ViewMode = back
 		return false, ""
 	}
 	if reason := w.ProximityRefusal(); reason != "" {
 		return false, reason
 	}
+	// The return address may legitimately be ViewLaunch — the two jump keys
+	// are documented to stack. What keeps that from becoming the mutual
+	// capture issue #348's review found is the mirror-image invariant on
+	// the other side: routeToLaunchView never records a SCENE in
+	// PrevViewMode, only the projection underneath it (see its doc
+	// comment), so this chain is always at most one hop deep and always
+	// bottoms out on the map.
 	w.ProxReturnView = w.ViewMode
 	w.ViewMode = ViewProximity
 	// Entering answers the hint, so it stops asking until the pair

--- a/internal/sim/view_launch.go
+++ b/internal/sim/view_launch.go
@@ -277,18 +277,30 @@ func (w *World) NudgeLaunchZoom(dir int, currentAutoScale float64) {
 // trail, resets LaunchZoom to auto. Idempotent guard lives in the
 // caller (tickLaunchView checks !LaunchSessionActive).
 //
-// The `ViewMode != ViewLaunch` guard on the PrevViewMode capture
-// matters for save-load: persisted saves carry ViewMode but not
-// LaunchSessionActive, so a save taken mid-session reloads with
-// ViewMode=ViewLaunch and LaunchSessionActive=false. The first
-// post-load tick then re-fires this handler on the already-Landed
-// vessel; without the guard, PrevViewMode would capture ViewLaunch
-// and the switch-end release would later "restore" to ViewLaunch
-// (a no-op). Leaving PrevViewMode at its zero value (ViewTilted) on
-// this path is the correct fallback.
+// PrevViewMode is captured through baseProjection, so it always holds a
+// MAP PROJECTION — never ViewLaunch, never ViewProximity. Two reasons,
+// one old and one learned the hard way:
+//
+//   - Save-load (the original `ViewMode != ViewLaunch` guard): persisted
+//     saves carry ViewMode but not LaunchSessionActive, so a save taken
+//     mid-session reloads with ViewMode=ViewLaunch and
+//     LaunchSessionActive=false. The first post-load tick re-fires this
+//     handler on the already-Landed vessel; capturing ViewLaunch would
+//     make the switch-end release "restore" to ViewLaunch, a no-op.
+//
+//   - The stacked jump keys (issue #348 §4). ViewProximity records its own
+//     return address in ProxReturnView, which may legitimately be
+//     ViewLaunch — the two toggles are documented to stack. If entering
+//     Launch FROM Proximity also captured ViewProximity here, the two
+//     return addresses would point at each other and neither `V` nor `o`
+//     could reach the map again: V/o would ping-pong Launch↔Proximity
+//     forever, with the launch session released and T+ frozen at 0.
+//     baseProjection unwinds the stack to the projection underneath, so a
+//     jump out of Proximity into Launch still returns to the map the
+//     player actually came from.
 func (w *World) routeToLaunchView() {
 	if w.ViewMode != ViewLaunch {
-		w.PrevViewMode = w.ViewMode
+		w.PrevViewMode = w.baseProjection(w.ViewMode)
 	}
 	w.LaunchSessionActive = true
 	w.ViewMode = ViewLaunch

--- a/internal/tui/app_inspect_test.go
+++ b/internal/tui/app_inspect_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -463,4 +465,161 @@ func findBodyCell(a *App) (col, row int, bodyID string, ok bool) {
 		}
 	}
 	return 0, 0, "", false
+}
+
+// coOrbitApp is the zoomed-in fixture the review's finding-3 probe used:
+// two vessels on the SAME circular orbit at opposite phase, camera locked
+// on the active one and zoomed in far enough that the sister's own marker
+// is off-canvas while the shared track still runs across the view.
+//
+// sisterApp (above) deliberately zooms OUT so both vessels stay on canvas.
+// That is the easy half of the contract, and it is the half that was
+// already covered — this is the half that was not, and it is also the more
+// common way to be flying: close in on your own trajectory with the other
+// vessel somewhere else in the orbit.
+func coOrbitApp(t *testing.T, zoomSteps int) (*App, *spacecraft.Spacecraft) {
+	t.Helper()
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	a.View()
+
+	active := a.world.ActiveCraft()
+	if active == nil {
+		t.Skip("no active vessel in the default world")
+	}
+	sister := *active
+	sister.Name = "Sister"
+	sister.ID = 0
+	// Opposite phase, on a slightly wider circle. Opposite phase is what
+	// puts the sister itself off-canvas; the 15 % radius offset keeps the
+	// two tracks DISTINCT curves, so "whose line is this?" has one right
+	// answer per pixel rather than two coincident ellipses overwriting
+	// each other.
+	const wider = 1.15
+	sister.State.R = active.State.R.Scale(-wider)
+	sister.State.V = active.State.V.Scale(-1 / math.Sqrt(wider))
+	a.world.Crafts = append(a.world.Crafts, &sister)
+	a.world.EnsureCraftIDs()
+	a.world.Focus = sim.Focus{Kind: sim.FocusCraft}
+	a.View()
+	for i := 0; i < zoomSteps; i++ {
+		a.orbitView.ZoomIn()
+	}
+	a.View()
+	return a, &sister
+}
+
+// TestClickingAnOffCanvasVesselsOrbitLineStillInspects is the review
+// regression for finding 3.
+//
+// The App's "clicking someone else's track must not plant on yours" guard
+// runs through InspectByOwner, which used to search only the `[j]` cycle
+// set — and that set is gated on the ENTITY projecting on-canvas. Orbit
+// lines are tagged regardless, so an on-canvas line belonging to an
+// off-canvas vessel produced hit.Owner != "" with ownerHit == false: the
+// click fell straight through to the stage-a-burn branch, pausing the
+// clock and swapping to the maneuver screen, and no name chip ever
+// appeared. Owner resolution now indexes what was DRAWN (drawnOwners), so
+// both halves work: the line answers, and the planner stays shut.
+func TestClickingAnOffCanvasVesselsOrbitLineStillInspects(t *testing.T) {
+	a, sister := coOrbitApp(t, 6)
+	sisterWorld := a.world.BodyPosition(sister.Primary).Add(sister.State.R)
+	if a.orbitView.OnCanvas(sisterWorld) {
+		t.Skip("the sister did not end up off-canvas at this zoom")
+	}
+	want := screens.InspectRef{Kind: screens.InspectVessel, CraftID: sister.ID}
+	col, row, ok := findClickableOwnerCell(a, want.OwnerKey())
+	if !ok {
+		t.Skip("the sister's orbit line did not land on a clickable cell")
+	}
+
+	nodesBefore := len(a.world.ActiveCraft().Nodes)
+	orbit := a.active
+	pausedBefore := a.world.Clock.Paused
+	a.Update(tea.MouseMsg{X: col, Y: row, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+
+	if a.active != orbit {
+		t.Errorf("clicking an off-canvas vessel's orbit line left the map for %v", a.active)
+	}
+	if n := len(a.world.ActiveCraft().Nodes); n != nodesBefore {
+		t.Errorf("clicking an off-canvas vessel's orbit line planted a node (%d -> %d)", nodesBefore, n)
+	}
+	if a.world.Clock.Paused != pausedBefore {
+		t.Error("clicking an off-canvas vessel's orbit line paused the clock — it opened the planner")
+	}
+	ref, _, inspecting := a.orbitView.InspectedRef()
+	if !inspecting || ref != want {
+		t.Errorf("inspected %+v (inspecting=%v), want %+v — the click must still answer 'whose line is this?'", ref, inspecting, want)
+	}
+	if name := a.orbitView.InspectedName(); name != "Sister" {
+		t.Errorf("InspectedName = %q, want %q — an answer with no name is no answer", name, "Sister")
+	}
+}
+
+// TestOffCanvasInspectStillPaintsItsNameChip: resolving the owner is only
+// half the answer. The entity is off-frame, so its chip anchor clamps to
+// the edge nearest it rather than being suppressed — otherwise the player
+// gets a flared line and no name, which is the question left hanging.
+func TestOffCanvasInspectStillPaintsItsNameChip(t *testing.T) {
+	a, sister := coOrbitApp(t, 6)
+	sisterWorld := a.world.BodyPosition(sister.Primary).Add(sister.State.R)
+	if a.orbitView.OnCanvas(sisterWorld) {
+		t.Skip("the sister did not end up off-canvas at this zoom")
+	}
+	key := screens.InspectRef{Kind: screens.InspectVessel, CraftID: sister.ID}.OwnerKey()
+	if _, ok := a.orbitView.InspectByOwner(key); !ok {
+		t.Skip("the sister's track was not drawn this frame")
+	}
+	if !strings.Contains(a.View(), "Sister") {
+		t.Error("the inspected off-canvas vessel's name chip never rendered")
+	}
+}
+
+// TestOwnOrbitLineStillStagesABurnWhenZoomedIn: the other side of the same
+// change. Clicking YOUR OWN track is a place, not an identity question, and
+// it has always opened the planner there. That kept working before this fix
+// only by accident — the owner failed to resolve, so the click fell through
+// to the canvas branch. Now it resolves and is allowed through on purpose,
+// so the behaviour has to be pinned rather than left to luck.
+func TestOwnOrbitLineStillStagesABurnWhenZoomedIn(t *testing.T) {
+	a, _ := coOrbitApp(t, 6)
+	active := a.world.ActiveCraft()
+	key := screens.InspectRef{Kind: screens.InspectVessel, CraftID: active.ID}.OwnerKey()
+	col, row, ok := findClickableOwnerCell(a, key)
+	if !ok {
+		t.Skip("no unambiguous, click-reachable own-orbit cell on the canvas")
+	}
+	a.Update(tea.MouseMsg{X: col, Y: row, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+	if a.active != screenManeuver {
+		t.Errorf("clicking your own orbit line landed on %v, want the maneuver screen", a.active)
+	}
+}
+
+// findClickableOwnerCell is findOwnerCell restricted to cells a click can
+// actually reach: the chips and the navball composite OVER the canvas and
+// swallow their own hits before the map ever sees them, so a cell hiding
+// under one is not a test of the click router. The plain findOwnerCell is
+// fine for the wide-terminal fixtures above, where the chips leave most of
+// the map exposed; a zoomed-in fixture puts far more ink under the
+// top-left stack, which is exactly where an unfiltered scan lands first.
+func findClickableOwnerCell(a *App, owner string) (col, row int, ok bool) {
+	for r := 2; r < a.height-1; r++ {
+		for c := 1; c < a.width-1; c++ {
+			if _, hit := a.orbitView.HitNavballControl(c, r); hit {
+				continue
+			}
+			if _, hit := a.orbitView.HitChip(c, r); hit {
+				continue
+			}
+			h := a.orbitView.HitAt(c, r)
+			if h.Owner == owner && !h.OwnerTied &&
+				h.BodyID == "" && !h.IsVessel && h.NodeIdx == 0 {
+				return c, r, true
+			}
+		}
+	}
+	return 0, 0, false
 }

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
@@ -207,6 +208,20 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 		// column is just the slim telemetry block. Canvas content sits 1
 		// col / 2 rows in (border + title), matching the orbit screen.
 		chips := v.hudSource.assembleChips(w)
+		// DESCENT and DESCENT CORRIDOR both answer "how is this landing
+		// going", and while the corridor is live they were both on screen
+		// — opposite corners, same altitude to two decimals, and the
+		// descent rate stated twice with opposite signs (`v_vert: -40.0
+		// m/s` against `descent: 40 m/s`). The corridor is the better
+		// block (it forecasts the ground contact and says whether the stop
+		// is still flyable), so it wins and DESCENT stands down here. Its
+		// two non-redundant rows moved into the corridor rather than being
+		// dropped — see sim.DescentCorridor's doc comment for which, and
+		// why `twr` and `sas` were not among them. The orbit map keeps its
+		// DESCENT chip untouched: there is no corridor there to replace it.
+		if descending {
+			chips = dropChip(chips, settings.ChipDescent)
+		}
 		// DESCENT CORRIDOR is the surface view's own chip — built here, not
 		// in assembleChips, because it's the launch/surface screen's
 		// instrument block and the orbit map has no ground line to read it
@@ -752,10 +767,28 @@ func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim
 // capability bound it, so the alarm names the fix instead of only the
 // fault.
 func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
+	// v_horiz and fpa are the two rows folded in from the DESCENT chip
+	// this block now replaces on this screen (see the dropChip call in
+	// Render, and sim.DescentCorridor's doc comment for why `twr` and
+	// `sas` weren't worth carrying over). v_horiz keeps its CRASH styling
+	// verbatim: crossing the ground fast enough sideways wrecks the vessel
+	// however gently the vertical rate has been nulled, and that is not
+	// something the four corridor numbers imply.
+	fpaLabel := "—"
+	if dc.HasFPA {
+		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(dc.FlightPathAngleDeg, 0))
+	}
+	horizLabel := fmt.Sprintf("%.0f m/s (surface-rel)", dc.HorizontalRateMps)
+	if dc.HorizontalRateMps > sim.CrashVCritMps {
+		horizLabel = v.theme.Alert.Render(
+			fmt.Sprintf("%.0f m/s (> %.0f = CRASH on contact)", dc.HorizontalRateMps, sim.CrashVCritMps))
+	}
 	return []string{
 		v.theme.Primary.Render("DESCENT CORRIDOR"),
 		fmt.Sprintf("  altitude:   %s", formatAltitude(dc.AltitudeM)),
 		fmt.Sprintf("  descent:    %.0f m/s", dc.DescentRateMps),
+		fmt.Sprintf("  v_horiz:    %s", horizLabel),
+		fmt.Sprintf("  fpa:        %s", fpaLabel),
 		fmt.Sprintf("  impact in:  %s (%.0f m/s)",
 			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
 		fmt.Sprintf("  margin:     %s", v.marginLabel(dc.Margin)),

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -59,11 +59,20 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 // TestDescentCorridorLinesInstruments pins the four instruments issue
 // #348 §3 asks for — altitude, descent rate, time to impact, burn margin
 // — as exact rendered rows, so a formatting change has to be deliberate.
+//
+// Since the review's chip-dedup fix the block also carries v_horiz and
+// fpa, folded in from the DESCENT chip it now replaces on this screen
+// (see the dropChip call in launch.go). Both are pinned here for the same
+// reason the original four are: they are the rows a player reads while
+// deciding whether this is a landing or a crash.
 func TestDescentCorridorLinesInstruments(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	dc := sim.DescentCorridor{
-		AltitudeM:      12_400,
-		DescentRateMps: 182,
+		AltitudeM:          12_400,
+		DescentRateMps:     182,
+		HorizontalRateMps:  4,
+		FlightPathAngleDeg: -88,
+		HasFPA:             true,
 		Impact: sim.ImpactPrediction{
 			TimeToImpact: 64 * time.Second,
 			SpeedMps:     240,
@@ -76,6 +85,8 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 		"DESCENT CORRIDOR",
 		"  altitude:   12.40 km",
 		"  descent:    182 m/s",
+		"  v_horiz:    4 m/s (surface-rel)",
+		"  fpa:        -88° (0 = horiz, −90 = straight down)",
 		"  impact in:  1m4s (240 m/s)",
 		"  margin:     1.50 ×",
 	}
@@ -87,6 +98,33 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("row %d:\n got: %q\nwant: %q", i, got[i], want[i])
 		}
+	}
+}
+
+// TestDescentCorridorHorizontalRateAlarm: the folded v_horiz row keeps
+// the DESCENT chip's own alarm — crossing the ground faster sideways than
+// V_CRIT wrecks the vessel however gently the vertical rate has been
+// nulled, and none of the corridor's other numbers say so.
+func TestDescentCorridorHorizontalRateAlarm(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	quiet := v.descentCorridorLines(sim.DescentCorridor{HorizontalRateMps: sim.CrashVCritMps - 1})
+	loud := v.descentCorridorLines(sim.DescentCorridor{HorizontalRateMps: sim.CrashVCritMps + 1})
+	if strings.Contains(quiet[3], "CRASH") {
+		t.Errorf("below V_CRIT raised the crash alarm: %q", quiet[3])
+	}
+	if !strings.Contains(loud[3], "CRASH on contact") {
+		t.Errorf("above V_CRIT did not raise the crash alarm: %q", loud[3])
+	}
+}
+
+// TestDescentCorridorFPAUndefinedBelowSpeedFloor: with no meaningful
+// surface-relative motion the angle is numerical dust, so the row says so
+// rather than printing a heading the pilot might steer by.
+func TestDescentCorridorFPAUndefinedBelowSpeedFloor(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+	got := v.descentCorridorLines(sim.DescentCorridor{})
+	if got[4] != "  fpa:        —" {
+		t.Errorf("fpa row without HasFPA = %q, want an em dash", got[4])
 	}
 }
 
@@ -231,5 +269,62 @@ func TestLaunchViewNoDescentInstrumentsOnAscent(t *testing.T) {
 	}
 	if n := v.canvas.CountOverlayColor(render.ColorMarkerImpact); n != 0 {
 		t.Errorf("climbing vehicle drew %d impact markers, want 0", n)
+	}
+}
+
+// TestSurfaceViewShowsOneDescentBlock is the review regression for the
+// chip duplication.
+//
+// The surface view assembles the shared chip set (which includes the
+// airless-body DESCENT chip) and then appends its own DESCENT CORRIDOR.
+// During a Moon descent both were live at once, in opposite corners,
+// reporting the same altitude to two decimals and the same rate with
+// OPPOSITE SIGNS — `v_vert: -40.0 m/s` on the left against `descent:
+// 40 m/s` on the right. The corridor wins (it forecasts ground contact
+// and says whether the stop is still flyable) and DESCENT stands down
+// while it is up.
+func TestSurfaceViewShowsOneDescentBlock(t *testing.T) {
+	w := descendingMoonCraft(t, 8_000, 40)
+	w.ViewMode = sim.ViewLaunch
+
+	hud := NewOrbitView(ghostTestTheme())
+	hud.Resize(200, 60)
+	hud.Render(w, 0, 200, 60)
+
+	v := NewLaunchView(launchThemeForTest(), hud)
+	v.Resize(200, 60)
+	out := stripANSI(v.Render(w, 200, 60))
+
+	if !strings.Contains(out, "DESCENT CORRIDOR") {
+		t.Fatal("precondition: the corridor block is not on screen for a Moon descent")
+	}
+	// Exactly one altitude row, and one rate row, across the whole frame.
+	if n := strings.Count(out, "altitude:"); n != 1 {
+		t.Errorf("frame carries %d `altitude:` rows, want 1 — the two descent blocks are duplicating", n)
+	}
+	if n := strings.Count(out, "v_vert:"); n != 0 {
+		t.Errorf("frame still carries %d `v_vert:` rows — the DESCENT chip did not stand down", n)
+	}
+	// The rows worth keeping came along rather than being dropped.
+	for _, row := range []string{"descent:", "v_horiz:", "fpa:", "impact in:", "margin:"} {
+		if !strings.Contains(out, row) {
+			t.Errorf("corridor block is missing the %q row", row)
+		}
+	}
+}
+
+// TestOrbitMapKeepsItsDescentChip: the substitution is the SURFACE view's
+// alone. The orbit map has no ground line and no corridor block, so
+// removing DESCENT there would delete the readout rather than replace it.
+func TestOrbitMapKeepsItsDescentChip(t *testing.T) {
+	w := descendingMoonCraft(t, 8_000, 40)
+	w.ViewMode = sim.ViewTilted
+
+	v := NewOrbitView(ghostTestTheme())
+	v.Resize(200, 60)
+	out := stripANSI(v.Render(w, 0, 200, 60))
+
+	if !strings.Contains(out, "v_vert:") {
+		t.Error("the orbit map lost its DESCENT chip — there is no corridor there to replace it")
 	}
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -254,12 +254,23 @@ type OrbitView struct {
 	// inspectable" true by construction instead of by a parallel
 	// visibility test that could drift from the renderer.
 	//
+	// drawnOwners is the wider index behind the same identities: every
+	// entity that INKED this frame, keyed by InspectRef.OwnerKey, whether
+	// or not its own marker landed on the canvas. It is deliberately a
+	// superset of inspectables — an entity can be off-canvas while a long
+	// arc of its orbit crosses the view, and a click on that arc still has
+	// to answer "whose line is this?" (and still has to NOT fall through to
+	// stage-a-burn). The `[j]` cycle keeps using the narrower on-canvas set,
+	// because a cycle stop with nothing visible to flare would be a dead
+	// press.
+	//
 	// inspectRef is the entity currently flaring, held ACROSS frames by
 	// identity (not by index into the slice above) so the highlight
 	// stays on the same vessel while the map redraws and the vessel
 	// moves. Transient screen state: cleared at every Framing Event,
 	// never persisted, never mirrored into the world.
 	inspectables []inspectable
+	drawnOwners  map[string]inspectable
 	inspectRef   InspectRef
 }
 
@@ -500,6 +511,16 @@ func (v *OrbitView) pan(dx, dy int) {
 // before the canvas content, so we offset (col-1, row-2). Returns a
 // zero-value CellTag when the click lands outside the canvas
 // content area, which the caller treats as "no hit." v0.6.4+.
+// OnCanvas reports whether a world point projects inside the canvas at
+// the frame's current camera — the same question every inspectable draw
+// site asks before making an entity a `[j]` cycle stop. Exported so the
+// App layer can distinguish "the entity is in frame" from "only its orbit
+// line is", which are different click contracts (see InspectByOwner).
+func (v *OrbitView) OnCanvas(p orbital.Vec3) bool {
+	_, _, ok := v.canvas.Project(p)
+	return ok
+}
+
 func (v *OrbitView) HitAt(screenCol, screenRow int) widgets.CellTag {
 	return v.canvas.HitAt(screenCol-1, screenRow-2)
 }
@@ -724,6 +745,10 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		bodyRef := InspectRef{Kind: InspectBody, BodyID: b.ID}
 		v.canvas.DrawEllipseClassTagged(el, orbital.Vec3{}, 360, widgets.ClassScenery, orbital.Vec3{}, 0,
 			widgets.CellTag{Color: v.inspectLineColor(bodyRef, render.ColorBodyOrbit), Owner: bodyRef.OwnerKey()})
+		// The track is now tagged, so it can be clicked even when the body
+		// itself is off-canvas — register the owner here, separately from
+		// the cycle stop the disk adds below when it IS on-canvas.
+		v.registerDrawnOwner(bodyRef, inspectBodyName(b.EnglishName), w.BodyPosition(b), i > 0)
 	}
 
 	// Plot each body at its perceived-size disk. System primary (index 0)
@@ -1053,6 +1078,9 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				}
 				v.canvas.DrawEllipseClassTagged(el, gPrimaryPos, 180, widgets.ClassReal, gPrimaryPos, gPxR,
 					widgets.CellTag{Color: v.inspectLineColor(ghostRef, orbitColor), Owner: ghostRef.OwnerKey()})
+				// Owner-only registration: a click on this track resolves
+				// to the ghost even when the ghost itself is off-canvas.
+				v.registerDrawnOwner(ghostRef, inspectGhostName(g.Handle, g.Name), g.Pos, true)
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted
 					// ghost's own apsides, dimmed via MarkerCounterfactual
@@ -1132,6 +1160,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			// hand-built one.
 			if _, _, onCanvas := v.canvas.Project(craftInertial); onCanvas {
 				v.addInspectable(activeRef, c.Name, craftInertial, false)
+			} else if orbitVisible {
+				// Zoomed in on a stretch of your own track with the vessel
+				// itself off-frame: the line is still yours, and the App
+				// reads that to keep click-to-stage-a-burn working there.
+				v.registerDrawnOwner(activeRef, c.Name, craftInertial, false)
 			}
 		}
 		// v0.8.3+: engine-firing flame trail behind the active craft
@@ -1225,6 +1258,12 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			if other.ID != 0 {
 				if _, _, onCanvas := v.canvas.Project(otherInertial); onCanvas {
 					v.addInspectable(otherRef, other.Name, otherInertial, true)
+				} else if otherOrbitVisible {
+					// The vessel is off-frame but its track crosses the view.
+					// Owner-only, so `[j]` doesn't stop on something invisible
+					// — but a click on that track still names it, and still
+					// doesn't plant a burn on YOUR orbit.
+					v.registerDrawnOwner(otherRef, other.Name, otherInertial, true)
 				}
 			}
 			otherColor = v.inspectLineColor(otherRef, otherColor)

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -64,6 +64,25 @@ type builtChip struct {
 	priority int
 }
 
+// dropChip removes every chip carrying `id` from an assembled list. The
+// escape hatch for a screen that assembles the shared chip set but owns a
+// BETTER block for one of them — today only the surface view, whose
+// DESCENT CORRIDOR supersedes DESCENT while a descent is live (see the
+// call site in launch.go). Filtering the assembled slice rather than
+// teaching assembleChips about the caller keeps the shared builder free
+// of per-screen conditionals, and keeps the substitution stated where the
+// replacement block is built.
+func dropChip(chips []builtChip, id settings.Chip) []builtChip {
+	out := chips[:0]
+	for _, c := range chips {
+		if c.id == id {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
 // Priority tiers for admitChipsByBudget (#328/#334). Highest first:
 //
 //   - chipPriorityCore (100): unconditionally pinned core telemetry that

--- a/internal/tui/screens/orbit_ghost_orbit_test.go
+++ b/internal/tui/screens/orbit_ghost_orbit_test.go
@@ -209,22 +209,54 @@ func TestSubPixelGhostOrbitGated(t *testing.T) {
 		return v.canvas.CountColor(lipgloss.Color(render.ColorDim))
 	}
 
-	// Above the primary's surface (so not occluded) yet well below the pixel
+	// The baseline is the SAME frame with no ghost at all. Stating the two
+	// gated cases as deltas against it is what makes this test bite: a bare
+	// `gated <= N` threshold passed even with the gate deleted from the draw
+	// path, because a sub-6px ellipse is only a couple of cells of ink and
+	// any tolerance loose enough to admit the marker also admitted the whole
+	// tiny ellipse. The marker is exactly one cell, so the contract is
+	// "adds a marker" versus "adds a marker AND a ring", and those are
+	// separable however few cells the ring costs.
+	w.Ghosts = nil
+	baseline := ghostInk()
+
+	// Above the primary's surface (so not occluded) yet just below the pixel
 	// gate → no ellipse, just the marker.
-	tinyR := 2 * bodyR // apoapsis*scale < gate/2 < 6 px
+	//
+	// JUST below, not far below: an orbit at 2× the body radius here
+	// projects to a fraction of a pixel, so drawing its ellipse and
+	// suppressing it produce the same picture and the assertion can't tell
+	// the gate from its absence (it passed with the gate deleted). At 0.9×
+	// the gate radius the ring is ~5 px across — plainly visible ink if it
+	// were drawn — which is where the threshold actually has to hold.
+	tinyR := 0.9 * gateR // apoapsis*scale ≈ 5.4 px, just under the 6 px gate
 	w.Ghosts = []sim.Ghost{circularGhost(w, tinyR)}
-	gated := ghostInk()
-	if gated > 4 {
-		t.Errorf("sub-pixel ghost orbit inked %d cells — gate not applied (marker only expected)", gated)
+	gated := ghostInk() - baseline
+	if gated > markerOnlyCells {
+		t.Errorf("sub-pixel ghost added %d cells over the ghost-free frame — gate not applied (marker only, ≤%d, expected)",
+			gated, markerOnlyCells)
 	}
 
 	// Same ghost, orbit comfortably above the gate → ellipse appears.
 	bigR := 4 * gateR // apoapsis*scale ≈ 24 px
 	w.Ghosts = []sim.Ghost{circularGhost(w, bigR)}
-	if shown := ghostInk(); shown < 15 {
-		t.Errorf("above-gate ghost orbit inked only %d cells — gate mis-firing", shown)
+	shown := ghostInk() - baseline
+	if shown < 15 {
+		t.Errorf("above-gate ghost added only %d cells — gate mis-firing", shown)
+	}
+	// And the two cases must be distinguishable at all: if the gate were
+	// removed, `gated` would grow toward `shown` and this ordering is what
+	// notices.
+	if gated >= shown {
+		t.Errorf("gated ghost (%d cells) inked as much as the above-gate one (%d) — the gate is doing nothing",
+			gated, shown)
 	}
 }
+
+// markerOnlyCells is the ink a gated ghost is allowed: its own position
+// marker. One cell, plus one of slack for the case where the marker's
+// braille pixel straddles a cell boundary with the backdrop.
+const markerOnlyCells = 2
 
 // Targeting a ghost promotes its ellipse to the TARGET treatment. Pre-ADR
 // 0041 this was denser sampling (stride 3 vs 5); under the LineClass

--- a/internal/tui/screens/orbit_inspect.go
+++ b/internal/tui/screens/orbit_inspect.go
@@ -125,19 +125,53 @@ const inspectFlareRingPx = 3
 // sites rather than from world state.
 func (v *OrbitView) resetInspectables() {
 	v.inspectables = v.inspectables[:0]
+	clear(v.drawnOwners)
 }
 
-// addInspectable records an entity as inspectable at the point it is
-// drawn. Call order IS cycle order (see InspectNext): the map's own draw
-// order — scenery, then ghosts, then your vessel, then other local
-// vessels, then plan overlays — is already the codebase's deterministic
-// overlap-priority rule (ADR 0020 D), so Inspect steps in the same order
-// the renderer commits to rather than inventing a second one.
+// addInspectable records an entity as a stop on the `[j]` cycle at the
+// point it is drawn. Call order IS cycle order (see InspectNext): the
+// map's own draw order — scenery, then ghosts, then your vessel, then
+// other local vessels, then plan overlays — is already the codebase's
+// deterministic overlap-priority rule (ADR 0020 D), so Inspect steps in
+// the same order the renderer commits to rather than inventing a second
+// one.
 //
 // Off-canvas entities are the caller's filter: every call site gates on
-// the anchor projecting onto the canvas.
+// the anchor projecting onto the canvas, so stepping the cycle never
+// lands on something with nothing visible to flare. Adding to the cycle
+// also registers the owner (see registerDrawnOwner) — the cycle set is
+// always a subset of what inked.
 func (v *OrbitView) addInspectable(ref InspectRef, name string, pos orbital.Vec3, targetable bool) {
-	v.inspectables = append(v.inspectables, inspectable{ref: ref, name: name, pos: pos, targetable: targetable})
+	it := inspectable{ref: ref, name: name, pos: pos, targetable: targetable}
+	v.inspectables = append(v.inspectables, it)
+	v.registerOwner(it)
+}
+
+// registerDrawnOwner records an entity's identity against the ink it just
+// laid down, WITHOUT making it a `[j]` cycle stop. Line draw sites call
+// it: an entity whose own marker is off-canvas can still have a long arc
+// of its orbit crossing the view, and a click on that arc has to resolve
+// to it — both so the map can answer "whose line is this?" and so the
+// App's stage-a-burn fallthrough stays gated (clicking someone else's
+// track must never plant on yours). Gating this on the entity's marker
+// being on-canvas, the way the cycle is gated, is exactly what left that
+// guard open: the tag was on the pixel but nothing could resolve it.
+//
+// Idempotent per frame — the same entity is registered by both its line
+// and its marker, and the two agree.
+func (v *OrbitView) registerDrawnOwner(ref InspectRef, name string, pos orbital.Vec3, targetable bool) {
+	v.registerOwner(inspectable{ref: ref, name: name, pos: pos, targetable: targetable})
+}
+
+func (v *OrbitView) registerOwner(it inspectable) {
+	key := it.ref.OwnerKey()
+	if key == "" {
+		return
+	}
+	if v.drawnOwners == nil {
+		v.drawnOwners = make(map[string]inspectable)
+	}
+	v.drawnOwners[key] = it
 }
 
 // isInspected reports whether ref is the entity currently flaring. The
@@ -161,21 +195,25 @@ func (v *OrbitView) inspectLineColor(ref InspectRef, base lipgloss.Color) lipglo
 	return base
 }
 
-// inspected resolves the current highlight against the frame's
-// inspectable set. ok=false both when nothing is inspected and when the
-// inspected entity is no longer drawn — a ghost that went offline, a
-// vessel that panned off-canvas, a node that fired. The caller treats
+// inspected resolves the current highlight against everything the frame
+// DREW (drawnOwners), not just the `[j]` cycle stops. ok=false both when
+// nothing is inspected and when the inspected entity is no longer drawn at
+// all — a ghost that went offline, a node that fired. The caller treats
 // those identically: no flare, no chip.
+//
+// Resolving against the wider set is what lets a click on an off-canvas
+// vessel's on-canvas orbit line produce a visible answer: the line itself
+// already flares (inspectLineColor runs at its draw site) and the name
+// chip clamps to the edge nearest the entity (composeInspectChip).
 func (v *OrbitView) inspected() (inspectable, bool) {
 	if v.inspectRef.Kind == InspectNone {
 		return inspectable{}, false
 	}
-	for _, it := range v.inspectables {
-		if it.ref == v.inspectRef {
-			return it, true
-		}
+	it, ok := v.drawnOwners[v.inspectRef.OwnerKey()]
+	if !ok || it.ref != v.inspectRef {
+		return inspectable{}, false
 	}
-	return inspectable{}, false
+	return it, true
 }
 
 // InspectNext steps the highlight one place along the frame's inspectable
@@ -246,17 +284,21 @@ func (v *OrbitView) InspectedName() string {
 // so a click and a key press are indistinguishable downstream. ok=false
 // when the key belongs to nothing drawn this frame (a stale tag from a
 // previous frame's pixels).
+//
+// Resolves against drawnOwners rather than the `[j]` cycle set: a pixel
+// carrying an Owner tag is by definition ink this frame laid down, so the
+// click must resolve it even when the entity's own marker sits off-canvas
+// and it is therefore not a cycle stop.
 func (v *OrbitView) InspectByOwner(key string) (InspectRef, bool) {
 	if key == "" {
 		return InspectRef{}, false
 	}
-	for _, it := range v.inspectables {
-		if it.ref.OwnerKey() == key {
-			v.inspectRef = it.ref
-			return it.ref, true
-		}
+	it, ok := v.drawnOwners[key]
+	if !ok {
+		return InspectRef{}, false
 	}
-	return InspectRef{}, false
+	v.inspectRef = it.ref
+	return it.ref, true
 }
 
 // InspectableCount reports how many entities this frame offered to
@@ -289,15 +331,20 @@ func (v *OrbitView) drawInspectFlare() {
 // cell, clamped onto the canvas so an entity near an edge still gets a
 // fully-visible chip. Painted last (after the navball and the corner
 // Chips) so it is never the thing that gets covered.
+//
+// An OFF-canvas anchor clamps to the edge nearest the entity rather than
+// suppressing the chip. That case is reached by clicking the on-canvas
+// arc of an off-canvas vessel's orbit: the line flares at its draw site,
+// so the map has already said "this one" — withholding the name would
+// leave the player with a highlight and no answer, which is the exact
+// failure Inspect exists to fix. An edge-anchored chip also reads as
+// "it's off that way", which is true.
 func (v *OrbitView) composeInspectChip(canvasStr string, cCols, cRows int) string {
 	it, ok := v.inspected()
 	if !ok {
 		return canvasStr
 	}
-	px, py, onCanvas := v.canvas.Project(it.pos)
-	if !onCanvas {
-		return canvasStr
-	}
+	px, py := v.canvas.ProjectClamped(it.pos)
 	label := it.name
 	if label == "" {
 		return canvasStr

--- a/internal/tui/screens/orbit_target_markers.go
+++ b/internal/tui/screens/orbit_target_markers.go
@@ -64,6 +64,12 @@ func (v *OrbitView) drawClosestApproachMarker(w *sim.World) {
 		// targeted, so committing it would be a no-op on the slot it
 		// describes.
 		v.addInspectable(caRef, inspectApproachName(w), ownPos, false)
+	} else if _, _, onCanvas := v.canvas.Project(targetPos); onCanvas {
+		// Only the target's end of the pair made the canvas. Not a cycle
+		// stop (the pair anchors on the craft's end, which isn't visible),
+		// but the ✕ that IS drawn carries the owner tag, so a click on it
+		// has to resolve — anchored on the end the player can actually see.
+		v.registerDrawnOwner(caRef, inspectApproachName(w), targetPos, false)
 	}
 	drawMarker(v.canvas, ownPos, render.MarkerClosestApproach, render.MarkerNominal, "", caTag)
 	drawMarker(v.canvas, targetPos, render.MarkerClosestApproach, render.MarkerNominal, "", caTag)

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -768,6 +768,11 @@ func (c *Canvas) walkPixelDashSegment(ax, ay, bx, by float64, tag CellTag, onPx,
 	if !(phase >= 0) { // NaN-safe
 		phase = 0
 	}
+	// A non-finite endpoint is not a point on this curve, so it neither inks
+	// nor advances the dash cadence — see finitePx and clipSegmentToCanvas.
+	if !finitePx(ax, ay) || !finitePx(bx, by) {
+		return phase
+	}
 	full := segLenPx(ax, ay, bx, by)
 	newPhase := math.Mod(phase+full, cycle)
 	cax, cay, cbx, cby, ok := clipSegmentToCanvas(ax, ay, bx, by, c.pxW, c.pxH)
@@ -837,6 +842,11 @@ func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int,
 	if !(phase >= 0) { // NaN-safe
 		phase = 0
 	}
+	// A non-finite endpoint is not a point on this curve, so it neither inks
+	// nor advances the dot cadence — see finitePx and clipSegmentToCanvas.
+	if !finitePx(ax, ay) || !finitePx(bx, by) {
+		return phase
+	}
 	full := segLenPx(ax, ay, bx, by)
 	advanced := math.Mod(phase+full, stepF)
 	cax, cay, cbx, cby, ok := clipSegmentToCanvas(ax, ay, bx, by, c.pxW, c.pxH)
@@ -898,6 +908,17 @@ func segLenPx(ax, ay, bx, by float64) float64 {
 	return d
 }
 
+// finitePx reports whether a projected pixel coordinate pair is a real
+// point. The clamp in segLenPx keeps a merely ENORMOUS coordinate honest —
+// the segment still clips correctly and the visible run is still right —
+// but a NaN or ±Inf coordinate is not a point at all, and the only correct
+// thing to do with it is draw nothing. Callers use it to bail before the
+// arc-length walk, so a bad sample costs one comparison instead of the
+// clamp's worth of iterations.
+func finitePx(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+
 // clipSegmentToCanvas clips the pixel segment [(ax,ay),(bx,by)] to the canvas
 // rectangle [0,w-1]×[0,h-1] via Liang-Barsky, returning the clipped endpoints
 // and ok=false when the segment lies wholly outside. Bounds the dense-line
@@ -905,7 +926,20 @@ func segLenPx(ax, ay, bx, by float64) float64 {
 // O(projected distance). Works in floats: an adaptively flattened arc hands
 // over raw projected coordinates, which are only rounded once inside the
 // canvas rectangle.
+//
+// A non-finite endpoint is refused outright. Liang-Barsky cannot reject one
+// on its own — every comparison against NaN is false, so all four
+// return-false branches are skipped and the routine reports ok=true with NaN
+// endpoints. The float rewrite (ADR 0042 §3) made that fatal rather than
+// merely wrong: the walkers then take segLenPx's 1e9 NaN clamp as a real
+// clipped length and iterate a billion times, which is a multi-second freeze
+// of the whole render loop rather than one dropped line. The pre-ADR-0042
+// callers rounded to int before clipping and so were bounded by accident;
+// this is where that bound now lives, on purpose.
 func clipSegmentToCanvas(ax, ay, bx, by float64, w, h int) (float64, float64, float64, float64, bool) {
+	if !finitePx(ax, ay) || !finitePx(bx, by) {
+		return 0, 0, 0, 0, false
+	}
 	x0, y0 := ax, ay
 	dx, dy := bx-ax, by-ay
 	maxX, maxY := float64(w-1), float64(h-1)
@@ -993,6 +1027,23 @@ func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
 		return px, py, false
 	}
 	return px, py, true
+}
+
+// ProjectClamped is Project with the result pinned inside the canvas
+// rectangle instead of reported as off-canvas: an off-screen world point
+// comes back as the edge pixel nearest to it. For overlays that must stay
+// visible while still pointing at where their subject actually is — the
+// Inspect name chip on an entity whose orbit line crosses the view but
+// whose own marker does not. A non-finite projection (see finitePx) has
+// no nearest edge, so it clamps to the canvas centre.
+func (c *Canvas) ProjectClamped(w orbital.Vec3) (int, int) {
+	fx, fy := c.projectPx(w)
+	if !finitePx(fx, fy) {
+		return c.pxW / 2, c.pxH / 2
+	}
+	px := int(math.Round(math.Min(math.Max(fx, 0), float64(c.pxW-1))))
+	py := int(math.Round(math.Min(math.Max(fy, 0), float64(c.pxH-1))))
+	return px, py
 }
 
 // Unproject returns the world coord whose Project would land at the

--- a/internal/tui/widgets/dense_line_test.go
+++ b/internal/tui/widgets/dense_line_test.go
@@ -1,6 +1,7 @@
 package widgets
 
 import (
+	"math"
 	"sort"
 	"testing"
 
@@ -203,5 +204,134 @@ func TestPlotDenseLineOffCanvasSkipped(t *testing.T) {
 	c.PlotDenseLineColored(orbital.Vec3{X: 1e6}, orbital.Vec3{X: 1.0001e6}, color, 1)
 	if n := len(taggedPixels(c, color)); n != 0 {
 		t.Errorf("off-canvas chord set %d pixels, want 0", n)
+	}
+}
+
+// nonFinitePoints enumerates the ways a world point can stop being a
+// point. Each is fed as the FAR endpoint of an otherwise ordinary chord
+// whose near endpoint sits dead centre on the canvas.
+var nonFinitePoints = []struct {
+	name string
+	p    orbital.Vec3
+}{
+	{"NaN x", orbital.Vec3{X: math.NaN()}},
+	{"NaN y", orbital.Vec3{Y: math.NaN()}},
+	{"+Inf x", orbital.Vec3{X: math.Inf(1)}},
+	{"-Inf y", orbital.Vec3{Y: math.Inf(-1)}},
+	{"NaN both", orbital.Vec3{X: math.NaN(), Y: math.NaN()}},
+}
+
+// TestNonFinitePointsDrawNothing is the review regression for the freeze
+// the ADR 0042 §3 float rewrite opened. Liang-Barsky cannot reject a NaN
+// endpoint on its own — every comparison against NaN is false, so all four
+// of clipSegmentToCanvas's return-false branches are skipped and it used to
+// report ok=true with NaN endpoints. The walkers then read segLenPx's 1e9
+// NaN clamp as a real clipped length and iterated a BILLION times: a single
+// PlotDensePolylineColored call measured at ~18 seconds, i.e. the whole TUI
+// wedged, not one dropped line.
+//
+// Asserted as "no ink" rather than "returns quickly": a wall-clock bound
+// would be a flaky way to state a correctness property, and zero pixels is
+// the honest requirement — a non-finite point has no place on the canvas.
+// (The loop bound follows: nothing can iterate a billion times and still
+// set no pixels.)
+func TestNonFinitePointsDrawNothing(t *testing.T) {
+	color := lipgloss.Color("#33AAFF")
+	centre := orbital.Vec3{}
+	for _, bad := range nonFinitePoints {
+		t.Run(bad.name, func(t *testing.T) {
+			for _, draw := range []struct {
+				name string
+				fn   func(c *Canvas)
+			}{
+				{"PlotDenseLineColored", func(c *Canvas) {
+					c.PlotDenseLineColored(centre, bad.p, color, 1)
+				}},
+				{"PlotDenseLineForcedColored", func(c *Canvas) {
+					c.PlotDenseLineForcedColored(centre, bad.p, color, 1)
+				}},
+				{"PlotDensePolylineColored", func(c *Canvas) {
+					c.PlotDensePolylineColored([]orbital.Vec3{centre, bad.p, centre}, color, 1)
+				}},
+				{"PlotPolylineClass/Planned", func(c *Canvas) {
+					c.PlotPolylineClass([]orbital.Vec3{centre, bad.p, centre}, color, ClassPlanned)
+				}},
+				{"PlotPolylineClass/Real", func(c *Canvas) {
+					c.PlotPolylineClass([]orbital.Vec3{centre, bad.p, centre}, color, ClassReal)
+				}},
+			} {
+				c := NewCanvas(60, 30)
+				c.SetScale(1)
+				c.Center(orbital.Vec3{})
+				c.Clear()
+				draw.fn(c)
+				if n := len(taggedPixels(c, color)); n != 0 {
+					t.Errorf("%s inked %d pixels for a %s endpoint, want 0", draw.name, n, bad.name)
+				}
+			}
+		})
+	}
+}
+
+// TestNonFiniteEndpointKeepsDashPhase: a bad sample must not silently
+// shift the cadence of the rest of the curve either. A non-finite chord
+// contributes no arc length, so the dots after it land exactly where they
+// would have with the bad point simply absent.
+func TestNonFiniteEndpointKeepsDashPhase(t *testing.T) {
+	color := lipgloss.Color("#33AAFF")
+	run := func(pts []orbital.Vec3) [][2]int {
+		c := NewCanvas(60, 30)
+		c.SetScale(1)
+		c.Center(orbital.Vec3{})
+		c.Clear()
+		c.PlotDensePolylineColored(pts, color, 3)
+		px := taggedPixels(c, color)
+		sort.Slice(px, func(i, j int) bool {
+			if px[i][0] != px[j][0] {
+				return px[i][0] < px[j][0]
+			}
+			return px[i][1] < px[j][1]
+		})
+		return px
+	}
+	clean := run([]orbital.Vec3{{X: -40}, {X: 40}})
+	// The same visible chord with a NaN excursion spliced into the middle:
+	// the NaN legs draw nothing and advance nothing, so what remains is the
+	// two half-chords at the same phase they had in `clean`.
+	spliced := run([]orbital.Vec3{{X: -40}, {X: math.NaN()}, {X: -40}, {X: 40}})
+	if len(clean) == 0 {
+		t.Fatal("precondition: the clean chord inked nothing")
+	}
+	if len(spliced) != len(clean) {
+		t.Fatalf("NaN excursion changed the dot count: %d vs %d", len(spliced), len(clean))
+	}
+	for i := range clean {
+		if spliced[i] != clean[i] {
+			t.Fatalf("dot %d moved to %v (want %v) — a NaN sample shifted the dash phase", i, spliced[i], clean[i])
+		}
+	}
+}
+
+// TestClipSegmentToCanvasRefusesNonFinite pins the guard at the level it
+// actually lives, so a future caller reaching for the clipper directly
+// inherits the same protection.
+func TestClipSegmentToCanvasRefusesNonFinite(t *testing.T) {
+	cases := [][4]float64{
+		{math.NaN(), 0, 10, 10},
+		{0, math.NaN(), 10, 10},
+		{0, 0, math.NaN(), 10},
+		{0, 0, 10, math.NaN()},
+		{math.Inf(1), 0, 10, 10},
+		{0, 0, math.Inf(-1), 10},
+	}
+	for _, c := range cases {
+		if _, _, _, _, ok := clipSegmentToCanvas(c[0], c[1], c[2], c[3], 120, 120); ok {
+			t.Errorf("clipSegmentToCanvas%v = ok, want refused", c)
+		}
+	}
+	// A merely enormous (but finite) coordinate still clips normally — the
+	// guard must not become a reason to drop a real off-screen chord.
+	if _, _, _, _, ok := clipSegmentToCanvas(60, 60, 1e18, 60, 120, 120); !ok {
+		t.Error("a huge finite endpoint was refused; only non-finite ones should be")
 	}
 }


### PR DESCRIPTION
Batch code review of the ADR 0041/0042/0043 look-and-feel arc — the 13 PRs
merged in `83b50f5..3733306` (#349–#361 plus the docs commit) — turned up
seven defects. All seven are fixed here, each with a pinning regression test.
Review-only findings; no design decisions from the ADRs are reopened.

Every fix follows the direction the review proposed. The two places
implementation taught otherwise are called out below.

---

### 1. MAJOR — a non-finite point in any polyline froze the render loop (~18 s)

`internal/tui/widgets/canvas.go`

Liang-Barsky cannot reject a NaN endpoint on its own: every comparison
against NaN is false, so all four of `clipSegmentToCanvas`'s return-false
branches were skipped and it reported `ok=true` with NaN endpoints. The
walkers then took `segLenPx`'s `1e9` NaN clamp as a real clipped length and
iterated a billion times. Measured: **17.7 s** for one
`PlotDensePolylineColored` call on a 60×30 canvas. Every predicted leg,
encounter arc, node leg, descent/ascent arc, proximity drift path and range
ring routes through this. The pre-ADR-0042 callers rounded to `int` before
clipping and so were bounded by accident; that bound now lives in the
clipper on purpose, plus a bail at the top of both walkers so a bad sample
doesn't advance the dash phase either.

Tests: `TestNonFinitePointsDrawNothing` (5 non-finite shapes × 5 draw entry
points), `TestNonFiniteEndpointKeepsDashPhase`,
`TestClipSegmentToCanvasRefusesNonFinite`. Asserted as **zero ink** rather
than by timing — a wall-clock bound is a flaky way to state a correctness
property, and nothing can iterate a billion times and still set no pixels.

### 2. MAJOR — the two jump keys could capture each other's return address

`internal/sim/view_launch.go`, `internal/sim/proximity.go`

`routeToLaunchView` stashed whatever `ViewMode` it found into
`PrevViewMode`. Pressing `[V]` from inside Proximity therefore made the two
return addresses point at each other:

```
tilted --V--> launch(prev=tilted) --o--> proximity(proxRet=launch)
        --V--> launch(prev=PROXIMITY)      ← the corruption
        --V--> proximity --o--> launch --V--> proximity ...
```

From there neither key reached the map again, and the ViewLaunch half of the
loop rendered with `LaunchSessionActive=false` — chase-cam chrome with T+
frozen at zero and no trail. `PrevViewMode` is now captured through
`baseProjection`, so a return address is always the map *underneath* the
stack, never another scene. Stacking `o` on top of `V` stays supported.

**Diverged from the suggested direction** on the symmetric half. The
review suggested guarding `ProxReturnView` against `ViewProximity`; that
branch is unreachable (the function returns early in that state), so it
would have been dead code. The reachable mirror problem is the *leave*
side: `ProxReturnView=ViewLaunch` is legitimate, but the session behind it
can end while the player is still in Proximity, and restoring it then drops
them into a dead scene. That is what is guarded instead.

Tests: `TestStackedJumpKeysAlwaysReachTheMap` (the verified trace),
`TestJumpKeysNeverPingPong`, `TestProximityReturnSkipsAReleasedChaseCam`.

### 3. MAJOR — clicking an off-canvas vessel's orbit line staged a burn

`internal/tui/screens/orbit_inspect.go`, `orbit.go`, `orbit_target_markers.go`

The App's "clicking someone else's track must not plant on yours" guard runs
through `InspectByOwner`, which searched only the `[j]` cycle set — and that
set is gated on the *entity* projecting on-canvas. Orbit lines are tagged
regardless, so an on-canvas line owned by an off-canvas vessel produced
`hit.Owner != ""` with `ownerHit == false`: the click fell straight through
to stage-a-burn, pausing the clock and swapping to the maneuver screen, and
no name chip ever appeared. The existing regression test zooms *out* so both
vessels stay on canvas, which is the half that already worked.

Owner resolution now indexes what was **drawn** (`drawnOwners`, registered at
the line draw sites), kept separate from the cycle set so `[j]` still never
stops on something invisible. Two follow-ons implementation forced:
`inspected()` resolves against the wider set (otherwise the click resolved
but produced no flare and no chip — a silent no-op), and the name chip
clamps to the edge nearest the entity instead of suppressing itself, so the
answer is visible and reads as "it's off that way".

Tests: `TestClickingAnOffCanvasVesselsOrbitLineStillInspects`,
`TestOffCanvasInspectStillPaintsItsNameChip`,
`TestOwnOrbitLineStillStagesABurnWhenZoomedIn` (the own-line path used to
work only by accident of the owner failing to resolve; now it works on
purpose, so it is pinned). Mutation-verified: reverting `InspectByOwner` to
the cycle set reproduces all four original symptoms.

### 4. MINOR — `TestSubPixelGhostOrbitGated` was vacuous

`internal/tui/screens/orbit_ghost_orbit_test.go`

It passed with the gate deleted from the draw path. Two causes: a bare
`gated <= 4` threshold, and a fixture radius so far below the gate that
drawing the ellipse and suppressing it produce the same picture. Now stated
as a delta against a ghost-free baseline, at 0.9× the gate radius where the
ring would be ~5 px of plainly visible ink. Mutation-verified: deleting the
gate now fails it (6 cells against a ≤2 budget).

### 5. MINOR — DESCENT and DESCENT CORRIDOR both rendered

`internal/tui/screens/launch.go`, `orbit_chips.go`, `internal/sim/descent.go`

During a Moon descent both were live at once, opposite corners, the same
altitude to two decimals and the same rate with opposite signs (`v_vert:
-40.0 m/s` against `descent: 40 m/s`).

Took **both** options the review offered, because suppression alone would
have dropped two rows worth keeping: the corridor wins on the surface view
and DESCENT stands down (`dropChip`), and `v_horiz` + `fpa` fold into the
corridor — `v_horiz` with its CRASH-on-contact alarm intact, since crossing
the ground fast sideways wrecks the vessel however gently the vertical rate
was nulled. `twr` and `sas` did not come along: `Margin` answers "can I
stop" better than a bare thrust-to-weight (it accounts for altitude and
speed), and `sas` is the ATTITUDE chip's own row. Net −7 rows on the surface
view. The orbit map keeps DESCENT untouched — there is no corridor there to
replace it.

Tests: `TestSurfaceViewShowsOneDescentBlock`, `TestOrbitMapKeepsItsDescentChip`,
`TestDescentCorridorHorizontalRateAlarm`,
`TestDescentCorridorFPAUndefinedBelowSpeedFloor`, and the existing
`TestDescentCorridorLinesInstruments` extended to pin the folded rows.

### 6. NIT — a dismiss issued before the crossing armed was discarded

`internal/sim/launch_hint.go`

The state machine armed with a whole-struct reassignment
(`launchHint{inside: true}`), throwing away `dismissed`. A player who
pressed `[V]` a moment before the forecast resolved got the chip anyway, on
the descent they had already answered. `proximityHint` never had this — it
sets `inside` in place and clears `dismissed` only when the crossing ends.
Mutation-verified.

Test: `TestLaunchHintDismissSurvivesArming` (including that the dismiss is
still per-crossing, not permanent).

### 7. NIT — `updateLaunchHint` was ~87 % of the sim tick

`internal/sim/launch_hint.go`, `internal/sim/descent.go`

It ran a ~1000-sub-step impact forecast on every 50 ms tick (~70 µs) to
maintain a one-line advisory chip. Three guard clauses: the cheap half of
the gate is split out of `DescentCorridorFor` (`descentKinematics`) and runs
first; an armed-and-dismissed crossing skips the forecast entirely (the
cheap gate is what ends it); and the forecast itself is throttled to one
tick in ten. It only ever delays the chip — the surface view's own corridor
block still calls `DescentCorridorFor` directly every frame, so the numbers
a player lands on stay exact and live under thrust.

Measured (`Tick`, ns/op, `-benchtime 3000x -count=4`, steady state):

| state | before | after |
|---|---|---|
| non-descending (circular) | 13 465 | 13 471 |
| falling | 55 117 | 17 756 |

Non-descending is back at the pre-arc baseline exactly; falling is 3.1×
cheaper. `BenchmarkUpdateLaunchHint` keeps watch (59 ns non-descending,
6.2 µs amortized falling).

---

## Verification

- `go vet ./...` clean.
- `go test ./... -race -count=1` green.
- New tests stable at `-race -count=20`, including the finding-3 tests,
  which live next to the #359 randomized-map-iteration flake.
- `gofmt` introduces no new offenders.
- No save-schema change; no new persisted state.
