### PR TITLE
docs: remove em dashes from cli.md and constellation-deploy.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 
 `terminal-space-program` opens, by default, with a vessel in a 500 km low Earth
 orbit. The flags below let you boot straight into a different starting
-scenario — a system, a body to orbit or launch from, an orbit shape, a launch
+scenario: a system, a body to orbit or launch from, an orbit shape, a launch
 site, and a vessel. They only shape a **fresh** game; loading a save from the
 in-game menu restores that save unchanged.
 
@@ -42,7 +42,7 @@ terminal-space-program --list-launch-sites
 | `--version`, `-v` | Print the version + build commit. |
 | `--list-systems` | List the available star systems. |
 | `--list-bodies` | List bodies (their IDs). Honours `--system`; otherwise lists every system. |
-| `--list-loadouts` | List the merged catalog — every loadout with its resolved stages, then the parts catalog. Reflects your user overlay (see [Custom vehicles](#custom-vehicles)), so a modded loadout shows up here once it loads. |
+| `--list-loadouts` | List the merged catalog: every loadout with its resolved stages, then the parts catalog. Reflects your user overlay (see [Custom vehicles](#custom-vehicles)), so a modded loadout shows up here once it loads. |
 | `--list-launch-sites` | List the named launch sites. |
 
 ### Where to start
@@ -54,7 +54,7 @@ terminal-space-program --list-launch-sites
 | `--loadout NAME` | `S-IVB-1` | Vessel loadout ID (`Saturn-V`, `Apollo-Stack`, `Kern-Stack`, …; see `--list-loadouts`). |
 
 A vessel is bound for its lifetime to the system it spawns in, and the camera
-follows it — so `--system Lumen` drops you straight into Lumen with the flight
+follows it, so `--system Lumen` drops you straight into Lumen with the flight
 HUD live.
 
 ### Orbital placement
@@ -78,8 +78,8 @@ flags above.
 | Flag | Default | Meaning |
 |---|---|---|
 | `--launchpad` | off | Spawn on the surface instead of in orbit. On its own, uses the KSC default site. |
-| `--launch-site NAME` | — | A named site: `Equator`, `KSC`, `Baikonur`, `Plesetsk`, `North-Pole` (see `--list-launch-sites`). Implies `--launchpad`. |
-| `--lat DEG`, `--lon DEG` | `0`, `0` | Numeric surface site — degrees north and degrees east of the prime meridian. Implies `--launchpad`. |
+| `--launch-site NAME` | (none) | A named site: `Equator`, `KSC`, `Baikonur`, `Plesetsk`, `North-Pole` (see `--list-launch-sites`). Implies `--launchpad`. |
+| `--lat DEG`, `--lon DEG` | `0`, `0` | Numeric surface site, in degrees north and degrees east of the prime meridian. Implies `--launchpad`. |
 
 Named sites are Earth-oriented; to launch from a pad on another body, give an
 explicit `--lat`/`--lon` (and `--orbit BODY` to choose the body).
@@ -93,8 +93,8 @@ explicit `--lat`/`--lon` (and `--orbit BODY` to choose the body).
   lists the valid values, and exits non-zero.
 - A body with no legal orbit altitude at all (e.g. `--orbit phobos`) refuses
   the start outright rather than silently substituting an orbit of its
-  parent — the error names the body that actually owns that space.
-- Body and loadout names are the catalog **IDs** — run the matching `--list-*`
+  parent; the error names the body that actually owns that space.
+- Body and loadout names are the catalog **IDs**; run the matching `--list-*`
   flag if a name is rejected (e.g. the Moon's ID is `moon`, Lumen's home planet
   is `kern`).
 
@@ -107,6 +107,6 @@ add your own loadouts and parts, or override a built-in by reusing its `id`. A
 **part** is one atomic stage (engine + tank + structure fused); a **loadout** is
 an ordered list of part references (bottom stage first) plus optional
 `decouple_plan` / `scale_class`. Run `terminal-space-program --list-loadouts` to
-see the merged catalog and confirm your overlay loaded — a malformed file is
+see the merged catalog and confirm your overlay loaded; a malformed file is
 skipped with a warning to stderr and never fails the rest. The built-in catalog
 (the shape to copy) ships embedded in the binary under `internal/spacecraft/data/`.

--- a/docs/constellation-deploy.md
+++ b/docs/constellation-deploy.md
@@ -8,7 +8,7 @@ first.
 ## The one mechanic that matters
 
 When you press `Y` (Deploy), the top payload is released into the carrier's
-**exact current orbit** — same position, same velocity, plus a tiny 75 m / 0.15
+**exact current orbit**: same position, same velocity, plus a tiny 75 m / 0.15
 m/s nudge so it doesn't auto-redock. There is no separate "insertion orbit"
 handed to the satellite, and nothing spaces the satellites for you. Every comsat
 comes out wherever the carrier happens to be at the instant you deploy.
@@ -16,20 +16,20 @@ comes out wherever the carrier happens to be at the instant you deploy.
 Two consequences drive everything below:
 
 1. **The satellites never have to change orbit.** A comsat with ~130 m/s of its
-   own is fine — that budget is for final trim and station-keeping, not for
+   own is fine; that budget is for final trim and station-keeping, not for
    covering the gap between where you dropped it and where it belongs. If you
    find yourself wanting the comsats to cover a large orbit difference, you
    deployed from the wrong place. Bring the *carrier* to the final orbit first.
 2. **The carrier gets lighter at every drop.** Deploy recomputes the carrier's
    mass to exclude the released payload (dry mass + whatever fuel/monoprop that
    comsat carried) the moment you press `Y`. So each successive phasing burn
-   costs *less* propellant than the last — see [What it costs in
+   costs *less* propellant than the last; see [What it costs in
    fuel](#what-it-costs-in-fuel).
 
 ## Deploy from the target orbit, not a transfer orbit
 
 The recipe in one line: **put the carrier in the final circular orbit, then
-space the constellation by phasing the carrier — not the satellites.**
+space the constellation by phasing the carrier, not the satellites.**
 
 1. Circularize the *carrier* into the target orbit. Spend the carrier's delta-v
    here (a tug carries far more than any single comsat).
@@ -54,7 +54,7 @@ T_phase = T_target × (N ± 1) / N
 - `(N+1)` → keep periapsis at the deploy point, **raise apoapsis** (carrier
   slower; the already-deployed sats pull ahead). Preferred in a low orbit.
 - `(N−1)` → keep apoapsis at the deploy point, **lower periapsis** (carrier
-  faster). Avoid in a low orbit — you're dipping toward atmosphere/terrain.
+  faster). Avoid in a low orbit; you're dipping toward atmosphere/terrain.
 
 After one phasing revolution the carrier is back at the exact deploy point and
 the previous satellite has drifted `360°/N`. Re-circularize, deploy the next,
@@ -89,7 +89,7 @@ speed at the deploy point is:
 v_apsis = √( μ · (2/r − 1/a_phase) )
 ```
 
-You burn twice per slot — into the phasing orbit and back out — each of equal
+You burn twice per slot (into the phasing orbit and back out), each of equal
 magnitude (same apsis, same speed), so:
 
 ```
@@ -109,7 +109,7 @@ approximation (`ε = 1/(mN)`):
 
 ## What it costs in fuel
 
-The delta-v above is pure orbital mechanics — **mass-independent**. What it
+The delta-v above is pure orbital mechanics, **mass-independent**. What it
 *costs* in propellant follows the rocket equation against the carrier's current
 mass:
 
@@ -140,16 +140,16 @@ Six comsats (`N = 6`), 360°/6 = 60° apart, in an orbit where `v_c ≈ 2300 m/s
 | 4 | ×25/24 (1.042) | ~32 m/s     | ~0.32 km/s       | 20         |
 
 Going from `m = 1` to `m = 4` takes the carrier from spending most of a typical
-tug's budget to about a quarter of it — at the cost of 4× the warp time.
+tug's budget to about a quarter of it, at the cost of 4× the warp time.
 
 ## Flying it in-game
 
 The **ORBIT** chip and the **PROJECTED ORBIT** chip both show the orbital period
-(`2π√(a³/μ)`) under the time-to-apoapsis / time-to-periapsis lines — that's your
+(`2π√(a³/μ)`) under the time-to-apoapsis / time-to-periapsis lines; that's your
 tuning instrument. As of **v0.24.4** the period reads down to the second
 (`6h04m21s`) rather than rounding to the minute, so you can tune a phasing orbit
 to roughly 1-second precision. The placement error that leaves is
-`Δφ ≈ 360°·m·δ/T` per slot — a fraction of a degree for any sane `m`, well below
+`Δφ ≈ 360°·m·δ/T` per slot, a fraction of a degree for any sane `m`, well below
 what a comsat's own trim budget cares about.
 
 1. Circularize the carrier into the target orbit; note its period `T` on the
@@ -166,7 +166,7 @@ what a comsat's own trim budget cares about.
 
 - **There's a floor.** At high `m` the burn gets too small to plant cleanly and
   the total warp time balloons. When the per-burn delta-v drops near a comsat's
-  own ~130 m/s, stop fussing over carrier precision — deploy a little roughly and
+  own ~130 m/s, stop fussing over carrier precision; deploy a little roughly and
   let each comsat trim its own final position with its onboard budget.
 - **Coarse carrier + comsat cleanup** is usually the cheapest overall plan: a
   low-`m` (cheap, fast) carrier phasing that gets each sat *close*, finished off
@@ -174,8 +174,8 @@ what a comsat's own trim budget cares about.
   step the pulse down with `p` (0.1 → 0.01 → 0.001 m/s) to null its period to the
   second without overshooting.
 - **Need finer than a second?** Tune the **projected apoapsis** instead of the
-  period — it reads to 0.1 km, and at a typical comsat orbit ~1 km of apoapsis is
+  period; it reads to 0.1 km, and at a typical comsat orbit ~1 km of apoapsis is
   ~1 second of period (`dT/dr_apo = ¾·T/a`), so it's an even sharper lever. You'll
   rarely need it now that the period shows seconds.
-- There is currently **no automated constellation/phasing helper** — the whole
+- There is currently **no automated constellation/phasing helper**; the whole
   flow above is manual.


### PR DESCRIPTION
Hand-rewritten, 8 + 13 em dashes → 0. The one table cell that used an em dash as 'no default' (`--launch-site`) now reads `(none)`. No wording changes beyond punctuation.