### PR TITLE
Fix silent no-op refusals on guarded flight keys

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -919,7 +919,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		case key.Matches(m, a.keys.Maneuver):
-			if a.active == screenOrbit && a.world.CraftVisibleHere() {
+			if a.active == screenOrbit {
+				// #282 sweep: same CraftVisibleHere state-guard as the
+				// planning keys below — say why instead of doing
+				// nothing.
+				if !a.world.CraftVisibleHere() {
+					a.refuse("maneuver", "vessel not in this system")
+					return a, nil
+				}
 				// Pressing `m` opens for a NEW node — drop any
 				// click-to-edit state that may be lingering from a
 				// previous open.
@@ -1132,66 +1139,74 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// body cursor. TargetCraft is the v0.9.3 rendezvous-tooling
 			// surface and routes through `R` once that lands; here it
 			// flashes a redirect rather than silently no-opping. None →
-			// silent no-op (nothing aimed at).
-			if a.world.CraftVisibleHere() {
-				switch a.world.Target.Kind {
-				case sim.TargetBody:
-					_, _ = a.world.PlanTransfer(a.world.Target.BodyIdx)
-					a.world.RecordAction(missions.ActionPlanTransfer) // ADR 0025 §7
-					// v0.12.x (ADR 0005): the intra-primary auto-plant is
-					// now a plane-aware dual-strategy solver (combined
-					// fused-Lambert vs split raise + apoapsis plane change)
-					// that plants the cheaper — so flash both candidate Δv
-					// totals and which was planted (supersedes the retired
-					// "match plane [I], circularize, then [H]" advisory).
-					// Non-intra-primary plants leave the comparison empty.
-					if cmp := a.world.LastTransfer.Format(); cmp != "" {
-						a.statusMsg = cmp
-						a.statusExpires = time.Now().Add(6 * time.Second)
-					}
-				case sim.TargetCraft:
-					a.statusMsg = "H targets bodies — for vessels, plan via [m]"
-					a.statusExpires = time.Now().Add(3 * time.Second)
+			// silent no-op (nothing aimed at) — that gap is deliberate,
+			// unrelated to #282: there is genuinely nothing to name
+			// when no target is aimed at.
+			if !a.world.CraftVisibleHere() {
+				// #282 sweep: same state-guard shape as K/E — say why.
+				a.refuse("transfer", "vessel not in this system")
+				return a, nil
+			}
+			switch a.world.Target.Kind {
+			case sim.TargetBody:
+				_, _ = a.world.PlanTransfer(a.world.Target.BodyIdx)
+				a.world.RecordAction(missions.ActionPlanTransfer) // ADR 0025 §7
+				// v0.12.x (ADR 0005): the intra-primary auto-plant is
+				// now a plane-aware dual-strategy solver (combined
+				// fused-Lambert vs split raise + apoapsis plane change)
+				// that plants the cheaper — so flash both candidate Δv
+				// totals and which was planted (supersedes the retired
+				// "match plane [I], circularize, then [H]" advisory).
+				// Non-intra-primary plants leave the comparison empty.
+				if cmp := a.world.LastTransfer.Format(); cmp != "" {
+					a.statusMsg = cmp
+					a.statusExpires = time.Now().Add(6 * time.Second)
 				}
+			case sim.TargetCraft:
+				a.statusMsg = "H targets bodies — for vessels, plan via [m]"
+				a.statusExpires = time.Now().Add(3 * time.Second)
 			}
 			return a, nil
 		case key.Matches(m, a.keys.PlanIncl):
-			if a.world.CraftVisibleHere() {
-				// v0.9.0+: I consumes World.Target. TargetBody → full
-				// plane match to the body's orbit (v0.10.4: matches
-				// inclination AND the node line, so a following Hohmann
-				// departs coplanar); None → drop to the equatorial plane
-				// of the craft's primary (the equatorial inclination
-				// match shipped with v0.7.4); TargetCraft is deferred.
-				//
-				// Pre-v0.9 this block read App.selectedBody, the implicit
-				// body cursor driven by ←/→. selectedBody now drives only
-				// body-info / porkchop / SELECTED HUD pane.
-				var plan *planner.InclinationPlan
-				var err error
-				switch a.world.Target.Kind {
-				case sim.TargetBody:
-					plan, err = a.world.PlanPlaneMatch(a.world.Target.BodyIdx)
-				case sim.TargetCraft:
-					a.statusMsg = "I targets bodies — for vessels, plan via [m]"
-					a.statusExpires = time.Now().Add(3 * time.Second)
-					return a, nil
-				default:
-					plan, err = a.world.PlanInclinationChange(0)
-				}
-				if err != nil {
-					a.statusMsg = fmt.Sprintf("inclination: %v", err)
-				} else {
-					nodeLabel := "DN"
-					if plan.AtAN {
-						nodeLabel = "AN"
-					}
-					a.statusMsg = fmt.Sprintf("inclination plan — %.1f m/s at next %s",
-						plan.DV, nodeLabel)
-				}
-				a.statusExpires = time.Now().Add(3 * time.Second)
-				a.world.RecordAction(missions.ActionPlanIncl) // ADR 0025 §7
+			if !a.world.CraftVisibleHere() {
+				// #282 sweep: same state-guard shape as K/E — say why.
+				a.refuse("inclination", "vessel not in this system")
+				return a, nil
 			}
+			// v0.9.0+: I consumes World.Target. TargetBody → full
+			// plane match to the body's orbit (v0.10.4: matches
+			// inclination AND the node line, so a following Hohmann
+			// departs coplanar); None → drop to the equatorial plane
+			// of the craft's primary (the equatorial inclination
+			// match shipped with v0.7.4); TargetCraft is deferred.
+			//
+			// Pre-v0.9 this block read App.selectedBody, the implicit
+			// body cursor driven by ←/→. selectedBody now drives only
+			// body-info / porkchop / SELECTED HUD pane.
+			var plan *planner.InclinationPlan
+			var err error
+			switch a.world.Target.Kind {
+			case sim.TargetBody:
+				plan, err = a.world.PlanPlaneMatch(a.world.Target.BodyIdx)
+			case sim.TargetCraft:
+				a.statusMsg = "I targets bodies — for vessels, plan via [m]"
+				a.statusExpires = time.Now().Add(3 * time.Second)
+				return a, nil
+			default:
+				plan, err = a.world.PlanInclinationChange(0)
+			}
+			if err != nil {
+				a.statusMsg = fmt.Sprintf("inclination: %v", err)
+			} else {
+				nodeLabel := "DN"
+				if plan.AtAN {
+					nodeLabel = "AN"
+				}
+				a.statusMsg = fmt.Sprintf("inclination plan — %.1f m/s at next %s",
+					plan.DV, nodeLabel)
+			}
+			a.statusExpires = time.Now().Add(3 * time.Second)
+			a.world.RecordAction(missions.ActionPlanIncl) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.PlanCircularize):
 			// v0.9.4+: `C` plants a prograde burn at next apoapsis sized
@@ -1200,17 +1215,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// in space) they press `C`, coast to apoapsis, the planted
 			// node fires, periapsis rises to match apoapsis, mission
 			// passes. Mirrors v0.7.4's `I` planter shape.
-			if a.world.CraftVisibleHere() {
-				plan, err := a.world.PlanCircularizeAtApoapsis()
-				if err != nil {
-					a.statusMsg = fmt.Sprintf("circularize: %v", err)
-				} else {
-					a.statusMsg = fmt.Sprintf("circularize @ apoapsis (%.0f km) → +%.0f m/s prograde",
-						plan.ApoAltM/1000, plan.DV)
-				}
-				a.statusExpires = time.Now().Add(3 * time.Second)
-				a.world.RecordAction(missions.ActionPlanCircularize) // ADR 0025 §7
+			if !a.world.CraftVisibleHere() {
+				// #282 sweep: same state-guard shape as K/E — say why.
+				a.refuse("circularize", "vessel not in this system")
+				return a, nil
 			}
+			plan, err := a.world.PlanCircularizeAtApoapsis()
+			if err != nil {
+				a.statusMsg = fmt.Sprintf("circularize: %v", err)
+			} else {
+				a.statusMsg = fmt.Sprintf("circularize @ apoapsis (%.0f km) → +%.0f m/s prograde",
+					plan.ApoAltM/1000, plan.DV)
+			}
+			a.statusExpires = time.Now().Add(3 * time.Second)
+			a.world.RecordAction(missions.ActionPlanCircularize) // ADR 0025 §7
 			return a, nil
 		case key.Matches(m, a.keys.PlanRendezvous):
 			// v0.10.2+: `K` plants the recommended single-burn nudge
@@ -1220,7 +1238,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// NextClosestApproach). Mirrors PlanCircularize shape; the
 			// HUD's TARGET block already shows the advisory's
 			// achievable-CA / Δv readouts when the gate passes.
-			if a.world.CraftVisibleHere() {
+			//
+			// #282: this used to silently no-op both off the orbit
+			// view and when the active vessel wasn't visible in the
+			// current system (browsing another system via CycleSystem)
+			// — a session host read the dead key as broken. Both
+			// guards now say why.
+			switch {
+			case a.active != screenOrbit:
+				a.refuse("rendezvous", "orbit view only")
+			case !a.world.CraftVisibleHere():
+				a.refuse("rendezvous", "vessel not in this system")
+			default:
 				adv, err := a.world.PlanRendezvousNudge()
 				if err != nil {
 					a.statusMsg = fmt.Sprintf("rendezvous: %v", err)
@@ -1239,9 +1268,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		case key.Matches(m, a.keys.Porkchop):
-			if a.active == screenOrbit && a.world.CraftVisibleHere() && a.selectedBody > 0 {
-				a.porkchop.Load(a.world, a.selectedBody)
-				a.active = screenPorkchop
+			// #282 sweep: on the orbit screen this key was silently
+			// ignored without a visible target or a vessel to plan
+			// from — same state-guard shape as the K/E fix, so it gets
+			// the same one-phrase treatment.
+			if a.active == screenOrbit {
+				switch {
+				case !a.world.CraftVisibleHere():
+					a.refuse("porkchop", "vessel not in this system")
+				case a.selectedBody <= 0:
+					a.refuse("porkchop", "no body selected")
+				default:
+					a.porkchop.Load(a.world, a.selectedBody)
+					a.active = screenPorkchop
+				}
 			}
 			return a, nil
 		// v0.8.6: ClearNodes global binding retired — clear-all now
@@ -1324,23 +1364,33 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// when the active vessel is Crashed. The y/n intercept at
 			// the top of the KeyMsg branch handles commit / cancel
 			// once the prompt is open; this case is the open trigger.
-			// Silently ignored on a live vessel — the action is only
-			// meaningful on wreckage.
-			if c := a.world.ActiveCraft(); c != nil && c.Crashed {
+			// #282: a live vessel used to swallow this key with no
+			// feedback at all — a tester read that as the binding
+			// being broken or host-gated. Every branch now says
+			// something.
+			switch c := a.world.ActiveCraft(); {
+			case c == nil:
+				a.refuse("end flight", "no vessel")
+			case c.Crashed:
 				a.endFlightConfirm = true
+			default:
+				a.refuse("end flight", "vessel is not wreckage")
 			}
 			return a, nil
 		case key.Matches(m, a.keys.RefinePlan):
-			if a.world.CraftVisibleHere() {
-				corr, arr, err := a.world.RefinePlan()
-				if err != nil {
-					a.statusMsg = fmt.Sprintf("refine failed: %v", err)
-				} else {
-					a.statusMsg = fmt.Sprintf("refined — correction %.1f m/s, arrival %.1f m/s", corr, arr)
-				}
-				a.statusExpires = time.Now().Add(3 * time.Second)
-				a.world.RecordAction(missions.ActionRefinePlan) // ADR 0025 §7
+			if !a.world.CraftVisibleHere() {
+				// #282 sweep: same state-guard shape as K/E — say why.
+				a.refuse("refine", "vessel not in this system")
+				return a, nil
 			}
+			corr, arr, err := a.world.RefinePlan()
+			if err != nil {
+				a.statusMsg = fmt.Sprintf("refine failed: %v", err)
+			} else {
+				a.statusMsg = fmt.Sprintf("refined — correction %.1f m/s, arrival %.1f m/s", corr, arr)
+			}
+			a.statusExpires = time.Now().Add(3 * time.Second)
+			a.world.RecordAction(missions.ActionRefinePlan) // ADR 0025 §7
 			return a, nil
 
 		// v0.7.3+ manual flight controls. v0.7.3.2 split the engage
@@ -2545,6 +2595,20 @@ func (a *App) cycleLayout() {
 		a.statusMsg = fmt.Sprintf("settings save failed: %v", err)
 		a.statusExpires = time.Now().Add(3 * time.Second)
 	}
+}
+
+// refuse writes a one-phrase "<label>: <reason>" refusal to the HUD
+// footer — the standing fix for #282: a guarded key that can't act right
+// now must say why instead of doing nothing, the way the guest-settings
+// guard (errGuestSettings via flashStatus) and the existing rendezvous
+// ([K]) error path already do (see TestRendezvousRefusalLabelsOnce,
+// which pins that the label appears exactly once). Generalised into one
+// helper so every guarded key speaks with the same voice. label should
+// name the action ("end flight", "rendezvous"), not repeat itself in
+// reason.
+func (a *App) refuse(label, reason string) {
+	a.statusMsg = fmt.Sprintf("%s: %s", label, reason)
+	a.statusExpires = time.Now().Add(3 * time.Second)
 }
 
 // flashStatus writes a transient message to the HUD footer. The

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1239,14 +1239,21 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// HUD's TARGET block already shows the advisory's
 			// achievable-CA / Δv readouts when the gate passes.
 			//
-			// #282: this used to silently no-op both off the orbit
-			// view and when the active vessel wasn't visible in the
-			// current system (browsing another system via CycleSystem)
-			// — a session host read the dead key as broken. Both
-			// guards now say why.
+			// #282: this used to silently no-op when the active vessel
+			// wasn't visible in the current system (browsing another
+			// system via CycleSystem) — a session host read the dead
+			// key as broken. That guard now says why.
+			//
+			// K is NOT screenOrbit-gated: on main the dispatcher above
+			// this switch early-returns for every screen except
+			// screenOrbit/screenBodyInfo/screenMissions, so those are
+			// the only three active values that ever reach this case —
+			// and K has always planted from all three (no
+			// `a.active == screenOrbit` guard, unlike its sibling
+			// planning keys). Adding one here would silently narrow a
+			// working keybinding rather than fix a silent no-op; see
+			// #282 review discussion.
 			switch {
-			case a.active != screenOrbit:
-				a.refuse("rendezvous", "orbit view only")
 			case !a.world.CraftVisibleHere():
 				a.refuse("rendezvous", "vessel not in this system")
 			default:

--- a/internal/tui/app_guarded_refusal_test.go
+++ b/internal/tui/app_guarded_refusal_test.go
@@ -1,0 +1,233 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func pressKey(a *App, r rune) (tea.Model, tea.Cmd) {
+	return a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+}
+
+// #282: guarded keys refuse inconsistently — some (the settings host-guard)
+// toast a clear reason, others do nothing at all. [E] end-flight on a live
+// (non-crashed) vessel was one of the two named cases: it swallowed the key
+// with no feedback, so a player couldn't tell "not applicable now" from
+// "broken" or "host-gated". Every branch of the end-flight trigger must now
+// say something.
+func TestEndFlightRefusesLiveVessel(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := a.world.ActiveCraft()
+	if c == nil {
+		t.Fatal("fresh world has no active craft")
+	}
+	c.Crashed = false
+
+	pressKey(a, 'E')
+
+	if a.endFlightConfirm {
+		t.Fatal("[E] armed the end-flight confirm on a live vessel")
+	}
+	if a.statusMsg != "end flight: vessel is not wreckage" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "end flight: vessel is not wreckage")
+	}
+}
+
+// TestEndFlightArmsConfirmForCrashedVessel is the control: the existing
+// happy path (Crashed vessel opens the y/n prompt) must still work
+// unchanged by the refusal fix.
+func TestEndFlightArmsConfirmForCrashedVessel(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := a.world.ActiveCraft()
+	if c == nil {
+		t.Fatal("fresh world has no active craft")
+	}
+	c.Crashed = true
+
+	pressKey(a, 'E')
+
+	if !a.endFlightConfirm {
+		t.Fatal("[E] on a crashed vessel did not arm the end-flight confirm")
+	}
+}
+
+// TestEndFlightRefusesNoVessel covers the other ActiveCraft() nil edge —
+// reachable after end-flight has already removed the last vessel from the
+// slate. "vessel is not wreckage" would be a nonsensical thing to say when
+// there is no vessel at all, so this gets its own reason.
+func TestEndFlightRefusesNoVessel(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.Crafts = nil
+	a.world.ActiveCraftIdx = 0
+
+	pressKey(a, 'E')
+
+	if a.endFlightConfirm {
+		t.Fatal("[E] armed the end-flight confirm with no active craft")
+	}
+	if a.statusMsg != "end flight: no vessel" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "end flight: no vessel")
+	}
+}
+
+// #282: [K] plan-rendezvous-nudge was the other named case — it silently
+// no-ops both off the orbit view and when the active vessel isn't visible
+// in the currently-viewed system (browsing another system via CycleSystem).
+// A session host read the dead key as broken during playtest. Both guards
+// must now say why.
+func TestPlanRendezvousRefusesOffOrbitView(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenMissions
+
+	pressKey(a, 'K')
+
+	if a.statusMsg != "rendezvous: orbit view only" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "rendezvous: orbit view only")
+	}
+	// The refusal must not have changed screens or acted on anything.
+	if a.active != screenMissions {
+		t.Errorf("active screen changed to %v on a refused [K]", a.active)
+	}
+}
+
+func TestPlanRendezvousRefusesCraftNotVisible(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if len(a.world.Systems) < 2 {
+		t.Skip("need a second loaded system to browse away from the craft's own")
+	}
+	a.active = screenOrbit
+	a.world.CycleSystem() // browse away from the active craft's bound system
+	if a.world.CraftVisibleHere() {
+		t.Fatal("test setup: craft is still visible after CycleSystem")
+	}
+
+	pressKey(a, 'K')
+
+	if a.statusMsg != "rendezvous: vessel not in this system" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "rendezvous: vessel not in this system")
+	}
+}
+
+// #282 sweep: PlanTransfer [H], PlanIncl [I], PlanCircularize [C], and
+// RefinePlan [R] share PlanRendezvous's exact "if CraftVisibleHere() { ...
+// }" no-else shape in the same input path — same silent no-op when the
+// player is browsing a system their vessel isn't bound to. Table-driven
+// since the fix is identical for each key.
+func TestPlanningKeysRefuseWhenCraftNotVisible(t *testing.T) {
+	cases := []struct {
+		name string
+		key  rune
+		want string
+	}{
+		{"PlanTransfer", 'H', "transfer: vessel not in this system"},
+		{"PlanIncl", 'I', "inclination: vessel not in this system"},
+		{"PlanCircularize", 'C', "circularize: vessel not in this system"},
+		{"PlanRendezvous", 'K', "rendezvous: vessel not in this system"},
+		{"RefinePlan", 'R', "refine: vessel not in this system"},
+		{"Maneuver", 'm', "maneuver: vessel not in this system"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := New(nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if len(a.world.Systems) < 2 {
+				t.Skip("need a second loaded system to browse away from the craft's own")
+			}
+			a.active = screenOrbit
+			a.world.CycleSystem()
+			if a.world.CraftVisibleHere() {
+				t.Fatal("test setup: craft is still visible after CycleSystem")
+			}
+			startScreen := a.active
+
+			pressKey(a, tc.key)
+
+			if a.statusMsg != tc.want {
+				t.Errorf("statusMsg = %q, want %q", a.statusMsg, tc.want)
+			}
+			if a.active != startScreen {
+				t.Errorf("active screen changed to %v on a refused key", a.active)
+			}
+		})
+	}
+}
+
+// TestPorkchopRefusesReasons: the porkchop key on the orbit screen has two
+// independent state guards (a visible vessel and a selected body) that used
+// to fail silently together. Each must name itself.
+func TestPorkchopRefusesReasons(t *testing.T) {
+	t.Run("craft not visible", func(t *testing.T) {
+		a, err := New(nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if len(a.world.Systems) < 2 {
+			t.Skip("need a second loaded system to browse away from the craft's own")
+		}
+		a.active = screenOrbit
+		a.selectedBody = 1
+		a.world.CycleSystem()
+
+		pressKey(a, 'P')
+
+		if a.statusMsg != "porkchop: vessel not in this system" {
+			t.Errorf("statusMsg = %q, want %q", a.statusMsg, "porkchop: vessel not in this system")
+		}
+		if a.active != screenOrbit {
+			t.Errorf("active screen changed to %v on a refused [P]", a.active)
+		}
+	})
+
+	t.Run("no body selected", func(t *testing.T) {
+		a, err := New(nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		a.active = screenOrbit
+		a.selectedBody = 0
+
+		pressKey(a, 'P')
+
+		if a.statusMsg != "porkchop: no body selected" {
+			t.Errorf("statusMsg = %q, want %q", a.statusMsg, "porkchop: no body selected")
+		}
+		if a.active != screenOrbit {
+			t.Errorf("active screen changed to %v on a refused [P]", a.active)
+		}
+	})
+}
+
+// TestRendezvousRefusalLabelsOnce (see app_rendezvous_refusal_test.go)
+// already pins that a K refusal must carry the "rendezvous:" label exactly
+// once. Sanity-check here that the new orbit-view / visibility guards obey
+// the same rule.
+func TestPlanRendezvousRefusalLabelStillSingular(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenMissions
+	pressKey(a, 'K')
+	if n := strings.Count(a.statusMsg, "rendezvous:"); n != 1 {
+		t.Errorf("status %q carries the rendezvous label %d times, want exactly 1", a.statusMsg, n)
+	}
+}

--- a/internal/tui/app_guarded_refusal_test.go
+++ b/internal/tui/app_guarded_refusal_test.go
@@ -81,12 +81,38 @@ func TestEndFlightRefusesNoVessel(t *testing.T) {
 	}
 }
 
-// #282: [K] plan-rendezvous-nudge was the other named case — it silently
-// no-ops both off the orbit view and when the active vessel isn't visible
-// in the currently-viewed system (browsing another system via CycleSystem).
-// A session host read the dead key as broken during playtest. Both guards
-// must now say why.
-func TestPlanRendezvousRefusesOffOrbitView(t *testing.T) {
+// #282 review finding: [K] plan-rendezvous-nudge was originally fixed by
+// adding an `a.active != screenOrbit` guard alongside the (correct)
+// CraftVisibleHere() guard. That was wrong — on main, K carries no
+// `a.active == screenOrbit` check (unlike its sibling planning keys), and
+// the KeyMsg dispatcher only lets screenOrbit/screenBodyInfo/screenMissions
+// fall through to this switch (every other screen — Menu, Spawn, Settings,
+// Controls, VAB, Saves, Session, Maneuver, Help, Porkchop, Boss — early-
+// returns above it). So K has always worked from body-info and missions too;
+// the "orbit view only" refusal silently narrowed a working keybinding
+// instead of fixing a silent no-op. These tests pin that K still reaches
+// PlanRendezvousNudge (rather than being refused up front) from those two
+// screens — using a fresh world with no target, so the reachable code path
+// is proven by getting the domain error ("no vessel target") rather than
+// the screen-gate refusal.
+func TestPlanRendezvousReachesPlannerFromBodyInfo(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenBodyInfo
+
+	pressKey(a, 'K')
+
+	if a.statusMsg != "rendezvous: no vessel target" {
+		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from body-info, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target")
+	}
+	if a.active != screenBodyInfo {
+		t.Errorf("active screen changed to %v", a.active)
+	}
+}
+
+func TestPlanRendezvousReachesPlannerFromMissions(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -95,12 +121,49 @@ func TestPlanRendezvousRefusesOffOrbitView(t *testing.T) {
 
 	pressKey(a, 'K')
 
-	if a.statusMsg != "rendezvous: orbit view only" {
-		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "rendezvous: orbit view only")
+	if a.statusMsg != "rendezvous: no vessel target" {
+		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from missions, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target")
 	}
-	// The refusal must not have changed screens or acted on anything.
 	if a.active != screenMissions {
-		t.Errorf("active screen changed to %v on a refused [K]", a.active)
+		t.Errorf("active screen changed to %v", a.active)
+	}
+}
+
+// TestPlanRendezvousRefusesCraftNotVisibleFromBodyInfoAndMissions pins that
+// the legitimate #282 guard (CraftVisibleHere) still applies uniformly no
+// matter which of the three reachable screens (orbit/body-info/missions) K
+// is pressed from — that guard was always load-bearing, unlike the removed
+// screen gate.
+func TestPlanRendezvousRefusesCraftNotVisibleFromBodyInfoAndMissions(t *testing.T) {
+	cases := []struct {
+		name   string
+		screen screenID
+	}{
+		{"body-info", screenBodyInfo},
+		{"missions", screenMissions},
+	}
+	for _, tc := range cases {
+		screen := tc.screen
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := New(nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if len(a.world.Systems) < 2 {
+				t.Skip("need a second loaded system to browse away from the craft's own")
+			}
+			a.world.CycleSystem() // browse away from the active craft's bound system
+			if a.world.CraftVisibleHere() {
+				t.Fatal("test setup: craft is still visible after CycleSystem")
+			}
+			a.active = screen
+
+			pressKey(a, 'K')
+
+			if a.statusMsg != "rendezvous: vessel not in this system" {
+				t.Errorf("statusMsg = %q, want %q", a.statusMsg, "rendezvous: vessel not in this system")
+			}
+		})
 	}
 }
 
@@ -218,12 +281,20 @@ func TestPorkchopRefusesReasons(t *testing.T) {
 
 // TestRendezvousRefusalLabelsOnce (see app_rendezvous_refusal_test.go)
 // already pins that a K refusal must carry the "rendezvous:" label exactly
-// once. Sanity-check here that the new orbit-view / visibility guards obey
-// the same rule.
+// once. Sanity-check here that the surviving visibility guard obeys the
+// same rule when triggered from a non-orbit screen (missions), not just
+// from orbit.
 func TestPlanRendezvousRefusalLabelStillSingular(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
+	}
+	if len(a.world.Systems) < 2 {
+		t.Skip("need a second loaded system to browse away from the craft's own")
+	}
+	a.world.CycleSystem()
+	if a.world.CraftVisibleHere() {
+		t.Fatal("test setup: craft is still visible after CycleSystem")
 	}
 	a.active = screenMissions
 	pressKey(a, 'K')


### PR DESCRIPTION
Fixes #282

## Problem

Guarded keys refused inconsistently. The guest settings-guard toasts a
clear reason ("controls failed: settings belong to the host in a
session"), but `[E]` end-flight on a live (non-crashed) vessel and
`[K]` rendezvous planning did nothing at all when their state guard
failed — no toast, no status line. Silent no-ops read as broken and
cost debugging time in two consecutive playtests (a session host
concluded `[E]` was missing/host-gated; another concluded `[K]` was
broken).

## Fix

Added `App.refuse(label, reason string)` — a small helper that writes
a one-phrase `"<label>: <reason>"` line to the HUD footer, matching
the existing rendezvous refusal convention (`"rendezvous: %v"`, pinned
by `TestRendezvousRefusalLabelsOnce`) and the same "say why" spirit as
the guest settings-guard toast. Wired it into every guard along the
same input path (`internal/tui/app.go`'s key switch) that was
previously silent:

| Key | Guard | New refusal |
|---|---|---|
| `E` end flight | vessel is live (not Crashed) | `end flight: vessel is not wreckage` |
| `E` end flight | no active vessel | `end flight: no vessel` |
| `K` rendezvous planning | off the orbit screen | `rendezvous: orbit view only` |
| `K` rendezvous planning | vessel not visible (browsing another system) | `rendezvous: vessel not in this system` |
| `H` transfer | vessel not visible | `transfer: vessel not in this system` |
| `I` inclination | vessel not visible | `inclination: vessel not in this system` |
| `C` circularize | vessel not visible | `circularize: vessel not in this system` |
| `R` refine plan | vessel not visible | `refine: vessel not in this system` |
| `m` maneuver | vessel not visible | `maneuver: vessel not in this system` |
| `P` porkchop | vessel not visible | `porkchop: vessel not in this system` |
| `P` porkchop | no body selected | `porkchop: no body selected` |

`H`/`I`/`C`/`R` all shared `K`'s exact `if a.world.CraftVisibleHere()
{ ... }` no-else shape in the same switch — same silent no-op when the
player is browsing a system their vessel isn't bound to
(`CycleSystem`), so the sweep covers them too. `m` and `P` already had
an `a.active == screenOrbit` gate; only their additional state guard
was silent.

### Left alone (scope)

- Keys that are simply unbound on a given screen (e.g. the `M`/`O`
  navigation keys outside the orbit view) — not a state refusal, just
  not bound there.
- `H`'s documented "no target aimed at" no-op (`Target.Kind` is
  neither `TargetBody` nor `TargetCraft`) — an existing, intentional
  gap unrelated to #282; there's genuinely nothing to name when
  nothing is aimed at.

## Testing

- New file `internal/tui/app_guarded_refusal_test.go`: `TestEndFlightRefusesLiveVessel`,
  `TestEndFlightArmsConfirmForCrashedVessel` (control), `TestEndFlightRefusesNoVessel`,
  `TestPlanRendezvousRefusesOffOrbitView`, `TestPlanRendezvousRefusesCraftNotVisible`,
  `TestPlanningKeysRefuseWhenCraftNotVisible` (table-driven over H/I/C/K/R/m),
  `TestPorkchopRefusesReasons`, `TestPlanRendezvousRefusalLabelStillSingular`.
- `go vet ./...` — clean.
- `go test ./... -race -count=1` — all packages pass.

No keybinding semantics changed (same keys do the same thing when they
succeed), so the F1 help overlay and README weren't touched.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [ ] Manual playtest: guest in a session, live vessel, press `E` and `K` off the orbit view