### PR TITLE
perf: memoize orbit-line ellipse geometry (#367)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -756,7 +756,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		// itself joins the inspectable set at its disk below, where its
 		// on-canvas test lives.
 		bodyRef := InspectRef{Kind: InspectBody, BodyID: b.ID}
-		v.canvas.DrawEllipseClassTagged(el, orbital.Vec3{}, 360, widgets.ClassScenery, orbital.Vec3{}, 0,
+		v.canvas.DrawEllipseClassCachedTagged(bodyRef.OwnerKey(), el, orbital.Vec3{}, 360, widgets.ClassScenery, orbital.Vec3{}, 0,
 			widgets.CellTag{Color: v.inspectLineColor(bodyRef, render.ColorBodyOrbit), Owner: bodyRef.OwnerKey()})
 		// The track is now tagged, so it can be clicked even when the body
 		// itself is off-canvas — register the owner here, separately from
@@ -1103,7 +1103,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				if isTarget {
 					orbitColor = render.ColorTarget
 				}
-				v.canvas.DrawEllipseClassTagged(el, gPrimaryPos, 180, widgets.ClassReal, gPrimaryPos, gPxR,
+				v.canvas.DrawEllipseClassCachedTagged(ghostRef.OwnerKey(), el, gPrimaryPos, 180, widgets.ClassReal, gPrimaryPos, gPxR,
 					widgets.CellTag{Color: v.inspectLineColor(ghostRef, orbitColor), Owner: ghostRef.OwnerKey()})
 				// Owner-only registration: a click on this track resolves
 				// to the ghost even when the ghost itself is off-canvas.
@@ -1165,7 +1165,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		if orbitVisible {
 			// Real class, bright (ADR 0041 §2): the active vessel's live
 			// orbit — solid, contiguous ink.
-			v.canvas.DrawEllipseClassTagged(el, primaryPos, 360, widgets.ClassReal, primaryPos, primaryPxR,
+			v.canvas.DrawEllipseClassCachedTagged(activeRef.OwnerKey(), el, primaryPos, 360, widgets.ClassReal, primaryPos, primaryPxR,
 				widgets.CellTag{Color: v.inspectLineColor(activeRef, render.ColorCurrentOrbit), Owner: activeRef.OwnerKey()})
 			peri := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, 0))
 			apo := primaryPos.Add(orbital.PositionAtTrueAnomaly(el, math.Pi))
@@ -1298,7 +1298,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				// Real class (ADR 0041 §2): another craft's orbit is solid
 				// like the active vessel's — the TARGET promotion above is
 				// a color change, not a denser pattern.
-				v.canvas.DrawEllipseClassTagged(otherEl, otherPrimaryPos, 180, widgets.ClassReal, otherPrimaryPos, otherPxR,
+				v.canvas.DrawEllipseClassCachedTagged(otherRef.OwnerKey(), otherEl, otherPrimaryPos, 180, widgets.ClassReal, otherPrimaryPos, otherPxR,
 					widgets.CellTag{Color: otherColor, Owner: otherRef.OwnerKey()})
 				if isTarget {
 					// Target's Ap/Pe (ADR 0020 / #346): the targeted

--- a/internal/tui/screens/orbit_curve_cache_test.go
+++ b/internal/tui/screens/orbit_curve_cache_test.go
@@ -1,0 +1,143 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestOrbitViewCurveCacheHitsAtIdleAndBustsOnCameraChange is the #367
+// end-to-end regression test the issue calls for: drive the real
+// OrbitView.Render path (not a synthetic Canvas scenario) through an idle
+// repeat, then a pan, a zoom, and a focus switch, and assert the curve
+// cache behaves — hits when nothing that feeds it changed, misses when the
+// camera moves. This exercises the actual screens/orbit.go wiring (the
+// four DrawEllipseClassCachedTagged call sites and the curveID each
+// passes), which the widgets-package unit tests (canvas_curve_cache_test.go)
+// can't reach on their own.
+func TestOrbitViewCurveCacheHitsAtIdleAndBustsOnCameraChange(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	v.Render(w, 0, 120, 40) // warm the Framing Event / zoom fit
+	_, computesAfterWarm := v.canvas.CurveCacheStats()
+	if computesAfterWarm == 0 {
+		t.Fatal("precondition: warm-up render recorded zero curve-cache computes — nothing drew an ellipse, test scenario is broken")
+	}
+
+	// Idle repeat: identical world, identical camera — every curve drawn
+	// on the warm-up should still be in the cache.
+	v.Render(w, 0, 120, 40)
+	hits, computes := v.canvas.CurveCacheStats()
+	if computes != computesAfterWarm {
+		t.Errorf("idle repeat re-flattened %d curve(s) that should have hit (computes %d -> %d)", computes-computesAfterWarm, computesAfterWarm, computes)
+	}
+	if hits == 0 {
+		t.Error("idle repeat recorded zero curve-cache hits")
+	}
+
+	// Pan: the camera center moves, nothing else does. Every on-canvas
+	// curve's key must change (relOffset/relBody are camera-relative).
+	v.PanRight()
+	v.Render(w, 0, 120, 40)
+	_, computesAfterPan := v.canvas.CurveCacheStats()
+	if computesAfterPan == computes {
+		t.Error("PanRight produced zero curve-cache misses — the cache didn't notice the camera moved")
+	}
+
+	// Idle again after the pan settles: should go back to all-hits.
+	v.Render(w, 0, 120, 40)
+	hitsBeforeSteady, _ := v.canvas.CurveCacheStats()
+	v.Render(w, 0, 120, 40)
+	hitsAfterSteady, computesAfterSteady := v.canvas.CurveCacheStats()
+	if computesAfterSteady != 0 && computesAfterSteady != computesAfterPan {
+		// (computesAfterPan carries forward; a further miss here would be
+		// a bug — the panned camera is now steady.)
+		t.Errorf("post-pan steady state kept missing (computes %d -> %d)", computesAfterPan, computesAfterSteady)
+	}
+	if hitsAfterSteady <= hitsBeforeSteady {
+		t.Error("post-pan steady state produced no hits — cache never recovered after the pan")
+	}
+
+	// Zoom busts too.
+	computesBeforeZoom := computesAfterSteady
+	v.ZoomIn()
+	v.Render(w, 0, 120, 40)
+	_, computesAfterZoom := v.canvas.CurveCacheStats()
+	if computesAfterZoom == computesBeforeZoom {
+		t.Error("ZoomIn produced zero curve-cache misses")
+	}
+
+	// Focus switch (body -> craft), a Framing Event: re-fits scale and
+	// re-centers, both of which must bust every curve's key.
+	if w.ActiveCraft() == nil {
+		t.Skip("no active craft in default world — can't exercise the focus-switch leg")
+	}
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: 0}
+	v.Render(w, 0, 120, 40)
+	_, computesBeforeSwitch := v.canvas.CurveCacheStats()
+
+	w.Focus = sim.Focus{Kind: sim.FocusCraft}
+	v.Render(w, 0, 120, 40)
+	_, computesAfterSwitch := v.canvas.CurveCacheStats()
+	if computesAfterSwitch == computesBeforeSwitch {
+		t.Error("focus switch (body -> craft) produced zero curve-cache misses")
+	}
+}
+
+// TestOrbitViewCurveCacheHitMatchesUncachedAfterPan is the same
+// cache-vs-ground-truth check orbit_disk_cache_pan_test.go runs for the
+// disk raster cache (TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan),
+// applied to orbit-line geometry: a render that the curve cache
+// recomputed after a pan must be byte-identical to the same frame
+// rendered on a cache-dropped, never-panned-before OrbitView. Forces
+// ANSI color for the same sync.Once test-ordering reason documented
+// there.
+func TestOrbitViewCurveCacheHitMatchesUncachedAfterPan(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	newWorld := func(t *testing.T) *sim.World {
+		t.Helper()
+		w, err := sim.NewWorld()
+		if err != nil {
+			t.Fatalf("NewWorld: %v", err)
+		}
+		return w
+	}
+
+	// One shared OrbitView, panned twice, so the second render is a
+	// genuine cache MISS on an already-warm cache (not a cold first draw).
+	v := NewOrbitView(plainTheme())
+	w := newWorld(t)
+	v.Render(w, 0, 120, 40)
+	v.PanRight()
+	v.Render(w, 0, 120, 40)
+	v.PanDown()
+	got := v.Render(w, 0, 120, 40)
+
+	// Reference: replay the identical pan sequence on a fresh OrbitView +
+	// World from scratch (cache never warm, so this is definitionally
+	// correct — nothing to hit yet).
+	freshV := NewOrbitView(plainTheme())
+	freshW := newWorld(t)
+	freshV.Render(freshW, 0, 120, 40)
+	freshV.PanRight()
+	freshV.Render(freshW, 0, 120, 40)
+	freshV.PanDown()
+	want := freshV.Render(freshW, 0, 120, 40)
+
+	if got != want {
+		t.Errorf("panned render diverges from a fresh reference\ngot:  %q\nwant: %q", got, want)
+	}
+	if !containsANSI(want) {
+		t.Fatal("test setup broken: expected lipgloss.SetColorProfile(termenv.TrueColor) to produce ANSI-colored output")
+	}
+}

--- a/internal/tui/screens/orbit_curve_cache_test.go
+++ b/internal/tui/screens/orbit_curve_cache_test.go
@@ -94,11 +94,21 @@ func TestOrbitViewCurveCacheHitsAtIdleAndBustsOnCameraChange(t *testing.T) {
 // TestOrbitViewCurveCacheHitMatchesUncachedAfterPan is the same
 // cache-vs-ground-truth check orbit_disk_cache_pan_test.go runs for the
 // disk raster cache (TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan),
-// applied to orbit-line geometry: a render that the curve cache
-// recomputed after a pan must be byte-identical to the same frame
-// rendered on a cache-dropped, never-panned-before OrbitView. Forces
-// ANSI color for the same sync.Once test-ordering reason documented
-// there.
+// applied to orbit-line geometry: a render that MAY be using warm curve-
+// cache entries after a pan must match the same frame rendered with the
+// cache forced empty. Forces ANSI color for the same sync.Once test-
+// ordering reason documented there.
+//
+// Review finding: an earlier version of this test replayed the identical
+// warm -> pan -> pan -> render sequence on BOTH v and the "reference"
+// freshV, so freshV's cache ended up exactly as warm as v's — the
+// comparison proved the render is deterministic run-to-run, not that it's
+// correct independent of what the cache did. The fix is
+// freshV.canvas.ResetCurveCache() immediately before the final render:
+// freshV still replays the same warm-up/pan sequence (so its camera
+// framing matches v's — reordering the pans ahead of the warm-up render
+// does NOT work, per ResetCurveCache's doc comment), but its cache is
+// forced empty for the one render actually under comparison.
 func TestOrbitViewCurveCacheHitMatchesUncachedAfterPan(t *testing.T) {
 	ambient := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -132,6 +142,11 @@ func TestOrbitViewCurveCacheHitMatchesUncachedAfterPan(t *testing.T) {
 	freshV.PanRight()
 	freshV.Render(freshW, 0, 120, 40)
 	freshV.PanDown()
+	// Force the reference's LAST render to be genuinely cache-free —
+	// otherwise freshV's cache is exactly as warm as v's at this point
+	// (both replayed the identical sequence) and this stops being a
+	// cached-vs-ground-truth check at all (review finding).
+	freshV.canvas.ResetCurveCache()
 	want := freshV.Render(freshW, 0, 120, 40)
 
 	if got != want {
@@ -140,4 +155,92 @@ func TestOrbitViewCurveCacheHitMatchesUncachedAfterPan(t *testing.T) {
 	if !containsANSI(want) {
 		t.Fatal("test setup broken: expected lipgloss.SetColorProfile(termenv.TrueColor) to produce ANSI-colored output")
 	}
+}
+
+// TestOrbitViewCurveCacheHitBoundedDeviationDuringLiveTicking is the #367
+// review's bounded-deviation regression test. A curve-cache HIT is
+// sub-pixel-equivalent to a fresh draw, not byte-identical (see
+// DrawEllipseClassCachedTagged's doc comment): the key quantizes its
+// inputs to stay within arcFlatTolerancePx of a fresh recompute, so during
+// LIVE ticking (physics actually advancing every frame, unlike the idle
+// benchmark's frozen clock) a hit can legitimately reuse geometry from up
+// to one quantum step earlier. That's bounded and non-accumulating —
+// review-measured live at 1x warp: 140/200 frames differ, max 9 of 4800
+// cells — but was previously undocumented and unguarded by any test. This
+// ticks a live world for 200 real steps, rendering the SAME world state
+// through a persistently-cached OrbitView and a reference OrbitView whose
+// curve cache is forced empty before every render, and asserts the
+// per-frame cell-diff count stays under a small cap: a future loosening of
+// the quantization tolerance (or an outright key bug re-widening the
+// staleness this cache exists to bound) shows up as a growing diff count
+// instead of silently passing.
+func TestOrbitViewCurveCacheHitBoundedDeviationDuringLiveTicking(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	cachedV := NewOrbitView(plainTheme())
+	freshV := NewOrbitView(plainTheme())
+	cachedV.Render(w, 0, 120, 40) // warm both once, identically, before ticking
+	freshV.Render(w, 0, 120, 40)
+	freshV.canvas.ResetCurveCache()
+
+	const ticks = 200
+	// Review-measured worst case at 1x warp was 9 of 4800 cells in any one
+	// frame; capped with headroom so this test only fires on a real
+	// regression (a wider quantum, or a key that stops covering something
+	// it should), not on ordinary sub-pixel noise.
+	const maxDiffCellsPerFrame = 40
+
+	worst, framesDiffering := 0, 0
+	for i := 0; i < ticks; i++ {
+		w.Tick() // real physics step at whatever warp NewWorld defaults to
+		cachedFrame := cachedV.Render(w, 0, 120, 40)
+		freshFrame := freshV.Render(w, 0, 120, 40)
+		freshV.canvas.ResetCurveCache() // next tick's freshFrame is cache-free too
+
+		diff := diffCellCount(cachedFrame, freshFrame)
+		if diff > 0 {
+			framesDiffering++
+		}
+		if diff > worst {
+			worst = diff
+		}
+		if diff > maxDiffCellsPerFrame {
+			t.Errorf("tick %d: cached render differs from a cache-free reference in %d cells, want <= %d", i, diff, maxDiffCellsPerFrame)
+		}
+	}
+	t.Logf("%d/%d frames differed from the cache-free reference; worst-case per-frame diff %d cells (cap %d)", framesDiffering, ticks, worst, maxDiffCellsPerFrame)
+}
+
+// diffCellCount counts the styled-cell positions where a and b differ.
+// splitStyledCells (navball_panel.go) turns an ANSI-styled render string
+// into one entry per rendered glyph (its active style plus its rune), so
+// this counts glyphs that actually render differently — not raw bytes,
+// which would overcount on an ANSI escape sequence's length varying
+// between two colors with no visible difference in cell count.
+func diffCellCount(a, b string) int {
+	ca, cb := splitStyledCells(a), splitStyledCells(b)
+	n := len(ca)
+	if len(cb) < n {
+		n = len(cb)
+	}
+	diff := 0
+	for i := 0; i < n; i++ {
+		if ca[i] != cb[i] {
+			diff++
+		}
+	}
+	if len(ca) > n {
+		diff += len(ca) - n
+	}
+	if len(cb) > n {
+		diff += len(cb) - n
+	}
+	return diff
 }

--- a/internal/tui/screens/orbit_disk_cache_pan_test.go
+++ b/internal/tui/screens/orbit_disk_cache_pan_test.go
@@ -164,8 +164,19 @@ func TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan(t *testing.T) {
 	if got != want {
 		t.Errorf("cache-HIT render diverges from the cache-dropped reference after a pan\ngot:  %q\nwant: %q", got, want)
 	}
-	if !containsANSI(got) {
-		t.Fatal("test setup broken: expected CLICOLOR_FORCE=1 to produce ANSI-colored output")
+	// Vacuity guard: checks want (the cache-DROPPED ground truth), not got
+	// (the cache-hit render under test) — a review finding on the
+	// original version of this test (#367). Asserting on got makes the
+	// guard vacuous exactly when it matters: if the stale-frame bug this
+	// test exists to catch were present, got would plausibly be blank/
+	// colorless (the bug's own symptom), and a got != want failure above
+	// would never reach this line to notice the setup itself was broken.
+	// want comes from a path this test doesn't otherwise exercise
+	// (renderPanned on a fresh, never-hit OrbitView), so it fails loudly
+	// on its own if color forcing ever stops working, independent of
+	// whatever the cache under test does.
+	if !containsANSI(want) {
+		t.Fatal("test setup broken: expected lipgloss.SetColorProfile(termenv.TrueColor) to produce ANSI-colored output")
 	}
 }
 

--- a/internal/tui/widgets/arc.go
+++ b/internal/tui/widgets/arc.go
@@ -230,6 +230,25 @@ func (c *Canvas) drawEllipseAdaptiveTagged(
 	bodyPxR int,
 	tag CellTag,
 ) {
+	c.drawEllipseAdaptiveTaggedRecording(el, offset, minSpans, nearSpacingPx, farSpacingPx, bodyPos, bodyPxR, tag, nil)
+}
+
+// drawEllipseAdaptiveTaggedRecording is drawEllipseAdaptiveTagged with an
+// optional pixel recorder (#367): every pixel actually plotted is also
+// handed to record (nil ⇒ identical to drawEllipseAdaptiveTagged). The
+// curve-geometry cache (canvas_curve_cache.go) calls this directly on a
+// cache miss to capture the flattened+walked output for replay, so
+// caching costs nothing beyond the draw that already had to happen.
+func (c *Canvas) drawEllipseAdaptiveTaggedRecording(
+	el orbital.Elements,
+	offset orbital.Vec3,
+	minSpans int,
+	nearSpacingPx, farSpacingPx int,
+	bodyPos orbital.Vec3,
+	bodyPxR int,
+	tag CellTag,
+	record func(px, py int),
+) {
 	if nearSpacingPx < 1 {
 		nearSpacingPx = 1
 	}
@@ -257,10 +276,10 @@ func (c *Canvas) drawEllipseAdaptiveTagged(
 		depth := mid.X*depthAxis.X + mid.Y*depthAxis.Y + mid.Z*depthAxis.Z
 		if depth < behindThreshold {
 			farPhase = c.walkPixelSegment(ch.ax, ch.ay, ch.bx, ch.by, tag, farSpacingPx, farPhase,
-				bodyX, bodyY, float64(bodyPxR))
+				bodyX, bodyY, float64(bodyPxR), record)
 			return
 		}
-		nearPhase = c.walkPixelSegment(ch.ax, ch.ay, ch.bx, ch.by, tag, nearSpacingPx, nearPhase, 0, 0, 0)
+		nearPhase = c.walkPixelSegment(ch.ax, ch.ay, ch.bx, ch.by, tag, nearSpacingPx, nearPhase, 0, 0, 0, record)
 	})
 }
 

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -175,92 +175,17 @@ type Canvas struct {
 	// the pixelTag-derived color (terminal default when untagged).
 	cellOverlayColors map[[2]int]lipgloss.TerminalColor
 
-	// diskOffsetCache memoizes the (dx, dy) offsets inside a disk of a
-	// given pixel radius (#363): the "is this offset inside the
-	// circle" test is a pure function of pxRadius alone, so profiling
-	// showed FillTexturedDiskTagged re-deriving it with a nested loop
-	// + distance check on every one of the ~1000+ pixels of a focused
-	// body's disk, every 50ms tick, even after the per-pixel COLOR
-	// itself was cached — the offset shape doesn't depend on the body,
-	// its texture, or the camera, only on the radius. Keyed per
-	// Canvas (not a package-level cache) so no locking is needed —
-	// same single-goroutine-per-Canvas assumption pixelTags already
-	// makes.
-	//
-	// diskOffsetOrder is diskOffsetCache's LRU recency list (oldest
-	// first) — review finding: the map was unbounded, and pxRadius
-	// changes on every zoom step/refit, so a session that zoomed
-	// across radii 1..384 once retained ~1.22 GB of masks that will
-	// never be reused. Capped to diskOffsetCacheCap distinct radii,
-	// comfortably above the number of bodies simultaneously visible in
-	// any one system, so a single frame's radii always fit without
-	// thrashing.
-	diskOffsetCache map[int][]diskOffset
-	diskOffsetOrder []int
-}
-
-// diskOffsetCacheCap bounds diskOffsetCache to this many distinct
-// radii (LRU-evicted beyond it). Generous headroom over the largest
-// body count in any one system (Lumen's ~17) so ordinary frame-to-
-// frame drawing never evicts a radius it's about to reuse; a wide zoom
-// sweep still can't grow the cache without bound.
-const diskOffsetCacheCap = 32
-
-// diskOffset is one (dx, dy) pixel offset inside a disk's radius,
-// relative to the disk's projected screen center.
-type diskOffset struct{ dx, dy int }
-
-// diskOffsets returns the (dx, dy) offsets inside a disk of the given
-// pixel radius, computing (and caching) them once per distinct radius
-// this Canvas has recently drawn. See diskOffsetCache.
-func (c *Canvas) diskOffsets(pxRadius int) []diskOffset {
-	if c.diskOffsetCache == nil {
-		c.diskOffsetCache = make(map[int][]diskOffset)
-	}
-	if offs, ok := c.diskOffsetCache[pxRadius]; ok {
-		c.touchDiskOffsetRadius(pxRadius)
-		return offs
-	}
-	r2 := pxRadius * pxRadius
-	// Tighter capacity estimate than the old 4r² bounding-square guess
-	// (review finding: ~21% of that was permanently-wasted retained
-	// capacity) — π·r² is the disk's true area, +8 for rounding slack.
-	estimate := int(math.Pi*float64(r2)) + 8
-	offs := make([]diskOffset, 0, estimate)
-	for dy := -pxRadius; dy <= pxRadius; dy++ {
-		for dx := -pxRadius; dx <= pxRadius; dx++ {
-			if dx*dx+dy*dy <= r2 {
-				offs = append(offs, diskOffset{dx, dy})
-			}
-		}
-	}
-	c.diskOffsetCache[pxRadius] = offs
-	c.touchDiskOffsetRadius(pxRadius)
-	c.evictOldDiskOffsets()
-	return offs
-}
-
-// touchDiskOffsetRadius moves pxRadius to the most-recently-used end
-// of diskOffsetOrder (appending it if new). O(cap) worst case, which
-// is fine at diskOffsetCacheCap's small bound.
-func (c *Canvas) touchDiskOffsetRadius(pxRadius int) {
-	for i, r := range c.diskOffsetOrder {
-		if r == pxRadius {
-			c.diskOffsetOrder = append(c.diskOffsetOrder[:i], c.diskOffsetOrder[i+1:]...)
-			break
-		}
-	}
-	c.diskOffsetOrder = append(c.diskOffsetOrder, pxRadius)
-}
-
-// evictOldDiskOffsets drops the least-recently-used radii once
-// diskOffsetCache exceeds diskOffsetCacheCap.
-func (c *Canvas) evictOldDiskOffsets() {
-	for len(c.diskOffsetOrder) > diskOffsetCacheCap {
-		oldest := c.diskOffsetOrder[0]
-		c.diskOffsetOrder = c.diskOffsetOrder[1:]
-		delete(c.diskOffsetCache, oldest)
-	}
+	// curveCache memoizes a drawn orbit LINE's flattened+projected pixel
+	// list (#367), the same predict-on-change discipline diskRasterCache
+	// applies to a body's textured-disk pixels — see
+	// canvas_curve_cache.go for the key derivation and why it must cover
+	// the canvas's own view state, not just the curve's orbital elements.
+	// curveCacheOrder is its LRU recency list (oldest first).
+	// curveCacheHits / …Computes are test hooks.
+	curveCache         map[string]*curveCacheEntry
+	curveCacheOrder    []string
+	curveCacheHits     int
+	curveCacheComputes int
 }
 
 // DiskIntersectsCanvas reports whether a disk of the given pixel
@@ -470,16 +395,29 @@ func (c *Canvas) FillColoredDiskTagged(center orbital.Vec3, pxRadius int, tag Ce
 	if c.pixelTags == nil {
 		c.pixelTags = make(map[[2]int]CellTag)
 	}
-	// #363: every non-focused body on the canvas (every planet/moon
-	// that isn't the focused, textured one) paints through this path
-	// each frame too — same offset-mask win as FillTexturedDiskTagged.
-	for _, o := range c.diskOffsets(pxRadius) {
-		px, py := cx+o.dx, cy+o.dy
-		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
-			continue
+	// #363 introduced a per-radius offset-mask cache here (diskOffsetCache);
+	// #367 removed it after re-benchmarking with the curve-geometry cache
+	// (canvas_curve_cache.go) also in place: with the color-grid cache
+	// (diskRasterCache) and the off-canvas DiskIntersectsCanvas skip
+	// already doing the heavy lifting, the offset mask's own nested-loop
+	// re-derivation benchmarked within noise on BenchmarkOrbitViewRenderIdle
+	// (see the #367 PR body) — not worth the cache's own bookkeeping and
+	// retained memory (the LRU cap existed specifically to bound a real
+	// leak: an unbounded version measured ~1.22 GB retained after a
+	// radius-1..384 zoom sweep).
+	r2 := pxRadius * pxRadius
+	for dy := -pxRadius; dy <= pxRadius; dy++ {
+		for dx := -pxRadius; dx <= pxRadius; dx++ {
+			if dx*dx+dy*dy > r2 {
+				continue
+			}
+			px, py := cx+dx, cy+dy
+			if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+				continue
+			}
+			c.dc.Set(px, py)
+			c.pixelTags[[2]int{px, py}] = tag
 		}
-		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = tag
 	}
 }
 
@@ -517,19 +455,24 @@ func (c *Canvas) FillTexturedDiskTagged(center orbital.Vec3, pxRadius int, textu
 	if c.pixelTags == nil {
 		c.pixelTags = make(map[[2]int]CellTag)
 	}
-	// #363: iterate the precomputed offset mask instead of a nested
-	// loop + per-pixel distance test — the mask is a pure function of
-	// pxRadius, recomputing it every frame was pure per-pixel overhead
-	// on top of the (now-cached) color lookup.
-	for _, o := range c.diskOffsets(pxRadius) {
-		px, py := cx+o.dx, cy+o.dy
-		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
-			continue
+	// See FillColoredDiskTagged's comment: the #363 offset-mask cache
+	// this loop used to go through was removed in #367 after
+	// re-benchmarking within noise.
+	r2 := pxRadius * pxRadius
+	for dy := -pxRadius; dy <= pxRadius; dy++ {
+		for dx := -pxRadius; dx <= pxRadius; dx++ {
+			if dx*dx+dy*dy > r2 {
+				continue
+			}
+			px, py := cx+dx, cy+dy
+			if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+				continue
+			}
+			c.dc.Set(px, py)
+			t := tag
+			t.Color = texture(dx, dy)
+			c.pixelTags[[2]int{px, py}] = t
 		}
-		c.dc.Set(px, py)
-		t := tag
-		t.Color = texture(o.dx, o.dy)
-		c.pixelTags[[2]int{px, py}] = t
 	}
 }
 
@@ -765,7 +708,7 @@ func (c *Canvas) PlotColoredTagged(w orbital.Vec3, tag CellTag) {
 func (c *Canvas) PlotDenseLineColored(a, b orbital.Vec3, color lipgloss.Color, step int) {
 	ax, ay := c.projectPx(a)
 	bx, by := c.projectPx(b)
-	c.walkPixelSegment(ax, ay, bx, by, CellTag{Color: color}, step, 0, 0, 0, 0)
+	c.walkPixelSegment(ax, ay, bx, by, CellTag{Color: color}, step, 0, 0, 0, 0, nil)
 }
 
 // PlotDenseLineForcedColored draws a dotted line between world points a and b.
@@ -806,7 +749,7 @@ func (c *Canvas) plotDensePolylineTagged(pts []orbital.Vec3, tag CellTag, step i
 	ax, ay := c.projectPx(pts[0])
 	for i := 1; i < len(pts); i++ {
 		bx, by := c.projectPx(pts[i])
-		phase = c.walkPixelSegment(ax, ay, bx, by, tag, step, phase, 0, 0, 0)
+		phase = c.walkPixelSegment(ax, ay, bx, by, tag, step, phase, 0, 0, 0, nil)
 		ax, ay = bx, by
 	}
 }
@@ -930,7 +873,13 @@ func (c *Canvas) walkPixelDashSegment(ax, ay, bx, by float64, tag CellTag, onPx,
 // exR > 0 excludes pixels within exR of (exCx, exCy) — the body-disk cut that
 // makes an occluded far-side arc read as passing behind the body. A zero-value
 // tag sets pixels without recording a colour (the untagged Plot path).
-func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int, phase float64, exCx, exCy, exR float64) float64 {
+//
+// record, if non-nil, is called with every pixel actually plotted (after the
+// bounds and exR exclusion tests) — #367's curve-geometry cache uses this to
+// capture the exact set of pixels a miss produced, so a later cache hit can
+// replay them without re-flattening or re-walking anything. nil for every
+// caller that isn't building a cache entry.
+func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int, phase float64, exCx, exCy, exR float64, record func(px, py int)) float64 {
 	if step < 1 {
 		step = 1
 	}
@@ -967,6 +916,9 @@ func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int,
 		c.dc.Set(px, py)
 		if tagged {
 			c.pixelTags[[2]int{px, py}] = tag
+		}
+		if record != nil {
+			record(px, py)
 		}
 	}
 	// Length clipped off the a-end still counts toward the cadence, so the

--- a/internal/tui/widgets/canvas_curve_cache.go
+++ b/internal/tui/widgets/canvas_curve_cache.go
@@ -1,0 +1,273 @@
+package widgets
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// #367: after #363/#364 memoized the textured-disk raster and coalesced
+// Canvas.String()'s per-cell styling, the dominant remaining idle-CPU cost
+// on the orbit screen is orbit-LINE geometry — flattenEllipse's recursive
+// chord subdivision (math.sin/cos via PositionAtTrueAnomaly) plus the
+// walkPixelSegment dot-cadence walk, re-run for every drawn ellipse (every
+// body in the system, the active vessel, every other vessel, every MP
+// ghost) on every one of 20 ticks/second, even though at a steady warp the
+// picture is as static frame to frame as the disk texture was.
+//
+// This is the disk cache's predict-on-change discipline (ADR 0017,
+// screens/orbit_disk_cache.go) applied to the render side rather than the
+// physics side: cache the FLATTENED + PROJECTED pixel list a curve drawer
+// actually produced, keyed on everything that can change that list, and
+// replay the cached pixels on a key hit instead of re-flattening.
+//
+// #363's pre-merge review caught a real bug in the disk cache from exactly
+// this kind of shortcut: a cache keyed on the subject (body/orbit) alone,
+// without the screen-projection state (pan, zoom, canvas size, view
+// direction), served a stale frame the instant the camera moved. This
+// cache's key is built entirely from Canvas's own view state (c.basis,
+// c.scale, c.centerW, c.pxW, c.pxH) plus the curve's own shape — see
+// curveCacheKeyFor — specifically so a pan/zoom/resize/rebasis busts it
+// the same way an orbital-element change does. orbit_curve_cache_test.go
+// (screens package) drives OrbitView.Render through a pan + zoom + focus
+// switch and asserts the frame is never a stale cache hit.
+
+// curveCacheEntry holds the last recorded pixel list for one curve
+// (identified by curveID, an opaque string the caller mints — mirrors
+// diskRasterCache using a body's ID as its map key) and the key it was
+// recorded for.
+type curveCacheEntry struct {
+	key    curveCacheKey
+	points []canvasPoint
+}
+
+// canvasPoint is one plotted pixel. int32 (not int) keeps a cached curve's
+// retained size tight — the #363 review's "budget or shrink" lesson on
+// diskOffsetCache — well within range for any realistic canvas (pxW/pxH
+// are terminal-cell counts times 2/4, nowhere near 2^31).
+type canvasPoint struct{ x, y int32 }
+
+// curveCacheCap bounds curveCache to this many distinct curveIDs
+// (LRU-evicted beyond it), the same discipline #363's review added to
+// diskOffsetCache. Body count is fixed per system (Lumen's largest is 17),
+// but vessel/ghost IDs can churn over a long-running --serve process as
+// players connect and disconnect; capping keeps that churn from being a
+// slow per-process leak instead of turning it into one.
+const curveCacheCap = 64
+
+// curveCacheKey fingerprints everything a curve's flattened+projected pixel
+// list depends on: the orbit's shape and embedding (quantized against
+// numerical jitter — a coasting vessel's live elements drift by
+// floating-point noise every physics tick even absent thrust) and the
+// canvas's own projection state (quantized against the same idle drift,
+// but exact — not quantized — where the value is already discrete: pixel
+// dimensions, span/spacing/occlusion-radius parameters). See
+// curveShapeQuantum / curvePositionQuantum for the quantum derivation.
+type curveCacheKey struct {
+	aQ, eQ, iQ, omegaQ, argQ int64
+	// relOffset / relBody are offset and bodyPos measured from the
+	// canvas's OWN camera center (c.centerW), not in absolute world
+	// coordinates. Two frames where offset and centerW moved by the same
+	// delta (offset stays fixed on screen — nothing to redraw) hit the
+	// cache; a real pan (only centerW moves) changes the delta and
+	// correctly misses. This also means centerW never needs its own key
+	// field — its effect on the projection is entirely captured here.
+	relOffsetXQ, relOffsetYQ, relOffsetZQ int64
+	relBodyXQ, relBodyYQ, relBodyZQ       int64
+	minSpans                              int
+	nearPx, farPx                         int
+	bodyPxR                               int
+	// View state (CRITICAL — #363's review finding: a render cache keyed
+	// on the subject alone, without what the camera is doing, serves
+	// stale pixels the instant the camera moves). scaleLogQ is quantized
+	// on a log scale so the same relative precision holds across scale's
+	// huge dynamic range (system view to surface view); basisQ quantizes
+	// the raw unit-vector components at a fixed epsilon, tight enough at
+	// any realistic canvas size (see curveBasisQuantum's derivation).
+	scaleLogQ int64
+	basisQ    [6]int64
+	pxW, pxH  int
+}
+
+const (
+	// curveScaleLogQuantum / curveBasisQuantum bound the projection-state
+	// quantization error to sub-pixel at any on-canvas point. A basis
+	// rotation of δ radians (from quantizing a unit-vector component at
+	// epsilon ε, δ ≈ ε for small ε) or a relative scale change of δ moves
+	// a point at pixel-distance R from the camera center by ≈ R·δ. Bounding
+	// that under arcFlatTolerancePx (0.5px) at a generously large R of
+	// 2000px (far past any real terminal's pixel diagonal) needs δ ≤
+	// 0.5/2000 = 2.5e-4; both constants sit an order of magnitude under
+	// that for margin.
+	curveScaleLogQuantum = 2e-5
+	curveBasisQuantum    = 2e-5
+)
+
+// curvePositionQuantum is the world-meter quantum for a screen-position
+// input (relOffset / relBody / the 'a' shape term): the world distance
+// that maps to arcFlatTolerancePx screen pixels at the canvas's current
+// scale. Mirrors diskRasterQuantDeg's derivation (screens/orbit_disk_cache.go)
+// — sub-pixel at the current zoom, recomputed every call since scale
+// changes on every zoom step. Degenerate scale (≤0, non-finite — the
+// canvas has nothing meaningful projected) falls back to a quantum of 1,
+// which just means such frames don't get to share a cache bucket; they
+// don't draw anything sensible to cache correctness over either.
+func curvePositionQuantum(scale float64) float64 {
+	if !(scale > 0) || math.IsInf(scale, 0) {
+		return 1
+	}
+	return arcFlatTolerancePx / scale
+}
+
+// curveShapeQuantum derives the eccentricity / angle quantum from the
+// orbit's own on-screen size (its apoapsis in pixels) rather than a fixed
+// constant: the same absolute angular error sweeps a much smaller arc on a
+// tiny, zoomed-out orbit than on one filling the canvas, so a single fixed
+// quantum would either be needlessly tight (wasted cache misses) at small
+// scale or unsafe (visible drift on a cache hit) at large scale. Mirrors
+// diskRasterQuantDeg's "arc_px ≈ pxRadius × quantum(rad)" derivation with
+// the orbit's apoapsis standing in for the disk's pixel radius.
+func curveShapeQuantum(scale, apoapsisM float64) float64 {
+	pxRadius := math.Abs(apoapsisM) * scale
+	if !(pxRadius > 1) || math.IsInf(pxRadius, 0) {
+		pxRadius = 1
+	}
+	return arcFlatTolerancePx / pxRadius
+}
+
+// quantize rounds x to integer multiples of step, returning 0 for a
+// non-finite x (keeps the cache key deterministic and comparable) or a
+// non-positive step (avoids a divide-by-zero/NaN cascade; callers only
+// ever pass a derived-positive step, but a defensive floor costs nothing).
+func quantize(x, step float64) int64 {
+	if math.IsNaN(x) || math.IsInf(x, 0) || !(step > 0) {
+		return 0
+	}
+	return int64(math.Round(x / step))
+}
+
+// curveCacheKeyFor builds the cache key for a curve as drawn RIGHT NOW —
+// this canvas's current view state plus the curve's own shape/embedding.
+func (c *Canvas) curveCacheKeyFor(el orbital.Elements, offset orbital.Vec3, minSpans, nearPx, farPx int, bodyPos orbital.Vec3, bodyPxR int) curveCacheKey {
+	posQ := curvePositionQuantum(c.scale)
+	shapeQ := curveShapeQuantum(c.scale, el.Apoapsis())
+	relOffset := offset.Sub(c.centerW)
+	relBody := bodyPos.Sub(c.centerW)
+	return curveCacheKey{
+		aQ:          quantize(el.A, posQ),
+		eQ:          quantize(el.E, shapeQ),
+		iQ:          quantize(el.I, shapeQ),
+		omegaQ:      quantize(el.Omega, shapeQ),
+		argQ:        quantize(el.Arg, shapeQ),
+		relOffsetXQ: quantize(relOffset.X, posQ),
+		relOffsetYQ: quantize(relOffset.Y, posQ),
+		relOffsetZQ: quantize(relOffset.Z, posQ),
+		relBodyXQ:   quantize(relBody.X, posQ),
+		relBodyYQ:   quantize(relBody.Y, posQ),
+		relBodyZQ:   quantize(relBody.Z, posQ),
+		minSpans:    minSpans,
+		nearPx:      nearPx,
+		farPx:       farPx,
+		bodyPxR:     bodyPxR,
+		scaleLogQ:   quantize(math.Log(c.scale), curveScaleLogQuantum),
+		basisQ: [6]int64{
+			quantize(c.basis.X.X, curveBasisQuantum), quantize(c.basis.X.Y, curveBasisQuantum), quantize(c.basis.X.Z, curveBasisQuantum),
+			quantize(c.basis.Y.X, curveBasisQuantum), quantize(c.basis.Y.Y, curveBasisQuantum), quantize(c.basis.Y.Z, curveBasisQuantum),
+		},
+		pxW: c.pxW,
+		pxH: c.pxH,
+	}
+}
+
+// DrawEllipseClassCachedTagged is DrawEllipseClassTagged with the #367
+// curve-geometry cache: on a key hit it replays the pixel list a prior
+// identical-key call produced instead of re-flattening the ellipse and
+// re-walking its chords. curveID is an opaque per-curve identity the
+// caller mints (screens/orbit.go reuses the same Inspect owner key it
+// already computes for tag.Owner) — kept as its own parameter rather than
+// read off tag.Owner so the cache's identity contract doesn't silently
+// depend on a field whose primary job is click hit-testing; an empty
+// curveID never caches (a shared "" bucket across unrelated anonymous
+// callers would serve one curve's geometry onto another's).
+//
+// Only geometry is cached, not color: tag is applied fresh on every call,
+// hit or miss, so a color-only change (e.g. a target promotion) reuses the
+// cached geometry rather than needlessly busting it.
+func (c *Canvas) DrawEllipseClassCachedTagged(curveID string, el orbital.Elements, offset orbital.Vec3, minSpans int, class LineClass, bodyPos orbital.Vec3, bodyPxR int, tag CellTag) {
+	if curveID == "" {
+		c.DrawEllipseClassTagged(el, offset, minSpans, class, bodyPos, bodyPxR, tag)
+		return
+	}
+	near, far := classRealNearSpacingPx, classRealFarSpacingPx
+	if class == ClassScenery {
+		near, far = classSceneryNearSpacingPx, classSceneryFarSpacingPx
+	}
+	key := c.curveCacheKeyFor(el, offset, minSpans, near, far, bodyPos, bodyPxR)
+	if c.curveCache == nil {
+		c.curveCache = make(map[string]*curveCacheEntry)
+	}
+	if entry, ok := c.curveCache[curveID]; ok && entry.key == key {
+		c.curveCacheHits++
+		c.touchCurveCacheID(curveID)
+		c.blitCurvePoints(entry.points, tag)
+		return
+	}
+	var points []canvasPoint
+	c.drawEllipseAdaptiveTaggedRecording(el, offset, minSpans, near, far, bodyPos, bodyPxR, tag, func(px, py int) {
+		points = append(points, canvasPoint{int32(px), int32(py)})
+	})
+	c.curveCache[curveID] = &curveCacheEntry{key: key, points: points}
+	c.curveCacheComputes++
+	c.touchCurveCacheID(curveID)
+	c.evictOldCurveCache()
+}
+
+// blitCurvePoints replays a cached pixel list: every point was already
+// bounds- and occlusion-clipped when recorded (walkPixelSegment's plotPx
+// only calls record for a pixel it actually set), so a hit is a flat loop
+// with no flattening, no trig, no clipping math.
+func (c *Canvas) blitCurvePoints(points []canvasPoint, tag CellTag) {
+	tagged := tag != (CellTag{})
+	if tagged && c.pixelTags == nil {
+		c.pixelTags = make(map[[2]int]CellTag)
+	}
+	for _, p := range points {
+		px, py := int(p.x), int(p.y)
+		c.dc.Set(px, py)
+		if tagged {
+			c.pixelTags[[2]int{px, py}] = tag
+		}
+	}
+}
+
+// touchCurveCacheID moves curveID to the most-recently-used end of
+// curveCacheOrder (appending it if new) — same O(cap) LRU as
+// touchDiskOffsetRadius, fine at curveCacheCap's small bound.
+func (c *Canvas) touchCurveCacheID(curveID string) {
+	for i, id := range c.curveCacheOrder {
+		if id == curveID {
+			c.curveCacheOrder = append(c.curveCacheOrder[:i], c.curveCacheOrder[i+1:]...)
+			break
+		}
+	}
+	c.curveCacheOrder = append(c.curveCacheOrder, curveID)
+}
+
+// evictOldCurveCache drops the least-recently-used curveIDs once
+// curveCache exceeds curveCacheCap.
+func (c *Canvas) evictOldCurveCache() {
+	for len(c.curveCacheOrder) > curveCacheCap {
+		oldest := c.curveCacheOrder[0]
+		c.curveCacheOrder = c.curveCacheOrder[1:]
+		delete(c.curveCache, oldest)
+	}
+}
+
+// CurveCacheStats reports the #367 curve-geometry cache's cumulative
+// hit/recompute counts. Exported as a test hook: the cache lives on
+// Canvas, but the call sites that exercise it end-to-end (screens/orbit.go)
+// live in a different package, so screens/orbit_curve_cache_test.go needs
+// this to assert an idle re-render hits and a pan/zoom/focus change misses.
+func (c *Canvas) CurveCacheStats() (hits, computes int) {
+	return c.curveCacheHits, c.curveCacheComputes
+}

--- a/internal/tui/widgets/canvas_curve_cache.go
+++ b/internal/tui/widgets/canvas_curve_cache.go
@@ -193,15 +193,21 @@ func (c *Canvas) curveCacheKeyFor(el orbital.Elements, offset orbital.Vec3, minS
 // Only geometry is cached, not color: tag is applied fresh on every call,
 // hit or miss, so a color-only change (e.g. a target promotion) reuses the
 // cached geometry rather than needlessly busting it.
+//
+// A cache HIT is sub-pixel-equivalent to a fresh draw, not necessarily
+// byte-identical: the key quantizes its inputs to stay within
+// arcFlatTolerancePx of a fresh recompute (see curvePositionQuantum /
+// curveShapeQuantum), so during live ticking a hit can legitimately reuse
+// geometry from up to one quantum step earlier — bounded, non-accumulating
+// drift below what the renderer can express, not a correctness bug. A
+// genuine MISS (a new key) always recomputes exactly, which is why the
+// widgets-package tests assert byte-identical output there specifically.
 func (c *Canvas) DrawEllipseClassCachedTagged(curveID string, el orbital.Elements, offset orbital.Vec3, minSpans int, class LineClass, bodyPos orbital.Vec3, bodyPxR int, tag CellTag) {
 	if curveID == "" {
 		c.DrawEllipseClassTagged(el, offset, minSpans, class, bodyPos, bodyPxR, tag)
 		return
 	}
-	near, far := classRealNearSpacingPx, classRealFarSpacingPx
-	if class == ClassScenery {
-		near, far = classSceneryNearSpacingPx, classSceneryFarSpacingPx
-	}
+	near, far := classEllipseSpacings(class)
 	key := c.curveCacheKeyFor(el, offset, minSpans, near, far, bodyPos, bodyPxR)
 	if c.curveCache == nil {
 		c.curveCache = make(map[string]*curveCacheEntry)
@@ -270,4 +276,23 @@ func (c *Canvas) evictOldCurveCache() {
 // this to assert an idle re-render hits and a pan/zoom/focus change misses.
 func (c *Canvas) CurveCacheStats() (hits, computes int) {
 	return c.curveCacheHits, c.curveCacheComputes
+}
+
+// ResetCurveCache drops every cached curve entry, forcing the next draw of
+// each curve to recompute from scratch. Exported as a test hook: a
+// cache-vs-ground-truth comparison needs a way to force a genuinely
+// cache-free render on demand. screens/orbit_curve_cache_test.go's
+// TestOrbitViewCurveCacheHitMatchesUncachedAfterPan calls this on the
+// reference OrbitView's canvas immediately before the FINAL render under
+// comparison (not earlier) — the reference still has to replay the exact
+// same warm-up/pan sequence as the OrbitView under test so both land on the
+// same camera state (ADR 0021's Framing Event only re-fits on Focus/
+// ViewMode/System changes or a resize, so reordering the pans ahead of the
+// warm-up render would fit a different — and wrong — baseScale). Dropping
+// the cache only immediately before that last render isolates "did this
+// specific render use a cached entry" without disturbing the camera framing
+// both views need to share.
+func (c *Canvas) ResetCurveCache() {
+	c.curveCache = nil
+	c.curveCacheOrder = nil
 }

--- a/internal/tui/widgets/canvas_curve_cache_test.go
+++ b/internal/tui/widgets/canvas_curve_cache_test.go
@@ -1,0 +1,272 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// forceANSIColor makes lipgloss emit real ANSI color in a test binary (no
+// TTY) instead of stripping it. Uses t.Setenv("CLICOLOR_FORCE", "1"), the
+// convention every other color-sensitive test in THIS package already
+// uses (canvas_test.go, canvas_string_coalesce_test.go,
+// lighting_pipeline_test.go) — deliberately NOT the
+// lipgloss.SetColorProfile approach screens/orbit_disk_cache_pan_test.go
+// uses: SetColorProfile explicitly overrides lipgloss's lazy env-based
+// detection for the rest of the process, which is exactly what that
+// screens-package test needs (its own sync.Once ordering problem is
+// documented there) but would instead BREAK every t.Setenv-based test
+// in this package that runs afterward, since the sync.Once would already
+// be pinned by the time they set CLICOLOR_FORCE (verified: swapping this
+// in caused TestColoredDiskEmitsAnsiOnRender and three sibling tests to
+// fail). Same env var, same package convention, no cross-file footgun.
+func forceANSIColor(t *testing.T) {
+	t.Helper()
+	t.Setenv("CLICOLOR_FORCE", "1")
+}
+
+// testEllipse is a modest inclined, eccentric orbit sized to fill a chunk
+// of a small test canvas — big enough that flattening actually subdivides,
+// small enough the test stays fast.
+func testEllipse() orbital.Elements {
+	return orbital.Elements{A: 30, E: 0.4, I: 0.3, Omega: 0.5, Arg: 0.8}
+}
+
+func newCurveCacheTestCanvas() *Canvas {
+	c := NewCanvas(20, 10) // 40x40 px
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	return c
+}
+
+// TestDrawEllipseClassCachedTaggedMatchesUncached confirms a cache MISS
+// (first draw) produces byte-identical canvas output to the uncached
+// DrawEllipseClassTagged — the cache must never change what gets drawn,
+// only whether it's recomputed.
+func TestDrawEllipseClassCachedTaggedMatchesUncached(t *testing.T) {
+	forceANSIColor(t)
+	el := testEllipse()
+	tag := CellTag{Color: "#00FF00", Owner: "test"}
+
+	cached := newCurveCacheTestCanvas()
+	cached.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+
+	uncached := newCurveCacheTestCanvas()
+	uncached.DrawEllipseClassTagged(el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+
+	if got, want := cached.String(), uncached.String(); got != want {
+		t.Errorf("cached miss diverges from uncached draw\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedHitsOnRepeat confirms an identical
+// second call is a cache hit (no recompute) and still renders the same
+// picture.
+func TestDrawEllipseClassCachedTaggedHitsOnRepeat(t *testing.T) {
+	forceANSIColor(t)
+	el := testEllipse()
+	tag := CellTag{Color: "#00FF00", Owner: "test"}
+
+	c := newCurveCacheTestCanvas()
+	c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+	first := c.String()
+	computesBefore := c.curveCacheComputes
+
+	c.Clear()
+	c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+	second := c.String()
+
+	if c.curveCacheComputes != computesBefore {
+		t.Fatalf("expected the identical second call to be a cache HIT, got a recompute (computes %d -> %d)", computesBefore, c.curveCacheComputes)
+	}
+	if c.curveCacheHits == 0 {
+		t.Error("expected curveCacheHits to be nonzero after an identical repeat call")
+	}
+	if first != second {
+		t.Errorf("cache-hit render diverges from the original draw\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedColorOnlyChangeStillHits confirms the
+// cache is keyed on GEOMETRY, not color: changing only tag.Color between
+// two otherwise-identical calls still hits (reuses the flattened pixel
+// list) but the rendered color reflects the new tag, not the stale one.
+func TestDrawEllipseClassCachedTaggedColorOnlyChangeStillHits(t *testing.T) {
+	forceANSIColor(t)
+	el := testEllipse()
+
+	c := newCurveCacheTestCanvas()
+	c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	computesBefore := c.curveCacheComputes
+
+	c.Clear()
+	c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#FF0000", Owner: "test"})
+	recolored := c.String()
+
+	if c.curveCacheComputes != computesBefore {
+		t.Fatalf("a color-only change should reuse cached geometry (HIT), got a recompute (computes %d -> %d)", computesBefore, c.curveCacheComputes)
+	}
+
+	fresh := newCurveCacheTestCanvas()
+	fresh.DrawEllipseClassTagged(el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#FF0000", Owner: "test"})
+	want := fresh.String()
+
+	if recolored != want {
+		t.Errorf("recolored cache-hit render diverges from an uncached reference in the new color\ngot:  %q\nwant: %q", recolored, want)
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedEmptyCurveIDNeverCaches confirms an
+// empty curveID falls through to the plain uncached path and never
+// touches curveCache — an empty-string map key shared by unrelated
+// anonymous callers would silently serve one curve's geometry onto
+// another's.
+func TestDrawEllipseClassCachedTaggedEmptyCurveIDNeverCaches(t *testing.T) {
+	c := newCurveCacheTestCanvas()
+	el := testEllipse()
+	c.DrawEllipseClassCachedTagged("", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00"})
+	if len(c.curveCache) != 0 {
+		t.Errorf("empty curveID populated curveCache (%d entries), want 0", len(c.curveCache))
+	}
+}
+
+// curveScenario draws the test curve on a canvas configured by setup, and
+// returns both the rendered string and the canvas for further cache
+// introspection.
+func curveScenario(t *testing.T, curveID string, el orbital.Elements, setup func(c *Canvas)) (*Canvas, string) {
+	t.Helper()
+	c := newCurveCacheTestCanvas()
+	if setup != nil {
+		setup(c)
+	}
+	c.DrawEllipseClassCachedTagged(curveID, el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	return c, c.String()
+}
+
+// TestDrawEllipseClassCachedTaggedBustsOnViewChange is the #367 stale-
+// frame regression guard directly called for by the issue: pan, zoom,
+// rebasis, and resize must all bust the geometry cache — #363's review
+// finding was that a render cache keyed on the subject alone, without
+// what the camera is doing, serves stale pixels the instant the camera
+// moves. Each case asserts BOTH a recompute happened AND the new frame
+// matches a from-scratch (never-cached) reference — a cache that merely
+// detects a miss but still blits the OLD geometry would pass a
+// hit/miss-counter-only test while still being visibly broken.
+func TestDrawEllipseClassCachedTaggedBustsOnViewChange(t *testing.T) {
+	forceANSIColor(t)
+	el := testEllipse()
+
+	cases := []struct {
+		name  string
+		setup func(c *Canvas)
+	}{
+		{"pan", func(c *Canvas) { c.Center(orbital.Vec3{X: 5, Y: -3}) }},
+		{"zoom", func(c *Canvas) { c.SetScale(2) }},
+		{"rebasis", func(c *Canvas) { c.SetBasis(Basis{X: orbital.Vec3{X: 1}, Y: orbital.Vec3{Z: 1}}) }},
+		{"resize", func(c *Canvas) { c.Resize(30, 15) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Warm the cache with the baseline view.
+			c := newCurveCacheTestCanvas()
+			c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+			computesBefore := c.curveCacheComputes
+
+			// Apply the view change and redraw the SAME curve.
+			c.Clear()
+			tc.setup(c)
+			c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+			got := c.String()
+
+			if c.curveCacheComputes == computesBefore {
+				t.Fatalf("%s: expected a cache MISS (recompute) after the view changed, got a HIT", tc.name)
+			}
+
+			// Reference: the same view, rendered on a fresh canvas that
+			// never cached anything.
+			fresh := newCurveCacheTestCanvas()
+			tc.setup(fresh)
+			fresh.DrawEllipseClassTagged(el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+			want := fresh.String()
+
+			if got != want {
+				t.Errorf("%s: post-change cache-miss render diverges from an uncached reference\ngot:  %q\nwant: %q", tc.name, got, want)
+			}
+		})
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedBustsOnElementChange confirms a real
+// (well past quantization) orbital-element change busts the cache too —
+// the geometry side of what predictRenderKey already protects on the
+// physics side.
+func TestDrawEllipseClassCachedTaggedBustsOnElementChange(t *testing.T) {
+	forceANSIColor(t)
+	el1 := testEllipse()
+	el2 := el1
+	el2.A *= 1.5 // well beyond any sub-pixel quantum at this canvas's scale
+
+	c := newCurveCacheTestCanvas()
+	c.DrawEllipseClassCachedTagged("curve-1", el1, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	computesBefore := c.curveCacheComputes
+
+	c.Clear()
+	c.DrawEllipseClassCachedTagged("curve-1", el2, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	got := c.String()
+
+	if c.curveCacheComputes == computesBefore {
+		t.Fatal("expected a cache MISS after el.A changed by 50%, got a HIT")
+	}
+
+	fresh := newCurveCacheTestCanvas()
+	fresh.DrawEllipseClassTagged(el2, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	if want := fresh.String(); got != want {
+		t.Errorf("post-element-change render diverges from an uncached reference\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedToleratesSubPixelJitter confirms the
+// OTHER half of the quantization contract: a coasting vessel's live
+// elements drift by floating-point noise every physics tick even absent
+// thrust (ElementsFromState recomputed from an integrator's R/V each
+// frame) — far too small to move any pixel — and that must still be a
+// cache HIT, or #367's whole premise (idle orbits are as static as the
+// disk was) buys nothing.
+func TestDrawEllipseClassCachedTaggedToleratesSubPixelJitter(t *testing.T) {
+	el1 := testEllipse()
+	el2 := el1
+	el2.A += 1e-6 // far below curvePositionQuantum at this canvas's scale
+
+	c := newCurveCacheTestCanvas()
+	c.DrawEllipseClassCachedTagged("curve-1", el1, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+	computesBefore := c.curveCacheComputes
+
+	c.Clear()
+	c.DrawEllipseClassCachedTagged("curve-1", el2, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
+
+	if c.curveCacheComputes != computesBefore {
+		t.Errorf("sub-pixel element jitter (ΔA=1e-6) busted the cache (computes %d -> %d) — quantum is too tight", computesBefore, c.curveCacheComputes)
+	}
+}
+
+// TestDrawEllipseClassCachedTaggedBoundedAcrossManyCurveIDs sweeps far
+// more distinct curveIDs than curveCacheCap through the same canvas — a
+// long-running --serve process with churning MP ghosts, worst case — and
+// asserts the cache never exceeds its bound (same LRU discipline #363's
+// review added to diskOffsetCache, applied here so per-vessel geometry
+// entries can't accumulate as a slow per-process leak).
+func TestDrawEllipseClassCachedTaggedBoundedAcrossManyCurveIDs(t *testing.T) {
+	c := newCurveCacheTestCanvas()
+	el := testEllipse()
+	for i := 0; i < curveCacheCap*3; i++ {
+		id := "curve-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+		c.DrawEllipseClassCachedTagged(id, el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: id})
+		if len(c.curveCache) > curveCacheCap {
+			t.Fatalf("after %d curveIDs: curveCache holds %d entries, want <= %d (cap)", i+1, len(c.curveCache), curveCacheCap)
+		}
+	}
+	if got := len(c.curveCache); got != curveCacheCap {
+		t.Errorf("after sweeping %d curveIDs, curveCache = %d entries, want exactly the cap (%d)", curveCacheCap*3, got, curveCacheCap)
+	}
+}

--- a/internal/tui/widgets/canvas_curve_cache_test.go
+++ b/internal/tui/widgets/canvas_curve_cache_test.go
@@ -130,19 +130,6 @@ func TestDrawEllipseClassCachedTaggedEmptyCurveIDNeverCaches(t *testing.T) {
 	}
 }
 
-// curveScenario draws the test curve on a canvas configured by setup, and
-// returns both the rendered string and the canvas for further cache
-// introspection.
-func curveScenario(t *testing.T, curveID string, el orbital.Elements, setup func(c *Canvas)) (*Canvas, string) {
-	t.Helper()
-	c := newCurveCacheTestCanvas()
-	if setup != nil {
-		setup(c)
-	}
-	c.DrawEllipseClassCachedTagged(curveID, el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: "test"})
-	return c, c.String()
-}
-
 // TestDrawEllipseClassCachedTaggedBustsOnViewChange is the #367 stale-
 // frame regression guard directly called for by the issue: pan, zoom,
 // rebasis, and resize must all bust the geometry cache — #363's review
@@ -259,14 +246,34 @@ func TestDrawEllipseClassCachedTaggedToleratesSubPixelJitter(t *testing.T) {
 func TestDrawEllipseClassCachedTaggedBoundedAcrossManyCurveIDs(t *testing.T) {
 	c := newCurveCacheTestCanvas()
 	el := testEllipse()
-	for i := 0; i < curveCacheCap*3; i++ {
-		id := "curve-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+	curveIDAt := func(i int) string {
+		return "curve-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+	}
+	const n = curveCacheCap * 3
+	for i := 0; i < n; i++ {
+		id := curveIDAt(i)
 		c.DrawEllipseClassCachedTagged(id, el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, CellTag{Color: "#00FF00", Owner: id})
 		if len(c.curveCache) > curveCacheCap {
 			t.Fatalf("after %d curveIDs: curveCache holds %d entries, want <= %d (cap)", i+1, len(c.curveCache), curveCacheCap)
 		}
 	}
 	if got := len(c.curveCache); got != curveCacheCap {
-		t.Errorf("after sweeping %d curveIDs, curveCache = %d entries, want exactly the cap (%d)", curveCacheCap*3, got, curveCacheCap)
+		t.Errorf("after sweeping %d curveIDs, curveCache = %d entries, want exactly the cap (%d)", n, got, curveCacheCap)
+	}
+	// Bound alone doesn't prove LRU — a no-op touchCurveCacheID would also
+	// pass the checks above (evictOldCurveCache still trims to the cap, it
+	// would just trim an arbitrary/insertion-order subset instead of the
+	// least-recently-used one). Mirrors diskOffsetCache's
+	// TestDiskOffsetCacheBoundedAcrossZoomSweep recency check (deleted
+	// alongside diskOffsetCache in this same PR): the most-recently-drawn
+	// curveID must still be resident, and the least-recently-drawn one
+	// must have been evicted.
+	mostRecent := curveIDAt(n - 1)
+	leastRecent := curveIDAt(0)
+	if _, ok := c.curveCache[mostRecent]; !ok {
+		t.Errorf("most-recently-drawn curveID %q was evicted — eviction isn't LRU", mostRecent)
+	}
+	if _, ok := c.curveCache[leastRecent]; ok {
+		t.Errorf("least-recently-drawn curveID %q is still resident after the sweep — eviction isn't LRU", leastRecent)
 	}
 }

--- a/internal/tui/widgets/canvas_disk_offset_test.go
+++ b/internal/tui/widgets/canvas_disk_offset_test.go
@@ -8,70 +8,11 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 )
 
-// bruteForceDiskOffsets recomputes the disk mask the slow way (the
-// original per-call double loop + distance test FillTexturedDiskTagged
-// and FillColoredDiskTagged used before #363), for comparison against
-// the cached diskOffsets().
-func bruteForceDiskOffsets(pxRadius int) map[[2]int]bool {
-	r2 := pxRadius * pxRadius
-	out := make(map[[2]int]bool)
-	for dy := -pxRadius; dy <= pxRadius; dy++ {
-		for dx := -pxRadius; dx <= pxRadius; dx++ {
-			if dx*dx+dy*dy <= r2 {
-				out[[2]int{dx, dy}] = true
-			}
-		}
-	}
-	return out
-}
-
-// TestDiskOffsetsMatchesBruteForce confirms the #363 offset-mask cache
-// produces exactly the same set of (dx, dy) pairs as the original
-// per-pixel distance test, for a range of radii including the
-// BodyTextureMinRadius boundary and some larger zoomed-in sizes.
-func TestDiskOffsetsMatchesBruteForce(t *testing.T) {
-	c := NewCanvas(200, 60)
-	for _, r := range []int{1, 2, 5, 11, 12, 13, 20, 24, 40, 100} {
-		want := bruteForceDiskOffsets(r)
-		got := c.diskOffsets(r)
-		if len(got) != len(want) {
-			t.Errorf("r=%d: len(offsets)=%d, want %d", r, len(got), len(want))
-		}
-		seen := make(map[[2]int]bool, len(got))
-		for _, o := range got {
-			key := [2]int{o.dx, o.dy}
-			if !want[key] {
-				t.Errorf("r=%d: offset (%d,%d) not in brute-force disk mask", r, o.dx, o.dy)
-			}
-			seen[key] = true
-		}
-		for key := range want {
-			if !seen[key] {
-				t.Errorf("r=%d: brute-force offset %v missing from cached mask", r, key)
-			}
-		}
-	}
-}
-
-// TestDiskOffsetsCachedAcrossCalls confirms the second call for the
-// same radius returns the identical backing slice (proof the mask is
-// actually memoized, not recomputed).
-func TestDiskOffsetsCachedAcrossCalls(t *testing.T) {
-	c := NewCanvas(200, 60)
-	first := c.diskOffsets(20)
-	second := c.diskOffsets(20)
-	if len(first) == 0 {
-		t.Fatal("expected a non-empty disk mask")
-	}
-	if &first[0] != &second[0] {
-		t.Error("diskOffsets(20) returned a different backing array on the second call — not cached")
-	}
-}
-
-// TestFillTexturedDiskTaggedMatchesColoredShape confirms the #363
-// offset-mask optimization didn't change which pixels get painted:
-// a textured disk and a colored disk of the same radius at the same
-// center must tag exactly the same set of on-canvas pixels.
+// TestFillTexturedDiskTaggedMatchesColoredShape confirms FillTexturedDiskTagged
+// and FillColoredDiskTagged paint exactly the same set of on-canvas pixels for
+// the same center/radius — the two disk-fill paths share the same nested
+// bounds/distance-test loop (the #363 offset-mask cache that used to sit in
+// front of it was removed in #367; see FillColoredDiskTagged's comment).
 func TestFillTexturedDiskTaggedMatchesColoredShape(t *testing.T) {
 	texturedCanvas := NewCanvas(200, 60)
 	texturedCanvas.SetScale(1)
@@ -93,41 +34,6 @@ func TestFillTexturedDiskTaggedMatchesColoredShape(t *testing.T) {
 		if _, ok := texturedCanvas.pixelTags[k]; !ok {
 			t.Errorf("pixel %v painted by colored disk but not textured disk", k)
 		}
-	}
-}
-
-// TestDiskOffsetCacheBoundedAcrossZoomSweep is the review-mandated
-// memory-bound regression test: pxRadius changes on every zoom
-// step/refit, and the offset cache used to be keyed on radius with no
-// eviction — a session that zoomed across a wide radius range once
-// retained a mask for every distinct radius it ever passed through
-// (measured ~1.22 GB retained sweeping 1..384). After the LRU cap, the
-// cache must never hold more than diskOffsetCacheCap distinct radii,
-// no matter how many distinct radii a session sweeps through.
-func TestDiskOffsetCacheBoundedAcrossZoomSweep(t *testing.T) {
-	c := NewCanvas(200, 60)
-	// Sweep every radius from 1 to 384 — far more distinct radii than
-	// diskOffsetCacheCap, standing in for a full zoom-in-then-out pass.
-	for r := 1; r <= 384; r++ {
-		c.diskOffsets(r)
-		if len(c.diskOffsetCache) > diskOffsetCacheCap {
-			t.Fatalf("after radius %d: diskOffsetCache holds %d entries, want <= %d (cap)", r, len(c.diskOffsetCache), diskOffsetCacheCap)
-		}
-		if len(c.diskOffsetOrder) > diskOffsetCacheCap {
-			t.Fatalf("after radius %d: diskOffsetOrder holds %d entries, want <= %d (cap)", r, len(c.diskOffsetOrder), diskOffsetCacheCap)
-		}
-	}
-	if got := len(c.diskOffsetCache); got != diskOffsetCacheCap {
-		t.Errorf("after a 384-radius sweep, diskOffsetCache = %d entries, want exactly the cap (%d) — the sweep should have filled and evicted, not stayed short", got, diskOffsetCacheCap)
-	}
-	// The most recently swept radii (nearest 384) must be the ones
-	// still resident — LRU eviction should have dropped the early,
-	// long-unused ones (nearest 1), not an arbitrary subset.
-	if _, ok := c.diskOffsetCache[384]; !ok {
-		t.Error("most-recently-used radius 384 was evicted — eviction isn't LRU")
-	}
-	if _, ok := c.diskOffsetCache[1]; ok {
-		t.Error("least-recently-used radius 1 is still resident after the sweep — eviction isn't LRU")
 	}
 }
 

--- a/internal/tui/widgets/lineclass.go
+++ b/internal/tui/widgets/lineclass.go
@@ -97,11 +97,25 @@ func (c *Canvas) DrawEllipseClass(el orbital.Elements, offset orbital.Vec3, minS
 // anywhere on ANY drawn orbit resolves to the entity that owns it, with
 // no per-call-site hit-test code.
 func (c *Canvas) DrawEllipseClassTagged(el orbital.Elements, offset orbital.Vec3, minSpans int, class LineClass, bodyPos orbital.Vec3, bodyPxR int, tag CellTag) {
-	near, far := classRealNearSpacingPx, classRealFarSpacingPx
-	if class == ClassScenery {
-		near, far = classSceneryNearSpacingPx, classSceneryFarSpacingPx
-	}
+	near, far := classEllipseSpacings(class)
 	c.drawEllipseAdaptiveTagged(el, offset, minSpans, near, far, bodyPos, bodyPxR, tag)
+}
+
+// classEllipseSpacings maps a LineClass to the near/far dot-spacing pair an
+// ellipse drawer walks at (see the ink-pattern constants above). The single
+// call site both DrawEllipseClassTagged and the #367 curve-geometry cache's
+// DrawEllipseClassCachedTagged (canvas_curve_cache.go) go through — this
+// file is documented as the ONE place that states what solid/dashed/dotted
+// mean, and a second inline copy of the class->spacing mapping would be a
+// second place to keep in sync by hand. ClassPlanned falls back to Real's
+// spacing, matching DrawEllipseClassTagged's pre-existing documented
+// fallback (a caller passing it is a mistake to fix, not a state worth
+// panicking the render loop over).
+func classEllipseSpacings(class LineClass) (near, far int) {
+	if class == ClassScenery {
+		return classSceneryNearSpacingPx, classSceneryFarSpacingPx
+	}
+	return classRealNearSpacingPx, classRealFarSpacingPx
 }
 
 // PlotPolylineClass draws a run of world points as one connected curve at


### PR DESCRIPTION
Closes #367.

## Summary

After #363/#364 (v0.36.1) memoized the textured-disk raster and coalesced `Canvas.String()`'s per-cell styling, the dominant remaining idle-CPU cost on the orbit screen was orbit-**line** geometry: `flattenEllipse`'s recursive chord subdivision (`math.sin`/`math.cos` via `PositionAtTrueAnomaly`) plus the `walkPixelSegment` dot-cadence walk, re-run for every drawn ellipse (every body in the system, the active vessel, every other vessel, every MP ghost) on every one of 20 ticks/second — even though at a steady warp the picture is as static frame to frame as the disk texture was.

**Measured first**, per the issue's instruction: a CPU profile of `BenchmarkOrbitViewRenderIdle` confirmed the hot symbols the issue named (`math.sin`/`cos`, `Canvas.flattenSpan`, `orbital.PositionAtTrueAnomaly`) before any code changed.

**Fix**: a new per-`Canvas` `curveCache` (`internal/tui/widgets/canvas_curve_cache.go`) memoizes a drawn curve's flattened+projected pixel list, keyed on an opaque caller-supplied `curveID` (screens/orbit.go reuses the Inspect owner key it already computes) plus everything that can change that list:

- the orbit's shape/embedding (`a`, `e`, `i`, `Ω`, `ω`), quantized against per-tick floating-point jitter in live-state elements (a coasting vessel's `ElementsFromState` drifts by noise every physics tick even absent thrust)
- **the canvas's own view state** — scale, basis, camera center, pixel dimensions — quantized tight enough to stay sub-pixel at any zoom

The view-state coverage is deliberate: #363's pre-merge review caught a real stale-frame bug from a render cache keyed on the subject alone, without what the camera is doing. `DrawEllipseClassCachedTagged` wraps the four `orbit.go` draw call sites (body scenery orbits, ghost orbits, the active vessel's orbit, other vessels' orbits). `walkPixelSegment` and `drawEllipseAdaptiveTagged` gained an optional pixel recorder so a cache miss captures its output during the very pass that already had to draw it — no duplicated work on a miss, mirroring the disk-raster cache's "self-heals on the same pass" discipline.

Only **geometry** is cached, not color — a target-promotion color change reuses the cached pixel list instead of busting it. A cache **hit** is sub-pixel-equivalent to a fresh draw, not byte-identical — see "Precision" below.

## What the cache key covers

`curveCacheKey` (see `canvas_curve_cache.go`):
- `aQ, eQ, iQ, omegaQ, argQ` — orbital elements, quantized by a shape-derived quantum (tighter for a curve that fills more of the canvas — same derivation style as `diskRasterQuantDeg`)
- `relOffset*Q, relBody*Q` — the ellipse's embedding position and the occlusion body's position, measured **relative to the canvas's own camera center**, not in absolute world coordinates, so a pan (only the center moves) busts the cache while a coincidental equal-delta shift of both correctly doesn't
- `scaleLogQ`, `basisQ[6]` — zoom and view-direction/orientation, so a zoom or a rebasis (view-mode switch, camera yaw) busts it
- `pxW, pxH` — exact, so a resize busts it
- `minSpans, nearPx, farPx, bodyPxR` — the remaining draw-call parameters (line class, occlusion radius)

Centering the position fields on the camera (rather than keying `offset` and `centerW` separately) means the key only needs one screen-relative vector per position input instead of two absolute ones, while still covering pan/zoom/resize/rebasis per the #363 lesson.

## Precision: a hit is sub-pixel-equivalent, not byte-identical

The key quantizes its inputs to stay within `arcFlatTolerancePx` (0.5px) of a fresh recompute, so during **live ticking** (physics actually advancing, unlike the idle benchmark's frozen clock) a hit can legitimately reuse geometry from up to one quantum step earlier. That's bounded and non-accumulating — a genuine miss always recomputes exactly — but it is not byte-identical frame to frame the way the disk-raster cache's color grid is. Measured live at 1× warp over 200 real ticks: 140/200 frames differ from a cache-free reference by a handful of styled cells (worst case 10 of 4800 in this repo's measurement; independently verified the diff drops to exactly 0/200 at ≥1000× warp, since every tick is then a genuine miss — ruling out unrelated noise sources like chip wall-clock animation, which would *not* go to zero with warp). `TestOrbitViewCurveCacheHitBoundedDeviationDuringLiveTicking` pins this with a capped-per-frame-diff regression guard.

## Benchmarks

`BenchmarkOrbitViewRenderIdle` (Apple M5, 120×40 canvas, `-benchtime=3s`):

```
before (main):  2427076 / 2448559 / 2453295 ns/op   (avg 2.443 ms)
after:          1796992 / 1805644 / 1806900 / 1812694 / 1808212 ns/op
                (avg 1.806 ms, -26.1%)
```

**Caveat on the baseline**: an independent re-run measured a faster `main` baseline (avg 2.378 ms, `-benchtime=3s -count=5`) against a PR-side number that reproduced almost exactly (~1.821 ms) — a −23.4% delta by that run, vs −26.1% by mine. Machine-load variance on `main`'s number, not a difference in what the PR itself does (the PR-side number is stable across both measurements). **Honest range: −23% to −26%** depending on which `main` baseline run you compare against; treat the PR-side ~1.8 ms figure as the more reproducible one.

Post-fix CPU profile: `flattenEllipse`/`flattenSpan`/`math.sin`/`math.cos` no longer appear in the top 25 samples under the `Render` subtree (previously `flattenEllipse` alone was ~6.5% of total samples). Remaining idle cost is `lipgloss.Style.Render`/`uniseg` frame assembly (#364's territory, untouched here) plus GC/malloc from cache-miss bookkeeping.

## Fold-in items (non-blocking findings from #365/#366 review)

**1. `diskOffsetCache` benchmarked within noise — deleted.** With the curve cache also in place, I benchmarked the #363 per-radius disk-fill offset mask against a reverted nested-loop version:

```
cached offsets:  1781314 / 1785461 / 1782636 / 1783387 / 1784309 ns/op  (avg 1.783 ms)
nested loop:     1807035 / 1791779 / 1792809 / 1885453 / 1790183 ns/op  (avg 1.813 ms)
```

The ~1.7% gap between the two averages is smaller than the ~5% run-to-run spread *within* the nested-loop configuration alone — within noise, matching PR #365's own review finding (2.31–2.36 ms vs 2.30–2.31 ms). Deleted `diskOffsetCache` + its LRU helpers (`touchDiskOffsetRadius`/`evictOldDiskOffsets`, ~90 lines) and the `diskOffset` type; `FillColoredDiskTagged`/`FillTexturedDiskTagged` fall back to the original nested distance-test loop. This removes the memory hazard the LRU cap existed to bound (an unbounded version measured ~1.22 GB retained after a radius-1..384 zoom sweep) — the "deletion is the expected outcome" case the issue called out.

**2. Fixed the `orbit_disk_cache_pan_test.go` vacuity guard.** It asserted the ANSI-color check on `got` (the cache-hit render under test) instead of `want` (the cache-dropped ground truth), so the guard was vacuous exactly when the stale-frame bug it exists to catch is present. Now checks `want`, and the failure message names the actual mechanism (`lipgloss.SetColorProfile(termenv.TrueColor)`) instead of the stale `CLICOLOR_FORCE=1` reference.

## Review-fix pass (Opus pre-merge review, verdict "merge after fixes")

Five confirmed findings, all applied on this branch:

- **F1 (should-fix)**: `TestOrbitViewCurveCacheHitMatchesUncachedAfterPan` was vacuous — the reference `freshV` replayed the identical warm→pan→pan sequence as `v`, so both caches ended up equally warm and the test only proved determinism, not cache correctness. Added `Canvas.ResetCurveCache()` and call it on `freshV` immediately before the final compared render (reordering the pans ahead of the warm-up render doesn't work — the Framing Event would fit a different `baseScale`). Verified: fails when the key's position-sensitivity is zeroed out, passes on the real key.
- **F2 (should-fix, docs+test)**: softened the "byte-identical" framing (see "Precision" above), added the doc-comment sentence on `DrawEllipseClassCachedTagged`, and added `TestOrbitViewCurveCacheHitBoundedDeviationDuringLiveTicking` — a live-ticking bounded-deviation regression guard, independently verified against the reviewer's own numbers and warp-dependence.
- **F3 (should-fix)**: extracted `classEllipseSpacings(class)` in `lineclass.go` (the documented "one place" for line-class semantics) instead of duplicating the class→spacing mapping in `canvas_curve_cache.go`.
- **F4 (nit)**: deleted the unused `curveScenario` test helper.
- **F5 (nit)**: restored an LRU-recency assertion (MRU resident / LRU evicted) in the many-curveIDs bound test, parity with the deleted `diskOffsetCache` test. Verified: fails when eviction is sabotaged to drop from the wrong end.

## Tests

- `internal/tui/widgets/canvas_curve_cache_test.go` — drives the cache directly through hit/miss/bust matrices (pan, zoom, rebasis, resize, real element change, sub-pixel jitter tolerance, color-only-change-still-hits, empty-curveID-never-caches, LRU bound + recency across many curveIDs), with a byte-identical-to-uncached correctness check at every **miss** (a genuine recompute is always exact; see "Precision" for what a hit guarantees instead).
- `internal/tui/screens/orbit_curve_cache_test.go` — the end-to-end regression the issue calls for: drives the real `OrbitView.Render` through an idle repeat, a pan, a zoom, and a focus switch, asserting hits at idle and misses on every camera change; a cache-vs-forced-cache-free check after a pan sequence (`ResetCurveCache`-based, see F1 above); and the live-ticking bounded-deviation guard (F2).
- **Verified the stale-frame guards actually catch the bug classes they exist for**: temporarily zeroed the camera-relative key fields (both the widgets-level bust test and, post-F1, the screens-level pan test correctly fail), and sabotaged LRU eviction to drop from the wrong end (F5's recency test correctly fails) — then restored.
- Updated `canvas_disk_offset_test.go` for the `diskOffsetCache` deletion (dropped the cache-specific tests, kept the shape-correctness and off-canvas-bbox tests, which are independent of the cache).

## Test plan

- [x] `go vet ./...` green
- [x] `go test ./... -race -count=1` green (full suite, all packages)
- [x] `go test ./internal/tui/... -count=1` repeated 3× clean (order-flake check)
- [x] New/updated tests verified to actually fail against deliberately broken code (sabotage-and-restore, documented above) for F1, the original bust test, and F5
- [x] Benchmarks captured before/after, including the honest baseline-variance range (above)

## Scope notes

- Only `DrawEllipseClassTagged`'s four `orbit.go` call sites are cached. `launch.go`/`maneuver.go`'s `DrawEllipseClass` (uncached, single-shot per-screen renders, not part of the idle-CPU hot path) and ring/SOI-ring geometry (`RingTiltedOutlineTagged`, a hot symbol in the issue's *production* profile but not exercised by the local idle scenario, a different code path) are left uncached — out of scope for this pass, worth a follow-up if a ringed-body or SOI-ring-heavy scenario turns out to still be hot.
- Tick rate and physics step untouched, per the issue's non-goals.
- No save-format changes.
