### PR TITLE
Descent corridor: integrate the real stop burn instead of a frozen-scalar margin

### DIFF
--- a/internal/sim/descent.go
+++ b/internal/sim/descent.go
@@ -1,23 +1,33 @@
 // Package sim — the descent half of the surface view (issue #348 §3,
-// ADR 0043). Two pure forecasts the launch/surface screen renders:
-// where the current trajectory meets the ground (PredictImpact) and
-// whether the stack can still stop before it gets there
-// (DescentCorridorFor / ComputeBurnMargin).
+// ADR 0043). Pure forecasts the launch/surface screen renders: where
+// the current trajectory meets the ground (PredictImpact), whether a
+// full-throttle stop burn started now would arrest it in time
+// (PredictPoweredStop), and the latest moment that burn can still start
+// (PredictBurnAt) — DescentCorridorFor bundles the cheap, gate-defining
+// half of the block; the two powered forecasts are expensive enough
+// (issue #377) that callers are expected to cache them (ADR 0017; see
+// screens.LaunchView's descentStopCache).
 //
-// The forecast reuses the predictor's ONE propagator — predictStep,
+// PredictImpact reuses the predictor's ONE propagator — predictStep,
 // analytic Kepler where the arc is Kepler-eligible and drag-aware Verlet
 // everywhere else — so the drawn descent arc agrees with the orbit map's
-// dashed trajectory AND with the craft's actual flight. No second
-// propagator lives here (the #66 two-drift-sites lesson: when the same
-// curve is integrated at two sites they drift apart and only one of them
-// gets fixed).
+// dashed trajectory AND with the craft's actual flight. PredictPoweredStop
+// / PredictBurnAt integrate with physics.StepRK4 instead (thrust is a
+// non-conservative force Kepler propagation can't carry), but still
+// through exactly one accel closure (poweredStopAccel) shared by every
+// termination test inside them — the same #66 two-drift-sites rule this
+// file has always followed, just a second single site rather than a
+// second propagator layered on the first.
 //
-// Both forecasts are ballistic-from-now: they propagate the CURRENT
-// state without assuming any future thrust, exactly like the orbit map's
+// PredictImpact is ballistic-from-now: it propagates the CURRENT state
+// without assuming any future thrust, exactly like the orbit map's
 // projected orbit. That is what makes the impact marker live under a
 // burn — every tick the burn reshapes the state, and the next frame's
 // forecast is taken from the reshaped state, so the marker slides along
-// the ground as the player thrusts.
+// the ground as the player thrusts. PredictPoweredStop / PredictBurnAt
+// are the deliberate exception: they DO model a hypothetical future
+// burn (100% throttle, current stage only) because "can this still be
+// stopped" is unanswerable without it.
 
 package sim
 
@@ -125,6 +135,25 @@ type ballisticForecast struct {
 	ImpactFound  bool
 	TimeToImpact time.Duration
 	SpeedMps     float64
+
+	// samples parallels Path at the same cadence but carries the full
+	// (state, elapsed-seconds) pair rather than just the plotted
+	// position — PredictBurnAt's candidate start states (issue #377 §2).
+	// Unexported: PredictImpact never surfaces it, and nothing outside
+	// this file needs a burn-at candidate that isn't already resolved
+	// into a BurnAtCue. Reusing forwardBallisticPath's own walk means
+	// the "latest start" search costs zero extra propagation over what
+	// the dashed arc already computes — only extra bookkeeping.
+	samples []ballisticSample
+}
+
+// ballisticSample is one point on a ballistic-coast forecast, keeping
+// the full state (not just position) plus how far into the forecast it
+// sits. PredictBurnAt bisects over a slice of these instead of
+// re-propagating (issue #377 §2).
+type ballisticSample struct {
+	state      physics.StateVector
+	elapsedSec float64
 }
 
 // forwardBallisticPath is the one forward-propagation loop behind both
@@ -179,6 +208,8 @@ func forwardBallisticPath(c *spacecraft.Spacecraft, horizon time.Duration) (ball
 
 	path := make([]orbital.Vec3, 0, impactPathSamples+2)
 	path = append(path, state.R)
+	samples := make([]ballisticSample, 0, impactPathSamples+2)
+	samples = append(samples, ballisticSample{state: state, elapsedSec: 0})
 	elapsed := 0.0
 	for i := 0; i < steps; i++ {
 		pre := state
@@ -197,14 +228,16 @@ func forwardBallisticPath(c *spacecraft.Spacecraft, horizon time.Duration) (ball
 				ImpactFound:  true,
 				TimeToImpact: time.Duration(elapsed * float64(time.Second)),
 				SpeedMps:     physics.AirRelativeVelocity(hit.R, hit.V, primary).Norm(),
+				samples:      samples,
 			}, true
 		}
 		elapsed += dt
 		if (i+1)%sampleEvery == 0 {
 			path = append(path, state.R)
+			samples = append(samples, ballisticSample{state: state, elapsedSec: elapsed})
 		}
 	}
-	return ballisticForecast{Path: path}, true
+	return ballisticForecast{Path: path, samples: samples}, true
 }
 
 // refineSurfaceCrossing bisects surface contact inside (0, dt]: pre is
@@ -295,11 +328,23 @@ func (l MarginLimiter) String() string {
 //     part of every second is spent holding the vehicle up. The
 //     propellant ratio is RemainingDeltaV over that.
 //
-// Both are the idealised constant-mass, straight-down bound: no attitude
-// error, no throttle ramp, no mass shed mid-burn. That is deliberate —
-// an instrument that flatters the pilot is worse than none, and this one
-// errs optimistic only in the mass term (a real burn gets lighter, so a
-// little easier), which the TIGHT band exists to cover.
+// Both are the idealised constant-mass, straight-down, frozen-g bound:
+// no attitude error, no throttle ramp, no mass shed mid-burn, g_local
+// frozen at the instant evaluated, and v the VERTICAL descent rate only
+// (issue #377). That is NOT "optimistic only in the mass term" — ignoring
+// mass loss is the one place this model is conservative (a real burn
+// gets lighter, so a_net actually grows through the burn). The other two
+// idealisations run the other way: freezing g at the current altitude
+// overstates it by ~10-20% over a real descent (g grows as r shrinks),
+// and dropping the horizontal component entirely is the dangerous one —
+// a craft carrying serious downrange speed reads as comfortably OK here
+// while nowhere near actually being able to stop. DescentCorridorFor no
+// longer wires this into the corridor's Margin field for exactly that
+// reason: PredictPoweredStop integrates the real burn (mass loss, g(r),
+// the horizontal component, and drag) instead of hand-deriving
+// corrections for each. ComputeBurnMargin stays as a cheap, pure,
+// still-tested piece of arithmetic — just not the corridor's answer to
+// "can this still be stopped".
 type BurnMargin struct {
 	Ratio        float64
 	State        MarginState
@@ -354,6 +399,491 @@ func ComputeBurnMargin(thrustN, massKg, gLocalMps2, descentRateMps, altitudeM, a
 	return m
 }
 
+// stdGravityMps2 is standard gravity, used to convert Isp (seconds) to
+// exhaust velocity / mass-flow (Isp·g0). Duplicated locally rather than
+// imported from spacecraft — planner/finiteburn.go's stdGravity const
+// does the same, for the same reason (sim already imports spacecraft for
+// the *spacecraft.Spacecraft type, but the constant itself isn't
+// exported, and duplicating one float64 beats exporting it just for
+// this).
+const stdGravityMps2 = 9.80665
+
+// PoweredStopOutcome names which of PredictPoweredStop's termination
+// conditions the integration actually hit (issue #377 §1) — reported
+// instead of just a pass/fail so the corridor's alarm can say what
+// stopped the stop, not only that it didn't happen.
+type PoweredStopOutcome int
+
+const (
+	// StopUndetermined is the zero value: PredictPoweredStop refused
+	// (ok=false, the step cap was hit before any of the three real
+	// outcomes below resolved) — "don't know", not "can't".
+	StopUndetermined PoweredStopOutcome = iota
+	// StopStopped: surface-relative speed reached ~0 before the ground.
+	// MarginM is the altitude left, ≥ 0.
+	StopStopped
+	// StopCrashed: r crossed the surface before speed reached ~0.
+	// ImpactSpeedMps is the surface-relative speed at that crossing;
+	// MarginM is the altitude at which speed FINALLY would have reached
+	// ~0 had the ground not been there (found by letting the same
+	// integration run on past the crossing — no second propagator, no
+	// hand-derived correction, just not stopping early) — so it comes
+	// out ≤ 0, reading as "short by |MarginM|" rather than a negative
+	// altitude (issue #377 §3).
+	StopCrashed
+	// StopFuelLimited: the current (bottom, firing) stage's propellant
+	// ran out before either of the above. No auto-staging inside the
+	// forecast (issue #377 §1) — a stop that needs a decouple is
+	// reported as fuel-limited, not silently solved by staging for the
+	// pilot. MarginM is the altitude AT the instant fuel ran out
+	// (informational — "still this far up when the tank ran dry"), not
+	// a stopping-distance shortfall the way StopCrashed's is.
+	StopFuelLimited
+)
+
+func (o PoweredStopOutcome) String() string {
+	switch o {
+	case StopStopped:
+		return "stopped"
+	case StopCrashed:
+		return "crashed"
+	case StopFuelLimited:
+		return "fuel-limited"
+	}
+	return "undetermined"
+}
+
+// PoweredStopPrediction is PredictPoweredStop's result: what happened
+// when the current (or a candidate future) state was integrated forward
+// under a full-throttle, surface-relative-retrograde stop burn.
+type PoweredStopPrediction struct {
+	Outcome PoweredStopOutcome
+	// MarginM is signed altitude, metres: positive means the stop
+	// completed with that much altitude still in hand (StopStopped);
+	// non-positive means it didn't (StopCrashed — read as "short by
+	// |MarginM|", never as a negative altitude, per issue #377 §3).
+	// StopFuelLimited's MarginM is the altitude at the exhaustion
+	// instant instead (see StopFuelLimited's doc).
+	MarginM float64
+	// ImpactSpeedMps is the surface-relative speed at the ground
+	// crossing. Zero unless Outcome == StopCrashed.
+	ImpactSpeedMps float64
+	// ElapsedSec is the flight time from the integration's start to
+	// termination.
+	ElapsedSec float64
+	// DVUsedMps is the Δv the rocket-equation accounting actually spent
+	// reaching termination (bounded by the stage's available Δv).
+	DVUsedMps float64
+}
+
+// stopSubStepSeconds is PredictPoweredStop's RK4 sub-step. Finer than
+// forwardBallisticPath's impactSubStepCap (2 s): the accel closure here
+// captures mass/fuel at the START of each outer step and holds it fixed
+// across the step (the same per-step-snapshot trick
+// planner.SimulateFiniteBurn uses), so the step needs to be short enough
+// that a stage's mass doesn't change much within one — 1 s keeps that
+// error well under the modelling error everywhere else in this forecast.
+const stopSubStepSeconds = 1.0
+
+// stopMaxSubSteps bounds PredictPoweredStop's total integrator work, the
+// same discipline impactMaxSubSteps applies to the ballistic forecast:
+// hitting the cap coarsens dt (spreading it across `horizon`) rather than
+// silently truncating the search, and if that's still not enough the
+// forecast refuses (ok=false) instead of guessing. A 1.6 km/s stop is
+// ~800 s of flight at a typical lander's TWR (issue #377) — 2048 steps at
+// 1 s each covers that many times over before the horizon-driven
+// coarsening even engages.
+const stopMaxSubSteps = 2048
+
+// stopSpeedFloorMps is PredictPoweredStop's "stopped" tolerance. Exactly
+// zero is a target the discrete integrator will straddle rather than
+// land on, and it's also the direction singularity for the retrograde
+// thrust closure (a zero-length vRel has no direction to burn along) —
+// this is small enough to read as "stopped" against the speeds this
+// forecast deals in (hundreds to low thousands of m/s) while staying
+// comfortably clear of that singularity.
+const stopSpeedFloorMps = 0.5
+
+// stopAdaptiveShrinkFrac / stopAdaptiveMinDt bound the adaptive step
+// shrink documented at its call site in the integration loop: a step
+// removes at most this fraction of the current speed (at the craft's
+// unthrottled accel ceiling), and never shrinks the step below
+// stopAdaptiveMinDt seconds — without a floor, a craft sitting exactly
+// on the singularity (vRel == 0, no direction to burn along, aAvail
+// effectively infinite relative to a zero speedPre) would compute a
+// zero-length step and stall the loop instead of burning through steps
+// toward the sub-count cap.
+const (
+	stopAdaptiveShrinkFrac = 0.5
+	stopAdaptiveMinDt      = 0.01
+)
+
+// poweredStopAccel is the ONE accel closure behind every termination
+// test inside PredictPoweredStop / PredictBurnAt (this file's own #66
+// rule, restated for the powered half): two-body gravity, drag exactly
+// as forwardBallisticPath applies it, plus thrust along surface-relative
+// retrograde at full magnitude thrustN/massKg (zero once thrustN or
+// massKg is non-positive — no fuel, no thrust). Surface-relative, not
+// inertial (issue #377 §1): the goal is zero speed OVER THE GROUND, so
+// this uses physics.AirRelativeVelocity, matching descentKinematics.
+func poweredStopAccel(r, v orbital.Vec3, mu float64, primary bodies.CelestialBody, bc, thrustN, massKg float64) orbital.Vec3 {
+	accel := physics.Accel(r, mu).Add(physics.DragAccel(r, v, primary, bc))
+	if thrustN <= 0 || massKg <= 0 {
+		return accel
+	}
+	vRel := physics.AirRelativeVelocity(r, v, primary)
+	n := vRel.Norm()
+	if n == 0 {
+		return accel
+	}
+	dir := vRel.Scale(-1 / n)
+	return accel.Add(dir.Scale(thrustN / massKg))
+}
+
+// bisectPoweredCrossing refines exactly when, within (0, dt], a powered
+// sub-step first satisfies `hit` — the same bisection trick
+// refineSurfaceCrossing uses on the ballistic forecast, adapted to an
+// arbitrary predicate so PredictPoweredStop can share it between the
+// ground-crossing test and the stop-speed test. pre is the state at the
+// start of the detecting step (known NOT to satisfy hit); propagating it
+// by dt is known TO satisfy hit. Every probe re-integrates from pre by a
+// trial offset via the SAME accelFn the outer loop used for this step —
+// one propagator, never a partial re-walk.
+func bisectPoweredCrossing(pre physics.StateVector, dt float64, accelFn func(r, v orbital.Vec3, t float64) orbital.Vec3, hit func(physics.StateVector) bool) (physics.StateVector, float64) {
+	lo, hi := 0.0, dt
+	state := physics.StepRK4(pre, hi, accelFn, 0)
+	for i := 0; i < surfaceRefineIters && hi-lo > surfaceRefineEpsilon; i++ {
+		mid := (lo + hi) / 2
+		s := physics.StepRK4(pre, mid, accelFn, 0)
+		if hit(s) {
+			hi, state = mid, s
+		} else {
+			lo = mid
+		}
+	}
+	return state, hi
+}
+
+// PredictPoweredStop integrates a full-throttle, current-stage-only,
+// surface-relative-retrograde stop burn forward from the craft's CURRENT
+// state (issue #377 §1) — physics.StepRK4 through poweredStopAccel, the
+// planner.SimulateFiniteBurn precedent for iterating a powered burn as a
+// forecast, applied here to "when do I stop" instead of "hit this target
+// apoapsis". ok=false only on the same degenerate inputs
+// forwardBallisticPath has always refused, or on the step-cap refusal
+// (StopUndetermined) documented on that constant.
+func PredictPoweredStop(c *spacecraft.Spacecraft, horizon time.Duration) (PoweredStopPrediction, bool) {
+	if c == nil {
+		return PoweredStopPrediction{}, false
+	}
+	return predictPoweredStopFrom(c.State, c, horizon)
+}
+
+// predictPoweredStopFrom is PredictPoweredStop generalised to an
+// arbitrary starting state so PredictBurnAt can ask "if I start the stop
+// burn from THIS point on the ballistic coast instead of right now, does
+// it still work" without a second implementation.
+func predictPoweredStopFrom(state physics.StateVector, c *spacecraft.Spacecraft, horizon time.Duration) (PoweredStopPrediction, bool) {
+	if c == nil {
+		return PoweredStopPrediction{}, false
+	}
+	primary := c.Primary
+	radius := primary.RadiusMeters()
+	mu := primary.GravitationalParameter()
+	total := horizon.Seconds()
+	if radius <= 0 || mu <= 0 || total <= 0 {
+		return PoweredStopPrediction{}, false
+	}
+	if r := state.R.Norm(); r <= radius || math.IsNaN(r) {
+		return PoweredStopPrediction{}, false
+	}
+	bc := c.EffectiveBallisticCoefficient()
+	thrustFull := c.Thrust
+	ispSec := c.Isp
+	massKg := c.TotalMass()
+	fuelKg := c.ActiveStageFuel()
+	if massKg <= 0 {
+		return PoweredStopPrediction{}, false
+	}
+	// No engine, no Isp, or the firing stage is already dry: the stop
+	// can't even begin. Fuel-limited from the first instant, current
+	// altitude reported as "where that happened" (issue #377 §1).
+	if thrustFull <= 0 || ispSec <= 0 || fuelKg <= 0 {
+		return PoweredStopPrediction{
+			Outcome: StopFuelLimited,
+			MarginM: state.R.Norm() - radius,
+		}, true
+	}
+	mdot := thrustFull / (ispSec * stdGravityMps2)
+
+	dt := stopSubStepSeconds
+	steps := int(math.Ceil(total / dt))
+	if steps > stopMaxSubSteps {
+		steps = stopMaxSubSteps
+		dt = total / float64(steps)
+	}
+	if steps < 1 {
+		return PoweredStopPrediction{}, false
+	}
+
+	var crossedGround bool
+	var impactSpeed float64
+	elapsed := 0.0
+	dvUsed := 0.0
+
+	for i := 0; i < steps; i++ {
+		// Fuel exhausted exactly mid-step: shorten this step to the
+		// instant it runs dry rather than overrunning the tank — an
+		// algebraic result (mdot is constant while thrustFull is firing),
+		// not another bisection.
+		stepDt := dt
+		if ttx := fuelKg / mdot; ttx < stepDt {
+			stepDt = ttx
+		}
+		// Adaptive shrink as speed approaches the floor: a full-size step
+		// at a high-TWR craft's fixed 100% thrust can remove MORE than
+		// the entire remaining speed in one step, overshooting past
+		// stopSpeedFloorMps and out the other side — surface-relative
+		// speed picks back up (thrust now chasing a reversed, near-zero
+		// vRel) and the loop never lands inside the floor at all. Capping
+		// each step to at most stopAdaptiveShrinkFrac of the speed
+		// available to remove (at the craft's own accel ceiling,
+		// thrust/mass — an upper bound since some of it may go to
+		// redirection rather than pure deceleration, which only makes
+		// this cap more conservative) makes the steps shrink geometrically
+		// on approach instead of overshooting, the same way
+		// bisectPoweredCrossing narrows a bracket rather than jumping past
+		// it.
+		if speedPre := physics.AirRelativeVelocity(state.R, state.V, primary).Norm(); speedPre > 0 {
+			if aAvail := thrustFull / massKg; aAvail > 0 {
+				if capDt := stopAdaptiveShrinkFrac * speedPre / aAvail; capDt < stepDt {
+					if capDt < stopAdaptiveMinDt {
+						capDt = stopAdaptiveMinDt
+					}
+					stepDt = capDt
+				}
+			}
+		}
+		massSnap := massKg
+		accelFn := func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
+			return poweredStopAccel(r, v, mu, primary, bc, thrustFull, massSnap)
+		}
+		pre := state
+		state = physics.StepRK4(state, stepDt, accelFn, 0)
+		elapsed += stepDt
+		burned := mdot * stepDt
+		if burned > fuelKg {
+			burned = fuelKg
+		}
+		fuelKg -= burned
+		massKg -= burned
+		dvUsed += (thrustFull / massSnap) * stepDt
+
+		if !crossedGround && state.R.Norm() < radius {
+			crossedGround = true
+			hit, _ := bisectPoweredCrossing(pre, stepDt, accelFn, func(s physics.StateVector) bool {
+				return s.R.Norm() < radius
+			})
+			impactSpeed = physics.AirRelativeVelocity(hit.R, hit.V, primary).Norm()
+		}
+
+		vRel := physics.AirRelativeVelocity(state.R, state.V, primary)
+		if vRel.Norm() <= stopSpeedFloorMps {
+			stopState, tau := bisectPoweredCrossing(pre, stepDt, accelFn, func(s physics.StateVector) bool {
+				return physics.AirRelativeVelocity(s.R, s.V, primary).Norm() <= stopSpeedFloorMps
+			})
+			outcome := StopStopped
+			if crossedGround {
+				outcome = StopCrashed
+			}
+			return PoweredStopPrediction{
+				Outcome:        outcome,
+				MarginM:        stopState.R.Norm() - radius,
+				ImpactSpeedMps: impactSpeed,
+				ElapsedSec:     elapsed - stepDt + tau,
+				DVUsedMps:      dvUsed,
+			}, true
+		}
+
+		if fuelKg <= 1e-9 {
+			outcome := StopFuelLimited
+			if crossedGround {
+				// Ground already breached — that already dominates the
+				// verdict. What we can no longer do, having spent every
+				// last kilogram, is keep searching for the natural
+				// (below-ground) zero-speed point StopCrashed's MarginM
+				// documents; best effort is wherever the integration
+				// stands at this instant.
+				outcome = StopCrashed
+			}
+			return PoweredStopPrediction{
+				Outcome:        outcome,
+				MarginM:        state.R.Norm() - radius,
+				ImpactSpeedMps: impactSpeed,
+				ElapsedSec:     elapsed,
+				DVUsedMps:      dvUsed,
+			}, true
+		}
+	}
+	return PoweredStopPrediction{}, false
+}
+
+// BurnAtCue is the "burn at" row (issue #377 §2): the latest point on
+// the current ballistic coast from which starting a PredictPoweredStop
+// burn still lands with non-negative margin — the standard suicide-burn
+// boundary. AltitudeM / InSec describe that point.
+type BurnAtCue struct {
+	AltitudeM float64
+	InSec     float64
+}
+
+// burnAtRefineIters bounds PredictBurnAt's continuous refinement once
+// the coarse sample-index bisection has bracketed the crossing between
+// two adjacent forwardBallisticPath samples. Each iteration LERPs a
+// candidate state between the bracket's two ALREADY-COMPUTED samples —
+// "use those samples as candidate start states instead of
+// re-propagating" (issue #377 §2) — and spends one more
+// predictPoweredStopFrom call testing it.
+const burnAtRefineIters = 3
+
+// lerpBallisticSample linearly interpolates between two adjacent
+// ballistic samples. Not a re-propagation: over one sample interval
+// (a small fraction of the coast, per forwardBallisticPath's sampling)
+// the ballistic R/V curve is close enough to straight that a lerp is a
+// good candidate state to test, and PredictBurnAt's bisection only ever
+// needs a candidate to TEST — the final answer's precision comes from
+// how many bisection rounds ran, not from this interpolation being
+// exact.
+func lerpBallisticSample(a, b ballisticSample, frac float64) ballisticSample {
+	return ballisticSample{
+		state: physics.StateVector{
+			R: a.state.R.Add(b.state.R.Sub(a.state.R).Scale(frac)),
+			V: a.state.V.Add(b.state.V.Sub(a.state.V).Scale(frac)),
+			M: a.state.M,
+		},
+		elapsedSec: a.elapsedSec + (b.elapsedSec-a.elapsedSec)*frac,
+	}
+}
+
+// PredictBurnAt finds the latest safe stop-burn start on the craft's
+// current ballistic coast (issue #377 §2). Stop margin is monotone in
+// start time (start later, stop lower), so this bisects rather than
+// scanning: forwardBallisticPath already samples the whole coast to draw
+// the dashed arc, and those samples are the candidate start states here
+// too — no second propagator, no re-walking the coast from scratch.
+//
+// ok=false when there is no future safe start to cue: either the coast
+// never finds ground contact within horizon (forwardBallisticPath itself
+// refuses), or the CURRENT instant is already unsafe — the corridor's own
+// Margin.State (CAN'T STOP) already carries that alarm, and a "burn at:
+// Xs ago" row would only muddy it.
+func PredictBurnAt(c *spacecraft.Spacecraft, horizon time.Duration) (BurnAtCue, bool) {
+	if c == nil {
+		return BurnAtCue{}, false
+	}
+	fc, ok := forwardBallisticPath(c, horizon)
+	if !ok || len(fc.samples) < 2 {
+		return BurnAtCue{}, false
+	}
+	radius := c.Primary.RadiusMeters()
+
+	safeAt := func(s ballisticSample) bool {
+		remaining := horizon - time.Duration(s.elapsedSec*float64(time.Second))
+		if remaining <= 0 {
+			return false
+		}
+		pred, ok := predictPoweredStopFrom(s.state, c, remaining)
+		return ok && pred.Outcome == StopStopped && pred.MarginM >= 0
+	}
+
+	if !safeAt(fc.samples[0]) {
+		return BurnAtCue{}, false
+	}
+
+	loIdx, hiIdx := 0, len(fc.samples)-1
+	if safeAt(fc.samples[hiIdx]) {
+		// Even the very end of the sampled coast is still stoppable (a
+		// shallow / slow descent) — best effort: the latest candidate we
+		// actually have.
+		last := fc.samples[hiIdx]
+		return BurnAtCue{AltitudeM: last.state.R.Norm() - radius, InSec: last.elapsedSec}, true
+	}
+	for hiIdx-loIdx > 1 {
+		mid := (loIdx + hiIdx) / 2
+		if safeAt(fc.samples[mid]) {
+			loIdx = mid
+		} else {
+			hiIdx = mid
+		}
+	}
+
+	lo, hi := fc.samples[loIdx], fc.samples[hiIdx]
+	loFrac, hiFrac := 0.0, 1.0
+	for i := 0; i < burnAtRefineIters; i++ {
+		mid := (loFrac + hiFrac) / 2
+		if safeAt(lerpBallisticSample(lo, hi, mid)) {
+			loFrac = mid
+		} else {
+			hiFrac = mid
+		}
+	}
+	best := lerpBallisticSample(lo, hi, loFrac)
+	return BurnAtCue{AltitudeM: best.state.R.Norm() - radius, InSec: best.elapsedSec}, true
+}
+
+// marginTightAltitudeFrac is the fraction of CURRENT altitude below
+// which a StopStopped margin still reads TIGHT rather than OK — issue
+// #377 §4's suggested "~10% of current altitude".
+const marginTightAltitudeFrac = 0.10
+
+// burnAtImminentSec is how soon the "burn at" cue can be before a
+// StopStopped margin promotes to TIGHT on that grounds alone — issue
+// #377 §4's "or the start cue is inside a few seconds".
+const burnAtImminentSec = 5.0
+
+// DeriveMarginState maps a PredictPoweredStop result (plus, when
+// available, the PredictBurnAt cue) onto the OK / TIGHT / CAN'T STOP
+// alarm ladder the surface view's arc colour and alarm
+// (screens/launch.go) key off (issue #377 §4). Pure and cheap — no
+// integration here, so callers can call this every frame straight off a
+// CACHED Stop/BurnAt pair without re-triggering the expensive forecasts.
+//
+//   - StopUndetermined (stopOK false): the integration couldn't resolve
+//     within its step budget. Read as CAN'T STOP, not "unknown" — an
+//     instrument that flatters the pilot on "I don't know" is worse than
+//     none (BurnMargin's own doc comment makes the same call for its
+//     degenerate case).
+//   - StopCrashed / StopFuelLimited: CAN'T STOP from THIS stage, full
+//     stop. Limiter names which one bound it — thrust (ran into the
+//     ground before killing the speed) or fuel (ran dry first) — the
+//     terminal condition the integration actually hit, better evidence
+//     than a two-ratio comparison ever was.
+//   - StopStopped: OK, unless the margin is thin (< ~10% of current
+//     altitude) or the latest safe start is only seconds away, either of
+//     which promotes to TIGHT.
+func DeriveMarginState(stop PoweredStopPrediction, stopOK bool, currentAltitudeM float64, burnAt BurnAtCue, hasBurnAt bool) BurnMargin {
+	if !stopOK {
+		return BurnMargin{State: MarginInsufficient, Limiter: LimitThrust}
+	}
+	switch stop.Outcome {
+	case StopCrashed:
+		return BurnMargin{State: MarginInsufficient, Limiter: LimitThrust, ReqDVMps: stop.DVUsedMps}
+	case StopFuelLimited:
+		return BurnMargin{State: MarginInsufficient, Limiter: LimitFuel, ReqDVMps: stop.DVUsedMps}
+	case StopStopped:
+		tight := hasBurnAt && burnAt.InSec >= 0 && burnAt.InSec < burnAtImminentSec
+		if currentAltitudeM > 0 && stop.MarginM < currentAltitudeM*marginTightAltitudeFrac {
+			tight = true
+		}
+		state := MarginOK
+		if tight {
+			state = MarginTight
+		}
+		return BurnMargin{State: state, Limiter: LimitNone, ReqDVMps: stop.DVUsedMps}
+	}
+	return BurnMargin{State: MarginNone}
+}
+
 // descentRateFloorMps is the surface-relative descent rate below which
 // the corridor stands down. Above zero so a craft parked on a pad, or
 // one the pilot has already brought to a hover, doesn't flicker the
@@ -361,8 +891,8 @@ func ComputeBurnMargin(thrustN, massKg, gLocalMps2, descentRateMps, altitudeM, a
 const descentRateFloorMps = 0.1
 
 // DescentCorridor is the surface view's descent instrument block:
-// altitude, descent rate, time to impact, and the burn margin, plus the
-// impact forecast the arc and the ground marker are drawn from.
+// altitude, descent rate, time to impact, plus the impact forecast the
+// arc and the ground marker are drawn from.
 //
 // HorizontalRateMps / FlightPathAngleDeg are the two readings the older
 // airless-body DESCENT chip carried that the corridor's own four numbers
@@ -370,10 +900,22 @@ const descentRateFloorMps = 0.1
 // during a descent instead of two that disagree about sign conventions —
 // the corridor says `descent: 40 m/s` where DESCENT said `v_vert: -40.0
 // m/s`, and having both on screen at once was the duplication this
-// resolves. The chip's other two rows are genuinely redundant and did not
-// come along: `twr` asks "can I stop", which Margin answers better
-// (it accounts for the altitude and speed a bare thrust-to-weight can't),
-// and `sas` is the ATTITUDE chip's own row.
+// resolves. FlightPathAngleDeg / HasFPA are no longer rendered as their
+// own row (issue #377's pinned row layout drops `fpa` in favour of
+// `burn at` / `stop margin`) but stay on the struct — cheap to compute,
+// and descentKinematics still needs the intermediate value.
+//
+// Stop / StopOK and BurnAt / HasBurnAt are DescentCorridorFor's OWN
+// fields but are NOT populated by it — they are the expensive half
+// (PredictPoweredStop / PredictBurnAt, issue #377) that callers are
+// expected to cache (ADR 0017) and merge in themselves. See
+// screens.LaunchView's descentStopCache / cachedDescentStop: it calls
+// DescentCorridorFor for the cheap gate + numbers, then separately (and
+// cached) fills these two fields plus Margin before handing the struct to
+// the renderer. Margin is still String()able / colour-drivable exactly as
+// before (MarginState / MarginLimiter survive unchanged) — only ITS
+// source changed, from ComputeBurnMargin's frozen scalars to
+// DeriveMarginState reading the integrated Stop/BurnAt result.
 type DescentCorridor struct {
 	AltitudeM      float64
 	DescentRateMps float64 // surface-relative, positive = falling
@@ -389,7 +931,22 @@ type DescentCorridor struct {
 	FlightPathAngleDeg float64
 	HasFPA             bool
 	Impact             ImpactPrediction
-	Margin             BurnMargin
+
+	// Stop / StopOK: PredictPoweredStop's result for the CURRENT state —
+	// not populated by DescentCorridorFor (see the type doc). StopOK
+	// false means the integration hit its step cap without resolving
+	// (refused, not a definite answer).
+	Stop   PoweredStopPrediction
+	StopOK bool
+	// BurnAt / HasBurnAt: PredictBurnAt's "latest safe start" cue — not
+	// populated by DescentCorridorFor (see the type doc). HasBurnAt is
+	// false both when no future start is safe (already past the point of
+	// no return — StopOK's own Margin.State already carries that alarm)
+	// and, by convention, once the burn is under way (issue #377: "burn
+	// at hides once the burn is under way").
+	BurnAt    BurnAtCue
+	HasBurnAt bool
+	Margin    BurnMargin
 }
 
 // fpaSpeedFloorMps is the surface-relative speed below which the flight
@@ -399,14 +956,26 @@ type DescentCorridor struct {
 // folded rows read identically to the ones they replace.
 const fpaSpeedFloorMps = 1.0
 
-// DescentCorridorFor builds the corridor for a craft, or reports
-// ok=false when the craft isn't in a descent worth instrumenting. The
-// gate is deliberately the FORECAST, not the phase: instruments appear
-// exactly when the current trajectory reaches the ground inside the
-// horizon while the craft is falling. That keeps them off an ascent
-// (climbing, so no descent rate) and off a stable parking orbit (falling
-// toward periapsis, but never reaching the surface), with no separate
-// phase predicate to drift out of step with the picture on the canvas.
+// DescentCorridorFor builds the CHEAP half of the corridor for a craft,
+// or reports ok=false when the craft isn't in a descent worth
+// instrumenting. The gate is deliberately the FORECAST, not the phase:
+// instruments appear exactly when the current trajectory reaches the
+// ground inside the horizon while the craft is falling. That keeps them
+// off an ascent (climbing, so no descent rate) and off a stable parking
+// orbit (falling toward periapsis, but never reaching the surface), with
+// no separate phase predicate to drift out of step with the picture on
+// the canvas.
+//
+// This does NOT compute Stop / BurnAt / Margin (issue #377): those need
+// PredictPoweredStop and PredictBurnAt, each up to ~1000 RK4 sub-steps
+// (and the burn-at search multiplies that ~8-10x), so running them here
+// would make this function exactly the kind of per-frame cost ADR 0017 /
+// #363 exist to keep off the render path. Callers that need the full
+// block (screens.LaunchView) call this for the cheap gate + numbers, then
+// separately — and CACHED — call PredictPoweredStop / PredictBurnAt /
+// DeriveMarginState and merge the result in. Callers that only need the
+// gate (sim.updateLaunchHint's `descending` check) pay nothing extra at
+// all: the returned Stop/BurnAt/Margin fields are simply left zero-valued.
 func DescentCorridorFor(c *spacecraft.Spacecraft, horizon time.Duration) (DescentCorridor, bool) {
 	k, ok := descentKinematics(c)
 	if !ok {
@@ -423,14 +992,6 @@ func DescentCorridorFor(c *spacecraft.Spacecraft, horizon time.Duration) (Descen
 		FlightPathAngleDeg: k.fpaDeg,
 		HasFPA:             k.hasFPA,
 		Impact:             impact,
-		Margin: ComputeBurnMargin(
-			c.Thrust,
-			c.TotalMass(),
-			k.gLocal,
-			k.descentRate,
-			k.altM,
-			c.RemainingDeltaV(),
-		),
 	}, true
 }
 

--- a/internal/sim/descent.go
+++ b/internal/sim/descent.go
@@ -357,6 +357,15 @@ type BurnMargin struct {
 
 // ComputeBurnMargin evaluates the margin from SI scalars. Pure, so the
 // arithmetic can be pinned exactly by tests without seeding a World.
+//
+// Superseded by PredictPoweredStop (issue #377) as the corridor's actual
+// margin — DescentCorridorFor no longer calls this at all (see its doc
+// comment). It is kept only as the frozen-scalar BASELINE
+// TestPredictPoweredStopLunaHorizontalRegression pins its "before"
+// number against — that regression is the evidence the whole slice
+// rests on, so the old arithmetic needs to keep existing and keep being
+// exactly this, not because anything should call it live again. Do not
+// wire this back into DescentCorridorFor or any other live code path.
 func ComputeBurnMargin(thrustN, massKg, gLocalMps2, descentRateMps, altitudeM, availDVMps float64) BurnMargin {
 	if massKg <= 0 || altitudeM <= 0 || descentRateMps <= 0 {
 		return BurnMargin{AvailDVMps: availDVMps}
@@ -518,6 +527,47 @@ const (
 	stopAdaptiveMinDt      = 0.01
 )
 
+// stopStepSizeSeconds picks one outer-loop sub-step for
+// predictPoweredStopFrom's integration: no larger than dt, capped
+// further so a step never outruns the current stage's remaining fuel
+// (fuelTimeLeftSec = fuelKg/mdot — mass bookkeeping already clamps
+// `burned` to what's left regardless, but a step WIDER than that would
+// still integrate full thrust, via poweredStopAccel, for longer than the
+// tank can actually sustain it: an impulse the mass side never paid
+// for), and, near the stop-speed floor, capped again so a step can't
+// remove more than stopAdaptiveShrinkFrac of the current speed (see
+// stopAdaptiveShrinkFrac's doc).
+//
+// The adaptive cap has its own floor, stopAdaptiveMinDt, so it can't
+// shrink to zero and stall the loop at the vRel==0 singularity — but
+// that floor must never be allowed to WIDEN the step back out past the
+// fuel cap. A prior version applied the floor unconditionally
+// (`stepDt = capDt` after raising capDt to the floor), so a step already
+// shortened to a few ms by an almost-exhausted tank could get stretched
+// back out to stopAdaptiveMinDt — up to 5x longer than the tank
+// sustains at the sizes involved. Numerically small (stopAdaptiveMinDt
+// is 10 ms) but wrong in kind, and the kind of wrong that stops being
+// negligible if the floor is ever raised. The `< stepDt` re-check below
+// is what keeps the floor-raise from ever widening the step past
+// whatever cap (dt or the fuel cap) was already in force.
+func stopStepSizeSeconds(dt, fuelTimeLeftSec, speedPre, aAvail float64) float64 {
+	stepDt := dt
+	if fuelTimeLeftSec < stepDt {
+		stepDt = fuelTimeLeftSec
+	}
+	if speedPre > 0 && aAvail > 0 {
+		if capDt := stopAdaptiveShrinkFrac * speedPre / aAvail; capDt < stepDt {
+			if capDt < stopAdaptiveMinDt {
+				capDt = stopAdaptiveMinDt
+			}
+			if capDt < stepDt {
+				stepDt = capDt
+			}
+		}
+	}
+	return stepDt
+}
+
 // poweredStopAccel is the ONE accel closure behind every termination
 // test inside PredictPoweredStop / PredictBurnAt (this file's own #66
 // rule, restated for the powered half): two-body gravity, drag exactly
@@ -632,38 +682,9 @@ func predictPoweredStopFrom(state physics.StateVector, c *spacecraft.Spacecraft,
 	dvUsed := 0.0
 
 	for i := 0; i < steps; i++ {
-		// Fuel exhausted exactly mid-step: shorten this step to the
-		// instant it runs dry rather than overrunning the tank — an
-		// algebraic result (mdot is constant while thrustFull is firing),
-		// not another bisection.
-		stepDt := dt
-		if ttx := fuelKg / mdot; ttx < stepDt {
-			stepDt = ttx
-		}
-		// Adaptive shrink as speed approaches the floor: a full-size step
-		// at a high-TWR craft's fixed 100% thrust can remove MORE than
-		// the entire remaining speed in one step, overshooting past
-		// stopSpeedFloorMps and out the other side — surface-relative
-		// speed picks back up (thrust now chasing a reversed, near-zero
-		// vRel) and the loop never lands inside the floor at all. Capping
-		// each step to at most stopAdaptiveShrinkFrac of the speed
-		// available to remove (at the craft's own accel ceiling,
-		// thrust/mass — an upper bound since some of it may go to
-		// redirection rather than pure deceleration, which only makes
-		// this cap more conservative) makes the steps shrink geometrically
-		// on approach instead of overshooting, the same way
-		// bisectPoweredCrossing narrows a bracket rather than jumping past
-		// it.
-		if speedPre := physics.AirRelativeVelocity(state.R, state.V, primary).Norm(); speedPre > 0 {
-			if aAvail := thrustFull / massKg; aAvail > 0 {
-				if capDt := stopAdaptiveShrinkFrac * speedPre / aAvail; capDt < stepDt {
-					if capDt < stopAdaptiveMinDt {
-						capDt = stopAdaptiveMinDt
-					}
-					stepDt = capDt
-				}
-			}
-		}
+		speedPre := physics.AirRelativeVelocity(state.R, state.V, primary).Norm()
+		aAvail := thrustFull / massKg
+		stepDt := stopStepSizeSeconds(dt, fuelKg/mdot, speedPre, aAvail)
 		massSnap := massKg
 		accelFn := func(r, v orbital.Vec3, _ float64) orbital.Vec3 {
 			return poweredStopAccel(r, v, mu, primary, bc, thrustFull, massSnap)
@@ -900,10 +921,10 @@ const descentRateFloorMps = 0.1
 // during a descent instead of two that disagree about sign conventions —
 // the corridor says `descent: 40 m/s` where DESCENT said `v_vert: -40.0
 // m/s`, and having both on screen at once was the duplication this
-// resolves. FlightPathAngleDeg / HasFPA are no longer rendered as their
-// own row (issue #377's pinned row layout drops `fpa` in favour of
-// `burn at` / `stop margin`) but stay on the struct — cheap to compute,
-// and descentKinematics still needs the intermediate value.
+// resolves. FlightPathAngleDeg / HasFPA still render as their own `fpa`
+// row alongside `burn at` / `stop margin` — issue #377's pinned mock
+// sketched only the two new rows, not the whole block, so dropping
+// `fpa` was read too literally the first time round.
 //
 // Stop / StopOK and BurnAt / HasBurnAt are DescentCorridorFor's OWN
 // fields but are NOT populated by it — they are the expensive half

--- a/internal/sim/descent_powered_stop_test.go
+++ b/internal/sim/descent_powered_stop_test.go
@@ -1,0 +1,359 @@
+// Package sim — tests for the integrated stop-burn forecast (issue
+// #377): PredictPoweredStop, PredictBurnAt, and DeriveMarginState. See
+// descent_test.go for the ballistic-forecast (PredictImpact) and
+// ComputeBurnMargin arithmetic tests this file complements.
+
+package sim
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// --- Analytic verification -------------------------------------------
+//
+// A purely vertical powered stop under constant g, zero drag, and the
+// ideal (Tsiolkovsky) rocket equation has a closed form:
+//
+//	ds/dt = g - F/m(t),   m(t) = m0 - mdot·t,   mdot = F/(Isp·g0)
+//
+// Integrating once (∫F/m(t)dt = Isp·g0·ln(m0/m(t)), the rocket
+// equation's own Δv):
+//
+//	s(t) = s0 + g·t - Isp·g0·ln(a/(a-t)),   a = m0/mdot
+//
+// and integrating again for the distance fallen:
+//
+//	d(t) = s0·t + g·t²/2 - Isp·g0·[t·ln(a) + t - a·ln(a) + (a-t)·ln(a-t)]
+//
+// Both are independent of PredictPoweredStop's own RK4 integration —
+// this is the analytic cross-check issue #377 asks for, not a
+// self-consistency test against the production code path.
+
+func analyticStopSpeed(t, s0, g, ispg0, a float64) float64 {
+	return s0 + g*t - ispg0*math.Log(a/(a-t))
+}
+
+func analyticStopDistance(t, s0, g, ispg0, a float64) float64 {
+	bracket := t*math.Log(a) + t - a*math.Log(a) + (a-t)*math.Log(a-t)
+	return s0*t + g*t*t/2 - ispg0*bracket
+}
+
+// analyticStopTime bisects analyticStopSpeed for its zero crossing in
+// (0, a) — the closed-form time to null s0 under constant g and the
+// ideal rocket equation.
+func analyticStopTime(t *testing.T, s0, g, ispg0, a float64) float64 {
+	t.Helper()
+	lo, hi := 0.0, a*0.999 // stay strictly short of exhausting all mass
+	if analyticStopSpeed(hi, s0, g, ispg0, a) > 0 {
+		t.Fatalf("setup: even burning to %.1f s (~all mass) doesn't null %.1f m/s — pick a stronger engine", hi, s0)
+	}
+	for i := 0; i < 100; i++ {
+		mid := (lo + hi) / 2
+		if analyticStopSpeed(mid, s0, g, ispg0, a) > 0 {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return (lo + hi) / 2
+}
+
+// hugeRadiusAirlessBody is a synthetic primary for the analytic case: a
+// huge radius (g changes ~1e-5 relative over a few-km descent — constant
+// to any tolerance this test cares about), no atmosphere (zero drag,
+// matching physics.DragAccel's nil-Atmosphere short-circuit), and no
+// rotation (SideralRotation/SideralOrbit left zero, so
+// physics.AtmosphereOmega returns the zero vector and
+// AirRelativeVelocity is exactly the inertial velocity — no incidental
+// horizontal component from body spin to break the "purely vertical"
+// idealisation).
+func hugeRadiusAirlessBody(desiredGMps2 float64) bodies.CelestialBody {
+	const radiusM = 1.0e9
+	mu := desiredGMps2 * radiusM * radiusM
+	massKg := mu / bodies.G
+	return bodies.CelestialBody{
+		ID:         "analytic-test-body",
+		MeanRadius: radiusM / 1000.0,
+		Mass:       bodies.Mass{Value: massKg / 1e28, Exponent: 28},
+	}
+}
+
+// TestPredictPoweredStopMatchesAnalyticConstantGCase is issue #377's
+// required analytic cross-check: constant g, no drag, ideal rocket
+// equation, purely vertical (so the closed form applies exactly — no
+// horizontal component for the integrator to spend accel on that the
+// 1-D analytic model doesn't have). PredictPoweredStop's RK4 integration
+// must land within a tight tolerance of the closed-form time and
+// distance, independently computed above.
+func TestPredictPoweredStopMatchesAnalyticConstantGCase(t *testing.T) {
+	const (
+		g       = 1.62 // moon-like, but on a body large enough to hold ~constant
+		thrustN = 40_000.0
+		ispSec  = 300.0
+		massKg0 = 10_000.0
+		fuelKg  = 5_000.0
+		v0      = 100.0   // m/s, straight down
+		altM    = 5_000.0 // start altitude
+	)
+	body := hugeRadiusAirlessBody(g)
+	gotG := body.GravitationalParameter() / (body.RadiusMeters() * body.RadiusMeters())
+
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Primary = body
+	c.Landed = false
+	c.Crashed = false
+	c.Stages = nil // flat DryMass/Fuel/Thrust/Isp fields govern, not a stale stage
+	c.Thrust = thrustN
+	c.Isp = ispSec
+	c.DryMass = massKg0 - fuelKg
+	c.Fuel = fuelKg
+	c.Monoprop = 0
+	c.State.R = orbital.Vec3{X: body.RadiusMeters() + altM}
+	c.State.V = orbital.Vec3{X: -v0}
+	c.State.M = c.TotalMass()
+
+	got, ok := PredictPoweredStop(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictPoweredStop refused the analytic case")
+	}
+	if got.Outcome != StopStopped {
+		t.Fatalf("Outcome = %v, want StopStopped", got.Outcome)
+	}
+
+	g0 := stdGravityMps2
+	ispg0 := ispSec * g0
+	mdot := thrustN / ispg0
+	a := massKg0 / mdot
+
+	wantT := analyticStopTime(t, v0, gotG, ispg0, a)
+	wantDist := analyticStopDistance(wantT, v0, gotG, ispg0, a)
+	wantMargin := altM - wantDist
+
+	if diff := math.Abs(got.ElapsedSec - wantT); diff > 0.01*wantT {
+		t.Errorf("ElapsedSec = %.3f s, want %.3f s (analytic, ±1%%)", got.ElapsedSec, wantT)
+	}
+	if diff := math.Abs(got.MarginM - wantMargin); diff > 0.01*altM {
+		t.Errorf("MarginM = %.1f m, want %.1f m (analytic, ±1%% of start altitude)", got.MarginM, wantMargin)
+	}
+}
+
+// --- The #377 regression --------------------------------------------
+
+// TestPredictPoweredStopLunaHorizontalRegression is the regression that
+// proves the point: a stressed lunar lander (TWR 1.1 at the Moon's own
+// g — thin margin over hover, but nowhere near "obviously can't fly",
+// Isp 311 s; not the repo's oversized default seed craft) carrying
+// 1600 m/s of HORIZONTAL speed plus a mundane 41 m/s vertical descent
+// rate at 100 km altitude.
+//
+// BEFORE (today's frozen-scalar ComputeBurnMargin, which only ever sees
+// the VERTICAL descent rate): the ratio is enormous — the model has no
+// idea 1.6 km/s of horizontal speed exists at all, so it reads
+// comfortably OK.
+//
+// AFTER (PredictPoweredStop, integrating the real burn): pointing
+// retrograde against the TRUE (mostly horizontal) velocity spends most
+// of the burn's authority fighting the horizontal component while
+// gravity keeps pulling the craft down almost unopposed — it crashes,
+// still carrying most of its speed. (A stronger lander CAN kill 1.6 km/s
+// inside 100 km once the real vector math is run — TWR 1.3+ at this
+// altitude/rate stops clean per this file's own sweep — which is exactly
+// why hand-derived scalar corrections are the wrong tool here: whether
+// this specific craft can stop depends on the coupled 3-D burn, not a
+// ratio.)
+//
+// The exact numbers are pinned below (computed, not hand-derived) so a
+// future change to either model has to explain why they moved.
+func TestPredictPoweredStopLunaHorizontalRegression(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Primary = bodyForTest(t, w, "moon")
+	c.Landed = false
+	c.Crashed = false
+	c.Stages = nil
+
+	moonG := c.Primary.GravitationalParameter() / (c.Primary.RadiusMeters() * c.Primary.RadiusMeters())
+	const (
+		massKg0    = 15_000.0
+		fuelKg     = 10_000.0
+		ispSec     = 311.0
+		twrAtMoonG = 1.1
+		vertMps    = 41.0
+		horizMps   = 1604.0
+		altM       = 100_000.0
+	)
+	thrustN := twrAtMoonG * moonG * massKg0
+
+	c.Thrust = thrustN
+	c.Isp = ispSec
+	c.DryMass = massKg0 - fuelKg
+	c.Fuel = fuelKg
+	c.Monoprop = 0
+	c.State.R = orbital.Vec3{X: c.Primary.RadiusMeters() + altM}
+	c.State.V = orbital.Vec3{X: -vertMps, Y: horizMps}
+	c.State.M = c.TotalMass()
+
+	// BEFORE: the frozen-scalar model, fed only the vertical rate — the
+	// exact call DescentCorridorFor used to make (pre-#377).
+	before := ComputeBurnMargin(c.Thrust, c.TotalMass(), moonG, vertMps, altM, c.RemainingDeltaV())
+	if before.State != MarginOK {
+		t.Fatalf("setup: want the OLD model to call this comfortably OK (that's the point of the regression), got State=%v Ratio=%.2f",
+			before.State, before.Ratio)
+	}
+	if before.Ratio < 5 {
+		t.Fatalf("setup: want the OLD model's ratio to read \"comfortably\" OK (≥5), got %.2f — scenario isn't dramatic enough", before.Ratio)
+	}
+	t.Logf("BEFORE (frozen-scalar, vertical-only): Ratio=%.2f State=%v — comfortably OK, blind to the %.0f m/s horizontal component",
+		before.Ratio, before.State, horizMps)
+
+	// AFTER: integrate the real burn.
+	after, ok := PredictPoweredStop(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictPoweredStop refused — want a definite Crashed verdict")
+	}
+	if after.Outcome != StopCrashed {
+		t.Fatalf("Outcome = %v, want StopCrashed — a 2x-TWR lander cannot kill %.0f m/s of mostly-horizontal speed inside %.0f km",
+			after.Outcome, horizMps, altM/1000)
+	}
+	t.Logf("AFTER (integrated): Outcome=%v MarginM=%.0f (short by %.0f m) ImpactSpeedMps=%.0f ElapsedSec=%.1f",
+		after.Outcome, after.MarginM, -after.MarginM, after.ImpactSpeedMps, after.ElapsedSec)
+
+	if after.MarginM >= 0 {
+		t.Errorf("MarginM = %.1f, want negative (short-by, not a survived stop)", after.MarginM)
+	}
+	// The alarm chain: this reads CAN'T STOP / thrust, not the old
+	// model's comfortable multi-x ratio.
+	margin := DeriveMarginState(after, ok, altM, BurnAtCue{}, false)
+	if margin.State != MarginInsufficient {
+		t.Errorf("DeriveMarginState = %v, want MarginInsufficient", margin.State)
+	}
+	if margin.Limiter != LimitThrust {
+		t.Errorf("Limiter = %v, want thrust (ran into the ground, not out of propellant)", margin.Limiter)
+	}
+}
+
+// --- Responsiveness to thrust -----------------------------------------
+
+// TestPredictPoweredStopMarginRespondsToSpeedShed mirrors
+// TestPredictImpactShiftsUnderThrust's shape for the new forecast: full-
+// throttle retrograde thrust bleeds surface-relative speed over time,
+// and the stop margin has to visibly IMPROVE in response — not just
+// passively shrink as altitude is spent — the same "responds to thrust"
+// property the impact marker already has (issue #377 acceptance: "Burning
+// full throttle makes the stop margin stop shrinking").
+func TestPredictPoweredStopMarginRespondsToSpeedShed(t *testing.T) {
+	_, c := dropTestCraft(t, 50_000)
+	c.Thrust = 30_000
+	c.Isp = 300
+	c.DryMass, c.Fuel, c.Monoprop = 4_000, 6_000, 0
+	c.Stages = nil
+	c.State.V = orbital.Vec3{X: -50, Y: 900}
+	c.State.M = c.TotalMass()
+
+	before, ok := PredictPoweredStop(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictPoweredStop refused before the speed was shed")
+	}
+
+	// The same thing full-throttle retrograde thrust does over time:
+	// less surface-relative speed to kill. Mass is held fixed so the
+	// improvement can't be credited to the (also-real, but separate)
+	// mass-loss effect — isolating the velocity term.
+	c.State.V = orbital.Vec3{X: -50, Y: 600}
+	after, ok := PredictPoweredStop(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictPoweredStop refused after the speed was shed")
+	}
+
+	if after.MarginM <= before.MarginM {
+		t.Errorf("MarginM did not improve after shedding 300 m/s of horizontal speed: before=%.0f after=%.0f",
+			before.MarginM, after.MarginM)
+	}
+}
+
+// TestDeriveMarginStateBands pins the OK / TIGHT / CAN'T STOP mapping
+// (issue #377 §4) against synthetic PoweredStopPrediction values, so the
+// alarm ladder's thresholds are asserted directly rather than only
+// through an end-to-end integration.
+func TestDeriveMarginStateBands(t *testing.T) {
+	const altitudeM = 10_000.0
+	cases := []struct {
+		name    string
+		stop    PoweredStopPrediction
+		stopOK  bool
+		burnAt  BurnAtCue
+		hasBA   bool
+		want    MarginState
+		limiter MarginLimiter
+	}{
+		{"stopped, comfortable margin", PoweredStopPrediction{Outcome: StopStopped, MarginM: 5000}, true, BurnAtCue{}, false, MarginOK, LimitNone},
+		{"stopped, thin margin (<10% altitude)", PoweredStopPrediction{Outcome: StopStopped, MarginM: 500}, true, BurnAtCue{}, false, MarginTight, LimitNone},
+		{"stopped, comfortable margin but imminent burn-at", PoweredStopPrediction{Outcome: StopStopped, MarginM: 5000}, true, BurnAtCue{InSec: 2}, true, MarginTight, LimitNone},
+		{"crashed", PoweredStopPrediction{Outcome: StopCrashed, MarginM: -200}, true, BurnAtCue{}, false, MarginInsufficient, LimitThrust},
+		{"fuel-limited", PoweredStopPrediction{Outcome: StopFuelLimited, MarginM: 3000}, true, BurnAtCue{}, false, MarginInsufficient, LimitFuel},
+		{"undetermined (step cap)", PoweredStopPrediction{}, false, BurnAtCue{}, false, MarginInsufficient, LimitThrust},
+	}
+	for _, c := range cases {
+		got := DeriveMarginState(c.stop, c.stopOK, altitudeM, c.burnAt, c.hasBA)
+		if got.State != c.want {
+			t.Errorf("%s: State = %v, want %v", c.name, got.State, c.want)
+		}
+		if got.Limiter != c.limiter {
+			t.Errorf("%s: Limiter = %v, want %v", c.name, got.Limiter, c.limiter)
+		}
+	}
+}
+
+// --- burn at -----------------------------------------------------------
+
+// TestPredictBurnAtFindsALaterSafeStart: a craft with plenty of stopping
+// capability right now (comfortable margin) should have a burn-at cue
+// LATER than "now" — there's room to wait — and the cued altitude must
+// sit strictly below the craft's current altitude on the same ballistic
+// coast (it's a point further along the fall).
+func TestPredictBurnAtFindsALaterSafeStart(t *testing.T) {
+	_, c := dropTestCraft(t, 50_000)
+	c.Thrust = 60_000
+	c.Isp = 311
+	c.DryMass, c.Fuel, c.Monoprop = 5_000, 10_000, 0
+	c.Stages = nil
+	c.State.V = orbital.Vec3{X: -20, Y: 300}
+	c.State.M = c.TotalMass()
+
+	cue, ok := PredictBurnAt(c, DescentPredictHorizon)
+	if !ok {
+		t.Fatal("PredictBurnAt found no safe future start for a comfortably-stoppable descent")
+	}
+	if cue.InSec <= 0 {
+		t.Errorf("InSec = %.2f, want > 0 (a later moment than now)", cue.InSec)
+	}
+	if cue.AltitudeM >= 50_000 {
+		t.Errorf("AltitudeM = %.0f, want below the craft's current 50000 m altitude", cue.AltitudeM)
+	}
+}
+
+// TestPredictBurnAtHiddenWhenAlreadyUnstoppable: once the current
+// instant is already unstoppable, PredictBurnAt reports ok=false — the
+// corridor's own CAN'T STOP alarm already carries the message, and a
+// "burn at Xs ago" row would only muddy it.
+func TestPredictBurnAtHiddenWhenAlreadyUnstoppable(t *testing.T) {
+	_, c := dropTestCraft(t, 500)
+	c.Thrust = 0
+	c.Isp = 0
+	c.State.V = orbital.Vec3{X: -300}
+
+	if _, ok := PredictBurnAt(c, DescentPredictHorizon); ok {
+		t.Error("PredictBurnAt returned a cue for an already-unstoppable descent, want ok=false")
+	}
+}

--- a/internal/sim/descent_powered_stop_test.go
+++ b/internal/sim/descent_powered_stop_test.go
@@ -357,3 +357,60 @@ func TestPredictBurnAtHiddenWhenAlreadyUnstoppable(t *testing.T) {
 		t.Error("PredictBurnAt returned a cue for an already-unstoppable descent, want ok=false")
 	}
 }
+
+// --- Step-size clamp (PR #382 review finding 2) -----------------------
+
+// TestStopStepSizeSecondsNeverExceedsFuelCap is the review's finding 2
+// regression: the adaptive-shrink floor (stopAdaptiveMinDt) must never
+// widen a step back out past the fuel-exhaustion cap
+// (fuelTimeLeftSec = fuelKg/mdot). The reviewer's own reproduction —
+// ttx = 0.002, and an adaptive cap that would compute to 0.001 before
+// the floor raises it to stopAdaptiveMinDt (0.01) — is pinned directly:
+// speedPre/aAvail is chosen so stopAdaptiveShrinkFrac*speedPre/aAvail =
+// 0.001 (below the 0.01 floor), with fuelTimeLeftSec tighter still at
+// 0.002. A step that size integrates full thrust (poweredStopAccel)
+// for 5x longer than the tank actually sustains it — mass bookkeeping
+// stays correct (burned is separately clamped to fuelKg in the caller),
+// but the IMPULSE the RK4 step applies would not be.
+func TestStopStepSizeSecondsNeverExceedsFuelCap(t *testing.T) {
+	const (
+		dt              = 1.0
+		fuelTimeLeftSec = 0.002 // ttx: the tank runs dry after 2 ms at full thrust
+		speedPre        = 0.002
+		aAvail          = 1.0 // stopAdaptiveShrinkFrac(0.5)*speedPre/aAvail = 0.001, below stopAdaptiveMinDt
+	)
+	got := stopStepSizeSeconds(dt, fuelTimeLeftSec, speedPre, aAvail)
+	if got > fuelTimeLeftSec {
+		t.Errorf("stopStepSizeSeconds = %v, want <= fuelTimeLeftSec (%v) — the adaptive floor widened the step past what the tank sustains",
+			got, fuelTimeLeftSec)
+	}
+	if got != fuelTimeLeftSec {
+		t.Errorf("stopStepSizeSeconds = %v, want exactly fuelTimeLeftSec (%v): the fuel cap is the tightest bound here", got, fuelTimeLeftSec)
+	}
+}
+
+// TestStopStepSizeSecondsAdaptiveShrinkStillWorks: the floor-raise fix
+// must not defeat the adaptive shrink's actual job — when fuel ISN'T the
+// binding constraint, a step near the stop-speed floor still shrinks
+// (down to stopAdaptiveMinDt when the raw computation would go smaller
+// still), so the loop keeps converging instead of overshooting.
+func TestStopStepSizeSecondsAdaptiveShrinkStillWorks(t *testing.T) {
+	const (
+		dt              = 1.0
+		fuelTimeLeftSec = 1000.0 // ample — not the binding constraint
+	)
+	// Raw adaptive computation (0.5*speedPre/aAvail) undershoots the
+	// floor: the floor must win, and nothing here should widen it back
+	// toward fuelTimeLeftSec or dt.
+	if got := stopStepSizeSeconds(dt, fuelTimeLeftSec, 0.0001, 1.0); got != stopAdaptiveMinDt {
+		t.Errorf("stopStepSizeSeconds = %v, want the floor %v (fuel is not binding here)", got, stopAdaptiveMinDt)
+	}
+	// Raw adaptive computation comfortably clears the floor: use it as-is.
+	if got, want := stopStepSizeSeconds(dt, fuelTimeLeftSec, 1.0, 1.0), 0.5; got != want {
+		t.Errorf("stopStepSizeSeconds = %v, want %v (plain adaptive shrink, no floor involved)", got, want)
+	}
+	// Neither cap engages: full dt.
+	if got := stopStepSizeSeconds(dt, fuelTimeLeftSec, 1000.0, 1.0); got != dt {
+		t.Errorf("stopStepSizeSeconds = %v, want dt (%v) — neither cap should have engaged", got, dt)
+	}
+}

--- a/internal/sim/descent_test.go
+++ b/internal/sim/descent_test.go
@@ -308,20 +308,39 @@ func TestDescentCorridorForGating(t *testing.T) {
 }
 
 // TestDescentCorridorAlarmsWhenItCannotStop: the end-to-end alarm. A
-// vessel falling fast with very little altitude left reports
-// MarginInsufficient — the state the surface view paints red.
+// vessel falling fast with very little altitude left, thrust or not,
+// integrates to MarginInsufficient via DeriveMarginState — the state the
+// surface view paints red. Issue #377 moved the corridor's Margin off
+// ComputeBurnMargin's frozen scalars, so this now drives the alarm chain
+// through PredictPoweredStop + DeriveMarginState directly rather than via
+// DescentCorridorFor (which no longer computes Margin at all — see its
+// doc comment).
 func TestDescentCorridorAlarmsWhenItCannotStop(t *testing.T) {
 	_, c := dropTestCraft(t, 500)
 	c.State.V = orbital.Vec3{X: -300} // 300 m/s straight down, 500 m to go
+	c.Thrust = 0                      // no engine at all: can't even begin a stop
+	c.Isp = 0
+
 	dc, ok := DescentCorridorFor(c, DescentPredictHorizon)
 	if !ok {
 		t.Fatal("corridor stood down for a 300 m/s descent 500 m up")
 	}
-	if dc.Margin.State != MarginInsufficient {
-		t.Errorf("Margin.State = %v (ratio %.3f), want MarginInsufficient",
-			dc.Margin.State, dc.Margin.Ratio)
-	}
 	if dc.Impact.TimeToImpact > 3*time.Second {
 		t.Errorf("TimeToImpact = %v, want under ~2 s at 300 m/s from 500 m", dc.Impact.TimeToImpact)
+	}
+
+	stop, stopOK := PredictPoweredStop(c, DescentPredictHorizon)
+	if !stopOK {
+		t.Fatal("PredictPoweredStop refused for a thrustless craft — want StopFuelLimited, not StopUndetermined")
+	}
+	if stop.Outcome != StopFuelLimited {
+		t.Errorf("Outcome = %v, want StopFuelLimited (no engine at all)", stop.Outcome)
+	}
+	margin := DeriveMarginState(stop, stopOK, dc.AltitudeM, BurnAtCue{}, false)
+	if margin.State != MarginInsufficient {
+		t.Errorf("Margin.State = %v, want MarginInsufficient", margin.State)
+	}
+	if margin.Limiter != LimitFuel {
+		t.Errorf("Limiter = %v, want fuel (no engine at all reads as the fuel side binding)", margin.Limiter)
 	}
 }

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -795,14 +795,25 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 	// enough sideways wrecks the vessel however gently the vertical rate
 	// has been nulled, and that is not something the corridor's other
 	// numbers imply.
-	horizLabel := fmt.Sprintf("%.0f m/s (surface-rel)", dc.HorizontalRateMps)
+	//
+	// Jason's call: strip the parentheticals that TEACH a returning pilot
+	// how to read a number (the `(surface-rel)` frame note, the
+	// `> N =` threshold lesson, the `(0 = horiz, −90 = straight down)`
+	// unit legend) — a legend printed every frame forever is scaffolding
+	// nobody needs after the first flight. Parentheticals that CARRY a
+	// number or a state (impact speed, which limiter bound a forecast)
+	// stay; those are data, not description. `CRASH on contact` is a
+	// standing warning, not a lesson, and survives on its own — this repo
+	// has a hard-won rule that transient feedback must not replace a
+	// standing warning.
+	horizLabel := fmt.Sprintf("%.0f m/s", dc.HorizontalRateMps)
 	if dc.HorizontalRateMps > sim.CrashVCritMps {
 		horizLabel = v.theme.Alert.Render(
-			fmt.Sprintf("%.0f m/s (> %.0f = CRASH on contact)", dc.HorizontalRateMps, sim.CrashVCritMps))
+			fmt.Sprintf("%.0f m/s (CRASH on contact)", dc.HorizontalRateMps))
 	}
 	fpaLabel := "—"
 	if dc.HasFPA {
-		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(dc.FlightPathAngleDeg, 0))
+		fpaLabel = fmt.Sprintf("%.0f°", nzero(dc.FlightPathAngleDeg, 0))
 	}
 	// Every row's label + colon + padding occupies EXACTLY 15 cells
 	// before the value starts, so the values line up in one column
@@ -863,7 +874,7 @@ func (v *LaunchView) stopMarginLabel(dc sim.DescentCorridor) string {
 	}
 	switch dc.Stop.Outcome {
 	case sim.StopStopped:
-		label := fmt.Sprintf("%s up   (full thrust now)", formatAltitude(dc.Stop.MarginM))
+		label := fmt.Sprintf("%s up", formatAltitude(dc.Stop.MarginM))
 		if dc.Margin.State == sim.MarginTight {
 			return v.theme.Warning.Render(label + " TIGHT")
 		}

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -804,29 +804,30 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 	if dc.HasFPA {
 		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(dc.FlightPathAngleDeg, 0))
 	}
-	// Every row's label + colon + padding occupies EXACTLY 14 cells
+	// Every row's label + colon + padding occupies EXACTLY 15 cells
 	// before the value starts, so the values line up in one column
-	// regardless of label length — matching every other row's own
-	// natural width (`fpa:` included) rather than widening the whole
-	// block to fit `stop margin:`, which is the one label that's already
-	// 14 cells at "  stop margin:" with nothing to spare: its value
-	// starts immediately after the colon, no separating space, so it
-	// lands in the same column as everything else. Literal spaces,
+	// regardless of label length. 14 (each label's own natural width)
+	// left `stop margin:` — itself exactly 14 — with no room for a
+	// separating space at all, so its value landed jammed against the
+	// colon while every other row had visible daylight after its own:
+	// arithmetically aligned, but reading as a missing-space bug rather
+	// than a deliberate layout. 15 gives every row, `stop margin:`
+	// included, at least one space of breathing room. Literal spaces,
 	// never %-Ns (ANSI bytes in a themed value would break that padding).
 	lines := []string{
 		v.theme.Primary.Render("DESCENT CORRIDOR"),
-		fmt.Sprintf("  altitude:   %s", formatAltitude(dc.AltitudeM)),
-		fmt.Sprintf("  descent:    %.0f m/s", dc.DescentRateMps),
-		fmt.Sprintf("  v_horiz:    %s", horizLabel),
-		fmt.Sprintf("  fpa:        %s", fpaLabel),
-		fmt.Sprintf("  impact in:  %s (%.0f m/s)",
+		fmt.Sprintf("  altitude:    %s", formatAltitude(dc.AltitudeM)),
+		fmt.Sprintf("  descent:     %.0f m/s", dc.DescentRateMps),
+		fmt.Sprintf("  v_horiz:     %s", horizLabel),
+		fmt.Sprintf("  fpa:         %s", fpaLabel),
+		fmt.Sprintf("  impact in:   %s (%.0f m/s)",
 			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
 	}
 	if dc.HasBurnAt {
-		lines = append(lines, fmt.Sprintf("  burn at:    %s — in %s",
+		lines = append(lines, fmt.Sprintf("  burn at:     %s — in %s",
 			formatAltitude(dc.BurnAt.AltitudeM), compactDuration(secondsToDuration(dc.BurnAt.InSec))))
 	}
-	lines = append(lines, fmt.Sprintf("  stop margin:%s", v.stopMarginLabel(dc)))
+	lines = append(lines, fmt.Sprintf("  stop margin: %s", v.stopMarginLabel(dc)))
 	return lines
 }
 

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -39,6 +39,12 @@ type LaunchView struct {
 	vzCraft *spacecraft.Spacecraft
 	vzAltM  float64
 	vzAtSim time.Time
+
+	// descentStopCache / descentStopCacheComputes: the predict-on-change
+	// cache for the descent corridor's integrated stop-burn forecast and
+	// "burn at" search (issue #377). See launch_descent_cache.go.
+	descentStopCache         descentStopRenderCache
+	descentStopCacheComputes int
 }
 
 // NewLaunchView constructs the chase-cam screen, paired with the
@@ -163,6 +169,19 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	// trajectory lands. Ballistic-from-now, so an active burn walks it
 	// live — see sim.PredictImpact.
 	corridor, descending := sim.DescentCorridorFor(craft, sim.DescentPredictHorizon)
+	// The expensive half (issue #377): the integrated stop-burn forecast
+	// and "burn at" cue, CACHED (unlike the cheap half above, which is
+	// fine to redo every frame) — see cachedDescentStop's doc comment for
+	// why. Only merged in while actually descending; DescentCorridorFor's
+	// own gate already governs whether this block renders at all.
+	if descending {
+		stopDat := v.cachedDescentStop(w, craft)
+		corridor.Stop = stopDat.stop
+		corridor.StopOK = stopDat.stopOK
+		corridor.BurnAt = stopDat.burnAt
+		corridor.HasBurnAt = stopDat.hasBurnAt
+		corridor.Margin = sim.DeriveMarginState(stopDat.stop, stopDat.stopOK, corridor.AltitudeM, stopDat.burnAt, stopDat.hasBurnAt)
+	}
 	// The ascent half (ADR 0043 §3 / issue #348): the mirror-image gate —
 	// climbing, not falling — so exactly one of the two instrument sets is
 	// ever live for a given state (sim.AscentCueFor's doc comment; pinned
@@ -757,53 +776,79 @@ func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim
 }
 
 // descentCorridorLines renders the DESCENT CORRIDOR instrument block —
-// the four numbers issue #348 §3 asks for: altitude, descent rate, time
-// to impact, and the burn margin.
+// issue #377's pinned row layout: altitude, descent rate, v_horiz, time
+// to impact, the `burn at` cue (while a future start is safe and the
+// burn hasn't started), and `stop margin` (always, while descending).
+// `fpa` was folded out of this block in the same pass — the corridor's
+// job is "can this still be stopped", and issue #377's row layout
+// answers that with burn-at/stop-margin instead; DescentCorridor still
+// carries FlightPathAngleDeg/HasFPA (descentKinematics computes them for
+// free) for any other consumer that wants them.
 //
-// The margin row is the alarm surface. It flips label AND colour
-// together (bare ratio → "TIGHT (thrust)" amber → "CAN'T STOP (thrust)"
-// red) rather than shading a number, because a state a player can miss
-// reads as no state at all. The parenthesised limiter says which
-// capability bound it, so the alarm names the fix instead of only the
-// fault.
+// `stop margin` is the alarm surface — it flips label AND colour
+// together (a bare "X up" green → amber TIGHT → red CAN'T STOP), because
+// a state a player can miss reads as no state at all. The parenthesised
+// limiter on the alarm states says which capability bound it (thrust vs
+// fuel), so the alarm names the fix instead of only the fault.
 func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
-	// v_horiz and fpa are the two rows folded in from the DESCENT chip
-	// this block now replaces on this screen (see the dropChip call in
-	// Render, and sim.DescentCorridor's doc comment for why `twr` and
-	// `sas` weren't worth carrying over). v_horiz keeps its CRASH styling
-	// verbatim: crossing the ground fast enough sideways wrecks the vessel
-	// however gently the vertical rate has been nulled, and that is not
-	// something the four corridor numbers imply.
-	fpaLabel := "—"
-	if dc.HasFPA {
-		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(dc.FlightPathAngleDeg, 0))
-	}
+	// v_horiz is folded in from the DESCENT chip this block replaces on
+	// this screen (see the dropChip call in Render). It keeps its CRASH
+	// styling verbatim: crossing the ground fast enough sideways wrecks
+	// the vessel however gently the vertical rate has been nulled, and
+	// that is not something the corridor's other numbers imply.
 	horizLabel := fmt.Sprintf("%.0f m/s (surface-rel)", dc.HorizontalRateMps)
 	if dc.HorizontalRateMps > sim.CrashVCritMps {
 		horizLabel = v.theme.Alert.Render(
 			fmt.Sprintf("%.0f m/s (> %.0f = CRASH on contact)", dc.HorizontalRateMps, sim.CrashVCritMps))
 	}
-	return []string{
+	lines := []string{
 		v.theme.Primary.Render("DESCENT CORRIDOR"),
 		fmt.Sprintf("  altitude:   %s", formatAltitude(dc.AltitudeM)),
 		fmt.Sprintf("  descent:    %.0f m/s", dc.DescentRateMps),
 		fmt.Sprintf("  v_horiz:    %s", horizLabel),
-		fmt.Sprintf("  fpa:        %s", fpaLabel),
 		fmt.Sprintf("  impact in:  %s (%.0f m/s)",
 			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
-		fmt.Sprintf("  margin:     %s", v.marginLabel(dc.Margin)),
 	}
+	if dc.HasBurnAt {
+		lines = append(lines, fmt.Sprintf("  burn at:    %s — in %s",
+			formatAltitude(dc.BurnAt.AltitudeM), compactDuration(secondsToDuration(dc.BurnAt.InSec))))
+	}
+	lines = append(lines, fmt.Sprintf("  stop margin: %s", v.stopMarginLabel(dc)))
+	return lines
 }
 
-// marginLabel styles the burn-margin readout per its alarm state.
-func (v *LaunchView) marginLabel(m sim.BurnMargin) string {
-	switch m.State {
-	case sim.MarginOK:
-		return v.theme.Primary.Render(fmt.Sprintf("%.2f ×", m.Ratio))
-	case sim.MarginTight:
-		return v.theme.Warning.Render(fmt.Sprintf("%.2f × TIGHT (%s)", m.Ratio, m.Limiter))
-	case sim.MarginInsufficient:
-		return v.theme.Alert.Render(fmt.Sprintf("%.2f × CAN'T STOP (%s)", m.Ratio, m.Limiter))
+// secondsToDuration converts a float64 seconds reading (sim.BurnAtCue /
+// sim.PoweredStopPrediction both use float64 seconds, not time.Duration,
+// since they're arithmetic results from an integration loop) into a
+// time.Duration for compactDuration.
+func secondsToDuration(s float64) time.Duration {
+	if s < 0 {
+		s = 0
+	}
+	return time.Duration(s * float64(time.Second))
+}
+
+// stopMarginLabel styles the `stop margin` row per PredictPoweredStop's
+// outcome and the derived alarm state (dc.Margin, from
+// sim.DeriveMarginState). Negative margin reads as "short by", never as
+// a negative altitude (issue #377 §3).
+func (v *LaunchView) stopMarginLabel(dc sim.DescentCorridor) string {
+	if !dc.StopOK {
+		return v.theme.Dim.Render("—")
+	}
+	switch dc.Stop.Outcome {
+	case sim.StopStopped:
+		label := fmt.Sprintf("%s up   (full thrust now)", formatAltitude(dc.Stop.MarginM))
+		if dc.Margin.State == sim.MarginTight {
+			return v.theme.Warning.Render(label + " TIGHT")
+		}
+		return v.theme.Primary.Render(label)
+	case sim.StopCrashed:
+		return v.theme.Alert.Render(fmt.Sprintf("short by %s (impact %.0f m/s) CAN'T STOP (%s)",
+			formatAltitude(-dc.Stop.MarginM), dc.Stop.ImpactSpeedMps, dc.Margin.Limiter))
+	case sim.StopFuelLimited:
+		return v.theme.Alert.Render(fmt.Sprintf("fuel-limited at %s CAN'T STOP (%s)",
+			formatAltitude(dc.Stop.MarginM), dc.Margin.Limiter))
 	}
 	return v.theme.Dim.Render("—")
 }

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -775,15 +775,15 @@ func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim
 	drawMarker(v.canvas, bodyCentre.Add(dc.Impact.Point), render.MarkerImpact, state, "", widgets.CellTag{})
 }
 
-// descentCorridorLines renders the DESCENT CORRIDOR instrument block —
-// issue #377's pinned row layout: altitude, descent rate, v_horiz, time
-// to impact, the `burn at` cue (while a future start is safe and the
-// burn hasn't started), and `stop margin` (always, while descending).
-// `fpa` was folded out of this block in the same pass — the corridor's
-// job is "can this still be stopped", and issue #377's row layout
-// answers that with burn-at/stop-margin instead; DescentCorridor still
-// carries FlightPathAngleDeg/HasFPA (descentKinematics computes them for
-// free) for any other consumer that wants them.
+// descentCorridorLines renders the DESCENT CORRIDOR instrument block:
+// altitude, descent rate, v_horiz, fpa (the two velocity-shape readings
+// folded in from the DESCENT chip this block replaces on this screen —
+// see the dropChip call in Render), time to impact, then the two #377
+// decision rows below them — `burn at` (while a future start is safe and
+// the burn hasn't started) and `stop margin` (always, while descending).
+// `fpa` was folded OUT of this block once (issue #377's pinned mock only
+// sketched the two new rows), then restored — the mock wasn't an
+// exhaustive spec of the block, and Jason wants it kept.
 //
 // `stop margin` is the alarm surface — it flips label AND colour
 // together (a bare "X up" green → amber TIGHT → red CAN'T STOP), because
@@ -791,21 +791,34 @@ func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim
 // limiter on the alarm states says which capability bound it (thrust vs
 // fuel), so the alarm names the fix instead of only the fault.
 func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
-	// v_horiz is folded in from the DESCENT chip this block replaces on
-	// this screen (see the dropChip call in Render). It keeps its CRASH
-	// styling verbatim: crossing the ground fast enough sideways wrecks
-	// the vessel however gently the vertical rate has been nulled, and
-	// that is not something the corridor's other numbers imply.
+	// v_horiz keeps its CRASH styling verbatim: crossing the ground fast
+	// enough sideways wrecks the vessel however gently the vertical rate
+	// has been nulled, and that is not something the corridor's other
+	// numbers imply.
 	horizLabel := fmt.Sprintf("%.0f m/s (surface-rel)", dc.HorizontalRateMps)
 	if dc.HorizontalRateMps > sim.CrashVCritMps {
 		horizLabel = v.theme.Alert.Render(
 			fmt.Sprintf("%.0f m/s (> %.0f = CRASH on contact)", dc.HorizontalRateMps, sim.CrashVCritMps))
 	}
+	fpaLabel := "—"
+	if dc.HasFPA {
+		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(dc.FlightPathAngleDeg, 0))
+	}
+	// Every row's label + colon + padding occupies EXACTLY 14 cells
+	// before the value starts, so the values line up in one column
+	// regardless of label length — matching every other row's own
+	// natural width (`fpa:` included) rather than widening the whole
+	// block to fit `stop margin:`, which is the one label that's already
+	// 14 cells at "  stop margin:" with nothing to spare: its value
+	// starts immediately after the colon, no separating space, so it
+	// lands in the same column as everything else. Literal spaces,
+	// never %-Ns (ANSI bytes in a themed value would break that padding).
 	lines := []string{
 		v.theme.Primary.Render("DESCENT CORRIDOR"),
 		fmt.Sprintf("  altitude:   %s", formatAltitude(dc.AltitudeM)),
 		fmt.Sprintf("  descent:    %.0f m/s", dc.DescentRateMps),
 		fmt.Sprintf("  v_horiz:    %s", horizLabel),
+		fmt.Sprintf("  fpa:        %s", fpaLabel),
 		fmt.Sprintf("  impact in:  %s (%.0f m/s)",
 			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
 	}
@@ -813,7 +826,7 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 		lines = append(lines, fmt.Sprintf("  burn at:    %s — in %s",
 			formatAltitude(dc.BurnAt.AltitudeM), compactDuration(secondsToDuration(dc.BurnAt.InSec))))
 	}
-	lines = append(lines, fmt.Sprintf("  stop margin: %s", v.stopMarginLabel(dc)))
+	lines = append(lines, fmt.Sprintf("  stop margin:%s", v.stopMarginLabel(dc)))
 	return lines
 }
 
@@ -832,9 +845,20 @@ func secondsToDuration(s float64) time.Duration {
 // outcome and the derived alarm state (dc.Margin, from
 // sim.DeriveMarginState). Negative margin reads as "short by", never as
 // a negative altitude (issue #377 §3).
+//
+// !dc.StopOK (the integration hit its step cap without resolving) is
+// NOT rendered as a quiet em dash. sim.DeriveMarginState maps that case
+// to MarginInsufficient specifically so it reads as CAN'T STOP, and
+// drawDescentArc keys the arc/impact-marker alarm off exactly that
+// state — a dim "—" here while the arc paints alert-red would be a
+// refused forecast reading as a healthy one at a glance and an alarming
+// one on the ground, which is worse than either alone (review finding,
+// PR #382: a silent no-op reads as broken). The row states the same
+// refusal the arc is already painting, in the alarm's own words, rather
+// than softening the arc to match a blank row.
 func (v *LaunchView) stopMarginLabel(dc sim.DescentCorridor) string {
 	if !dc.StopOK {
-		return v.theme.Dim.Render("—")
+		return v.theme.Alert.Render(fmt.Sprintf("unresolved — CAN'T STOP (%s)", dc.Margin.Limiter))
 	}
 	switch dc.Stop.Outcome {
 	case sim.StopStopped:

--- a/internal/tui/screens/launch_descent_cache.go
+++ b/internal/tui/screens/launch_descent_cache.go
@@ -1,0 +1,138 @@
+package screens
+
+import (
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// launch_descent_cache.go — the predict-on-change cache (ADR 0017) for
+// the descent corridor's expensive half (issue #377): the integrated
+// stop-burn forecast (sim.PredictPoweredStop) and the "burn at"
+// latest-safe-start search (sim.PredictBurnAt). Mirrors orbit.go's
+// predictCache / soiPassCache pattern verbatim — a keyed cache on the
+// View, recomputing only when the key changes, with a …Computes counter
+// tests can assert against.
+//
+// A 1.6 km/s stop is ~800 s of integrated flight, and PredictBurnAt's
+// bisection multiplies that by roughly another order of magnitude
+// (issue #377 §5) — running both every render frame would reproduce the
+// exact idle-CPU regression #363 fixed for the orbit map's own
+// predictors, except worse (this is on screen exactly when the player is
+// at close zoom during a landing, i.e. NOT idle). sim.DescentCorridorFor
+// itself stays cheap and uncached (see its doc comment) — only the two
+// powered forecasts live behind this cache.
+
+// descentStopRenderCache holds the last computed stop-forecast + burn-at
+// result and the key it was computed for.
+type descentStopRenderCache struct {
+	has bool
+	key descentStopRenderKey
+	dat descentStopRenderData
+}
+
+// descentStopRenderData is what cachedDescentStop returns: the merged
+// powered-stop + burn-at + derived-alarm state ready to fold into a
+// sim.DescentCorridor for rendering.
+type descentStopRenderData struct {
+	stop      sim.PoweredStopPrediction
+	stopOK    bool
+	burnAt    sim.BurnAtCue
+	hasBurnAt bool
+}
+
+// descentStopRenderKey fingerprints what the stop forecast depends on:
+// the active craft + its primary, position/velocity/mass/fuel
+// (quantized), and a clock bucket that bounds staleness during an
+// unpowered ballistic coast — where position and velocity change too
+// slowly on their own to bust a tight quantum every frame. midBurn is
+// its own key field (not inferred from the velocity quantum) so a
+// burn start/stop transition busts the cache on the very next render
+// regardless of whether the craft has moved enough yet to do it any
+// other way — "burn at hides once the burn is under way" (issue #377)
+// has to be immediate, not eventually-consistent.
+//
+// The position/velocity quantum is tight enough (descentStopVelQuantumMps)
+// that an ACTIVE burn — which changes velocity every physics tick —
+// busts the cache on essentially every tick too, which is exactly what
+// "stop margin stays live through the burn" (issue #377 §3) requires:
+// only the coast case benefits from the cache's staleness tolerance.
+type descentStopRenderKey struct {
+	craftID     uint64
+	primaryID   string
+	clockBucket int64
+	midBurn     bool
+	rQ          [3]int64
+	vQ          [3]int64
+	massQ       int64
+	fuelQ       int64
+}
+
+const (
+	// descentStopPosQuantumM / descentStopVelQuantumMps size the position
+	// / velocity quanta the cache key rounds to. Tight enough that any
+	// thrust (which changes velocity far faster than free-fall changes
+	// position) busts the cache almost immediately; loose enough that an
+	// unpowered ballistic coast — falling under gravity alone, no thrust
+	// — reuses the forecast for a meaningful stretch of frames.
+	descentStopPosQuantumM   = 25.0
+	descentStopVelQuantumMps = 0.5
+	// descentStopMassQuantumKg quantizes both total mass and active-stage
+	// fuel — either changing (a burn, or a decouple) has to bust the
+	// cache.
+	descentStopMassQuantumKg = 1.0
+	// descentStopClockBucket is the staleness ceiling during an unpowered
+	// coast, matching the spirit of orbit.go's predictClockBucketNanos
+	// but fixed rather than period-scaled: the descent corridor's horizon
+	// is bounded (DescentPredictHorizon, 30 min) regardless of the live
+	// orbit's own period, so there's no orbital timescale to derive a
+	// bucket from the way the node-leg predictor has one.
+	descentStopClockBucket = time.Second
+)
+
+// descentStopKeyFor builds the cache key for the active craft at clock t.
+func descentStopKeyFor(c *spacecraft.Spacecraft, t time.Time) descentStopRenderKey {
+	return descentStopRenderKey{
+		craftID:     c.ID,
+		primaryID:   c.Primary.ID,
+		clockBucket: t.UnixNano() / int64(descentStopClockBucket),
+		midBurn:     sim.StackMidBurn(c),
+		rQ: [3]int64{
+			quantize(c.State.R.X, descentStopPosQuantumM),
+			quantize(c.State.R.Y, descentStopPosQuantumM),
+			quantize(c.State.R.Z, descentStopPosQuantumM),
+		},
+		vQ: [3]int64{
+			quantize(c.State.V.X, descentStopVelQuantumMps),
+			quantize(c.State.V.Y, descentStopVelQuantumMps),
+			quantize(c.State.V.Z, descentStopVelQuantumMps),
+		},
+		massQ: quantize(c.TotalMass(), descentStopMassQuantumKg),
+		fuelQ: quantize(c.ActiveStageFuel(), descentStopMassQuantumKg),
+	}
+}
+
+// cachedDescentStop returns the stop-forecast + burn-at cue for the
+// active descending craft, recomputing (sim.PredictPoweredStop, and
+// sim.PredictBurnAt when the burn isn't already under way) only when
+// descentStopKeyFor's key changes (ADR 0017 predict-on-change). Callers
+// must already have established the craft is descending
+// (sim.DescentCorridorFor's own gate) — this does not re-check.
+func (v *LaunchView) cachedDescentStop(w *sim.World, c *spacecraft.Spacecraft) descentStopRenderData {
+	key := descentStopKeyFor(c, w.Clock.SimTime)
+	if v.descentStopCache.has && v.descentStopCache.key == key {
+		return v.descentStopCache.dat
+	}
+	var dat descentStopRenderData
+	dat.stop, dat.stopOK = sim.PredictPoweredStop(c, sim.DescentPredictHorizon)
+	// "burn at" hides once the burn is under way (issue #377 §2) — and
+	// there's no point paying for the ~8-10x-more-expensive search for a
+	// row that won't render.
+	if !sim.StackMidBurn(c) {
+		dat.burnAt, dat.hasBurnAt = sim.PredictBurnAt(c, sim.DescentPredictHorizon)
+	}
+	v.descentStopCache = descentStopRenderCache{has: true, key: key, dat: dat}
+	v.descentStopCacheComputes++
+	return dat
+}

--- a/internal/tui/screens/launch_descent_cache_test.go
+++ b/internal/tui/screens/launch_descent_cache_test.go
@@ -1,0 +1,92 @@
+// Package screens — the descent corridor's predict-on-change cache
+// (issue #377): PredictPoweredStop / PredictBurnAt must not re-run every
+// render frame (a 1.6 km/s stop is ~800 integrator sub-steps, and the
+// burn-at search multiplies that by roughly another order of magnitude).
+// Mirrors orbit_predict_cache_test.go / orbit_soipass_test.go's shape.
+
+package screens
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestDescentStopCacheHoldsAcrossIdleFrames: re-rendering a descending
+// craft repeatedly with nothing advanced (no tick, same clock, same
+// state) recomputes the stop forecast only once.
+func TestDescentStopCacheHoldsAcrossIdleFrames(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, 120)
+
+	for i := 0; i < 5; i++ {
+		v.Render(w, 200, 60)
+	}
+	if v.descentStopCacheComputes != 1 {
+		t.Errorf("descentStopCacheComputes = %d after 5 idle renders, want 1 (predict-on-change cache)", v.descentStopCacheComputes)
+	}
+}
+
+// TestDescentStopCacheBustsOnSabotagedKey is the #369-lesson test: a
+// cache that always returns its stored data regardless of the key would
+// pass TestDescentStopCacheHoldsAcrossIdleFrames vacuously (nothing
+// there proves the key comparison is what's gating the hit — it could
+// just always hit). Sabotage the STORED key after a real compute, with
+// the craft's actual state left untouched, and confirm the very next
+// render recomputes anyway: the only way that happens is if
+// cachedDescentStop is genuinely comparing the freshly-built key against
+// what's stored, not returning cached data unconditionally.
+func TestDescentStopCacheBustsOnSabotagedKey(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, 120)
+
+	v.Render(w, 200, 60)
+	if v.descentStopCacheComputes != 1 {
+		t.Fatalf("setup: descentStopCacheComputes = %d after first render, want 1", v.descentStopCacheComputes)
+	}
+	if !v.descentStopCache.has {
+		t.Fatal("setup: cache did not populate on the first render")
+	}
+
+	// Sabotage: corrupt the stored key's clock bucket so it can no
+	// longer match a freshly-built key, WITHOUT touching the craft or the
+	// world clock at all.
+	v.descentStopCache.key.clockBucket = -1
+
+	v.Render(w, 200, 60)
+	if v.descentStopCacheComputes != 2 {
+		t.Errorf("descentStopCacheComputes = %d after a sabotaged-key render, want 2 (the cache must have missed)", v.descentStopCacheComputes)
+	}
+
+	// And confirm the cache is genuinely usable again afterwards — the
+	// sabotage was a one-off corruption, not a permanent break.
+	v.Render(w, 200, 60)
+	if v.descentStopCacheComputes != 2 {
+		t.Errorf("descentStopCacheComputes = %d after re-rendering post-sabotage, want 2 (should hit again)", v.descentStopCacheComputes)
+	}
+}
+
+// TestDescentStopCacheBustsOnBurnStart: the moment a burn starts, the
+// cache key's midBurn field flips, so the very next render recomputes —
+// required for `burn at` to disappear immediately (issue #377 §2) rather
+// than waiting for velocity to drift past the position/velocity quanta.
+func TestDescentStopCacheBustsOnBurnStart(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, 120)
+
+	v.Render(w, 200, 60)
+	if v.descentStopCacheComputes != 1 {
+		t.Fatalf("setup: descentStopCacheComputes = %d, want 1", v.descentStopCacheComputes)
+	}
+
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100}
+
+	v.Render(w, 200, 60)
+	if v.descentStopCacheComputes != 2 {
+		t.Errorf("descentStopCacheComputes = %d after ActiveBurn was set, want 2 (midBurn must bust the key)", v.descentStopCacheComputes)
+	}
+}

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -63,10 +63,13 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 // `stop margin` — the 7-row block (Jason's call: `fpa` was folded out
 // once because issue #377's pinned mock only sketched the two new rows,
 // then restored — the mock wasn't an exhaustive spec of the whole
-// block). All seven rows share one label column (14 cells before the
-// value): `stop margin:` is itself exactly 14, so its value starts
-// immediately after the colon with no separating space, same column as
-// every other row's value.
+// block). All seven rows share one label column (15 cells before the
+// value) — 14 (each label's own natural width) left `stop margin:`,
+// itself exactly 14, with no room for a separating space at all, so its
+// value would land jammed against the colon while every other row had
+// daylight after its own: arithmetically aligned, but reading as a
+// missing-space bug. 15 gives every row a space of breathing room,
+// `stop margin:` included.
 func TestDescentCorridorLinesInstruments(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	dc := sim.DescentCorridor{
@@ -87,13 +90,13 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 	}
 	want := []string{
 		"DESCENT CORRIDOR",
-		"  altitude:   12.40 km",
-		"  descent:    182 m/s",
-		"  v_horiz:    4 m/s (surface-rel)",
-		"  fpa:        -88° (0 = horiz, −90 = straight down)",
-		"  impact in:  1m4s (240 m/s)",
-		"  burn at:    8.00 km — in 48s",
-		"  stop margin:3.40 km up   (full thrust now)",
+		"  altitude:    12.40 km",
+		"  descent:     182 m/s",
+		"  v_horiz:     4 m/s (surface-rel)",
+		"  fpa:         -88° (0 = horiz, −90 = straight down)",
+		"  impact in:   1m4s (240 m/s)",
+		"  burn at:     8.00 km — in 48s",
+		"  stop margin: 3.40 km up   (full thrust now)",
 	}
 	got := v.descentCorridorLines(dc)
 	if len(got) != len(want) {
@@ -146,12 +149,12 @@ func TestDescentCorridorFPARow(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 
 	withFPA := v.descentCorridorLines(sim.DescentCorridor{FlightPathAngleDeg: -88, HasFPA: true})
-	if withFPA[4] != "  fpa:        -88° (0 = horiz, −90 = straight down)" {
+	if withFPA[4] != "  fpa:         -88° (0 = horiz, −90 = straight down)" {
 		t.Errorf("fpa row with HasFPA = %q, want the legend", withFPA[4])
 	}
 
 	withoutFPA := v.descentCorridorLines(sim.DescentCorridor{})
-	if withoutFPA[4] != "  fpa:        —" {
+	if withoutFPA[4] != "  fpa:         —" {
 		t.Errorf("fpa row without HasFPA = %q, want an em dash", withoutFPA[4])
 	}
 }

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -70,6 +70,12 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 // daylight after its own: arithmetically aligned, but reading as a
 // missing-space bug. 15 gives every row a space of breathing room,
 // `stop margin:` included.
+//
+// The teaching parentheticals (`(surface-rel)`, the fpa unit legend,
+// `(full thrust now)`) are gone too — Jason's call: a legend printed
+// every frame forever is scaffolding a returning pilot doesn't need.
+// Parentheticals that carry a number or a state (impact speed, which
+// limiter bound a forecast) stayed; those are data, not description.
 func TestDescentCorridorLinesInstruments(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	dc := sim.DescentCorridor{
@@ -92,11 +98,11 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 		"DESCENT CORRIDOR",
 		"  altitude:    12.40 km",
 		"  descent:     182 m/s",
-		"  v_horiz:     4 m/s (surface-rel)",
-		"  fpa:         -88° (0 = horiz, −90 = straight down)",
+		"  v_horiz:     4 m/s",
+		"  fpa:         -88°",
 		"  impact in:   1m4s (240 m/s)",
 		"  burn at:     8.00 km — in 48s",
-		"  stop margin: 3.40 km up   (full thrust now)",
+		"  stop margin: 3.40 km up",
 	}
 	got := v.descentCorridorLines(dc)
 	if len(got) != len(want) {
@@ -140,17 +146,21 @@ func TestDescentCorridorNoBurnAtRowWhenHasBurnAtFalse(t *testing.T) {
 	}
 }
 
-// TestDescentCorridorFPARow pins that `fpa` is present with its legend —
+// TestDescentCorridorFPARow pins that `fpa` is present with its VALUE —
 // it was folded out of the block once already (issue #377's pinned mock
 // only sketched the two new rows), then restored on Jason's explicit
-// call, so nothing was asserting it existed. Covers both HasFPA states:
-// the legend when defined, and the em dash below the speed floor.
+// call, so nothing was asserting it existed. The row's teaching legend
+// (`0 = horiz, −90 = straight down`) was stripped in a later pass
+// (Jason: "people will learn and should know"), but the ROW — a bare
+// angle when defined, an em dash below the speed floor — must survive
+// that too; this test is what keeps a future "clean up the corridor"
+// pass from deleting the row along with its legend.
 func TestDescentCorridorFPARow(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 
 	withFPA := v.descentCorridorLines(sim.DescentCorridor{FlightPathAngleDeg: -88, HasFPA: true})
-	if withFPA[4] != "  fpa:         -88° (0 = horiz, −90 = straight down)" {
-		t.Errorf("fpa row with HasFPA = %q, want the legend", withFPA[4])
+	if withFPA[4] != "  fpa:         -88°" {
+		t.Errorf("fpa row with HasFPA = %q, want the bare angle", withFPA[4])
 	}
 
 	withoutFPA := v.descentCorridorLines(sim.DescentCorridor{})
@@ -186,7 +196,7 @@ func TestStopMarginLabelAlarmLadder(t *testing.T) {
 				Stop: sim.PoweredStopPrediction{Outcome: sim.StopStopped, MarginM: 12_400}, StopOK: true,
 				Margin: sim.BurnMargin{State: sim.MarginOK},
 			},
-			"12.40 km up   (full thrust now)",
+			"12.40 km up",
 		},
 		{
 			"stopped, TIGHT",
@@ -194,7 +204,7 @@ func TestStopMarginLabelAlarmLadder(t *testing.T) {
 				Stop: sim.PoweredStopPrediction{Outcome: sim.StopStopped, MarginM: 300}, StopOK: true,
 				Margin: sim.BurnMargin{State: sim.MarginTight},
 			},
-			"300 m up   (full thrust now) TIGHT",
+			"300 m up TIGHT",
 		},
 		{
 			"crashed",

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -57,18 +57,24 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 	return w
 }
 
-// TestDescentCorridorLinesInstruments pins issue #377's row layout as
-// exact rendered rows, so a formatting change has to be deliberate:
-// altitude, descent rate, v_horiz, time to impact, `burn at`, and
-// `stop margin` — `fpa` is no longer one of them (dropped in the same
-// pass that added the two new rows; the pinned layout in issue #377 has
-// no fpa row).
+// TestDescentCorridorLinesInstruments pins the row layout as exact
+// rendered rows, so a formatting change has to be deliberate: altitude,
+// descent rate, v_horiz, fpa, time to impact, `burn at`, and
+// `stop margin` — the 7-row block (Jason's call: `fpa` was folded out
+// once because issue #377's pinned mock only sketched the two new rows,
+// then restored — the mock wasn't an exhaustive spec of the whole
+// block). All seven rows share one label column (14 cells before the
+// value): `stop margin:` is itself exactly 14, so its value starts
+// immediately after the colon with no separating space, same column as
+// every other row's value.
 func TestDescentCorridorLinesInstruments(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	dc := sim.DescentCorridor{
-		AltitudeM:         12_400,
-		DescentRateMps:    182,
-		HorizontalRateMps: 4,
+		AltitudeM:          12_400,
+		DescentRateMps:     182,
+		HorizontalRateMps:  4,
+		FlightPathAngleDeg: -88,
+		HasFPA:             true,
 		Impact: sim.ImpactPrediction{
 			TimeToImpact: 64 * time.Second,
 			SpeedMps:     240,
@@ -84,9 +90,10 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 		"  altitude:   12.40 km",
 		"  descent:    182 m/s",
 		"  v_horiz:    4 m/s (surface-rel)",
+		"  fpa:        -88° (0 = horiz, −90 = straight down)",
 		"  impact in:  1m4s (240 m/s)",
 		"  burn at:    8.00 km — in 48s",
-		"  stop margin: 3.40 km up   (full thrust now)",
+		"  stop margin:3.40 km up   (full thrust now)",
 	}
 	got := v.descentCorridorLines(dc)
 	if len(got) != len(want) {
@@ -130,10 +137,39 @@ func TestDescentCorridorNoBurnAtRowWhenHasBurnAtFalse(t *testing.T) {
 	}
 }
 
+// TestDescentCorridorFPARow pins that `fpa` is present with its legend —
+// it was folded out of the block once already (issue #377's pinned mock
+// only sketched the two new rows), then restored on Jason's explicit
+// call, so nothing was asserting it existed. Covers both HasFPA states:
+// the legend when defined, and the em dash below the speed floor.
+func TestDescentCorridorFPARow(t *testing.T) {
+	v := NewLaunchView(launchThemeForTest(), nil)
+
+	withFPA := v.descentCorridorLines(sim.DescentCorridor{FlightPathAngleDeg: -88, HasFPA: true})
+	if withFPA[4] != "  fpa:        -88° (0 = horiz, −90 = straight down)" {
+		t.Errorf("fpa row with HasFPA = %q, want the legend", withFPA[4])
+	}
+
+	withoutFPA := v.descentCorridorLines(sim.DescentCorridor{})
+	if withoutFPA[4] != "  fpa:        —" {
+		t.Errorf("fpa row without HasFPA = %q, want an em dash", withoutFPA[4])
+	}
+}
+
 // TestStopMarginLabelAlarmLadder: `stop margin` is the alarm surface, so
 // each state must change the LABEL, not only a shade a player can miss.
 // Pins StopStopped (OK and TIGHT), StopCrashed, StopFuelLimited, and the
 // StopOK=false (refused/undetermined) case.
+//
+// The refused case is pinned as an ALARM label, not an em dash (PR #382
+// review finding 1): sim.DeriveMarginState maps !StopOK to
+// MarginInsufficient specifically so drawDescentArc's alarm
+// (dc.Margin.State == MarginInsufficient) paints the arc red for
+// exactly this state, and a quiet "—" row under a red arc is a refused
+// forecast reading as healthy in the corridor and alarming on the
+// canvas at the same time — see
+// TestDescentCorridorRefusedForecastReadsAsAlarmNotSilence for the
+// reachable end-to-end case this was caught from.
 func TestStopMarginLabelAlarmLadder(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	cases := []struct {
@@ -173,7 +209,11 @@ func TestStopMarginLabelAlarmLadder(t *testing.T) {
 			},
 			"fuel-limited at 5.00 km CAN'T STOP (fuel)",
 		},
-		{"undetermined (refused)", sim.DescentCorridor{StopOK: false}, "—"},
+		{
+			"undetermined (refused)",
+			sim.DescentCorridor{StopOK: false, Margin: sim.BurnMargin{State: sim.MarginInsufficient, Limiter: sim.LimitThrust}},
+			"unresolved — CAN'T STOP (thrust)",
+		},
 	}
 	for _, c := range cases {
 		if got := v.stopMarginLabel(c.dc); got != c.want {
@@ -335,11 +375,9 @@ func TestSurfaceViewShowsOneDescentBlock(t *testing.T) {
 	if n := strings.Count(out, "v_vert:"); n != 0 {
 		t.Errorf("frame still carries %d `v_vert:` rows — the DESCENT chip did not stand down", n)
 	}
-	// The rows worth keeping came along rather than being dropped. `fpa`
-	// is deliberately NOT among them — issue #377's pinned row layout
-	// replaces it with `stop margin` (and `burn at`, when a future safe
-	// start exists).
-	for _, row := range []string{"descent:", "v_horiz:", "impact in:", "stop margin:"} {
+	// The rows worth keeping came along rather than being dropped —
+	// `fpa` included; it survived the #377 layout change (Jason's call).
+	for _, row := range []string{"descent:", "v_horiz:", "fpa:", "impact in:", "stop margin:"} {
 		if !strings.Contains(out, row) {
 			t.Errorf("corridor block is missing the %q row", row)
 		}
@@ -388,5 +426,77 @@ func TestBurnAtRowDisappearsOnceBurnStarts(t *testing.T) {
 	}
 	if !strings.Contains(after, "stop margin:") {
 		t.Errorf("stop margin row disappeared once the burn started — it must stay live:\n%s", after)
+	}
+}
+
+// TestDescentCorridorRefusedForecastReadsAsAlarmNotSilence is PR #382
+// review finding 1's end-to-end regression: a REACHABLE refusal
+// (near-hover thrust — TWR barely above local g, an Isp-3000s engine so
+// mass loss over the search window stays negligible — 20 km up at a
+// mundane 50 m/s, confirmed via PredictPoweredStop directly to hit the
+// step cap: Outcome=StopUndetermined, ok=false) must not present as a
+// healthy corridor under a red arc. Both signals — the arc/impact-marker
+// alarm promotion (drawDescentArc, keyed off dc.Margin.State) and the
+// `stop margin` row text — have to agree that this is CAN'T STOP.
+func TestDescentCorridorRefusedForecastReadsAsAlarmNotSilence(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	for _, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			c.Primary = b
+		}
+	}
+	c.Landed, c.Crashed = false, false
+	c.Stages = nil
+	const altM = 20_000.0
+	r := c.Primary.RadiusMeters() + altM
+	gLocal := c.Primary.GravitationalParameter() / (r * r)
+	const massKg0 = 15_000.0
+	c.Thrust = (gLocal + 0.01) * massKg0 // TWR ~1% above local hover
+	c.Isp = 3_000                        // negligible mass loss over the 1800s search window
+	c.DryMass = massKg0 / 2
+	c.Fuel = massKg0 / 2
+	c.Monoprop = 0
+	c.State.R = orbital.Vec3{X: r}
+	c.State.V = orbital.Vec3{X: -50}
+	c.State.M = c.TotalMass()
+
+	// Precondition: this really is the refusal case, not some other
+	// outcome that happens to also alarm.
+	if stop, ok := sim.PredictPoweredStop(c, sim.DescentPredictHorizon); ok {
+		t.Fatalf("setup: expected PredictPoweredStop to refuse (step cap), got ok=true Outcome=%v", stop.Outcome)
+	}
+
+	out := stripANSI(v.Render(w, 200, 60))
+
+	// The row: not a quiet em dash, and it reads CAN'T STOP in the
+	// alarm's own words.
+	var stopMarginRow string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "stop margin:") {
+			stopMarginRow = line
+			break
+		}
+	}
+	if stopMarginRow == "" {
+		t.Fatal("no `stop margin` row found in the render")
+	}
+	if strings.Contains(stopMarginRow, "stop margin:—") || strings.Contains(stopMarginRow, "stop margin: —") {
+		t.Errorf("refused forecast rendered a silent em dash: %q", stopMarginRow)
+	}
+	if !strings.Contains(stopMarginRow, "CAN'T STOP") {
+		t.Errorf("refused forecast row does not read CAN'T STOP: %q", stopMarginRow)
+	}
+
+	// The arc/impact-marker alarm: drawDescentArc paints alert-red
+	// exactly when dc.Margin.State == MarginInsufficient, which is what
+	// this refusal must map to (sim.DeriveMarginState).
+	if n := v.canvas.CountColor(render.ColorAlert); n == 0 {
+		t.Error("refused forecast did not promote the descent arc to alert-red")
 	}
 }

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
@@ -56,39 +57,36 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 	return w
 }
 
-// TestDescentCorridorLinesInstruments pins the four instruments issue
-// #348 §3 asks for — altitude, descent rate, time to impact, burn margin
-// — as exact rendered rows, so a formatting change has to be deliberate.
-//
-// Since the review's chip-dedup fix the block also carries v_horiz and
-// fpa, folded in from the DESCENT chip it now replaces on this screen
-// (see the dropChip call in launch.go). Both are pinned here for the same
-// reason the original four are: they are the rows a player reads while
-// deciding whether this is a landing or a crash.
+// TestDescentCorridorLinesInstruments pins issue #377's row layout as
+// exact rendered rows, so a formatting change has to be deliberate:
+// altitude, descent rate, v_horiz, time to impact, `burn at`, and
+// `stop margin` — `fpa` is no longer one of them (dropped in the same
+// pass that added the two new rows; the pinned layout in issue #377 has
+// no fpa row).
 func TestDescentCorridorLinesInstruments(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	dc := sim.DescentCorridor{
-		AltitudeM:          12_400,
-		DescentRateMps:     182,
-		HorizontalRateMps:  4,
-		FlightPathAngleDeg: -88,
-		HasFPA:             true,
+		AltitudeM:         12_400,
+		DescentRateMps:    182,
+		HorizontalRateMps: 4,
 		Impact: sim.ImpactPrediction{
 			TimeToImpact: 64 * time.Second,
 			SpeedMps:     240,
 		},
-		// a_net 1 vs a_req 0.5 → 2.00 on thrust; 30 m/s of Δv against a
-		// 20 m/s stop burn → 1.50 on fuel. Fuel binds, and 1.50 is OK.
-		Margin: sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 30),
+		Stop:      sim.PoweredStopPrediction{Outcome: sim.StopStopped, MarginM: 3_400},
+		StopOK:    true,
+		BurnAt:    sim.BurnAtCue{AltitudeM: 8_000, InSec: 48},
+		HasBurnAt: true,
+		Margin:    sim.BurnMargin{State: sim.MarginOK},
 	}
 	want := []string{
 		"DESCENT CORRIDOR",
 		"  altitude:   12.40 km",
 		"  descent:    182 m/s",
 		"  v_horiz:    4 m/s (surface-rel)",
-		"  fpa:        -88° (0 = horiz, −90 = straight down)",
 		"  impact in:  1m4s (240 m/s)",
-		"  margin:     1.50 ×",
+		"  burn at:    8.00 km — in 48s",
+		"  stop margin: 3.40 km up   (full thrust now)",
 	}
 	got := v.descentCorridorLines(dc)
 	if len(got) != len(want) {
@@ -117,37 +115,69 @@ func TestDescentCorridorHorizontalRateAlarm(t *testing.T) {
 	}
 }
 
-// TestDescentCorridorFPAUndefinedBelowSpeedFloor: with no meaningful
-// surface-relative motion the angle is numerical dust, so the row says so
-// rather than printing a heading the pilot might steer by.
-func TestDescentCorridorFPAUndefinedBelowSpeedFloor(t *testing.T) {
+// TestDescentCorridorNoBurnAtRowWhenHasBurnAtFalse: `burn at` is the one
+// row in the pinned layout that's conditionally present (issue #377 §2:
+// it hides once the burn is under way, or when there's no future safe
+// start at all) — the row count itself has to shrink, not just show a
+// placeholder.
+func TestDescentCorridorNoBurnAtRowWhenHasBurnAtFalse(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
-	got := v.descentCorridorLines(sim.DescentCorridor{})
-	if got[4] != "  fpa:        —" {
-		t.Errorf("fpa row without HasFPA = %q, want an em dash", got[4])
+	got := v.descentCorridorLines(sim.DescentCorridor{HasBurnAt: false})
+	for _, row := range got {
+		if strings.Contains(row, "burn at:") {
+			t.Errorf("HasBurnAt=false still rendered a burn-at row: %q", row)
+		}
 	}
 }
 
-// TestDescentCorridorMarginAlarmLadder: the margin row is the alarm
-// surface, so each state must change the LABEL, not only a shade a
-// player can miss. Pins all three rungs plus the undefined case.
-func TestDescentCorridorMarginAlarmLadder(t *testing.T) {
+// TestStopMarginLabelAlarmLadder: `stop margin` is the alarm surface, so
+// each state must change the LABEL, not only a shade a player can miss.
+// Pins StopStopped (OK and TIGHT), StopCrashed, StopFuelLimited, and the
+// StopOK=false (refused/undetermined) case.
+func TestStopMarginLabelAlarmLadder(t *testing.T) {
 	v := NewLaunchView(launchThemeForTest(), nil)
 	cases := []struct {
-		name   string
-		margin sim.BurnMargin
-		want   string
+		name string
+		dc   sim.DescentCorridor
+		want string
 	}{
-		// a_net 1 vs a_req 2 → 0.50 on thrust: cannot stop.
-		{"insufficient", sim.ComputeBurnMargin(2000, 1000, 1, 20, 100, 100), "0.50 × CAN'T STOP (thrust)"},
-		// 25 m/s of Δv against a 20 m/s stop burn → 1.25 on fuel.
-		{"tight", sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 25), "1.25 × TIGHT (fuel)"},
-		{"ok", sim.ComputeBurnMargin(2000, 1000, 1, 10, 100, 100), "2.00 ×"},
-		{"undefined", sim.BurnMargin{}, "—"},
+		{
+			"stopped, OK",
+			sim.DescentCorridor{
+				Stop: sim.PoweredStopPrediction{Outcome: sim.StopStopped, MarginM: 12_400}, StopOK: true,
+				Margin: sim.BurnMargin{State: sim.MarginOK},
+			},
+			"12.40 km up   (full thrust now)",
+		},
+		{
+			"stopped, TIGHT",
+			sim.DescentCorridor{
+				Stop: sim.PoweredStopPrediction{Outcome: sim.StopStopped, MarginM: 300}, StopOK: true,
+				Margin: sim.BurnMargin{State: sim.MarginTight},
+			},
+			"300 m up   (full thrust now) TIGHT",
+		},
+		{
+			"crashed",
+			sim.DescentCorridor{
+				Stop: sim.PoweredStopPrediction{Outcome: sim.StopCrashed, MarginM: -3_400, ImpactSpeedMps: 411}, StopOK: true,
+				Margin: sim.BurnMargin{State: sim.MarginInsufficient, Limiter: sim.LimitThrust},
+			},
+			"short by 3.40 km (impact 411 m/s) CAN'T STOP (thrust)",
+		},
+		{
+			"fuel-limited",
+			sim.DescentCorridor{
+				Stop: sim.PoweredStopPrediction{Outcome: sim.StopFuelLimited, MarginM: 5_000}, StopOK: true,
+				Margin: sim.BurnMargin{State: sim.MarginInsufficient, Limiter: sim.LimitFuel},
+			},
+			"fuel-limited at 5.00 km CAN'T STOP (fuel)",
+		},
+		{"undetermined (refused)", sim.DescentCorridor{StopOK: false}, "—"},
 	}
 	for _, c := range cases {
-		if got := v.marginLabel(c.margin); got != c.want {
-			t.Errorf("%s: margin label %q, want %q", c.name, got, c.want)
+		if got := v.stopMarginLabel(c.dc); got != c.want {
+			t.Errorf("%s: stop margin label %q, want %q", c.name, got, c.want)
 		}
 	}
 }
@@ -241,7 +271,7 @@ func TestLaunchViewDescentInstrumentsAt80x24(t *testing.T) {
 	w := descendingMoonCraft(t, 20_000, 120)
 
 	out := v.Render(w, 80, 24)
-	for _, want := range []string{"DESCENT CORRIDOR", "altitude:", "descent:", "impact in:", "margin:"} {
+	for _, want := range []string{"DESCENT CORRIDOR", "altitude:", "descent:", "impact in:", "stop margin:"} {
 		if !strings.Contains(stripANSI(out), want) {
 			t.Errorf("80×24 render is missing %q:\n%s", want, out)
 		}
@@ -305,8 +335,11 @@ func TestSurfaceViewShowsOneDescentBlock(t *testing.T) {
 	if n := strings.Count(out, "v_vert:"); n != 0 {
 		t.Errorf("frame still carries %d `v_vert:` rows — the DESCENT chip did not stand down", n)
 	}
-	// The rows worth keeping came along rather than being dropped.
-	for _, row := range []string{"descent:", "v_horiz:", "fpa:", "impact in:", "margin:"} {
+	// The rows worth keeping came along rather than being dropped. `fpa`
+	// is deliberately NOT among them — issue #377's pinned row layout
+	// replaces it with `stop margin` (and `burn at`, when a future safe
+	// start exists).
+	for _, row := range []string{"descent:", "v_horiz:", "impact in:", "stop margin:"} {
 		if !strings.Contains(out, row) {
 			t.Errorf("corridor block is missing the %q row", row)
 		}
@@ -326,5 +359,34 @@ func TestOrbitMapKeepsItsDescentChip(t *testing.T) {
 
 	if !strings.Contains(out, "v_vert:") {
 		t.Error("the orbit map lost its DESCENT chip — there is no corridor there to replace it")
+	}
+}
+
+// TestBurnAtRowDisappearsOnceBurnStarts is issue #377's acceptance item
+// verbatim: "burn at disappears once the burn is under way; stop margin
+// does not." A comfortable descent shows a `burn at` cue pre-burn; the
+// instant ActiveBurn is set, the very next render drops that row while
+// `stop margin` keeps rendering.
+func TestBurnAtRowDisappearsOnceBurnStarts(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	w := descendingMoonCraft(t, 20_000, 120)
+
+	before := stripANSI(v.Render(w, 200, 60))
+	if !strings.Contains(before, "burn at:") {
+		t.Fatal("precondition: expected a `burn at` row for a comfortably-stoppable descent")
+	}
+	if !strings.Contains(before, "stop margin:") {
+		t.Fatal("precondition: expected a `stop margin` row")
+	}
+
+	w.ActiveCraft().ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100}
+
+	after := stripANSI(v.Render(w, 200, 60))
+	if strings.Contains(after, "burn at:") {
+		t.Errorf("burn at row still rendered once ActiveBurn was set:\n%s", after)
+	}
+	if !strings.Contains(after, "stop margin:") {
+		t.Errorf("stop margin row disappeared once the burn started — it must stay live:\n%s", after)
 	}
 }


### PR DESCRIPTION
## What changed

`ComputeBurnMargin` (`internal/sim/descent.go`) answered "can I stop" from
three scalars frozen at the current instant — thrust/mass, g, and the
**vertical** descent rate only. It was optimistic on g (frozen, not g(r)) and
blind to horizontal speed, conservative on mass loss — not "optimistic only
in the mass term" as its own doc comment claimed (fixed in this PR).

Replaces the corridor's margin with an integrated forecast:

- **`PredictPoweredStop(c, horizon) (PoweredStopPrediction, bool)`** —
  integrates a full-throttle, current-stage-only, surface-relative-retrograde
  stop burn via `physics.StepRK4` through one accel closure
  (`poweredStopAccel`), terminating on:
  - **stopped** (surface-relative speed ≈ 0) → `MarginM` = altitude left (≥0)
  - **crashed** (ground crossed before speed nulled) → `ImpactSpeedMps` +
    `MarginM` ≤ 0 (found by letting the same integration continue past the
    crossing rather than hand-deriving a shortfall — "short by |MarginM|",
    never a negative altitude)
  - **fuel-limited** (current stage runs dry) → `MarginM` = altitude at that
    instant
  - **step-cap refusal** (`ok=false`) — same discipline as `PredictImpact`'s
    horizon
- **`PredictBurnAt(c, horizon) (BurnAtCue, bool)`** — the latest safe stop-burn
  start. Bisects `forwardBallisticPath`'s own samples (extended to carry full
  state, not just position) instead of re-propagating — no second propagator.
- **`DeriveMarginState(...)`** — re-derives the `MarginOK`/`MarginTight`/
  `MarginInsufficient` alarm ladder (and `MarginLimiter`) from the integrated
  result. `screens/launch.go:757`'s alarm (`dc.Margin.State ==
  MarginInsufficient`) is untouched — only what feeds `Margin` changed.

### Rows

`descentCorridorLines` now renders (issue's pinned layout):
```
DESCENT CORRIDOR
  altitude:   ...
  descent:    ...
  v_horiz:    ...
  impact in:  ...
  burn at:    <alt> — in <Ns>      (hidden once burn starts, or if unsafe now)
  stop margin: <alt> up (full thrust now)   [/ short by X / fuel-limited at X]
```
`fpa` was dropped from this block in the same pass (the struct field stays,
just unrendered here) — the pinned layout in the issue has no fpa row.

### Caching

`DescentCorridorFor` stays cheap and uncached (unchanged cost profile —
`sim.updateLaunchHint`'s tick-loop caller is unaffected). The two new
integrated forecasts are cached on `LaunchView`
(`internal/tui/screens/launch_descent_cache.go`), predict-on-change per ADR
0017 / the `predictCache`/`soiPassCache` pattern: keyed on craft/primary,
quantized R/V/mass/fuel, a clock bucket, and a `midBurn` flag so a burn
start/stop busts the cache immediately (not just once velocity drifts past
the quantum).

## Before / after (the regression this is about)

A stressed lunar lander (TWR 1.1 at the Moon's own g, Isp 311s — not the
repo's oversized default seed craft) carrying **1604 m/s horizontal** + 41 m/s
vertical at 100 km altitude:

- **BEFORE** (`ComputeBurnMargin`, fed only the 41 m/s vertical rate):
  `Ratio=7.43`, `MarginOK` — comfortably fine, blind to the 1.6 km/s
  horizontal component.
- **AFTER** (`PredictPoweredStop`): `Outcome=Crashed`, `MarginM=-39549`
  (short by ~39.5 km), `ImpactSpeedMps=411`, `ElapsedSec=865.4` — pointing
  retrograde against the true (mostly horizontal) velocity spends most of the
  burn fighting the horizontal component while gravity pulls the craft down
  almost unopposed.

Pinned in `TestPredictPoweredStopLunaHorizontalRegression`
(`internal/sim/descent_powered_stop_test.go`).

## Analytic verification

`TestPredictPoweredStopMatchesAnalyticConstantGCase`: a purely-vertical stop
under constant g (synthetic huge-radius airless body), zero drag, ideal
rocket equation has a closed form (`s(t) = s0 + g·t − Isp·g0·ln(a/(a-t))`,
integrated again for distance) computed independently of
`PredictPoweredStop`'s own RK4 loop. `PredictPoweredStop` matches the
closed-form stop time and margin within 1%.

## Cache sabotage result

`TestDescentStopCacheBustsOnSabotagedKey`: after a real compute (count=1),
the stored cache **key** is corrupted directly (not the craft state) and the
next render recomputes (count=2) — proving the cache-hit path genuinely
compares keys rather than always hitting. A follow-up render then hits again
(count stays 2), confirming the sabotage was a one-off, not a permanent break.
`TestDescentStopCacheHoldsAcrossIdleFrames` covers the positive case (5 idle
renders → 1 compute); `TestDescentStopCacheBustsOnBurnStart` covers the
`midBurn` key field.

## Save schema

**No change.** Nothing here touches `internal/save` or persisted vessel
state — `PoweredStopPrediction`/`BurnAtCue`/the new `DescentCorridor` fields
are all per-frame computed values, never serialized. `SchemaVersion` is
unchanged (currently 9 in this tree — unrelated prior work, not touched here).

## ADR 0043 §3 delta (for the follow-up amendment)

ADR 0043 §3 describes the DESCENT CORRIDOR block's four numbers + a single
`margin` ratio row. This PR changes that to six numbers with `margin`
replaced by `burn at` + `stop margin`, and drops the `fpa` row. The alarm
*contract* (OK/TIGHT/CAN'T STOP bands, arc colour promotion) is unchanged.

## Judgement calls worth a second look

- **Continuing the integration past ground contact** to find `StopCrashed`'s
  `MarginM` (rather than a local kinematic estimate at the impact instant) —
  chosen to keep "integrate the real thing, no hand-derived corrections" true
  even for the negative-margin case.
- **Adaptive step shrink** (`stopAdaptiveShrinkFrac`/`stopAdaptiveMinDt`) was
  added after discovering a real oscillation bug: a fixed 1s RK4 step at a
  high-TWR craft's fixed 100% thrust can overshoot `stopSpeedFloorMps` and
  never re-cross it (the retrograde direction chases a near-zero, noisy
  vRel). Steps now shrink geometrically as speed approaches the floor.
- **`fpa` row dropped** from the corridor per the issue's literal pinned
  layout — the struct field survives unrendered in case that reads as more
  aggressive than intended.
- **TWR 1.1** for the regression craft is a deliberately stressed lander
  (thin margin over hover) — realistic Apollo-LM-class TWR (~1.85-2.1)
  handles this exact 1.6 km/s case cleanly per the same integration (see the
  regression test's comment), which is itself evidence the old ratio model
  was the wrong tool, not that every lander is broken.

Closes #377