### PR TITLE
perf: memoize the orbit-view textured-disk raster

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -272,6 +272,19 @@ type OrbitView struct {
 	inspectables []inspectable
 	drawnOwners  map[string]inspectable
 	inspectRef   InspectRef
+
+	// diskRasterCache memoizes the per-pixel rasterized textured-disk
+	// grid, keyed per body, under the same ADR 0017 predict-on-change
+	// discipline as predictCache / soiPassCache above (#363). At idle
+	// this turns the per-tick per-pixel texture-closure evaluation
+	// (trig + feature-polygon tests) into a cache-key comparison plus a
+	// slice read; zoom, camera moves, focus switches, high warp, and
+	// lighting changes all move the quantized key and still force a
+	// real re-raster. diskRasterCacheHits / …Computes are test hooks.
+	// See orbit_disk_cache.go.
+	diskRasterCache         map[string]*diskRasterEntry
+	diskRasterCacheHits     int
+	diskRasterCacheComputes int
 }
 
 // navballSubObserverDeadbandDeg is the great-circle angle the nose
@@ -914,8 +927,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		}
 		if tex := render.TextureFor(b, r, subLat, subLon, upX, upY, light); tex != nil {
 			pxR := r
+			// #363: serve the cached raster grid on a quantized-key
+			// hit instead of re-evaluating tex per pixel every tick.
+			cached := v.texturedDiskRaster(b, pxR, subLat, subLon, upX, upY, light, tex)
 			v.canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
-				return tex(dx, dy, pxR)
+				return cached(dx, dy, pxR)
 			}, bodyTag)
 		} else {
 			v.canvas.FillColoredDiskTagged(pos, r, bodyTag)

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -925,16 +925,27 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				}
 			}
 		}
-		if tex := render.TextureFor(b, r, subLat, subLon, upX, upY, light); tex != nil {
-			pxR := r
-			// #363: serve the cached raster grid on a quantized-key
-			// hit instead of re-evaluating tex per pixel every tick.
-			cached := v.texturedDiskRaster(b, pxR, subLat, subLon, upX, upY, light, tex)
-			v.canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
-				return cached(dx, dy, pxR)
-			}, bodyTag)
-		} else {
-			v.canvas.FillColoredDiskTagged(pos, r, bodyTag)
+		// #363 review fix: skip the disk fill (and any raster-cache
+		// allocation) entirely when the disk's screen-space bounding
+		// box doesn't intersect the canvas. At the default view most
+		// bodies in a system are off-canvas; before this check every
+		// one of them still built (and retained) a full raster grid
+		// that painted nothing — measured ~70x the idle retained heap
+		// at default zoom. FillTexturedDiskTagged/FillColoredDiskTagged
+		// already no-op per off-canvas pixel, so skipping the whole
+		// call draws identically (nothing) while skipping the setup.
+		if v.canvas.DiskIntersectsCanvas(pos, r) {
+			if tex := render.TextureFor(b, r, subLat, subLon, upX, upY, light); tex != nil {
+				pxR := r
+				// #363: serve the cached raster grid on a quantized-key
+				// hit instead of re-evaluating tex per pixel every tick.
+				cached := v.texturedDiskRaster(w.SystemIdx, b, pxR, subLat, subLon, upX, upY, light, tex)
+				v.canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
+					return cached(dx, dy, pxR)
+				}, bodyTag)
+			} else {
+				v.canvas.FillColoredDiskTagged(pos, r, bodyTag)
+			}
 		}
 		// v0.8.5.7+: stars get a faint two-ring corona halo so the
 		// disk reads as "this is a luminous body" instead of a

--- a/internal/tui/screens/orbit_disk_cache.go
+++ b/internal/tui/screens/orbit_disk_cache.go
@@ -1,0 +1,134 @@
+package screens
+
+import (
+	"math"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+)
+
+// #363: idle CPU on the orbit screen was dominated by re-rasterizing the
+// focused body's textured disk every 20 Hz tick — per-pixel lat/lon
+// projection, trig, and feature-polygon tests via the render.BodyTexture
+// closure — even though at a steady warp the visible picture is
+// essentially unchanged frame to frame. This mirrors the ADR 0017
+// predict-on-change discipline (see predictCache / soiPassCache above):
+// memoize the rasterized disk, keyed on everything the picture actually
+// depends on, and blit the cached grid on a key hit instead of calling
+// the texture closure per pixel.
+//
+// diskRasterQuantDeg is the angular quantum (degrees) used to bucket
+// every lat/lon-shaped input to the raster: the camera sub-observer
+// point, the light source's sub-solar point, and the screen-up
+// orientation (folded to an angle via atan2). It must be coarse enough
+// that a steady warp-1× idle frame (sub-observer longitude drifts
+// ~0.0002°/tick) keeps landing in the same bucket for many consecutive
+// ticks, and fine enough that one bucket step never moves a rendered
+// pixel — i.e. it must stay well under one pixel of arc at the limb of
+// the largest disk the game actually draws.
+//
+// arc_px ≈ pxRadius × quantum(rad) = pxRadius × quantum(deg) × π/180.
+// At the extreme end of the zoom range the focused body can fill a
+// large fraction of a big terminal — call it pxRadius ≈ 300 px, well
+// past anything a real playthrough sits at. 300 × 0.02 × π/180 ≈ 0.10
+// px: under half a pixel even at that extreme, and BodyTextureMinRadius
+// (12 px) floors the ratio from the other side. 0.02° is also 250×
+// coarser than the ~0.0002°/tick idle drift, so consecutive idle ticks
+// land in the same bucket for ~2.5 s (50 ticks) before a real miss.
+const diskRasterQuantDeg = 0.02
+
+// diskRasterQuantEclipse is the quantum for SolarLight.EclipseFactor
+// (range [0, 1]). Shade() rounds the shaded color to 8-bit channels, so
+// any factor step smaller than 1/255 can never change the rendered
+// color; 1/512 stays comfortably under that with margin to spare.
+const diskRasterQuantEclipse = 1.0 / 512.0
+
+// diskRasterKey fingerprints everything a body's textured-disk raster
+// depends on. Two frames with an equal key are guaranteed to paint the
+// identical grid of pixel colors (up to sub-pixel drift smaller than the
+// quantum, per the derivation above), so a key hit can blit the cached
+// grid instead of re-running the texture closure.
+type diskRasterKey struct {
+	bodyID    string
+	pxRadius  int
+	subLatQ   int64
+	subLonQ   int64
+	upAngleQ  int64
+	hasLight  bool
+	lightLatQ int64
+	lightLonQ int64
+	eclipseQ  int64
+}
+
+// diskRasterEntry holds the last rasterized grid for one body and the
+// key it was computed for. grid is (2r+1)×(2r+1), indexed
+// (dy+r)*(2r+1)+(dx+r) — the same (dx, dy) offsets FillTexturedDiskTagged
+// feeds the texture closure.
+type diskRasterEntry struct {
+	key  diskRasterKey
+	r    int
+	grid []lipgloss.Color
+}
+
+// texturedDiskRaster wraps tex (the freshly-built per-frame BodyTexture
+// closure for body b) with the #363 raster cache. On a key hit it
+// returns a closure that reads the cached grid — no trig, no
+// feature-polygon tests, no Shade() hex parsing. On a miss it returns a
+// closure that calls tex as before AND records each result into a fresh
+// grid, so the cache is populated for free during the very pass that
+// draws the frame (no duplicated raster work on a miss).
+//
+// Bodies are cached independently (keyed by ID) rather than in one
+// single-slot cache, so a frame that textures more than one body (e.g.
+// the Sun plus the focused planet) doesn't thrash a shared slot.
+func (v *OrbitView) texturedDiskRaster(b bodies.CelestialBody, r int, subLat, subLon, upX, upY float64, light *render.SolarLight, tex render.BodyTexture) render.BodyTexture {
+	if tex == nil {
+		return nil
+	}
+	key := diskRasterKey{
+		bodyID:   b.ID,
+		pxRadius: r,
+		subLatQ:  quantize(subLat, diskRasterQuantDeg),
+		subLonQ:  quantize(subLon, diskRasterQuantDeg),
+		upAngleQ: quantize(math.Atan2(upY, upX)*180.0/math.Pi, diskRasterQuantDeg),
+	}
+	if light != nil {
+		key.hasLight = true
+		key.lightLatQ = quantize(light.SubSolarLatDeg, diskRasterQuantDeg)
+		key.lightLonQ = quantize(light.SubSolarLonDeg, diskRasterQuantDeg)
+		key.eclipseQ = quantize(light.EclipseFactor, diskRasterQuantEclipse)
+	}
+
+	if v.diskRasterCache == nil {
+		v.diskRasterCache = make(map[string]*diskRasterEntry)
+	}
+	side := 2*r + 1
+
+	if entry, ok := v.diskRasterCache[b.ID]; ok && entry.key == key && entry.r == r {
+		v.diskRasterCacheHits++
+		grid := entry.grid
+		return func(dx, dy, rr int) lipgloss.Color {
+			idx := (dy+r)*side + (dx + r)
+			if idx < 0 || idx >= len(grid) {
+				// Defensive: should be unreachable since the caller
+				// always uses the same (r, mask) that built the grid.
+				return tex(dx, dy, rr)
+			}
+			return grid[idx]
+		}
+	}
+
+	grid := make([]lipgloss.Color, side*side)
+	v.diskRasterCache[b.ID] = &diskRasterEntry{key: key, r: r, grid: grid}
+	v.diskRasterCacheComputes++
+	return func(dx, dy, rr int) lipgloss.Color {
+		c := tex(dx, dy, rr)
+		idx := (dy+r)*side + (dx + r)
+		if idx >= 0 && idx < len(grid) {
+			grid[idx] = c
+		}
+		return c
+	}
+}

--- a/internal/tui/screens/orbit_disk_cache.go
+++ b/internal/tui/screens/orbit_disk_cache.go
@@ -51,6 +51,7 @@ const diskRasterQuantEclipse = 1.0 / 512.0
 // quantum, per the derivation above), so a key hit can blit the cached
 // grid instead of re-running the texture closure.
 type diskRasterKey struct {
+	systemIdx int
 	bodyID    string
 	pxRadius  int
 	subLatQ   int64
@@ -83,16 +84,23 @@ type diskRasterEntry struct {
 // Bodies are cached independently (keyed by ID) rather than in one
 // single-slot cache, so a frame that textures more than one body (e.g.
 // the Sun plus the focused planet) doesn't thrash a shared slot.
-func (v *OrbitView) texturedDiskRaster(b bodies.CelestialBody, r int, subLat, subLon, upX, upY float64, light *render.SolarLight, tex render.BodyTexture) render.BodyTexture {
+// systemIdx rides along in the key (not just the map's b.ID key) because
+// user-overlay catalogs can reuse a body ID across systems (review
+// finding) — without it, switching systems could serve one system's
+// cached colors onto another system's body of the same ID. Including it
+// in diskRasterKey is enough: an equal-ID, different-systemIdx entry
+// simply compares unequal and is correctly treated as a miss.
+func (v *OrbitView) texturedDiskRaster(systemIdx int, b bodies.CelestialBody, r int, subLat, subLon, upX, upY float64, light *render.SolarLight, tex render.BodyTexture) render.BodyTexture {
 	if tex == nil {
 		return nil
 	}
 	key := diskRasterKey{
-		bodyID:   b.ID,
-		pxRadius: r,
-		subLatQ:  quantize(subLat, diskRasterQuantDeg),
-		subLonQ:  quantize(subLon, diskRasterQuantDeg),
-		upAngleQ: quantize(math.Atan2(upY, upX)*180.0/math.Pi, diskRasterQuantDeg),
+		systemIdx: systemIdx,
+		bodyID:    b.ID,
+		pxRadius:  r,
+		subLatQ:   quantize(subLat, diskRasterQuantDeg),
+		subLonQ:   quantize(subLon, diskRasterQuantDeg),
+		upAngleQ:  quantize(math.Atan2(upY, upX)*180.0/math.Pi, diskRasterQuantDeg),
 	}
 	if light != nil {
 		key.hasLight = true
@@ -109,6 +117,19 @@ func (v *OrbitView) texturedDiskRaster(b bodies.CelestialBody, r int, subLat, su
 	if entry, ok := v.diskRasterCache[b.ID]; ok && entry.key == key && entry.r == r {
 		v.diskRasterCacheHits++
 		grid := entry.grid
+		// Self-healing hit path (fix for a viewport-clip bug caught in
+		// review): FillTexturedDiskTagged never calls this closure for
+		// an off-canvas offset (it clips BEFORE calling texture()), so
+		// a grid built on one frame is only guaranteed complete for the
+		// offsets that were actually on-canvas THAT frame. A later
+		// identical-key frame — same body/radius/lighting, but panned
+		// or resized so a previously-clipped offset is now on-canvas —
+		// would otherwise read the zero value (lipgloss.Color(""))
+		// for that offset and paint an uncolored cell. Since an equal
+		// key guarantees identical colors regardless of when an offset
+		// is first requested, it's always correct to lazily fill any
+		// gap on the hit path too: the grid converges to the union of
+		// every window this key has ever drawn.
 		return func(dx, dy, rr int) lipgloss.Color {
 			idx := (dy+r)*side + (dx + r)
 			if idx < 0 || idx >= len(grid) {
@@ -116,7 +137,12 @@ func (v *OrbitView) texturedDiskRaster(b bodies.CelestialBody, r int, subLat, su
 				// always uses the same (r, mask) that built the grid.
 				return tex(dx, dy, rr)
 			}
-			return grid[idx]
+			if c := grid[idx]; c != "" {
+				return c
+			}
+			c := tex(dx, dy, rr)
+			grid[idx] = c
+			return c
 		}
 	}
 

--- a/internal/tui/screens/orbit_disk_cache_bench_test.go
+++ b/internal/tui/screens/orbit_disk_cache_bench_test.go
@@ -60,13 +60,13 @@ func BenchmarkBodyDiskRaster(b *testing.B) {
 		tag := widgets.CellTag{Color: lipgloss.Color(body.Color), BodyID: body.ID}
 		// Warm the cache once (the one real miss a frame-to-frame idle
 		// sequence pays) before timing the steady-state hit path.
-		warm := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+		warm := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
 		canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
 			return warm(dx, dy, r)
 		}, tag)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			cached := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+			cached := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
 			canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
 				return cached(dx, dy, r)
 			}, tag)

--- a/internal/tui/screens/orbit_disk_cache_bench_test.go
+++ b/internal/tui/screens/orbit_disk_cache_bench_test.go
@@ -1,0 +1,75 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// diskRasterBenchRadius mirrors a realistic focused-body pixel radius —
+// large enough to clear BodyTextureMinRadius (12) with room to spare, in
+// the range the live idle-CPU measurement (#363 PR) was taken at.
+const diskRasterBenchRadius = 24
+
+// BenchmarkBodyDiskRaster compares the #363 raster cache's hit path
+// against the pre-#363 behavior of calling the texture closure for
+// every pixel every frame. Run with:
+//
+//	go test ./internal/tui/screens/ -run '^$' -bench BenchmarkBodyDiskRaster -benchmem
+//
+// "Uncached" reproduces the old per-tick cost (what every idle frame
+// paid before this change); "CachedHit" is what every idle frame pays
+// after it — a cache-key build, a map lookup, and a blit instead of the
+// texture closure's trig + feature-polygon evaluation per pixel.
+func BenchmarkBodyDiskRaster(b *testing.B) {
+	body := diskCacheTestBody()
+	const r = diskRasterBenchRadius
+	subLat, subLon := 12.3, 45.6
+	upX, upY := 0.0, 1.0
+	light := &render.SolarLight{SubSolarLatDeg: 8.0, SubSolarLonDeg: 30.0, EclipseFactor: 1}
+	pos := orbital.Vec3{}
+
+	b.Run("Uncached", func(b *testing.B) {
+		canvas := widgets.NewCanvas(200, 60)
+		canvas.SetScale(1)
+		tex := render.TextureFor(body, r, subLat, subLon, upX, upY, light)
+		if tex == nil {
+			b.Fatal("expected a non-nil texture for the bench body")
+		}
+		tag := widgets.CellTag{Color: lipgloss.Color(body.Color), BodyID: body.ID}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
+				return tex(dx, dy, r)
+			}, tag)
+		}
+	})
+
+	b.Run("CachedHit", func(b *testing.B) {
+		canvas := widgets.NewCanvas(200, 60)
+		canvas.SetScale(1)
+		v := NewOrbitView(plainTheme())
+		tex := render.TextureFor(body, r, subLat, subLon, upX, upY, light)
+		if tex == nil {
+			b.Fatal("expected a non-nil texture for the bench body")
+		}
+		tag := widgets.CellTag{Color: lipgloss.Color(body.Color), BodyID: body.ID}
+		// Warm the cache once (the one real miss a frame-to-frame idle
+		// sequence pays) before timing the steady-state hit path.
+		warm := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+		canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
+			return warm(dx, dy, r)
+		}, tag)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			cached := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+			canvas.FillTexturedDiskTagged(pos, r, func(dx, dy int) lipgloss.Color {
+				return cached(dx, dy, r)
+			}, tag)
+		}
+	})
+}

--- a/internal/tui/screens/orbit_disk_cache_pan_test.go
+++ b/internal/tui/screens/orbit_disk_cache_pan_test.go
@@ -1,0 +1,179 @@
+package screens
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// offsetColoredTexture returns a BodyTexture whose color is a pure
+// function of (dx, dy) — distinct per offset — so a stale or blank
+// cache read at any single offset is individually detectable, unlike
+// a flat single-color texture where a bug could hide behind "every
+// pixel happens to look the same anyway."
+func offsetColoredTexture() render.BodyTexture {
+	return func(dx, dy, rr int) lipgloss.Color {
+		return lipgloss.Color(fmt.Sprintf("#%02X%02X01", (dx+128)&0xFF, (dy+128)&0xFF))
+	}
+}
+
+// TestTexturedDiskRasterSelfHealsAfterPan is the review-mandated
+// regression test for the viewport-clip cache bug: FillTexturedDiskTagged
+// clips off-canvas offsets BEFORE calling the texture closure, so a
+// grid built while only PART of a disk was on-canvas is incomplete for
+// the offsets that were clipped away that frame. A pan that brings a
+// previously-clipped region into view, with an otherwise IDENTICAL
+// raster key (same body/radius/lighting — a pure pan doesn't change
+// any of those), must still be served correct (non-blank) colors on
+// the cache-HIT path, not the zero-value lipgloss.Color("").
+func TestTexturedDiskRasterSelfHealsAfterPan(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	body := diskCacheTestBody()
+	const r = 20
+	subLat, subLon := 10.0, 20.0
+	upX, upY := 0.0, 1.0
+	light := &render.SolarLight{SubSolarLatDeg: 5, SubSolarLonDeg: 15, EclipseFactor: 1}
+	tex := offsetColoredTexture()
+
+	// Frame 1: only the LEFT half of the disk's offsets get touched —
+	// standing in for a viewport that clips away the right half.
+	cached1 := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
+	for dy := -r; dy <= r; dy++ {
+		for dx := -r; dx <= 0; dx++ {
+			if dx*dx+dy*dy > r*r {
+				continue
+			}
+			cached1(dx, dy, r)
+		}
+	}
+
+	// Frame 2: an IDENTICAL key (a pure pan changes screen position,
+	// not the raster inputs) must be a cache HIT...
+	computesBefore := v.diskRasterCacheComputes
+	cached2 := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
+	if v.diskRasterCacheComputes != computesBefore {
+		t.Fatalf("expected a cache HIT on the panned call, got a recompute (computes %d -> %d)", computesBefore, v.diskRasterCacheComputes)
+	}
+	// ...yet still return CORRECT colors for the right-half offsets
+	// frame 1 never drew — the pan-onto-never-drawn-region case.
+	for dy := -r; dy <= r; dy++ {
+		for dx := 1; dx <= r; dx++ {
+			if dx*dx+dy*dy > r*r {
+				continue
+			}
+			got := cached2(dx, dy, r)
+			want := tex(dx, dy, r)
+			if got != want {
+				t.Errorf("pan onto never-drawn offset (%d,%d): got %q, want %q (stale/blank cache read)", dx, dy, got, want)
+			}
+			if got == "" {
+				t.Errorf("pan onto never-drawn offset (%d,%d): got the blank zero-value color", dx, dy)
+			}
+		}
+	}
+}
+
+// TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan is the
+// review-specified end-to-end regression test: a cache-HIT render must
+// be byte-identical to the same frame rendered with the cache dropped
+// (a fresh OrbitView), with lipgloss forced to emit real ANSI color
+// (Go tests have no TTY, so lipgloss strips color by default — the
+// very reason the original bug's earlier tests, which compared
+// cache-hit COUNTERS rather than rendered pixels/bytes, never caught
+// this). Uses a disk radius larger than the canvas (zoomed past the
+// viewport) so every frame is necessarily clipped, and pans the canvas
+// center between frames so the two frames clip DIFFERENT halves of the
+// disk while sharing an identical raster key.
+//
+// Forces color via lipgloss.SetColorProfile rather than
+// t.Setenv("CLICOLOR_FORCE", "1"): lipgloss's global renderer detects
+// (and permanently caches, via sync.Once) its color profile on the
+// FIRST Style.Render() call in the process — in the full `screens`
+// package test binary, many earlier tests already render through
+// Canvas.String() without CLICOLOR_FORCE set, so by the time this test
+// runs the profile is already cached as colorless and a plain env-var
+// change here arrives too late to matter (verified: this test flaked
+// exactly that way under `go test ./internal/tui/screens/...`, passing
+// alone but failing as part of the full package run).
+// SetColorProfile bypasses that lazy detection outright, so it's
+// immune to execution order. It has no dedicated "restore" API, but
+// leaving TrueColor forced for the rest of the process is NOT safe —
+// verified: doing so broke TestHyperbolicGhostGlyphOnly /
+// TestOrbitViewRendersGhosts / TestLaunchHUDRendersOrbitReadyOnApAboveFloor,
+// which depend on the default colorless profile for their assertions.
+// So this reads (and lazily triggers, if nothing has yet) the
+// process's natural ambient profile via lipgloss.ColorProfile() FIRST,
+// then restores exactly that value in t.Cleanup — same effective
+// color output for every test that runs after this one, whether the
+// renderer got there by lazy env detection or an explicit restore.
+func TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	body := diskCacheTestBody()
+	const r = 30 // bigger than the 20x10-cell (40x40px) canvas below
+	subLat, subLon := 10.0, 20.0
+	upX, upY := 0.0, 1.0
+	light := &render.SolarLight{SubSolarLatDeg: 5, SubSolarLonDeg: 15, EclipseFactor: 1}
+
+	renderPanned := func(v *OrbitView, canvas *widgets.Canvas, centerX float64) string {
+		canvas.Clear()
+		canvas.Center(orbital.Vec3{X: centerX})
+		tex := offsetColoredTexture()
+		cached := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
+		canvas.FillTexturedDiskTagged(orbital.Vec3{}, r, func(dx, dy int) lipgloss.Color {
+			return cached(dx, dy, r)
+		}, widgets.CellTag{})
+		return canvas.String()
+	}
+
+	// One shared OrbitView + Canvas, so frame 2 below is a genuine
+	// cache HIT (identical key, only the canvas center — i.e. pan —
+	// differs from frame 1).
+	v := NewOrbitView(plainTheme())
+	canvas := widgets.NewCanvas(20, 10)
+	canvas.SetScale(1)
+
+	// Frame 1: disk centered near the canvas's left edge — clips away
+	// most of the right half.
+	_ = renderPanned(v, canvas, -25)
+
+	// Frame 2 (PAN): disk now centered near the right edge — clips
+	// away most of the LEFT half instead, bringing much of the
+	// previously-clipped region into view under an identical key.
+	computesBefore := v.diskRasterCacheComputes
+	got := renderPanned(v, canvas, 25)
+	if v.diskRasterCacheComputes != computesBefore {
+		t.Fatalf("expected frame 2 (the pan) to be a raster cache HIT, got a recompute (computes %d -> %d)", computesBefore, v.diskRasterCacheComputes)
+	}
+
+	// Reference: render the identical frame 2 from scratch with the
+	// cache dropped (a fresh OrbitView never hits).
+	freshV := NewOrbitView(plainTheme())
+	freshCanvas := widgets.NewCanvas(20, 10)
+	freshCanvas.SetScale(1)
+	want := renderPanned(freshV, freshCanvas, 25)
+
+	if got != want {
+		t.Errorf("cache-HIT render diverges from the cache-dropped reference after a pan\ngot:  %q\nwant: %q", got, want)
+	}
+	if !containsANSI(got) {
+		t.Fatal("test setup broken: expected CLICOLOR_FORCE=1 to produce ANSI-colored output")
+	}
+}
+
+func containsANSI(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/screens/orbit_disk_cache_test.go
+++ b/internal/tui/screens/orbit_disk_cache_test.go
@@ -42,7 +42,7 @@ func TestTexturedDiskRasterHitsOnIdenticalKey(t *testing.T) {
 		return lipgloss.Color("#123456")
 	})
 
-	c1 := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+	c1 := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
 	for dy := -r; dy <= r; dy++ {
 		for dx := -r; dx <= r; dx++ {
 			if dx*dx+dy*dy > r*r {
@@ -60,7 +60,7 @@ func TestTexturedDiskRasterHitsOnIdenticalKey(t *testing.T) {
 	}
 
 	// Second call with an IDENTICAL key must not touch tex again.
-	c2 := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+	c2 := v.texturedDiskRaster(0, body, r, subLat, subLon, upX, upY, light, tex)
 	for dy := -r; dy <= r; dy++ {
 		for dx := -r; dx <= r; dx++ {
 			if dx*dx+dy*dy > r*r {
@@ -89,13 +89,13 @@ func TestTexturedDiskRasterSubPixelDriftHits(t *testing.T) {
 	const r = 20
 	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color { return lipgloss.Color("#123456") })
 
-	v.texturedDiskRaster(body, r, 10.0, 20.0, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, body, r, 10.0, 20.0, 0, 1, nil, tex)
 	if v.diskRasterCacheComputes != 1 {
 		t.Fatalf("first call: computes=%d, want 1", v.diskRasterCacheComputes)
 	}
 
 	const idleDriftDeg = 0.0002 // one warp-1x tick, per #363
-	v.texturedDiskRaster(body, r, 10.0, 20.0+idleDriftDeg, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, body, r, 10.0, 20.0+idleDriftDeg, 0, 1, nil, tex)
 	if v.diskRasterCacheComputes != 1 || v.diskRasterCacheHits != 1 {
 		t.Errorf("idle-drift call: computes=%d hits=%d, want computes=1 hits=1 (sub-quantum drift must hit)", v.diskRasterCacheComputes, v.diskRasterCacheHits)
 	}
@@ -128,7 +128,7 @@ func TestTexturedDiskRasterBustsOnChange(t *testing.T) {
 	}
 
 	v := NewOrbitView(plainTheme())
-	v.texturedDiskRaster(body, 20, 10, 20, 0, 1, baseLight, tex) // seed the baseline entry
+	v.texturedDiskRaster(0, body, 20, 10, 20, 0, 1, baseLight, tex) // seed the baseline entry
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -136,13 +136,13 @@ func TestTexturedDiskRasterBustsOnChange(t *testing.T) {
 				return
 			}
 			before := v.diskRasterCacheComputes
-			v.texturedDiskRaster(body, tc.r, tc.subLat, tc.subLon, tc.upX, tc.upY, tc.light, tex)
+			v.texturedDiskRaster(0, body, tc.r, tc.subLat, tc.subLon, tc.upX, tc.upY, tc.light, tex)
 			if v.diskRasterCacheComputes != before+1 {
 				t.Errorf("%s: computes went %d -> %d, want a miss (bust)", tc.name, before, v.diskRasterCacheComputes)
 			}
 			// Restore the shared entry to baseline so the next case's
 			// diff is isolated to its own single changed input.
-			v.texturedDiskRaster(body, 20, 10, 20, 0, 1, baseLight, tex)
+			v.texturedDiskRaster(0, body, 20, 10, 20, 0, 1, baseLight, tex)
 		})
 	}
 }
@@ -157,13 +157,13 @@ func TestTexturedDiskRasterPerBodyIndependent(t *testing.T) {
 	bodyB.ID = "disktest-b"
 	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color { return lipgloss.Color("#123456") })
 
-	v.texturedDiskRaster(bodyA, 20, 10, 20, 0, 1, nil, tex)
-	v.texturedDiskRaster(bodyB, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, bodyA, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, bodyB, 20, 10, 20, 0, 1, nil, tex)
 	if v.diskRasterCacheComputes != 2 {
 		t.Fatalf("two distinct bodies: computes=%d, want 2", v.diskRasterCacheComputes)
 	}
-	v.texturedDiskRaster(bodyA, 20, 10, 20, 0, 1, nil, tex)
-	v.texturedDiskRaster(bodyB, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, bodyA, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(0, bodyB, 20, 10, 20, 0, 1, nil, tex)
 	if v.diskRasterCacheComputes != 2 || v.diskRasterCacheHits != 2 {
 		t.Fatalf("second pass over both bodies: computes=%d hits=%d, want computes=2 hits=2", v.diskRasterCacheComputes, v.diskRasterCacheHits)
 	}
@@ -223,5 +223,34 @@ func TestOrbitRenderDiskCacheBustsOnWarpRotation(t *testing.T) {
 	v.Render(w, 0, 120, 40)
 	if v.diskRasterCacheComputes == firstComputes {
 		t.Error("a full-day clock jump did not bust the raster cache — disk would render stale")
+	}
+}
+
+// TestOrbitRenderDiskCacheSkipsOffCanvasBodies is the review-mandated
+// heap-bound regression test for the other retained-heap cause: at the
+// default LEO-Earth start, most of Sol's bodies (Mercury, Venus, Mars,
+// the outer planets, the Sun itself) are off-canvas — before the
+// #363 review fix, every one of them still built and RETAINED a full
+// raster grid that painted nothing (measured ~70x the idle retained
+// heap). The raster cache must end up with far fewer entries than the
+// system's total body count — only the bodies that actually intersect
+// the canvas get one.
+func TestOrbitRenderDiskCacheSkipsOffCanvasBodies(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(120, 40)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	totalBodies := len(w.System().Bodies)
+	if totalBodies < 2 {
+		t.Skip("system has too few bodies to distinguish on-canvas from off-canvas")
+	}
+
+	v.Render(w, 0, 120, 40)
+
+	if got := len(v.diskRasterCache); got >= totalBodies {
+		t.Errorf("diskRasterCache holds %d entries for a %d-body system — expected most off-canvas bodies (at default LEO zoom) to be skipped entirely, not cached empty", got, totalBodies)
 	}
 }

--- a/internal/tui/screens/orbit_disk_cache_test.go
+++ b/internal/tui/screens/orbit_disk_cache_test.go
@@ -1,0 +1,227 @@
+package screens
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// diskCacheTestBody is a minimal textured body (base + one continent),
+// mirroring internal/render's litTestBody helper, sized for the #363
+// raster-cache tests below.
+func diskCacheTestBody() bodies.CelestialBody {
+	return bodies.CelestialBody{
+		ID:    "disktest",
+		Color: "#4080C0",
+		Texture: &bodies.Texture{
+			Base:       "#4080C0",
+			Continents: []bodies.TextureEllipse{{Lat: 0, Lon: 0, LatR: 40, LonR: 40, Color: "#40A040"}},
+		},
+	}
+}
+
+// TestTexturedDiskRasterHitsOnIdenticalKey confirms an identical call
+// (same body, radius, sub-observer, up-vector, light) serves the cached
+// grid instead of invoking tex again — the whole point of #363.
+func TestTexturedDiskRasterHitsOnIdenticalKey(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	body := diskCacheTestBody()
+	const r = 20
+	subLat, subLon := 10.0, 20.0
+	upX, upY := 0.0, 1.0
+	light := &render.SolarLight{SubSolarLatDeg: 5, SubSolarLonDeg: 15, EclipseFactor: 1}
+
+	calls := 0
+	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color {
+		calls++
+		return lipgloss.Color("#123456")
+	})
+
+	c1 := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+	for dy := -r; dy <= r; dy++ {
+		for dx := -r; dx <= r; dx++ {
+			if dx*dx+dy*dy > r*r {
+				continue
+			}
+			c1(dx, dy, r)
+		}
+	}
+	firstCalls := calls
+	if firstCalls == 0 {
+		t.Fatal("expected the uncached raster pass to invoke tex")
+	}
+	if v.diskRasterCacheComputes != 1 || v.diskRasterCacheHits != 0 {
+		t.Fatalf("after first pass: computes=%d hits=%d, want computes=1 hits=0", v.diskRasterCacheComputes, v.diskRasterCacheHits)
+	}
+
+	// Second call with an IDENTICAL key must not touch tex again.
+	c2 := v.texturedDiskRaster(body, r, subLat, subLon, upX, upY, light, tex)
+	for dy := -r; dy <= r; dy++ {
+		for dx := -r; dx <= r; dx++ {
+			if dx*dx+dy*dy > r*r {
+				continue
+			}
+			if got, want := c2(dx, dy, r), lipgloss.Color("#123456"); got != want {
+				t.Errorf("cached pixel (%d,%d) = %q, want %q", dx, dy, got, want)
+			}
+		}
+	}
+	if calls != firstCalls {
+		t.Errorf("cache hit still invoked tex: calls went %d -> %d", firstCalls, calls)
+	}
+	if v.diskRasterCacheComputes != 1 || v.diskRasterCacheHits != 1 {
+		t.Fatalf("after second (hit) pass: computes=%d hits=%d, want computes=1 hits=1", v.diskRasterCacheComputes, v.diskRasterCacheHits)
+	}
+}
+
+// TestTexturedDiskRasterSubPixelDriftHits confirms the whole point of
+// quantization: a sub-observer longitude nudge far smaller than one
+// quantum (the ~0.0002°/tick idle drift at warp 1×, per #363) still
+// hits the cache.
+func TestTexturedDiskRasterSubPixelDriftHits(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	body := diskCacheTestBody()
+	const r = 20
+	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color { return lipgloss.Color("#123456") })
+
+	v.texturedDiskRaster(body, r, 10.0, 20.0, 0, 1, nil, tex)
+	if v.diskRasterCacheComputes != 1 {
+		t.Fatalf("first call: computes=%d, want 1", v.diskRasterCacheComputes)
+	}
+
+	const idleDriftDeg = 0.0002 // one warp-1x tick, per #363
+	v.texturedDiskRaster(body, r, 10.0, 20.0+idleDriftDeg, 0, 1, nil, tex)
+	if v.diskRasterCacheComputes != 1 || v.diskRasterCacheHits != 1 {
+		t.Errorf("idle-drift call: computes=%d hits=%d, want computes=1 hits=1 (sub-quantum drift must hit)", v.diskRasterCacheComputes, v.diskRasterCacheHits)
+	}
+}
+
+// TestTexturedDiskRasterBustsOnChange enumerates every input the raster
+// depends on and confirms a real change in each one busts the cache —
+// the acceptance criterion that rotation, zoom, camera moves, focus
+// switches, and lighting changes never produce a stale frame.
+func TestTexturedDiskRasterBustsOnChange(t *testing.T) {
+	body := diskCacheTestBody()
+	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color { return lipgloss.Color("#123456") })
+	baseLight := &render.SolarLight{SubSolarLatDeg: 5, SubSolarLonDeg: 15, EclipseFactor: 1}
+
+	cases := []struct {
+		name           string
+		r              int
+		subLat, subLon float64
+		upX, upY       float64
+		light          *render.SolarLight
+	}{
+		{"baseline", 20, 10, 20, 0, 1, baseLight},
+		{"radius changed (zoom)", 24, 10, 20, 0, 1, baseLight},
+		{"sub-observer lat rotated", 20, 10 + 5, 20, 0, 1, baseLight},
+		{"sub-observer lon rotated (high warp)", 20, 10, 20 + 5, 0, 1, baseLight},
+		{"screen-up rotated (camera move)", 20, 10, 20, 1, 0, baseLight},
+		{"light direction changed", 20, 10, 20, 0, 1, &render.SolarLight{SubSolarLatDeg: 40, SubSolarLonDeg: 40, EclipseFactor: 1}},
+		{"eclipse factor changed", 20, 10, 20, 0, 1, &render.SolarLight{SubSolarLatDeg: 5, SubSolarLonDeg: 15, EclipseFactor: 0.3}},
+		{"light removed", 20, 10, 20, 0, 1, nil},
+	}
+
+	v := NewOrbitView(plainTheme())
+	v.texturedDiskRaster(body, 20, 10, 20, 0, 1, baseLight, tex) // seed the baseline entry
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "baseline" {
+				return
+			}
+			before := v.diskRasterCacheComputes
+			v.texturedDiskRaster(body, tc.r, tc.subLat, tc.subLon, tc.upX, tc.upY, tc.light, tex)
+			if v.diskRasterCacheComputes != before+1 {
+				t.Errorf("%s: computes went %d -> %d, want a miss (bust)", tc.name, before, v.diskRasterCacheComputes)
+			}
+			// Restore the shared entry to baseline so the next case's
+			// diff is isolated to its own single changed input.
+			v.texturedDiskRaster(body, 20, 10, 20, 0, 1, baseLight, tex)
+		})
+	}
+}
+
+// TestTexturedDiskRasterPerBodyIndependent confirms two distinct bodies
+// textured in the same frame each get their own cache slot rather than
+// thrashing a single shared one.
+func TestTexturedDiskRasterPerBodyIndependent(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	bodyA := diskCacheTestBody()
+	bodyB := diskCacheTestBody()
+	bodyB.ID = "disktest-b"
+	tex := render.BodyTexture(func(dx, dy, rr int) lipgloss.Color { return lipgloss.Color("#123456") })
+
+	v.texturedDiskRaster(bodyA, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(bodyB, 20, 10, 20, 0, 1, nil, tex)
+	if v.diskRasterCacheComputes != 2 {
+		t.Fatalf("two distinct bodies: computes=%d, want 2", v.diskRasterCacheComputes)
+	}
+	v.texturedDiskRaster(bodyA, 20, 10, 20, 0, 1, nil, tex)
+	v.texturedDiskRaster(bodyB, 20, 10, 20, 0, 1, nil, tex)
+	if v.diskRasterCacheComputes != 2 || v.diskRasterCacheHits != 2 {
+		t.Fatalf("second pass over both bodies: computes=%d hits=%d, want computes=2 hits=2", v.diskRasterCacheComputes, v.diskRasterCacheHits)
+	}
+}
+
+// TestOrbitRenderDiskCacheHitsAcrossIdleFrames is an integration-level
+// check: two Render() calls with the world clock unchanged (the idle
+// case #363 targets) must not re-raster the focused body's disk.
+func TestOrbitRenderDiskCacheHitsAcrossIdleFrames(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(120, 40)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	v.Render(w, 0, 120, 40)
+	firstComputes := v.diskRasterCacheComputes
+	if firstComputes == 0 {
+		t.Skip("no textured body reached the raster path at default zoom (radius below BodyTextureMinRadius) — nothing to assert")
+	}
+
+	// Idle: render again with the clock untouched, exactly what happens
+	// between two 20 Hz ticks with warp paused / at rest.
+	v.Render(w, 0, 120, 40)
+	if v.diskRasterCacheComputes != firstComputes {
+		t.Errorf("idle re-render caused a raster recompute: computes went %d -> %d", firstComputes, v.diskRasterCacheComputes)
+	}
+	if v.diskRasterCacheHits == 0 {
+		t.Error("idle re-render recorded no cache hits")
+	}
+}
+
+// TestOrbitRenderDiskCacheBustsOnWarpRotation confirms that advancing
+// the clock enough to rotate the body past one quantum (as high warp
+// does) forces a real recompute — the disk must keep animating.
+func TestOrbitRenderDiskCacheBustsOnWarpRotation(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(120, 40)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	v.Render(w, 0, 120, 40)
+	firstComputes := v.diskRasterCacheComputes
+	if firstComputes == 0 {
+		t.Skip("no textured body reached the raster path at default zoom — nothing to assert")
+	}
+
+	// Jump the sim clock forward by a large margin — Earth's rotation
+	// period is ~24h, so a full day moves the sub-observer longitude by
+	// far more than one 0.02° quantum.
+	w.Clock.SimTime = w.Clock.SimTime.Add(24 * time.Hour)
+	v.Render(w, 0, 120, 40)
+	if v.diskRasterCacheComputes == firstComputes {
+		t.Error("a full-day clock jump did not bust the raster cache — disk would render stale")
+	}
+}

--- a/internal/tui/screens/orbit_render_idle_bench_test.go
+++ b/internal/tui/screens/orbit_render_idle_bench_test.go
@@ -1,0 +1,34 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// BenchmarkOrbitViewRenderIdle exercises the whole per-tick OrbitView.Render
+// path in the idle steady state (#363/#364 idle-CPU diagnosis): the world
+// clock is never advanced between calls, so this is exactly the picture
+// painted twice in a row between two 20 Hz ticks with warp paused / at rest.
+//
+// Useful with `-cpuprofile` for a repeatable, noise-free breakdown of where
+// idle-frame CPU goes, independent of the live-CPU `ps -o %cpu` measurement
+// (which also carries tea.Program / terminal I/O overhead this benchmark
+// doesn't exercise):
+//
+//	go test ./internal/tui/screens/ -run '^$' -bench BenchmarkOrbitViewRenderIdle \
+//	  -benchtime=3s -cpuprofile=/tmp/cpu.prof
+//	go tool pprof -top /tmp/cpu.prof
+func BenchmarkOrbitViewRenderIdle(b *testing.B) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		b.Fatalf("NewWorld: %v", err)
+	}
+	v.Render(w, 0, 120, 40) // warm the Framing Event / zoom fit
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.Render(w, 0, 120, 40)
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -174,6 +174,46 @@ type Canvas struct {
 	// untagged background cells. Cells absent from this map fall back to
 	// the pixelTag-derived color (terminal default when untagged).
 	cellOverlayColors map[[2]int]lipgloss.TerminalColor
+
+	// diskOffsetCache memoizes the (dx, dy) offsets inside a disk of a
+	// given pixel radius (#363): the "is this offset inside the
+	// circle" test is a pure function of pxRadius alone, so profiling
+	// showed FillTexturedDiskTagged re-deriving it with a nested loop
+	// + distance check on every one of the ~1000+ pixels of a focused
+	// body's disk, every 50ms tick, even after the per-pixel COLOR
+	// itself was cached — the offset shape doesn't depend on the body,
+	// its texture, or the camera, only on the radius. Keyed per
+	// Canvas (not a package-level cache) so no locking is needed —
+	// same single-goroutine-per-Canvas assumption pixelTags already
+	// makes.
+	diskOffsetCache map[int][]diskOffset
+}
+
+// diskOffset is one (dx, dy) pixel offset inside a disk's radius,
+// relative to the disk's projected screen center.
+type diskOffset struct{ dx, dy int }
+
+// diskOffsets returns the (dx, dy) offsets inside a disk of the given
+// pixel radius, computing (and caching) them once per distinct radius
+// this Canvas has ever drawn. See diskOffsetCache.
+func (c *Canvas) diskOffsets(pxRadius int) []diskOffset {
+	if c.diskOffsetCache == nil {
+		c.diskOffsetCache = make(map[int][]diskOffset)
+	}
+	if offs, ok := c.diskOffsetCache[pxRadius]; ok {
+		return offs
+	}
+	r2 := pxRadius * pxRadius
+	offs := make([]diskOffset, 0, 4*r2) // generous upper bound (circle ⊂ bounding square)
+	for dy := -pxRadius; dy <= pxRadius; dy++ {
+		for dx := -pxRadius; dx <= pxRadius; dx++ {
+			if dx*dx+dy*dy <= r2 {
+				offs = append(offs, diskOffset{dx, dy})
+			}
+		}
+	}
+	c.diskOffsetCache[pxRadius] = offs
+	return offs
 }
 
 // NewCanvas builds a canvas sized to fit cols × rows terminal cells.
@@ -366,22 +406,19 @@ func (c *Canvas) FillColoredDiskTagged(center orbital.Vec3, pxRadius int, tag Ce
 		pxRadius = 1
 	}
 	cx, cy, _ := c.Project(center)
-	r2 := pxRadius * pxRadius
 	if c.pixelTags == nil {
 		c.pixelTags = make(map[[2]int]CellTag)
 	}
-	for dy := -pxRadius; dy <= pxRadius; dy++ {
-		for dx := -pxRadius; dx <= pxRadius; dx++ {
-			if dx*dx+dy*dy > r2 {
-				continue
-			}
-			px, py := cx+dx, cy+dy
-			if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
-				continue
-			}
-			c.dc.Set(px, py)
-			c.pixelTags[[2]int{px, py}] = tag
+	// #363: every non-focused body on the canvas (every planet/moon
+	// that isn't the focused, textured one) paints through this path
+	// each frame too — same offset-mask win as FillTexturedDiskTagged.
+	for _, o := range c.diskOffsets(pxRadius) {
+		px, py := cx+o.dx, cy+o.dy
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			continue
 		}
+		c.dc.Set(px, py)
+		c.pixelTags[[2]int{px, py}] = tag
 	}
 }
 
@@ -416,24 +453,22 @@ func (c *Canvas) FillTexturedDiskTagged(center orbital.Vec3, pxRadius int, textu
 		pxRadius = 1
 	}
 	cx, cy, _ := c.Project(center)
-	r2 := pxRadius * pxRadius
 	if c.pixelTags == nil {
 		c.pixelTags = make(map[[2]int]CellTag)
 	}
-	for dy := -pxRadius; dy <= pxRadius; dy++ {
-		for dx := -pxRadius; dx <= pxRadius; dx++ {
-			if dx*dx+dy*dy > r2 {
-				continue
-			}
-			px, py := cx+dx, cy+dy
-			if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
-				continue
-			}
-			c.dc.Set(px, py)
-			t := tag
-			t.Color = texture(dx, dy)
-			c.pixelTags[[2]int{px, py}] = t
+	// #363: iterate the precomputed offset mask instead of a nested
+	// loop + per-pixel distance test — the mask is a pure function of
+	// pxRadius, recomputing it every frame was pure per-pixel overhead
+	// on top of the (now-cached) color lookup.
+	for _, o := range c.diskOffsets(pxRadius) {
+		px, py := cx+o.dx, cy+o.dy
+		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+			continue
 		}
+		c.dc.Set(px, py)
+		t := tag
+		t.Color = texture(o.dx, o.dy)
+		c.pixelTags[[2]int{px, py}] = t
 	}
 }
 

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -186,8 +186,25 @@ type Canvas struct {
 	// Canvas (not a package-level cache) so no locking is needed —
 	// same single-goroutine-per-Canvas assumption pixelTags already
 	// makes.
+	//
+	// diskOffsetOrder is diskOffsetCache's LRU recency list (oldest
+	// first) — review finding: the map was unbounded, and pxRadius
+	// changes on every zoom step/refit, so a session that zoomed
+	// across radii 1..384 once retained ~1.22 GB of masks that will
+	// never be reused. Capped to diskOffsetCacheCap distinct radii,
+	// comfortably above the number of bodies simultaneously visible in
+	// any one system, so a single frame's radii always fit without
+	// thrashing.
 	diskOffsetCache map[int][]diskOffset
+	diskOffsetOrder []int
 }
+
+// diskOffsetCacheCap bounds diskOffsetCache to this many distinct
+// radii (LRU-evicted beyond it). Generous headroom over the largest
+// body count in any one system (Lumen's ~17) so ordinary frame-to-
+// frame drawing never evicts a radius it's about to reuse; a wide zoom
+// sweep still can't grow the cache without bound.
+const diskOffsetCacheCap = 32
 
 // diskOffset is one (dx, dy) pixel offset inside a disk's radius,
 // relative to the disk's projected screen center.
@@ -195,16 +212,21 @@ type diskOffset struct{ dx, dy int }
 
 // diskOffsets returns the (dx, dy) offsets inside a disk of the given
 // pixel radius, computing (and caching) them once per distinct radius
-// this Canvas has ever drawn. See diskOffsetCache.
+// this Canvas has recently drawn. See diskOffsetCache.
 func (c *Canvas) diskOffsets(pxRadius int) []diskOffset {
 	if c.diskOffsetCache == nil {
 		c.diskOffsetCache = make(map[int][]diskOffset)
 	}
 	if offs, ok := c.diskOffsetCache[pxRadius]; ok {
+		c.touchDiskOffsetRadius(pxRadius)
 		return offs
 	}
 	r2 := pxRadius * pxRadius
-	offs := make([]diskOffset, 0, 4*r2) // generous upper bound (circle ⊂ bounding square)
+	// Tighter capacity estimate than the old 4r² bounding-square guess
+	// (review finding: ~21% of that was permanently-wasted retained
+	// capacity) — π·r² is the disk's true area, +8 for rounding slack.
+	estimate := int(math.Pi*float64(r2)) + 8
+	offs := make([]diskOffset, 0, estimate)
 	for dy := -pxRadius; dy <= pxRadius; dy++ {
 		for dx := -pxRadius; dx <= pxRadius; dx++ {
 			if dx*dx+dy*dy <= r2 {
@@ -213,7 +235,46 @@ func (c *Canvas) diskOffsets(pxRadius int) []diskOffset {
 		}
 	}
 	c.diskOffsetCache[pxRadius] = offs
+	c.touchDiskOffsetRadius(pxRadius)
+	c.evictOldDiskOffsets()
 	return offs
+}
+
+// touchDiskOffsetRadius moves pxRadius to the most-recently-used end
+// of diskOffsetOrder (appending it if new). O(cap) worst case, which
+// is fine at diskOffsetCacheCap's small bound.
+func (c *Canvas) touchDiskOffsetRadius(pxRadius int) {
+	for i, r := range c.diskOffsetOrder {
+		if r == pxRadius {
+			c.diskOffsetOrder = append(c.diskOffsetOrder[:i], c.diskOffsetOrder[i+1:]...)
+			break
+		}
+	}
+	c.diskOffsetOrder = append(c.diskOffsetOrder, pxRadius)
+}
+
+// evictOldDiskOffsets drops the least-recently-used radii once
+// diskOffsetCache exceeds diskOffsetCacheCap.
+func (c *Canvas) evictOldDiskOffsets() {
+	for len(c.diskOffsetOrder) > diskOffsetCacheCap {
+		oldest := c.diskOffsetOrder[0]
+		c.diskOffsetOrder = c.diskOffsetOrder[1:]
+		delete(c.diskOffsetCache, oldest)
+	}
+}
+
+// DiskIntersectsCanvas reports whether a disk of the given pixel
+// radius centered at center could paint any on-canvas pixel — a cheap
+// screen-space bounding-box test callers use to skip disk-fill work
+// (and any per-body raster-cache allocation) entirely for a body
+// that's off-canvas this frame, rather than paying for a fill loop
+// that would clip away to nothing anyway (#363 review fix).
+func (c *Canvas) DiskIntersectsCanvas(center orbital.Vec3, pxRadius int) bool {
+	if pxRadius < 1 {
+		pxRadius = 1
+	}
+	cx, cy, _ := c.Project(center)
+	return cx+pxRadius >= 0 && cx-pxRadius < c.pxW && cy+pxRadius >= 0 && cy-pxRadius < c.pxH
 }
 
 // NewCanvas builds a canvas sized to fit cols × rows terminal cells.

--- a/internal/tui/widgets/canvas_disk_offset_test.go
+++ b/internal/tui/widgets/canvas_disk_offset_test.go
@@ -95,3 +95,65 @@ func TestFillTexturedDiskTaggedMatchesColoredShape(t *testing.T) {
 		}
 	}
 }
+
+// TestDiskOffsetCacheBoundedAcrossZoomSweep is the review-mandated
+// memory-bound regression test: pxRadius changes on every zoom
+// step/refit, and the offset cache used to be keyed on radius with no
+// eviction — a session that zoomed across a wide radius range once
+// retained a mask for every distinct radius it ever passed through
+// (measured ~1.22 GB retained sweeping 1..384). After the LRU cap, the
+// cache must never hold more than diskOffsetCacheCap distinct radii,
+// no matter how many distinct radii a session sweeps through.
+func TestDiskOffsetCacheBoundedAcrossZoomSweep(t *testing.T) {
+	c := NewCanvas(200, 60)
+	// Sweep every radius from 1 to 384 — far more distinct radii than
+	// diskOffsetCacheCap, standing in for a full zoom-in-then-out pass.
+	for r := 1; r <= 384; r++ {
+		c.diskOffsets(r)
+		if len(c.diskOffsetCache) > diskOffsetCacheCap {
+			t.Fatalf("after radius %d: diskOffsetCache holds %d entries, want <= %d (cap)", r, len(c.diskOffsetCache), diskOffsetCacheCap)
+		}
+		if len(c.diskOffsetOrder) > diskOffsetCacheCap {
+			t.Fatalf("after radius %d: diskOffsetOrder holds %d entries, want <= %d (cap)", r, len(c.diskOffsetOrder), diskOffsetCacheCap)
+		}
+	}
+	if got := len(c.diskOffsetCache); got != diskOffsetCacheCap {
+		t.Errorf("after a 384-radius sweep, diskOffsetCache = %d entries, want exactly the cap (%d) — the sweep should have filled and evicted, not stayed short", got, diskOffsetCacheCap)
+	}
+	// The most recently swept radii (nearest 384) must be the ones
+	// still resident — LRU eviction should have dropped the early,
+	// long-unused ones (nearest 1), not an arbitrary subset.
+	if _, ok := c.diskOffsetCache[384]; !ok {
+		t.Error("most-recently-used radius 384 was evicted — eviction isn't LRU")
+	}
+	if _, ok := c.diskOffsetCache[1]; ok {
+		t.Error("least-recently-used radius 1 is still resident after the sweep — eviction isn't LRU")
+	}
+}
+
+// TestDiskIntersectsCanvas checks the bounding-box viewport test used
+// to skip disk-fill work (and any per-body raster-cache allocation,
+// #363 review fix) for a body that's entirely off-canvas: a disk
+// dead-center is on-canvas, a disk far enough away that even its
+// radius can't reach the canvas is not, and a disk whose center is
+// off-canvas but whose edge still overlaps the canvas is correctly
+// reported as intersecting (the bounding-box test must not be a
+// center-point-only test).
+func TestDiskIntersectsCanvas(t *testing.T) {
+	c := NewCanvas(40, 20) // pxW=80, pxH=80
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+
+	if !c.DiskIntersectsCanvas(orbital.Vec3{}, 10) {
+		t.Error("a disk centered on-canvas should intersect")
+	}
+	if c.DiskIntersectsCanvas(orbital.Vec3{X: 10000}, 10) {
+		t.Error("a disk far off-canvas with a small radius should not intersect")
+	}
+	// Center just past the right edge (canvas half-width 40px), but
+	// with a radius large enough that the disk's LEFT edge still
+	// overlaps the canvas.
+	if !c.DiskIntersectsCanvas(orbital.Vec3{X: 45}, 20) {
+		t.Error("a disk whose center is off-canvas but whose edge overlaps should intersect")
+	}
+}

--- a/internal/tui/widgets/canvas_disk_offset_test.go
+++ b/internal/tui/widgets/canvas_disk_offset_test.go
@@ -1,0 +1,97 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// bruteForceDiskOffsets recomputes the disk mask the slow way (the
+// original per-call double loop + distance test FillTexturedDiskTagged
+// and FillColoredDiskTagged used before #363), for comparison against
+// the cached diskOffsets().
+func bruteForceDiskOffsets(pxRadius int) map[[2]int]bool {
+	r2 := pxRadius * pxRadius
+	out := make(map[[2]int]bool)
+	for dy := -pxRadius; dy <= pxRadius; dy++ {
+		for dx := -pxRadius; dx <= pxRadius; dx++ {
+			if dx*dx+dy*dy <= r2 {
+				out[[2]int{dx, dy}] = true
+			}
+		}
+	}
+	return out
+}
+
+// TestDiskOffsetsMatchesBruteForce confirms the #363 offset-mask cache
+// produces exactly the same set of (dx, dy) pairs as the original
+// per-pixel distance test, for a range of radii including the
+// BodyTextureMinRadius boundary and some larger zoomed-in sizes.
+func TestDiskOffsetsMatchesBruteForce(t *testing.T) {
+	c := NewCanvas(200, 60)
+	for _, r := range []int{1, 2, 5, 11, 12, 13, 20, 24, 40, 100} {
+		want := bruteForceDiskOffsets(r)
+		got := c.diskOffsets(r)
+		if len(got) != len(want) {
+			t.Errorf("r=%d: len(offsets)=%d, want %d", r, len(got), len(want))
+		}
+		seen := make(map[[2]int]bool, len(got))
+		for _, o := range got {
+			key := [2]int{o.dx, o.dy}
+			if !want[key] {
+				t.Errorf("r=%d: offset (%d,%d) not in brute-force disk mask", r, o.dx, o.dy)
+			}
+			seen[key] = true
+		}
+		for key := range want {
+			if !seen[key] {
+				t.Errorf("r=%d: brute-force offset %v missing from cached mask", r, key)
+			}
+		}
+	}
+}
+
+// TestDiskOffsetsCachedAcrossCalls confirms the second call for the
+// same radius returns the identical backing slice (proof the mask is
+// actually memoized, not recomputed).
+func TestDiskOffsetsCachedAcrossCalls(t *testing.T) {
+	c := NewCanvas(200, 60)
+	first := c.diskOffsets(20)
+	second := c.diskOffsets(20)
+	if len(first) == 0 {
+		t.Fatal("expected a non-empty disk mask")
+	}
+	if &first[0] != &second[0] {
+		t.Error("diskOffsets(20) returned a different backing array on the second call — not cached")
+	}
+}
+
+// TestFillTexturedDiskTaggedMatchesColoredShape confirms the #363
+// offset-mask optimization didn't change which pixels get painted:
+// a textured disk and a colored disk of the same radius at the same
+// center must tag exactly the same set of on-canvas pixels.
+func TestFillTexturedDiskTaggedMatchesColoredShape(t *testing.T) {
+	texturedCanvas := NewCanvas(200, 60)
+	texturedCanvas.SetScale(1)
+	coloredCanvas := NewCanvas(200, 60)
+	coloredCanvas.SetScale(1)
+
+	center := orbital.Vec3{}
+	const r = 20
+	texturedCanvas.FillTexturedDiskTagged(center, r, func(dx, dy int) lipgloss.Color {
+		return "#123456"
+	}, CellTag{})
+	coloredCanvas.FillColoredDiskTagged(center, r, CellTag{Color: "#123456"})
+
+	if len(texturedCanvas.pixelTags) != len(coloredCanvas.pixelTags) {
+		t.Fatalf("textured disk painted %d pixels, colored disk painted %d — offset mask should agree",
+			len(texturedCanvas.pixelTags), len(coloredCanvas.pixelTags))
+	}
+	for k := range coloredCanvas.pixelTags {
+		if _, ok := texturedCanvas.pixelTags[k]; !ok {
+			t.Errorf("pixel %v painted by colored disk but not textured disk", k)
+		}
+	}
+}


### PR DESCRIPTION
## Update 2 — corrected live-CPU methodology (important)

The live idle-CPU numbers in the update below (and in the original PR
description further down) were each measured by launching **one**
binary at a time in its own `tmux` session, at a different point in
time, and comparing against a number measured in an **earlier,
separate session**. That turned out to be unreliable: this machine's
ambient CPU availability visibly drifts between sessions (other
processes, thermal state), enough to swing a single binary's
apparent idle % by several points run to run — which was large
enough to fully explain the originally-reported "~52% relative
reduction, close to single digits."

**Corrected methodology:** run `main`, this branch (`363-only`,
review-fixed), and the `363+364` stack **simultaneously**, each in
its own `tmux` session on the same 120×36 idle orbit screen, and
sample all three with `ps -o %cpu` in the same interleaved loop, so
every sample point reflects identical system conditions for all
three. 30 samples (2 rounds × 15, ~2s apart):

```
main:              22.65% avg
363-only (this PR): 19.19% avg   (-15.3% relative to main)
363+364 (stacked):  18.36% avg   (-19.0% relative to main;
                                  -4.3% relative to 363-only)
```

This is **not** single digits, and the improvement is real but modest
— roughly a third of what was originally claimed. The `pprof`
findings (the disk-raster cost share of `Render()`'s own time
dropping from ~19% to ~10-14% cum) are still accurate; what was wrong
was extrapolating that to the LIVE process number using sequential,
not-controlled-for-drift measurements. `Render()` itself is only a
fraction of the process's total per-tick cost (tmux/pty I/O, Bubble
Tea's own diff/render pipeline, goroutine scheduling, GC), which
bounds how much a `Render()`-only fix can move the live number — this
several-times-smaller-than-claimed result is consistent with that
bound.

The benchmark numbers, the retained-heap numbers, and the correctness
fixes above are unaffected by this — they were measured with
controlled, single-process methodologies (`go test -bench`,
`runtime.MemStats` deltas) that don't have this confound. Only the
**live `ps -o %cpu` comparison** needed correcting. Treat the numbers
in this section as the authoritative live-CPU figures for this PR;
the sequential-session numbers further down are left in place for
the historical record of what was measured at each step, not as
current claims.

---

## Update — pre-merge review fixes (commit `abe8390`)

The opus pre-merge review found two must-fix bugs in the original cache
(`708e6ae`), both now fixed, plus the cheap-hardening items from the
same pass. **All numbers below are re-measured after the fixes.**

**MUST-FIX 1 — cache served unrasterized pixels after a pan.**
`FillTexturedDiskTagged` clips an offset *before* calling the texture
closure, so a raster grid built while only part of a disk was
on-canvas was only complete for the offsets that frame actually
touched. A later identical-key frame (same body/radius/lighting — a
pure pan doesn't change any of those) hit the cache and returned the
zero-value `lipgloss.Color("")` for any never-drawn offset, which
`Canvas.String()` renders as default-fg (uncolored) braille — review
reproduced it as 17 of 33 rows uncolored after a 12-step zoom-in + 5×
pan; 90 of 144 zoom/pan configurations showed a stale frame. **Fix:**
the cache-hit path in `texturedDiskRaster`
(`internal/tui/screens/orbit_disk_cache.go`) is now self-healing — on
a hit, an empty grid slot falls through to `tex()` and fills itself,
instead of trusting the grid is already complete. Same key ⇒ same
colors, so lazily filling a gap on the hit path is always correct; the
grid converges to the union of every on-canvas window that key has
ever drawn.

New regression tests (`internal/tui/screens/orbit_disk_cache_pan_test.go`),
both **verified to fail against the pre-fix hit path** (reverted
locally, confirmed the failure reproduces the exact "blank cache read"
symptom, then restored the fix):
- `TestTexturedDiskRasterSelfHealsAfterPan` — drives the cache directly
  through a half-drawn-then-panned scenario, checks every offset for
  the blank zero-value color.
- `TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan` — the
  review-specified end-to-end check: a cache-HIT render compared
  byte-for-byte against the same frame rendered from a fresh
  (cache-dropped) `OrbitView`, disk radius larger than the canvas
  (guaranteed clipping), pan between frames. Forces real ANSI via
  `lipgloss.SetColorProfile(termenv.TrueColor)` + `t.Cleanup` restore
  rather than `t.Setenv("CLICOLOR_FORCE", "1")` — lipgloss's global
  renderer caches its color profile via `sync.Once` on the first
  `Style.Render()` call in the process, so a plain env-var set only
  works if nothing rendered before it in that test binary, which
  doesn't hold in a ~100-file package. (Leaving the profile forced
  globally isn't safe either — verified it broke three unrelated tests
  that depend on the default colorless profile; hence the
  `t.Cleanup` restore.)

**MUST-FIX 2 — both caches unbounded, ~70x idle retained heap.**
Measured: main **0.41 MB** → pre-fix stacked head **28.03 MB** at
120×36, **81.36 MB** at 200×60 (reproduced locally against `708e6ae`
to confirm before fixing). Two causes, both fixed:
- *(a)* A raster grid got built and retained for every textured body,
  even ones entirely off-canvas — at the default LEO-Earth view, 5 of
  6 textured Sol bodies are off-canvas and were caching 100%-empty
  grids (the Sun alone, ~737px radius at that zoom, ~8.7 MB). **Fix:**
  `Canvas.DiskIntersectsCanvas`, a cheap screen-space bounding-box
  test — the disk fill and any raster-cache allocation are now skipped
  entirely when a body's disk can't paint any on-canvas pixel
  (identical drawn output, since it painted nothing before either).
- *(b)* `diskOffsetCache` was keyed on pixel radius with no eviction,
  and radius changes on every zoom step/refit — a session that swept
  radii 1..384 once retained a mask for every one of them (~1.22 GB).
  **Fix:** capped to 32 distinct radii via a simple LRU
  (`diskOffsetOrder`), well above the body count in any one system.
  Also tightened the per-mask capacity estimate from 4r² (bounding
  square) to πr² (true disk area) + slack.

New regression tests: `TestDiskOffsetCacheBoundedAcrossZoomSweep`
(canvas_disk_offset_test.go) sweeps radii 1..384 and asserts the cache
never exceeds the cap and evicts LRU-correctly.
`TestOrbitRenderDiskCacheSkipsOffCanvasBodies`
(orbit_disk_cache_test.go) renders the default scenario and asserts
the raster cache ends up with far fewer entries than the system's
total body count. `TestDiskIntersectsCanvas` covers the bounding-box
test directly.

**Cheap hardening:** `diskRasterKey` now carries `systemIdx` alongside
`bodyID` (a user-overlay catalog can reuse a body ID across systems;
without this a system switch could serve one system's cached colors
onto another system's same-ID body).

**Re-measured after all fixes:**

```
BenchmarkBodyDiskRaster (r=24px):
  Uncached-10    394021 ns/op   14456 B/op   1793 allocs/op
  CachedHit-10    86620 ns/op      64 B/op      1 allocs/op
```
Unchanged from the original PR — confirms the self-healing hit path
and viewport clipping didn't cost back the win.

```
BenchmarkOrbitViewRenderIdle: 2441717 ns/op
```
Slightly *better* than the original PR's 2769797 ns/op (skipping
off-canvas `TextureFor()` setup for 5 bodies helps).

```
Live idle CPU (ps -o %cpu, same methodology as below):
  ~21.1% avg (11.4–24.5% range, 8 samples)
```
Consistent with the originally-reported ~20.3% avg — not regressed.

```
Retained heap (heap-delta harness: construct OrbitView + Canvas at a
given terminal size, render 30 idle ticks of the default scenario,
GC + measure before/after):
  120×36:  0.442 MB  (was 28.030 MB pre-fix)
  200×60:  0.867 MB  (was 81.361 MB pre-fix)
```
Matches main's ~0.41 MB baseline.

`go vet ./...` and `go test ./... -race -count=1` are green, verified
repeatedly (including 3× repeated runs of the `tui/screens` package
alone) to rule out the test-ordering flake this review surfaced.

---

## Summary

At idle on the orbit screen, the game re-rasterized the focused body's
textured disk every 20 Hz tick — the `render.BodyTexture` closure
(lat/lon projection, trig, feature-polygon tests) ran fresh per pixel
every frame even though the picture is essentially static between
ticks at a steady warp.

Two complementary caches, both `OrbitView`/`Canvas`-scoped (no global
state, no locking needed — same single-goroutine-per-instance
assumption the existing `pixelTags` map already makes):

1. **`diskRasterCache`** (`internal/tui/screens/orbit_disk_cache.go`) —
   memoizes the rasterized per-pixel color grid, keyed on body
   identity, pixel radius, and **quantized** sub-observer lat/lon,
   light direction, and screen-up orientation. This is the ADR 0017
   predict-on-change pattern already used for the node-leg
   (`predictCache`) and SOI Pass (`soiPassCache`) caches in the same
   file.

   **Quantum: 0.02°.** Chosen so a one-quantum step stays sub-pixel
   even at a generously large 300px disk radius (`arc ≈ pxRadius ×
   0.02° × π/180 ≈ 0.10px`), while staying ~250× coarser than the
   ~0.0002°/tick idle drift at warp 1× — idle frames land in the same
   bucket for ~2.5s (50 ticks) before a real miss. Zoom, camera moves,
   focus switches, high warp, and lighting changes all move the key
   and correctly bust the cache — covered by
   `orbit_disk_cache_test.go` (`TestTexturedDiskRasterBustsOnChange`
   enumerates every input; `TestOrbitRenderDiskCacheBustsOnWarpRotation`
   confirms a clock jump busts it end-to-end).

2. **`Canvas.diskOffsets`** (`internal/tui/widgets/canvas.go`) — while
   profiling with `go test -cpuprofile` on a synthetic idle-render
   benchmark, the color cache alone turned out not to be enough: the
   disk-fill loop itself (the per-pixel bounds/distance check plus the
   `pixelTags` map insert in `FillTexturedDiskTagged` /
   `FillColoredDiskTagged`) was comparable in cost to the texture
   evaluation it replaced — a fresh "is this offset inside the circle"
   test doesn't depend on color at all, it's a pure function of pixel
   radius. Both disk-fill methods now iterate a per-`Canvas`
   memoized offset mask instead of a nested loop + per-pixel distance
   test. `canvas_disk_offset_test.go` checks the cached mask against a
   brute-force reference for a range of radii and confirms textured
   vs. colored disks of the same radius paint the identical pixel set.

## Benchmarks (original, pre-review; see update above for current numbers)

`BenchmarkBodyDiskRaster` (`internal/tui/screens/orbit_disk_cache_bench_test.go`),
a single body's textured-disk raster at r=24px:

```
BenchmarkBodyDiskRaster/Uncached-10    396610 ns/op   14458 B/op   1793 allocs/op
BenchmarkBodyDiskRaster/CachedHit-10    86439 ns/op      64 B/op      1 allocs/op
```

~4.6x faster, allocations essentially eliminated.

`BenchmarkOrbitViewRenderIdle` (`internal/tui/screens/orbit_render_idle_bench_test.go`),
whole `OrbitView.Render()` in the idle steady state (clock unchanged
between calls — exactly two consecutive 20 Hz ticks at rest):

```
main:            3766282 ns/op
this branch:     2769797 ns/op   (-26.5%)
```

## Live idle CPU (original, pre-review; see update above for current numbers)

`ps -o %cpu`, warp 1×, default LEO-Earth start (`--system Sol --orbit
Earth --altitude 400km`), 120×36 terminal, orbit screen, ~40s settle
via `script -q /dev/null` in a backgrounded `tmux` session:

```
baseline (main):    ~26.0% avg  (22.1–28.7% range, 5 samples)
this branch:         ~20.3% avg (14.6–22.5% range, 8 samples)
```

This is a real, repeatable reduction (matches the ~26.5% Render()-only
benchmark delta) but **not single digits on its own**. A follow-up
`pprof` profile (`go test -cpuprofile` on `BenchmarkOrbitViewRenderIdle`)
shows the now-dominant idle cost is `lipgloss.Style.Render` /
`uniseg` string-width scanning assembling the HUD/chip panel strings
every tick regardless of content change (~33% cumulative of
`Render()`'s own cost, vs. `FillTexturedDiskTagged` down to ~7.6%
cum from ~19.4% before this fix) — exactly the frame-assembly churn
#364 describes as the second slice of this idle-CPU diagnosis. #364
(stacked on this branch) re-profiles fresh after this change lands
and closes the rest; the two together are expected to reach the
single-digit target.

## Test plan

- [x] `go vet ./...` green
- [x] `go test ./... -race -count=1` green
- [x] Existing golden texture tests (`sol_texture_test.go`,
      `lumen_texture_test.go`, `texture_engine_test.go`) pass
      unchanged — the cache only skips recomputation, it never changes
      a pixel's color
- [x] New tests: `orbit_disk_cache_test.go` (cache hit/miss/bust
      matrix, per-body independence, idle-frame + warp-rotation
      integration checks through `OrbitView.Render`),
      `canvas_disk_offset_test.go` (offset-mask correctness + memoization)
- [x] New benchmarks: `BenchmarkBodyDiskRaster` (cached vs uncached),
      `BenchmarkOrbitViewRenderIdle` (whole-render idle regression seam,
      also the seam #364 profiles from)
- [x] Live idle-CPU measured before and after on this machine (above)
- [x] **Review round 2:** pan/clip regression tests + off-canvas-skip
      + LRU-bounded offset cache + systemIdx cache-key hardening (see
      Update section above); re-verified benchmarks, live idle CPU,
      and retained heap after the fixes

Closes #363

