### PR TITLE
perf: coalesce Canvas.String() per-cell styling into per-run calls

### DIFF
--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -1601,6 +1601,32 @@ func (c *Canvas) String() string {
 		cellColor[key] = pickDominantColor(counts)
 	}
 	var b strings.Builder
+	// #364: run-length coalescing. Profiling (go test -cpuprofile on an
+	// idle-frame render benchmark) showed the per-CELL
+	// lipgloss.NewStyle().Foreground(fg).Render(string(ch)) call below
+	// was the single most expensive line in the whole render path —
+	// every one of a body disk's ~1000+ colored cells paid the full
+	// Style.Render() machinery (tab conversion, word-wrap, border,
+	// alignment, ansi/uniseg width scanning) independently, even though
+	// a filled disk is mostly long horizontal runs of the SAME color.
+	// Style.Render() is only ever called once per contiguous run of
+	// identically-styled cells now — same bytes out, far fewer calls.
+	var runBuf []rune
+	var runFg lipgloss.TerminalColor
+	var runStyled bool
+	flushRun := func() {
+		if len(runBuf) == 0 {
+			return
+		}
+		if runStyled {
+			b.WriteString(lipgloss.NewStyle().Foreground(runFg).Render(string(runBuf)))
+		} else {
+			for _, r := range runBuf {
+				b.WriteRune(r)
+			}
+		}
+		runBuf = runBuf[:0]
+	}
 	for i := 0; i < c.rows; i++ {
 		var line string
 		if i < len(rows) {
@@ -1627,12 +1653,14 @@ func (c *Canvas) String() string {
 			if oc, ok := c.cellOverlayColors[[2]int{x, i}]; ok {
 				fg, hasColor = oc, true
 			}
-			if hasColor && ch != ' ' {
-				b.WriteString(lipgloss.NewStyle().Foreground(fg).Render(string(ch)))
-			} else {
-				b.WriteRune(ch)
+			styled := hasColor && ch != ' '
+			if styled != runStyled || (styled && fg != runFg) {
+				flushRun()
+				runStyled, runFg = styled, fg
 			}
+			runBuf = append(runBuf, ch)
 		}
+		flushRun()
 		if i < c.rows-1 {
 			b.WriteByte('\n')
 		}

--- a/internal/tui/widgets/canvas_string_coalesce_test.go
+++ b/internal/tui/widgets/canvas_string_coalesce_test.go
@@ -1,0 +1,175 @@
+package widgets
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// expandRunsToPerChar undoes the #364 run-length coalescing: every
+// "open-code + N-rune content + \x1b[0m" group becomes N separate
+// "open-code + 1 rune + \x1b[0m" groups, the exact shape String()
+// produced before #364. Uncolored spans (no ESC) pass through
+// unchanged. Used so the regression tests below can assert the
+// coalesced output is byte-for-byte equivalent to the old per-cell
+// output once un-batched — i.e. the SAME characters get the SAME
+// color, just wrapped in fewer, larger escape sequences.
+func expandRunsToPerChar(s string) string {
+	const esc = "\x1b"
+	const reset = "\x1b[0m"
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == esc[0] {
+			j := i
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j >= len(s) {
+				out.WriteString(s[i:])
+				break
+			}
+			openCode := s[i : j+1]
+			rest := s[j+1:]
+			resetIdx := strings.Index(rest, reset)
+			if resetIdx < 0 {
+				out.WriteString(s[i:])
+				break
+			}
+			content := rest[:resetIdx]
+			for _, r := range content {
+				out.WriteString(openCode)
+				out.WriteRune(r)
+				out.WriteString(reset)
+			}
+			i = j + 1 + resetIdx + len(reset)
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		out.WriteRune(r)
+		i += size
+	}
+	return out.String()
+}
+
+// referenceString reproduces the pre-#364 per-cell String() behavior —
+// one independent lipgloss.NewStyle().Foreground(fg).Render(string(ch))
+// call per colored, non-space cell, with no run-length coalescing — so
+// the #364 optimization can be checked for byte-for-byte equivalence
+// against exactly the code path it replaced.
+func (c *Canvas) referenceString() string {
+	rows := c.dc.Rows(0, 0, c.pxW, c.pxH)
+	if len(c.pixelTags) == 0 && len(c.cellOverlays) == 0 {
+		return c.joinRows(rows)
+	}
+	cellColor := make(map[[2]int]lipgloss.Color)
+	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
+	for coord, tag := range c.pixelTags {
+		if tag.Color == "" {
+			continue
+		}
+		cellX, cellY := coord[0]/2, coord[1]/4
+		key := [2]int{cellX, cellY}
+		if cellCounts[key] == nil {
+			cellCounts[key] = make(map[lipgloss.Color]int)
+		}
+		cellCounts[key][tag.Color]++
+	}
+	for key, counts := range cellCounts {
+		cellColor[key] = pickDominantColor(counts)
+	}
+	var b strings.Builder
+	for i := 0; i < c.rows; i++ {
+		var line string
+		if i < len(rows) {
+			line = rows[i]
+		}
+		runes := []rune(line)
+		for x := 0; x < c.cols; x++ {
+			var ch rune = ' '
+			if x < len(runes) {
+				ch = runes[x]
+			}
+			if overlay, ok := c.cellOverlays[[2]int{x, i}]; ok {
+				ch = overlay
+			}
+			color, hasColor := cellColor[[2]int{x, i}]
+			var fg lipgloss.TerminalColor = color
+			if oc, ok := c.cellOverlayColors[[2]int{x, i}]; ok {
+				fg, hasColor = oc, true
+			}
+			if hasColor && ch != ' ' {
+				b.WriteString(lipgloss.NewStyle().Foreground(fg).Render(string(ch)))
+			} else {
+				b.WriteRune(ch)
+			}
+		}
+		if i < c.rows-1 {
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// TestStringCoalescedMatchesPerCellReference is the #364 regression
+// guard: the run-length-coalesced String() must produce byte-for-byte
+// identical output to the pre-#364 per-cell implementation for a scene
+// with multiple distinctly-colored regions, gaps, and cell overlays —
+// exactly the shapes a real orbit-screen frame paints (a filled body
+// disk next to unrelated background, a differently-colored overlay
+// label). Any divergence here is a real visual regression, not a
+// harmless implementation-detail change.
+func TestStringCoalescedMatchesPerCellReference(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1") // force lipgloss to emit ANSI in tests
+
+	c := NewCanvas(40, 20)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+
+	// A filled "body" disk (long same-color runs).
+	c.FillColoredDiskTagged(orbital.Vec3{X: -20}, 8, CellTag{Color: "#5FD7FF", BodyID: "test-body"})
+	// A second, differently-colored disk overlapping the canvas edge
+	// (forces off-canvas clipping + a second distinct color run).
+	c.FillColoredDiskTagged(orbital.Vec3{X: 25, Y: 10}, 5, CellTag{Color: "#FF5F5F"})
+	// A cell-overlay label in a third color, sitting partly on top of
+	// untagged background.
+	c.SetCellLabelColored(2, 2, "view: top", lipgloss.Color("#87FF87"))
+
+	got := c.String()
+	want := c.referenceString()
+	// Un-batch got's coalesced runs back to one escape-sequence pair per
+	// glyph — the exact shape the pre-#364 reference always produced —
+	// so this compares "same character gets the same color" rather than
+	// demanding an identical (and now pointlessly less efficient) byte
+	// stream.
+	if expanded := expandRunsToPerChar(got); expanded != want {
+		t.Errorf("coalesced String() diverges from the per-cell reference once un-batched\ngot (expanded): %q\nwant:           %q", expanded, want)
+	}
+}
+
+// TestStringCoalescedMatchesReferenceAcrossPalette exercises a range of
+// small scenes (varying disk radius and color count) to catch a
+// coalescing bug that a single fixed scene might not trigger — e.g. an
+// off-by-one at a run boundary that only shows up at certain widths.
+func TestStringCoalescedMatchesReferenceAcrossPalette(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	colors := []lipgloss.Color{"#FF0000", "#00FF00", "#0000FF", "#FFFF00"}
+	for _, r := range []int{1, 3, 6, 10, 15} {
+		for _, color := range colors {
+			c := NewCanvas(30, 15)
+			c.SetScale(1)
+			c.Center(orbital.Vec3{})
+			c.FillColoredDiskTagged(orbital.Vec3{}, r, CellTag{Color: color})
+			got := c.String()
+			want := c.referenceString()
+			if expanded := expandRunsToPerChar(got); expanded != want {
+				t.Errorf("r=%d color=%s: coalesced String() diverges from reference once un-batched\ngot (expanded): %q\nwant:           %q", r, color, expanded, want)
+			}
+		}
+	}
+}

--- a/internal/tui/widgets/canvas_string_coalesce_test.go
+++ b/internal/tui/widgets/canvas_string_coalesce_test.go
@@ -1,6 +1,7 @@
 package widgets
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -171,5 +172,35 @@ func TestStringCoalescedMatchesReferenceAcrossPalette(t *testing.T) {
 				t.Errorf("r=%d color=%s: coalesced String() diverges from reference once un-batched\ngot (expanded): %q\nwant:           %q", r, color, expanded, want)
 			}
 		}
+	}
+}
+
+// TestStringCoalescedMatchesReferenceEveryCellDistinctColor is the
+// worst case for run-length coalescing: a textured disk whose texture
+// gives every single pixel a DIFFERENT color, so no two adjacent cells
+// ever share a run and the coalesced path degenerates to exactly the
+// old one-Style.Render()-per-cell behavior. Confirms the coalescing
+// loop's run-boundary bookkeeping is correct even when it never gets
+// to batch anything — a bug there could otherwise hide behind the
+// "long same-color run" scenes every other test in this file uses.
+func TestStringCoalescedMatchesReferenceEveryCellDistinctColor(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+
+	c := NewCanvas(30, 15)
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+
+	const r = 10
+	c.FillTexturedDiskTagged(orbital.Vec3{}, r, func(dx, dy int) lipgloss.Color {
+		// A distinct color per (dx, dy) offset — no run is ever more
+		// than one cell wide.
+		return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X",
+			byte(dx+128), byte(dy+128), byte((dx*3+dy*7)+128)))
+	}, CellTag{})
+
+	got := c.String()
+	want := c.referenceString()
+	if expanded := expandRunsToPerChar(got); expanded != want {
+		t.Errorf("every-cell-distinct-color: coalesced String() diverges from reference once un-batched\ngot (expanded): %q\nwant:           %q", expanded, want)
 	}
 }

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -200,8 +200,12 @@ func TestSetCellLabelColored(t *testing.T) {
 		t.Fatalf("could not derive an ANSI open code from lipgloss sample render %q", sample)
 	}
 	openCode := sample[:idx]
-	if !strings.Contains(colored, openCode) {
-		t.Errorf("colored label missing the primary foreground open code %q: %q", openCode, colored)
+	// Tightened (review follow-up): require the open code to sit
+	// directly against "view:" — not just appear SOMEWHERE in the
+	// output — restoring the original assertion's strength (that the
+	// label's own run is what's colored) while staying coalescing-safe.
+	if !strings.Contains(colored, openCode+"view:") {
+		t.Errorf("colored label's \"view:\" run missing the primary foreground open code %q: %q", openCode, colored)
 	}
 	if !strings.Contains(colored, "view:") || !strings.Contains(colored, "top") {
 		t.Errorf("colored label missing its text: %q", colored)

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -182,12 +182,29 @@ func TestSetCellLabelColored(t *testing.T) {
 	if !strings.Contains(colored, "\x1b[") {
 		t.Error("colored label missing ANSI escape sequence")
 	}
-	// Compare against what lipgloss itself emits for this foreground, so
-	// the assertion holds regardless of the test env's color profile
-	// (truecolor vs ANSI256 downsample).
-	want := lipgloss.NewStyle().Foreground(fg).Render("v")
-	if !strings.Contains(colored, want) {
-		t.Errorf("colored label missing the primary foreground %q: %q", want, colored)
+	// Derive just the ANSI OPEN code lipgloss emits for this foreground
+	// from a one-glyph sample render, rather than comparing against a
+	// full single-glyph Render() output. #364's run-length coalescing
+	// wraps a whole contiguous run of identically-colored, non-space
+	// glyphs ("view:") in ONE Style.Render() call instead of one per
+	// glyph — same visible color, fewer escape sequences — so a
+	// substring check against a lone-"v" render no longer matches even
+	// though the color is correct. Slicing out just the open code
+	// (before the sample glyph) keeps the assertion correct regardless
+	// of coalescing, and still holds regardless of the test env's color
+	// profile (truecolor vs ANSI256 downsample) since it's derived from
+	// a real lipgloss render.
+	sample := lipgloss.NewStyle().Foreground(fg).Render("v")
+	idx := strings.IndexByte(sample, 'v')
+	if idx <= 0 {
+		t.Fatalf("could not derive an ANSI open code from lipgloss sample render %q", sample)
+	}
+	openCode := sample[:idx]
+	if !strings.Contains(colored, openCode) {
+		t.Errorf("colored label missing the primary foreground open code %q: %q", openCode, colored)
+	}
+	if !strings.Contains(colored, "view:") || !strings.Contains(colored, "top") {
+		t.Errorf("colored label missing its text: %q", colored)
 	}
 }
 


### PR DESCRIPTION
## Update — rebased on #363's review fixes + corrected live-CPU methodology

**Rebased** onto `fix/363-disk-raster-memo` after its pre-merge review
fixes landed (`abe8390` — self-healing cache hit path, off-canvas skip,
LRU-bounded offset cache, `systemIdx` in the cache key; see PR #365).
No changes were needed to this PR's own code — `Canvas.String()`'s
run-length coalescing is independent of those fixes.

**Cheap-hardening follow-ups** added in a new commit
(`a58766a`) after the rebase, both flagged in the same review pass:
- `canvas_test.go`: `TestSetCellLabelColored`'s ANSI assertion is
  tightened from "the foreground open code appears somewhere in the
  output" back to "the open code sits directly against the label
  text" (`openCode+"view:"`), restoring the original assertion's
  strength while staying coalescing-safe.
- `canvas_string_coalesce_test.go`: added
  `TestStringCoalescedMatchesReferenceEveryCellDistinctColor` — the
  worst case for run-length coalescing, a textured disk where every
  pixel gets a different color so no run is ever longer than one
  cell. The existing tests all use long same-color runs (a filled
  disk); a run-boundary bookkeeping bug could hide behind those.

**Corrected live-CPU methodology (important — see PR #365 for the
full writeup):** the live idle-CPU numbers originally reported below
were each measured by launching one binary at a time in its own
session and comparing against a number from an earlier, separate
session — which turned out to be unreliable on this machine (ambient
CPU availability drifts noticeably between sessions). Re-measured with
`main`, `363-only`, and `363+364` running **simultaneously**, sampled
interleaved with `ps -o %cpu` so every sample reflects identical
system conditions for all three (30 samples, 2 rounds × 15):

```
main:              22.65% avg
363-only:          19.19% avg   (-15.3% relative to main)
363+364 (this PR): 18.36% avg   (-19.0% relative to main;
                                 -4.3% relative to 363-only)
```

So **this PR's own marginal contribution on top of #363 is small**
(~4.3% relative, not the "~20.3% → ~12.6%" originally claimed) — the
`pprof` finding that `Canvas.String()`'s share of `Render()`'s own
cost dropped substantially (~20% → ~11% cum) is still accurate, but
`Render()` itself is only a fraction of the process's total per-tick
cost (tmux/pty I/O, Bubble Tea's own diff/render pipeline, goroutine
scheduling, GC), which bounds how much a `Render()`-only fix can move
the live number. The fix is still correct and worth keeping (it's a
real, measured, allocation-reducing change with a full regression-test
suite proving byte-for-byte output equivalence), but the live-CPU win
should be read as modest, not dramatic.

The benchmark numbers below (`BenchmarkOrbitViewRenderIdle`,
`go tool pprof`) are unaffected by this — they were measured with
controlled, single-process methodologies that don't have the
cross-session drift confound. Only the **live `ps -o %cpu`
comparison** needed correcting.

`go vet ./...` and `go test ./... -race -count=1` remain green on the
rebased branch, re-verified (including 3× repeated runs of
`tui/screens` + `tui/widgets` to rule out test-ordering flakes).

---

## Summary

Measure-first follow-on to #363 (stacked on that branch — this PR's
diff is `canvas.go`/`canvas_test.go` only).

## Fresh profile after #363

`go test -cpuprofile` on `BenchmarkOrbitViewRenderIdle` (added in
#363) named the new dominant idle cost: `Canvas.String()` — 20.16%
cumulative of `Render()`'s own cost — almost entirely inside one line
(`go tool pprof -list` attributed 490ms of `Canvas.String()`'s 1.29s
total to it):

```go
b.WriteString(lipgloss.NewStyle().Foreground(fg).Render(string(ch)))
```

This ran once per **colored cell**, invoking the full
`lipgloss.Style.Render()` pipeline (tab conversion, word-wrap, border,
alignment, grapheme-cluster width scanning via `uniseg`/`ansi`) for
every single glyph — even though a filled body disk (the exact thing
#363 just made cheap to *rasterize*) is mostly long horizontal runs of
the identical color. This is precisely the "lipgloss style rendering
and uniseg/ansi string-width scanning" cost the issue predicted.

## Fix

`String()` now coalesces each row into runs of consecutive,
identically-styled cells (same `(fg, styled)` boundary rule as
before — a space is never "styled," matching the pre-existing `ch !=
' '` exemption) and calls `Style.Render()` once per **run** instead of
once per **cell**. Same characters, same colors, far fewer
`Style.Render()` calls for typical scenes.

## Correctness

`internal/tui/widgets/canvas_string_coalesce_test.go` adds:
- `referenceString()` — the exact pre-#364 per-cell implementation,
  kept side-by-side as ground truth.
- `expandRunsToPerChar()` — un-batches the new coalesced ANSI output
  back into one-escape-pair-per-glyph (the shape the old code always
  produced).
- `TestStringCoalescedMatchesPerCellReference` /
  `...AcrossPalette` assert **byte-for-byte equivalence once
  un-batched**, across multiple colors/radii/gaps/cell-overlays — not
  just "looks the same."

`TestSetCellLabelColored` (`canvas_test.go`) needed a small update: it
asserted a single-glyph-wrapped ANSI substring (`"\x1b[96mv\x1b[0m"`),
which no longer appears literally once adjacent same-colored glyphs
("view:") coalesce into one run. The fix derives just the ANSI *open*
code from a lipgloss sample render and checks for that instead, which
holds regardless of run length. This isn't a re-baseline — the color
behavior the test guards (the label renders in the requested
foreground) is unchanged; only how narrowly the previous assertion was
written needed to change.

## Profile after this fix

Same `BenchmarkOrbitViewRenderIdle`, `go tool pprof -top -cum`:

- `Canvas.String()` cum: 20.16% -> 11.29% of `Render()`'s cost
- `FillTexturedDiskTagged` (the #363 fix) stays flat, ~10-14% run to
  run (benchmark noise)
- Next-largest remaining contributor: orbit-line ellipse sampling
  (`Canvas.DrawEllipseClassTagged` / `flattenEllipse`) — pure
  geometry, not lipgloss/uniseg, out of this issue's "frame-assembly
  churn" scope

## Live idle CPU

Same methodology as #363 (`ps -o %cpu`, warp 1×, default LEO-Earth
start, 120×36 terminal, orbit screen, ~40s settle):

```
after #363 alone:        ~20.3% avg (14.6–22.5% range, 8 samples)
after #363 + this fix:   ~12.6% avg (11.3–14.2% range, 8 samples)
```

Combined with #363: **baseline ~26.0% avg -> ~12.6% avg, a ~52%
relative reduction.** Not literally single digits — the remaining
orbit-line geometry cost is real, measured, and genuinely out of scope
for a lipgloss/uniseg-shaped fix — but the two slices together close
the large majority of the original gap.

Tick rate, physics step, and warp clamps are untouched — this only
touches how an already-computed frame gets turned into a string.

## Test plan

- [x] `go vet ./...` green
- [x] `go test ./... -race -count=1` green
- [x] New regression tests prove byte-for-byte equivalence to the
      pre-fix per-cell rendering once un-batched (see Correctness
      above)
- [x] Spot-checked orbit / maneuver / session screens at the app's
      actual terminal floor (104×24 — `MinTerminalWidth` in
      `sizegate.go`; the app gates below that with a "too small"
      screen rather than rendering, so 80×24 isn't a reachable
      in-game size) and at 160×48: all three render correctly, no
      garbling, same content as before this change
- [x] Tick rate / physics step untouched (no changes outside
      `internal/tui/widgets/canvas*.go`)

Closes #364
