### PR TITLE
Reframe degraded-band comms warning for relay-class craft

### DIFF
--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -1138,43 +1138,56 @@ func (s *SpawnCraft) Render(width int) string {
 // sampler models the selected craft's own best antenna — a Relay-Tug at
 // the Moon links home and must not be warned off the exact spawn the band
 // pressure exists to motivate (v0.32 review finding). A value in the
-// degraded band names the band AND the fix (relays); zero coverage is the
-// out-of-range case and must not advise a relay. Empty when the sampler is
-// absent, the position mode doesn't orbit, the current parent has no legal
-// orbit altitude at all, or coverage is clean — the form never guesses.
+// degraded band names the band AND the fix (relays) for an ordinary
+// probe; zero coverage is the out-of-range case and must not advise a
+// relay. #283: for a relay-class craft (one that itself carries
+// AntennaRelay hardware) the degraded tier is reframed as neutral
+// information — "relays advised" is circular when the craft being spawned
+// IS the relay, and the ⚠ warns the player off exactly the deployment
+// that fixes the gap. The coverage number stays; only the warning framing
+// and the fix-suffix go. Empty when the sampler is absent, the position
+// mode doesn't orbit, the current parent has no legal orbit altitude at
+// all, or coverage is clean — the form never guesses.
 //
 // ADR 0044 / S4: the cache key is now altitude in metres (bandCacheKey),
 // not a ladder index — Render calls this only from altitudeNoteLines,
 // which returns before reaching here while the edit box is open, so
 // sampling (≈400 connectivity solves) runs on commit, never per keystroke.
-func (s *SpawnCraft) bandWarning() string {
+//
+// Returns the line text plus whether it should render with warning
+// styling (⚠ lines) or neutral styling (the relay-class reframe).
+func (s *SpawnCraft) bandWarning() (text string, isWarning bool) {
 	if s.bandCoverage == nil || s.posMode != posOrbit || s.altBandEmpty {
-		return ""
+		return "", false
 	}
 	if s.parentIdx < 0 || s.parentIdx >= len(s.parentBodies) {
-		return ""
+		return "", false
 	}
-	crewed, antennaRangeM := spawnCommsProfile(s.selectedCraftStages())
+	crewed, antennaRangeM, relayClass := spawnCommsProfile(s.selectedCraftStages())
 	if crewed {
-		return "" // crewed vessels are never comms-gated
+		return "", false // crewed vessels are never comms-gated
 	}
 	key := bandCacheKey{parentIdx: s.parentIdx, altM: s.altM, antennaRangeM: antennaRangeM}
 	cov, cached := s.bandCache[key]
 	if !cached {
 		c, ok := s.bandCoverage(s.parentBodies[s.parentIdx].ID, s.SelectedAltitudeM(), antennaRangeM)
 		if !ok {
-			return ""
+			return "", false
 		}
 		cov = c
 		s.bandCache[key] = cov
 	}
 	switch {
 	case cov <= 0:
-		return "⚠ out of network reach — no signal at this body"
+		return "⚠ out of network reach — no signal at this body", true
 	case cov < sim.CommBandDegradedThreshold:
-		return fmt.Sprintf("⚠ degraded comms band — ~%d%% coverage, relays advised", int(cov*100+0.5))
+		pct := int(cov*100 + 0.5)
+		if relayClass {
+			return fmt.Sprintf("coverage from here: ~%d%%", pct), false
+		}
+		return fmt.Sprintf("⚠ degraded comms band — ~%d%% coverage, relays advised", pct), true
 	}
-	return ""
+	return "", false
 }
 
 // altitudeValueLine renders field 3's value in orbit/alongside mode (ADR
@@ -1245,18 +1258,24 @@ func (s *SpawnCraft) altitudeNoteLines(width int) []string {
 	if s.altNote != "" {
 		out = append(out, "    "+s.theme.Warning.Render("↳ "+s.altNote))
 	}
-	if warn := s.bandWarning(); warn != "" {
-		out = append(out, "  "+s.theme.Warning.Render(warn))
+	if warn, isWarning := s.bandWarning(); warn != "" {
+		style := s.theme.Warning
+		if !isWarning {
+			style = s.theme.Dim
+		}
+		out = append(out, "  "+style.Render(warn))
 	}
 	return out
 }
 
 // spawnCommsProfile derives the comms-relevant shape of a stage list the
 // way vessel construction does: crewed if any stage carries a crewed
-// command source, and the best stage antenna's rated range (zero → the
-// caller lets the sampler assume the EnsureCommandSource direct-basic
-// backfill every non-debris vessel receives).
-func spawnCommsProfile(stages []spacecraft.Stage) (crewed bool, antennaRangeM float64) {
+// command source, the best stage antenna's rated range (zero → the caller
+// lets the sampler assume the EnsureCommandSource direct-basic backfill
+// every non-debris vessel receives), and relayClass (#283) — whether any
+// stage carries its own AntennaRelay hardware, i.e. this craft IS a relay
+// rather than merely a consumer of one.
+func spawnCommsProfile(stages []spacecraft.Stage) (crewed bool, antennaRangeM float64, relayClass bool) {
 	for _, st := range stages {
 		if st.CommandSource == spacecraft.CommandCrewed {
 			crewed = true
@@ -1264,8 +1283,11 @@ func spawnCommsProfile(stages []spacecraft.Stage) (crewed bool, antennaRangeM fl
 		if st.AntennaKind != spacecraft.AntennaNone && st.AntennaRangeM > antennaRangeM {
 			antennaRangeM = st.AntennaRangeM
 		}
+		if st.AntennaKind == spacecraft.AntennaRelay {
+			relayClass = true
+		}
 	}
-	return crewed, antennaRangeM
+	return crewed, antennaRangeM, relayClass
 }
 
 // craftRow renders one selectable CRAFT TYPE row (a catalog loadout, the

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -34,17 +34,17 @@ type SpawnCraft struct {
 	// sim.ClampToOrbitBand. altNote / altBandEmpty are that call's last
 	// result, kept in lockstep with altM so Render never has to re-derive
 	// them.
-	altM         float64 // metres above the parent's mean radius
-	altEditing   bool    // the typed-edit box is open (§1 state machine)
-	altInput     string  // in-progress digits while altEditing
+	altM       float64 // metres above the parent's mean radius
+	altEditing bool    // the typed-edit box is open (§1 state machine)
+	altInput   string  // in-progress digits while altEditing
 	// altLeftBox arms the ADR's third mockup frame: the player has just
 	// stepped back out of the edit box, so the next Enter LAUNCHES rather
 	// than reopening it. Any other key clears it, so the arming can never
 	// outlive the moment — a player who tabs away and back gets "Enter to
 	// edit" again, and can never launch by an Enter they meant for the box.
-	altLeftBox bool
-	altNote      string  // sim.ClampToOrbitBand's note, verbatim (raised/lowered/no-orbit)
-	altBandEmpty bool    // true when the current parent has NO legal orbit altitude (Phobos/Deimos)
+	altLeftBox   bool
+	altNote      string // sim.ClampToOrbitBand's note, verbatim (raised/lowered/no-orbit)
+	altBandEmpty bool   // true when the current parent has NO legal orbit altitude (Phobos/Deimos)
 
 	latIdx     int // v0.9.2+: latitude preset cursor when posMode=launchpad
 	retrograde bool
@@ -1272,22 +1272,27 @@ func (s *SpawnCraft) altitudeNoteLines(width int) []string {
 // way vessel construction does: crewed if any stage carries a crewed
 // command source, the best stage antenna's rated range (zero → the caller
 // lets the sampler assume the EnsureCommandSource direct-basic backfill
-// every non-debris vessel receives), and relayClass (#283) — whether any
-// stage carries its own AntennaRelay hardware, i.e. this craft IS a relay
-// rather than merely a consumer of one.
+// every non-debris vessel receives), and relayClass (#283) — whether the
+// BUILT VESSEL, once resolved, actually forwards CommNet traffic.
+//
+// Review finding on #283/PR #390: relayClass used to be "any stage carries
+// AntennaRelay hardware," which diverges from what the vessel resolves to.
+// Spacecraft.SyncFields (internal/spacecraft/stage.go) picks the
+// longest-ranged antenna across the whole stack as THE vessel's antenna —
+// a custom loadout pairing a short relay antenna with a longer-ranged
+// Direct dish resolves to Direct, not Relay. And commnet.go's forwarding
+// gate additionally requires Controllable (a command source somewhere on
+// the stack), not just relay hardware. So relayClass now runs the exact
+// same resolution (via SyncFields, reused rather than re-derived) and the
+// exact same forwarding condition, so the form and CommNet can't drift
+// apart again: relayClass is true only when the resolved antenna is
+// AntennaRelay AND the vessel is Controllable — anything else (a
+// Direct-winning mixed loadout, or a relay antenna with no command source)
+// falls back to the ordinary ⚠ consumer warning.
 func spawnCommsProfile(stages []spacecraft.Stage) (crewed bool, antennaRangeM float64, relayClass bool) {
-	for _, st := range stages {
-		if st.CommandSource == spacecraft.CommandCrewed {
-			crewed = true
-		}
-		if st.AntennaKind != spacecraft.AntennaNone && st.AntennaRangeM > antennaRangeM {
-			antennaRangeM = st.AntennaRangeM
-		}
-		if st.AntennaKind == spacecraft.AntennaRelay {
-			relayClass = true
-		}
-	}
-	return crewed, antennaRangeM, relayClass
+	craft := spacecraft.Spacecraft{Stages: stages}
+	craft.SyncFields()
+	return craft.Crewed, craft.AntennaRangeM, craft.AntennaKind == spacecraft.AntennaRelay && craft.Controllable
 }
 
 // craftRow renders one selectable CRAFT TYPE row (a catalog loadout, the

--- a/internal/tui/screens/spawn_band_test.go
+++ b/internal/tui/screens/spawn_band_test.go
@@ -131,12 +131,13 @@ func TestClampAndCommsWarningBothRenderAtLowCeilingBody(t *testing.T) {
 	degraded := func(bodyID string, altM, antennaRangeM float64) (float64, bool) { return 0.5, true }
 	s.Reset(sys.Bodies, "enceladus", nil, "", degraded)
 
-	// An uncrewed craft with an antenna, so bandWarning has something to
-	// say (crewed craft are never comms-gated).
+	// An uncrewed craft with a direct (non-relay) antenna, so bandWarning
+	// has something to say (crewed craft are never comms-gated) and #283's
+	// relay-class reframe doesn't swallow the ⚠ this test is checking for.
 	selectCustom(s)
 	s.customStages = []spacecraft.Stage{{
 		Name: "Bus", CommandSource: spacecraft.CommandProbe,
-		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+		AntennaKind: spacecraft.AntennaDirect, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
 	}}
 
 	if s.altNote == "" {
@@ -154,6 +155,66 @@ func TestClampAndCommsWarningBothRenderAtLowCeilingBody(t *testing.T) {
 	}
 	if clampIdx >= 0 && warnIdx >= 0 && clampIdx > warnIdx {
 		t.Errorf("comms warning rendered BEFORE the clamp note; want clamp first:\n%s", out)
+	}
+}
+
+// #283: a relay-class craft (one carrying its own AntennaRelay hardware) is
+// the fix for a degraded band, not a craft that should be warned off it —
+// the v0.32.0 antenna-aware fix already fixed the out-of-reach tier
+// (TestSpawnFormPassesSelectedAntennaToSampler above), but the degraded
+// tier still fired the ⚠ + "relays advised" for exactly this craft class.
+// The fix keeps the coverage number (still useful) but drops the warning
+// framing and the circular "relays advised" suffix for relay-class craft
+// only; an ordinary probe (direct antenna, or none) still gets the
+// original ⚠ wording unchanged.
+
+func TestSpawnFormRelayClassDegradedBandIsNeutral(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	s.customStages = []spacecraft.Stage{{
+		Name: "Bus", CommandSource: spacecraft.CommandProbe,
+		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+	}}
+	setAltitude(t, s, 5000)
+	out := s.Render(80)
+	if strings.Contains(out, "⚠") {
+		t.Errorf("a relay-class craft must not be warned off the deployment that fixes its own band:\n%s", out)
+	}
+	if strings.Contains(out, "relays advised") {
+		t.Errorf("\"relays advised\" is circular for a craft that IS the relay:\n%s", out)
+	}
+	if !strings.Contains(out, "~92%") {
+		t.Errorf("the coverage number is still useful and must survive the reframe:\n%s", out)
+	}
+}
+
+func TestSpawnFormNonRelayDegradedBandUnchanged(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	s.customStages = []spacecraft.Stage{{
+		Name: "Bus", CommandSource: spacecraft.CommandProbe,
+		AntennaKind: spacecraft.AntennaDirect, AntennaRangeM: 1e9,
+	}}
+	setAltitude(t, s, 5000)
+	out := s.Render(80)
+	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
+		t.Errorf("an ordinary (non-relay) probe below threshold must keep the original warning:\n%s", out)
+	}
+}
+
+func TestSpawnFormRelayClassCrewedStillNeverWarned(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	s.customStages = []spacecraft.Stage{{
+		Name: "Pod", CommandSource: spacecraft.CommandCrewed,
+		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+	}}
+	setAltitude(t, s, 5000)
+	if out := s.Render(80); strings.Contains(out, "⚠") || strings.Contains(out, "coverage from here") {
+		t.Errorf("crewed suppression must still win outright, even for a relay-class craft:\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/spawn_band_test.go
+++ b/internal/tui/screens/spawn_band_test.go
@@ -218,6 +218,94 @@ func TestSpawnFormRelayClassCrewedStillNeverWarned(t *testing.T) {
 	}
 }
 
+// Review finding on #283/PR #390: relayClass used to fire whenever ANY
+// stage carried AntennaRelay hardware, which diverges from what the built
+// vessel actually resolves to (Spacecraft.SyncFields picks the
+// longest-ranged antenna across the stack) and from what CommNet actually
+// forwards for (AntennaKind==AntennaRelay && Controllable — commnet.go).
+// These three multi-stage cases pin the corrected, resolution-mirroring
+// predicate; the single-stage tests above still pass unchanged because a
+// single stage can't produce the divergence.
+
+func TestSpawnFormMixedAntennaResolvesDirectNotRelay(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	// A relay antenna coexists with a longer-ranged Direct dish elsewhere on
+	// the stack. SyncFields resolves the vessel to the longest-ranged
+	// antenna — Direct wins — so this is an ordinary consumer craft, not a
+	// relay, even though relay hardware is present somewhere on it.
+	s.customStages = []spacecraft.Stage{
+		{
+			Name: "Relay Bus", CommandSource: spacecraft.CommandProbe,
+			AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+		},
+		{
+			Name: "Deep Dish", CommandSource: spacecraft.CommandNone,
+			AntennaKind: spacecraft.AntennaDirect, AntennaRangeM: spacecraft.AntennaRangeDeepSpace,
+		},
+	}
+	setAltitude(t, s, 5000)
+	out := s.Render(80)
+	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
+		t.Errorf("a mixed loadout that resolves to Direct must get the ordinary warning, not the relay-class reframe:\n%s", out)
+	}
+}
+
+func TestSpawnFormRelayAntennaWithoutCommandSourceIsNotRelayClass(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	// A relay antenna with no command source anywhere on the stack: the
+	// vessel is not Controllable, so CommNet would never forward through it
+	// (commnet.go: forwards iff AntennaKind==Relay && Controllable). The
+	// form must not reframe the warning for a "relay" that can't relay.
+	s.customStages = []spacecraft.Stage{
+		{
+			Name: "Dumb Relay Bus", CommandSource: spacecraft.CommandNone,
+			AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+		},
+		{
+			Name: "Tank", CommandSource: spacecraft.CommandNone,
+		},
+	}
+	setAltitude(t, s, 5000)
+	out := s.Render(80)
+	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
+		t.Errorf("a relay antenna with no command source is not Controllable and must keep the ordinary warning:\n%s", out)
+	}
+}
+
+func TestSpawnFormMultiStageGenuineRelayIsNeutral(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	resetWithBand(s, bandStub(map[int]float64{5000: 0.92}))
+	selectCustom(s)
+	// A genuine multi-stage relay: the relay antenna is also the
+	// longest-ranged one on the stack, and a probe core elsewhere makes the
+	// vessel Controllable. This resolves to Relay + Controllable, matching
+	// what CommNet forwards for, so the neutral reframe still applies.
+	s.customStages = []spacecraft.Stage{
+		{
+			Name:        "Relay Payload",
+			AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
+		},
+		{
+			Name: "Probe Core", CommandSource: spacecraft.CommandProbe,
+		},
+	}
+	setAltitude(t, s, 5000)
+	out := s.Render(80)
+	if strings.Contains(out, "⚠") {
+		t.Errorf("a genuine multi-stage relay (resolves to relay, controllable) must not be warned off its own deployment:\n%s", out)
+	}
+	if strings.Contains(out, "relays advised") {
+		t.Errorf("\"relays advised\" is circular for a craft that IS the relay:\n%s", out)
+	}
+	if !strings.Contains(out, "~92%") {
+		t.Errorf("the coverage number is still useful and must survive the reframe:\n%s", out)
+	}
+}
+
 // setAltitude commits a typed altitude (km) via the real edit-box path
 // (ADR 0044 / S4) — HandleKey drives fieldIdx to ALTITUDE, opens the box,
 // types each digit, then commits, exercising the same state machine a


### PR DESCRIPTION
Fixes #283

## Problem

Selecting a Relay-Tug at the Moon on the spawn form showed
`⚠ degraded comms band — ~92% coverage, relays advised`. The v0.32.0
antenna-aware fix already fixed the out-of-reach tier for this case
(the tug's own antenna links home), but the degraded-band tier
(coverage below `sim.CommBandDegradedThreshold`, 99.5%) still fired,
and "relays advised" is circular when the craft being spawned IS the
relay.

## Approach: neutral reframe, not suppression

Per the issue's stated preference, I reframed rather than suppressed:
a relay-class craft (one whose stages carry `spacecraft.AntennaRelay`
hardware — the same signal `spawnCommsProfile` already inspects for
antenna range, not a name/category string match) now sees an unwarned
line for the degraded tier:

```
coverage from here: ~92%
```

instead of

```
⚠ degraded comms band — ~92% coverage, relays advised
```

The number is accurate and useful, so it survives; the ⚠ framing and
the circular "relays advised" suffix are dropped, and the line renders
with the form's dim/neutral style instead of the warning style.

Suppression (mirroring the existing crewed-craft suppression) would
have been a smaller diff, but it throws away real information — the
coverage number is exactly what a relay-constellation builder wants to
see when deciding where to park the next node. Reframe keeps that
signal.

Unaffected, on purpose:
- **Out-of-reach tier** (`cov <= 0`, `⚠ out of network reach`) — already
  didn't say "relays advised"; left as-is.
- **Ordinary (non-relay) probes** below the degraded threshold — still
  get the original `⚠ degraded comms band … relays advised` wording,
  unchanged.
- **Crewed suppression** — still wins outright before the relay check
  even runs, including for a crewed craft that happens to carry relay
  hardware.

## Changes

- `internal/tui/screens/spawn.go`
  - `spawnCommsProfile` now also returns `relayClass bool` (true when
    any stage carries `AntennaKind == AntennaRelay`).
  - `bandWarning` now returns `(text string, isWarning bool)` so the
    caller can style the relay-class reframe as neutral info instead
    of a warning; the degraded-tier branch reframes when `relayClass`
    is true.
  - `altitudeNoteLines`'s call site picks `theme.Warning` vs.
    `theme.Dim` based on the new `isWarning` flag.
- `internal/tui/screens/spawn_band_test.go`
  - New tests: `TestSpawnFormRelayClassDegradedBandIsNeutral`,
    `TestSpawnFormNonRelayDegradedBandUnchanged`,
    `TestSpawnFormRelayClassCrewedStillNeverWarned`.
  - `TestClampAndCommsWarningBothRenderAtLowCeilingBody`'s fixture
    craft switched from `AntennaRelay` to `AntennaDirect` — it was
    incidentally using a relay-antenna stage just to get "an uncrewed
    craft with an antenna" for the clamp+warning coexistence check,
    which the new relay reframe would otherwise (correctly) swallow.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1` (full suite, all packages green)