### PR TITLE
fix(rendezvous): Engage commits only to the current-course encounter

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2580,6 +2580,65 @@ func (w *World) PostBurnState(n ManeuverNode) (physics.StateVector, string) {
 	return state, primaryID
 }
 
+// postBurnStateWithTarget is PostBurnState extended with the target's
+// relative state at the node's trigger time, so a target-relative node
+// (BurnTargetPrograde / BurnTargetRetrograde, the axes K's rendezvous
+// advisory can pick — planner/rendezvous_recommend.go ~349,
+// axisLabelToBurnMode in rendezvous.go) resolves a real burn direction
+// instead of silently applying zero Δv.
+//
+// PostBurnState alone can't do this: it resolves direction via
+// spacecraft.NodeBurnDirection, which falls through to DirectionUnit for
+// every mode it doesn't special-case — and DirectionUnit returns the
+// zero vector for the four target-relative modes (thrust.go ~287-290),
+// since they need target state DirectionUnit doesn't have. Without a
+// target snapshot, a target-relative planted node used to commit as an
+// unburned coast (PR #392 review, finding 1).
+//
+// Callers pass rT, vT already resolved in the SAME frame and at the SAME
+// instant as the returned state — rendezvousCommitFromPlantedNode Kepler-
+// propagates the target's current relative state forward by the node's
+// own dt before calling this, so both sides of the direction resolution
+// (state.R/V from propagateCraftWithPrimary, rT/vT from KeplerStep) are
+// evaluated at the node's TriggerTime.
+//
+// ok=false when the active craft is nil, or when the node is
+// target-relative and the resolved direction is degenerate (identical
+// relative velocity for Target Prograde/Retrograde, identical relative
+// position for Target/AntiTarget — DirectionUnitTarget's own zero-vector
+// convention). That is "the direction cannot be resolved", not "no burn
+// needed" — callers must treat ok=false as a reason to skip this course
+// entirely rather than commit to an unburned one.
+func (w *World) postBurnStateWithTarget(n ManeuverNode, rT, vT orbital.Vec3) (physics.StateVector, string, bool) {
+	if w.ActiveCraft() == nil {
+		return physics.StateVector{}, "", false
+	}
+	dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	var state physics.StateVector
+	var primaryID string
+	if dt <= 0 {
+		state = w.ActiveCraft().State
+		primaryID = w.ActiveCraft().Primary.ID
+	} else {
+		var primary bodies.CelestialBody
+		state, primary = w.propagateCraftWithPrimary(dt)
+		primaryID = primary.ID
+	}
+	var dir orbital.Vec3
+	if n.IsTargetRelative() {
+		dir = spacecraft.DirectionUnitTarget(n.Mode, state.R, state.V, rT, vT)
+		if dir.Norm() == 0 {
+			return physics.StateVector{}, "", false
+		}
+	} else {
+		dir = spacecraft.NodeBurnDirection(n, state.R, state.V)
+	}
+	if dir.Norm() != 0 && n.DV != 0 {
+		state.V = state.V.Add(dir.Scale(n.DV))
+	}
+	return state, primaryID, true
+}
+
 // CapturePreview describes the post-arrival orbit at the last
 // inter-primary node in the active craft's planted chain. v0.8.2.x:
 // surfaces the capture-orbit inclination prominently so the player

--- a/internal/sim/node_identity.go
+++ b/internal/sim/node_identity.go
@@ -97,6 +97,27 @@ func (w *World) replaceAdvisoryNode(c *spacecraft.Spacecraft, key string) {
 	c.Nodes = kept
 }
 
+// plantedAdvisoryNode returns c's currently-queued node carrying the
+// given AdvisoryKey, and ok=false when none is planted (key is empty,
+// c is nil, or no queued node matches). Companion to replaceAdvisoryNode
+// — that one strips a stale advisory node before a fresh plant; this one
+// lets a caller (RendezvousCommit, PR #392 review Finding 1) find and
+// honor one that's already sitting there. Same "every node in c.Nodes is
+// by definition unfired" invariant applies (see replaceAdvisoryNode):
+// once the node fires it's popped out of c.Nodes, so a hit here always
+// means "planted but not yet flown".
+func plantedAdvisoryNode(c *spacecraft.Spacecraft, key string) (spacecraft.ManeuverNode, bool) {
+	if key == "" || c == nil {
+		return spacecraft.ManeuverNode{}, false
+	}
+	for _, n := range c.Nodes {
+		if n.AdvisoryKey == key {
+			return n, true
+		}
+	}
+	return spacecraft.ManeuverNode{}, false
+}
+
 // nodeByID returns the planted node with stable ID nodeID on the craft
 // with stable ID craftID, and ok=false when either no longer resolves —
 // the craft was removed, the node was deleted or re-planted, or an id is

--- a/internal/sim/node_identity.go
+++ b/internal/sim/node_identity.go
@@ -98,20 +98,35 @@ func (w *World) replaceAdvisoryNode(c *spacecraft.Spacecraft, key string) {
 }
 
 // plantedAdvisoryNode returns c's currently-queued node carrying the
-// given AdvisoryKey, and ok=false when none is planted (key is empty,
-// c is nil, or no queued node matches). Companion to replaceAdvisoryNode
-// — that one strips a stale advisory node before a fresh plant; this one
-// lets a caller (RendezvousCommit, PR #392 review Finding 1) find and
-// honor one that's already sitting there. Same "every node in c.Nodes is
-// by definition unfired" invariant applies (see replaceAdvisoryNode):
-// once the node fires it's popped out of c.Nodes, so a hit here always
-// means "planted but not yet flown".
-func plantedAdvisoryNode(c *spacecraft.Spacecraft, key string) (spacecraft.ManeuverNode, bool) {
+// given AdvisoryKey AND whose own target binding (TargetCraftID +
+// TargetGhostOwner) matches targetCraftID/targetGhostOwner, and
+// ok=false when none is planted (key is empty, c is nil, or no queued
+// node matches both the key and the binding). Companion to
+// replaceAdvisoryNode — that one strips a stale advisory node before a
+// fresh plant; this one lets a caller (RendezvousCommit, PR #392
+// review Finding 1) find and honor one that's already sitting there.
+// Same "every node in c.Nodes is by definition unfired" invariant
+// applies (see replaceAdvisoryNode): once the node fires it's popped
+// out of c.Nodes, so a hit here always means "planted but not yet
+// flown".
+//
+// The binding check (PR #392 review, finding — engage-toward-stale-
+// nudge) matters because PlanRendezvousNudge stamps TargetCraftID/
+// TargetGhostOwner at plant time so a later target switch doesn't
+// retarget the burn (rendezvous.go ~606-611): a node planted against
+// peer A must not be picked up here when the caller is now engaging
+// peer B, or the commit path would feed B's target state into a node
+// whose Δv/direction was computed for A — a phantom co-warp toward a
+// course that will never be flown. A binding mismatch is treated
+// exactly like "nothing planted": the caller falls through to its
+// current-course path (and its refusal, if the current course doesn't
+// converge either).
+func plantedAdvisoryNode(c *spacecraft.Spacecraft, key string, targetCraftID uint64, targetGhostOwner string) (spacecraft.ManeuverNode, bool) {
 	if key == "" || c == nil {
 		return spacecraft.ManeuverNode{}, false
 	}
 	for _, n := range c.Nodes {
-		if n.AdvisoryKey == key {
+		if n.AdvisoryKey == key && n.TargetCraftID == targetCraftID && n.TargetGhostOwner == targetGhostOwner {
 			return n, true
 		}
 	}

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -289,6 +289,29 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	}
 
 	// Source 2: the current-course fallback (no burn assumed).
+	return w.rendezvousCommitCurrentCourse(active, rT, vT, mu)
+}
+
+// rendezvousCommitCurrentCourse searches for a closest approach on the
+// CURRENT, no-burn courses only (#276) — active.State as-is against the
+// target's rT/vT snapshot, nothing forward-integrated or Δv-applied.
+//
+// This is its own function (PR #392 review, finding 2) because it has
+// two distinct callers with two distinct contracts: RendezvousCommit's
+// own Source 2 fallback (Engage may prefer a planted-but-unfired nudge
+// first, then fall back to this), and rendezvousNextWaypoint's mid-coast
+// re-derivation, which must NEVER prefer an unfired node — a standing
+// waypoint/τ that re-derives itself off a node that might be deleted,
+// refused, or superseded before it ever fires would coast the pair
+// toward an encounter that can evaporate out from under them. Before
+// this split, rendezvousNextWaypoint called RendezvousCommit itself,
+// which was safe only as long as RendezvousCommit had no planted-node
+// preference of its own — finding 1 added that preference, silently
+// breaking rendezvousNextWaypoint's own pinned "honors a nudge only once
+// FIRED" comment. Extracting the current-course search keeps that
+// invariant true by construction: rendezvousNextWaypoint's mid-coast
+// path calls THIS, never RendezvousCommit.
+func (w *World) rendezvousCommitCurrentCourse(active *spacecraft.Spacecraft, rT, vT orbital.Vec3, mu float64) (time.Time, float64, bool) {
 	tCA, distCA, _, err := planner.NextClosestApproach(
 		orbital.Vec3State{R: active.State.R, V: active.State.V},
 		orbital.Vec3State{R: rT, V: vT},
@@ -300,27 +323,33 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 }
 
 // rendezvousCommitFromPlantedNode computes the encounter a planted
-// rendezvous-nudge node actually leads to: forward-integrate the active
-// craft to the node's TriggerTime and apply its Δv (PostBurnState),
-// Kepler-propagate the target's CURRENT relative state (rT, vT) forward
-// by the same dt so both sides are compared at the same instant, then
-// search for a closest approach from there. ok=false when the node is
-// already past-due, PostBurnState lands in a different primary's frame
-// (an SOI crossing before the burn fires — the target's frame no longer
-// matches, so no meaningful comparison exists), the target's coast
-// doesn't admit a Kepler propagation (hyperbolic/degenerate — KeplerStep
-// returns ok=false), or no approach turns up inside the horizon.
+// rendezvous-nudge node actually leads to: Kepler-propagate the target's
+// CURRENT relative state (rT, vT) forward to the node's TriggerTime
+// first, then forward-integrate the active craft to the same instant and
+// apply its Δv in the node's direction mode — resolving target-relative
+// axes (BurnTargetPrograde/Retrograde, PR #392 review finding 1) against
+// that SAME propagated target state, not the target's state now, so the
+// direction and the closest-approach search below share one consistent
+// snapshot. ok=false when the node is already past-due, the target's
+// coast doesn't admit a Kepler propagation (hyperbolic/degenerate —
+// KeplerStep returns ok=false), the post-burn state lands in a different
+// primary's frame (an SOI crossing before the burn fires — the target's
+// frame no longer matches, so no meaningful comparison exists), the
+// node's direction can't be resolved (a target-relative axis with a
+// degenerate relative state — postBurnStateWithTarget's own ok=false;
+// this is "skip the planted-node path", never "commit an unburned
+// coast"), or no approach turns up inside the horizon.
 func (w *World) rendezvousCommitFromPlantedNode(active *spacecraft.Spacecraft, node spacecraft.ManeuverNode, rT, vT orbital.Vec3, mu float64) (time.Time, float64, bool) {
 	dt := node.TriggerTime.Sub(w.Clock.SimTime).Seconds()
 	if dt <= 0 {
 		return time.Time{}, 0, false
 	}
-	postState, primaryID := w.PostBurnState(node)
-	if primaryID != active.Primary.ID {
+	targetState, tok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
+	if !tok {
 		return time.Time{}, 0, false
 	}
-	targetState, ok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
-	if !ok {
+	postState, primaryID, pok := w.postBurnStateWithTarget(node, targetState.R, targetState.V)
+	if !pok || primaryID != active.Primary.ID {
 		return time.Time{}, 0, false
 	}
 	tCA, distCA, _, err := planner.NextClosestApproach(
@@ -343,13 +372,17 @@ func (w *World) rendezvousCommitFromPlantedNode(active *spacecraft.Spacecraft, n
 const rendezvousWaypointMinLead = 5 * time.Second
 
 // rendezvousNextWaypoint derives the standing intent's next waypoint
-// after the previous one passed (#252). Two paths, mirroring the Engage
-// commit:
-//   - the target slot still holds the armed partner's ghost → reuse
-//     RendezvousCommit verbatim, which is CURRENT-course-only (#276) — a
-//     nudge planted and FIRED mid-coast is honoured automatically once
-//     its burn has actually changed the craft's course; an unfired
-//     advisory nudge is not;
+// after the previous one passed (#252). Two paths:
+//   - the target slot still holds the armed partner's ghost → call
+//     rendezvousCommitCurrentCourse directly (PR #392 review, finding 2
+//     — NOT RendezvousCommit, which since finding 1 prefers a planted-
+//     but-unfired rendezvous nudge). This path must stay CURRENT-
+//     course-only (#276): a nudge planted and FIRED mid-coast is
+//     honoured automatically once its burn has actually changed the
+//     craft's course; an unfired advisory nudge is not — delete the
+//     node, or let it get refused at ignition, and a waypoint derived
+//     from its hypothetical post-burn course would coast the pair
+//     toward an encounter that will never occur;
 //   - otherwise (player retargeted mid-coast, or the ghost slate is
 //     momentarily stale) → target-slot-independent fallback: the
 //     current-course closest approach against the partner's same-primary
@@ -362,12 +395,19 @@ const rendezvousWaypointMinLead = 5 * time.Second
 // only when no future approach can be found at all this tick.
 func (w *World) rendezvousNextWaypoint(partner *CoWarpPeer) (tau time.Time, ca float64, ok bool) {
 	floor := w.Clock.SimTime.Add(rendezvousWaypointMinLead)
-	if w.Target.Kind == TargetGhost && w.Target.GhostOwner == partner.Owner {
-		if t, c, cok := w.RendezvousCommit(); cok && t.After(floor) {
-			return t, c, true
+	active := w.ActiveCraft()
+	if w.Target.Kind == TargetGhost && w.Target.GhostOwner == partner.Owner && active != nil {
+		if primary, pok := w.rendezvousTargetPrimary(); pok && primary.ID == active.Primary.ID {
+			if rT, vT, rok := w.TargetStateRelativeToActivePrimary(); rok {
+				mu := active.Primary.GravitationalParameter()
+				if mu > 0 {
+					if t, c, cok := w.rendezvousCommitCurrentCourse(active, rT, vT, mu); cok && t.After(floor) {
+						return t, c, true
+					}
+				}
+			}
 		}
 	}
-	active := w.ActiveCraft()
 	if active == nil || active.Landed || active.Crashed {
 		return time.Time{}, 0, false
 	}

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -187,23 +188,50 @@ const rendezvousCommitHorizonSec = 4 * 3600.0
 
 // RendezvousCommit returns the encounter the initiator commits a
 // Rendezvous Warp to (v0.29 S2, ADR 0034 v0.29 addendum): the absolute
-// τ and its predicted approach against the current relative target,
-// found on the players' CURRENT courses — no burn assumed. ok=false
-// when no encounter can be found at all: no relative target,
+// τ and its predicted approach against the current relative target.
+// ok=false when no encounter can be found at all: no relative target,
 // cross-primary, or no approach inside the horizon — the App toasts
 // instead of arming.
 //
-// #276: this used to prefer the K-nudge advisory's post-burn encounter
-// on the theory that the initiator would go on to plant (K) and fly
-// that burn — but Engage never plants the nudge itself, so with two
-// craft on matched orbits (zero relative drift, no approach on the
-// current course) the advisory could still find a hypothetical nudge
-// and Engage would silently commit to ITS post-burn closest approach:
-// an encounter the player was never actually flying toward. Committing
-// only to the current-course search means a phantom advisory can no
-// longer bypass the "no real encounter" refusal below; a player who
-// wants the advisory's encounter must plant it with K first, then
-// Engage sees it via their new current course.
+// Two sources, tried in order:
+//
+//  1. A PLANTED rendezvous nudge (K). If the active craft is currently
+//     carrying an unfired ManeuverNode tagged AdvisoryKeyRendezvousNudge,
+//     the encounter is found on the course that node actually promises:
+//     forward-integrate to the node's own TriggerTime, apply its Δv
+//     (PostBurnState), Kepler-propagate the target to the same instant,
+//     then search from there. This is the real course the player is
+//     already committed to flying — the burn is queued and will fire on
+//     its own; Engage is just naming where it leads.
+//  2. Falls back to the CURRENT-course search (no burn assumed) when no
+//     such node is planted, or the node doesn't yield an encounter
+//     inside the horizon.
+//
+// ok=false from both means there is genuinely no encounter to commit to
+// yet: the App's refusal names the doctrine's actionable remedy, plant
+// a nudge with K first (see app.go's SessionCmdRendezvous handling).
+//
+// #276: this used to prefer the K-nudge ADVISORY's post-burn encounter
+// — the HUD preview, computed fresh every tick whether or not the
+// player ever presses K — on the theory that the initiator would go on
+// to plant and fly it. But Engage never plants the nudge itself, so
+// with two craft on matched orbits (zero relative drift, no approach on
+// the current course) the advisory could still preview a hypothetical
+// nudge and Engage would silently commit to ITS post-burn closest
+// approach: an encounter the player was never actually flying toward.
+// The fix restricted RendezvousCommit to the current-course search only
+// — closing that hole, but also making the refusal's own prescribed
+// remedy ("plant a nudge [K] first") a dead end: planting a node alone
+// doesn't touch active.State (only FIRING does), so the very next
+// Engage press hit the identical current-course refusal again with no
+// way out (PR #392 review, finding 1).
+//
+// The fix here is narrower than the pre-#276 behavior it replaces: it
+// doesn't resurrect the transient advisory preview, it honors an
+// ACTUALLY-PLANTED node — one the player pressed K to queue, which will
+// fire on its own whether or not Engage ever runs. Committing to that
+// course is not committing to a "hypothetical" burn; the burn is
+// already scheduled.
 // rendezvousGapNoteBar is the "far above the lock gate" bar for the
 // engage-time gap note (ADR 0039 S3, #281): a generous multiple of the
 // couple gate, not "just outside" it — a committed CA a little past
@@ -249,6 +277,18 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 		return time.Time{}, 0, false
 	}
 	mu := active.Primary.GravitationalParameter()
+
+	// Source 1: an actually-planted rendezvous nudge (finding 1). Tried
+	// first — a queued, self-firing burn is a more concrete commitment
+	// than the no-burn current course, so when both would yield an
+	// encounter the planted one wins.
+	if node, nok := plantedAdvisoryNode(active, AdvisoryKeyRendezvousNudge); nok {
+		if t, c, cok := w.rendezvousCommitFromPlantedNode(active, node, rT, vT, mu); cok {
+			return t, c, true
+		}
+	}
+
+	// Source 2: the current-course fallback (no burn assumed).
 	tCA, distCA, _, err := planner.NextClosestApproach(
 		orbital.Vec3State{R: active.State.R, V: active.State.V},
 		orbital.Vec3State{R: rT, V: vT},
@@ -257,6 +297,40 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 		return time.Time{}, 0, false
 	}
 	return w.Clock.SimTime.Add(time.Duration(tCA * float64(time.Second))), distCA, true
+}
+
+// rendezvousCommitFromPlantedNode computes the encounter a planted
+// rendezvous-nudge node actually leads to: forward-integrate the active
+// craft to the node's TriggerTime and apply its Δv (PostBurnState),
+// Kepler-propagate the target's CURRENT relative state (rT, vT) forward
+// by the same dt so both sides are compared at the same instant, then
+// search for a closest approach from there. ok=false when the node is
+// already past-due, PostBurnState lands in a different primary's frame
+// (an SOI crossing before the burn fires — the target's frame no longer
+// matches, so no meaningful comparison exists), the target's coast
+// doesn't admit a Kepler propagation (hyperbolic/degenerate — KeplerStep
+// returns ok=false), or no approach turns up inside the horizon.
+func (w *World) rendezvousCommitFromPlantedNode(active *spacecraft.Spacecraft, node spacecraft.ManeuverNode, rT, vT orbital.Vec3, mu float64) (time.Time, float64, bool) {
+	dt := node.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	if dt <= 0 {
+		return time.Time{}, 0, false
+	}
+	postState, primaryID := w.PostBurnState(node)
+	if primaryID != active.Primary.ID {
+		return time.Time{}, 0, false
+	}
+	targetState, ok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
+	if !ok {
+		return time.Time{}, 0, false
+	}
+	tCA, distCA, _, err := planner.NextClosestApproach(
+		orbital.Vec3State{R: postState.R, V: postState.V},
+		orbital.Vec3State{R: targetState.R, V: targetState.V},
+		active.Primary, mu, rendezvousCommitHorizonSec)
+	if err != nil || tCA <= 0 {
+		return time.Time{}, 0, false
+	}
+	return node.TriggerTime.Add(time.Duration(tCA * float64(time.Second))), distCA, true
 }
 
 // rendezvousWaypointMinLead is the minimum forward distance a newly

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -278,11 +278,17 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	}
 	mu := active.Primary.GravitationalParameter()
 
-	// Source 1: an actually-planted rendezvous nudge (finding 1). Tried
-	// first — a queued, self-firing burn is a more concrete commitment
-	// than the no-burn current course, so when both would yield an
-	// encounter the planted one wins.
-	if node, nok := plantedAdvisoryNode(active, AdvisoryKeyRendezvousNudge); nok {
+	// Source 1: an actually-planted rendezvous nudge (finding 1), but
+	// ONLY when it's still bound to the peer being engaged right now
+	// (PR #392 review, follow-up finding): a nudge planted against peer
+	// A must not be honored when w.Target has since moved to peer B —
+	// plantedAdvisoryNode's own TargetCraftID/TargetGhostOwner check
+	// enforces that, falling through to Source 2 on a mismatch exactly
+	// as if nothing were planted. Tried first when it does match — a
+	// queued, self-firing burn is a more concrete commitment than the
+	// no-burn current course, so when both would yield an encounter the
+	// planted one wins.
+	if node, nok := plantedAdvisoryNode(active, AdvisoryKeyRendezvousNudge, w.Target.CraftID, w.Target.GhostOwner); nok {
 		if t, c, cok := w.rendezvousCommitFromPlantedNode(active, node, rT, vT, mu); cok {
 			return t, c, true
 		}

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -187,13 +187,23 @@ const rendezvousCommitHorizonSec = 4 * 3600.0
 
 // RendezvousCommit returns the encounter the initiator commits a
 // Rendezvous Warp to (v0.29 S2, ADR 0034 v0.29 addendum): the absolute
-// τ and its predicted approach against the current relative target.
-// Prefers the K-nudge advisory's post-burn encounter — the initiator is
-// expected to plant that burn and live through it en route — and falls
-// back to the current-course closest approach when the advisory has no
-// useful nudge (the encounter is already set up). ok=false when no
-// encounter can be found at all: no relative target, cross-primary, or
-// no approach inside the horizon — the App toasts instead of arming.
+// τ and its predicted approach against the current relative target,
+// found on the players' CURRENT courses — no burn assumed. ok=false
+// when no encounter can be found at all: no relative target,
+// cross-primary, or no approach inside the horizon — the App toasts
+// instead of arming.
+//
+// #276: this used to prefer the K-nudge advisory's post-burn encounter
+// on the theory that the initiator would go on to plant (K) and fly
+// that burn — but Engage never plants the nudge itself, so with two
+// craft on matched orbits (zero relative drift, no approach on the
+// current course) the advisory could still find a hypothetical nudge
+// and Engage would silently commit to ITS post-burn closest approach:
+// an encounter the player was never actually flying toward. Committing
+// only to the current-course search means a phantom advisory can no
+// longer bypass the "no real encounter" refusal below; a player who
+// wants the advisory's encounter must plant it with K first, then
+// Engage sees it via their new current course.
 // rendezvousGapNoteBar is the "far above the lock gate" bar for the
 // engage-time gap note (ADR 0039 S3, #281): a generous multiple of the
 // couple gate, not "just outside" it — a committed CA a little past
@@ -216,9 +226,6 @@ func (w *World) RendezvousNeedsBurnToClose(ca float64) bool {
 }
 
 func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
-	if adv, aok := w.RecommendedRendezvousBurn(); aok && adv.Ok {
-		return w.Clock.SimTime.Add(time.Duration(adv.TArrival * float64(time.Second))), adv.AchievableCA, true
-	}
 	active := w.ActiveCraft()
 	if active == nil || !w.HasRelativeTarget() {
 		return time.Time{}, 0, false
@@ -265,8 +272,10 @@ const rendezvousWaypointMinLead = 5 * time.Second
 // after the previous one passed (#252). Two paths, mirroring the Engage
 // commit:
 //   - the target slot still holds the armed partner's ghost → reuse
-//     RendezvousCommit verbatim, so a planted next nudge's post-burn
-//     encounter is honoured exactly like the first one was;
+//     RendezvousCommit verbatim, which is CURRENT-course-only (#276) — a
+//     nudge planted and FIRED mid-coast is honoured automatically once
+//     its burn has actually changed the craft's course; an unfired
+//     advisory nudge is not;
 //   - otherwise (player retargeted mid-coast, or the ghost slate is
 //     momentarily stale) → target-slot-independent fallback: the
 //     current-course closest approach against the partner's same-primary

--- a/internal/sim/rendezvous_matched_orbit_test.go
+++ b/internal/sim/rendezvous_matched_orbit_test.go
@@ -1,0 +1,37 @@
+package sim
+
+import "testing"
+
+// TestRendezvousCommitMatchedOrbitsRefusesPhantomNudge (#276): two craft
+// on the exact same circular orbit, differing only by a small phase lag,
+// have zero relative drift — their separation on the CURRENT courses is
+// constant for all time, so no future closest approach exists to commit
+// to. The K-nudge advisory, however, DOES find a real burn here (a small
+// phasing nudge would close the gap) — rendezvousSmallLagWorld exists
+// specifically to guarantee that precondition (see
+// TestPlanRendezvousNudge_PlantsOneNode).
+//
+// Before the fix, RendezvousCommit tried the advisory first and adopted
+// its post-burn τ/CA even though PlanRendezvousNudge (K) was never
+// called and no burn was ever made — so Engage silently armed toward an
+// encounter the player was not actually flying toward. Engage must
+// commit only to an encounter reachable on the CURRENT courses; if only
+// a nudge would create one, it must refuse (the same refusal the
+// current-course fallback already produces) rather than borrow the
+// advisory's unfired result.
+func TestRendezvousCommitMatchedOrbitsRefusesPhantomNudge(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+
+	// Precondition: confirm the advisory finds a real plantable nudge for
+	// this geometry — otherwise this test would trivially pass for the
+	// wrong reason (no advisory to wrongly prefer in the first place).
+	adv, aok := w.RecommendedRendezvousBurn()
+	if !aok || !adv.Ok {
+		t.Skipf("this geometry yields no advisory nudge (ok=%v adv.Ok=%v); not exercising the phantom-commit path", aok, adv.Ok)
+	}
+
+	if _, _, ok := w.RendezvousCommit(); ok {
+		t.Error("RendezvousCommit committed to an encounter with no burn fired — " +
+			"matched orbits have zero relative drift and can never close on the current courses (#276)")
+	}
+}

--- a/internal/sim/rendezvous_planted_nudge_test.go
+++ b/internal/sim/rendezvous_planted_nudge_test.go
@@ -1,6 +1,13 @@
 package sim
 
-import "testing"
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
 
 // TestRendezvousCommitHonorsPlantedNudge (PR #392 review, finding 1):
 // the #276 fix's own prescribed remedy — refuse, then "plant a nudge
@@ -90,4 +97,118 @@ func TestRendezvousCommitPlantedNudgeIgnoredWhenPastDue(t *testing.T) {
 	if _, _, ok := w.RendezvousCommit(); ok {
 		t.Error("RendezvousCommit committed via a past-due planted node instead of falling back")
 	}
+}
+
+// TestPostBurnStateWithTarget_TargetRelativeAxisAppliesBurn (PR #392
+// review, finding 1, root cause): PostBurnState resolves a planted
+// node's direction via spacecraft.NodeBurnDirection, which falls
+// through to DirectionUnit for every mode it doesn't special-case —
+// and DirectionUnit returns the ZERO vector for the four target-
+// relative modes (thrust.go ~287-290), since they need target state
+// DirectionUnit doesn't have. So a BurnTargetPrograde/Retrograde
+// planted node used to silently commit with NO applied Δv. This pins
+// the fix at the lowest level, independent of whether a resulting
+// encounter converges within the search horizon: the post-burn
+// velocity must differ from the plain coast velocity by exactly the
+// node's DV.
+func TestPostBurnStateWithTarget_TargetRelativeAxisAppliesBurn(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	rT, vT, rok := w.TargetStateRelativeToActivePrimary()
+	if !rok {
+		t.Fatal("TargetStateRelativeToActivePrimary: not ok")
+	}
+	mu := c.Primary.GravitationalParameter()
+
+	node := spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnTargetRetrograde,
+		DV:          5.0,
+		Event:       spacecraft.TriggerAbsolute,
+		TriggerTime: w.Clock.SimTime.Add(60 * time.Second),
+		PrimaryID:   c.Primary.ID,
+	}
+	dt := node.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+
+	// Same propagation rendezvousCommitFromPlantedNode performs: the
+	// target's relative state Kepler-propagated forward to the node's
+	// TriggerTime, and the craft's own coast (no-burn) state at the
+	// same instant as a baseline to diff against.
+	targetState, tok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
+	if !tok {
+		t.Fatal("KeplerStep on target state: not ok")
+	}
+	coastState, _ := w.propagateCraftWithPrimary(dt)
+
+	postState, primaryID, ok := w.postBurnStateWithTarget(node, targetState.R, targetState.V)
+	if !ok {
+		t.Fatal("postBurnStateWithTarget: expected ok=true — this fixture's rotated " +
+			"co-orbital geometry has nonzero relative velocity, so BurnTargetRetrograde's " +
+			"direction is not degenerate")
+	}
+	if primaryID != c.Primary.ID {
+		t.Errorf("primaryID = %q, want %q", primaryID, c.Primary.ID)
+	}
+	delta := postState.V.Sub(coastState.V).Norm()
+	if math.Abs(delta-node.DV) > 1e-6 {
+		t.Errorf("|post-burn V - coast V| = %.9f, want %.9f (== node.DV) — "+
+			"a target-relative axis must resolve a real burn direction, not silently "+
+			"apply zero Δv (finding 1)", delta, node.DV)
+	}
+}
+
+// TestRendezvousCommitHonorsPlantedNudge_BothAxisFamilies (PR #392
+// review, finding 1): the existing TestRendezvousCommitHonorsPlantedNudge
+// only covers whatever axis PlanRendezvousNudge's own advisory happens
+// to pick for the fixture — it could land on a velocity-frame axis
+// (prograde/retrograde/normal/radial) or a target-relative one
+// (BurnTargetPrograde/Retrograde) depending on the Lambert scan, and
+// only the former exercised PostBurnState's working path before this
+// fix. This test hand-plants BOTH families directly (bypassing the
+// advisory's own axis choice) with the same Δv magnitude, so both a
+// velocity-frame axis and a target-relative axis are pinned committing
+// successfully via RendezvousCommit's planted-node path.
+func TestRendezvousCommitHonorsPlantedNudge_BothAxisFamilies(t *testing.T) {
+	const dv = 20.0 // m/s — enough to break the matched-orbit symmetry within the 4h horizon
+
+	plant := func(t *testing.T, w *World, mode spacecraft.BurnMode) {
+		t.Helper()
+		c := w.ActiveCraft()
+		node := ManeuverNode{
+			Mode:          mode,
+			DV:            dv,
+			Event:         spacecraft.TriggerAbsolute,
+			TriggerTime:   w.Clock.SimTime.Add(rendezvousBurnLeadMin),
+			PrimaryID:     c.Primary.ID,
+			Throttle:      1.0,
+			TargetCraftID: w.Target.CraftID,
+			AdvisoryKey:   AdvisoryKeyRendezvousNudge,
+		}
+		w.PlanNode(node)
+	}
+
+	t.Run("target-relative axis", func(t *testing.T) {
+		w := rendezvousSmallLagWorld(t)
+		plant(t, w, spacecraft.BurnTargetRetrograde)
+		tau, ca, ok := w.RendezvousCommit()
+		if !ok {
+			t.Fatal("RendezvousCommit refused a planted BurnTargetRetrograde nudge — " +
+				"finding 1: target-relative axes must resolve a real post-burn course")
+		}
+		if !tau.After(w.Clock.SimTime) || ca <= 0 {
+			t.Errorf("tau=%v ca=%.3f — expected a future τ with positive CA", tau, ca)
+		}
+	})
+
+	t.Run("velocity-frame axis", func(t *testing.T) {
+		w := rendezvousSmallLagWorld(t)
+		plant(t, w, spacecraft.BurnPrograde)
+		tau, ca, ok := w.RendezvousCommit()
+		if !ok {
+			t.Fatal("RendezvousCommit refused a planted BurnPrograde nudge")
+		}
+		if !tau.After(w.Clock.SimTime) || ca <= 0 {
+			t.Errorf("tau=%v ca=%.3f — expected a future τ with positive CA", tau, ca)
+		}
+	})
 }

--- a/internal/sim/rendezvous_planted_nudge_test.go
+++ b/internal/sim/rendezvous_planted_nudge_test.go
@@ -1,0 +1,93 @@
+package sim
+
+import "testing"
+
+// TestRendezvousCommitHonorsPlantedNudge (PR #392 review, finding 1):
+// the #276 fix's own prescribed remedy — refuse, then "plant a nudge
+// [K] first" — was a dead end. Planting a node doesn't touch
+// active.State (only firing does), so a plant-then-Engage sequence hit
+// the identical current-course refusal every time. RendezvousCommit
+// must honor an ACTUALLY-PLANTED rendezvous-nudge node: once K has
+// queued a burn, Engage commits to the encounter that burn leads to,
+// not to the (still zero-drift) current course.
+func TestRendezvousCommitHonorsPlantedNudge(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+
+	// Precondition: this geometry has zero relative drift on the
+	// current courses — the phantom-commit regression test
+	// (rendezvous_matched_orbit_test.go) already pins that
+	// RendezvousCommit refuses with nothing planted.
+	if _, _, ok := w.RendezvousCommit(); ok {
+		t.Fatal("precondition: RendezvousCommit should refuse with no planted node on matched orbits")
+	}
+
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not exercising the planted-node commit path", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if adv == nil || !adv.Ok {
+		t.Fatalf("expected a successful plant, got %+v", adv)
+	}
+	c := w.ActiveCraft()
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node, got %d", len(c.Nodes))
+	}
+	node := c.Nodes[0]
+
+	tau, ca, ok := w.RendezvousCommit()
+	if !ok {
+		t.Fatal("RendezvousCommit refused despite a freshly planted rendezvous nudge — " +
+			"the #276 refusal's own \"plant a nudge [K] first\" remedy is a dead end without this")
+	}
+	if !tau.After(w.Clock.SimTime) {
+		t.Errorf("committed τ %v is not in the future (SimTime %v)", tau, w.Clock.SimTime)
+	}
+	if tau.Before(node.TriggerTime) {
+		t.Errorf("committed τ %v precedes the node's own TriggerTime %v — "+
+			"the encounter can only exist once the burn has actually fired", tau, node.TriggerTime)
+	}
+	if ca <= 0 {
+		t.Errorf("committed CA = %.3f, want > 0", ca)
+	}
+	// Sanity bound, not exact equality: the planted node's TriggerTime
+	// carries a small lead buffer past "now" (v0.10.0 slew lead-comp),
+	// so the honest post-burn CA (searched from TriggerTime) need not
+	// exactly match the advisory's own preview (which previews the burn
+	// as if fired instantly at t=0) — but on this fixture's small,
+	// slowly-evolving lag geometry they should stay in the same
+	// ballpark.
+	if adv.AchievableCA > 0 && (ca > adv.AchievableCA*5 || ca < adv.AchievableCA/5) {
+		t.Errorf("committed CA %.0f m is far from the advisory's own preview %.0f m — "+
+			"expected the same ballpark for this slowly-evolving geometry", ca, adv.AchievableCA)
+	}
+}
+
+// TestRendezvousCommitPlantedNudgeIgnoredWhenPastDue: a planted node
+// whose TriggerTime has already elapsed (but hasn't fired yet this
+// tick — a same-tick race) must not be treated as a future course to
+// search from; RendezvousCommit falls back to the current-course
+// search instead of dividing by a non-positive dt.
+func TestRendezvousCommitPlantedNudgeIgnoredWhenPastDue(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not exercising this path", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if adv == nil || !adv.Ok {
+		t.Fatalf("expected a successful plant, got %+v", adv)
+	}
+	c := w.ActiveCraft()
+	c.Nodes[0].TriggerTime = w.Clock.SimTime // due "now" — dt <= 0
+
+	// Must not panic or misbehave; falls through to the (refusing,
+	// zero-drift) current-course search.
+	if _, _, ok := w.RendezvousCommit(); ok {
+		t.Error("RendezvousCommit committed via a past-due planted node instead of falling back")
+	}
+}

--- a/internal/sim/rendezvous_refusal_reasons_test.go
+++ b/internal/sim/rendezvous_refusal_reasons_test.go
@@ -54,11 +54,15 @@ func TestRendezvousReasonToErr_S1DistinctReasons(t *testing.T) {
 // TestRendezvousReasonToErr_S2PhasingCoachBucket — ADR 0039 S2 / #277:
 // the four inner Lambert-lookahead dead ends share ONE remedy — none of
 // them found a real encounter to score, so K has nothing more specific
-// to say than "make a phasing burn". This is the SAME wording Engage's
-// own no-encounter refusal uses (rendezvousPhasingCoachMsg), so the two
-// refusal chains stop pointing at each other: before this, `w` said "use
-// K", and K said "no useful nudge in range" — a dead end with no
-// explanation on either side (#277).
+// to say than "make a phasing burn" (rendezvousPhasingCoachMsg). PR #392
+// review finding 1 later gave Engage's own refusal its wording back
+// ("plant a rendezvous nudge [K] first", #276) now that a plant-then-
+// Engage sequence actually arms once K finds something — so the two
+// refusal chains no longer share identical text, but they still don't
+// dead-end into each other: Engage points at K, and if K itself also
+// finds nothing (a true matched-orbit stalemate) K names this same
+// phasing-coach remedy instead of repeating Engage's line back
+// unchanged.
 func TestRendezvousReasonToErr_S2PhasingCoachBucket(t *testing.T) {
 	for _, reason := range []string{
 		"no lambert convergence", "degenerate axes", "horizon too short", "ca-verify failed",

--- a/internal/sim/rendezvous_stale_nudge_target_test.go
+++ b/internal/sim/rendezvous_stale_nudge_target_test.go
@@ -1,0 +1,126 @@
+package sim
+
+import "testing"
+
+// rendezvousThreeCraftWorld extends rendezvousSmallLagWorld (active=0,
+// peer A=1, matched-orbit small lag, target bound to A) with a third
+// craft, peer B, whose state is cloned from A's CURRENT (pre-nudge)
+// state — same primary, same R, same V. This is deliberate: it makes
+// B, at plant time, dynamically indistinguishable from A. So a burn
+// computed and planted against A will, if incorrectly replayed against
+// B's identical snapshot, "succeed" (find a real closest approach) —
+// not because the binding was honored, but purely because B's state
+// happens to coincide with A's. That is exactly what makes this a good
+// regression fixture for the AdvisoryKey-only match bug (PR #392
+// review): the bug doesn't just risk refusing when it shouldn't, it can
+// produce a plausible-looking phantom commit. Only checking the node's
+// own TargetCraftID/TargetGhostOwner binding (not the physics outcome)
+// tells the two apart.
+func rendezvousThreeCraftWorld(t *testing.T) *World {
+	t.Helper()
+	w := rendezvousSmallLagWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 700e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 3 {
+		t.Fatalf("expected 3 crafts after spawn, got %d", len(w.Crafts))
+	}
+	// SpawnCraft snaps the active craft to the newly spawned one
+	// (spawn.go SetActiveCraftIdx); restore it to the original craft
+	// (idx 0) so this fixture's "active=0, A=1, B=2" shape holds.
+	w.ActiveCraftIdx = 0
+	a := w.Crafts[1]
+	b := w.Crafts[2]
+	b.State.R = a.State.R
+	b.State.V = a.State.V
+	b.Primary = a.Primary
+	// rendezvousSmallLagWorld already points the target at A (idx 1);
+	// re-assert it here so the fixture's starting condition is explicit
+	// regardless of what SpawnCraft does to the active target slot.
+	w.SetTargetCraft(1)
+	return w
+}
+
+// TestRendezvousCommitIgnoresNudgePlantedAgainstDifferentPeer (PR #392
+// review): PlanRendezvousNudge deliberately stamps TargetCraftID/
+// TargetGhostOwner at plant time (rendezvous.go ~606-611) precisely so
+// a later target switch doesn't retarget the burn — but before this
+// fix, RendezvousCommit's Source 1 (plantedAdvisoryNode) matched by
+// AdvisoryKey alone, ignoring that binding. Engage toward peer B after
+// a nudge was planted against peer A would replay A's node against
+// B's target state, committing a τ/CA describing a course that will
+// never be flown — the exact phantom-co-warp class #276 was about.
+//
+// The fixture (rendezvousThreeCraftWorld) clones B's state from A's own
+// state, so the bug doesn't merely risk a wrong refusal here — it
+// produces a spurious SUCCESSFUL commit toward B, since replaying A's
+// node against B's (identical) snapshot finds the same real closest
+// approach A's own node was computed for. Only the binding check tells
+// the two peers apart. This pins: plant against A, retarget to B,
+// Engage — must refuse (falls to the current-course path, which
+// refuses on this fixture's matched, zero-drift orbits, mirroring the
+// no-node precondition below). Retargeting back to A must still honor
+// the node, exactly as the existing pinned tests assert.
+func TestRendezvousCommitIgnoresNudgePlantedAgainstDifferentPeer(t *testing.T) {
+	w := rendezvousThreeCraftWorld(t)
+
+	// Precondition: matched orbits, zero relative drift, nothing planted
+	// yet — Engage toward A refuses on the current course.
+	if _, _, ok := w.RendezvousCommit(); ok {
+		t.Fatal("precondition: RendezvousCommit should refuse toward A with no planted node")
+	}
+
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not exercising this path", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if adv == nil || !adv.Ok {
+		t.Fatalf("expected a successful plant against A, got %+v", adv)
+	}
+	c := w.ActiveCraft()
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node bound to A, got %d", len(c.Nodes))
+	}
+	nodeForA := c.Nodes[0]
+	if nodeForA.TargetCraftID != w.Crafts[1].ID {
+		t.Fatalf("planted node TargetCraftID = %d, want A's ID %d", nodeForA.TargetCraftID, w.Crafts[1].ID)
+	}
+
+	// Sanity: confirm the fixture actually set up the "B looks just like
+	// A" trap — otherwise a refusal toward B below would prove nothing.
+	if w.Crafts[2].State.R != w.Crafts[1].State.R || w.Crafts[2].State.V != w.Crafts[1].State.V {
+		t.Fatal("fixture invariant broken: B's state must clone A's for this regression to be meaningful")
+	}
+
+	// Retarget to peer B. The node planted against A is still queued
+	// (retargeting doesn't touch c.Nodes), but it must be ignored now —
+	// even though B's state would make the stale node's search "succeed"
+	// if the binding weren't checked.
+	w.SetTargetCraft(2)
+	if w.Target.CraftID != w.Crafts[2].ID {
+		t.Fatalf("target not switched to B: Target.CraftID = %d, want %d", w.Target.CraftID, w.Crafts[2].ID)
+	}
+	if len(w.ActiveCraft().Nodes) != 1 {
+		t.Fatalf("retargeting should not touch the planted node queue, got %d nodes", len(w.ActiveCraft().Nodes))
+	}
+
+	if tau, ca, ok := w.RendezvousCommit(); ok {
+		t.Fatalf("RendezvousCommit toward B honored a nudge planted against A "+
+			"(stale AdvisoryKey-only match) — committed tau=%v ca=%.3f describing a course "+
+			"that will never be flown toward B", tau, ca)
+	}
+
+	// Retarget back to A: the same node, still queued, must be honored
+	// again exactly as the pinned single-peer tests assert.
+	w.SetTargetCraft(1)
+	tau, ca, ok := w.RendezvousCommit()
+	if !ok {
+		t.Fatal("RendezvousCommit toward A (re-targeted back) refused despite its own matching planted node")
+	}
+	if !tau.After(w.Clock.SimTime) || ca <= 0 {
+		t.Errorf("tau=%v ca=%.3f — expected a future tau with positive CA once retargeted back to A", tau, ca)
+	}
+}

--- a/internal/sim/rendezvous_waypoint_unfired_node_test.go
+++ b/internal/sim/rendezvous_waypoint_unfired_node_test.go
@@ -1,0 +1,72 @@
+package sim
+
+import "testing"
+
+// TestRendezvousNextWaypointIgnoresUnfiredPlantedNode (PR #392 review,
+// finding 2): rendezvousNextWaypoint's own pinned doc comment asserts a
+// mid-coast waypoint "honors a nudge only once its burn has actually
+// fired" — an unfired advisory nudge is not. But its ghost path used to
+// reuse RendezvousCommit verbatim, which was a safe cross-purpose reuse
+// only as long as RendezvousCommit itself never preferred an unfired
+// node. Finding 1 gave RendezvousCommit exactly that preference, so
+// pressing K mid-coast would instantly re-derive the standing
+// waypoint/τ from the unfired node's hypothetical post-burn course —
+// delete the node (or have it refuse to fire) and the pair would coast
+// toward an encounter that will never occur, silently contradicting the
+// comment's own asserted invariant.
+//
+// This pins that planting a rendezvous nudge mid-coast does NOT move
+// the derived waypoint: the ghost path must call
+// rendezvousCommitCurrentCourse (current-course-only, #276), never
+// RendezvousCommit.
+func TestRendezvousNextWaypointIgnoresUnfiredPlantedNode(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	sister := w.Crafts[1]
+
+	ghost := ghostShapedLike(w, w.ActiveCraft().Primary, sister.State.R, sister.State.V,
+		"SHA256:gern", "gern", 77)
+	w.Ghosts = []Ghost{ghost}
+	w.SetTargetGhost(ghost.Owner, ghost.CraftID)
+
+	partner := &CoWarpPeer{
+		Owner: ghost.Owner, Handle: ghost.Handle, SubspaceTime: w.Clock.SimTime,
+		ArmedTowardViewer: true,
+		Crafts:            []CoWarpCraft{{Primary: w.ActiveCraft().Primary.ID, R: sister.State.R, V: sister.State.V}},
+	}
+
+	// Precondition: matched orbit, zero relative drift, no node planted
+	// yet — neither the ghost path nor the peer-set fallback finds a
+	// future approach (mirrors the RendezvousCommit precondition in
+	// TestRendezvousCommitHonorsPlantedNudge).
+	if tau, ca, ok := w.rendezvousNextWaypoint(partner); ok {
+		t.Fatalf("precondition: rendezvousNextWaypoint should find nothing on the matched-orbit, "+
+			"no-node baseline; got tau=%v ca=%.3f", tau, ca)
+	}
+
+	adv, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("small-lag geometry yielded no useful nudge (%v); not exercising this path", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+	if adv == nil || !adv.Ok {
+		t.Fatalf("expected a successful plant, got %+v", adv)
+	}
+
+	// Contrast case, not the thing under test: confirm the plant is
+	// real by checking Engage's own commit (RendezvousCommit) now finds
+	// an encounter via the planted-node path (finding 1).
+	if _, _, ok := w.RendezvousCommit(); !ok {
+		t.Fatal("expected RendezvousCommit to honor the freshly planted nudge (finding 1) — " +
+			"if this fails, the plant itself didn't take and the test below is meaningless")
+	}
+
+	// The thing under test: the mid-coast waypoint must NOT move just
+	// because a node got planted — it hasn't FIRED yet.
+	if tau, ca, ok := w.rendezvousNextWaypoint(partner); ok {
+		t.Errorf("rendezvousNextWaypoint derived a waypoint (τ=%v ca=%.0f) from an UNFIRED "+
+			"planted node — a mid-coast waypoint must honor a nudge only once fired (finding 2)",
+			tau, ca)
+	}
+}

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -72,6 +72,26 @@ func (w *World) ClearTarget() {
 	w.reconcileNavMode()
 }
 
+// RestoreTarget resets Target and NavMode directly to a previously
+// captured pair, bypassing the individual Set*/Clear setters'
+// validation — the caller already knows this was a valid live state (it
+// read it straight off the World a moment earlier). Mirrors the
+// restored Target onto the active craft the same way every other
+// setter does, so the per-craft binding stays consistent.
+//
+// Added for PR #392 review finding 2: SessionCmdRendezvous
+// (app.go) calls SetTargetGhost before RendezvousCommit to give the
+// commit search something to aim at, but a refusal must not leave that
+// switch behind — the player's previous target (mid-transfer TargetBody
+// Moon, say) would otherwise be silently replaced, and the stale ghost
+// ref would persist into the next save, even though the game said no to
+// the rendezvous itself.
+func (w *World) RestoreTarget(t Target, nav NavMode) {
+	w.Target = t
+	w.mirrorTargetToActiveCraft()
+	w.NavMode = nav
+}
+
 // mirrorTargetToActiveCraft writes w.Target onto the active craft's
 // per-craft Target field so the binding survives an active-craft
 // switch (v0.9.3 polish). Maintains the invariant

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2202,21 +2202,32 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 	case screens.SessionCmdRendezvous:
 		// Rendezvous Warp initiate (v0.29 S2 / ADR 0034 v0.29 addendum):
 		// target the partner's ghost (the advisory + TARGET chip context),
-		// commit the encounter — the current-course closest approach
-		// (#276: never the K-nudge advisory's unfired post-burn result) —
-		// and arm toward them. The coast starts only when they respond
-		// (mutual arm); the screen already gated same-subspace and ghost
-		// presence.
+		// commit the encounter — a planted rendezvous-nudge node's
+		// post-burn course when one exists, else the current-course
+		// closest approach (#276: never the K-nudge ADVISORY's unfired
+		// preview) — and arm toward them. The coast starts only when they
+		// respond (mutual arm); the screen already gated same-subspace and
+		// ghost presence.
+		//
+		// PR #392 review finding 2: SetTargetGhost runs before the commit
+		// gate, so a refusal below must not leave the switch behind —
+		// capture the prior target/NavMode and restore them on !ok. Without
+		// this a refused Engage silently stole whatever the player was
+		// targeting before (mid-transfer TargetBody Moon, say), flipped
+		// NavMode along with it, and left the stale ghost ref to persist
+		// into the next save.
+		prevTarget, prevNav := a.world.Target, a.world.NavMode
 		a.world.SetTargetGhost(cmd.Owner, cmd.CraftID)
 		tau, ca, ok := a.world.RendezvousCommit()
 		switch {
 		case !ok:
-			// ADR 0039 S2 / #277: name the doctrine's own remedy instead of
-			// pointing at K — K's own refusal for this same "no real
-			// encounter" situation used to say the opposite ("no useful
-			// nudge in range"), so the two refusals dead-ended into each
-			// other with no way out. Both sides now coach the same burn.
-			a.statusMsg = fmt.Sprintf("no encounter with %s on current courses — make a phasing burn (wide prograde or radial) and watch the CA shrink", cmd.Handle)
+			a.world.RestoreTarget(prevTarget, prevNav)
+			// #276's own remedy, restored (finding 1): RendezvousCommit now
+			// honors an actually-planted rendezvous nudge, so "plant a
+			// nudge [K] first" is a real next step again, not the dead end
+			// ADR 0039 S2 papered over by pointing at the doctrine's
+			// generic phasing-coach line instead.
+			a.statusMsg = fmt.Sprintf("no closable encounter with %s — plant a rendezvous nudge [K] first", cmd.Handle)
 		// The seat is fixed here (ADR 0037 §2): proposing the rendezvous
 		// makes you pilot-in-command of the pair's time once the terminal
 		// phase begins.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2202,10 +2202,11 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 	case screens.SessionCmdRendezvous:
 		// Rendezvous Warp initiate (v0.29 S2 / ADR 0034 v0.29 addendum):
 		// target the partner's ghost (the advisory + TARGET chip context),
-		// commit the encounter — the K-nudge advisory's post-burn τ+CA, or
-		// the current-course closest approach — and arm toward them. The
-		// coast starts only when they respond (mutual arm); the screen
-		// already gated same-subspace and ghost presence.
+		// commit the encounter — the current-course closest approach
+		// (#276: never the K-nudge advisory's unfired post-burn result) —
+		// and arm toward them. The coast starts only when they respond
+		// (mutual arm); the screen already gated same-subspace and ghost
+		// presence.
 		a.world.SetTargetGhost(cmd.Owner, cmd.CraftID)
 		tau, ca, ok := a.world.RendezvousCommit()
 		switch {

--- a/internal/tui/app_rendezvous_engage_test.go
+++ b/internal/tui/app_rendezvous_engage_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
-// TestEngageRendezvousNoEncounterCoachesPhasingBurn — ADR 0039 S2 / #277:
-// a genuinely stalemated geometry (matched circular orbit, opposite
-// phase — zero relative drift, an encounter can never form on the
-// current courses, #276) must refuse Engage with the doctrine's own
-// phasing-burn remedy, not the old "plant a rendezvous nudge [K] first"
-// — which dead-ended into K's OWN refusal with no explanation on either
-// side.
+// TestEngageRendezvousNoEncounterCoachesPhasingBurn — PR #392 review
+// finding 1 supersedes ADR 0039 S2 / #277 for this refusal: a genuinely
+// stalemated geometry (matched circular orbit, opposite phase — zero
+// relative drift, an encounter can never form on the current courses,
+// #276) with NO rendezvous nudge planted must refuse Engage with #276's
+// own requested remedy, "plant a rendezvous nudge [K] first" — no
+// longer a dead end now that RendezvousCommit actually honors a planted
+// node (finding 1), so pointing at K is a real next step again instead
+// of the generic phasing-coach line ADR 0039 S2 substituted when it
+// wasn't.
 func TestEngageRendezvousNoEncounterCoachesPhasingBurn(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
@@ -45,10 +48,7 @@ func TestEngageRendezvousNoEncounterCoachesPhasingBurn(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
-		t.Errorf("refusal still points at K instead of coaching the phasing burn directly: %q", app.statusMsg)
-	}
-	if !strings.Contains(app.statusMsg, "make a phasing burn") {
-		t.Errorf("refusal %q missing the phasing-coach remedy", app.statusMsg)
+	if !strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
+		t.Errorf("refusal %q missing the #276 remedy (plant a rendezvous nudge [K] first)", app.statusMsg)
 	}
 }

--- a/internal/tui/app_rendezvous_gap_note_test.go
+++ b/internal/tui/app_rendezvous_gap_note_test.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
@@ -35,6 +36,33 @@ func lagGhostWorld(a *App, angleDeg float64) {
 	}}
 }
 
+// gapGhostBeside mirrors ghostBesideActive (app_rendezvous_test.go,
+// #276's converging-geometry fixture) with a controllable lateral
+// offset: relR carries both the 50 km closing-axis offset and a
+// lateralOffsetM component the closing velocity never cancels, so the
+// resulting current-course closest approach lands near lateralOffsetM
+// itself rather than collapsing to ~0 on a head-on intercept. Lets the
+// two gap-note tests below dial the committed CA to opposite sides of
+// the far-CA bar (ADR 0039 S3, 3× the 35 km couple gate = 105 km)
+// without relying on a matched-orbit/zero-drift fixture that
+// RendezvousCommit (correctly, #276) always refuses with nothing
+// planted — PR #392 review finding 3.
+func gapGhostBeside(w *sim.World, owner string, craftID uint64, lateralOffsetM float64) sim.Ghost {
+	c := w.ActiveCraft()
+	relR := c.State.R.Add(orbital.Vec3{X: 50_000, Y: lateralOffsetM})
+	closingVel := c.State.V.Add(orbital.Vec3{X: -50})
+	return sim.Ghost{
+		Owner:     owner,
+		CraftID:   craftID,
+		Handle:    "gern",
+		Name:      "Aloft",
+		PrimaryID: c.Primary.ID,
+		Pos:       w.BodyPosition(c.Primary).Add(relR),
+		RelPos:    relR,
+		Vel:       closingVel,
+	}
+}
+
 // TestEngageRendezvousFarCAAddsGapNote — ADR 0039 S3 / #281: Engage on a
 // committed CA far above the 35 km lock gate adds one info line so
 // riding waypoints indefinitely is a visible choice, not a mystery.
@@ -50,12 +78,8 @@ func TestEngageRendezvousFarCAAddsGapNote(t *testing.T) {
 	if a.world.ActiveCraft() == nil {
 		t.Fatal("no active craft in a fresh world")
 	}
-	// -2° of co-orbital lag lands K's own recommended-nudge encounter
-	// (which RendezvousCommit prefers when available) around ~170 km —
-	// comfortably above the 3×-gate bar even though K itself calls the
-	// plant a "success". A K nudge landing outside the couple gate is
-	// exactly the case the gap note exists for.
-	lagGhostWorld(a, -2)
+	// 150 km lateral offset — comfortably above the 105 km far-CA bar.
+	a.world.Ghosts = []sim.Ghost{gapGhostBeside(a.world, "SHA256:gern", 7, 150_000)}
 
 	model, _ := a.applySessionCommand(screens.SessionCommand{
 		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
@@ -65,8 +89,8 @@ func TestEngageRendezvousFarCAAddsGapNote(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if strings.Contains(app.statusMsg, "phasing burn") {
-		t.Skipf("Engage refused on this geometry (%q); not exercising the gap note", app.statusMsg)
+	if strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
+		t.Fatalf("Engage refused on a genuinely converging current-course geometry (%q)", app.statusMsg)
 	}
 	if !strings.Contains(app.statusMsg, "a burn will be needed to close this") {
 		t.Errorf("armed status %q missing the far-CA gap note", app.statusMsg)
@@ -82,10 +106,9 @@ func TestEngageRendezvousCloseCANoGapNote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	// -0.5° lands K's recommended nudge around ~43 km — just above the
-	// 35 km couple gate itself, but well under the far-CA bar this note
-	// exists for.
-	lagGhostWorld(a, -0.5)
+	// 60 km lateral offset — above the 35 km couple gate itself, but
+	// well under the 105 km far-CA bar this note exists for.
+	a.world.Ghosts = []sim.Ghost{gapGhostBeside(a.world, "SHA256:gern", 7, 60_000)}
 
 	model, _ := a.applySessionCommand(screens.SessionCommand{
 		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
@@ -95,8 +118,8 @@ func TestEngageRendezvousCloseCANoGapNote(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if strings.Contains(app.statusMsg, "phasing burn") {
-		t.Skipf("Engage refused on this geometry (%q); not exercising the gap note", app.statusMsg)
+	if strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
+		t.Fatalf("Engage refused on a genuinely converging current-course geometry (%q)", app.statusMsg)
 	}
 	if strings.Contains(app.statusMsg, "a burn will be needed to close this") {
 		t.Errorf("close-CA armed status wrongly carries the gap note: %q", app.statusMsg)

--- a/internal/tui/app_rendezvous_matched_orbit_test.go
+++ b/internal/tui/app_rendezvous_matched_orbit_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
-// TestEngageRendezvousSmallLagRefusesPhantomArm (#276): a small co-orbital
-// phase lag (same circular orbit, differing only by -0.5°) is the
-// geometry TestEngageRendezvousCloseCANoGapNote already documents as one
-// where the K-nudge advisory finds a real, plantable burn (~43 km
-// post-burn CA). But the player here has not pressed K — no burn has been
-// made, and matched orbits never close on their own. Engage must refuse
-// with the phasing-coach remedy, not silently arm toward the advisory's
-// unfired post-burn encounter.
+// TestEngageRendezvousSmallLagRefusesPhantomArm (#276, wording updated
+// for PR #392 review finding 1): a small co-orbital phase lag (same
+// circular orbit, differing only by -0.5°) is the geometry
+// TestEngageRendezvousCloseCANoGapNote already documents as one where
+// the K-nudge advisory finds a real, plantable burn (~43 km post-burn
+// CA). But the player here has not pressed K — no burn has been made
+// or planted, and matched orbits never close on their own. Engage must
+// refuse (pointing at K, #276's own remedy — now a real next step since
+// RendezvousCommit honors an actually-planted node), not silently arm
+// toward the advisory's unfired preview.
 func TestEngageRendezvousSmallLagRefusesPhantomArm(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
@@ -33,7 +35,7 @@ func TestEngageRendezvousSmallLagRefusesPhantomArm(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if !strings.Contains(app.statusMsg, "phasing burn") {
+	if !strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
 		t.Errorf("Engage armed on a phantom encounter instead of refusing: %q", app.statusMsg)
 	}
 	if app.world.RendezvousArm != nil {

--- a/internal/tui/app_rendezvous_matched_orbit_test.go
+++ b/internal/tui/app_rendezvous_matched_orbit_test.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// TestEngageRendezvousSmallLagRefusesPhantomArm (#276): a small co-orbital
+// phase lag (same circular orbit, differing only by -0.5°) is the
+// geometry TestEngageRendezvousCloseCANoGapNote already documents as one
+// where the K-nudge advisory finds a real, plantable burn (~43 km
+// post-burn CA). But the player here has not pressed K — no burn has been
+// made, and matched orbits never close on their own. Engage must refuse
+// with the phasing-coach remedy, not silently arm toward the advisory's
+// unfired post-burn encounter.
+func TestEngageRendezvousSmallLagRefusesPhantomArm(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.ActiveCraft() == nil {
+		t.Fatal("no active craft in a fresh world")
+	}
+	lagGhostWorld(a, -0.5)
+
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:gern", CraftID: 7, Handle: "gern",
+	})
+	app := model.(*App)
+
+	if app.statusMsg == "" {
+		t.Fatal("Engage produced no status message")
+	}
+	if !strings.Contains(app.statusMsg, "phasing burn") {
+		t.Errorf("Engage armed on a phantom encounter instead of refusing: %q", app.statusMsg)
+	}
+	if app.world.RendezvousArm != nil {
+		t.Error("RendezvousArm set despite no encounter on the current courses (#276)")
+	}
+}

--- a/internal/tui/app_rendezvous_success_test.go
+++ b/internal/tui/app_rendezvous_success_test.go
@@ -53,10 +53,13 @@ func TestRendezvousNudgeSuccessQuotesArrivalSpeed(t *testing.T) {
 		t.Fatal("K produced no status message")
 	}
 	if strings.Contains(a.statusMsg, "rendezvous: ") {
-		// A refusal, not a plant — the fixed small-lag geometry should
-		// always plant, but if planner tuning ever changes that, this is
-		// a clearer failure than a silent false-pass below.
-		t.Skipf("K refused on this geometry (%q); not exercising the success message", a.statusMsg)
+		// A refusal, not a plant — the fixed small-lag geometry is
+		// documented (below) as deterministic and always-plantable, so a
+		// refusal here means the geometry or planner tuning drifted, not
+		// that this test's precondition is merely "not exercised" (PR
+		// #392 review finding 3: a Skipf hedge here would report PASS
+		// while covering nothing).
+		t.Fatalf("K refused on the deterministic small-lag geometry (%q); expected a plant", a.statusMsg)
 	}
 	if !strings.Contains(a.statusMsg, "arriving ~") || !strings.Contains(a.statusMsg, "m/s") {
 		t.Errorf("success status %q missing the arrival-speed info row", a.statusMsg)

--- a/internal/tui/app_rendezvous_target_restore_test.go
+++ b/internal/tui/app_rendezvous_target_restore_test.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// TestSessionRendezvousRefusalRestoresPriorTarget (PR #392 review
+// finding 2): SessionCmdRendezvous calls SetTargetGhost BEFORE
+// RendezvousCommit so the commit search has something to aim at, but a
+// refusal must not leave that switch behind. Before the fix, a refused
+// Engage silently replaced whatever the player was targeting before
+// (mid-transfer TargetBody Moon, say) with the rejected ghost ref, and
+// left it there — even though the game said no to the rendezvous
+// itself.
+func TestSessionRendezvousRefusalRestoresPriorTarget(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+
+	// Prior target: a body (the finding's own "mid-transfer TargetBody
+	// Moon" example) — deliberately NOT a craft/ghost target, so
+	// HasRelativeTarget is false and NavMode is pinned to NavOrbit,
+	// giving both fields concrete "before" values to check for.
+	w.SetTargetBody(1)
+	prevTarget := w.Target
+	prevNav := w.NavMode
+	if prevTarget.Kind != sim.TargetBody {
+		t.Fatalf("precondition: target kind = %v, want TargetBody", prevTarget.Kind)
+	}
+
+	// No ghost registered for this owner/craftID — RendezvousCommit's
+	// primary resolution fails immediately, guaranteeing a refusal
+	// without depending on any particular orbital geometry.
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:nobody", CraftID: 999, Handle: "ghost",
+	})
+	app := model.(*App)
+
+	if app.world.RendezvousArm != nil {
+		t.Fatal("precondition: refusal path must not have armed a rendezvous")
+	}
+	if app.world.Target != prevTarget {
+		t.Errorf("Target after refused Engage = %+v, want restored prior target %+v", app.world.Target, prevTarget)
+	}
+	if app.world.NavMode != prevNav {
+		t.Errorf("NavMode after refused Engage = %v, want restored prior NavMode %v", app.world.NavMode, prevNav)
+	}
+}
+
+// TestSessionRendezvousSuccessKeepsGhostTarget: the companion positive
+// case — a successful arm (RendezvousCommit ok=true) is exactly the
+// case where the target SHOULD end up pointed at the partner's ghost;
+// the restore added for finding 2 must be scoped to the refusal branch
+// only, not swallow a successful Engage's own target switch.
+func TestSessionRendezvousSuccessKeepsGhostTarget(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	w := a.world
+	w.Ghosts = []sim.Ghost{ghostBesideActive(w, "SHA256:guest", 42)}
+
+	model, _ := a.applySessionCommand(screens.SessionCommand{
+		Kind: screens.SessionCmdRendezvous, Owner: "SHA256:guest", CraftID: 42, Handle: "gern",
+	})
+	app := model.(*App)
+
+	if app.world.RendezvousArm == nil {
+		t.Fatal("expected the converging-geometry fixture to arm")
+	}
+	if app.world.Target.Kind != sim.TargetGhost || app.world.Target.GhostOwner != "SHA256:guest" {
+		t.Errorf("Target after a successful Engage = %+v, want gern's ghost", app.world.Target)
+	}
+}

--- a/internal/tui/app_rendezvous_test.go
+++ b/internal/tui/app_rendezvous_test.go
@@ -13,10 +13,17 @@ import (
 )
 
 // ghostBesideActive plants a ghost 50 km from the active craft in the
-// same primary, resolvable by the target/rendezvous machinery.
+// same primary, resolvable by the target/rendezvous machinery. The
+// velocity carries a small closing component (#276: a ghost placed with
+// the active craft's exact velocity is a matched-orbit/zero-drift
+// geometry — RendezvousCommit now correctly refuses that on the current
+// course, since no real burn was made) so a genuine current-course
+// closest approach exists within RendezvousCommit's horizon for these
+// arm/naming tests to exercise.
 func ghostBesideActive(w *sim.World, owner string, craftID uint64) sim.Ghost {
 	c := w.ActiveCraft()
 	relR := c.State.R.Add(orbital.Vec3{X: 50_000})
+	closingVel := c.State.V.Add(orbital.Vec3{X: -50})
 	return sim.Ghost{
 		Owner:     owner,
 		CraftID:   craftID,
@@ -25,7 +32,7 @@ func ghostBesideActive(w *sim.World, owner string, craftID uint64) sim.Ghost {
 		PrimaryID: c.Primary.ID,
 		Pos:       w.BodyPosition(c.Primary).Add(relR),
 		RelPos:    relR,
-		Vel:       c.State.V,
+		Vel:       closingVel,
 	}
 }
 


### PR DESCRIPTION
Fixes #276

## Cause

`RendezvousCommit` tried the K-nudge advisory (`RecommendedRendezvousBurn`) first, and when the advisory found a viable nudge it committed to *that nudge's post-burn* closest approach. But Engage (`w` on a partner's roster row) never plants the nudge — only `K` does — so two craft on matched orbits (zero relative drift, no approach on the current course) still armed a rendezvous toward an encounter the player was never actually flying toward. The current-course fallback search would have correctly refused this geometry (no closest approach before t=0), but the advisory-first ordering bypassed it entirely.

## Fix

`RendezvousCommit` now searches only the players' *current* courses (no burn assumed). A geometry that only closes via a nudge falls through to the existing "no encounter … make a phasing burn" refusal instead of silently borrowing the advisory's unfired result. `RecommendedRendezvousBurn` is untouched and still backs the HUD advisory display and `rendezvousNextWaypoint`'s fired-nudge path (confirmed still referenced from `app.go`, `input.go`, and `rendezvous.go`), so no dead code.

Also updated `ghostBesideActive` (`internal/tui/app_rendezvous_test.go`), a shared fixture used by two pre-existing tests, which placed its ghost with the active craft's *exact* velocity — itself a matched-orbit/zero-drift geometry that only ever armed because of this bug. Gave it a small radial closing velocity component so a genuine current-course closest approach exists within the commit horizon.

## Tests

- `TestRendezvousCommitMatchedOrbitsRefusesPhantomNudge` (`internal/sim/rendezvous_matched_orbit_test.go`) — confirms the advisory finds a real nudge for this geometry, then asserts `RendezvousCommit` refuses (ok=false) rather than adopting it.
- `TestEngageRendezvousSmallLagRefusesPhantomArm` (`internal/tui/app_rendezvous_matched_orbit_test.go`) — end-to-end through the Engage session command: asserts the status message points at the phasing-burn remedy and `RendezvousArm` stays nil.

Both fail against the pre-fix code and pass after (verified by stashing the fix and re-running).

## Verification

- `go vet ./...` clean
- `go test ./... -race -count=1` all green