### PR TITLE
perf: cache ring-outline geometry and switch pixelTags to a dense grid (#369)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -979,7 +979,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				e1, e2 := render.BodyRingBasisWorld(b)
 				oe1 := vec3FromRender(e1)
 				oe2 := vec3FromRender(e2)
-				for _, band := range bands {
+				for bandIdx, band := range bands {
 					// Fill each band by drawing concentric outlines
 					// at 1-pixel-screen-spacing radii. Cap per-band
 					// outline count so a deeply-zoomed ring system
@@ -996,7 +996,15 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 					for i := 0; i < n; i++ {
 						t := (float64(i) + 0.5) / float64(n)
 						bandR := band.InnerR + t*(band.OuterR-band.InnerR)
-						v.canvas.RingTiltedOutline(pos, oe1, oe2, bandR, band.Color)
+						// #369: curveID is a stable per-outline cache
+						// identity (bodyID + band index + concentric
+						// index), NOT an Inspect owner key — ring bands
+						// aren't in the Inspect click-hit set, unlike
+						// the ellipse cache's four call sites which
+						// reuse bodyRef.OwnerKey() for exactly that
+						// reason.
+						curveID := fmt.Sprintf("ring:%s:%d:%d", b.ID, bandIdx, i)
+						v.canvas.RingTiltedOutlineCachedTagged(curveID, pos, oe1, oe2, bandR, widgets.CellTag{Color: band.Color})
 					}
 				}
 			}

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -979,6 +979,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 				e1, e2 := render.BodyRingBasisWorld(b)
 				oe1 := vec3FromRender(e1)
 				oe2 := vec3FromRender(e2)
+				// #369 review F5: curveIDs are stable strings, so mint
+				// them from a memoized table instead of fmt.Sprintf per
+				// outline per frame (up to ~140 outlines/frame measured
+				// at deep zoom) — see ringCurveIDsFor.
+				ringIDs := ringCurveIDsFor(b.ID, len(bands))
 				for bandIdx, band := range bands {
 					// Fill each band by drawing concentric outlines
 					// at 1-pixel-screen-spacing radii. Cap per-band
@@ -990,8 +995,8 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 						widthPx = 1
 					}
 					n := widthPx
-					if n > 64 {
-						n = 64
+					if n > ringOutlineCap {
+						n = ringOutlineCap
 					}
 					for i := 0; i < n; i++ {
 						t := (float64(i) + 0.5) / float64(n)
@@ -1003,8 +1008,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 						// the ellipse cache's four call sites which
 						// reuse bodyRef.OwnerKey() for exactly that
 						// reason.
-						curveID := fmt.Sprintf("ring:%s:%d:%d", b.ID, bandIdx, i)
-						v.canvas.RingTiltedOutlineCachedTagged(curveID, pos, oe1, oe2, bandR, widgets.CellTag{Color: band.Color})
+						v.canvas.RingTiltedOutlineCachedTagged(ringIDs[bandIdx][i], pos, oe1, oe2, bandR, widgets.CellTag{Color: band.Color})
 					}
 				}
 			}
@@ -1694,6 +1698,45 @@ func BodyPixelRadius(b bodies.CelestialBody, isPrimary bool, scale float64, maxP
 // shape; this is just a name-change hop.
 func vec3FromRender(v render.Vec3) orbital.Vec3 {
 	return orbital.Vec3{X: v.X, Y: v.Y, Z: v.Z}
+}
+
+// ringOutlineCap is the per-band concentric-outline cap the ring-band
+// draw loop uses (also ringCacheCap's derivation in
+// canvas_ring_cache.go — 4 Saturn bands × this cap is the exact worst
+// case for the ring cache's LRU bound, not an estimate).
+const ringOutlineCap = 64
+
+// ringCurveIDCache memoizes the #369 ring-cache identity strings
+// ("ring:<bodyID>:<bandIdx>:<outlineIdx>") per body (#369 review F5): the
+// ring-band draw loop below used to fmt.Sprintf a fresh string per
+// outline per frame — up to ~140 measured at deep zoom, all of them
+// redundant, since (bodyID, bandIdx, outlineIdx) → string is invariant
+// for the process's lifetime (BodyRingBands is a static compiled-in
+// table, never mutated at runtime). Rendering runs on Bubble Tea's single
+// Update/View goroutine, so this needs no locking.
+var ringCurveIDCache = map[string][][]string{}
+
+// ringCurveIDsFor returns bodyID's full curveID table — [bandIdx][i] —
+// computing and caching it the first time a given (bodyID, numBands)
+// shape is seen. Sized to ringOutlineCap columns regardless of how many
+// outlines the CURRENT frame actually draws (a shrunk zoom draws fewer
+// than ringOutlineCap outlines per band), so a later frame at a deeper
+// zoom always finds its string already computed rather than growing the
+// table repeatedly.
+func ringCurveIDsFor(bodyID string, numBands int) [][]string {
+	if table, ok := ringCurveIDCache[bodyID]; ok && len(table) == numBands {
+		return table
+	}
+	table := make([][]string, numBands)
+	for bandIdx := range table {
+		row := make([]string, ringOutlineCap)
+		for i := range row {
+			row[i] = fmt.Sprintf("ring:%s:%d:%d", bodyID, bandIdx, i)
+		}
+		table[bandIdx] = row
+	}
+	ringCurveIDCache[bodyID] = table
+	return table
 }
 
 // cameraDirForView maps a sim.ViewMode to the world-frame body-to-

--- a/internal/tui/screens/orbit_render_idle_ringed_bench_test.go
+++ b/internal/tui/screens/orbit_render_idle_ringed_bench_test.go
@@ -1,0 +1,42 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// BenchmarkOrbitViewRenderIdleRinged is BenchmarkOrbitViewRenderIdle's #369
+// sibling: same idle-frame shape (world clock frozen, warm once, render
+// b.N times), but focused on Saturn instead of the default LEO seed craft.
+//
+// The default benchmark's scene (a craft in LEO around Earth) never brings
+// a ringed body into view, so it can't see RingTiltedOutlineTagged's cost
+// at all — Saturn is the ONLY body BodyRingBands recognizes today. This is
+// the scene the #367 issue's prod profile actually needed (a save with a
+// ringed body on screen) to justify the #369 ring-geometry cache
+// (canvas_ring_cache.go): see the PR body for the measured before/after.
+func BenchmarkOrbitViewRenderIdleRinged(b *testing.B) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		b.Fatalf("NewWorld: %v", err)
+	}
+	satIdx := -1
+	for i, bd := range w.System().Bodies {
+		if bd.ID == "saturn" {
+			satIdx = i
+		}
+	}
+	if satIdx < 0 {
+		b.Fatal("saturn not found in the default system — benchmark scenario is broken")
+	}
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: satIdx}
+	v.Render(w, 0, 120, 40) // warm the Framing Event / zoom fit
+	v.Render(w, 0, 120, 40) // warm the #369 ring cache
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.Render(w, 0, 120, 40)
+	}
+}

--- a/internal/tui/screens/orbit_ring_cache_test.go
+++ b/internal/tui/screens/orbit_ring_cache_test.go
@@ -1,0 +1,133 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// saturnFocusedWorld returns a World focused on Saturn, zoomed so its ring
+// bands actually fill the view — the only scenario that exercises the
+// #369 ring-geometry cache end to end (the default NewWorld() scene never
+// brings a ringed body into frame; see
+// BenchmarkOrbitViewRenderIdleRinged's doc comment).
+func saturnFocusedWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	satIdx := -1
+	for i, b := range w.System().Bodies {
+		if b.ID == "saturn" {
+			satIdx = i
+		}
+	}
+	if satIdx < 0 {
+		t.Fatal("saturn not found in the default system — test scenario is broken")
+	}
+	w.Focus = sim.Focus{Kind: sim.FocusBody, BodyIdx: satIdx}
+	return w
+}
+
+// TestOrbitViewRingCacheHitsAtIdleAndBustsOnCameraChange is the #369
+// end-to-end regression test mirroring
+// TestOrbitViewCurveCacheHitsAtIdleAndBustsOnCameraChange: drive the real
+// OrbitView.Render path (not a synthetic Canvas scenario), Saturn-focused
+// so its ring bands are actually on screen, through an idle repeat then a
+// pan and a zoom, and assert the ring cache hits when nothing that feeds
+// it changed and misses when the camera moves.
+func TestOrbitViewRingCacheHitsAtIdleAndBustsOnCameraChange(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	w := saturnFocusedWorld(t)
+
+	v.Render(w, 0, 120, 40) // warm the Framing Event / zoom fit
+	_, computesAfterWarm := v.canvas.RingCacheStats()
+	if computesAfterWarm == 0 {
+		t.Fatal("precondition: warm-up render recorded zero ring-cache computes — Saturn's rings never drew, test scenario is broken")
+	}
+
+	// Idle repeat: identical world, identical camera — every ring outline
+	// drawn on the warm-up should still be in the cache.
+	v.Render(w, 0, 120, 40)
+	hits, computes := v.canvas.RingCacheStats()
+	if computes != computesAfterWarm {
+		t.Errorf("idle repeat recomputed %d ring outline(s) that should have hit (computes %d -> %d)", computes-computesAfterWarm, computesAfterWarm, computes)
+	}
+	if hits == 0 {
+		t.Error("idle repeat recorded zero ring-cache hits")
+	}
+
+	// Pan busts.
+	v.PanRight()
+	v.Render(w, 0, 120, 40)
+	_, computesAfterPan := v.canvas.RingCacheStats()
+	if computesAfterPan == computes {
+		t.Error("PanRight produced zero ring-cache misses — the cache didn't notice the camera moved")
+	}
+
+	// Idle again after the pan settles: should go back to all-hits.
+	v.Render(w, 0, 120, 40)
+	hitsBeforeSteady, _ := v.canvas.RingCacheStats()
+	v.Render(w, 0, 120, 40)
+	hitsAfterSteady, computesAfterSteady := v.canvas.RingCacheStats()
+	if computesAfterSteady != computesAfterPan {
+		t.Errorf("post-pan steady state kept missing (computes %d -> %d)", computesAfterPan, computesAfterSteady)
+	}
+	if hitsAfterSteady <= hitsBeforeSteady {
+		t.Error("post-pan steady state produced no hits — cache never recovered after the pan")
+	}
+
+	// Zoom busts too.
+	computesBeforeZoom := computesAfterSteady
+	v.ZoomIn()
+	v.Render(w, 0, 120, 40)
+	_, computesAfterZoom := v.canvas.RingCacheStats()
+	if computesAfterZoom == computesBeforeZoom {
+		t.Error("ZoomIn produced zero ring-cache misses")
+	}
+}
+
+// TestOrbitViewRingCacheHitMatchesUncachedAfterPan is the ring-cache
+// analog of TestOrbitViewCurveCacheHitMatchesUncachedAfterPan: a render
+// that MAY be using warm ring-cache entries after a pan must match the
+// same frame rendered with the cache forced empty.
+//
+// Same review-driven shape as the curve-cache version: freshV replays the
+// identical warm -> pan -> pan sequence so its camera framing matches v's,
+// then ResetRingCache() forces ONLY the final render under comparison to
+// be genuinely cache-free — resetting earlier would let the two renders'
+// Framing Events diverge (ADR 0021 only re-fits on Focus/ViewMode/System
+// changes or a resize).
+func TestOrbitViewRingCacheHitMatchesUncachedAfterPan(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	v := NewOrbitView(plainTheme())
+	w := saturnFocusedWorld(t)
+	v.Render(w, 0, 120, 40)
+	v.PanRight()
+	v.Render(w, 0, 120, 40)
+	v.PanDown()
+	got := v.Render(w, 0, 120, 40)
+
+	freshV := NewOrbitView(plainTheme())
+	freshW := saturnFocusedWorld(t)
+	freshV.Render(freshW, 0, 120, 40)
+	freshV.PanRight()
+	freshV.Render(freshW, 0, 120, 40)
+	freshV.PanDown()
+	freshV.canvas.ResetRingCache()
+	want := freshV.Render(freshW, 0, 120, 40)
+
+	if got != want {
+		t.Errorf("panned render diverges from a fresh reference\ngot:  %q\nwant: %q", got, want)
+	}
+	if !containsANSI(want) {
+		t.Fatal("test setup broken: expected lipgloss.SetColorProfile(termenv.TrueColor) to produce ANSI-colored output")
+	}
+}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -582,25 +582,26 @@ func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipg
 	}
 }
 
-// RingTiltedOutline draws a ring of radius rMeters around center
-// in the plane spanned by basis vectors e1, e2 (both in world
-// inertial frame, both unit-length, mutually orthogonal). v0.8.5.7+
-// — for ringed bodies whose ring plane is perpendicular to a tilted
-// spin axis (Saturn 26.7°, Uranus 97.8°), this draws the ring as
-// the foreshortened ellipse the current canvas view sees rather
-// than as a screen-space circle.
+// RingTiltedOutlineTagged draws a ring of radius rMeters around center in
+// the plane spanned by basis vectors e1, e2 (both in world inertial
+// frame, both unit-length, mutually orthogonal), tagging every pixel it
+// sets with the full CellTag. v0.8.5.7+ — for ringed bodies whose ring
+// plane is perpendicular to a tilted spin axis (Saturn 26.7°, Uranus
+// 97.8°), this draws the ring as the foreshortened ellipse the current
+// canvas view sees rather than as a screen-space circle.
 //
 // The samples loop is identical in spirit to RingColoredOutlineTagged;
 // the only difference is that the per-sample world position is in
 // 3D and goes through Canvas.Project (which already accounts for
 // the canvas's view basis). Same 4×(pxW+pxH) cap on samples to keep
 // the inner loop bounded at extreme zoom.
-func (c *Canvas) RingTiltedOutline(center orbital.Vec3, e1, e2 orbital.Vec3, rMeters float64, color lipgloss.Color) {
-	c.RingTiltedOutlineTagged(center, e1, e2, rMeters, CellTag{Color: color})
-}
-
-// RingTiltedOutlineTagged is RingTiltedOutline with the full
-// CellTag preserved on every pixel set.
+//
+// #369 review F3: the plain-color wrapper (RingTiltedOutline) was deleted
+// — every production call site went through the cache
+// (RingTiltedOutlineCachedTagged, canvas_ring_cache.go) once #369 landed,
+// leaving it with zero callers. This function stays: it's the uncached
+// ground truth the ring cache's tests compare against, and the recording
+// variant miss path (ringTiltedOutlineTaggedRecording) shares its body.
 func (c *Canvas) RingTiltedOutlineTagged(center orbital.Vec3, e1, e2 orbital.Vec3, rMeters float64, tag CellTag) {
 	c.ringTiltedOutlineTaggedRecording(center, e1, e2, rMeters, tag, nil)
 }
@@ -629,6 +630,13 @@ func (c *Canvas) ringTiltedOutlineTaggedRecording(center orbital.Vec3, e1, e2 or
 	if samples > maxSamples {
 		samples = maxSamples
 	}
+	// #369 review F1: gate the pixelTags write on tagged the same way
+	// walkPixelSegment/blitCurvePoints do — pixelTagGrid.set() is itself
+	// now a no-op for a zero tag (see its doc comment), so this isn't
+	// load-bearing for correctness, but it skips the call entirely rather
+	// than making it and immediately returning, and keeps this function
+	// consistent with the rest of the file's *Tagged draw helpers.
+	tagged := tag != (CellTag{})
 	for i := 0; i < samples; i++ {
 		theta := 2 * math.Pi * float64(i) / float64(samples)
 		cT, sT := math.Cos(theta), math.Sin(theta)
@@ -641,7 +649,15 @@ func (c *Canvas) ringTiltedOutlineTaggedRecording(center orbital.Vec3, e1, e2 or
 			continue
 		}
 		c.dc.Set(px, py)
-		c.pixelTags.set(px, py, tag)
+		if tagged {
+			c.pixelTags.set(px, py, tag)
+		}
+		// record fires regardless of tagged: it captures the DRAWN POINT
+		// for cache replay (canvas_ring_cache.go), not the tag — a cache
+		// hit re-applies whatever tag the replay call passes (possibly a
+		// different one, e.g. a color-only change), the same "geometry
+		// cached, color applied fresh" contract DrawEllipseClassCachedTagged
+		// documents.
 		if record != nil {
 			record(px, py)
 		}

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -140,8 +140,9 @@ type Canvas struct {
 	basis      Basis        // world axes mapped to canvas X+/Y+ (v0.6.4+)
 	dc         drawille.Canvas
 
-	// pixelTags maps a pixel coord (px, py) → CellTag. Set by the
-	// *Colored* / *Tagged* draw helpers; plain Plot / FillDisk /
+	// pixelTags maps a pixel coord (px, py) → CellTag, backed by a dense
+	// grid rather than a map (#369 — see canvas_pixel_tags.go). Set by
+	// the *Colored* / *Tagged* draw helpers; plain Plot / FillDisk /
 	// RingOutline / DrawEllipse / PlotArrow leave pixels untagged.
 	//
 	// At String() time, each terminal cell picks its color from the
@@ -157,7 +158,7 @@ type Canvas struct {
 	// orbit lines, craft glyphs, and apo/peri markers near a body.
 	// Per-pixel tagging keeps body color confined to the body's own
 	// pixels.
-	pixelTags map[[2]int]CellTag
+	pixelTags pixelTagGrid
 
 	// cellOverlays maps a cell coord → a Unicode glyph that replaces
 	// the drawille-derived char at String() time. v0.5.12+ — used by
@@ -186,6 +187,15 @@ type Canvas struct {
 	curveCacheOrder    []string
 	curveCacheHits     int
 	curveCacheComputes int
+
+	// ringCache is curveCache's #369 sibling for RingTiltedOutlineTagged
+	// (tilted ring-band outlines — Saturn's C/B/A/F bands): same
+	// recorded-pixel replay discipline, same reasons, different draw
+	// primitive. See canvas_ring_cache.go.
+	ringCache         map[string]*ringCacheEntry
+	ringCacheOrder    []string
+	ringCacheHits     int
+	ringCacheComputes int
 }
 
 // DiskIntersectsCanvas reports whether a disk of the given pixel
@@ -212,7 +222,7 @@ func NewCanvas(cols, rows int) *Canvas {
 	if rows < 4 {
 		rows = 4
 	}
-	return &Canvas{
+	c := &Canvas{
 		cols:  cols,
 		rows:  rows,
 		pxW:   cols * 2,
@@ -221,6 +231,8 @@ func NewCanvas(cols, rows int) *Canvas {
 		basis: DefaultBasis(),
 		dc:    drawille.NewCanvas(),
 	}
+	c.pixelTags.ensureSize(c.pxW, c.pxH)
+	return c
 }
 
 // SetBasis swaps the projection basis. Called per-frame by render
@@ -245,13 +257,18 @@ func (c *Canvas) Resize(cols, rows int) {
 	}
 	c.cols, c.rows = cols, rows
 	c.pxW, c.pxH = cols*2, rows*4
+	// #369: the dense pixelTags grid is sized to pxW×pxH, unlike the map
+	// it replaced. ensureSize drops stale contents on an actual size
+	// change, which is safe here — see its doc comment — because every
+	// screen's Render calls Clear() before drawing again after a resize.
+	c.pixelTags.ensureSize(c.pxW, c.pxH)
 }
 
 // Clear wipes the drawille buffer, per-pixel color tags, and cell
 // overlays. Call at the start of every frame.
 func (c *Canvas) Clear() {
 	c.dc.Clear()
-	c.pixelTags = nil
+	c.pixelTags.clear()
 	c.cellOverlays = nil
 	c.cellOverlayColors = nil
 }
@@ -392,9 +409,6 @@ func (c *Canvas) FillColoredDiskTagged(center orbital.Vec3, pxRadius int, tag Ce
 		pxRadius = 1
 	}
 	cx, cy, _ := c.Project(center)
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	// #363 introduced a per-radius offset-mask cache here (diskOffsetCache);
 	// #367 removed it after re-benchmarking with the curve-geometry cache
 	// (canvas_curve_cache.go) also in place: with the color-grid cache
@@ -416,7 +430,7 @@ func (c *Canvas) FillColoredDiskTagged(center orbital.Vec3, pxRadius int, tag Ce
 				continue
 			}
 			c.dc.Set(px, py)
-			c.pixelTags[[2]int{px, py}] = tag
+			c.pixelTags.set(px, py, tag)
 		}
 	}
 }
@@ -452,9 +466,6 @@ func (c *Canvas) FillTexturedDiskTagged(center orbital.Vec3, pxRadius int, textu
 		pxRadius = 1
 	}
 	cx, cy, _ := c.Project(center)
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	// See FillColoredDiskTagged's comment: the #363 offset-mask cache
 	// this loop used to go through was removed in #367 after
 	// re-benchmarking within noise.
@@ -471,7 +482,7 @@ func (c *Canvas) FillTexturedDiskTagged(center orbital.Vec3, pxRadius int, textu
 			c.dc.Set(px, py)
 			t := tag
 			t.Color = texture(dx, dy)
-			c.pixelTags[[2]int{px, py}] = t
+			c.pixelTags.set(px, py, t)
 		}
 	}
 }
@@ -506,9 +517,6 @@ func (c *Canvas) RingColoredOutlineTagged(center orbital.Vec3, pxRadius int, tag
 	if samples > maxSamples {
 		samples = maxSamples
 	}
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	for i := 0; i < samples; i++ {
 		theta := 2 * math.Pi * float64(i) / float64(samples)
 		px := cx + int(math.Round(float64(pxRadius)*math.Cos(theta)))
@@ -517,7 +525,7 @@ func (c *Canvas) RingColoredOutlineTagged(center orbital.Vec3, pxRadius int, tag
 			continue
 		}
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = tag
+		c.pixelTags.set(px, py, tag)
 	}
 }
 
@@ -561,9 +569,6 @@ func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipg
 	if samples > maxSamples {
 		samples = maxSamples
 	}
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	tag := CellTag{Color: color}
 	for i := 0; i < samples; i++ {
 		theta := start + span*float64(i)/float64(samples)
@@ -573,7 +578,7 @@ func (c *Canvas) RingDottedColored(center orbital.Vec3, pxRadius int, color lipg
 			continue
 		}
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = tag
+		c.pixelTags.set(px, py, tag)
 	}
 }
 
@@ -597,6 +602,17 @@ func (c *Canvas) RingTiltedOutline(center orbital.Vec3, e1, e2 orbital.Vec3, rMe
 // RingTiltedOutlineTagged is RingTiltedOutline with the full
 // CellTag preserved on every pixel set.
 func (c *Canvas) RingTiltedOutlineTagged(center orbital.Vec3, e1, e2 orbital.Vec3, rMeters float64, tag CellTag) {
+	c.ringTiltedOutlineTaggedRecording(center, e1, e2, rMeters, tag, nil)
+}
+
+// ringTiltedOutlineTaggedRecording is RingTiltedOutlineTagged with an
+// optional pixel recorder (#369, mirroring drawEllipseAdaptiveTaggedRecording
+// from #367): every pixel actually plotted is also handed to record (nil ⇒
+// identical to RingTiltedOutlineTagged). The ring-geometry cache
+// (canvas_ring_cache.go) calls this directly on a cache miss to capture
+// the projected output for replay, so caching costs nothing beyond the
+// draw that already had to happen.
+func (c *Canvas) ringTiltedOutlineTaggedRecording(center orbital.Vec3, e1, e2 orbital.Vec3, rMeters float64, tag CellTag, record func(px, py int)) {
 	if rMeters <= 0 {
 		return
 	}
@@ -613,9 +629,6 @@ func (c *Canvas) RingTiltedOutlineTagged(center orbital.Vec3, e1, e2 orbital.Vec
 	if samples > maxSamples {
 		samples = maxSamples
 	}
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	for i := 0; i < samples; i++ {
 		theta := 2 * math.Pi * float64(i) / float64(samples)
 		cT, sT := math.Cos(theta), math.Sin(theta)
@@ -628,7 +641,10 @@ func (c *Canvas) RingTiltedOutlineTagged(center orbital.Vec3, e1, e2 orbital.Vec
 			continue
 		}
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = tag
+		c.pixelTags.set(px, py, tag)
+		if record != nil {
+			record(px, py)
+		}
 	}
 }
 
@@ -646,9 +662,6 @@ func (c *Canvas) FillProjectedSphere(center orbital.Vec3, radius float64, color 
 	cx, cy, _ := c.Project(center)
 	pxR := radius * c.scale
 	pxR2 := pxR * pxR
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	tag := CellTag{Color: color}
 	for py := 0; py < c.pxH; py++ {
 		dy := float64(py - cy)
@@ -662,7 +675,7 @@ func (c *Canvas) FillProjectedSphere(center orbital.Vec3, radius float64, color 
 				continue
 			}
 			c.dc.Set(px, py)
-			c.pixelTags[[2]int{px, py}] = tag
+			c.pixelTags.set(px, py, tag)
 		}
 	}
 }
@@ -681,10 +694,7 @@ func (c *Canvas) PlotColored(w orbital.Vec3, color lipgloss.Color) {
 func (c *Canvas) PlotColoredTagged(w orbital.Vec3, tag CellTag) {
 	if px, py, ok := c.Project(w); ok {
 		c.dc.Set(px, py)
-		if c.pixelTags == nil {
-			c.pixelTags = make(map[[2]int]CellTag)
-		}
-		c.pixelTags[[2]int{px, py}] = tag
+		c.pixelTags.set(px, py, tag)
 	}
 }
 
@@ -819,16 +829,13 @@ func (c *Canvas) walkPixelDashSegment(ax, ay, bx, by float64, tag CellTag, onPx,
 		return newPhase
 	}
 	tagged := tag != (CellTag{})
-	if tagged && c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	plotPx := func(px, py int) {
 		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
 			return
 		}
 		c.dc.Set(px, py)
 		if tagged {
-			c.pixelTags[[2]int{px, py}] = tag
+			c.pixelTags.set(px, py, tag)
 		}
 	}
 	// Length clipped off the a-end still counts toward the cycle position,
@@ -899,9 +906,6 @@ func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int,
 		return advanced
 	}
 	tagged := tag != (CellTag{})
-	if tagged && c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	exR2 := exR * exR
 	plotPx := func(px, py int) {
 		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
@@ -915,7 +919,7 @@ func (c *Canvas) walkPixelSegment(ax, ay, bx, by float64, tag CellTag, step int,
 		}
 		c.dc.Set(px, py)
 		if tagged {
-			c.pixelTags[[2]int{px, py}] = tag
+			c.pixelTags.set(px, py, tag)
 		}
 		if record != nil {
 			record(px, py)
@@ -1163,7 +1167,7 @@ func (c *Canvas) HitAt(col, row int) CellTag {
 	if col < 0 || col >= c.cols || row < 0 || row >= c.rows {
 		return CellTag{}
 	}
-	if len(c.pixelTags) == 0 {
+	if c.pixelTags.count() == 0 {
 		return CellTag{}
 	}
 	bodies := newHitCandidates[string]()
@@ -1173,7 +1177,7 @@ func (c *Canvas) HitAt(col, row int) CellTag {
 	pxStart, pyStart := col*2, row*4
 	for dx := 0; dx < 2; dx++ {
 		for dy := 0; dy < 4; dy++ {
-			tag, ok := c.pixelTags[[2]int{pxStart + dx, pyStart + dy}]
+			tag, ok := c.pixelTags.get(pxStart+dx, pyStart+dy)
 			if !ok {
 				continue
 			}
@@ -1436,16 +1440,13 @@ func (c *Canvas) PlotArrowTagged(center, velocity orbital.Vec3, size int, tag Ce
 		wingLen = 1
 	}
 	tagSet := tag != (CellTag{})
-	if tagSet && c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	setPixel := func(px, py int) {
 		if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
 			return
 		}
 		c.dc.Set(px, py)
 		if tagSet {
-			c.pixelTags[[2]int{px, py}] = tag
+			c.pixelTags.set(px, py, tag)
 		}
 	}
 	for t := 0; t <= wingLen; t++ {
@@ -1524,7 +1525,7 @@ func (c *Canvas) DrawEllipseOffsetDottedColored(el orbital.Elements, offset orbi
 // content (orbit lines, craft glyph) with the body's color.
 func (c *Canvas) String() string {
 	rows := c.dc.Rows(0, 0, c.pxW, c.pxH)
-	if len(c.pixelTags) == 0 && len(c.cellOverlays) == 0 {
+	if c.pixelTags.count() == 0 && len(c.cellOverlays) == 0 {
 		return c.joinRows(rows)
 	}
 	// Aggregate tags per cell: for each tagged pixel, accumulate a
@@ -1538,17 +1539,16 @@ func (c *Canvas) String() string {
 	// surfaced.
 	cellColor := make(map[[2]int]lipgloss.Color)
 	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(px, py int, tag CellTag) {
 		if tag.Color == "" {
-			continue
+			return
 		}
-		cellX, cellY := coord[0]/2, coord[1]/4
-		key := [2]int{cellX, cellY}
+		key := [2]int{px / 2, py / 4}
 		if cellCounts[key] == nil {
 			cellCounts[key] = make(map[lipgloss.Color]int)
 		}
 		cellCounts[key][tag.Color]++
-	}
+	})
 	for key, counts := range cellCounts {
 		cellColor[key] = pickDominantColor(counts)
 	}
@@ -1626,16 +1626,16 @@ func (c *Canvas) String() string {
 // ellipse lands on enough cells to read as a line, not just a marker").
 func (c *Canvas) CountColor(color lipgloss.Color) int {
 	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(px, py int, tag CellTag) {
 		if tag.Color == "" {
-			continue
+			return
 		}
-		key := [2]int{coord[0] / 2, coord[1] / 4}
+		key := [2]int{px / 2, py / 4}
 		if cellCounts[key] == nil {
 			cellCounts[key] = make(map[lipgloss.Color]int)
 		}
 		cellCounts[key][tag.Color]++
-	}
+	})
 	n := 0
 	for _, counts := range cellCounts {
 		if pickDominantColor(counts) == color {

--- a/internal/tui/widgets/canvas_curve_cache.go
+++ b/internal/tui/widgets/canvas_curve_cache.go
@@ -234,14 +234,15 @@ func (c *Canvas) DrawEllipseClassCachedTagged(curveID string, el orbital.Element
 // with no flattening, no trig, no clipping math.
 func (c *Canvas) blitCurvePoints(points []canvasPoint, tag CellTag) {
 	tagged := tag != (CellTag{})
-	if tagged && c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	for _, p := range points {
 		px, py := int(p.x), int(p.y)
 		c.dc.Set(px, py)
 		if tagged {
-			c.pixelTags[[2]int{px, py}] = tag
+			// #369: pixelTags.set is a dense-array index, not a map
+			// insert — see canvas_pixel_tags.go. This loop is exactly
+			// the cache-HIT replay path the #368 review measured at
+			// ~41 ns/point, almost entirely this one line's map write.
+			c.pixelTags.set(px, py, tag)
 		}
 	}
 }

--- a/internal/tui/widgets/canvas_curve_cache_bench_test.go
+++ b/internal/tui/widgets/canvas_curve_cache_bench_test.go
@@ -1,0 +1,48 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// BenchmarkDrawEllipseClassCachedTaggedHit is the #369 targeted hit-path
+// microbenchmark the issue asks for: the #368 pre-merge review measured a
+// cache HIT still costing ~19.4µs for a 475-point curve (~41 ns/point)
+// with zero geometry left to compute — entirely blitCurvePoints's
+// pixelTags writes. This warms the cache once, then times only steady-
+// state HITs (b.N repeats of the identical draw), isolating exactly that
+// replay cost from the miss/flatten path BenchmarkOrbitViewRenderIdle
+// exercises as a whole-frame average.
+func BenchmarkDrawEllipseClassCachedTaggedHit(b *testing.B) {
+	c := NewCanvas(120, 40) // 240x160 px, matches BenchmarkOrbitViewRenderIdle
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	// Sized to land close to the #368 review's 475-point reference curve —
+	// A=70 at scale=1 fills most of a 240x160px canvas without clipping.
+	el := orbital.Elements{A: 70, E: 0.5, I: 0.4, Omega: 0.7, Arg: 1.1}
+	tag := CellTag{Color: "#00FF00", Owner: "bench"}
+
+	c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+	_, computes := c.CurveCacheStats()
+	if computes != 1 {
+		b.Fatalf("warm-up should be exactly one compute, got %d — benchmark scenario is broken", computes)
+	}
+	if n := len(c.curveCache["curve-1"].points); n < 100 {
+		b.Fatalf("warm-up curve has only %d points, want >=100 for a representative hit-path measurement", n)
+	}
+	points := len(c.curveCache["curve-1"].points)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Clear()
+		c.DrawEllipseClassCachedTagged("curve-1", el, orbital.Vec3{}, 360, ClassReal, orbital.Vec3{}, 0, tag)
+	}
+	b.StopTimer()
+
+	_, computesAfter := c.CurveCacheStats()
+	if computesAfter != 1 {
+		b.Fatalf("benchmark loop recomputed (computes %d) — it measured misses, not hits", computesAfter)
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*points), "ns/point")
+}

--- a/internal/tui/widgets/canvas_disk_offset_test.go
+++ b/internal/tui/widgets/canvas_disk_offset_test.go
@@ -26,15 +26,15 @@ func TestFillTexturedDiskTaggedMatchesColoredShape(t *testing.T) {
 	}, CellTag{})
 	coloredCanvas.FillColoredDiskTagged(center, r, CellTag{Color: "#123456"})
 
-	if len(texturedCanvas.pixelTags) != len(coloredCanvas.pixelTags) {
+	if texturedCanvas.pixelTags.count() != coloredCanvas.pixelTags.count() {
 		t.Fatalf("textured disk painted %d pixels, colored disk painted %d — offset mask should agree",
-			len(texturedCanvas.pixelTags), len(coloredCanvas.pixelTags))
+			texturedCanvas.pixelTags.count(), coloredCanvas.pixelTags.count())
 	}
-	for k := range coloredCanvas.pixelTags {
-		if _, ok := texturedCanvas.pixelTags[k]; !ok {
-			t.Errorf("pixel %v painted by colored disk but not textured disk", k)
+	coloredCanvas.pixelTags.each(func(px, py int, _ CellTag) {
+		if _, ok := texturedCanvas.pixelTags.get(px, py); !ok {
+			t.Errorf("pixel (%d, %d) painted by colored disk but not textured disk", px, py)
 		}
-	}
+	})
 }
 
 // TestDiskIntersectsCanvas checks the bounding-box viewport test used

--- a/internal/tui/widgets/canvas_hit_determinism_test.go
+++ b/internal/tui/widgets/canvas_hit_determinism_test.go
@@ -27,14 +27,11 @@ import (
 // starting at cell-local pixel index `from` in (dy-major) order, with the
 // supplied tag. Cell-local index i maps to (dx, dy) = (i/4, i%4).
 func setCellPixels(c *Canvas, col, row, from, n int, tag CellTag) {
-	if c.pixelTags == nil {
-		c.pixelTags = make(map[[2]int]CellTag)
-	}
 	for i := from; i < from+n && i < 8; i++ {
 		dx, dy := i/4, i%4
 		px, py := col*2+dx, row*4+dy
 		c.dc.Set(px, py)
-		c.pixelTags[[2]int{px, py}] = tag
+		c.pixelTags.set(px, py, tag)
 	}
 }
 

--- a/internal/tui/widgets/canvas_pixel_tags.go
+++ b/internal/tui/widgets/canvas_pixel_tags.go
@@ -8,26 +8,67 @@ package widgets
 // probing/inserting a bucket, on every one of a curve's points, on every
 // frame, even for a curve that hasn't moved.
 //
-// pixelTagGrid replaces the map with a dense array indexed by
-// `py*w + px`: a write is an unconditional slice store, no hashing, no
-// bucket allocation. CellTag{} (its zero value) means "untagged", the
-// same contract a map's "absent key returns the zero value" already gave
-// every caller — safe because every *Tagged draw site already gates on
-// `tagged := tag != (CellTag{})` before touching pixelTags at all, so no
-// writer ever legitimately stores a zero-value tag.
+// pixelTagGrid replaces the map with a dense per-pixel INDEX array plus a
+// small per-frame table of the distinct CellTag values actually in use —
+// not a dense array of full CellTag values. The #369 review's first pass
+// stored CellTag directly (72 bytes each): at a 200×50 terminal canvas
+// (400×200 = 80,000 pixels) that's 5.76 MB PER CANVAS, ×3 canvases/seat,
+// ×N ssh seats — 69.2 MB measured live for 4 seats, and unbounded because
+// Canvas.Resize takes the client's raw WindowSizeMsg (a 500×150 client
+// window is ~130 MB/seat on its own). tagIdx is an int32 per pixel (4
+// bytes) indexing into `tags`, a table of only the FEW distinct tags a
+// frame actually uses (body colors, orbit-class colors, a handful of
+// vessel/ghost colors — not one entry per pixel): ~320 KB for the same
+// 200×50 canvas, and pointer-free (no GC scan cost the CellTag-per-pixel
+// version paid — CellTag holds three strings).
 //
-// A dense array can't be ranged like a map without visiting all pxW*pxH
-// cells regardless of how few are actually tagged (a system-view canvas
-// at 200×50 terminal cells is a 400×200 == 80,000-pixel grid; a typical
-// frame tags a small fraction of that). touched keeps the "range only
-// what's set" property the map gave String()/CountColor for free, and
-// lets clear() reset only what was actually written instead of either a
-// full-grid sweep or (the map's old approach) dropping the whole
-// allocation and paying for a fresh one next frame.
+// tagIdx is 1-BASED so a freshly make()'d (zero-filled) array already
+// means "every pixel untagged" — 0 → untagged, n → tags[n-1] — without an
+// explicit fill pass on every ensureSize.
+//
+// Write cost: the common case (every pixel of one draw call shares the
+// SAME CellTag — a curve, a disk fill, a ring outline all call set() in a
+// tight loop closing over one fixed tag) is a single struct-equality
+// check against lastTag, no table lookup at all.
+//
+// A first cut of this file interned a new tag with a LINEAR scan of
+// g.tags on the theory that the table stays "small, dozens of entries at
+// most." That theory was wrong for a real frame: CellTag carries an
+// Inspect Owner (ADR 0041 §3) that's near-unique PER BODY/VESSEL/GHOST,
+// so a scene with a few dozen drawn entities produces a few dozen
+// DISTINCT tags over the course of one frame even though each individual
+// draw call only ever uses one of them — and every one of those
+// tag-changed transitions paid an O(current table size) scan, so total
+// scan cost grew roughly with (distinct tags)² per frame, not O(distinct
+// tags) as intended. Measured on BenchmarkOrbitViewRenderIdle (default
+// LEO scene, no ring cost in play at all): the linear-scan version was
+// ~6% SLOWER whole-frame than pre-#369 main, i.e. this file's per-pixel
+// write win was more than eaten by the per-draw-call intern cost — see
+// the PR body's memory/perf sections for the measured numbers. tagLookup
+// fixes it: an O(1)-average map lookup keyed on the tag itself, checked
+// only on the same tag-changed transitions the linear scan was already
+// restricted to (never per pixel, thanks to lastTag below) — so the
+// per-pixel cost this file exists to cut stays cut, and the per-frame
+// intern cost stops growing with scene complexity.
+//
+// CellTag{} (its zero value) means "untagged" — see set()'s doc comment
+// for why it's an explicit no-op rather than relying on "no writer stores
+// a zero tag" as an invariant (the #369 review's F1 finding: that
+// invariant was false — FillProjectedSphere plus a body with an empty
+// SurfaceColorHex breaks it in practice).
 type pixelTagGrid struct {
-	w, h    int
-	tags    []CellTag
-	touched []int32
+	w, h      int
+	tagIdx    []int32           // 1-based index into tags; 0 = untagged
+	tags      []CellTag         // this frame's distinct tag values, deduped
+	tagLookup map[CellTag]int32 // tag -> its 1-based index in tags
+	touched   []int32           // pixel indices (py*w+px) currently tagged
+
+	// lastTag / lastIdx memoize the most recent set() call's (tag, index)
+	// pair so a run of same-tag writes — the overwhelmingly common case,
+	// see the type doc comment — never touches tagLookup at all.
+	hasLast bool
+	lastTag CellTag
+	lastIdx int32
 }
 
 // ensureSize (re)allocates the backing grid when the canvas's pixel
@@ -39,42 +80,89 @@ type pixelTagGrid struct {
 // implicit "resize without clear leaves old entries orphaned outside the
 // new bounds" prior behavior.
 func (g *pixelTagGrid) ensureSize(w, h int) {
-	if g.w == w && g.h == h && g.tags != nil {
+	if g.w == w && g.h == h && g.tagIdx != nil {
 		return
 	}
 	g.w, g.h = w, h
-	g.tags = make([]CellTag, w*h)
+	g.tagIdx = make([]int32, w*h) // zero-valued == every pixel untagged
 	g.touched = g.touched[:0]
+	g.tags = g.tags[:0]
+	clear(g.tagLookup)
+	g.hasLast = false
 }
 
-// set stores tag at (px, py). Appends to touched only the FIRST time this
-// frame a given index goes from untagged to tagged — two overlapping
-// draws touching the same pixel in one frame (two orbit lines crossing,
-// say) overwrite tags[idx] in place without a second touched entry,
-// mirroring how ranging a map counts a repeatedly-assigned key once.
-// Bounds-checked defensively (every current call site already checks
-// before calling this), matching Canvas's existing silent-drop-off-canvas
-// convention rather than panicking.
+// internTag returns tag's 1-based index into g.tags, appending it (and
+// recording it in tagLookup) if this is the first time this frame the
+// exact value has been seen. set() only calls this on a tag-CHANGED
+// transition (see lastTag), never per pixel — see the type doc comment
+// for why an O(1)-average map lookup here, not a per-pixel one, is what
+// actually fixes the #368 review's map-write finding without
+// reintroducing an O(distinct tags)² per-frame cost.
+func (g *pixelTagGrid) internTag(tag CellTag) int32 {
+	if idx, ok := g.tagLookup[tag]; ok {
+		return idx
+	}
+	g.tags = append(g.tags, tag)
+	idx := int32(len(g.tags))
+	if g.tagLookup == nil {
+		g.tagLookup = make(map[CellTag]int32)
+	}
+	g.tagLookup[tag] = idx
+	return idx
+}
+
+// set stores tag at (px, py). A zero-value tag (CellTag{}) is an explicit
+// no-op — NOT a write of "untagged" — matching the old map's observable
+// behavior exactly: a map write of CellTag{} still inserted an entry, but
+// pickDominantColor's aggregation skips any tag.Color == "" entry, so it
+// never contributed to a cell's color count either way. Treating it as a
+// true no-op here is behaviorally equivalent and closes a real bug (#369
+// review F1): FillProjectedSphere calls set() unconditionally with
+// CellTag{Color: color}, and every body in alpha-centauri.json,
+// trappist-1.json, and kepler-452.json has SurfaceColorHex() == "" —
+// CellTag{Color: ""} equals the zero value. Under the PRIOR
+// touched-dedup logic (`if g.tags[idx] == (CellTag{}) { touched =
+// append(...) }`), a zero write marked the pixel touched WITHOUT
+// recording a real value; a later real write on the same pixel then
+// found tags[idx] still reading as zero and appended to touched a SECOND
+// time, so each()/String() visited that one pixel twice with the same
+// (real) tag — double-counting it in pickDominantColor's per-cell vote
+// and potentially flipping which color wins a cell where an orbit path,
+// descent arc, or marker overpaints a horizon fill. No-opping the zero
+// write here means only real writes ever touch state, so a pixel is
+// marked touched at most once regardless of write order or how many
+// zero writes land on it first.
 func (g *pixelTagGrid) set(px, py int, tag CellTag) {
+	if tag == (CellTag{}) {
+		return
+	}
 	if px < 0 || px >= g.w || py < 0 || py >= g.h {
 		return
 	}
 	idx := py*g.w + px
-	if g.tags[idx] == (CellTag{}) {
+	oneBased := g.lastIdx
+	if !g.hasLast || tag != g.lastTag {
+		oneBased = g.internTag(tag)
+		g.hasLast, g.lastTag, g.lastIdx = true, tag, oneBased
+	}
+	if g.tagIdx[idx] == 0 {
 		g.touched = append(g.touched, int32(idx))
 	}
-	g.tags[idx] = tag
+	g.tagIdx[idx] = oneBased
 }
 
 // get returns the tag at (px, py) and whether it's actually tagged (the
 // map's comma-ok pattern) — ok is false for an out-of-bounds pixel or one
-// that was never set this frame.
+// that was never set (with a non-zero tag) this frame.
 func (g *pixelTagGrid) get(px, py int) (CellTag, bool) {
 	if px < 0 || px >= g.w || py < 0 || py >= g.h {
 		return CellTag{}, false
 	}
-	tag := g.tags[py*g.w+px]
-	return tag, tag != (CellTag{})
+	oneBased := g.tagIdx[py*g.w+px]
+	if oneBased == 0 {
+		return CellTag{}, false
+	}
+	return g.tags[oneBased-1], true
 }
 
 // count mirrors len(map) for the emptiness checks String()/HitAt open with.
@@ -89,19 +177,29 @@ func (g *pixelTagGrid) count() int { return len(g.touched) }
 func (g *pixelTagGrid) each(fn func(px, py int, tag CellTag)) {
 	for _, idx := range g.touched {
 		i := int(idx)
-		fn(i%g.w, i/g.w, g.tags[i])
+		oneBased := g.tagIdx[i]
+		if oneBased == 0 { // defensive; touched and tagIdx should stay in sync
+			continue
+		}
+		fn(i%g.w, i/g.w, g.tags[oneBased-1])
 	}
 }
 
-// clear resets every touched pixel back to CellTag{} and empties the
-// touched list, reusing its backing array. O(touched), not O(w*h): a
-// canvas typically inks a small fraction of its pixel grid, so this is
-// cheaper than a full-array clear() would be, and — unlike the old
+// clear resets every touched pixel back to untagged, empties the touched
+// list, and empties the per-frame tag table (and its lookup map) — all
+// reusing their backing storage. O(touched + distinct tags), not O(w×h):
+// a canvas typically inks a small fraction of its pixel grid, so this is
+// cheaper than a full-grid clear would be, and — unlike the old
 // `pixelTags = nil` — never forces a fresh allocation (and the GC churn
-// that comes with one) on the next frame's first write.
+// that comes with one) on the next frame's first write. clear(map) (Go
+// 1.21+ builtin) empties tagLookup's entries without releasing its
+// bucket allocation, the map equivalent of touched/tags reslicing to :0.
 func (g *pixelTagGrid) clear() {
 	for _, idx := range g.touched {
-		g.tags[idx] = CellTag{}
+		g.tagIdx[idx] = 0
 	}
 	g.touched = g.touched[:0]
+	g.tags = g.tags[:0]
+	clear(g.tagLookup)
+	g.hasLast = false
 }

--- a/internal/tui/widgets/canvas_pixel_tags.go
+++ b/internal/tui/widgets/canvas_pixel_tags.go
@@ -1,0 +1,107 @@
+package widgets
+
+// #369: pixelTags used to be a map[[2]int]CellTag. The PR #368 pre-merge
+// review measured a cache HIT on the #367 curve-geometry cache still
+// costing ~19.4µs for a 475-point curve (~41 ns/point) with zero geometry
+// left to compute — entirely blitCurvePoints's per-pixel
+// `pixelTags[[2]int{px, py}] = tag` writes, i.e. hashing a [2]int key and
+// probing/inserting a bucket, on every one of a curve's points, on every
+// frame, even for a curve that hasn't moved.
+//
+// pixelTagGrid replaces the map with a dense array indexed by
+// `py*w + px`: a write is an unconditional slice store, no hashing, no
+// bucket allocation. CellTag{} (its zero value) means "untagged", the
+// same contract a map's "absent key returns the zero value" already gave
+// every caller — safe because every *Tagged draw site already gates on
+// `tagged := tag != (CellTag{})` before touching pixelTags at all, so no
+// writer ever legitimately stores a zero-value tag.
+//
+// A dense array can't be ranged like a map without visiting all pxW*pxH
+// cells regardless of how few are actually tagged (a system-view canvas
+// at 200×50 terminal cells is a 400×200 == 80,000-pixel grid; a typical
+// frame tags a small fraction of that). touched keeps the "range only
+// what's set" property the map gave String()/CountColor for free, and
+// lets clear() reset only what was actually written instead of either a
+// full-grid sweep or (the map's old approach) dropping the whole
+// allocation and paying for a fresh one next frame.
+type pixelTagGrid struct {
+	w, h    int
+	tags    []CellTag
+	touched []int32
+}
+
+// ensureSize (re)allocates the backing grid when the canvas's pixel
+// dimensions change (Resize / a fresh NewCanvas). A stale-sized grid from
+// before a resize would index the wrong cell, or panic out of bounds —
+// Canvas.Resize is always followed by Clear before anything draws again
+// (every screen's Render starts there), so dropping stale contents on a
+// size change is unobservable, not a behavior change from the map's
+// implicit "resize without clear leaves old entries orphaned outside the
+// new bounds" prior behavior.
+func (g *pixelTagGrid) ensureSize(w, h int) {
+	if g.w == w && g.h == h && g.tags != nil {
+		return
+	}
+	g.w, g.h = w, h
+	g.tags = make([]CellTag, w*h)
+	g.touched = g.touched[:0]
+}
+
+// set stores tag at (px, py). Appends to touched only the FIRST time this
+// frame a given index goes from untagged to tagged — two overlapping
+// draws touching the same pixel in one frame (two orbit lines crossing,
+// say) overwrite tags[idx] in place without a second touched entry,
+// mirroring how ranging a map counts a repeatedly-assigned key once.
+// Bounds-checked defensively (every current call site already checks
+// before calling this), matching Canvas's existing silent-drop-off-canvas
+// convention rather than panicking.
+func (g *pixelTagGrid) set(px, py int, tag CellTag) {
+	if px < 0 || px >= g.w || py < 0 || py >= g.h {
+		return
+	}
+	idx := py*g.w + px
+	if g.tags[idx] == (CellTag{}) {
+		g.touched = append(g.touched, int32(idx))
+	}
+	g.tags[idx] = tag
+}
+
+// get returns the tag at (px, py) and whether it's actually tagged (the
+// map's comma-ok pattern) — ok is false for an out-of-bounds pixel or one
+// that was never set this frame.
+func (g *pixelTagGrid) get(px, py int) (CellTag, bool) {
+	if px < 0 || px >= g.w || py < 0 || py >= g.h {
+		return CellTag{}, false
+	}
+	tag := g.tags[py*g.w+px]
+	return tag, tag != (CellTag{})
+}
+
+// count mirrors len(map) for the emptiness checks String()/HitAt open with.
+func (g *pixelTagGrid) count() int { return len(g.touched) }
+
+// each visits every currently-tagged pixel — the touched list, not a full
+// w×h sweep. Mirrors `for coord, tag := range pixelTags` over the old map;
+// map iteration order was never something callers could rely on anyway
+// (String()'s per-cell color aggregation already tie-breaks
+// deterministically for exactly that reason), so touched's write-order
+// walk is a strictly more predictable replacement, not a looser one.
+func (g *pixelTagGrid) each(fn func(px, py int, tag CellTag)) {
+	for _, idx := range g.touched {
+		i := int(idx)
+		fn(i%g.w, i/g.w, g.tags[i])
+	}
+}
+
+// clear resets every touched pixel back to CellTag{} and empties the
+// touched list, reusing its backing array. O(touched), not O(w*h): a
+// canvas typically inks a small fraction of its pixel grid, so this is
+// cheaper than a full-array clear() would be, and — unlike the old
+// `pixelTags = nil` — never forces a fresh allocation (and the GC churn
+// that comes with one) on the next frame's first write.
+func (g *pixelTagGrid) clear() {
+	for _, idx := range g.touched {
+		g.tags[idx] = CellTag{}
+	}
+	g.touched = g.touched[:0]
+}

--- a/internal/tui/widgets/canvas_pixel_tags_bench_test.go
+++ b/internal/tui/widgets/canvas_pixel_tags_bench_test.go
@@ -1,0 +1,60 @@
+package widgets
+
+import "testing"
+
+// BenchmarkPixelTagGridSet measures the #369 dense-grid write path in
+// isolation: N sets on a pre-sized grid, the same shape of work
+// blitCurvePoints does on every cache-HIT replay (the #368 review's
+// ~41 ns/point finding). No canvas, no drawille, no projection — just the
+// write this file exists to make cheap.
+func BenchmarkPixelTagGridSet(b *testing.B) {
+	const w, h = 240, 160 // a 120x40-cell canvas's pixel grid
+	const n = 475         // #368 review's measured curve point count
+	tag := CellTag{Color: "#00FF00", Owner: "bench"}
+
+	var g pixelTagGrid
+	g.ensureSize(w, h)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for p := 0; p < n; p++ {
+			px, py := (p*37)%w, (p*23)%h // scattered, not a tight run
+			g.set(px, py, tag)
+		}
+		g.clear()
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/point")
+}
+
+// benchPixelTagsMap is a byte-for-byte reproduction of the pre-#369
+// map[[2]int]CellTag write path (Canvas.pixelTags before this file's
+// change), kept ONLY here as a same-binary comparison baseline so the
+// grid-vs-map delta is measured in one benchmark run rather than across
+// two separate `main`/branch sessions.
+func benchPixelTagsMapSet(m map[[2]int]CellTag, px, py int, tag CellTag) map[[2]int]CellTag {
+	if m == nil {
+		m = make(map[[2]int]CellTag)
+	}
+	m[[2]int{px, py}] = tag
+	return m
+}
+
+// BenchmarkPixelTagsMapSetBaseline is BenchmarkPixelTagGridSet's baseline:
+// the same N-point write pattern through the OLD map[[2]int]CellTag
+// implementation, so `go test -bench PixelTag` in one run reports both
+// numbers directly comparable (same process, same machine load, no
+// separate-session variance).
+func BenchmarkPixelTagsMapSetBaseline(b *testing.B) {
+	const w, h = 240, 160
+	const n = 475
+	tag := CellTag{Color: "#00FF00", Owner: "bench"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var m map[[2]int]CellTag
+		for p := 0; p < n; p++ {
+			px, py := (p*37)%w, (p*23)%h
+			m = benchPixelTagsMapSet(m, px, py, tag)
+		}
+	}
+	b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*n), "ns/point")
+}

--- a/internal/tui/widgets/canvas_pixel_tags_test.go
+++ b/internal/tui/widgets/canvas_pixel_tags_test.go
@@ -1,0 +1,167 @@
+package widgets
+
+import "testing"
+
+// TestPixelTagGridSetGetRoundTrips confirms the basic map-replacement
+// contract: a set pixel reads back with ok=true and the exact tag; an
+// unset pixel reads back CellTag{} with ok=false — the same "absent key
+// returns the zero value, comma-ok reports absence" contract the old
+// map[[2]int]CellTag gave every caller for free.
+func TestPixelTagGridSetGetRoundTrips(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(10, 10)
+
+	if tag, ok := g.get(3, 4); ok || tag != (CellTag{}) {
+		t.Fatalf("unset pixel: got (%v, %v), want (CellTag{}, false)", tag, ok)
+	}
+
+	want := CellTag{Color: "#FF00FF", Owner: "v:1"}
+	g.set(3, 4, want)
+	if tag, ok := g.get(3, 4); !ok || tag != want {
+		t.Errorf("set pixel: got (%v, %v), want (%v, true)", tag, ok, want)
+	}
+}
+
+// TestPixelTagGridSetOutOfBoundsIsNoop mirrors the old map's implicit
+// safety: every existing call site already bounds-checks before writing,
+// but set() bounds-checks defensively too rather than panicking on an
+// index a future caller might not have guarded.
+func TestPixelTagGridSetOutOfBoundsIsNoop(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(10, 10)
+
+	g.set(-1, 0, CellTag{Color: "#FFFFFF"})
+	g.set(0, -1, CellTag{Color: "#FFFFFF"})
+	g.set(10, 0, CellTag{Color: "#FFFFFF"})
+	g.set(0, 10, CellTag{Color: "#FFFFFF"})
+
+	if got := g.count(); got != 0 {
+		t.Errorf("out-of-bounds set()s changed count to %d, want 0", got)
+	}
+	if tag, ok := g.get(-1, 0); ok || tag != (CellTag{}) {
+		t.Errorf("out-of-bounds get(-1, 0) = (%v, %v), want (CellTag{}, false)", tag, ok)
+	}
+}
+
+// TestPixelTagGridOverwriteDoesNotDoubleCountTouched confirms the
+// dedup-on-overwrite property the map iteration relied on implicitly: two
+// writes to the SAME pixel in one frame (two overlapping draws — genuinely
+// happens, e.g. two orbit lines crossing) must appear exactly once in
+// count()/each(), with the SECOND tag winning — exactly like a map's
+// `m[k] = v` overwrite semantics.
+//
+// Non-vacuousness: an implementation that appended to touched on EVERY
+// set (not just the first, untagged->tagged transition) would make count()
+// report 2 here instead of 1 — this test was run against exactly that
+// broken variant (touched = append(touched, idx) unconditionally) and
+// failed as expected before the dedup guard was added, confirming the
+// assertion actually exercises the guard.
+func TestPixelTagGridOverwriteDoesNotDoubleCountTouched(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(10, 10)
+
+	g.set(2, 2, CellTag{Color: "#111111"})
+	g.set(2, 2, CellTag{Color: "#222222"}) // overwrite, same pixel
+
+	if got := g.count(); got != 1 {
+		t.Fatalf("count() = %d after two writes to the same pixel, want 1", got)
+	}
+	if tag, ok := g.get(2, 2); !ok || tag.Color != "#222222" {
+		t.Errorf("get(2,2) = (%v, %v), want the SECOND write's color #222222", tag, ok)
+	}
+	n := 0
+	g.each(func(px, py int, tag CellTag) { n++ })
+	if n != 1 {
+		t.Errorf("each() visited the overwritten pixel %d times, want 1", n)
+	}
+}
+
+// TestPixelTagGridClearResetsTouchedOnly confirms clear() drops every
+// touched pixel back to CellTag{} and empties the touched list, without
+// needing (or performing) a full w×h sweep — get() on a cleared pixel
+// returns the zero value exactly like a fresh grid.
+func TestPixelTagGridClearResetsTouchedOnly(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(10, 10)
+
+	g.set(1, 1, CellTag{Color: "#111111"})
+	g.set(5, 5, CellTag{Color: "#222222"})
+	g.clear()
+
+	if got := g.count(); got != 0 {
+		t.Errorf("count() = %d after clear(), want 0", got)
+	}
+	if tag, ok := g.get(1, 1); ok || tag != (CellTag{}) {
+		t.Errorf("get(1,1) after clear() = (%v, %v), want (CellTag{}, false)", tag, ok)
+	}
+	if tag, ok := g.get(5, 5); ok || tag != (CellTag{}) {
+		t.Errorf("get(5,5) after clear() = (%v, %v), want (CellTag{}, false)", tag, ok)
+	}
+
+	// A pixel can be re-set after clear() and shows up in count()/each()
+	// again — clear() didn't leave the grid in a state where touched
+	// tracking is permanently broken.
+	g.set(1, 1, CellTag{Color: "#333333"})
+	if got := g.count(); got != 1 {
+		t.Errorf("count() = %d after re-setting a cleared pixel, want 1", got)
+	}
+}
+
+// TestPixelTagGridEnsureSizeDropsStaleContentsOnResize confirms a size
+// change reallocates the grid (and so drops whatever was tagged under the
+// old dimensions) — Canvas.Resize's doc comment explains why this is safe
+// (every screen's Render calls Clear() before drawing again after a
+// resize).
+func TestPixelTagGridEnsureSizeDropsStaleContentsOnResize(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(10, 10)
+	g.set(1, 1, CellTag{Color: "#111111"})
+	if got := g.count(); got != 1 {
+		t.Fatalf("precondition: count() = %d, want 1", got)
+	}
+
+	g.ensureSize(20, 20)
+	if got := g.count(); got != 0 {
+		t.Errorf("count() = %d immediately after a resize, want 0 (stale contents should be dropped)", got)
+	}
+
+	// Same-size ensureSize is a no-op — must NOT drop live contents (a
+	// per-frame Resize call with unchanged dimensions is common: the
+	// terminal simply didn't change size between ticks).
+	g.set(3, 3, CellTag{Color: "#222222"})
+	g.ensureSize(20, 20)
+	if got := g.count(); got != 1 {
+		t.Errorf("count() = %d after a same-size ensureSize(), want 1 (should be a no-op)", got)
+	}
+}
+
+// TestPixelTagGridEachVisitsExactlySetPixels confirms each() visits
+// precisely the tagged set — no more, no less — regardless of grid size,
+// mirroring `for coord, tag := range oldMap`.
+func TestPixelTagGridEachVisitsExactlySetPixels(t *testing.T) {
+	var g pixelTagGrid
+	g.ensureSize(50, 50)
+
+	want := map[[2]int]CellTag{
+		{0, 0}:   {Color: "#111111"},
+		{49, 49}: {Color: "#222222"},
+		{10, 20}: {Color: "#333333"},
+	}
+	for coord, tag := range want {
+		g.set(coord[0], coord[1], tag)
+	}
+
+	got := make(map[[2]int]CellTag)
+	g.each(func(px, py int, tag CellTag) {
+		got[[2]int{px, py}] = tag
+	})
+
+	if len(got) != len(want) {
+		t.Fatalf("each() visited %d pixels, want %d", len(got), len(want))
+	}
+	for coord, tag := range want {
+		if got[coord] != tag {
+			t.Errorf("each() reported %v at %v, want %v", got[coord], coord, tag)
+		}
+	}
+}

--- a/internal/tui/widgets/canvas_pixel_tags_test.go
+++ b/internal/tui/widgets/canvas_pixel_tags_test.go
@@ -76,6 +76,82 @@ func TestPixelTagGridOverwriteDoesNotDoubleCountTouched(t *testing.T) {
 	}
 }
 
+// TestPixelTagGridZeroThenRealDoesNotDoubleCountTouched is the #369
+// review's F1 regression test: a ZERO-value write (CellTag{}, e.g.
+// FillProjectedSphere fed a body whose SurfaceColorHex() is "" —
+// alpha-centauri.json, trappist-1.json, and kepler-452.json all have
+// bodies like this) followed by a REAL write to the SAME pixel must
+// still land the pixel in touched/each() exactly once — the existing
+// overwrite test above only covers real-then-real. A zero write is a
+// true no-op (see set()'s doc comment for why), so this also covers the
+// reverse order (real-then-zero) and a zero-only write, which must never
+// appear as touched at all.
+//
+// Non-vacuousness (per the review's request): run with the zero-tag
+// no-op guard at the top of set() removed (so a zero tag flows through
+// internTag/tagIdx like any other value). "zero-then-real" still passed
+// under that sabotage — this implementation's touched-dedup flag is
+// tagIdx[idx]==0 (a presence bit, independent of the tag's CONTENT), not
+// "does the stored value read as zero" the way the review's original
+// finding described, so that specific double-touch shape doesn't
+// reproduce here. But "real-then-zero" and "zero-only" both failed
+// exactly as expected: without the guard, a later zero write clobbers a
+// real tag instead of no-opping (get(5,5) returned the zero tag, not the
+// real one), and a zero-only write registers as touched (count()==1
+// instead of 0) — both confirmed, then reverted. All three sub-tests
+// together pin the "zero is a true no-op regardless of order" contract
+// set()'s doc comment describes.
+func TestPixelTagGridZeroThenRealDoesNotDoubleCountTouched(t *testing.T) {
+	t.Run("zero-then-real", func(t *testing.T) {
+		var g pixelTagGrid
+		g.ensureSize(10, 10)
+
+		g.set(4, 4, CellTag{})                 // e.g. an empty SurfaceColorHex()
+		g.set(4, 4, CellTag{Color: "#ABCDEF"}) // a real overpaint (orbit path, marker, ...)
+
+		if got := g.count(); got != 1 {
+			t.Fatalf("count() = %d after a zero write then a real write to the same pixel, want 1", got)
+		}
+		if tag, ok := g.get(4, 4); !ok || tag.Color != "#ABCDEF" {
+			t.Errorf("get(4,4) = (%v, %v), want the real write's color #ABCDEF", tag, ok)
+		}
+		n := 0
+		g.each(func(px, py int, tag CellTag) { n++ })
+		if n != 1 {
+			t.Errorf("each() visited the pixel %d times, want 1 (zero-then-real should not double-count)", n)
+		}
+	})
+
+	t.Run("real-then-zero", func(t *testing.T) {
+		var g pixelTagGrid
+		g.ensureSize(10, 10)
+
+		g.set(5, 5, CellTag{Color: "#ABCDEF"})
+		g.set(5, 5, CellTag{}) // a later zero write must not erase or double-touch
+
+		if got := g.count(); got != 1 {
+			t.Fatalf("count() = %d after a real write then a zero write to the same pixel, want 1", got)
+		}
+		if tag, ok := g.get(5, 5); !ok || tag.Color != "#ABCDEF" {
+			t.Errorf("get(5,5) = (%v, %v), want the real tag to survive a later zero write", tag, ok)
+		}
+	})
+
+	t.Run("zero-only", func(t *testing.T) {
+		var g pixelTagGrid
+		g.ensureSize(10, 10)
+
+		g.set(6, 6, CellTag{})
+
+		if got := g.count(); got != 0 {
+			t.Errorf("count() = %d after a zero-only write, want 0 (never touched)", got)
+		}
+		if tag, ok := g.get(6, 6); ok || tag != (CellTag{}) {
+			t.Errorf("get(6,6) after a zero-only write = (%v, %v), want (CellTag{}, false)", tag, ok)
+		}
+	})
+}
+
 // TestPixelTagGridClearResetsTouchedOnly confirms clear() drops every
 // touched pixel back to CellTag{} and empties the touched list, without
 // needing (or performing) a full w×h sweep — get() on a cleared pixel

--- a/internal/tui/widgets/canvas_ring_cache.go
+++ b/internal/tui/widgets/canvas_ring_cache.go
@@ -45,12 +45,18 @@ type ringCacheEntry struct {
 }
 
 // ringCacheCap bounds ringCache the same LRU way curveCacheCap bounds
-// curveCache. Sized to the deterministic worst case rather than an
-// estimate: BodyRingBands' only ringed body today (Saturn) has 4 bands,
-// each capped at 64 concentric outlines (orbit.go's per-band `n`, capped
-// at 64) — 256 distinct curveIDs, all stable strings ("ring:saturn:B:i")
-// that don't churn the way vessel/ghost curveIDs can. A future second
-// ringed body would need this raised; 256 leaves headroom without it.
+// curveCache. Sized to the exact deterministic worst case, not an
+// estimate with headroom: BodyRingBands' only ringed body today (Saturn)
+// has 4 bands, each capped at 64 concentric outlines (orbit.go's
+// per-band `n`, capped at 64) — 4×64 = 256 distinct curveIDs is the most
+// that can EVER be live in one frame, arithmetically, not a guess.
+// Measured in practice the real number stays well under that (~140
+// outlines/frame at a deep-zoom scale of ≈2.4e-6, where most bands'
+// widthPx is still short of the 64 cap) — 256 is the ceiling, not the
+// typical case. curveIDs are stable strings ("ring:saturn:B:i") that
+// don't churn the way vessel/ghost curveIDs can, so nothing here grows
+// unbounded between frames either. A future second ringed body would
+// need this cap raised.
 const ringCacheCap = 256
 
 // ringCacheKey fingerprints everything a ring outline's projected pixel

--- a/internal/tui/widgets/canvas_ring_cache.go
+++ b/internal/tui/widgets/canvas_ring_cache.go
@@ -1,0 +1,196 @@
+package widgets
+
+import (
+	"math"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// #369: after #367/#368 memoized orbit-LINE geometry (canvas_curve_cache.go),
+// the prod host-seat profile that originally flagged that cost (#367's
+// issue body, detached 200×50 tmux) ALSO named
+// Canvas.RingTiltedOutlineTagged among the hot symbols — a different draw
+// primitive (tilted ring-band outlines: Saturn's C/B/A/F bands), out of
+// scope for #368's cache, which covers only the 4 DrawEllipseClassTagged
+// call sites in orbit.go.
+//
+// MEASURED before writing this file (per the issue's instruction — see the
+// PR body for the full profile/benchmark numbers): a Saturn-focused idle
+// render (screens.BenchmarkOrbitViewRenderIdleRinged — the default
+// BenchmarkOrbitViewRenderIdle scene never brings a ringed body into view
+// at all, so it can't see this cost) ran ~2.03ms/frame on pre-#369 main vs
+// ~1.76ms for the same canvas with no ring bands in view —
+// RingTiltedOutlineTagged alone was ~3.3% of total cpu samples and ~24% of
+// cumulative time under (*OrbitView).Render in a `pprof -focus` breakdown.
+// Not negligible when a ringed body actually fills the view (worst case:
+// up to 64 concentric outlines per band × 4 bands, each up to
+// 4×(pxW+pxH) samples, every one of 20 ticks/second) — this earns the
+// same treatment #367 gave orbit lines.
+//
+// Same discipline as the curve cache: memoize the drawn ring's
+// projected pixel list, keyed on everything that can change it — the
+// ring's own embedding (center, e1/e2 basis, radius) AND the canvas's own
+// view state (scale, basis, camera center, pixel dimensions), for the
+// exact #363-review reason curveCacheKey documents (a cache keyed on the
+// subject alone serves a stale frame the instant the camera moves).
+
+// ringCacheEntry holds the last recorded pixel list for one ring outline
+// (identified by curveID, an opaque string the caller mints — orbit.go
+// mints one per body+band+concentric-outline-index) and the key it was
+// recorded for. Reuses curveCache's canvasPoint (int32 x, y) — same
+// "retained size tight" reasoning applies here.
+type ringCacheEntry struct {
+	key    ringCacheKey
+	points []canvasPoint
+}
+
+// ringCacheCap bounds ringCache the same LRU way curveCacheCap bounds
+// curveCache. Sized to the deterministic worst case rather than an
+// estimate: BodyRingBands' only ringed body today (Saturn) has 4 bands,
+// each capped at 64 concentric outlines (orbit.go's per-band `n`, capped
+// at 64) — 256 distinct curveIDs, all stable strings ("ring:saturn:B:i")
+// that don't churn the way vessel/ghost curveIDs can. A future second
+// ringed body would need this raised; 256 leaves headroom without it.
+const ringCacheCap = 256
+
+// ringCacheKey fingerprints everything a ring outline's projected pixel
+// list depends on. Mirrors curveCacheKey's shape and camera-relative
+// centering exactly (see its doc comment for why relCenter is measured
+// from c.centerW rather than in absolute world coordinates).
+type ringCacheKey struct {
+	relCenterXQ, relCenterYQ, relCenterZQ int64
+	// e1Q / e2Q are the ring-plane basis vectors' raw components,
+	// quantized by ringBasisQuantum (angle-equivalent to
+	// curveShapeQuantum, not curveBasisQuantum — these are WORLD-space
+	// unit vectors scaled by rMeters, not canvas-basis vectors scaled by
+	// a pixel distance, so the error budget has to scale off the ring's
+	// OWN pixel radius the same way curveShapeQuantum derives an orbit's
+	// element quantum off its apoapsis).
+	e1Q, e2Q [3]int64
+	rQ       int64
+	// View state (CRITICAL — see curveCacheKey's identical field for the
+	// #363 review finding this protects against).
+	scaleLogQ int64
+	basisQ    [6]int64
+	pxW, pxH  int
+}
+
+// ringBasisQuantum derives the angle-equivalent quantum for e1/e2's raw
+// components from the ring's own on-screen radius, exactly the way
+// curveShapeQuantum derives an orbit's shape quantum from its apoapsis: a
+// basis error of δ radians moves a point at the ring's pixel radius
+// (rMeters·scale) by ≈ rMeters·scale·δ screen pixels, so bounding that
+// under arcFlatTolerancePx needs δ ≤ arcFlatTolerancePx / (rMeters·scale)
+// — precisely curveShapeQuantum's formula with rMeters standing in for
+// the orbit's apoapsis.
+func ringBasisQuantum(scale, rMeters float64) float64 {
+	return curveShapeQuantum(scale, rMeters)
+}
+
+// ringCacheKeyFor builds the cache key for a ring outline as drawn RIGHT
+// NOW — this canvas's current view state plus the ring's own embedding.
+func (c *Canvas) ringCacheKeyFor(center, e1, e2 orbital.Vec3, rMeters float64) ringCacheKey {
+	posQ := curvePositionQuantum(c.scale)
+	basisQ := ringBasisQuantum(c.scale, rMeters)
+	relCenter := center.Sub(c.centerW)
+	return ringCacheKey{
+		relCenterXQ: quantize(relCenter.X, posQ),
+		relCenterYQ: quantize(relCenter.Y, posQ),
+		relCenterZQ: quantize(relCenter.Z, posQ),
+		e1Q: [3]int64{
+			quantize(e1.X, basisQ), quantize(e1.Y, basisQ), quantize(e1.Z, basisQ),
+		},
+		e2Q: [3]int64{
+			quantize(e2.X, basisQ), quantize(e2.Y, basisQ), quantize(e2.Z, basisQ),
+		},
+		rQ:        quantize(rMeters, posQ),
+		scaleLogQ: quantize(math.Log(c.scale), curveScaleLogQuantum),
+		basisQ: [6]int64{
+			quantize(c.basis.X.X, curveBasisQuantum), quantize(c.basis.X.Y, curveBasisQuantum), quantize(c.basis.X.Z, curveBasisQuantum),
+			quantize(c.basis.Y.X, curveBasisQuantum), quantize(c.basis.Y.Y, curveBasisQuantum), quantize(c.basis.Y.Z, curveBasisQuantum),
+		},
+		pxW: c.pxW,
+		pxH: c.pxH,
+	}
+}
+
+// RingTiltedOutlineCachedTagged is RingTiltedOutlineTagged with the #369
+// ring-geometry cache: on a key hit it replays the pixel list a prior
+// identical-key call produced instead of resampling+reprojecting the
+// ring. curveID is an opaque per-outline identity the caller mints
+// (screens/orbit.go uses "ring:<bodyID>:<bandIdx>:<i>" — the ring bands
+// aren't Inspect-owned the way orbit lines are, so unlike
+// DrawEllipseClassCachedTagged this isn't reusing an existing Inspect
+// owner key, just minting a stable cache identity) — kept as its own
+// parameter for the same reason DrawEllipseClassCachedTagged's is: an
+// empty curveID never caches, so unrelated anonymous callers can't
+// collide on a shared "" bucket.
+//
+// Same precision contract as DrawEllipseClassCachedTagged: a HIT is
+// sub-pixel-equivalent to a fresh draw (within arcFlatTolerancePx), not
+// necessarily byte-identical, because the key quantizes its inputs — see
+// ringCacheKeyFor / ringBasisQuantum. A genuine MISS always recomputes
+// exactly.
+func (c *Canvas) RingTiltedOutlineCachedTagged(curveID string, center, e1, e2 orbital.Vec3, rMeters float64, tag CellTag) {
+	if curveID == "" {
+		c.RingTiltedOutlineTagged(center, e1, e2, rMeters, tag)
+		return
+	}
+	key := c.ringCacheKeyFor(center, e1, e2, rMeters)
+	if c.ringCache == nil {
+		c.ringCache = make(map[string]*ringCacheEntry)
+	}
+	if entry, ok := c.ringCache[curveID]; ok && entry.key == key {
+		c.ringCacheHits++
+		c.touchRingCacheID(curveID)
+		c.blitCurvePoints(entry.points, tag)
+		return
+	}
+	var points []canvasPoint
+	c.ringTiltedOutlineTaggedRecording(center, e1, e2, rMeters, tag, func(px, py int) {
+		points = append(points, canvasPoint{int32(px), int32(py)})
+	})
+	c.ringCache[curveID] = &ringCacheEntry{key: key, points: points}
+	c.ringCacheComputes++
+	c.touchRingCacheID(curveID)
+	c.evictOldRingCache()
+}
+
+// touchRingCacheID moves curveID to the most-recently-used end of
+// ringCacheOrder — same O(cap) LRU as touchCurveCacheID.
+func (c *Canvas) touchRingCacheID(curveID string) {
+	for i, id := range c.ringCacheOrder {
+		if id == curveID {
+			c.ringCacheOrder = append(c.ringCacheOrder[:i], c.ringCacheOrder[i+1:]...)
+			break
+		}
+	}
+	c.ringCacheOrder = append(c.ringCacheOrder, curveID)
+}
+
+// evictOldRingCache drops the least-recently-used curveIDs once
+// ringCache exceeds ringCacheCap.
+func (c *Canvas) evictOldRingCache() {
+	for len(c.ringCacheOrder) > ringCacheCap {
+		oldest := c.ringCacheOrder[0]
+		c.ringCacheOrder = c.ringCacheOrder[1:]
+		delete(c.ringCache, oldest)
+	}
+}
+
+// RingCacheStats reports the #369 ring-geometry cache's cumulative
+// hit/recompute counts — CurveCacheStats' sibling, same test-hook role
+// for screens-package end-to-end tests that can't reach Canvas's private
+// counters directly.
+func (c *Canvas) RingCacheStats() (hits, computes int) {
+	return c.ringCacheHits, c.ringCacheComputes
+}
+
+// ResetRingCache drops every cached ring entry, forcing the next draw of
+// each ring outline to recompute from scratch. Mirrors ResetCurveCache's
+// role and the same "drop immediately before the one render under
+// comparison" usage discipline — see its doc comment.
+func (c *Canvas) ResetRingCache() {
+	c.ringCache = nil
+	c.ringCacheOrder = nil
+}

--- a/internal/tui/widgets/canvas_ring_cache_test.go
+++ b/internal/tui/widgets/canvas_ring_cache_test.go
@@ -1,0 +1,263 @@
+package widgets
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// testRing is a modest tilted ring embedding, sized to land real pixels on
+// a small test canvas — mirrors testEllipse()'s role in
+// canvas_curve_cache_test.go.
+func testRingEmbedding() (center, e1, e2 orbital.Vec3, rMeters float64) {
+	e1 = orbital.Vec3{X: 1}
+	e2 = orbital.Vec3{Y: 0.8, Z: 0.6} // tilted, not orthogonal-to-basis-plane
+	return orbital.Vec3{}, e1, e2, 15
+}
+
+func newRingCacheTestCanvas() *Canvas {
+	c := NewCanvas(20, 10) // 40x40 px
+	c.SetScale(1)
+	c.Center(orbital.Vec3{})
+	return c
+}
+
+// TestRingTiltedOutlineCachedTaggedMatchesUncached confirms a cache MISS
+// (first draw) produces byte-identical canvas output to the uncached
+// RingTiltedOutlineTagged.
+func TestRingTiltedOutlineCachedTaggedMatchesUncached(t *testing.T) {
+	forceANSIColor(t)
+	center, e1, e2, r := testRingEmbedding()
+	tag := CellTag{Color: "#00FF00"}
+
+	cached := newRingCacheTestCanvas()
+	cached.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, tag)
+
+	uncached := newRingCacheTestCanvas()
+	uncached.RingTiltedOutlineTagged(center, e1, e2, r, tag)
+
+	if got, want := cached.String(), uncached.String(); got != want {
+		t.Errorf("cached miss diverges from uncached draw\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedHitsOnRepeat confirms an identical
+// second call is a cache hit (no recompute) and still renders the same
+// picture.
+func TestRingTiltedOutlineCachedTaggedHitsOnRepeat(t *testing.T) {
+	forceANSIColor(t)
+	center, e1, e2, r := testRingEmbedding()
+	tag := CellTag{Color: "#00FF00"}
+
+	c := newRingCacheTestCanvas()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, tag)
+	first := c.String()
+	computesBefore := c.ringCacheComputes
+
+	c.Clear()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, tag)
+	second := c.String()
+
+	if c.ringCacheComputes != computesBefore {
+		t.Fatalf("expected the identical second call to be a cache HIT, got a recompute (computes %d -> %d)", computesBefore, c.ringCacheComputes)
+	}
+	if c.ringCacheHits == 0 {
+		t.Error("expected ringCacheHits to be nonzero after an identical repeat call")
+	}
+	if first != second {
+		t.Errorf("cache-hit render diverges from the original draw\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedColorOnlyChangeStillHits confirms the
+// cache is keyed on GEOMETRY, not color.
+func TestRingTiltedOutlineCachedTaggedColorOnlyChangeStillHits(t *testing.T) {
+	forceANSIColor(t)
+	center, e1, e2, r := testRingEmbedding()
+
+	c := newRingCacheTestCanvas()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#00FF00"})
+	computesBefore := c.ringCacheComputes
+
+	c.Clear()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#FF0000"})
+	recolored := c.String()
+
+	if c.ringCacheComputes != computesBefore {
+		t.Fatalf("a color-only change should reuse cached geometry (HIT), got a recompute (computes %d -> %d)", computesBefore, c.ringCacheComputes)
+	}
+
+	fresh := newRingCacheTestCanvas()
+	fresh.RingTiltedOutlineTagged(center, e1, e2, r, CellTag{Color: "#FF0000"})
+	want := fresh.String()
+
+	if recolored != want {
+		t.Errorf("recolored cache-hit render diverges from an uncached reference in the new color\ngot:  %q\nwant: %q", recolored, want)
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedEmptyCurveIDNeverCaches confirms an
+// empty curveID falls through to the plain uncached path and never
+// touches ringCache.
+func TestRingTiltedOutlineCachedTaggedEmptyCurveIDNeverCaches(t *testing.T) {
+	c := newRingCacheTestCanvas()
+	center, e1, e2, r := testRingEmbedding()
+	c.RingTiltedOutlineCachedTagged("", center, e1, e2, r, CellTag{Color: "#00FF00"})
+	if len(c.ringCache) != 0 {
+		t.Errorf("empty curveID populated ringCache (%d entries), want 0", len(c.ringCache))
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedBustsOnViewChange is the ring-cache
+// analog of TestDrawEllipseClassCachedTaggedBustsOnViewChange: pan, zoom,
+// rebasis, and resize must all bust the geometry cache. Each case asserts
+// BOTH a recompute happened AND the new frame matches a from-scratch
+// (never-cached) reference — a cache that merely detects a miss but still
+// blits the OLD geometry would pass a hit/miss-counter-only test while
+// still being visibly broken.
+//
+// Non-vacuousness check performed manually (not committed): temporarily
+// hard-coding scaleLogQ/basisQ/pxW/pxH out of ringCacheKeyFor made every
+// sub-test in this function fail exactly as expected (recompute count
+// stayed flat instead of increasing) before the fix was reverted —
+// confirming the assertions actually exercise the view-state coverage
+// rather than passing regardless of what the key contains.
+func TestRingTiltedOutlineCachedTaggedBustsOnViewChange(t *testing.T) {
+	forceANSIColor(t)
+	center, e1, e2, r := testRingEmbedding()
+
+	cases := []struct {
+		name  string
+		setup func(c *Canvas)
+	}{
+		{"pan", func(c *Canvas) { c.Center(orbital.Vec3{X: 5, Y: -3}) }},
+		{"zoom", func(c *Canvas) { c.SetScale(2) }},
+		{"rebasis", func(c *Canvas) { c.SetBasis(Basis{X: orbital.Vec3{X: 1}, Y: orbital.Vec3{Z: 1}}) }},
+		{"resize", func(c *Canvas) { c.Resize(30, 15) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRingCacheTestCanvas()
+			c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#00FF00"})
+			computesBefore := c.ringCacheComputes
+
+			c.Clear()
+			tc.setup(c)
+			c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#00FF00"})
+			got := c.String()
+
+			if c.ringCacheComputes == computesBefore {
+				t.Fatalf("%s: expected a cache MISS (recompute) after the view changed, got a HIT", tc.name)
+			}
+
+			fresh := newRingCacheTestCanvas()
+			tc.setup(fresh)
+			fresh.RingTiltedOutlineTagged(center, e1, e2, r, CellTag{Color: "#00FF00"})
+			want := fresh.String()
+
+			if got != want {
+				t.Errorf("%s: post-change cache-miss render diverges from an uncached reference\ngot:  %q\nwant: %q", tc.name, got, want)
+			}
+		})
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedBustsOnEmbeddingChange confirms a real
+// (well past quantization) change to the ring's own embedding — center,
+// basis, or radius — busts the cache too.
+func TestRingTiltedOutlineCachedTaggedBustsOnEmbeddingChange(t *testing.T) {
+	forceANSIColor(t)
+	center, e1, e2, r := testRingEmbedding()
+
+	cases := []struct {
+		name string
+		draw func(c *Canvas)
+	}{
+		{"center", func(c *Canvas) {
+			c.RingTiltedOutlineCachedTagged("ring-1", orbital.Vec3{X: 8}, e1, e2, r, CellTag{Color: "#00FF00"})
+		}},
+		{"radius", func(c *Canvas) {
+			c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r*1.5, CellTag{Color: "#00FF00"})
+		}},
+		{"e1", func(c *Canvas) {
+			c.RingTiltedOutlineCachedTagged("ring-1", center, orbital.Vec3{Y: 1}, e2, r, CellTag{Color: "#00FF00"})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRingCacheTestCanvas()
+			c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#00FF00"})
+			computesBefore := c.ringCacheComputes
+
+			c.Clear()
+			tc.draw(c)
+			got := c.String()
+
+			if c.ringCacheComputes == computesBefore {
+				t.Fatalf("%s: expected a cache MISS after the embedding changed, got a HIT", tc.name)
+			}
+			_ = got
+		})
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedToleratesSubPixelJitter confirms the
+// quantization half of the contract: a change far below
+// curvePositionQuantum/ringBasisQuantum at this canvas's scale must still
+// be a cache HIT.
+//
+// Non-vacuousness check performed manually (not committed): tightening
+// ringBasisQuantum's formula (dropping the arcFlatTolerancePx numerator
+// to an unreasonably small constant) made this test fail as expected
+// before the change was reverted — confirming the quantum is actually
+// gating the hit, not a check that would pass unconditionally.
+func TestRingTiltedOutlineCachedTaggedToleratesSubPixelJitter(t *testing.T) {
+	center, e1, e2, r := testRingEmbedding()
+	e1Jittered := e1
+	e1Jittered.Y += 1e-9 // far below ringBasisQuantum at this canvas's scale
+
+	c := newRingCacheTestCanvas()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1, e2, r, CellTag{Color: "#00FF00"})
+	computesBefore := c.ringCacheComputes
+
+	c.Clear()
+	c.RingTiltedOutlineCachedTagged("ring-1", center, e1Jittered, e2, r, CellTag{Color: "#00FF00"})
+
+	if c.ringCacheComputes != computesBefore {
+		t.Errorf("sub-pixel e1 jitter busted the cache (computes %d -> %d) — quantum is too tight", computesBefore, c.ringCacheComputes)
+	}
+}
+
+// TestRingTiltedOutlineCachedTaggedBoundedAcrossManyCurveIDs sweeps far
+// more distinct curveIDs than ringCacheCap through the same canvas — a
+// deeply-zoomed ring system's full band×outline sweep, worst case — and
+// asserts the cache never exceeds its bound, and that eviction is LRU
+// (not just a bound).
+func TestRingTiltedOutlineCachedTaggedBoundedAcrossManyCurveIDs(t *testing.T) {
+	c := newRingCacheTestCanvas()
+	center, e1, e2, r := testRingEmbedding()
+	curveIDAt := func(i int) string {
+		return "ring-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+	}
+	const n = ringCacheCap * 2
+	for i := 0; i < n; i++ {
+		id := curveIDAt(i)
+		c.RingTiltedOutlineCachedTagged(id, center, e1, e2, r, CellTag{Color: "#00FF00"})
+		if len(c.ringCache) > ringCacheCap {
+			t.Fatalf("after %d curveIDs: ringCache holds %d entries, want <= %d (cap)", i+1, len(c.ringCache), ringCacheCap)
+		}
+	}
+	if got := len(c.ringCache); got != ringCacheCap {
+		t.Errorf("after sweeping %d curveIDs, ringCache = %d entries, want exactly the cap (%d)", n, got, ringCacheCap)
+	}
+	mostRecent := curveIDAt(n - 1)
+	leastRecent := curveIDAt(0)
+	if _, ok := c.ringCache[mostRecent]; !ok {
+		t.Errorf("most-recently-drawn curveID %q was evicted — eviction isn't LRU", mostRecent)
+	}
+	if _, ok := c.ringCache[leastRecent]; ok {
+		t.Errorf("least-recently-drawn curveID %q is still resident after the sweep — eviction isn't LRU", leastRecent)
+	}
+}

--- a/internal/tui/widgets/canvas_string_coalesce_test.go
+++ b/internal/tui/widgets/canvas_string_coalesce_test.go
@@ -64,22 +64,21 @@ func expandRunsToPerChar(s string) string {
 // against exactly the code path it replaced.
 func (c *Canvas) referenceString() string {
 	rows := c.dc.Rows(0, 0, c.pxW, c.pxH)
-	if len(c.pixelTags) == 0 && len(c.cellOverlays) == 0 {
+	if c.pixelTags.count() == 0 && len(c.cellOverlays) == 0 {
 		return c.joinRows(rows)
 	}
 	cellColor := make(map[[2]int]lipgloss.Color)
 	cellCounts := make(map[[2]int]map[lipgloss.Color]int)
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(px, py int, tag CellTag) {
 		if tag.Color == "" {
-			continue
+			return
 		}
-		cellX, cellY := coord[0]/2, coord[1]/4
-		key := [2]int{cellX, cellY}
+		key := [2]int{px / 2, py / 4}
 		if cellCounts[key] == nil {
 			cellCounts[key] = make(map[lipgloss.Color]int)
 		}
 		cellCounts[key][tag.Color]++
-	}
+	})
 	for key, counts := range cellCounts {
 		cellColor[key] = pickDominantColor(counts)
 	}

--- a/internal/tui/widgets/canvas_test.go
+++ b/internal/tui/widgets/canvas_test.go
@@ -287,7 +287,7 @@ func TestRingOutlineHugeRadiusDoesNotHang(t *testing.T) {
 	c.RingColoredOutline(orbital.Vec3{}, 1_000_000, lipgloss.Color("#FF0000"))
 	// If we get here, the cap held. Without it the test would never
 	// finish (or OOM the map). Sanity: at least one pixel got tagged.
-	if len(c.pixelTags) == 0 {
+	if c.pixelTags.count() == 0 {
 		t.Skip("ring entirely off-canvas — test setup issue, not a regression")
 	}
 }

--- a/internal/tui/widgets/dense_line_test.go
+++ b/internal/tui/widgets/dense_line_test.go
@@ -14,11 +14,11 @@ import (
 // same white-box store ringDottedPixels reads.
 func taggedPixels(c *Canvas, color lipgloss.Color) [][2]int {
 	var px [][2]int
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(x, y int, tag CellTag) {
 		if tag.Color == color {
-			px = append(px, coord)
+			px = append(px, [2]int{x, y})
 		}
-	}
+	})
 	return px
 }
 

--- a/internal/tui/widgets/lineclass_inspect_test.go
+++ b/internal/tui/widgets/lineclass_inspect_test.go
@@ -107,9 +107,9 @@ func TestUntaggedClassDrawsStayUntagged(t *testing.T) {
 	c.DrawEllipseClass(circularElements(4_000_000), orbital.Vec3{}, 180, ClassScenery,
 		orbital.Vec3{}, 0, lipgloss.Color("#6E6E6E"))
 
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(x, y int, tag CellTag) {
 		if tag.Owner != "" {
-			t.Fatalf("untagged DrawEllipseClass wrote an owner %q at %v", tag.Owner, coord)
+			t.Fatalf("untagged DrawEllipseClass wrote an owner %q at (%d, %d)", tag.Owner, x, y)
 		}
-	}
+	})
 }

--- a/internal/tui/widgets/ring_dotted_test.go
+++ b/internal/tui/widgets/ring_dotted_test.go
@@ -14,11 +14,11 @@ import (
 // aggregates.
 func ringDottedPixels(c *Canvas, color lipgloss.Color) [][2]int {
 	var px [][2]int
-	for coord, tag := range c.pixelTags {
+	c.pixelTags.each(func(x, y int, tag CellTag) {
 		if tag.Color == color {
-			px = append(px, coord)
+			px = append(px, [2]int{x, y})
 		}
-	}
+	})
 	return px
 }
 


### PR DESCRIPTION
Closes #369.

## Summary

Two residual idle-render costs #368 deliberately left out of scope, both measured before committing to a shape per the issue's instruction. **Updated after a pre-merge review** — see "Review round (F1–F6)" below for six findings addressed on top of the original approach; the sections above that describe the current (post-review-fix) state.

## 1. Ring-outline geometry (`Canvas.RingTiltedOutlineTagged`)

**Measure-first verdict: not negligible when a ringed body is actually in view — earns the cache.** The default `BenchmarkOrbitViewRenderIdle` scene (LEO around Earth) never brings a ringed body into frame at all — Saturn is the only body `BodyRingBands` recognizes — so a new benchmark, `BenchmarkOrbitViewRenderIdleRinged` (Saturn-focused, checked in), was needed to see this cost at all.

Profile (`pprof -focus='.*OrbitView.*Render$'` on the Saturn-focused scene, pre-#369):
- `RingTiltedOutlineTagged` was ~3.3% of total CPU samples and **~24% of cumulative time under `(*OrbitView).Render`**.

**Fix**: `canvas_ring_cache.go`, the same recorded-pixel-replay pattern as `canvas_curve_cache.go` (#367) — a cache miss records the projected pixel list during the draw that already had to happen (`ringTiltedOutlineTaggedRecording`), a hit replays it. Key (`ringCacheKey`) covers the ring's own embedding (center, e1/e2 basis, radius, all camera-relative like the curve cache) **and** the canvas's view state (scale, basis, pixel dimensions) — the #363-review lesson that a cache keyed on the subject alone serves stale pixels the instant the camera moves. `curveID` is a stable mint (`"ring:<bodyID>:<bandIdx>:<outlineIdx>"`, `orbit.go`) rather than an Inspect owner key — ring bands aren't in the Inspect hit-test set. Since review: curveIDs come from a memoized per-body table (`ringCurveIDsFor`) instead of `fmt.Sprintf` per outline per frame (F5), and the now-callerless plain-color `RingTiltedOutline` wrapper was deleted (F3).

Quantization: `ringBasisQuantum` reuses `curveShapeQuantum`'s exact derivation (angle-error-vs-pixel-radius) with the ring's own radius standing in for an orbit's apoapsis — a hit is sub-pixel-equivalent to a fresh draw, not byte-identical, same contract `DrawEllipseClassCachedTagged` documents.

## 2. `pixelTags` map writes on the cache hit path

**Chosen direction: flat grid instead of a map** (the issue's other candidate — caching post-blit tag state per curve — was rejected: it would either break the existing "tag applied fresh every call, hit or miss" contract, or require keying the geometry cache on tag too, defeating `TestDrawEllipseClassCachedTaggedColorOnlyChangeStillHits`).

`canvas_pixel_tags.go`'s `pixelTagGrid` went through two shapes across the review, both replacing `map[[2]int]CellTag`:

- **Original**: a dense `[]CellTag` sized `pxW×pxH`. Fast (matched the map-vs-grid microbenchmark), but review finding F2 caught it at 72 bytes/pixel — 5.76 MB per 200×50 canvas, 69.2 MB measured for 4 ssh seats × 3 canvases, unbounded because `Canvas.Resize` takes the client's raw `WindowSizeMsg`.
- **Current**: a 1-based `int32` index per pixel into a small per-frame table of the *distinct* `CellTag` values actually in use (bodies/orbit-classes/vessels typically number in the dozens, not one entry per pixel) — ~320 KB for the same canvas. See "Memory" below for measured numbers.

`CellTag{}` (zero value) means "untagged" — see `set()`'s doc comment and F1 below for why this is now an *explicit* no-op rather than an assumed invariant. A `touched []int32` write-order list stands in for the map's free sparse iteration (`String()`/`CountColor`/tests need "visit only what's set", not a full 80,000-pixel sweep on a 200×50 canvas) and lets `Clear()` reset only what was touched instead of dropping the whole map every frame.

15 write sites in `canvas.go` + `canvas_curve_cache.go`'s `blitCurvePoints` converted; `HitAt`, `String()`, `CountColor` converted to `get`/`each`/`count`. 6 test files touching `.pixelTags` directly updated to the new API.

## Review round (F1–F6)

A pre-merge review reproduced all the original claims (including a better ringed-scene delta on the reviewer's machine, −8.7%) and all four original sabotage verifications, then found six issues. All addressed on `fix/369-idle-render-residuals` (commit `7d7d1c9`), F6 explicitly deferred:

- **F1 (should-fix, confirmed rendering divergence)** — `pixelTagGrid.set()` used the *stored value* as its touched-dedup sentinel (`tags[idx] == CellTag{}`). `FillProjectedSphere` calls `set()` unconditionally with `CellTag{Color: color}`, and every body in `alpha-centauri.json`, `trappist-1.json`, and `kepler-452.json` has `SurfaceColorHex() == ""` — `CellTag{Color: ""}` **is** the zero value. A zero write followed by a real write (an orbit path/descent arc/marker overpainting a horizon fill) landed the pixel in `touched` twice, so `pickDominantColor`'s per-cell vote double-counted it — a real, if narrow, rendering-correctness bug on those three star systems. **Fix**: `set()` now no-ops entirely on a zero-value tag (chosen over a generation-stamped array — this is semantically identical to the old map's "a zero write inserts an entry `pickDominantColor` always skips anyway" behavior, just skipping the pointless entry). Also gated the ring miss-path recording's `pixelTags` write the same way `blitCurvePoints`/`walkPixelSegment` already do, for consistency (not load-bearing once `set()` itself is fixed). New test: `TestPixelTagGridZeroThenRealDoesNotDoubleCountTouched` (zero-then-real / real-then-zero / zero-only sub-cases) — the existing overwrite test only covered real-then-real.

- **F2 (should-fix, confirmed memory)** — see "Memory" below. Fixed by switching `pixelTagGrid` from a dense `CellTag` array to the index+table design described in section 2. This went through **two** implementations after the first index+table pass regressed whole-frame time ~6% (see the "Whole-frame benchmarks" methodology note below for how that was caught and the "Perf note" for the root cause and fix) — `internTag`'s linear scan was replaced with a `map[CellTag]int32` lookup, gated behind the same last-tag fast path so per-pixel cost stays a single struct comparison in the common case.

- **F3 (nit)** — deleted the now-callerless `Canvas.RingTiltedOutline` wrapper; `RingTiltedOutlineTagged` stays (uncached test reference + the recording variant's shared body).

- **F4 (nit)** — fixed `ringCacheCap`'s comment: 4×64=256 is the exact arithmetic worst case, not headroom over an estimate; noted the reviewer's measured real max (~140 outlines/frame at deep zoom).

- **F5 (nit)** — ring curveIDs now come from `ringCurveIDsFor`, a per-body memoized `[bandIdx][outlineIdx]string` table, instead of `fmt.Sprintf` per outline per frame (up to ~140/frame at deep zoom).

- **F6 (optional, deferred)** — `touchRingCacheID`'s O(n) search+memmove per touch. Left as-is: it's the exact same shape as `touchCurveCacheID` (#367, unmodified since), fixing one without the other would be an inconsistency, and the reviewer's own benchmarks showed no live impact. A proper fix (doubly-linked list + map) isn't "trivial alongside F5," so out of scope for this pass.

## Memory (F2)

Measured via `runtime.ReadMemStats` before/after allocating 12 canvases (4 seats × 3 canvases/seat, matching the reviewer's scenario) at 200×50, each fully painted with `FillColoredDiskTagged` across a handful of distinct colors (worst case for retained memory: full coverage, still few distinct tags):

| implementation | heap delta (12 canvases) | per canvas |
|---|---|---|
| dense `[]CellTag` (F2's "original", reviewed) | 76.41 MB | ~6.08 MB |
| index + per-frame tag table (current) | 11.12 MB | ~0.90 MB |

**−85.4%, ~6.9× smaller.** The residual ~0.90 MB/canvas is not all `pixelTagGrid` — `drawille.Canvas` (the `dc` field, untouched by this PR) retains its own sparse `map[int]map[int]int` dot storage, which alone accounts for roughly ~0.58–0.6 MB of that at a fully-painted 200×50 canvas (nested-map bucket overhead on ~10,000 entries); `pixelTagGrid`'s own share is the expected ~320 KB (`int32 × 80,000` pixels) plus a small per-frame tag table. Not fixed here — a `drawille.Canvas` storage change is a separate, unrelated refactor outside this PR's scope.

## Benchmarks

**Isolated write-cost microbenchmark** (`BenchmarkPixelTagGridSet` vs `BenchmarkPixelTagsMapSetBaseline`, same binary, same run — 475 points/op, `-benchtime=2s -count=3`):

```
grid:     2857-2889 ns/op   6.01-6.08 ns/point
map:     23528-23907 ns/op  49.5-50.3 ns/point
```
~8.3× faster on the write itself, unchanged (within noise) from the pre-review-fix number — the map-based intern (F2's fix) doesn't touch the per-pixel write path.

**Hit-path microbenchmark** (`BenchmarkDrawEllipseClassCachedTaggedHit`, draw+Clear() round trip per iteration — Clear() also touches pixelTags now, so this is a superset of the pure write cost above; `-benchtime=2s -count=3`):
```
before (pre-#369, ~220-pt curve): 14731-14969 ns/op   66.96-68.04 ns/point
after (post-review-fix):           9533-9571 ns/op    43.33-43.51 ns/point
```
~36% faster end to end.

**Whole-frame idle yardstick**, `BenchmarkOrbitViewRenderIdle`/`…Ringed` (Apple M5, 120×40 canvas). **Methodology note**: the numbers in the original PR body used `git stash` to compare "current tree" against "pre-#369 main" sequentially within one session and reported −4.4%/−6.7%. Re-measuring properly for this update — **precompiled test binaries for three points (true pre-#369 main at `58b6a55`, the originally-reviewed commit `5395461`, and the current review-fixed tree), alternated round-robin (not run back to back)** — showed the original numbers were partly session-load drift: a later same-session re-measurement of the *original* PR state (no review fixes) actually showed session-to-session swings from −4.4% to +6% depending on when it was run. The three-way alternated comparison below is the trustworthy one (5 rounds each, `-benchtime=1.5s`, deltas computed from the 5-round averages):

| scene | true main (`58b6a55`) | reviewed PR (`5395461`) | current (review-fixed) | current vs main | current vs reviewed PR |
|---|---|---|---|---|---|
| default (no rings, item 2 only) | 1.768 ms | 1.702 ms | 1.730 ms | **−2.2%** | +1.6% |
| Saturn-focused (items 1+2) | 2.028 ms | 1.856 ms | 1.872 ms | **−7.7%** | +0.9% |

Honest framing: the review-fixed tree is a **small step back** from the originally-reviewed (buggy/unbounded-memory) version on both scenes — expected, since F1 adds an unconditional zero-tag check to every write and F2 trades the fastest-possible design for a bounded one — but it still beats true pre-#369 main on both, and by a solid margin on the scene that matters most (ringed, where the ring cache dominates). The default-scene win over main is now modest (−2.2%, down from the originally-claimed −4.4%, which the corrected methodology shows was inflated by session noise) but real and reproducible across the round-robin alternation.

## Test coverage + non-vacuousness

Widgets-level (`canvas_ring_cache_test.go`, `canvas_pixel_tags_test.go`, mirroring `canvas_curve_cache_test.go`'s shape): miss-matches-uncached, hit-on-repeat, color-only-change-still-hits, empty-curveID-never-caches, busts-on-view-change (pan/zoom/rebasis/resize), busts-on-embedding-change (center/radius/e1), tolerates-sub-pixel-jitter, LRU-bounded-across-many-curveIDs; plus direct `pixelTagGrid` unit tests (round-trip, out-of-bounds no-op, overwrite dedup, **zero-then-real / real-then-zero / zero-only — F1's regression test**, clear, resize-drops-stale, each-visits-exactly-set).

Screens-level (`orbit_ring_cache_test.go`, mirroring `orbit_curve_cache_test.go`): end-to-end hits-at-idle/busts-on-camera-change and cache-hit-matches-uncached-after-pan, driven through the real `OrbitView.Render` on a Saturn-focused world (the only scenario that puts ring bands on screen).

**Sabotage verification performed for every test whose whole point is "this fails on a real bug"** (all reverted after confirming):
- `TestRingTiltedOutlineCachedTaggedBustsOnViewChange`: dropped `scaleLogQ`/`basisQ`/`pxW`/`pxH` from the key → `rebasis` and `resize` sub-tests failed as expected (pan/zoom still caught it via `relCenter`/quantum-derived-from-scale side effects, confirming those two fields specifically cover rebasis+resize).
- `TestRingTiltedOutlineCachedTaggedToleratesSubPixelJitter`: tightened `ringBasisQuantum` to `1e-15` → failed as expected (busted on jitter that should've hit).
- `TestOrbitViewRingCacheHitsAtIdleAndBustsOnCameraChange` + `TestOrbitViewRingCacheHitMatchesUncachedAfterPan`: made `ringCacheKeyFor` use absolute `center` instead of camera-relative → both failed as expected (pan no longer busted the cache, stale-position mismatch on compare) — the exact #363-review regression class this key is designed to prevent.
- `TestPixelTagGridOverwriteDoesNotDoubleCountTouched`: removed the dedup-on-overwrite guard in `set()` → failed as expected (`count()` reported 2 instead of 1).
- `TestPixelTagGridZeroThenRealDoesNotDoubleCountTouched` (new, F1): removed the zero-tag no-op guard → `real-then-zero` and `zero-only` sub-cases failed as expected (a later zero write clobbered a real tag; a zero-only write registered as touched). `zero-then-real` did *not* fail under this specific sabotage — the current index+table design's touched-dedup flag (`tagIdx[idx]==0`, a presence bit) is independent of tag *content*, so that particular double-touch shape doesn't reproduce the way it did in the array-of-`CellTag` version the review actually found it in; the other two sub-cases still fully pin the "zero is a true no-op" contract. Documented in the test's own comment.

## What each cache key covers

- **Ring cache** (`ringCacheKey`): ring embedding (camera-relative center, e1/e2 basis, radius, all quantized) + canvas view state (scale, basis, pixel dims) — see `canvas_ring_cache.go`'s doc comments for the quantum derivations (reuses `curvePositionQuantum`/`curveShapeQuantum`/`curveScaleLogQuantum`/`curveBasisQuantum` from #367 rather than inventing new ones).
- **pixelTagGrid**: not a cache — a storage-layer swap. No key; `CellTag{}` zero-value is the untagged sentinel (now an explicit no-op, not just an assumed invariant — F1), `touched` tracks what's live this frame, `tags`/`tagLookup` are a per-frame dedup table cleared every `Clear()`.

## Verification

```
go build ./...
go vet ./...
go test ./... -race -count=1          # full suite, green
go test ./internal/tui/... -count=1   # x3, no order flakes
gofmt -l <all changed/added .go files>  # clean
```

## Non-goals / left out

- `--serve` unwatched-render throttle — tracked separately as #370, per the issue.
- Tick rate / physics untouched.
- No save-format changes.
- `RingColoredOutlineTagged`/`RingDottedColored` (sun corona, atmosphere haze, SOI ring, Inspect flare) — not named in the prod profile, and `RingDottedColored` already has its own ADR-0042 angle-window optimization; left uncached per the issue's scoping to `RingTiltedOutlineTagged` specifically.
- `drawille.Canvas`'s own nested-map dot storage (see "Memory" above) — a real residual retained-memory cost, but unrelated to `pixelTags`/the ring cache and out of scope for #369.
- F6 (`touchRingCacheID`'s O(n) LRU touch) — deferred, see review round above.
