### PR TITLE
fix: a Landed vessel is given a real orbit — suppress the co-rotation pseudo-orbit

### DIFF
--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -2572,11 +2572,14 @@ const launchMissionFloorM = sim.LaunchMissionFloorM
 // primary's centre, sign-flipping at the display quantum every tick).
 // Nothing about the physics is wrong; a Landed craft simply isn't
 // orbiting, so every surface that would otherwise read its elements —
-// the map's ellipse + apsis markers, the ORBIT/TARGET chips — gates
-// on this instead of re-deriving "is this real" from Landed each time.
-// Ghosts (internal/relay/ghosts.go) never carry Landed=true (skipped
-// at the source), so this predicate only ever fires false for local
-// and target craft, never for a relayed ghost.
+// the map's ellipse + apsis markers, the ORBIT/TARGET chips, and the
+// TARGET chip's closest-approach TCA/CA prediction + ✕ marker (the
+// batched-review follow-up: NextClosestApproach(Positions) Kepler-
+// propagates the same pseudo-orbit if fed a landed target's state) —
+// gates on this instead of re-deriving "is this real" from Landed each
+// time. Ghosts (internal/relay/ghosts.go) never carry Landed=true
+// (skipped at the source), so this predicate only ever fires false for
+// local and target craft, never for a relayed ghost.
 func craftHasOrbit(c *spacecraft.Spacecraft) bool {
 	return c != nil && !c.Landed
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1161,7 +1161,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 		el := orbital.ElementsFromState(c.State.R, c.State.V, muCraft)
 		primaryPos := w.BodyPosition(c.Primary)
 		scale := v.canvas.Scale()
-		orbitVisible := el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) && el.Apoapsis()*scale >= minOrbitPixels
+		// #375: a Landed craft's (R, ω×R) state resolves to a valid-
+		// looking degenerate ellipse (periapsis a few metres from the
+		// primary's centre) — craftHasOrbit excludes it so the map
+		// draws no needle through the body for a parked vessel.
+		orbitVisible := craftHasOrbit(c) && el.A > 0 && !math.IsNaN(el.A) && !math.IsInf(el.A, 0) && el.Apoapsis()*scale >= minOrbitPixels
 		// v0.6.4: in side views, the spacecraft orbit can pass behind
 		// the primary body. The canvas's IsBehindBody / occluded-
 		// ellipse helpers skip back-half samples that fall inside
@@ -1280,7 +1284,9 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			otherPxR := BodyPixelRadius(other.Primary, false, scale, canvasReach)
 			otherInertial := otherPrimaryPos.Add(other.State.R)
 			otherEl := orbital.ElementsFromState(other.State.R, other.State.V, other.Primary.GravitationalParameter())
-			otherOrbitVisible := otherEl.A > 0 && !math.IsNaN(otherEl.A) && !math.IsInf(otherEl.A, 0) && otherEl.Apoapsis()*scale >= minOrbitPixels
+			// #375: same craftHasOrbit exclusion as the active vessel above
+			// — every other landed vessel on the map loses its needle too.
+			otherOrbitVisible := craftHasOrbit(other) && otherEl.A > 0 && !math.IsNaN(otherEl.A) && !math.IsInf(otherEl.A, 0) && otherEl.Apoapsis()*scale >= minOrbitPixels
 			isTarget := i == targetCraftIdx
 			otherColor := lipgloss.Color(render.ColorDim)
 			if other.Color != "" {
@@ -2556,6 +2562,24 @@ func shouldShowLaunchHUD(c *spacecraft.Spacecraft) bool {
 // shouldShowLaunchHUD, ORBIT READY gate) keep their local name; the
 // JSON mirror at internal/missions/missions.json:40 is unchanged.
 const launchMissionFloorM = sim.LaunchMissionFloorM
+
+// craftHasOrbit is the single "does this vessel have a real orbit"
+// predicate (issue #375). integrateLanded (internal/sim/landed.go)
+// deliberately feeds a parked craft V = ω × R — surface co-rotation
+// velocity, correct physics for a future liftoff — but that state
+// happens to satisfy ElementsFromState as a valid-looking ellipse
+// (apoapsis pinned at the vessel, periapsis a few metres from the
+// primary's centre, sign-flipping at the display quantum every tick).
+// Nothing about the physics is wrong; a Landed craft simply isn't
+// orbiting, so every surface that would otherwise read its elements —
+// the map's ellipse + apsis markers, the ORBIT/TARGET chips — gates
+// on this instead of re-deriving "is this real" from Landed each time.
+// Ghosts (internal/relay/ghosts.go) never carry Landed=true (skipped
+// at the source), so this predicate only ever fires false for local
+// and target craft, never for a relayed ghost.
+func craftHasOrbit(c *spacecraft.Spacecraft) bool {
+	return c != nil && !c.Landed
+}
 
 // descentHUDAltitudeM is the altitude threshold (above the airless
 // primary's mean radius) below which the DESCENT block lights up.

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1306,6 +1306,16 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	if shouldShowLaunchHUD(c) {
 		return nil
 	}
+	// #375: a Landed craft carries no orbit (craftHasOrbit) — on an
+	// airless primary shouldShowLaunchHUD above never fires (no
+	// Atmosphere to gate ascent on), so without this the co-rotation
+	// pseudo-orbit would render here as a real ellipse. Swap in the
+	// facts that ARE true on the ground rather than leaving the chip
+	// blank — the same move buildLaunchChip already makes (incl. →
+	// launch lat) — since a chip that vanishes reads as broken.
+	if !craftHasOrbit(c) {
+		return v.buildLandedOrbitChip(c)
+	}
 	mu := c.Primary.GravitationalParameter()
 	frame := orbital.ReferenceFrameForPrimary(c.Primary)
 	el := orbital.ElementsFromStateInFrame(c.State.R, c.State.V, mu, frame)
@@ -1318,8 +1328,8 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	st := orbital.Vec3State{R: c.State.R, V: c.State.V}
 	lines := []string{
 		v.theme.Primary.Render("ORBIT"),
-		chipRow("altitude:", fmt.Sprintf("%.1f km", c.Altitude()/1000)),
-		chipRow("Ap:", fmt.Sprintf("%.1f km", apoAlt/1000)),
+		chipRow("altitude:", formatChipKm(c.Altitude())),
+		chipRow("Ap:", formatChipKm(apoAlt)),
 	}
 	// On a circular orbit the apsides are not locatable points (#286), so
 	// the countdowns say "—" rather than the constant half-period the
@@ -1338,7 +1348,7 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	if s, ok := apsisTime(orbital.TimeToApoapsis(st, mu)); ok {
 		lines = append(lines, chipRow("t→Ap:", s))
 	}
-	lines = append(lines, chipRow("Pe:", fmt.Sprintf("%.1f km", periAlt/1000)))
+	lines = append(lines, chipRow("Pe:", formatChipKm(periAlt)))
 	if s, ok := apsisTime(orbital.TimeToPeriapsis(st, mu)); ok {
 		lines = append(lines, chipRow("t→Pe:", s))
 	}
@@ -1354,6 +1364,27 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
 	}
 	return lines
+}
+
+// buildLandedOrbitChip is buildOrbitMetricsChip's landed branch (#375).
+// A parked craft's (R, ω×R) co-rotation state resolves through
+// ElementsFromState to a valid-looking ellipse (apoapsis pinned at the
+// vessel, periapsis a few metres from the primary's centre, sign-
+// flipping at the display quantum tick to tick), so the chip must not
+// read elements at all while Landed. Instead it shows the facts that
+// ARE true on the ground — body, landed lat/lon, altitude (always 0),
+// and surface co-rotation speed (c.State.V IS ω×R for a Landed craft,
+// per integrateLanded) — the same swap buildLaunchChip already makes
+// (incl. → launch lat) rather than leaving the chip blank.
+func (v *OrbitView) buildLandedOrbitChip(c *spacecraft.Spacecraft) []string {
+	lat, lon := c.SurfaceLatLon()
+	return []string{
+		v.theme.Primary.Render("ORBIT"),
+		chipRow("body:", c.Primary.EnglishName),
+		chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", lat, lon)),
+		chipRow("altitude:", "0.0 km"),
+		chipRow("co-rotation:", fmt.Sprintf("%.1f m/s", c.State.V.Norm())),
+	}
 }
 
 // buildDockGuestOrbitChip is the ORBIT chip's badged rider-view sibling
@@ -1387,8 +1418,8 @@ func (v *OrbitView) buildDockGuestOrbitChip(w *sim.World) []string {
 	}
 	lines := []string{
 		v.theme.Primary.Render(header),
-		chipRow("Ap:", fmt.Sprintf("%.1f km", apoAlt/1000)),
-		chipRow("Pe:", fmt.Sprintf("%.1f km", periAlt/1000)),
+		chipRow("Ap:", formatChipKm(apoAlt)),
+		chipRow("Pe:", formatChipKm(periAlt)),
 		chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)),
 	}
 	if periAlt < 0 {
@@ -1524,16 +1555,26 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			return nil
 		}
 		lines := []string{v.theme.Primary.Render("TARGET"), chipRow("vessel:", tc.Name)}
-		tMu := tc.Primary.GravitationalParameter()
-		tFrame := orbital.ReferenceFrameForPrimary(tc.Primary)
-		tEl := orbital.ElementsFromStateInFrame(tc.State.R, tc.State.V, tMu, tFrame)
-		if tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0) {
-			tPrimaryR := tc.Primary.RadiusMeters()
-			lines = append(lines,
-				chipRow("Ap:", fmt.Sprintf("%.1f km", (tEl.Apoapsis()-tPrimaryR)/1000)),
-				chipRow("Pe:", fmt.Sprintf("%.1f km", (tEl.Periapsis()-tPrimaryR)/1000)),
-				chipRow("inclin.:", fmt.Sprintf("%.2f°", tEl.I*180/math.Pi)),
-			)
+		if craftHasOrbit(tc) {
+			tMu := tc.Primary.GravitationalParameter()
+			tFrame := orbital.ReferenceFrameForPrimary(tc.Primary)
+			tEl := orbital.ElementsFromStateInFrame(tc.State.R, tc.State.V, tMu, tFrame)
+			if tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0) {
+				tPrimaryR := tc.Primary.RadiusMeters()
+				lines = append(lines,
+					chipRow("Ap:", formatChipKm(tEl.Apoapsis()-tPrimaryR)),
+					chipRow("Pe:", formatChipKm(tEl.Periapsis()-tPrimaryR)),
+					chipRow("inclin.:", fmt.Sprintf("%.2f°", tEl.I*180/math.Pi)),
+				)
+			}
+		} else {
+			// #375: a landed target's (R, ω×R) co-rotation state is not an
+			// orbit — swap Ap/Pe/inclin. for its landing site rather than
+			// reading elements off the pseudo-orbit. Range / |v_rel| /
+			// closing below stay meaningful (relative-state math, not
+			// elements) so they're untouched.
+			tLat, tLon := tc.SurfaceLatLon()
+			lines = append(lines, chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", tLat, tLon)))
 		}
 		var rRel, vRelVec orbital.Vec3
 		if tc.Primary.ID == c.Primary.ID {
@@ -1582,8 +1623,8 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		if gEl.A > 0 && !math.IsNaN(gEl.A) && !math.IsInf(gEl.A, 0) {
 			gPrimaryR := gPrimary.RadiusMeters()
 			lines = append(lines,
-				chipRow("Ap:", fmt.Sprintf("%.1f km", (gEl.Apoapsis()-gPrimaryR)/1000)),
-				chipRow("Pe:", fmt.Sprintf("%.1f km", (gEl.Periapsis()-gPrimaryR)/1000)),
+				chipRow("Ap:", formatChipKm(gEl.Apoapsis()-gPrimaryR)),
+				chipRow("Pe:", formatChipKm(gEl.Periapsis()-gPrimaryR)),
 				chipRow("inclin.:", fmt.Sprintf("%.2f°", gEl.I*180/math.Pi)),
 			)
 		}
@@ -1796,6 +1837,16 @@ func nzero(x float64, decimals int) float64 {
 		return 0
 	}
 	return x
+}
+
+// formatChipKm renders a metres reading as a one-decimal kilometre
+// string with nzero applied (#375), so an altitude/apsis that legitimately
+// sits at the display quantum — the co-rotation noise a near-zero orbit
+// carries, not just a Landed craft's pseudo-orbit — can't flip a "-0.0"
+// sign from one tick to the next. Shared by the ORBIT / TARGET chips'
+// altitude, Ap, and Pe rows.
+func formatChipKm(m float64) string {
+	return fmt.Sprintf("%.1f km", nzero(m/1000, 1))
 }
 
 // formatTCA renders a time-to-closest-approach with s / min / h bands.

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1599,7 +1599,17 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
 		if tc.Primary.ID == c.Primary.ID {
-			lines = append(lines, v.closestApproachRows(w, c)...)
+			// #375 follow-up: closestApproachRows Kepler-propagates the
+			// target's (R, V) forward to find the encounter — feeding it a
+			// landed target's (R, ω×R) co-rotation state would propagate
+			// the very pseudo-orbit the rest of #375 suppresses (periapsis
+			// metres from the primary's centre) and print a TCA/CA pair for
+			// a phantom trajectory. Range/closing above stay meaningful for
+			// a landed target (relative-state math, not propagation) so
+			// only this predicted-encounter row group is gated.
+			if craftHasOrbit(tc) {
+				lines = append(lines, v.closestApproachRows(w, c)...)
+			}
 			if rangeM < 50 && vRel < 0.1 {
 				dockStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3DDC84")).Bold(true)
 				lines = append(lines, "  "+dockStyle.Render("DOCK READY"))

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -74,6 +74,73 @@ func TestLandedActiveVesselDrawsNoEllipseOrApsisMarkers(t *testing.T) {
 	}
 }
 
+// TestLandedVesselKeepsGlyphAndInspectRegistration (#375 fix item 2):
+// suppressing the ellipse/apsis markers must not take the vessel itself
+// off the map — "Keep the glyph, the label, and inspect/click
+// registration — the vessel is still there, it just has no track."
+//
+// The active-vessel test above uses lat 10°/lon 0°, which IsBehindBody
+// occludes for the launch-anchored camera (confirmed by direct render:
+// no glyph in the output at that lat/lon) — a happy accident for the
+// ellipse-only test, but it means nothing exercises this half of the
+// fix, and a glyph assertion added there would be vacuous by
+// occlusion, not by a real guard. Lat 30°N is verified by direct render
+// (every longitude at 30°N, and 60°N, all render the glyph — the
+// anchor recenters on the vessel regardless of longitude) to be
+// camera-facing, so the glyph assertion below is meaningful, and the
+// ellipse/marker assertions repeated at the end of this test are the
+// non-vacuous witness at THIS SAME lat/lon (see sabotage results in the
+// PR description — reverting the craftHasOrbit guard at these
+// coordinates still fails the ellipse/marker checks, and blanking the
+// glyph draw still fails the glyph check).
+func TestLandedVesselKeepsGlyphAndInspectRegistration(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, c := spawnLandedOnMoon(t, 30, 0) // 30°N — camera-facing, verified above
+
+	out := v.Render(w, 0, 80, 24)
+
+	vesselGlyph := []rune(spacecraft.VesselGlyph)[0]
+	if !strings.ContainsRune(out, vesselGlyph) {
+		t.Errorf("landed vessel glyph missing from render at a camera-facing lat/lon:\n%s", out)
+	}
+
+	// "The label" + "inspect/click registration": addInspectable records
+	// both the [j]-cycle stop (with the name its flare chip would show)
+	// and the click-resolution entry (drawnOwners) in one call, so a
+	// vessel that vanished from either would vanish from both.
+	wantRef := InspectRef{Kind: InspectVessel, CraftID: c.ID}
+	found := false
+	for _, it := range v.inspectables {
+		if it.ref == wantRef {
+			found = true
+			if it.name != c.Name {
+				t.Errorf("inspect entry name = %q, want %q", it.name, c.Name)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("landed vessel not registered in the inspect/[j] cycle at a camera-facing lat/lon")
+	}
+	if _, ok := v.drawnOwners[wantRef.OwnerKey()]; !ok {
+		t.Errorf("landed vessel not registered for click resolution (drawnOwners) at a camera-facing lat/lon")
+	}
+
+	// Same guard as TestLandedActiveVesselDrawsNoEllipseOrApsisMarkers,
+	// repeated at THIS lat/lon: still no ellipse, still no apsis markers.
+	if got := v.canvas.CountColor(render.ColorCurrentOrbit); got != 0 {
+		t.Errorf("landed vessel at camera-facing lat/lon drew %d cell(s) of the current-orbit ellipse color, want 0", got)
+	}
+	apoColor := render.MarkerColor(render.MarkerApoapsis, render.MarkerNominal, "")
+	periColor := render.MarkerColor(render.MarkerPeriapsis, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(apoColor); got != 0 {
+		t.Errorf("landed vessel at camera-facing lat/lon drew %d apoapsis marker(s), want 0", got)
+	}
+	if got := v.canvas.CountOverlayColor(periColor); got != 0 {
+		t.Errorf("landed vessel at camera-facing lat/lon drew %d periapsis marker(s), want 0", got)
+	}
+}
+
 // TestLandedOtherVesselDrawsNoEllipse (#375, site orbit.go:1283): a
 // second, non-active landed vessel on the same map must also draw no
 // track — "every other landed vessel on the map draws its own needle"

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -1,0 +1,252 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// spawnLandedOnMoon spawns a Saturn V landed on the Moon — an airless
+// body, so shouldShowLaunchHUD's Atmosphere==nil gate never fires and
+// (pre-#375) the ORBIT chip / map ellipse took over instead of the
+// LAUNCH chip, reading the co-rotation pseudo-orbit as a real one.
+func spawnLandedOnMoon(t *testing.T, lat, lonOffset float64) (*sim.World, *spacecraft.Spacecraft) {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "moon",
+		Launchpad:       true,
+		Latitude:        lat,
+		LongitudeOffset: lonOffset,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: launchpad spawn should set Landed=true")
+	}
+	if c.Primary.Atmosphere != nil {
+		t.Fatalf("setup: Moon should have no atmosphere; got %+v", c.Primary.Atmosphere)
+	}
+	if shouldShowLaunchHUD(c) {
+		t.Fatal("setup: want the LAUNCH chip's ascent gate OFF on an airless body, so the ORBIT chip owns this case")
+	}
+	return w, c
+}
+
+// TestLandedActiveVesselDrawsNoEllipseOrApsisMarkers (#375, site
+// orbit.go:1164): a Landed active vessel's (R, ω×R) state resolves
+// through ElementsFromState to a valid-looking ellipse (periapsis a
+// few metres from the Moon's centre) — the map must draw no needle
+// and no ▲/▼ apsis markers for it, while still keeping the vessel
+// glyph on the canvas.
+//
+// "Nothing is drawn" is vacuous by default; this test was verified to
+// actually fail when the craftHasOrbit guard at orbit.go's active-craft
+// orbitVisible line was sabotaged back to the pre-fix condition (see
+// PR description).
+func TestLandedActiveVesselDrawsNoEllipseOrApsisMarkers(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	v.Render(w, 0, 80, 24)
+
+	if got := v.canvas.CountColor(render.ColorCurrentOrbit); got != 0 {
+		t.Errorf("landed active vessel drew %d cell(s) of the current-orbit ellipse color, want 0", got)
+	}
+	apoColor := render.MarkerColor(render.MarkerApoapsis, render.MarkerNominal, "")
+	periColor := render.MarkerColor(render.MarkerPeriapsis, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(apoColor); got != 0 {
+		t.Errorf("landed active vessel drew %d apoapsis marker(s), want 0", got)
+	}
+	if got := v.canvas.CountOverlayColor(periColor); got != 0 {
+		t.Errorf("landed active vessel drew %d periapsis marker(s), want 0", got)
+	}
+}
+
+// TestLandedOtherVesselDrawsNoEllipse (#375, site orbit.go:1283): a
+// second, non-active landed vessel on the same map must also draw no
+// track — "every other landed vessel on the map draws its own needle"
+// per the issue repro. The active vessel here has a real, visible
+// orbit so the test also proves the guard is landed-specific, not a
+// blanket "no ellipses" regression.
+func TestLandedOtherVesselDrawsNoEllipse(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("expected an active craft from NewWorld")
+	}
+	active.Landed = false // active vessel has a real orbit (sanity anchor)
+
+	// Same primary as the active craft (Earth, NewWorld's default LEO
+	// seed) so the pseudo-orbit's scale actually lands in the visible
+	// map/apoapsis-pixel-threshold range — a landed vessel on a
+	// different body/primary wouldn't draw here regardless of the
+	// Landed guard, which would make this assertion vacuous.
+	other, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    active.Primary.ID,
+		Launchpad:       true,
+		Latitude:        -20,
+		LongitudeOffset: 15,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(other): %v", err)
+	}
+	if !other.Landed {
+		t.Fatal("setup: other vessel should be Landed")
+	}
+	// A distinctive color unused elsewhere on the canvas, so the ellipse
+	// count below can't be confused with dim UI chrome / RCS trails that
+	// also default to render.ColorDim.
+	const otherColor = lipgloss.Color("#123456")
+	other.Color = string(otherColor)
+	// SpawnCraft made `other` active; restore the real-orbit craft as
+	// active so this exercises the "every OTHER landed vessel" path.
+	w.ActiveCraftIdx = 0
+
+	v.Render(w, 0, 80, 24)
+	if got := v.canvas.CountColor(otherColor); got != 0 {
+		t.Errorf("other landed vessel drew %d cell(s) of its own orbit color, want 0", got)
+	}
+}
+
+// TestOrbitChipShowsSurfaceFactsWhenLanded (#375, site
+// orbit_chip_builders.go:1300 / buildOrbitMetricsChip): the ORBIT chip
+// for a Landed vessel on an airless body must not vanish (a chip that
+// disappears reads as broken) and must not show Ap/Pe/period computed
+// from the co-rotation pseudo-orbit — it shows the facts that ARE true
+// on the ground instead.
+func TestOrbitChipShowsSurfaceFactsWhenLanded(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	lines := v.buildOrbitMetricsChip(w)
+	if lines == nil {
+		t.Fatal("ORBIT chip vanished for a landed vessel, want surface facts instead")
+	}
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"body:", "Moon", "landed at:", "altitude:", "co-rotation:"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("landed ORBIT chip missing %q:\n%s", want, joined)
+		}
+	}
+	for _, unwanted := range []string{"Ap:", "Pe:", "period:", "t→Ap:", "t→Pe:", "PERIAPSIS BELOW SURFACE"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("landed ORBIT chip still shows orbital readout %q, want it suppressed:\n%s", unwanted, joined)
+		}
+	}
+}
+
+// TestTargetChipLandedTargetShowsNoApPe (#375, site
+// orbit_chip_builders.go:1533): a landed TARGET keeps range / closing /
+// |v_rel| (still meaningful relative-state math) but swaps its Ap/Pe/
+// inclin. for the landing site, since those numbers came from the same
+// co-rotation pseudo-orbit as the ORBIT chip's.
+func TestTargetChipLandedTargetShowsNoApPe(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("expected an active craft from NewWorld")
+	}
+	active.Landed = false
+
+	targetCraft, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    active.Primary.ID,
+		Launchpad:       true,
+		Latitude:        5,
+		LongitudeOffset: 5,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(target): %v", err)
+	}
+	if !targetCraft.Landed {
+		t.Fatal("setup: target vessel should be Landed")
+	}
+	w.ActiveCraftIdx = 0 // restore the orbiting craft as active
+	w.SetTargetCraft(1)  // target the landed vessel
+
+	lines := v.buildTargetChip(w)
+	if lines == nil {
+		t.Fatal("TARGET chip returned nil for a landed target")
+	}
+	joined := strings.Join(lines, "\n")
+	for _, unwanted := range []string{"Ap:", "Pe:", "inclin.:"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("landed target's TARGET chip still shows %q, want it swapped for landing site:\n%s", unwanted, joined)
+		}
+	}
+	for _, want := range []string{"landed at:", "range:", "|v_rel|:", "closing:"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("landed target's TARGET chip missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+// TestLandedVesselNeverPrintsNegativeZero (#375 acceptance): the
+// original bug's Ap/Pe/altitude sign-flipped between "0.0" and "-0.0"
+// every tick because ω×R sits the craft exactly at the pseudo-orbit's
+// apoapsis. A single-frame check can pass by luck (the flip is
+// per-tick), so this drives 200 physics ticks and checks the ORBIT
+// chip on every one of them.
+func TestLandedVesselNeverPrintsNegativeZero(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	for i := 0; i < 200; i++ {
+		w.Tick()
+		lines := v.buildOrbitMetricsChip(w)
+		for _, l := range lines {
+			if strings.Contains(l, "-0.0") || strings.Contains(l, "-0 ") {
+				t.Fatalf("tick %d: landed ORBIT chip printed a negative zero: %q\nfull chip:\n%s",
+					i, l, strings.Join(lines, "\n"))
+			}
+		}
+	}
+}
+
+// TestFormatChipKmSnapsNegativeZero locks the #375 item-6 fix: the km
+// formatter shared by the ORBIT/TARGET chips' altitude/Ap/Pe rows must
+// never print a "-0.0" for a magnitude that rounds to zero at its
+// display precision, even where the underlying number is legitimately
+// noise-level rather than exactly zero — nzero is already proven for
+// v_vert; formatChipKm is the same treatment for km readouts.
+func TestFormatChipKmSnapsNegativeZero(t *testing.T) {
+	cases := []struct {
+		m    float64
+		want string
+	}{
+		{-3, "0.0 km"},              // noise-level negative -> snapped
+		{3, "0.0 km"},               // noise-level positive -> unaffected either way
+		{-1_737_393.6, "-1737.4 km"}, // real negative value stays negative
+		{1500, "1.5 km"},
+	}
+	for _, c := range cases {
+		if got := formatChipKm(c.m); got != c.want {
+			t.Errorf("formatChipKm(%g) = %q, want %q", c.m, got, c.want)
+		}
+	}
+}

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -295,6 +295,78 @@ func TestLandedVesselNeverPrintsNegativeZero(t *testing.T) {
 	}
 }
 
+// TestLandedTargetHasNoClosestApproachPrediction (#375 batched-review
+// follow-up): craftHasOrbit correctly gates the TARGET chip's Ap/Pe and
+// the map's ellipse/apsis markers, but closestApproachRows (the TCA/CA
+// chip rows) and drawClosestApproachMarker (the map's ✕ marker) both
+// feed the target's raw (R, V) straight into
+// planner.NextClosestApproach(Positions) — bypassing craftHasOrbit
+// entirely. For a landed target that Kepler-propagates the same
+// co-rotation pseudo-orbit the rest of #375 suppresses and reports a
+// TCA/CA pair (plus a ✕ on the map) for a phantom trajectory diving
+// through the body.
+//
+// Range/closing/|v_rel| stay meaningful for a landed target (plain
+// relative-state math, not propagation) so only the predicted-encounter
+// rows and marker are gated — the chip must not blank those either.
+//
+// Same primary as the active craft (Earth) and the same camera-facing
+// lat/lon pattern as TestLandedVesselKeepsGlyphAndInspectRegistration
+// (30°N) — a different-primary or occluded target would make the
+// marker assertion pass vacuously regardless of the guard, the same
+// trap TestLandedOtherVesselDrawsNoEllipse hit on the first pass.
+func TestLandedTargetHasNoClosestApproachPrediction(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(80, 24)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	active := w.ActiveCraft()
+	if active == nil {
+		t.Fatal("expected an active craft from NewWorld")
+	}
+	active.Landed = false
+
+	target, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    active.Primary.ID, // same primary as the active craft
+		Launchpad:       true,
+		Latitude:        30, // camera-facing, per TestLandedVesselKeepsGlyphAndInspectRegistration
+		LongitudeOffset: 0,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft(target): %v", err)
+	}
+	if !target.Landed {
+		t.Fatal("setup: target vessel should be Landed")
+	}
+	w.ActiveCraftIdx = 0 // restore the orbiting craft as active
+	w.SetTargetCraft(1)  // target the landed vessel
+
+	lines := v.buildTargetChip(w)
+	if lines == nil {
+		t.Fatal("TARGET chip returned nil for a landed target")
+	}
+	joined := strings.Join(lines, "\n")
+	for _, unwanted := range []string{"TCA:", "CA:"} {
+		if strings.Contains(joined, unwanted) {
+			t.Errorf("landed target's TARGET chip still shows %q (a propagated closest-approach prediction), want it suppressed:\n%s", unwanted, joined)
+		}
+	}
+	for _, want := range []string{"range:", "|v_rel|:", "closing:"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("landed target's TARGET chip lost %q — only the propagated CA/TCA prediction should be gated, not the whole row group:\n%s", want, joined)
+		}
+	}
+
+	v.Render(w, 0, 80, 24)
+	caColor := render.MarkerColor(render.MarkerClosestApproach, render.MarkerNominal, "")
+	if got := v.canvas.CountOverlayColor(caColor); got != 0 {
+		t.Errorf("landed target drew %d closest-approach ✕ marker(s), want 0 — the marker plots the same propagated pseudo-orbit as the chip rows", got)
+	}
+}
+
 // TestFormatChipKmSnapsNegativeZero locks the #375 item-6 fix: the km
 // formatter shared by the ORBIT/TARGET chips' altitude/Ap/Pe rows must
 // never print a "-0.0" for a magnitude that rounds to zero at its

--- a/internal/tui/screens/orbit_target_markers.go
+++ b/internal/tui/screens/orbit_target_markers.go
@@ -40,6 +40,15 @@ func (v *OrbitView) drawClosestApproachMarker(w *sim.World) {
 	if c == nil || !w.TargetSharesActivePrimary() {
 		return
 	}
+	// #375 follow-up: mirrors the TARGET chip's closestApproachRows guard
+	// (orbit_chip_builders.go) — a landed target's (R, ω×R) state isn't an
+	// orbit, so propagating it here would plant the ✕ marker inside the
+	// body, the same needle-through-the-planet defect the rest of #375
+	// suppresses, just on a different glyph. ResolveTargetCraft is
+	// ok=false for a body/ghost target, so this is a no-op for those.
+	if tc, _, ok := w.ResolveTargetCraft(); ok && !craftHasOrbit(tc) {
+		return
+	}
 	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
 	if !ok {
 		return


### PR DESCRIPTION
## What

`integrateLanded` (`internal/sim/landed.go`) deliberately feeds a
parked vessel `V = ω × R` — surface co-rotation velocity, correct
physics so a `Landed=false` liftoff releases it with the ground's
motion. But nothing downstream knew a Landed vessel isn't orbiting:
`ElementsFromState` reads that state as a valid-looking ellipse
(periapsis a few metres from the primary's centre, apoapsis pinned
exactly at the vessel, `Ap`/`Pe` sign-flipping between `0.0`/`-0.0`
every tick). The map drew this as a needle through the body; the ORBIT
chip reported the fake numbers.

Physics is unchanged — `integrateLanded` still sets `V = ω × R` exactly
as before. This is a display-layer fix only.

## Fix (per issue #375's 6-part spec)

One shared predicate, `craftHasOrbit` (`internal/tui/screens/orbit.go`),
applied at every display site instead of sprinkling `!c.Landed`:

| Site | Change |
|---|---|
| `orbit.go` (active vessel's ellipse + ▲/▼ markers) | gated on `craftHasOrbit(c)` — no needle for a Landed active vessel |
| `orbit.go` (every other vessel's ellipse) | gated on `craftHasOrbit(other)` — no needle for any other Landed vessel on the map |
| `orbit_chip_builders.go` `buildOrbitMetricsChip` (ORBIT chip) | swaps to `buildLandedOrbitChip` while Landed: body, landed lat/lon, altitude (0), co-rotation speed — mirrors `buildLaunchChip`'s existing incl.→launch-lat swap. Chip never vanishes. |
| `orbit_chip_builders.go` `buildTargetChip` (TARGET chip, `TargetCraft` case) | swaps Ap/Pe/inclin. for the landed target's landing site; range/closing/\|v_rel\| stay (still meaningful relative-state math) |
| `orbit_chip_builders.go` `buildTargetChip` (`TargetGhost` case) | **left untouched** — see Reachability below |

`⚠ PERIAPSIS BELOW SURFACE` no longer fires for a Landed vessel — the
landed branch return happens before that check is ever reached.

`formatChipKm` applies the existing `nzero` treatment (already used for
`v_vert`) to every km-formatted altitude/Ap/Pe row in the ORBIT/TARGET/
DockGuest chips, so no readout can print a negative zero even at
noise-level magnitudes, not just the Landed case specifically.

## Ghost-chip reachability (asked for in the issue)

Confirmed **unreachable**, so no guard was added there (would be dead
code): `relay/ghosts.go:28` (`GhostsFor`) skips any craft with
`Landed == true` at the source — `w.Ghosts` is written nowhere else
(`internal/serve/reporting.go:374` is the only writer, and it goes
through `GhostsFor`). A `sim.Ghost` can therefore never represent a
landed vessel, so `buildTargetChip`'s `TargetGhost` branch (the 5th
site in the issue's table) can never see a landed pseudo-orbit.

## Follow-up 1: glyph/label/inspect-registration (fix item 2's other half)

Fix item 2 has two halves: "no ellipse/apsis markers" AND "keep the
glyph, the label, and inspect/click registration — the vessel is still
there, it just has no track." The original test suite only proved the
first half, at lat 10°N — a lat/lon that happens to sit on the far side
of the launch-anchored camera (confirmed by direct render), so nothing
exercised the second half. A future change that made a landed vessel
disappear entirely would have stayed green.

Added `TestLandedVesselKeepsGlyphAndInspectRegistration` at lat 30°N —
verified camera-facing by direct render (`IsBehindBody`==false, glyph
present in output; checked across lat -60°..60° × lon -150°..150°, and
every longitude at 30°N/60°N renders the glyph since the anchor
recenters on the vessel regardless of longitude). It checks the glyph
is drawn, the vessel is registered in the `[j]` inspect cycle with its
name, and it's registered for click resolution (`drawnOwners`) — while
also repeating the ellipse/apsis-marker assertions at this same lat/lon,
since a coordinate change is only a valid substitute if the original
guard is still non-vacuous there too.

Sabotage (both reverted independently, then restored):
- Suppressing the active-craft glyph draw for a Landed vessel → glyph
  assertion fails.
- Reverting the `craftHasOrbit` guard on the active-craft
  `orbitVisible` line, at lat 30°N → ellipse assertion fails (2 cells
  drawn), confirming 30°N isn't the same trap the 10°N pick was for the
  other-vessel test.

## Follow-up 2: closest-approach TCA/CA rows + ✕ marker (batched-review finding)

`closestApproachRows` (the TARGET chip's TCA/CA rows) and
`drawClosestApproachMarker` (the map's ✕ marker) both bypassed
`craftHasOrbit` entirely — they feed the target's raw `(R, V)` straight
into `planner.NextClosestApproach(Positions)`, which Kepler-propagates
whatever it's given. For a landed target that's the same co-rotation
pseudo-orbit the rest of #375 suppresses (periapsis metres from the
primary's centre), so the chip printed a TCA/CA pair — and the map
plotted a ✕ — for a phantom trajectory diving through the body. Same
defect as the original issue, just on different glyphs, and it made
`craftHasOrbit`'s doc comment ("every surface that would otherwise read
its elements gates on this") false.

**Judgement call:** gate only the propagated-encounter row group and
marker, not the whole TARGET chip / row block. Range, closing, and
`|v_rel|` stay meaningful for a landed target — they're plain
relative-state math (subtraction), not propagation — and fix item 4
already says to keep them. Blanking the whole chip or the whole row
group would over-correct; the bug is specifically in feeding a
co-rotation state to a Kepler propagator, not in every number derived
from a landed target.

Gated both call sites on `craftHasOrbit(tc)` (the resolved target
craft):
- `orbit_chip_builders.go`: the `closestApproachRows()` call in the
  `TargetCraft` case is now conditional. `DOCK READY` untouched (range
  < 50 m / |v_rel| < 0.1 m/s is still a meaningful physical statement
  for a landed target, and wasn't part of this finding).
- `orbit_target_markers.go`: `drawClosestApproachMarker` returns early
  when the resolved target craft is Landed. `ResolveTargetCraft` is
  `ok=false` for a body/ghost target, so this is a no-op there —
  ghosts can never be Landed (existing #375 finding), so nothing
  reachable through the `TargetGhost` path is affected.

Updated `craftHasOrbit`'s doc comment to name this surface explicitly,
since gating both sites (the reviewer's suggested fix, over correcting
the comment) is what keeps its "every surface... gates on this" claim
true again.

New test: `TestLandedTargetHasNoClosestApproachPrediction`. Landed
target on the **same primary** as the active craft, at the **same
camera-facing lat** (30°N) `TestLandedVesselKeepsGlyphAndInspectRegistration`
established — avoiding the off-map/wrong-primary trap that made an
earlier assertion in this PR (`TestLandedOtherVesselDrawsNoEllipse`)
pass vacuously on the first attempt. Asserts no `TCA:`/`CA:` rows and
no ✕ marker, while `range:`/`|v_rel|:`/`closing:` survive.

Sabotage (each guard reverted independently, then together, then
restored):
- Chip guard alone reverted → `TCA:`/`CA:` rows reappear, test fails.
- Marker guard alone reverted → 2 ✕ markers drawn, test fails.
- Both reverted together → both failures reproduce simultaneously,
  matching the exact player-visible report (`landed at:` row followed
  by a TCA/CA pair for a phantom encounter).

## Testing

New file `internal/tui/screens/orbit_landed_no_orbit_test.go`:
- `TestLandedActiveVesselDrawsNoEllipseOrApsisMarkers` — map, site 1
- `TestLandedVesselKeepsGlyphAndInspectRegistration` — map, fix item 2's
  glyph/label/inspect-registration half (Follow-up 1)
- `TestLandedOtherVesselDrawsNoEllipse` — map, site 2 (spawns the other
  landed vessel on the *same* primary as the active craft, so the
  assertion isn't vacuous by scale/primary mismatch)
- `TestOrbitChipShowsSurfaceFactsWhenLanded` — chip, site 3
- `TestTargetChipLandedTargetShowsNoApPe` — chip, site 4
- `TestLandedTargetHasNoClosestApproachPrediction` — chip TCA/CA rows +
  map ✕ marker (Follow-up 2)
- `TestLandedVesselNeverPrintsNegativeZero` — 200 ticks of `w.Tick()`,
  checked every tick (a single-frame check can pass by luck since the
  sign flip is per-tick)
- `TestFormatChipKmSnapsNegativeZero` — unit test for the `nzero` km
  formatter

**Sabotage checks** (per repo discipline — "nothing is drawn" is
vacuous by default): each guard was temporarily reverted and the
corresponding test confirmed to fail before being restored:
- Reverting `craftHasOrbit(c) &&` / `craftHasOrbit(other) &&` in
  `orbit.go` → both map tests fail (1 periapsis marker drawn; 4 ellipse
  cells drawn).
- Removing the landed branch in `buildOrbitMetricsChip` → chip test
  fails, reproducing the issue's exact repro output (`Ap: 0.0 km`,
  `Pe: -1737.4 km`, `⚠ PERIAPSIS BELOW SURFACE`).
- Removing the landed branch in `buildTargetChip` → target test fails,
  reproducing the same pattern for a landed target (`Ap: 0.0 km`,
  `Pe: -6360.1 km`).
- Reverting `formatChipKm` to drop `nzero` (with the landed branch also
  reverted) → `TestLandedVesselNeverPrintsNegativeZero` fails on tick 0
  with `Ap: -0.0 km`, reproducing the issue's flicker exactly.
- See Follow-up 1 and Follow-up 2 above for their own sabotage results.

All sabotage reverts were restored before each commit.

## Gates

- `go vet ./...` — clean
- `go test ./... -race -count=1` — full suite green

Closes #375
