### PR TITLE
fix: surface view chase-cam axis follows velocity, not attitude (#378)

### DIFF
--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -52,9 +52,25 @@ type LaunchView struct {
 	// instead. chaseHAxis latches the last velocity-derived axis
 	// through that dead zone. Re-keyed on active-craft change (mirrors
 	// vzCraft) so switching vessels doesn't inherit a stale heading.
-	hAxisCraft   *spacecraft.Spacecraft
-	hAxisLatched bool
-	hAxisValue   orbital.Vec3
+	//
+	// hAxisWasLanded is the same craft's Landed value as of the
+	// previous chaseHAxis call, used to detect the true→false
+	// (liftoff) edge — a second #380-review-round finding: a
+	// touchdown-latched axis is otherwise still sitting on
+	// hAxisValue when the vessel relaunches, and the early vertical
+	// climb's horizontal speed (~0.01-0.1 m/s of integrator noise,
+	// TestChaseHAxisStaysEastDuringVerticalClimb) stays under the
+	// floor for seconds, not one tick — long enough for the stale
+	// touchdown heading (an arbitrary direction from a previous
+	// flight, possibly minutes earlier) to visibly hold instead of
+	// the surface-frame-east a fresh pad spawn would show. Clearing
+	// on false→true (touchdown itself) would reintroduce the
+	// touchdown-mirroring this latch exists to prevent, so the reset
+	// has to sit on the liftoff edge specifically, not on landing.
+	hAxisCraft     *spacecraft.Spacecraft
+	hAxisLatched   bool
+	hAxisValue     orbital.Vec3
+	hAxisWasLanded bool
 }
 
 // NewLaunchView constructs the chase-cam screen, paired with the
@@ -747,11 +763,34 @@ func chaseHorizontalAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, ca
 // LaunchView (or a craft that's never had a valid velocity-derived
 // axis — the pad-spawn case the floor was originally for) has nothing
 // to latch, so it still falls back to surface-frame east.
+//
+// Second #380-review-round finding: holding the latch is right while a
+// vessel sits parked after touchdown (the scene is static; nothing
+// visibly moves), but wrong once the SAME vessel relaunches — the early
+// climb's horizontal speed stays under chaseHorizSpeedFloorMps for
+// seconds (TestChaseHAxisStaysEastDuringVerticalClimb measures ~0.014
+// m/s there, ~7x under the 0.1 m/s floor), long enough for a stale
+// touchdown heading from a previous flight to visibly hold instead of
+// the surface-frame-east a fresh pad spawn would show. Clearing the
+// latch belongs on LIFTOFF (Landed true→false), not on touchdown
+// (Landed false→true) — clearing on touchdown would snap the axis to
+// east at the exact instant of landing, reintroducing the mirroring
+// this latch exists to prevent. c.Landed flips false→true exactly at
+// ground contact (applySurfaceArrival, internal/sim/lifecycle.go) and
+// true→false exactly at engine ignition on a parked craft
+// (StartManualBurn / planted-node ignition, internal/sim/maneuver.go)
+// — so hAxisWasLanded tracks the previous call's Landed value per craft
+// and the latch clears only on the true→false edge.
 func (v *LaunchView) chaseHAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) orbital.Vec3 {
 	if v.hAxisCraft != c {
 		v.hAxisCraft = c
 		v.hAxisLatched = false
+	} else if v.hAxisWasLanded && !c.Landed {
+		// Liftoff: don't let a touchdown heading from a previous
+		// flight (or minutes-ago landing) bleed into the new ascent.
+		v.hAxisLatched = false
 	}
+	v.hAxisWasLanded = c.Landed
 	if axis, ok := chaseHorizVelocityAxis(c, body, camFromBody, localUp); ok {
 		v.hAxisValue = axis
 		v.hAxisLatched = true

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -39,6 +39,22 @@ type LaunchView struct {
 	vzCraft *spacecraft.Spacecraft
 	vzAltM  float64
 	vzAtSim time.Time
+
+	// hAxisCraft/hAxisLatched/hAxisValue cache the chase-cam's
+	// horizontal axis across renders (issue #380 review, following
+	// #378). The axis is derived from surface-relative horizontal
+	// velocity, which crosses chaseHorizSpeedFloorMps on every
+	// touchdown — the pilot is deliberately nulling it there — and can
+	// even reverse sign on a braking overshoot. Recomputing from
+	// scratch at that crossing would snap to an unrelated
+	// surface-frame-east default, or flip 180°: the same whole-scene
+	// mirroring #378 removed from burn start, reappearing at touchdown
+	// instead. chaseHAxis latches the last velocity-derived axis
+	// through that dead zone. Re-keyed on active-craft change (mirrors
+	// vzCraft) so switching vessels doesn't inherit a stale heading.
+	hAxisCraft   *spacecraft.Spacecraft
+	hAxisLatched bool
+	hAxisValue   orbital.Vec3
 }
 
 // NewLaunchView constructs the chase-cam screen, paired with the
@@ -388,11 +404,12 @@ func (v *LaunchView) renderNoActiveVesselMessage() {
 // non-nil and craft.Primary has a non-zero radius.
 //
 // Camera basis (per ADR-0002 + plan, amended by issue #378): X =
-// h_axis (surface-relative horizontal velocity, falling back to
-// surface-frame east when horizontal speed is near zero); Y =
-// local-up (radial from body centre). Depth axis points laterally —
-// useful for hemisphere culling. ViewTilt.Theta is suppressed inside
-// ViewLaunch per ADR-0002.
+// h_axis (surface-relative horizontal velocity, latched through
+// touchdown/near-zero-speed dips per v.chaseHAxis, falling back to
+// surface-frame east only when nothing has latched yet); Y = local-up
+// (radial from body centre). Depth axis points laterally — useful for
+// hemisphere culling. ViewTilt.Theta is suppressed inside ViewLaunch
+// per ADR-0002.
 func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, corridor sim.DescentCorridor, descending bool, ascent sim.AscentCue, ascending bool) {
 	body := craft.Primary
 	// craft.State.R is primary-relative (Earth-centred for a LEO craft,
@@ -410,7 +427,7 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, cor
 	bodyCentre := orbital.Vec3{}
 	camWorld := camFromBody
 	localUp := camFromBody.Scale(1.0 / camDist)
-	hAxis := chaseHorizontalAxis(craft, body, camFromBody, localUp)
+	hAxis := v.chaseHAxis(craft, body, camFromBody, localUp)
 
 	basis := widgets.Basis{X: hAxis, Y: localUp}
 	v.canvas.SetBasis(basis)
@@ -624,11 +641,42 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 // speed up or slow down the visual pulse.
 const flameFrameMs = 100
 
-// chaseHorizontalAxis computes the projection-plane horizontal axis:
-// the surface-relative velocity's horizontal component, normalised,
-// falling back to surface-frame east at the craft's surface point
-// when that horizontal speed is near zero (rocket on the pad / a pure
-// vertical climb or drop).
+// chaseHorizVelocityAxis is chaseHorizontalAxis's raw half: the
+// surface-relative velocity's horizontal component, normalised, and
+// whether its magnitude clears chaseHorizSpeedFloorMps. ok=false means
+// "no meaningful direction of travel this frame" (rocket on the pad, a
+// pure vertical climb/drop, or a pilot flaring through zero horizontal
+// speed at touchdown) — the axis returned in that case is the zero
+// vector and callers must not use it directly.
+//
+// Split out from chaseHorizontalAxis so LaunchView.chaseHAxis can
+// latch on ok=true and hold through ok=false instead of recomputing a
+// fallback from scratch every frame (issue #380 review, following
+// #378's whole-scene-mirror fix — see chaseHAxis's doc comment).
+func chaseHorizVelocityAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) (orbital.Vec3, bool) {
+	vRel := physics.AirRelativeVelocity(camFromBody, c.State.V, body)
+	vVert := vRel.Dot(localUp)
+	horiz := vRel.Sub(localUp.Scale(vVert))
+	if n := horiz.Norm(); n > chaseHorizSpeedFloorMps {
+		return horiz.Scale(1.0 / n), true
+	}
+	return orbital.Vec3{}, false
+}
+
+// chaseSurfaceEastAxis returns the surface-frame-east unit vector at
+// camFromBody, as an orbital.Vec3. Small wrapper so both
+// chaseHorizontalAxis and LaunchView.chaseHAxis share the exact same
+// fallback computation.
+func chaseSurfaceEastAxis(body bodies.CelestialBody, camFromBody orbital.Vec3) orbital.Vec3 {
+	east := render.BodyFrameEast(body, render.Vec3{X: camFromBody.X, Y: camFromBody.Y, Z: camFromBody.Z})
+	return orbital.Vec3{X: east.X, Y: east.Y, Z: east.Z}
+}
+
+// chaseHorizontalAxis computes the projection-plane horizontal axis
+// STATELESSLY: the surface-relative velocity's horizontal component,
+// normalised, falling back to surface-frame east at the craft's
+// surface point when that horizontal speed is near zero (rocket on
+// the pad / a pure vertical climb or drop).
 //
 // Issue #378: this used to derive X from CurrentAttitudeDir — the
 // *commanded* attitude — projected onto the local horizontal. That is
@@ -655,15 +703,64 @@ const flameFrameMs = 100
 // class of noise v0.11.1's chaseHorizEpsilon threshold used to guard
 // against on the attitude vector) rather than a meaningful direction
 // of travel, so the axis falls back to surface-frame east.
+//
+// This stateless function is what the production scene used to call
+// directly. It's kept — unchanged in signature and behaviour — as the
+// building block chaseHorizVelocityAxis/chaseSurfaceEastAxis compose,
+// and as a plain reference implementation the dot-product tests pin
+// directly. The render path itself now goes through the stateful
+// LaunchView.chaseHAxis below, which adds latching so the fallback
+// here isn't reached mid-flight at every touchdown (issue #380
+// review).
 func chaseHorizontalAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) orbital.Vec3 {
-	vRel := physics.AirRelativeVelocity(camFromBody, c.State.V, body)
-	vVert := vRel.Dot(localUp)
-	horiz := vRel.Sub(localUp.Scale(vVert))
-	if n := horiz.Norm(); n > chaseHorizSpeedFloorMps {
-		return horiz.Scale(1.0 / n)
+	if axis, ok := chaseHorizVelocityAxis(c, body, camFromBody, localUp); ok {
+		return axis
 	}
-	east := render.BodyFrameEast(body, render.Vec3{X: camFromBody.X, Y: camFromBody.Y, Z: camFromBody.Z})
-	return orbital.Vec3{X: east.X, Y: east.Y, Z: east.Z}
+	return chaseSurfaceEastAxis(body, camFromBody)
+}
+
+// chaseHAxis is renderScene's actual horizontal-axis call: a stateful,
+// per-LaunchView wrapper around chaseHorizVelocityAxis that latches the
+// last velocity-derived axis instead of recomputing a fallback from
+// scratch every frame (issue #380 review of #378).
+//
+// Why this matters: the axis is stateless-by-velocity, so |v_horiz|
+// crosses chaseHorizSpeedFloorMps exactly when a pilot deliberately
+// nulls horizontal speed for touchdown — the moment it costs the most
+// to get wrong. Recomputing surface-frame east at that crossing snaps
+// the whole scene (impact marker, pad, tower, trail, rocket lean) to
+// an unrelated direction; a braking overshoot that carries the
+// horizontal component through zero to the opposite sign would instead
+// flip the scene 180°. Either way it's the same whole-scene mirroring
+// #378 set out to remove, relocated from burn start to touchdown. The
+// old attitude-derived rule had its own version of this (the v0.11.0
+// east/west flip during vertical climb, "fixed" by raising an
+// epsilon) — raising thresholds doesn't close the class, latching
+// does.
+//
+// LaunchView owns this state, not the spacecraft: screens read from
+// the shared world and don't mutate it (see the package doc comment on
+// World/screens), and "which way the camera happens to be facing right
+// now" is a rendering concern, not simulation state. Mirrors vzCraft's
+// pattern: re-keyed on active-craft change so switching vessels can't
+// inherit a stale heading from a different craft, and a fresh
+// LaunchView (or a craft that's never had a valid velocity-derived
+// axis — the pad-spawn case the floor was originally for) has nothing
+// to latch, so it still falls back to surface-frame east.
+func (v *LaunchView) chaseHAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) orbital.Vec3 {
+	if v.hAxisCraft != c {
+		v.hAxisCraft = c
+		v.hAxisLatched = false
+	}
+	if axis, ok := chaseHorizVelocityAxis(c, body, camFromBody, localUp); ok {
+		v.hAxisValue = axis
+		v.hAxisLatched = true
+		return axis
+	}
+	if v.hAxisLatched {
+		return v.hAxisValue
+	}
+	return chaseSurfaceEastAxis(body, camFromBody)
 }
 
 // chaseHorizSpeedFloorMps is the surface-relative horizontal speed

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -387,9 +387,9 @@ func (v *LaunchView) renderNoActiveVesselMessage() {
 // and active-vessel glyph into v.canvas. Caller guarantees craft is
 // non-nil and craft.Primary has a non-zero radius.
 //
-// Camera basis (per ADR-0002 + plan): X = h_axis (commanded-attitude
-// projected onto the local-horizontal plane, falling back to surface-
-// frame east when the commanded direction is near-vertical); Y =
+// Camera basis (per ADR-0002 + plan, amended by issue #378): X =
+// h_axis (surface-relative horizontal velocity, falling back to
+// surface-frame east when horizontal speed is near zero); Y =
 // local-up (radial from body centre). Depth axis points laterally —
 // useful for hemisphere culling. ViewTilt.Theta is suppressed inside
 // ViewLaunch per ADR-0002.
@@ -625,39 +625,57 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 const flameFrameMs = 100
 
 // chaseHorizontalAxis computes the projection-plane horizontal axis:
-// the commanded (CurrentAttitudeDir) projection onto the local-
-// horizontal plane when its magnitude is well-defined, falling back
-// to surface-frame east at the craft's surface point when the
-// attitude is near-vertical (rocket on the pad / just after liftoff).
+// the surface-relative velocity's horizontal component, normalised,
+// falling back to surface-frame east at the craft's surface point
+// when that horizontal speed is near zero (rocket on the pad / a pure
+// vertical climb or drop).
 //
-// Threshold: |horiz| > sin(~0.6°) ≈ 0.01. v0.11.0 shipped at 1e-9
-// which filtered only floating-point dust — but the integrator's
-// per-tick snap leaves CurrentAttitudeDir lagging localUp by the
-// rocket's per-tick rotation in inertial frame (ω·Δt at engine
-// ignition: 3.6e-6 rad at Earth's spin × 50 ms base step). That lag
-// is ~3600× above 1e-9, so `horiz` picked up the lag vector and
-// normalised it to a unit west-ish direction during pure vertical
-// climb, flipping the chase-cam east↔west until the player applied
-// pitch trim. v0.11.1 raises the floor above the warp-scaled lag
-// (≤ ~1e-4 rad at the 10× burn warp cap) but well below the
-// smallest meaningful pitch trim (one step = 5° = 0.087 rad) — the camera
-// orients east during vertical climb (intent), then swings to the
-// pitch direction as the player gravity-turns.
+// Issue #378: this used to derive X from CurrentAttitudeDir — the
+// *commanded* attitude — projected onto the local horizontal. That is
+// the same instruction as "align with travel" during an ascent's
+// gravity turn (nose and velocity point the same way), but on a
+// braking descent the pilot points surface-retrograde, so the old
+// rule pointed screen-right *against* travel: an exact -1.000 dot
+// product between the old axis and horizontal velocity, i.e. the
+// whole surface view mirrored rather than merely skewed. Orienting by
+// velocity instead gives one rule for both halves of the surface view
+// and makes screen-right "the way the vessel is going," always — the
+// nose can then draw pointing left during a braking burn instead of
+// the world flipping to keep it pointing right.
+//
+// Uses physics.AirRelativeVelocity (not the raw inertial V) to match
+// descentKinematics — the surface view is a ground-relative
+// instrument, and a fast-rotating primary would otherwise reintroduce
+// a smaller version of the same disagreement between the camera axis
+// and what the ground actually does underneath the craft.
+//
+// Speed floor: chaseHorizSpeedFloorMps. Below it the horizontal
+// velocity is noise (numerical residue at rest on the pad, or the
+// per-tick integrator wobble during a near-vertical climb — the same
+// class of noise v0.11.1's chaseHorizEpsilon threshold used to guard
+// against on the attitude vector) rather than a meaningful direction
+// of travel, so the axis falls back to surface-frame east.
 func chaseHorizontalAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, camFromBody, localUp orbital.Vec3) orbital.Vec3 {
-	cmd := c.CurrentAttitudeDir
-	if cmd.Norm() > 0 {
-		horiz := cmd.Sub(localUp.Scale(cmd.Dot(localUp)))
-		if n := horiz.Norm(); n > chaseHorizEpsilon {
-			return horiz.Scale(1.0 / n)
-		}
+	vRel := physics.AirRelativeVelocity(camFromBody, c.State.V, body)
+	vVert := vRel.Dot(localUp)
+	horiz := vRel.Sub(localUp.Scale(vVert))
+	if n := horiz.Norm(); n > chaseHorizSpeedFloorMps {
+		return horiz.Scale(1.0 / n)
 	}
 	east := render.BodyFrameEast(body, render.Vec3{X: camFromBody.X, Y: camFromBody.Y, Z: camFromBody.Z})
 	return orbital.Vec3{X: east.X, Y: east.Y, Z: east.Z}
 }
 
-// chaseHorizEpsilon — sin(~0.6°). See chaseHorizontalAxis docstring
-// for the slew-lag vs. pitch-trim noise-floor derivation.
-const chaseHorizEpsilon = 0.01
+// chaseHorizSpeedFloorMps is the surface-relative horizontal speed
+// (m/s) below which chaseHorizontalAxis treats the direction of
+// travel as undefined and falls back to surface-frame east. Measured
+// (TestChaseHAxisStaysEastDuringVerticalClimb's scenario) at ~0.014
+// m/s of horizontal drift from per-tick integrator noise during a
+// vertical climb with zero pitch trim; set an order of magnitude
+// above that and below sim.fpaSpeedFloorMps's 1.0 m/s convention for
+// "is this vessel usefully moving" so a real, if gentle, sideways
+// drift still steers the camera.
+const chaseHorizSpeedFloorMps = 0.1
 
 // drawHorizonAndFill paints the body's projected silhouette below the
 // horizon with SurfaceColor. In the chase-cam basis (h_axis,

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -660,6 +660,73 @@ func TestChaseHAxisDoesNotFlipOnSignReversalOvershoot(t *testing.T) {
 	}
 }
 
+// TestChaseHAxisResetsOnLiftoffAfterTouchdownLatch — issue #380 review,
+// second round: the touchdown latch is right to hold WHILE a vessel
+// sits parked (the scene is static, nothing visibly moves), but wrong
+// once the SAME vessel relaunches. The early vertical climb's
+// horizontal speed stays under chaseHorizSpeedFloorMps for seconds, not
+// one tick (TestChaseHAxisStaysEastDuringVerticalClimb measures ~0.014
+// m/s there), so without an explicit reset the latch would hold the
+// heading from whenever the vessel touched down — an arbitrary
+// direction from a previous flight, unrelated to the new ascent — for
+// that whole window instead of the surface-frame-east a fresh pad spawn
+// shows.
+//
+// End-to-end sequence pinned here: land travelling in a distinct
+// non-east horizontal direction, confirm the latch holds through
+// touchdown itself (Landed false->true must NOT reset it — that would
+// reintroduce the touchdown mirroring this latch exists to prevent),
+// then lift off (Landed true->false) and confirm the still-near-zero
+// early-climb horizontal speed now renders surface-frame east rather
+// than the stale touchdown heading.
+func TestChaseHAxisResetsOnLiftoffAfterTouchdownLatch(t *testing.T) {
+	// Distinct, non-east horizontal direction: air-relative velocity
+	// along body-frame Z (east sits along Y here — see
+	// touchdownFlareCraft's doc comment). 5 m/s, comfortably above the
+	// floor, establishes a real latch while still descending.
+	c, moon, camFromBody, localUp := touchdownFlareCraft(t, 5.0)
+	v := NewLaunchView(launchThemeForTest(), NewOrbitView(launchThemeForTest()))
+
+	axisDescending := v.chaseHAxis(c, moon, camFromBody, localUp)
+	eastV := chaseSurfaceEastAxis(moon, camFromBody)
+	if dot := axisDescending.Dot(eastV); dot > 0.5 {
+		t.Fatalf("setup: descending axis should not already be east-ish (dot=%.4f) — "+
+			"the test needs a heading clearly distinguishable from the fallback", dot)
+	}
+
+	// Touchdown: Landed flips false -> true (applySurfaceArrival,
+	// internal/sim/lifecycle.go). Horizontal air-relative velocity
+	// nulls to co-rotating (~0), as a real soft landing leaves it.
+	c.Landed = true
+	setAirRelativeFlareVelocity(c, moon, 0, 0)
+	axisLanded := v.chaseHAxis(c, moon, camFromBody, localUp)
+	if dot := axisDescending.Dot(axisLanded); dot < 0.999 {
+		t.Errorf("axis moved across touchdown itself: descending·landed = %.4f "+
+			"(want ~1.0 — the latch must hold through landing, not reset there)", dot)
+	}
+
+	// Liftoff: Landed flips true -> false (StartManualBurn /
+	// planted-node ignition, internal/sim/maneuver.go). Horizontal
+	// speed during the early vertical climb is integrator noise, well
+	// under the floor — same order of magnitude as
+	// TestChaseHAxisStaysEastDuringVerticalClimb's ~0.014 m/s and a
+	// fresh pad spawn's early frames.
+	c.Landed = false
+	setAirRelativeFlareVelocity(c, moon, -2, 0.01)
+	axisAscending := v.chaseHAxis(c, moon, camFromBody, localUp)
+
+	if dot := axisAscending.Dot(eastV); dot < 0.999 {
+		t.Errorf("post-liftoff axis is not surface-frame east: dot(ascending,east) = %.4f "+
+			"(want ~1.0 — a relaunch should start from the same fallback a fresh pad "+
+			"spawn gets)", dot)
+	}
+	if dot := axisAscending.Dot(axisLanded); dot > 0.5 {
+		t.Errorf("post-liftoff axis still resembles the stale touchdown heading: "+
+			"dot(ascending,landed) = %.4f (want small — liftoff should have cleared "+
+			"the touchdown latch)", dot)
+	}
+}
+
 // During vertical climb (Radial+, no pitch trim), the chase-cam's
 // horizontal axis must remain body-frame east. v0.11.0 ships with
 // epsilon = 1e-9 in chaseHorizontalAxis, which is below the per-tick

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
@@ -355,6 +357,201 @@ func TestCraftInDifferentSOIDoesNotRender(t *testing.T) {
 	out := v.Render(w, 120, 40)
 	if strings.Contains(out, "Ω") {
 		t.Errorf("expected sister-in-Luna-SOI to be culled, got:\n%s", out)
+	}
+}
+
+// brakingDescentCraft builds a Luna descent scenario matching issue
+// #378's measured repro: 20 km altitude, 400 m/s surface-relative
+// horizontal speed, 40 m/s descent rate. R sits along body-frame X so
+// "horizontal" here is the Y axis; V's X component is the (radially
+// inward) descent rate and Y is the horizontal speed. attitudeRetro
+// selects which way the nose points — surface-retrograde (braking,
+// opposing the horizontal velocity) when true, surface-prograde
+// (opposing the braking, i.e. pointing with travel) when false — so
+// callers can flip attitude at a fixed velocity without touching
+// anything else.
+func brakingDescentCraft(t *testing.T, attitudeRetro bool) (*spacecraft.Spacecraft, bodies.CelestialBody) {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		t.Fatal("setup: Moon not found in default system")
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("setup: NewWorld should produce an active craft")
+	}
+	c.Primary = *moon
+	c.Landed = false
+	c.Crashed = false
+	c.State.R = orbital.Vec3{X: moon.RadiusMeters() + 20_000}
+	c.State.V = orbital.Vec3{X: -40, Y: 400}
+	c.State.M = c.TotalMass()
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	if attitudeRetro {
+		c.CurrentAttitudeDir = vRel.Scale(-1.0 / vRel.Norm()) // surface-retrograde: braking
+	} else {
+		c.CurrentAttitudeDir = vRel.Scale(1.0 / vRel.Norm()) // surface-prograde
+	}
+	return c, *moon
+}
+
+// horizVelUnit returns the unit vector of the surface-relative
+// horizontal velocity component (the same quantity chaseHorizontalAxis
+// is now supposed to track), computed independently of
+// chaseHorizontalAxis so the test isn't just re-deriving the
+// production formula and comparing it to itself.
+func horizVelUnit(c *spacecraft.Spacecraft, localUp orbital.Vec3) orbital.Vec3 {
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	horiz := vRel.Sub(localUp.Scale(vRel.Dot(localUp)))
+	return horiz.Scale(1.0 / horiz.Norm())
+}
+
+// TestChaseHAxisAlignsWithHorizVelocityDuringBraking pins issue #378's
+// measurement, inverted: on a braking (surface-retrograde) descent,
+// the old attitude-derived axis measured hAxis·v̂_horiz = -1.000 exactly
+// (the scene mirrored, not skewed). The fixed axis must measure
+// strictly positive — screen-right is the way the vessel is going,
+// even while the nose points backwards to brake.
+func TestChaseHAxisAlignsWithHorizVelocityDuringBraking(t *testing.T) {
+	c, moon := brakingDescentCraft(t, true /* retrograde: braking */)
+	camFromBody := c.State.R
+	localUp := camFromBody.Scale(1.0 / camFromBody.Norm())
+
+	hAxis := chaseHorizontalAxis(c, moon, camFromBody, localUp)
+	vHat := horizVelUnit(c, localUp)
+
+	dot := hAxis.Dot(vHat)
+	if dot <= 0 {
+		t.Fatalf("braking descent: hAxis·v̂_horiz = %.4f (want > 0; the issue #378 "+
+			"measurement was exactly -1.000 — screen-right pointed against travel)", dot)
+	}
+	if dot < 0.999 {
+		t.Errorf("braking descent: hAxis·v̂_horiz = %.4f (want ~1.0 — hAxis should be "+
+			"the horizontal-velocity direction itself, not merely same-signed)", dot)
+	}
+}
+
+// TestChaseHAxisSenseStableAcrossAttitudeFlip: acceptance criterion —
+// switching the pilot's commanded attitude between surface-prograde and
+// surface-retrograde at a fixed velocity must not change which way the
+// camera's horizontal axis points. Attitude no longer has any say in
+// this axis; only velocity does.
+func TestChaseHAxisSenseStableAcrossAttitudeFlip(t *testing.T) {
+	cRetro, moon := brakingDescentCraft(t, true)
+	camFromBody := cRetro.State.R
+	localUp := camFromBody.Scale(1.0 / camFromBody.Norm())
+	hAxisRetro := chaseHorizontalAxis(cRetro, moon, camFromBody, localUp)
+
+	cPro, _ := brakingDescentCraft(t, false)
+	hAxisPro := chaseHorizontalAxis(cPro, moon, camFromBody, localUp)
+
+	if dot := hAxisRetro.Dot(hAxisPro); dot < 0.999 {
+		t.Errorf("chase axis changed when attitude flipped prograde<->retrograde at a "+
+			"fixed velocity: hAxisRetro·hAxisPro = %.4f (want ~1.0 — pointing the nose "+
+			"around must not mirror the world)", dot)
+	}
+}
+
+// TestChaseHAxisFallsBackToEastBelowSpeedFloor: acceptance criterion —
+// a pad-bound vessel (zero *surface-relative* velocity) must still get
+// surface-frame east, unchanged from before this fix. Uses the same
+// pad-spawn helper the vertical-climb regression test below relies on,
+// but asserts the floor directly on a Landed, unignited craft rather
+// than mid-ascent.
+//
+// Note: c.State.V (inertial) is NOT zero here — a landed craft
+// co-rotates with the body, so it carries the body's rotational
+// velocity at that latitude (~408 m/s at KSC's 28.6°N). It's the
+// *air-relative* velocity (physics.AirRelativeVelocity, what
+// chaseHorizontalAxis actually uses) that's ~0 for a vessel sitting
+// still on the ground — that's the quantity this test's floor check
+// is really about.
+func TestChaseHAxisFallsBackToEastBelowSpeedFloor(t *testing.T) {
+	_, c := spawnSaturnVOnPad(t)
+	if got := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary).Norm(); got > chaseHorizSpeedFloorMps {
+		t.Fatalf("setup: pad-bound craft should be at rest relative to the ground, "+
+			"got |v_rel|=%.6f m/s (>= floor %.2f)", got, chaseHorizSpeedFloorMps)
+	}
+
+	camFromBody := c.State.R
+	localUp := camFromBody.Scale(1.0 / camFromBody.Norm())
+	hAxis := chaseHorizontalAxis(c, c.Primary, camFromBody, localUp)
+
+	rR := render.Vec3{X: c.State.R.X, Y: c.State.R.Y, Z: c.State.R.Z}
+	eastR := render.BodyFrameEast(c.Primary, rR)
+	eastV := orbital.Vec3{X: eastR.X, Y: eastR.Y, Z: eastR.Z}
+	if dot := hAxis.Dot(eastV); dot < 0.999 {
+		t.Errorf("pad-bound vessel (V=0): hAxis·east = %.4f (want ~1.0 — a stationary "+
+			"vessel has no direction of travel, so the axis must fall back to "+
+			"surface-frame east, matching pre-fix behaviour)", dot)
+	}
+}
+
+// TestDescentArcAheadTrailBehindOnScreen — acceptance criterion: the
+// descent arc/impact point projects to screen-right (ahead, ok=true
+// side of centre) and a trail breadcrumb behind the vessel projects to
+// screen-left, using the real DescentCorridorFor forecast and the real
+// LaunchView.Render pipeline (not a hand-rolled projection), on the
+// same braking-descent scenario as the dot-product tests above.
+func TestDescentArcAheadTrailBehindOnScreen(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		t.Fatal("setup: Moon not found in default system")
+	}
+	c := w.ActiveCraft()
+	c.Primary = *moon
+	c.Landed = false
+	c.Crashed = false
+	c.State.R = orbital.Vec3{X: moon.RadiusMeters() + 20_000}
+	c.State.V = orbital.Vec3{X: -40, Y: 400}
+	c.State.M = c.TotalMass()
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	c.CurrentAttitudeDir = vRel.Scale(-1.0 / vRel.Norm()) // braking: nose backwards
+
+	// A trail breadcrumb ~60s behind the current position (roughly
+	// along -V — good enough for a directional check over a short
+	// baseline), stored body-fixed the way maybeSampleLaunchTrail does.
+	pastWorld := c.State.R.Sub(c.State.V.Scale(60))
+	pastUnit := pastWorld.Scale(1.0 / pastWorld.Norm())
+	pastAlt := pastWorld.Norm() - moon.RadiusMeters()
+	pastLat, pastLon := render.WorldToBodyFixed(*moon, render.Vec3{X: pastUnit.X, Y: pastUnit.Y, Z: pastUnit.Z}, w.Clock.SimTime)
+	w.LaunchTrail = []sim.TrailPoint{{LatDeg: pastLat, LonDeg: pastLon, AltM: pastAlt, SampledAt: w.Clock.SimTime}}
+
+	corridor, descending := sim.DescentCorridorFor(c, sim.DescentPredictHorizon)
+	if !descending {
+		t.Fatal("setup: expected the scenario to gate as descending")
+	}
+	if len(corridor.Impact.Path) < 2 {
+		t.Fatal("setup: expected a forecast impact path")
+	}
+
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Render(w, 80, 24)
+
+	pxCenter := v.canvas.Cols()                               // canvas pxW = cols*2, so pxW/2 == cols
+	impactPx, _, _ := v.canvas.Project(corridor.Impact.Point) // body-relative; bodyCentre is the origin
+	if impactPx <= pxCenter {
+		t.Errorf("descent impact point projected at px=%d, canvas centre=%d — want strictly "+
+			"right of centre (ahead, in the direction of travel)", impactPx, pxCenter)
+	}
+
+	trailWorld := render.BodyFixedToWorld(*moon, pastLat, pastLon, w.Clock.SimTime)
+	trailPt := orbital.Vec3{X: trailWorld.X, Y: trailWorld.Y, Z: trailWorld.Z}.Scale(moon.RadiusMeters() + pastAlt)
+	trailPx, _, _ := v.canvas.Project(trailPt)
+	if trailPx >= pxCenter {
+		t.Errorf("trail breadcrumb projected at px=%d, canvas centre=%d — want strictly "+
+			"left of centre (behind, opposite the direction of travel)", trailPx, pxCenter)
 	}
 }
 

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -555,6 +555,111 @@ func TestDescentArcAheadTrailBehindOnScreen(t *testing.T) {
 	}
 }
 
+// setAirRelativeFlareVelocity sets c.State.V so that
+// physics.AirRelativeVelocity(c.State.R, c.State.V, moon) — the
+// quantity chaseHorizontalAxis/chaseHAxis actually consume — comes out
+// to exactly {X: radialMps, Z: horizZMps}. The Moon is tidally locked,
+// so a fixed body-frame position still co-rotates with it at a
+// non-trivial rate (~4.6 m/s at low lunar altitude); setting c.State.V
+// (inertial) directly, as an earlier version of these tests did, lets
+// that co-rotation term leak into the "horizontal" component and
+// silently invalidates a floor/sign-reversal test built around a
+// specific air-relative magnitude. Adding back the co-rotation term
+// (physics.AtmosphereOmega(moon).Cross(r)) cancels it out.
+func setAirRelativeFlareVelocity(c *spacecraft.Spacecraft, moon bodies.CelestialBody, radialMps, horizZMps float64) {
+	omegaCrossR := physics.AtmosphereOmega(moon).Cross(c.State.R)
+	c.State.V = orbital.Vec3{X: radialMps, Z: horizZMps}.Add(omegaCrossR)
+}
+
+// touchdownFlareCraft builds a low-altitude Moon craft with a
+// horizontal velocity component along body-frame Z — deliberately NOT
+// aligned with body-frame east (which sits along Y for a position on
+// the X axis; see render.BodyFrameEast) — so a latch test can tell
+// "held the prior axis" apart from "snapped to the east fallback" by
+// dot product instead of the two directions being coincidentally
+// close. horizZMps is the horizontal (Z) component of AIR-RELATIVE
+// velocity; the radial (X) component is a small fixed descent rate.
+func touchdownFlareCraft(t *testing.T, horizZMps float64) (*spacecraft.Spacecraft, bodies.CelestialBody, orbital.Vec3, orbital.Vec3) {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	sys := w.System()
+	moon := sys.FindBody("Moon")
+	if moon == nil {
+		t.Fatal("setup: Moon not found in default system")
+	}
+	c := w.ActiveCraft()
+	c.Primary = *moon
+	c.Landed = false
+	c.Crashed = false
+	c.State.R = orbital.Vec3{X: moon.RadiusMeters() + 500}
+	setAirRelativeFlareVelocity(c, *moon, -2, horizZMps)
+	c.State.M = c.TotalMass()
+	camFromBody := c.State.R
+	localUp := camFromBody.Scale(1.0 / camFromBody.Norm())
+	return c, *moon, camFromBody, localUp
+}
+
+// TestChaseHAxisLatchesThroughSpeedFloorAtTouchdown — issue #380 review
+// finding: chaseHorizontalAxis was stateless in horizontal velocity, so
+// the final flare before touchdown (the pilot deliberately nulling
+// horizontal speed) crosses chaseHorizSpeedFloorMps and would snap the
+// whole scene to an unrelated surface-frame-east default at exactly the
+// moment it costs the pilot most. LaunchView.chaseHAxis must instead
+// hold the last velocity-derived axis through that dip.
+func TestChaseHAxisLatchesThroughSpeedFloorAtTouchdown(t *testing.T) {
+	// 5 m/s horizontal — comfortably above chaseHorizSpeedFloorMps
+	// (0.1) — establishes a real latch.
+	c, moon, camFromBody, localUp := touchdownFlareCraft(t, 5.0)
+	v := NewLaunchView(launchThemeForTest(), NewOrbitView(launchThemeForTest()))
+	axisBefore := v.chaseHAxis(c, moon, camFromBody, localUp)
+
+	// Final flare: horizontal speed nulled to 0.01 m/s, well under the
+	// floor. Same craft pointer, same LaunchView — this is what
+	// consecutive frames during touchdown look like.
+	setAirRelativeFlareVelocity(c, moon, -2, 0.01)
+	axisAfter := v.chaseHAxis(c, moon, camFromBody, localUp)
+
+	if dot := axisBefore.Dot(axisAfter); dot < 0.999 {
+		t.Errorf("axis moved across the speed-floor dip at touchdown: "+
+			"before·after = %.4f (want ~1.0 — should hold, not recompute)", dot)
+	}
+
+	// Prove it didn't merely coincide with holding — check it did NOT
+	// snap to the (deliberately different) surface-frame-east fallback.
+	eastV := chaseSurfaceEastAxis(moon, camFromBody)
+	if dot := axisAfter.Dot(eastV); dot > 0.5 {
+		t.Errorf("axis after the dip aligned with surface-frame east (dot=%.4f) — "+
+			"looks like it snapped to the fallback instead of latching", dot)
+	}
+}
+
+// TestChaseHAxisDoesNotFlipOnSignReversalOvershoot — issue #380 review
+// finding: a braking overshoot that carries horizontal velocity through
+// zero to the opposite sign, while staying inside the
+// chaseHorizSpeedFloorMps dead zone the whole time, must not flip the
+// chase-cam 180°. The latch should hold across the sign change as long
+// as the magnitude never re-clears the floor.
+func TestChaseHAxisDoesNotFlipOnSignReversalOvershoot(t *testing.T) {
+	// +5 m/s horizontal (above floor) establishes the latch.
+	c, moon, camFromBody, localUp := touchdownFlareCraft(t, 5.0)
+	v := NewLaunchView(launchThemeForTest(), NewOrbitView(launchThemeForTest()))
+	axisBefore := v.chaseHAxis(c, moon, camFromBody, localUp)
+
+	// Overshoot: horizontal component reverses sign to -0.05 m/s —
+	// magnitude 0.05 < chaseHorizSpeedFloorMps (0.1), so this is still
+	// inside the dead zone despite crossing zero.
+	setAirRelativeFlareVelocity(c, moon, -2, -0.05)
+	axisAfter := v.chaseHAxis(c, moon, camFromBody, localUp)
+
+	if dot := axisBefore.Dot(axisAfter); dot < 0.999 {
+		t.Errorf("axis flipped across a sub-floor sign reversal: "+
+			"before·after = %.4f (want ~1.0, not ~-1.0)", dot)
+	}
+}
+
 // During vertical climb (Radial+, no pitch trim), the chase-cam's
 // horizontal axis must remain body-frame east. v0.11.0 ships with
 // epsilon = 1e-9 in chaseHorizontalAxis, which is below the per-tick


### PR DESCRIPTION
## What

`chaseHorizontalAxis` (`internal/tui/screens/launch.go:646`) derived the
surface view's screen-right axis from `CurrentAttitudeDir` — the commanded
attitude. During a braking (surface-retrograde) descent the nose points
opposite the horizontal velocity, so the axis inherited that: measured on
the issue's Luna repro (20 km alt, 400 m/s horizontal, 40 m/s down),
`hAxis·v̂_horiz = -1.000` exactly. The surface view mirrored the descent
relative to the top-down orbit map instead of merely skewing it — the
descent arc, trail, pad marker, and impact point were all affected since
they share the basis.

## Fix (commit 1: bf9c459)

Orient the axis by **surface-relative horizontal velocity** instead —
`physics.AirRelativeVelocity`'s horizontal component (matching
`descentKinematics`, so a fast-rotating primary can't reintroduce a
smaller version of the same disagreement), normalised. Below a
`chaseHorizSpeedFloorMps = 0.1` m/s floor it falls back to the existing
surface-frame-east default, same as before — just keyed off velocity
instead of attitude. One rule now covers both ascent and descent; the
nose can draw pointing left during a braking burn instead of the world
flipping to keep it pointing right.

### Dot product before/after

| scenario | before (attitude-derived) | after (velocity-derived) |
|---|---|---|
| surface-retrograde (braking) | `hAxis·v̂_horiz = -1.000` | `hAxis·v̂_horiz ≈ +1.000` |
| surface-prograde | `hAxis·v̂_horiz = +1.000` | `hAxis·v̂_horiz ≈ +1.000` |

## Fix 2 (commit cc66840): latch through the touchdown speed-floor — batched Opus review, MEDIUM finding

The velocity-derived axis from fix 1 is still stateless in `|v_horiz|`.
The review caught that this crosses `chaseHorizSpeedFloorMps` on every
touchdown — the pilot is deliberately nulling horizontal speed there —
snapping the whole scene to an unrelated surface-frame-east default at
exactly the moment it costs the pilot most. A braking overshoot that
carries the horizontal component through zero to the opposite sign could
flip the axis 180°. Both are the same whole-scene mirroring #378 removed
from burn start, relocated to touchdown.

**Latch design:** `LaunchView` gained a small cache —
`hAxisCraft *spacecraft.Spacecraft`, `hAxisLatched bool`, `hAxisValue
orbital.Vec3` — mirroring the existing `vzCraft`/`vzAltM`/`vzAtSim`
pattern already on the struct for the HUD's finite-difference v_z. A new
method `(v *LaunchView) chaseHAxis(...)`:

1. Re-keys (clears the latch) when the active craft pointer changes, so
   switching vessels can't inherit a stale heading.
2. When surface-relative horizontal speed clears the floor
   (`chaseHorizVelocityAxis` returns `ok=true`), uses and latches that
   axis.
3. Below the floor, returns the latched axis if one exists.
4. Only falls back to surface-frame east when nothing has ever latched —
   the pad-spawn case the floor was originally for.

`renderScene` now calls `v.chaseHAxis(...)` instead of the free
`chaseHorizontalAxis(...)`. Screens don't mutate world state, so this
lives on the view, not the spacecraft — the axis is a rendering concern
("which way the camera happens to be facing"), not simulation state.

The original `chaseHorizontalAxis` free function is **unchanged in
signature and behavior** — it's now built from two small pieces
(`chaseHorizVelocityAxis` returning `(axis, ok)`, and
`chaseSurfaceEastAxis` for the fallback) that the stateful method also
composes from. It stays around as the stateless reference the
dot-product tests pin directly.

## Fix 3 (commit 091734a): clear the latch on liftoff, not touchdown — round 2 of the review

Fix 2 shipped a real gap: the touchdown latch held indefinitely across
`Landed` true→false too, which fires on a *relaunch* of the same craft,
not just the initial pad spawn. `TestChaseHAxisStaysEastDuringVerticalClimb`
measures ~0.014 m/s of horizontal air-relative velocity during a vertical
climb — ~7x *under* the 0.1 m/s floor — so a fresh liftoff doesn't clear
the floor in one tick; it stays under it for as long as the early climb
lasts (seconds). For that whole window the latch was still serving
whatever heading the vessel happened to be travelling when it touched
down on a *previous* flight — an arbitrary direction with no relationship
to the new ascent, and a real behavioural divergence from `main` (which
renders east there).

**Where the reset belongs, and why not the tempting alternative:**
clearing on *touchdown* (`Landed` false→true) would snap the axis to east
at the exact instant of landing — reintroducing the touchdown mirroring
this whole latch exists to remove. Holding the latch while the vessel
sits parked is correct (the scene is static, nothing visibly moves).
Clearing on *liftoff* (`Landed` true→false) is the one edge that gives:
descent keeps the latch through the flare, a parked vessel holds it
harmlessly, and a new launch starts from the surface-frame-east fallback
exactly as a fresh pad spawn does.

Verified the transition semantics against the sim code rather than
assuming them: `internal/sim/lifecycle.go`'s `applySurfaceArrival` sets
`Landed = true` at ground contact (false→true, touchdown);
`internal/sim/maneuver.go`'s `StartManualBurn` and the planted-node
ignition path both set `Landed = false` when the engine lights on a
parked craft (true→false, liftoff). That confirmed the coordinator's
framing was right before I built against it.

**Implementation:** `LaunchView` gained `hAxisWasLanded bool`, the
previous call's `c.Landed` value for the currently-latched craft. On
each `chaseHAxis` call: craft-switch still fully resets the latch (as
before); same-craft with `hAxisWasLanded == true && c.Landed == false`
clears the latch (liftoff edge) before falling through to the normal
velocity/latch/east logic; `hAxisWasLanded` is updated to `c.Landed` at
the end of every call regardless of branch.

## Tests added (`internal/tui/screens/launch_test.go`)

From fix 1:
- `TestChaseHAxisAlignsWithHorizVelocityDuringBraking` — pins the issue's
  measurement, inverted.
- `TestChaseHAxisSenseStableAcrossAttitudeFlip` — prograde vs. retrograde
  at fixed velocity, axis must not change.
- `TestChaseHAxisFallsBackToEastBelowSpeedFloor` — pad-bound vessel
  (co-rotating, so *air-relative* velocity ≈ 0) still gets east.
- `TestDescentArcAheadTrailBehindOnScreen` — end-to-end through the real
  `DescentCorridorFor` forecast + `LaunchView.Render`.

From fix 2 (the latch):
- `TestChaseHAxisLatchesThroughSpeedFloorAtTouchdown` — establishes a
  latch, nulls horizontal speed below the floor on the same craft/view;
  asserts the axis holds (`dot > 0.999`) and explicitly did *not* land on
  surface-frame east (`dot(axis, east) < 0.5`).
- `TestChaseHAxisDoesNotFlipOnSignReversalOvershoot` — same setup,
  reverses the horizontal component's sign while staying below the
  floor; asserts `dot > 0.999`, not `~-1.0`.

From fix 3 (the liftoff reset), **the test requested this round**:
- `TestChaseHAxisResetsOnLiftoffAfterTouchdownLatch` — full sequence on
  one `LaunchView`/craft: (1) descending with 5 m/s horizontal velocity
  along a distinctly non-east direction (body-frame Z, not Y) establishes
  a latch; (2) `Landed` flips false→true (touchdown) with horizontal
  air-relative velocity nulled to co-rotating — asserts the axis is
  unchanged (latch holds through landing itself); (3) `Landed` flips
  true→false (liftoff) with horizontal velocity at 0.01 m/s (same order
  as the measured early-climb noise, still below the floor) — asserts the
  axis is now surface-frame east, and explicitly asserts it does **not**
  still resemble the pre-liftoff latched heading.

**Test-vector gotcha caught while building the latch tests (fix 2):** the
Moon is tidally locked, so a fixed body-frame position still co-rotates
with it at ~4.6 m/s at low altitude. Setting `c.State.V` directly with
only the intended horizontal component let that co-rotation leak into the
*air-relative* horizontal velocity and silently invalidated the first
draft of the latch tests. Fixed with a `setAirRelativeFlareVelocity`
helper that adds back `physics.AtmosphereOmega(moon).Cross(r)` so tests
control the air-relative velocity directly; reused for fix 3's test too.

**Sabotage (all three fixes), all confirmed to fire:**
- Fix 1: reverted `chaseHorizontalAxis` to the old attitude-based logic.
  The braking/flip tests failed with the exact -1.000 dot product; the
  arc/trail test failed with points on the wrong side of canvas centre.
  Everything else stayed green.
- Fix 2: disabled the latch (delegated straight to the stateless
  function). Both latch tests failed with `before·after = 0.0000` (the
  touchdown test's east-check showed `dot(axis, east) = 1.0000` — it had
  snapped straight to the fallback). Everything else stayed green.
- Fix 3: removed just the liftoff-edge clear (kept the craft-switch reset
  and the rest of the latch logic intact). `TestChaseHAxisResetsOnLiftoffAfterTouchdownLatch`
  failed with **`dot(ascending, east) = 0.0000`** and
  **`dot(ascending, landed) = 1.0000`** — the post-liftoff axis was
  *exactly* the stale touchdown heading, not east at all. Everything
  else (including both fix-2 latch tests and both pre-existing ascent
  tests) stayed green. Restored in every case; all green again.

## Existing tests — no re-baselining needed (any of the three fixes)

`TestChaseHAxisStaysEastDuringVerticalClimb` and
`TestChaseHAxisFollowsPitchTrimAfterCommand` pass **unchanged, no edits**,
across all three commits.

**Corrected pitch-trim branch analysis** (flagged as wrong in an earlier
report, fixing it here for the record): its ~0.91 m/s horizontal velocity
is *above* `chaseHorizSpeedFloorMps` (0.1), so
`chaseHorizVelocityAxis` returns `ok=true` — **the test exercises the
velocity branch, not the east fallback.** It passes because that
velocity direction measures ~0.9999-aligned with body-frame east anyway
(a 5° eastward pitch trim genuinely pushes the vessel east), not because
of any fallback. Since this test only calls the stateless
`chaseHorizontalAxis` free function directly, it never touches the latch
or the liftoff-reset logic either.

`TestChaseHAxisStaysEastDuringVerticalClimb` (~0.014 m/s horizontal, pure
integrator noise) does take the floor-fallback branch, and that same
measured value is what motivated fix 3's "under the floor for seconds,
not one tick" analysis.

## Scope

Touches only `chaseHorizontalAxis`/`chaseHorizVelocityAxis`/
`chaseSurfaceEastAxis`/`LaunchView.chaseHAxis`, the `LaunchView` struct
(new cache fields, same pattern as `vzCraft`), and the `renderScene` doc
comment describing the basis. Left `drawDescentArc` /
`descentCorridorLines` / the margin/alarm path (issue #377's territory)
untouched.

## Note for reviewers

This amends ADR 0043's camera-axis rule: screen-right is now "aligned
with surface-relative horizontal velocity, latched through near-zero-
speed dips and reset on liftoff" rather than "aligned with commanded
attitude." Per instructions I haven't touched the ADR itself — that
amendment is being written up separately.

`chaseHorizSpeedFloorMps = 0.1` m/s is unchanged across all three fixes —
untouched, per the standing instruction that the value itself isn't in
question.

The judgment call I raised after fix 2 (latch persisting across a
landing, sized as "a single below-floor tick at most") was corrected by
the coordinator and is now fix 3 — the exposure was actually several
seconds, backed by `TestChaseHAxisStaysEastDuringVerticalClimb`'s own
measurement, and is now resolved rather than left open.

Closes #378