### PR TITLE
Fix landed-vessel zoom-cap twitch from signed-zero altitude (#376)

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -783,7 +783,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// the HUD altitude readout. Skipped when the focus is unrelated
 	// (system view or a different body) so an unrelated zoom-in isn't
 	// surprisingly capped.
-	if c := w.ActiveCraft(); c != nil && c.Altitude() <= 0 {
+	if c := w.ActiveCraft(); c != nil && (c.Landed || c.Altitude() <= 0) {
 		focused := false
 		switch w.Focus.Kind {
 		case sim.FocusCraft:

--- a/internal/tui/screens/orbit_landed_zoom_cap_test.go
+++ b/internal/tui/screens/orbit_landed_zoom_cap_test.go
@@ -1,0 +1,73 @@
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestLandedZoomCapStableAcrossTicks is the regression test for #376:
+// a landed vessel's altitude is signed float noise around zero —
+// integrateLanded rebuilds R = radius * unit(lat, lon) every tick, so
+// |R| - radius is zero to float precision but flips sign tick to
+// tick — and orbit.go:786 gated the surface zoom cap on
+// `c.Altitude() <= 0`, a coin flip on that noise. At a zoom past the
+// point where the cap actually binds, this made the canvas scale (and
+// with it every drawn line) flip between two values roughly every
+// other frame. The fix additionally gates on `c.Landed`, which is
+// stable regardless of the sign noise.
+//
+// Zoomed to setUserZoom's max (1e4×, well past the cap for any body
+// in the catalog) so the assertion binds — per the issue, at wide
+// zoom (before the cap engages) scale stability holds even with the
+// bug present, which would make this test pass vacuously.
+func TestLandedZoomCapStableAcrossTicks(t *testing.T) {
+	v := NewOrbitView(plainTheme())
+	v.Resize(80, 24)
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := moonIdxOf(t, w)
+	moonID := w.System().Bodies[moonIdx].ID
+
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:    spacecraft.LoadoutSaturnVID,
+		ParentBodyID: moonID,
+		Launchpad:    true,
+		Latitude:     10,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: launchpad spawn should set Landed=true")
+	}
+	if w.Focus.Kind != sim.FocusCraft {
+		t.Fatalf("setup: expected FocusCraft after a launchpad spawn, got %v", w.Focus.Kind)
+	}
+
+	// Fit once, then zoom in to the manual-zoom ceiling so the surface
+	// cap (canvasReach / primary radius) is well and truly binding.
+	v.Render(w, 0, 80, 24)
+	for i := 0; i < 60; i++ {
+		v.ZoomIn()
+	}
+
+	const frames = 12
+	var scales [frames]float64
+	for i := 0; i < frames; i++ {
+		v.Render(w, 0, 80, 24)
+		scales[i] = v.canvas.Scale()
+		w.Tick()
+	}
+
+	for i := 1; i < frames; i++ {
+		if scales[i] != scales[0] {
+			t.Fatalf("canvas scale not stable across idle frames on a landed vessel: frame 0 scale=%.9e, frame %d scale=%.9e (zoom-cap flip from Altitude() sign noise — #376)",
+				scales[0], i, scales[i])
+		}
+	}
+}


### PR DESCRIPTION
## What changed

`internal/tui/screens/orbit.go:786` gated the landed surface zoom cap on `c.Altitude() <= 0`. For a landed vessel, `Altitude()` is float noise on the order of ~1e-9 m that flips sign every tick (`integrateLanded` rebuilds `R = radius * unit(lat, lon)` each tick, so `|R| - radius` is zero to float precision but alternates sign). That made the cap engage and disengage on alternating frames once zoomed close enough to see the ground, flipping the canvas scale ~2.05x and making the whole map (terrain, orbit lines, markers) twitch every other frame.

Fix: gate on `c.Landed || c.Altitude() <= 0` — stable regardless of the sign noise, while still catching a vessel below the surface without the `Landed` flag set (the presumed original intent of the float check).

## Regression test

Added `TestLandedZoomCapStableAcrossTicks` in `internal/tui/screens/orbit_landed_zoom_cap_test.go`: spawns a Saturn V on the Moon's launchpad (`Landed=true`), zooms in to the manual-zoom ceiling (well past where the surface cap binds), then renders 12 consecutive frames interleaved with `w.Tick()` (only sim time advancing) and asserts `canvas.Scale()` is identical across all of them.

**Sabotage check** (guard reverted to the original `c.Altitude() <= 0` only, run 5x with `-count=5`): fails deterministically every run —

```
canvas scale not stable across idle frames on a landed vessel: frame 0 scale=7.252215955e-02, frame 3 scale=1.381374468e-04 (zoom-cap flip from Altitude() sign noise — #376)
```

With the fix restored: passes 5/5.

## Survey of other zero-boundary sites (not changed here)

Per the issue's "worth a look while in there," I searched for other places a landed vessel's altitude/apoapsis/radius is compared against zero to mean "on the ground":

- `internal/tui/screens/orbit_chip_builders.go` (~lines 1073–1160, 1316–1394) and the ellipse-drawing sites at `orbit.go:1164` / `orbit.go:1283` — these already show the same signed-zero pattern (the file even has an existing comment at line ~1094 documenting it for `apoAlt`/`rApo`). Per the task's scope boundary these are explicitly **#375's territory** (chip builders + ellipse drawing) and were intentionally left untouched.
- `internal/sim/ascent.go:213` and `internal/sim/descent.go:463` (`rNorm <= 0 || alt <= 0`) — these functions already gate on `c.Landed` at the top (`if c == nil || c.Landed || c.Crashed { return ... }`), so the later zero check can't be reached by a landed vessel's noise. Not a live instance of the bug.
- `internal/sim/focus.go:201` (`alt := ...R.Norm(); if alt <= 0 { alt = ...RadiusMeters()*2 }`) — a defensive fallback for a degenerate zero-radius state vector, not a "landed" test.
- `internal/sim/world.go:1864` / `:1938` (`periAlt < 0` in `canKeplerStepState`) — Kepler-step feasibility on a coasting orbit's derived periapsis, unrelated to the `Landed` flag.
- `internal/tui/screens/orbit_chip_builders.go:1510` (`alt <= 0` → "IMPACT") — a predicted-trajectory impact flag on a future closest-approach, not live landed-state noise.

None of these are additional live instances of this issue's exact defect (a `Landed` vessel's own signed-zero altitude flipping a boolean); they were checked and ruled out.

Closes #376