### PR TITLE
docs: restructure controls.md by function, no em dashes

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -1,13 +1,36 @@
 # Controls & flight guide
 
-How to actually fly the thing, then the full list of keys. The in-game `F1`
-overlay is the quick reference; the tables below are the same thing with a
-little more explanation.
+How to fly the thing, then every key grouped by what it does. The in-game
+`F1` overlay is the quick reference; this page is the same list with a little
+more explanation. Multiplayer has its own guide in
+[multiplayer.md](multiplayer.md).
+
+**Contents**
+
+- [Quick tour](#quick-tour): your first trip to the Moon
+- [Surface launches](#surface-launches): flying a Saturn V off the pad
+- [Keyboard layout](#keyboard-layout): QWERTZ support
+- [Keybindings](#keybindings)
+  - [Global](#global)
+  - [Time](#time)
+  - [Camera and views](#camera-and-views)
+  - [Targets and the map cursor](#targets-and-the-map-cursor)
+  - [Planning burns](#planning-burns)
+  - [Vessels, staging, and docking](#vessels-staging-and-docking)
+  - [Manual flight](#manual-flight)
+  - [Multiplayer](#multiplayer)
+  - [Mouse](#mouse)
+- [Screens](#screens)
+  - [Spawn form (`n`)](#spawn-form-n)
+  - [Saves](#saves-esc--save-game--load-game)
+  - [Maneuver planner (`m`)](#maneuver-planner-m)
+  - [Porkchop plot (`P`)](#porkchop-plot-p)
+  - [Vehicle Assembly Building](#vehicle-assembly-building-esc--build-vab)
 
 ## Quick tour
 
 You start as a vessel called **S-IVB-1** in a 500 km circular orbit around
-Earth, moving prograde (the direction of travel). The left panel is the map —
+Earth, moving prograde (the direction of travel). The left panel is the map:
 the Sun (or whatever you've focused on) in the middle, planets on their real
 orbits, and your vessel as a little chevron pointing the way it's moving. The
 right-hand panel is your readout: the clock, what you're looking at, fuel and
@@ -16,40 +39,40 @@ attitude, any burns you've planned, and a preview of where they'll put you.
 Speed time up or slow it down with `.` and `,` to watch the planets move;
 pause with `0`.
 
-To go somewhere — say, the Moon:
+To go somewhere, say the Moon:
 
 1. Press `t` to pick a **target**. Keep tapping until the target readout shows
    the Moon. (`h` / `l` move a separate map cursor used by the body info
-   screen and the porkchop plot — they don't set your travel target. The
-   arrow keys instead **pan** the map — see below.)
+   screen and the porkchop plot; they don't set your travel target. The arrow
+   keys **pan** the map.)
 2. Press `H` to plan the trip. Because the Moon orbits the same planet you do,
-   the planner works out two different ways to get there, plans the cheaper one,
-   and flashes both fuel costs — something like
+   the planner works out two ways to get there, plans the cheaper one, and
+   flashes both fuel costs, something like
    `combined 4.12 / split 3.95 km/s → planted split`. Two burn markers appear:
    one to leave your orbit and one to capture at the Moon, each showing its Δv
    (the speed change it costs) and a countdown.
-3. Speed time up. From a fresh game the first burn is only a few hours out — a
-   new game starts you shortly before the Moon lines up with your orbital plane,
-   which is the cheapest moment to leave. (Deeper into a game, or after loading a
-   save, it can sit further out, since it always waits for that next line-up.)
-   When the countdown hits zero the burn fires on its own (time warp eases off
-   around a burn so nothing gets skipped). Your path stretches out toward the
-   Moon, still curving under Earth's gravity.
-4. The second burn fires near the Moon and drops you into a low orbit around it.
-   (The porkchop plot, `P`, is for trips to other planets — for a moon of your
-   own planet, `H` is the way.)
+3. Speed time up. From a fresh game the first burn is only a few hours out,
+   because a new game starts you shortly before the Moon lines up with your
+   orbital plane, the cheapest moment to leave. Deeper into a game, or after
+   loading a save, it can sit further out, since it always waits for that next
+   line-up. When the countdown hits zero the burn fires on its own; time warp
+   eases off around a burn so nothing gets skipped. Your path stretches out
+   toward the Moon, still curving under Earth's gravity.
+4. The second burn fires near the Moon and drops you into a low orbit around
+   it. (The porkchop plot, `P`, is for trips to other planets. For a moon of
+   your own planet, `H` is the way.)
 
 Prefer to set up a burn by hand? Press `m` for the planner. Choose a direction
 (prograde, retrograde, normal, or radial), choose when it fires (a specific
 time, or the next high/low point of your orbit, or the next time you cross the
 target's orbital plane), set how much Δv you want, and pick a throttle. The
 burn's length is worked out for you. A live preview shows the orbit you'll end
-up with as you tweak the numbers. Press Enter to lock it in.
+up with as you tweak the numbers. Press `Enter` to lock it in.
 
 For hands-on, stick-and-throttle flying: `z` to throttle up, the
 `w` `s` `a` `d` `q` `e` keys to point the vessel, then `b` to light the engine.
 
-### Surface launches
+## Surface launches
 
 You can also spawn a Saturn V on the launchpad and fly it to orbit by hand,
 just like KSP: tip the rocket slightly east, let your speed build, switch the
@@ -60,10 +83,10 @@ and the Δv still needed to circularise, so you can fly by watching the numbers.
 A good first attempt:
 
 1. Press `n` to open the spawn form. Set position to **launchpad**, pick a
-   latitude (28.6° N is Cape Canaveral), choose **Saturn V**, and press Enter.
-   The autopilot comes up pointing straight up and is already set to follow
-   your motion relative to the ground, so `w` does the right thing from the
-   start.
+   latitude (28.6° N is Cape Canaveral), choose **Saturn V**, and press
+   `Enter`. The autopilot comes up pointing straight up and already set to
+   follow your motion relative to the ground, so `w` does the right thing from
+   the start.
 2. `z` for full throttle, `b` to light the engine. The first stage lifts off
    at a thrust-to-weight ratio of about 1.24.
 3. Around 3 km up, tap `>` a couple of times to tip ~5° east each. The rocket
@@ -75,10 +98,10 @@ A good first attempt:
    stage and the stage list advances. Keep burning, drop the next stage, then
    the last one.
 6. Watch the projected high point climb. When it passes 200 km the **● ORBIT
-   READY** note appears — that's your cue to cut the throttle (`x`) and coast.
+   READY** note appears. That's your cue to cut the throttle (`x`) and coast.
 7. Press `C` to plan a circularising burn at the top of your arc.
 8. Coast up to that point. The planned burn fires on its own and rounds out
-   your orbit — once your low point also clears 200 km you're safely in orbit,
+   your orbit. Once your low point also clears 200 km you're safely in orbit,
    and the LAUNCH readout tracks the gap along the way.
 
 The whole thing runs on numbers, not memorised pitch tables: the high point
@@ -86,89 +109,99 @@ climbs as you burn, ORBIT READY tells you when to stop, `C` sets up the last
 burn, and the LAUNCH readout closes the gap. If a stage flames out early, the
 readout shows you why before you watch it fall back.
 
+## Keyboard layout
+
+The keys below are written for **QWERTY**. If you play on a **QWERTZ** keyboard
+(where the physical `Y` and `Z` keys are swapped), open `Esc → [Controls]` and
+switch the layout to QWERTZ. Every binding then stays under the same finger as
+on QWERTY, and the in-game help overlay (`F1`) relabels itself to match your
+keycaps. The choice is saved to your config and applies to every game. AZERTY,
+Dvorak, and free per-key remapping aren't supported yet.
+
 ## Keybindings
 
 ### Global
 
 | Key | Action |
 |---|---|
-| `Esc` | Back, or open the save / load / build / settings / controls / quit menu on the main view |
+| `Esc` | Back; on the main view, open the save / load / build / settings / controls / quit menu |
 | `Ctrl+C` | Quit immediately |
-| `F1` | Toggle the help overlay (scroll it with `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End`) |
-| `` ` `` | **Boss key** — instantly swap the whole screen for a convincing fake developer shell (works from any screen). Type `exit`, `logout`, or `Ctrl+D` to drop back into the game right where you left off. Deliberately left out of the in-game help overlay so it stays discreet |
-| `i` | Body info screen |
-| `M` | Mission ladder — your program / objective progress, with the active mission's checklist and locked rungs shown with what unlocks them (same screen as the `[Missions]` button). Missions are **off by default** — enable the Tutorial and/or Challenge ladder in `[Menu]` → Settings |
-| `O` | Session roster (multiplayer) — one row per player with online state, last-known system, vessel count, and their time offset vs you. `t` targets a player's ghost vessel for rendezvous planning — when they have more than one vessel in your system the row expands into a picker so you aim at the right vessel (`esc` backs out one level), and the count reads `3 vessels (1 here)` when some of theirs are landed or in another system; `v` **spectates** — fits the camera to that player's ghost orbit and then follows it, so you can watch their burns re-shape the ellipse (press `f` to return to your own vessel); `s` **sync-warps** you forward to a player's time (forward only — a player behind you syncs to you); `w` arms a **rendezvous warp** — once the other player answers the main-screen prompt with `y`, both warps rate-lock (slowest wins) and you coast together to your predicted closest approach, arriving at 1× already warp-coupled. Arrival hands the vessel back but keeps you time-locked through the whole terminal phase — the proposer flies the pair's clock, the joiner rides copilot — until you dock or either side presses `/`. Hosts and admins mint (`i`), revoke (`r`) invite codes and remove players (`x`) here, and restart the server with `F4` — which warns every connected player, drains them with their progress saved (yours included), and exits into the supervisor that relaunches it; where the host machine is set up to self-update, `F4` reads as *restart to adopt vX.Y.Z* once a newer release is published, and otherwise points at the releases page. `F4`, not a letter, deliberately: it's the one irreversible admin action on this screen, and no irreversible admin action may share a key with a flight verb. The roster's own footer says as much — flight controls are inactive here, only the keys listed apply. The host alone delegates: `p` promotes the selected player to **admin** or demotes them back. An admin carries the invite/removal/restart capability but cannot promote anyone, remove another admin, remove the host, or remove themselves — escalation stays single-rooted. The host also toggles the SSH listener with `h` (start hosting from single-player; stop it, dropping guests, while hosting). Single-player offers `h` to start hosting in-place — no restart, no `--serve`. Other players' vessels are drawn as dim **ghost** orbits on your map (evaluated at *your* clock), and coming within 35 km of a player you're synced with, closing slower than 100 m/s, **couples** your time-warp to theirs so neither of you can skip past the other during an approach — the roster's `RANGE` column shows how close you already are, and the rule is spelled out under the table |
-| `~` | **Chat** (multiplayer, flight view) — opens a one-line input on the canvas edge; type and press `enter` to broadcast to the session, `esc` to bail. A leading `@handle` sends a **private line** (rendered distinctly on both ends); `tab` completes the handle against the online roster and cycles matches, and a typo'd or offline handle *refuses to send* — your text stays put to fix, it never falls back to a broadcast. The sim keeps running while you type (flight keys are text until you close the input), and messages show as transient chips for ~30 s. Chat is live coordination, not messaging: nothing is stored, reconnecting shows no history, and it works regardless of your vessel's CommNet state — you're two people talking, not two vessels transmitting |
-| `Tab` | Switch star system (Sol → Alpha Centauri → TRAPPIST-1 → Kepler-452) |
+| `F1` | Toggle the help overlay (scroll with `↑`/`↓`, `PgUp`/`PgDn`, `Home`/`End`) |
+| `F2` | Declutter: hide the corner chips and the navball for a clean look at the orbit. Press again to restore. The telemetry column stays |
+| `` ` `` | **Boss key**: instantly swap the screen for a convincing fake developer shell. Type `exit`, `logout`, or `Ctrl+D` to come back where you left off. Left out of the `F1` overlay on purpose |
+| `Tab` | Switch star system (Sol first, then alphabetical: Alpha Centauri, Kepler-452, Lumen, TRAPPIST-1). A camera toggle only; vessels stay in the system they spawned in |
+| `i` | Body info screen for the body under the map cursor |
+| `M` | Mission ladder: program and objective progress, the active mission's checklist, and locked rungs with what unlocks them. Same as the `[Missions]` button. Missions are **off by default**; enable the Tutorial or Challenge ladder in `[Menu]` → Settings |
+| `O` | Session roster (multiplayer). See [Multiplayer](#multiplayer) |
+
+### Time
+
+| Key | Action |
+|---|---|
 | `0` | Pause / resume |
-| `.` / `,` | Speed time up / down (up to 100,000×; eases off around a burn). Inert while a rendezvous-warp coast is engaged — the coast owns the rate, and `/` is the one gesture that cancels it. In a rendezvous **terminal phase** these become the copilot's brake: `,` slows the pair a rung, `.` releases back to following the other player's clock, and neither can push the pair faster than the player who proposed the rendezvous |
-| `G` | Auto-warp to the next burn — speeds time to 30 seconds before whichever burn fires first (any vessel's), ramps back down, and hands you 1× to watch it arm. Tapping `.` / `,` cancels it back to your own warp; click the `[»Burn]` button to do the same. Inert while a rendezvous-warp coast is engaged — like the warp keys, `/` is the one gesture that cancels the coast |
-| `/` | Cancel warp — drop straight back to 1× from any warp level, and cancel auto-warp or an armed/coasting rendezvous warp if one is running |
+| `.` / `,` | Speed time up / down, to 100,000×. Eases off automatically around a burn |
+| `G` | Auto-warp to the next burn (any vessel's): warps to 30 s before it fires, ramps down, and hands you 1× to watch it arm. `.` / `,` or the `[»Burn]` button cancels it |
+| `/` | Cancel warp: straight back to 1× from any level, and cancel auto-warp or a rendezvous warp if one is running |
 
-### Keyboard layout
+During a multiplayer rendezvous warp the manual warp keys and `G` are inert
+and `/` is the only cancel; in the terminal phase `,` and `.` become the
+copilot's brake. See [multiplayer.md](multiplayer.md#rendezvous-warp).
 
-The keys below are written for **QWERTY**. If you play on a **QWERTZ** keyboard
-(where the physical `Y` and `Z` keys are swapped), open `Esc → [Controls]` and
-switch the layout to QWERTZ. Every binding then stays under the same finger as
-on QWERTY, and the in-game help overlay (`F1`) relabels itself to match your
-keycaps. The choice is saved to your config and applies to every game. (AZERTY,
-Dvorak, and free per-key remapping aren't supported yet.)
-
-### Map view
+### Camera and views
 
 | Key | Action |
 |---|---|
-| `l` | Move the map cursor to the next body. This cursor feeds the body info screen (`i`) and the porkchop plot (`P`) — it does **not** set your travel target. For that, use `t` / `T` |
-| `h` | Move the map cursor to the previous body |
-| `j` | **Inspect** — ask the map what something is. Each press steps a bright highlight onto the next thing drawn (bodies, your vessel, other vessels, other players' ghosts, planned burns, the closest-approach ✕) and names it in a small chip beside it; one more press than there are things clears it again, and `Esc` drops it immediately. Nothing is labelled until you ask, which is why orbit colours are free to mean *targeting* rather than *who owns this*. You can also click any orbit line or marker to jump the highlight straight there |
-| `Enter` | While inspecting: make the highlighted thing your target (the same commit the body cursor does, but it works on vessels and other players too) and clear the highlight. Things that can't be a target — your own vessel, the star, a planned burn, the ✕ — say so instead |
-| `↑` `↓` `←` `→` | Pan the map — slides the view off the tracked center without losing it: the camera keeps following your focus, just displaced. `g` or any refocus snaps it back |
-| `+` / `-` | Zoom in / out |
-| `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your vessel). Also the way back from **spectating** a player's ghost (`v` on the `O` roster) — it returns the camera to your own vessel |
-| `g` | Reset the camera to the whole system (also clears any pan) |
-| `o` | **Proximity view** — the close-range picture, for the last kilometres of a rendezvous. Your target vessel sits dead centre, its direction of travel runs to the right and the planet is below, so you read your drift the way the physics works instead of watching two dots chase each other around an orbit. Press again to drop straight back to the map exactly as you left it. Needs a **vessel** target (`t`, or another player's ship) — it will tell you if you haven't got one, and a `CLOSE RANGE` chip reminds you the key is there once you get within 35 km |
-| `V` | **Launch / surface view** — the chase-cam on your active vessel: the horizon curves below in the body's own colour, with a pad marker and breadcrumb trail. Scaled to the moment — tight on the pad at liftoff, pulled back to arc-length context once you're high and coming down. Lifting off routes you here automatically; press `V` again to drop straight back to the map exactly as you left it. A `DESCENDING` chip reminds you the key is there once your trajectory is headed for the ground |
-| `v` | Cycle the view — six projections only (tilted → top → right → bottom → left → flat), then wraps. Tilted is the default — a 3D-style perspective that shows orbits leaning in space. Views are projections only: the camera re-frames once when you change focus, view, or system, and otherwise stays exactly where you put it — to read an upcoming encounter, focus the body it passes (`f`) and the camera fits to its sphere of influence so the capture curve fills the canvas. Launch/surface (`V`) and proximity (`o`) are their own toggle keys, not cycle stops |
-| `shift+↑` / `shift+↓` | Tilt the 3D view up / down (only in the tilted view) |
-| `shift+←` / `shift+→` | Yaw the 3D view left / right in 5° steps, wrapping all the way around (only in the tilted view) |
-| `F2` | Declutter — hide all overlays (the corner chips and the navball) for a clean look at the orbit. Press again to bring them back. Your core telemetry column stays put |
-| `n` | Open the spawn form (vessel, where to start, which body, altitude, direction). ALTITUDE is typed, not picked from a list: `Enter` opens it for digits, `Enter` again keeps the number and closes the box, `Esc` throws away what you typed without closing the form, and only once you're back out does `Enter` launch. Outside the box, `←`/`→` step between a handful of altitudes derived from the body itself — a floor a safe margin above its atmosphere (or 25 km with no atmosphere at all), a couple of round waypoints, geostationary where the body actually has one, and a ceiling before you'd lose its gravity's grip — holding at either end instead of wrapping. Type or arrow past either end and the number is moved back in range for you, with a line saying by how much and why. A body too small to hold any orbit at all (Phobos, Deimos) still lists as a place to land, just not to orbit — `Enter` is dead there while POSITION is `orbit`. Pick **Custom…** to build a quick stack from whole modules, or pick one of your **saved designs** (listed after Custom…) built in the VAB (`Esc → [Build (VAB)]`). Vessels are grouped by category and filtered to the current system's scale class by default — use `[f]` to see all systems' vessels |
-| `f` | Inside the spawn form: toggle the **scale-class system filter** — shows all systems' vessels when off, hides off-scale vessels when on (on by default) |
-| `H` | Plan a transfer to your target. To a moon of the planet you're at, it works out two ways to get there and plans the cheaper one, showing you both fuel costs. To another planet, it plans a standard Hohmann transfer. To a moon's parent planet, it plans an escape |
-| `I` | Plan a burn to match your target's orbital tilt (or to level out to the equator when nothing is targeted) |
-| `C` | Plan a circularising burn at the top of your orbit — pairs with the ORBIT READY cue on launch. Won't work if the top of your orbit is still inside the atmosphere or you're on an escape trajectory |
-| `K` | Plan a small nudge to close in on a target vessel. Reads the closest-approach numbers in the target readout. Needs a vessel target sharing your planet, and only works when there's an improvement to be had |
+| `↑` `↓` `←` `→` | Pan the map. The camera keeps following your focus, just displaced; `g` or any refocus snaps it back |
+| `+` / `-` | Zoom in / out. Zoom is remembered per focus |
+| `f` / `F` | Cycle what the camera follows, forward / back (whole system → each body → your vessel). Focusing a body your trajectory passes fits the camera to its sphere of influence so the capture curve fills the canvas. Also the way back from spectating another player |
+| `g` | Reset the camera to the whole system (clears any pan) |
+| `v` | Cycle the projection: tilted (default, a 3D-style perspective) → top → right → bottom → left → flat. The camera re-frames once when focus, view, or system changes and otherwise stays where you put it |
+| `shift+↑` / `shift+↓` | Tilt the 3D view up / down (tilted view only) |
+| `shift+←` / `shift+→` | Yaw the 3D view left / right in 5° steps, wrapping (tilted view only) |
+| `o` | **Proximity view** for the last kilometres of a rendezvous: the target vessel sits dead centre, its direction of travel runs right, the planet is below, so you read your drift the way the physics works. Needs a vessel target; a `CLOSE RANGE` chip reminds you once within 35 km. Press again to return to the map as you left it |
+| `V` | **Launch / surface view**: chase-cam on your active vessel with a curved horizon, pad marker, and breadcrumb trail, scaled tight at liftoff and pulled back high up. Lifting off routes you here automatically; a `DESCENDING` chip reminds you when you're headed for the ground. Press again to return to the map |
+| `j` | **Inspect**: each press steps a bright highlight onto the next thing drawn (bodies, vessels, other players' ghosts, planned burns, the closest-approach `✕`) and names it in a chip. One press past the last item clears it; `Esc` clears immediately. Clicking any orbit line or marker jumps the highlight there |
+| `Enter` | While inspecting: make the highlighted thing your target and clear the highlight. Works on vessels and other players, not just bodies. Things that can't be a target say so |
+
+### Targets and the map cursor
+
+Two different things point at bodies. The **target** (`t` / `T`) is what you
+plan trips to and what the target readout describes. The **map cursor**
+(`h` / `l`) feeds the body info screen (`i`) and the porkchop plot (`P`) and
+does not affect your travel target.
+
+| Key | Action |
+|---|---|
 | `t` / `T` | Pick / clear your target (other vessels nearby → bodies in the system → none) |
-| `space` | Drop the bottom stage of your vessel (only if it has more than one). On a bare capsule with a parachute, this arms the chute instead — it opens on its own once you hit the atmosphere |
-| `P` | Porkchop plot for the body under the map cursor (not your `t` target). `Enter` on a cell plans that transfer. For another planet only — moon targets point you back to `H`. Press `o` inside for transfer options |
-| `R` | Refine the plan — recompute the transfer from where you are right now and update the arrival |
-| `m` | Open the maneuver planner |
-| `F5` / `F9` | Quicksave / quickload — a fixed quick slot, separate from your named saves (see **Saves** below) |
-| `[` / `]` | Switch which vessel you're flying (when you have more than one) |
-| `1`–`9` | Jump straight to vessel N (does nothing if that slot is empty) |
-| `U` | Undock a docked vessel back into its parts. On a **cross-player** stack you own it releases your partner's vessel through the dock ledger instead of splitting locally — and it works whether or not they are connected: an absent partner's vessel is parked as a **Parcel** and delivered, safed and correctly placed, the moment they next connect |
-| `c` | Re-arm docking — undocking (or drifting back together afterward) holds a pair apart even if you settle back inside docking range, until you clear 100 m or ten minutes pass. `c` says "yes, I meant it" and clears that hold right now: with a vessel targeted it clears just that pair, otherwise it clears every hold on your active vessel. A pair already close and slow enough docks on the very next tick. Pressing it with nothing held says so |
-| `Y` | Deploy the top carried payload as its own vessel — releases a satellite/probe/station while you keep flying the carrier (press again to drop the next one). Undock (`U`) instead splits everything and switches you to a released piece |
-| `D` | Apollo transposition — flip the Service Module to the front to do the flying, leaving the Lunar Module as a nose payload (then `U` to release it) |
-| `J` | **Transfer control** of a cross-player docked stack to the guest riding in it — the whole stack, and the flying of it, changes hands instantly (a chip confirms on both sides; refused mid-burn, and refused when your partner has no live session — handing someone the stick needs someone there to take it). Multiplayer only; the guest can always `U` **undock** their own component regardless, and a guest riding a stack whose owner has gone can press `J` to take the stick back immediately |
-| `E` | End the flight — remove a crashed vessel after a `y` / `n` confirm |
+| `l` / `h` | Move the map cursor to the next / previous body |
 
-### Saves (`Esc → [Save Game]` / `[Load Game]`)
-
-One browser for every save: your named saves plus the managed quicksave
-(`F5`) and the three rotating autosaves, newest first, with when it was
-saved, the in-game date, and the vessel you were flying. `[Save Game]`
-opens it in save mode (with a `＋ New save…` row), `[Load Game]` in load
-mode.
+### Planning burns
 
 | Key | Action |
 |---|---|
-| `↑` / `↓` | Move the save cursor (click a row to select it; click again to activate) |
-| `Enter` | Load mode: load the save (asks first). Save mode: `＋ New save…` prompts for a name (prefilled with your vessel + in-game day), an existing named save asks to overwrite it |
-| `d` | Delete the highlighted save (asks first — works on quicksave / autosaves too) |
-| `r` | Rename a named save. The quicksave / autosave slots are managed and can't be renamed or overwritten by hand |
-| `Esc` | Back |
+| `m` | Open the [maneuver planner](#maneuver-planner-m) |
+| `H` | Plan a transfer to your target. To a moon of your current planet it works out two routes and plans the cheaper, showing both costs. To another planet it plans a Hohmann transfer. To a moon's parent planet it plans an escape |
+| `I` | Plan a burn to match your target's orbital tilt (or to level out to the equator with no target) |
+| `C` | Plan a circularising burn at the top of your orbit; pairs with the ORBIT READY cue on launch. Refused if the top of your orbit is inside the atmosphere or you're on an escape trajectory |
+| `K` | Plan a small nudge to close in on a target vessel, using the closest-approach numbers in the target readout. Needs a vessel target sharing your planet, and only fires when there's an improvement to be had |
+| `P` | [Porkchop plot](#porkchop-plot-p) for the body under the map cursor (not your `t` target). Other planets only; moon targets point you back to `H` |
+| `R` | Refine the plan: recompute the transfer from where you are now and update the arrival |
+
+### Vessels, staging, and docking
+
+| Key | Action |
+|---|---|
+| `n` | Open the [spawn form](#spawn-form-n) |
+| `[` / `]` | Switch which vessel you're flying |
+| `1`–`9` | Jump straight to vessel N (nothing happens if the slot is empty) |
+| `space` | Drop the bottom stage (only if there's more than one). On a bare capsule with a parachute this arms the chute instead; it opens on its own in the atmosphere |
+| `Y` | Deploy the top carried payload as its own vessel (satellite, probe, station) while you keep flying the carrier. Press again for the next one |
+| `D` | Apollo transposition: flip the Service Module to the front to do the flying, leaving the Lunar Module as a nose payload (then `U` to release it) |
+| `U` | Undock a docked vessel into its parts and switch you to a released piece. On a cross-player stack it releases your partner's vessel through the dock ledger, connected or not (an absent partner's vessel is parked as a **Parcel** and delivered, safed, when they next connect) |
+| `c` | Re-arm docking. After an undock a pair is held apart until you clear 100 m or ten minutes pass, even if you drift back inside docking range. `c` clears that hold now: with a vessel targeted, just that pair; otherwise every hold on your active vessel. A pair already close and slow docks on the next tick |
+| `J` | Transfer control of a cross-player docked stack to the guest riding in it. Multiplayer only; see [multiplayer.md](multiplayer.md#docking-across-players) |
+| `E` | End the flight: remove a crashed vessel after a `y` / `n` confirm |
+| `F5` / `F9` | Quicksave / quickload to a fixed quick slot, separate from named saves. See [Saves](#saves-esc--save-game--load-game) |
 
 ### Manual flight
 
@@ -176,42 +209,104 @@ mode.
 |---|---|
 | `z` / `x` | Throttle to full / cut to zero |
 | `Z` / `X` | Throttle up / down 10% |
+| `b` | Light / cut the main engine (needs throttle above zero) |
 | `w` / `s` | Point prograde / retrograde (with / against your motion) |
 | `a` / `d` | Point normal+ / normal- (perpendicular to your orbit) |
 | `q` / `e` | Point radial+ / radial- (away from / toward the body) |
-| `b` | Light / cut the main engine (needs throttle above zero) |
-| `r` | Switch between the main engine and RCS thrusters |
-| `p` | RCS pulse step: cycle the per-press Δv (0.1 → 0.01 → 0.001 m/s) for fine trim |
-| `k` | Steering style: smooth turning (the default) or instant snap |
-| `;` | Switch the autopilot's reference: Orbit → Surface → Target (skips Target when none is set) |
-| `W` / `S` | Point along / against your ground speed — matches your velocity relative to the spinning atmosphere. Use this for the launch gravity turn |
+| `W` / `S` | Point along / against your ground speed (velocity relative to the spinning atmosphere). Use this for the launch gravity turn |
 | `>` / `<` | Tip the nose 5° east / west on top of whatever the autopilot is doing (hold to ramp) |
-| `?` | Clear the manual tip (reset pitch trim to 0) |
+| `?` | Clear the manual tip (pitch trim back to 0) |
+| `;` | Autopilot reference: Orbit → Surface → Target (skips Target when none is set) |
+| `k` | Steering style: smooth turning (default) or instant snap |
+| `r` | Switch between the main engine and RCS thrusters |
+| `p` | RCS pulse step: cycle the per-press Δv (0.1 → 0.01 → 0.001 m/s) |
 
-The pointing keys only aim the vessel — `b` is what actually fires the engine.
-In RCS mode those same keys also fire one small thruster pulse per press (hold
-a key for a steady stream). Each pulse is 0.1 m/s by default; press `p` to step
-it down to 0.01 or 0.001 m/s for fine work like nulling out an orbital period to
-the second (see the [constellation deployment guide](constellation-deploy.md)).
-The readouts show which engine is armed, the current pulse size, how much RCS
-fuel you have, and how much Δv it's worth.
+The pointing keys only aim the vessel; `b` is what fires the engine. In RCS
+mode those same keys also fire one small thruster pulse per press (hold for a
+steady stream). Each pulse is 0.1 m/s by default; `p` steps it down for fine
+work like nulling an orbital period to the second (see the
+[constellation deployment guide](constellation-deploy.md)). The readouts show
+which engine is armed, the pulse size, RCS fuel, and how much Δv it's worth.
+
+### Multiplayer
+
+Full mechanics (hosting, independent time, rendezvous warp, cross-player
+docking, chat) are in [multiplayer.md](multiplayer.md). The keys:
+
+| Key | Where | Action |
+|---|---|---|
+| `O` | flight view | Open the **session roster**: one row per player with online state, last-known system, vessel count, and time offset vs you |
+| `~` | flight view | **Chat**. `enter` broadcasts, `esc` bails; a leading `@handle` sends a private line, `tab` completes the handle, and a typo refuses to send. Messages show as chips for ~30 s; nothing is stored |
+| `J` | flight view | Transfer control of a docked stack to the guest riding in it |
+| `t` | roster | Target a player's vessel (expands to a picker when they have several in your system; `esc` backs out) |
+| `v` | roster | Spectate: fit the camera to their ghost orbit and follow it. `f` returns to your own vessel |
+| `s` | roster | Sync-warp forward to a player's time (forward only; a player behind you syncs to you) |
+| `w` | roster | Arm a rendezvous warp toward your predicted closest approach; they answer `y` on their main screen |
+| `y` | flight view | Accept a rendezvous warp |
+| `/` | flight view | Cancel a rendezvous warp (either side) |
+| `h` | roster | Host: start hosting from single-player in place, or stop hosting (drops guests, keeps progress) |
+| `i` / `r` | roster | Host or admin: mint / revoke an invite code |
+| `x` | roster | Host or admin: remove the selected player |
+| `p` | roster | Host only: promote the selected player to admin, or demote them |
+| `F4` | roster | Host or admin: restart the server. Everyone is warned and drained with progress saved; on a self-updating host it adopts a newer release |
+
+Flight controls are inactive on the roster; only the keys listed apply.
 
 ### Mouse
 
-Click only — no dragging, no scroll-to-zoom.
+Click only; no dragging, no scroll-to-zoom.
 
 | Click | Action |
 |---|---|
-| `[»Burn]` (top-right) | Toggle auto-warp to the next burn (same as `G`, including staying inert during a rendezvous-warp coast). Shows `[■Burn]` while running, dimmed when no burn is planned |
+| `[»Burn]` (top-right) | Toggle auto-warp to the next burn (same as `G`). Shows `[■Burn]` while running, dimmed with no burn planned |
 | `[Menu]` (top-right) | Save / load / settings / controls / quit menu |
-| `[Missions]` (top-right) | Mission ladder — active mission checklist on top, the rest of the program below with locked rungs and pass / fail marks (same as `M`). Off by default; enable a program in `[Menu]` → Settings |
-| A body | Follow it with the camera (same as cursoring onto it) |
-| A vessel | Follow it with the camera |
-| A planned burn | Open the planner for that burn (its fire time is kept) |
-| An orbit line | **Inspect** it — the line flares and a name chip says whose it is (the same highlight `j` steps through; `Enter` makes it your target, `Esc` clears it). Clicking a body, a vessel or a burn marker inspects it *as well as* doing the thing above. Your **own** orbit line is the exception: clicking it still plants a burn there, since you already know whose line that is |
+| `[Missions]` (top-right) | Mission ladder (same as `M`). Off by default; enable a program in `[Menu]` → Settings |
+| A body | Follow it with the camera, and inspect it |
+| A vessel | Follow it with the camera, and inspect it |
+| A planned burn | Open the planner for that burn (fire time kept), and inspect it |
+| An orbit line | Inspect it: the line flares and a chip names whose it is (`Enter` targets, `Esc` clears). Your **own** orbit line instead plants a burn there |
 | Empty space | Open the planner with a new burn at the nearest point on your orbit |
 | A readout panel | Open body info |
 | A porkchop cell | Move the cursor there (then `Enter` to plan it) |
+
+## Screens
+
+### Spawn form (`n`)
+
+Choose a vessel, where to start (orbit or launchpad), which body, altitude,
+and direction.
+
+- **Vessels** are grouped by category and filtered to the current system's
+  scale class by default; `f` inside the form toggles the filter to show every
+  system's vessels. Pick **Custom…** to build a quick stack from whole
+  modules, or one of your **saved designs** (listed after Custom…) from the
+  [VAB](#vehicle-assembly-building-esc--build-vab).
+- **Altitude** is typed, not picked from a list. `Enter` opens the field for
+  digits, `Enter` again keeps the number, `Esc` discards what you typed
+  without closing the form, and only once you're back out does `Enter` launch.
+- Outside the box, `←` / `→` step through altitudes derived from the body
+  itself: a floor a safe margin above its atmosphere (or 25 km with none), a
+  couple of round waypoints, geostationary where the body has one, and a
+  ceiling before you'd lose its gravity's grip. They hold at either end
+  instead of wrapping. Type past either end and the number is moved back in
+  range with a line saying by how much and why.
+- A body too small to hold any orbit (Phobos, Deimos) still lists as a place
+  to land, not to orbit: `Enter` is dead there while POSITION is `orbit`.
+
+### Saves (`Esc → [Save Game]` / `[Load Game]`)
+
+One browser for every save: your named saves plus the managed quicksave
+(`F5`) and the three rotating autosaves, newest first, with when it was
+saved, the in-game date, and the vessel you were flying. `[Save Game]` opens
+it in save mode (with a `＋ New save…` row), `[Load Game]` in load mode.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move the save cursor (click a row to select it; click again to activate) |
+| `Enter` | Load mode: load the save (asks first). Save mode: `＋ New save…` prompts for a name (prefilled with vessel + in-game day); an existing named save asks to overwrite |
+| `d` | Delete the highlighted save (asks first; works on quicksave and autosaves too) |
+| `r` | Rename a named save. Quicksave and autosave slots are managed and can't be renamed or overwritten by hand |
+| `Esc` | Back |
 
 ### Maneuver planner (`m`)
 
@@ -223,23 +318,24 @@ Click only — no dragging, no scroll-to-zoom.
 | digits / backspace | Type a Δv or throttle value |
 | `Enter` | Lock in the burn |
 | `Esc` | Cancel and go back |
-| `Ctrl+D` | Delete the burn you're editing (does nothing when creating a new one) |
+| `Ctrl+D` | Delete the burn you're editing (nothing happens when creating a new one) |
 | `c` / `C` | Clear every planned burn for this vessel |
 
-The panel lists all the burns you've planned for the current vessel —
-direction, Δv, and a countdown — with the one you're editing marked, so you
-can see your whole schedule, not just the burn in front of you.
+The panel lists all the burns you've planned for the current vessel
+(direction, Δv, countdown) with the one you're editing marked, so you see your
+whole schedule, not just the burn in front of you.
 
-The Δv you enter sets the burn's length automatically; vessels with no engine
-fall back to an instant nudge. The "when" field lets you fire at a set time or
-at the next high point, low point, or orbital-plane crossing. Throttle is saved
-per burn, so changing your live throttle while coasting won't slow down a burn
-you've already planned. The preview updates the resulting orbit as you edit.
-
-The **refine** toggle spends a little extra Δv to make up for the fuel lost
-steering and fighting gravity during a long burn, so you end up where an
-instant burn of the same size would have put you. Leave it off for short burns;
-turn it on for low-thrust vessels or big burns where the loss is noticeable.
+- The Δv you enter sets the burn's length automatically; vessels with no
+  engine fall back to an instant nudge.
+- **When** fires at a set time or at the next high point, low point, or
+  orbital-plane crossing.
+- **Throttle** is saved per burn, so changing your live throttle while
+  coasting won't slow a burn you've already planned.
+- **Refine** spends a little extra Δv to make up for the fuel lost steering
+  and fighting gravity during a long burn, so you end up where an instant burn
+  of the same size would have put you. Leave it off for short burns; turn it
+  on for low-thrust vessels or big burns.
+- The preview updates the resulting orbit as you edit.
 
 ### Porkchop plot (`P`)
 
@@ -248,60 +344,60 @@ turn it on for low-thrust vessels or big burns where the loss is noticeable.
 | `←` / `→` | Move the departure-day cursor |
 | `↑` / `↓` | Move the travel-time cursor |
 | `Enter` | Plan the transfer for the selected cell |
-| `o` | Open transfer options — number of laps, prograde/retrograde, and the short/long path; closing re-draws the grid |
+| `o` | Transfer options: number of laps, prograde/retrograde, short/long path. Closing re-draws the grid |
 | Click a cell | Move the cursor there (then `Enter` to plan) |
 | `Esc` | Back to the map |
 
 The cursor opens on the cheapest cell. A `·` marks cells where no transfer was
-found — `Enter` does nothing there.
+found; `Enter` does nothing there.
 
-### Vehicle Assembly (VAB) (`Esc → [Build (VAB)]`)
+### Vehicle Assembly Building (`Esc → [Build (VAB)]`)
 
-The VAB is where you design a custom vehicle from fine parts and save it to
-launch later. You compose **components** — engines, fuel tanks, command cores,
-antennas, and structure — into stages, stack the stages into a vehicle, and
-read a live **Δv / TWR / mass** panel as you go. Saved designs are global (they
-survive across games) and show up in the spawn form (`n`) alongside the
-built-in vessels, so you design once and launch many.
+Design a custom vehicle from fine parts and save it to launch later. You
+compose **components** (engines, fuel tanks, command cores, antennas,
+structure) into stages, stack the stages, and read a live **Δv / TWR / mass**
+panel as you go. Saved designs are global across games and show up in the
+spawn form (`n`) alongside the built-in vessels.
 
 Editing happens **in place** on the vehicle rows, the same idiom as the
-maneuver form: the VAB opens focused on the vehicle column with the cursor on a
-fresh stage's `engine —` placeholder, and `←/→` cycles that row's part. You
-rarely need the palette at all — `←/→` to pick an engine, `↓` and `←/→` for a
-tank, `+/-` for the count, done.
+maneuver form. The VAB opens focused on the vehicle column with the cursor on
+a fresh stage's `engine` placeholder, and `←` / `→` cycles that row's part.
+You rarely need the palette: `←` / `→` to pick an engine, `↓` and `←` / `→`
+for a tank, `+` / `-` for the count, done.
 
 | Key | Action |
 |---|---|
-| `Tab` | Switch the active column (palette ↔ vehicle) — the **only** column switch now |
-| `←` / `→` | Swap the selected vehicle row's part within its kind — cycle engines on an engine row, tanks on a tank row. On an empty stage the `engine —` / `tank —` placeholder rows cycle from nothing through the catalog. No-op on a stage header or in the palette |
+| `Tab` | Switch the active column (palette ↔ vehicle) |
 | `↑` / `↓` | Move the cursor in the active column |
-| `PgUp` / `PgDn` | Jump to the previous / next kind section in the palette, or to the previous / next stage in the vehicle column |
-| `a` | Add the selected component to the current stage — or, for a catalog part, add it as a new whole stage |
+| `PgUp` / `PgDn` | Previous / next kind section in the palette, or previous / next stage in the vehicle column |
+| `←` / `→` | Swap the selected row's part within its kind (engines on an engine row, tanks on a tank row). On an empty stage the placeholder rows cycle from nothing through the catalog. No-op on a stage header or in the palette |
+| `a` | Add the selected component to the current stage, or add a catalog part as a new whole stage |
 | `n` | Start a new empty stage on top |
-| `x` | Remove the component group under the cursor — or the whole stage when the cursor is on a stage header or the stage is empty / a catalog part |
-| `+` / `-` | Increase / decrease the count of the component group under the cursor (the `×N` cluster count) |
-| `[` / `]` | Move the cursor's stage down / up in the stack (reorder) |
+| `x` | Remove the component group under the cursor, or the whole stage when on a stage header or the stage is empty / a catalog part |
+| `+` / `-` | Increase / decrease the count of the component group under the cursor (`×N`) |
+| `[` / `]` | Move the cursor's stage down / up in the stack |
 | `y` | Duplicate the stage under the cursor |
-| `Enter` | **Crack open** the atomic catalog part under the cursor (a stage header) into its editable seed components, so you can start from a shipped stage — an S-IVB, a Falcon booster — and tweak it. A flash shows the honest Δv change; parts with no decomposition stay whole |
-| `d` | Toggle a **dock seam** below the stage — everything above the seam becomes a nose payload you release with Undock (`U`) instead of staging. Mark several seams for several payloads |
-| `c` | Toggle a **fused decouple** — the stage drops together with the group below it on one staging press |
-| `t` | Set a session **Σ Δv target**. The stats strip then reads `current / target (delta)`, and with a tank row selected a hint shows how many of that tank close the gap (`+2 → Σ ≈ 9280 ✓`) or that it is unreachable |
+| `Enter` | **Crack open** the catalog part under the cursor (a stage header) into editable components, so you can start from an S-IVB or a Falcon booster and tweak it. A flash shows the Δv change; parts with no decomposition stay whole |
+| `d` | Toggle a **dock seam** below the stage. Everything above the seam becomes a nose payload released with `U` instead of staging; mark several seams for several payloads |
+| `c` | Toggle a **fused decouple**: the stage drops together with the group below it on one staging press |
+| `t` | Set a session **Σ Δv target**. The stats strip reads `current / target (delta)`, and with a tank row selected a hint shows how many of that tank close the gap (`+2 → Σ ≈ 9280 ✓`) or that it's unreachable |
 | `s` | Name and save the design |
 | `o` | Open a saved design to edit (`x` deletes the highlighted one) |
 | `Esc` | Back to the map |
 
-A stage can hold only **one fuel chemistry** — the VAB won't let you mix, say,
-a kerolox engine with a hydrolox tank in the same stage. The **engine row leads
-the chemistry**: cycling the engine with `←/→` can cross chemistries (a kerolox
-→ hydrolox swap lands and leaves the stage briefly flagged), and the tank rows
-then cycle only the new chemistry, so one `←/→` per tank repairs the mix. Adding
-a mismatched part with `a` is still rejected outright. Multiple engines in one
-stage are fine and combine honestly (thrust adds; the effective Isp is the
-thrust-weighted blend). Soft warnings flag the usual snags — no engine, no
-command source (it defaults to a probe core on spawn), or a lift-off TWR below
-1 — but never block you from saving.
+Rules the VAB enforces:
+
+- A stage holds **one fuel chemistry**. The engine row leads: cycling the
+  engine with `←` / `→` can cross chemistries (the stage is briefly flagged),
+  and the tank rows then cycle only the new chemistry, so one `←` / `→` per
+  tank repairs the mix. Adding a mismatched part with `a` is rejected outright.
+- Multiple engines in one stage combine honestly: thrust adds, effective Isp
+  is the thrust-weighted blend.
+- Soft warnings flag the usual snags (no engine, no command source, lift-off
+  TWR below 1) but never block saving. A design with no command source gets a
+  probe core on spawn.
 
 Designs are stored as portable files under
 `$XDG_CONFIG_HOME/terminal-space-program/designs/` (typically
-`~/.config/terminal-space-program/designs/`); copy one into the
-`loadouts/` overlay dir next to it to share it as a mod.
+`~/.config/terminal-space-program/designs/`); copy one into the sibling
+`loadouts/` overlay dir to share it as a mod.


### PR DESCRIPTION
Follows #386/#387.

- Keybindings regrouped by what they do: Global, Time, Camera and views, Targets and the map cursor, Planning burns, Vessels/staging/docking, Manual flight, Multiplayer, Mouse
- Screens (spawn form, saves, maneuver planner, porkchop, VAB) under their own heading; table of contents at the top
- The 2,720-char multiplayer roster cell is now a 14-row key table pointing at `docs/multiplayer.md`; the spawn-form `n` cell is a short bullet list
- Fix: `Tab` system order is Sol first then alphabetical (Alpha Centauri, Kepler-452, Lumen, TRAPPIST-1); the old list omitted Lumen and had the order wrong
- 62 em dashes → 0; longest line 2,720 → 335 chars
- Verified every key row from the old file survives (only `f` moved into the spawn-form prose and `l`/`h` merged into one row)

No bindings changed, so the F1 overlay is untouched. Docs only.