### PR TITLE
Fix craft/rendezvous target lock dropped on server-restart reconnect

### DIFF
--- a/internal/relay/dock.go
+++ b/internal/relay/dock.go
@@ -659,8 +659,20 @@ func (l *DockLedger) reconcileOwner(w *sim.World, r *DockRecord, chips *[]DockCh
 			sim.PlaceAcrossSubspaceGap(r.transferPayload, dt)
 			r.reclaimAtNano = 0
 		}
-		w.AdoptCraft(r.transferPayload, true)
-		r.CompositeID = r.transferPayload.ID
+		// Cross-owner delivery (review finding on this transfer path,
+		// following #294 review finding 3 / finding G): this composite is
+		// landing in a DIFFERENT player's World, live, with no wire
+		// round-trip to sanitize it the way a restart-persisted handover
+		// does via save.CraftToWireForTransfer. w.AdoptCraft only remaps
+		// the craft's OWN id, not the local/ghost refs a planted node or
+		// the active burn carries against a SISTER craft in the sending
+		// world — craft IDs are dense per-World small ints, so that ref
+		// can silently resolve against an unrelated craft on this side
+		// and fire a real burn at it. Strip with the exact same logic
+		// the persistence path uses, so the two can't drift.
+		payload := spacecraft.StripCrossOwnerTargetRefs(r.transferPayload)
+		w.AdoptCraft(payload, true)
+		r.CompositeID = payload.ID
 		r.transferPayload = nil
 		*chips = append(*chips, DockChip{Kind: sim.SessionEventTransfer, Handle: r.GuestHandle})
 		return false

--- a/internal/relay/dock_cross_owner_refs_test.go
+++ b/internal/relay/dock_cross_owner_refs_test.go
@@ -1,0 +1,138 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestLiveTransferControlStripsCrossOwnerTargetRefs — review finding
+// following #294 review finding 3 / finding G: a LIVE (no-restart) control
+// transfer hands the whole migrating composite into the recipient's World
+// via w.AdoptCraft, with NO wire round-trip to sanitize it the way a
+// restart-persisted handover does through save.CraftToWireForTransfer.
+// AdoptCraft only remaps the composite's OWN id, not a local ref a planted
+// node or the craft's Target carries against a SISTER craft in the sending
+// world — craft ids are dense per-World small ints, so that ref can
+// silently resolve against an unrelated craft that happens to hold the
+// same number on the recipient's side and fire a real burn toward it.
+//
+// This exercises the exact live (same-server-lifetime) path: A docks B,
+// then transfers control to B — the composite (carrying A's docker craft's
+// own Target and a planted node bound to a SISTER craft still in A's
+// World) must land in B's World with those refs stripped.
+func TestLiveTransferControlStripsCrossOwnerTargetRefs(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 700
+	wA, wB := alignedPair(t, guestID)
+	dockerID := wA.ActiveCraft().ID
+	now := time.Now()
+
+	// A second, unrelated craft in A's World — the "sister craft" whose
+	// local ID the docker craft's own Target/node will reference. Per-World
+	// ID spaces are independent, so this same number can (and, on a real
+	// host, eventually will) belong to something else entirely in B's
+	// World.
+	sister := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	sister.Primary = wA.ActiveCraft().Primary
+	sister.State = wA.ActiveCraft().State
+	wA.AdoptCraft(sister, false)
+	sisterID := sister.ID
+
+	// Point the docker craft's own Target and a planted node at the
+	// sister craft — a bare LOCAL ref (no ghost owner), exactly the shape
+	// #294 review finding G showed a stale wire round-trip could alias.
+	wA.ActiveCraft().Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: sisterID}
+	wA.ActiveCraft().Nodes = append(wA.ActiveCraft().Nodes, spacecraft.ManeuverNode{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            10,
+		TriggerTime:   wA.Clock.SimTime.Add(time.Minute),
+		PrimaryID:     wA.ActiveCraft().Primary.ID,
+		TargetCraftID: sisterID,
+	})
+
+	// Dock, then hand control to B — live, no restart involved anywhere in
+	// this sequence.
+	ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports)
+	ledger.Reconcile(wA, fpA, reports)
+	if ok, why := ledger.RequestTransfer(fpA, allOnline); !ok {
+		t.Fatalf("RequestTransfer refused: %s", why)
+	}
+	ledger.Reconcile(wA, fpA, reports) // A migrates the stack out
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B adopts the transferred stack
+
+	if len(wB.Crafts) != 1 {
+		t.Fatalf("B did not adopt the transferred stack: %d crafts", len(wB.Crafts))
+	}
+	comp := wB.Crafts[0]
+
+	if comp.Target.Kind != spacecraft.TargetNone {
+		t.Errorf("migrated composite Target = %+v, want stripped to TargetNone (A-local craft id %d)", comp.Target, sisterID)
+	}
+	if len(comp.Nodes) != 1 {
+		t.Fatalf("migrated composite lost the node itself, not just its ref: %+v", comp.Nodes)
+	}
+	if comp.Nodes[0].TargetCraftID != 0 || comp.Nodes[0].TargetGhostOwner != "" {
+		t.Errorf("migrated composite node still targets A-local craft id %d — would fire at whatever unrelated craft holds that id in B's World", comp.Nodes[0].TargetCraftID)
+	}
+	if comp.Nodes[0].DV != 10 || comp.Nodes[0].Mode != spacecraft.BurnTargetPrograde {
+		t.Errorf("migrated composite node lost its burn geometry: %+v", comp.Nodes[0])
+	}
+}
+
+// TestLiveAbortReturnKeepsFullFidelityRefs pins the IMPORTANT carve-out
+// alongside the fix above: a live abort-return delivers the guest's own
+// craft back to the SAME owner that planted its refs — those refs stayed
+// valid the whole time and must NOT be stripped. This is
+// TestFullRecordsPreservesReturnPayloadRefs's persisted-path guarantee,
+// exercised on the live (no-restart) delivery path instead: the docker's
+// craft vanishes between Claim and handover, so the guest's craft comes
+// straight back via the abort branch's w.AdoptCraft — carrying a Target the
+// guest had set on ITS OWN craft before ever handing it over.
+func TestLiveAbortReturnKeepsFullFidelityRefs(t *testing.T) {
+	store := NewStore()
+	ledger := NewDockLedger()
+	const guestID = 701
+	wA, wB := alignedPair(t, guestID)
+	dockerID := wA.ActiveCraft().ID
+	now := time.Now()
+
+	// Give B a second craft so its guest craft can carry a LOCAL target ref
+	// that stays perfectly meaningful within B's own World.
+	sister := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	sister.Primary = wB.ActiveCraft().Primary
+	sister.State = wB.ActiveCraft().State
+	wB.AdoptCraft(sister, false)
+	sisterID := sister.ID
+	// The guest craft is B's ACTIVE craft, so its live Target lives on
+	// w.Target (checked out per-craft only on a vessel switch) — set it
+	// there, not directly on the Spacecraft struct, or RemoveCraftByID's
+	// own outgoing-target checkpoint below overwrites it with the zero
+	// value.
+	wB.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: sisterID}
+
+	ledger.Claim(fpA, "alice", dockerID, fpB, "bob", guestID)
+	reports := reportMap(store, wA, wB, now)
+	ledger.Reconcile(wB, fpB, reports) // B hands its craft over
+
+	// The docker's craft vanishes before A's tick can fuse it (staged /
+	// ended flight) — reconcileOwner's abort branch fires and hands the
+	// guest's craft straight back.
+	wA.Crafts = nil
+	ledger.Reconcile(wA, fpA, reports)
+	reports = reportMap(store, wA, wB, now.Add(time.Second))
+	ledger.Reconcile(wB, fpB, reports) // B reclaims its own craft
+
+	got, _, ok := wB.CraftByID(guestID)
+	if !ok {
+		t.Fatalf("B did not reclaim its own craft after the abort")
+	}
+	if got.Target.Kind != spacecraft.TargetCraft || got.Target.CraftID != sisterID {
+		t.Errorf("abort-return stripped a same-owner ref: Target = %+v, want it kept (%d)", got.Target, sisterID)
+	}
+}

--- a/internal/relay/dock_persist.go
+++ b/internal/relay/dock_persist.go
@@ -80,9 +80,9 @@ func (l *DockLedger) FullRecords() []DockSnapshot {
 			GuestOwner: r.GuestOwner, GuestHandle: r.GuestHandle,
 			GuestCraftID:    r.GuestCraftID,
 			Phase:           r.Phase,
-			GuestPayload:    craftToWire(r.guestPayload),
-			ReturnPayload:   craftToWire(r.returnPayload),
-			TransferPayload: craftToWire(r.transferPayload),
+			GuestPayload:    craftToWireTransfer(r.guestPayload),
+			ReturnPayload:   craftToWireSameOwner(r.returnPayload),
+			TransferPayload: craftToWireTransfer(r.transferPayload),
 			UndockAsk:       r.undockAsk,
 			UndockRefused:   r.undockRefused,
 			TransferTo:      r.transferTo,
@@ -138,22 +138,47 @@ func (l *DockLedger) SeedFull(snaps []DockSnapshot, systems []bodies.System) {
 	}
 }
 
-// craftToWire / craftFromWire adapt one parked craft to and from the save
-// package's per-craft form. Both tolerate nil (no payload parked).
+// craftToWireTransfer / craftToWireSameOwner / craftFromWire adapt one
+// parked craft to and from the save package's per-craft form. Both
+// `craftToWire*` variants tolerate nil (no payload parked).
 //
-// #294 review finding 3: this is the parcel-bound path (GuestPayload /
-// ReturnPayload / TransferPayload above), delivered into a DIFFERENT
-// player's world — so it must go through save.CraftToWireForTransfer,
-// which sanitizes ghost refs, never the plain save.CraftToWire a
-// session save/reconnect uses. Keeping the two calls syntactically
-// distinct (one wrapper each, not a shared helper with a bool flag) is
-// deliberate: it's the whole point, so the two paths can't silently
-// drift back onto the same call.
-func craftToWire(c *spacecraft.Spacecraft) *save.Craft {
+// #294 review finding 3, corrected by the second-round review finding 4:
+// NOT every parked payload crosses into a different player's world.
+// GuestPayload (guest→docker: the guest's craft being fused into the
+// DOCKER's composite) and TransferPayload (old owner→new owner on a
+// control transfer, or the stack handed over on an empty-seat reclaim)
+// really do land in someone else's World — those go through
+// save.CraftToWireForTransfer, which sanitizes ghost refs (a Target or a
+// node/burn ref that pointed at a craft on the OTHER side's slate is
+// meaningless once the craft lands on this side's). ReturnPayload is
+// different: reconcileGuest always dispatches it back into the world of
+// the session matching r.GuestOwner — the SAME owner who originally
+// contributed the craft, whether via an abort (the guest's own pre-dock
+// craft, parked verbatim and handed straight back), an undock, or a
+// release (both split fresh off the composite). Sanitizing THAT payload
+// strips a Target and node/burn refs that stayed perfectly valid the
+// whole time — AdoptCraft only ever restamps the incoming craft's own
+// ID, so any local ref to a SISTER craft in the same (guest's) slate
+// survives the round trip untouched. ReturnPayload goes through the
+// plain save.CraftToWire a session save/reconnect uses instead.
+//
+// Keeping the two wrappers syntactically distinct (one call each, not a
+// shared helper with a bool flag) is deliberate: it's the whole point,
+// so the three payload paths can't silently drift back onto the same
+// call as this ages.
+func craftToWireTransfer(c *spacecraft.Spacecraft) *save.Craft {
 	if c == nil {
 		return nil
 	}
 	wc := save.CraftToWireForTransfer(c)
+	return &wc
+}
+
+func craftToWireSameOwner(c *spacecraft.Spacecraft) *save.Craft {
+	if c == nil {
+		return nil
+	}
+	wc := save.CraftToWire(c)
 	return &wc
 }
 

--- a/internal/relay/dock_persist.go
+++ b/internal/relay/dock_persist.go
@@ -140,11 +140,20 @@ func (l *DockLedger) SeedFull(snaps []DockSnapshot, systems []bodies.System) {
 
 // craftToWire / craftFromWire adapt one parked craft to and from the save
 // package's per-craft form. Both tolerate nil (no payload parked).
+//
+// #294 review finding 3: this is the parcel-bound path (GuestPayload /
+// ReturnPayload / TransferPayload above), delivered into a DIFFERENT
+// player's world — so it must go through save.CraftToWireForTransfer,
+// which sanitizes ghost refs, never the plain save.CraftToWire a
+// session save/reconnect uses. Keeping the two calls syntactically
+// distinct (one wrapper each, not a shared helper with a bool flag) is
+// deliberate: it's the whole point, so the two paths can't silently
+// drift back onto the same call.
 func craftToWire(c *spacecraft.Spacecraft) *save.Craft {
 	if c == nil {
 		return nil
 	}
-	wc := save.CraftToWire(c)
+	wc := save.CraftToWireForTransfer(c)
 	return &wc
 }
 

--- a/internal/relay/dock_persist_ghost_sanitize_test.go
+++ b/internal/relay/dock_persist_ghost_sanitize_test.go
@@ -124,3 +124,93 @@ func TestSeedFullDeliversSanitizedPayload(t *testing.T) {
 		t.Errorf("restored payload ActiveBurn still carries a ghost ref: %+v", ab)
 	}
 }
+
+// TestFullRecordsStripsGhostRefsFromTransferPayload — same shape as
+// TestFullRecordsStripsGhostRefsFromParkedPayload, for TransferPayload:
+// a control transfer (or an empty-seat reclaim, GrantReclaim) hands the
+// whole migrating stack to a DIFFERENT owner's world, so it must go
+// through the same sanitized wire form GuestPayload does (#294
+// second-round review finding 4 — this direction of the fix was
+// already correct; this test pins it against a future regression).
+func TestFullRecordsStripsGhostRefsFromTransferPayload(t *testing.T) {
+	ledger := NewDockLedger()
+	c := ghostBoundParkedCraft(t)
+	ledger.mu.Lock()
+	ledger.records[1] = &DockRecord{ID: 1, Owner: fpA, GuestOwner: fpB, transferPayload: c}
+	ledger.nextID = 2
+	ledger.mu.Unlock()
+
+	snaps := ledger.FullRecords()
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	tp := snaps[0].TransferPayload
+	if tp == nil {
+		t.Fatal("TransferPayload lost entirely")
+	}
+	if tp.Target != nil {
+		t.Errorf("transfer payload Target = %+v, want nil (ghost target dropped outright)", tp.Target)
+	}
+	if len(tp.Nodes) != 1 || tp.Nodes[0].TargetGhostOwner != "" || tp.Nodes[0].TargetCraftID != 0 {
+		t.Errorf("transfer payload node ref not stripped: %+v", tp.Nodes)
+	}
+	if tp.ActiveBurn == nil || tp.ActiveBurn.TargetGhostOwner != "" || tp.ActiveBurn.TargetCraftID != 0 {
+		t.Errorf("transfer payload ActiveBurn ref not stripped: %+v", tp.ActiveBurn)
+	}
+}
+
+// TestFullRecordsPreservesReturnPayloadRefs — #294 second-round review
+// finding 4. Unlike GuestPayload/TransferPayload, ReturnPayload never
+// crosses into a different player's world: reconcileGuest always
+// dispatches it back into the world of the session matching
+// r.GuestOwner — the SAME owner who originally contributed the craft,
+// whether via an abort-return (the guest's own pre-dock craft, parked
+// verbatim), an undock, or a release. Sanitizing it (the pre-fix
+// behaviour, sharing GuestPayload's CraftToWireForTransfer call) would
+// strip a Target and node/burn refs that stayed perfectly valid the
+// whole time — AdoptCraft only restamps the incoming craft's own ID, so
+// a local ref to a SISTER craft in the guest's own slate survives
+// untouched. FullRecords must round-trip ReturnPayload at full
+// fidelity via the plain save.CraftToWire instead.
+func TestFullRecordsPreservesReturnPayloadRefs(t *testing.T) {
+	ledger := NewDockLedger()
+	c := ghostBoundParkedCraft(t)
+	ledger.mu.Lock()
+	ledger.records[1] = &DockRecord{ID: 1, Owner: fpA, GuestOwner: fpB, returnPayload: c}
+	ledger.nextID = 2
+	ledger.mu.Unlock()
+
+	snaps := ledger.FullRecords()
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	rp := snaps[0].ReturnPayload
+	if rp == nil {
+		t.Fatal("ReturnPayload lost entirely")
+	}
+	if rp.Target == nil || rp.Target.Kind != int(spacecraft.TargetGhost) || rp.Target.GhostOwner != fpA {
+		t.Errorf("return payload lost its valid ghost Target: %+v", rp.Target)
+	}
+	if len(rp.Nodes) != 1 || rp.Nodes[0].TargetGhostOwner != fpA || rp.Nodes[0].TargetCraftID != 987654 {
+		t.Errorf("return payload node ref stripped, want preserved: %+v", rp.Nodes)
+	}
+	if rp.ActiveBurn == nil || rp.ActiveBurn.TargetGhostOwner != fpA || rp.ActiveBurn.TargetCraftID != 987654 {
+		t.Errorf("return payload ActiveBurn ref stripped, want preserved: %+v", rp.ActiveBurn)
+	}
+
+	// The restart round trip: rehydrating must still see the refs.
+	fresh := NewDockLedger()
+	fresh.SeedFull(snaps, loadedSystems(t))
+	fresh.mu.Lock()
+	rec := fresh.records[1]
+	fresh.mu.Unlock()
+	if rec == nil || rec.returnPayload == nil {
+		t.Fatal("returnPayload lost across the restart round trip")
+	}
+	if rec.returnPayload.Target.Kind != spacecraft.TargetGhost || rec.returnPayload.Target.GhostOwner != fpA {
+		t.Errorf("restored return payload lost its ghost Target: %+v", rec.returnPayload.Target)
+	}
+	if len(rec.returnPayload.Nodes) != 1 || rec.returnPayload.Nodes[0].TargetGhostOwner != fpA {
+		t.Errorf("restored return payload lost its node ref: %+v", rec.returnPayload.Nodes)
+	}
+}

--- a/internal/relay/dock_persist_ghost_sanitize_test.go
+++ b/internal/relay/dock_persist_ghost_sanitize_test.go
@@ -1,0 +1,126 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// ghostBoundParkedCraft builds a craft carrying a ghost ref on Target, a
+// planted node, and the active burn — standing in for a guest craft
+// whose node/target is aimed at the HOST's own ghost right before it
+// gets parked on a dock record for delivery into the host's world.
+func ghostBoundParkedCraft(t *testing.T) *spacecraft.Spacecraft {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Target = spacecraft.Target{Kind: spacecraft.TargetGhost, CraftID: 987654, GhostOwner: fpA}
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		Mode:             spacecraft.BurnTarget,
+		DV:               42,
+		TriggerTime:      w.Clock.SimTime.Add(time.Minute),
+		PrimaryID:        c.Primary.ID,
+		TargetGhostOwner: fpA,
+		TargetCraftID:    987654,
+	})
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      15,
+		EndTime:          w.Clock.SimTime.Add(30 * time.Second),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: fpA,
+		TargetCraftID:    987654,
+	}
+	return c
+}
+
+// TestFullRecordsStripsGhostRefsFromParkedPayload — #294 review finding
+// 3. A parked craft on a dock record (GuestPayload / ReturnPayload /
+// TransferPayload, ADR 0040) is delivered into a DIFFERENT player's
+// world across a restart, where (owner, craftID) can never resolve and
+// can even alias the RECIPIENT's own fingerprint. FullRecords must go
+// through the sanitized wire form, not the plain session one — the
+// craft itself (mass, position, burn geometry) must still round-trip
+// intact.
+func TestFullRecordsStripsGhostRefsFromParkedPayload(t *testing.T) {
+	ledger := NewDockLedger()
+	c := ghostBoundParkedCraft(t)
+	ledger.mu.Lock()
+	ledger.records[1] = &DockRecord{ID: 1, Owner: fpA, GuestOwner: fpB, guestPayload: c}
+	ledger.nextID = 2
+	ledger.mu.Unlock()
+
+	snaps := ledger.FullRecords()
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	gp := snaps[0].GuestPayload
+	if gp == nil {
+		t.Fatal("GuestPayload lost entirely")
+	}
+	if gp.Target != nil {
+		t.Errorf("parked payload Target = %+v, want nil (ghost target dropped outright)", gp.Target)
+	}
+	if len(gp.Nodes) != 1 {
+		t.Fatalf("parked payload lost the node itself: %+v", gp.Nodes)
+	}
+	if gp.Nodes[0].TargetGhostOwner != "" || gp.Nodes[0].TargetCraftID != 0 {
+		t.Errorf("parked payload node ref = %+v, want the ghost ref stripped", gp.Nodes[0])
+	}
+	if gp.Nodes[0].DV != 42 {
+		t.Errorf("parked payload node lost its Δv: %+v", gp.Nodes[0])
+	}
+	if gp.ActiveBurn == nil {
+		t.Fatal("parked payload lost the active burn itself")
+	}
+	if gp.ActiveBurn.TargetGhostOwner != "" || gp.ActiveBurn.TargetCraftID != 0 {
+		t.Errorf("parked payload ActiveBurn ref = %+v, want the ghost ref stripped", gp.ActiveBurn)
+	}
+	if gp.ActiveBurn.DVRemaining != 15 {
+		t.Errorf("parked payload ActiveBurn lost its DVRemaining: %+v", gp.ActiveBurn)
+	}
+	if gp.M != c.State.M {
+		t.Errorf("parked payload lost craft mass: got %v want %v", gp.M, c.State.M)
+	}
+}
+
+// TestSeedFullDeliversSanitizedPayload — the restart round trip: a
+// ghost-bound parked craft survives FullRecords -> SeedFull with the
+// craft intact and the ghost refs gone, matching a fresh ledger built
+// straight from a sanitized snapshot (no ghost ref ever reaches
+// craftFromWire to rehydrate in the first place).
+func TestSeedFullDeliversSanitizedPayload(t *testing.T) {
+	ledger := NewDockLedger()
+	c := ghostBoundParkedCraft(t)
+	ledger.mu.Lock()
+	ledger.records[1] = &DockRecord{ID: 1, Owner: fpA, GuestOwner: fpB, guestPayload: c}
+	ledger.nextID = 2
+	ledger.mu.Unlock()
+
+	fresh := NewDockLedger()
+	fresh.SeedFull(ledger.FullRecords(), loadedSystems(t))
+
+	fresh.mu.Lock()
+	rec := fresh.records[1]
+	fresh.mu.Unlock()
+	if rec == nil || rec.guestPayload == nil {
+		t.Fatal("guestPayload lost across the restart round trip")
+	}
+	if rec.guestPayload.Target.Kind == spacecraft.TargetGhost {
+		t.Errorf("restored payload still carries a ghost Target: %+v", rec.guestPayload.Target)
+	}
+	for _, n := range rec.guestPayload.Nodes {
+		if n.TargetGhostOwner != "" {
+			t.Errorf("restored payload node still carries a ghost ref: %+v", n)
+		}
+	}
+	if ab := rec.guestPayload.ActiveBurn; ab != nil && ab.TargetGhostOwner != "" {
+		t.Errorf("restored payload ActiveBurn still carries a ghost ref: %+v", ab)
+	}
+}

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -138,15 +138,26 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 	// no target so untargeted craft still write out the same minimal JSON
 	// they did pre-polish.
 	//
-	// Ghost targets (v0.27) are session-local — the owner fingerprint isn't
-	// persisted, so a saved ghost ref could never resolve again. Normalise
-	// to no-target instead of writing a permanently-stuck Kind (also keeps
-	// the persisted Kind vocabulary at its pre-v0.27 range — no schema bump).
-	if c.Target.Kind != spacecraft.TargetNone && c.Target.Kind != spacecraft.TargetGhost {
+	// Ghost targets (v0.27) used to be normalised to no-target here on the
+	// reasoning that they're session-local and the owner fingerprint was
+	// never persisted, so a saved ref could never resolve again. That
+	// silently dropped a guest's cross-player rendezvous lock across every
+	// reconnect that round-trips through the per-player session payload —
+	// most visibly the [u] restart-to-adopt flow (#294) — while a body
+	// target survived the same reconnect untouched. The fingerprint IS
+	// meaningful within the session it was set in: persist it, and let the
+	// ordinary "ghost not resolvable yet" tolerance every ghost-target
+	// consumer already has (ResolveTargetGhost / TargetState / HUD) do the
+	// re-latching once the owner's craft reports resume. A standalone save
+	// loaded outside that session (or in single-player, which never sets a
+	// ghost target) just carries a ref that never resolves — inert, same
+	// as any other stale target.
+	if c.Target.Kind != spacecraft.TargetNone {
 		wc.Target = &Target{
-			Kind:    int(c.Target.Kind),
-			BodyIdx: c.Target.BodyIdx,
-			CraftID: c.Target.CraftID,
+			Kind:       int(c.Target.Kind),
+			BodyIdx:    c.Target.BodyIdx,
+			CraftID:    c.Target.CraftID,
+			GhostOwner: c.Target.GhostOwner,
 		}
 	}
 	return wc
@@ -316,12 +327,16 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 	}
 	// v0.9.3 polish: per-craft Target. Pre-polish saves omit the field; nil
 	// pointer leaves the craft's Target at zero (TargetNone) which is the
-	// fresh-craft default.
+	// fresh-craft default. GhostOwner (#294) round-trips a TargetGhost's
+	// remote-player fingerprint; absent on every save predating the fix,
+	// which decodes to "" — harmless since those saves never wrote
+	// Kind==TargetGhost in the first place (it was normalised away).
 	if wc.Target != nil {
 		c.Target = spacecraft.Target{
-			Kind:    spacecraft.TargetKind(wc.Target.Kind),
-			BodyIdx: wc.Target.BodyIdx,
-			CraftID: wc.Target.CraftID,
+			Kind:       spacecraft.TargetKind(wc.Target.Kind),
+			BodyIdx:    wc.Target.BodyIdx,
+			CraftID:    wc.Target.CraftID,
+			GhostOwner: wc.Target.GhostOwner,
 		}
 	}
 	return c, nil

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -181,34 +181,43 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 }
 
 // CraftToWireForTransfer projects one live craft onto its serialisable
-// form exactly like CraftToWire, then strips every ghost ref (Target,
-// planted nodes, the active burn) before returning it. #294 review
-// finding 3: a ghost ref is a (owner fingerprint, remote craft ID) pair
-// meaningful only within the player's OWN world — relay.GhostsFor never
-// emits a player's own craft as a ghost to itself, so the pair can never
-// resolve anywhere else. CraftToWire round-tripping it is correct for a
-// session save/reconnect, which stays within that same world. It is
-// wrong for the dock ledger's parcel/return/transfer payloads (ADR
-// 0040, internal/relay/dock_persist.go): those are delivered into a
-// DIFFERENT player's world, where the ref can never resolve and — worse
-// — can alias the RECIPIENT's own fingerprint (a guest craft carrying a
-// node targeted at the HOST's ghost, transferred into the host's own
-// world, now holds the host's own fingerprint as a "remote" ref). Local
-// craft refs (TargetGhostOwner == "") are untouched — those are a
-// different craft in the SAME world and resolve or refuse exactly as
-// any local ref already does.
+// form exactly like CraftToWire, then strips every target-relative ref
+// (Target, planted nodes, the active burn) before returning it — both
+// ghost refs AND local craft refs. #294 review finding 3: a ghost ref is
+// a (owner fingerprint, remote craft ID) pair meaningful only within the
+// player's OWN world — relay.GhostsFor never emits a player's own craft
+// as a ghost to itself, so the pair can never resolve anywhere else.
+// CraftToWire round-tripping it is correct for a session save/
+// reconnect, which stays within that same world. It is wrong for the
+// dock ledger's parcel/return/transfer payloads (ADR 0040, internal/
+// relay/dock_persist.go): those are delivered into a DIFFERENT player's
+// world, where the ref can never resolve and — worse — can alias the
+// RECIPIENT's own fingerprint (a guest craft carrying a node targeted at
+// the HOST's ghost, transferred into the host's own world, now holds
+// the host's own fingerprint as a "remote" ref).
+//
+// #294 review round 3 (finding G): a LOCAL ref (TargetGhostOwner=="")
+// is just as unsafe here, for a different reason — w.AdoptCraft remaps
+// only the transferred craft's OWN id, not the TargetCraftID a node or
+// the active burn on it points at. A node targeting the sender's SISTER
+// craft (a different local craft in the sender's own world) transfers
+// with that sender-local id intact, and in the recipient's world that
+// same numeric id belongs to whatever unrelated vessel happens to hold
+// it — the node then resolves against, and fires at, a craft the player
+// never chose. Both kinds of ref are equally meaningless once the craft
+// leaves the world it was planned in, so both are stripped.
 func CraftToWireForTransfer(c *spacecraft.Spacecraft) Craft {
 	wc := CraftToWire(c)
-	if wc.Target != nil && wc.Target.Kind == int(spacecraft.TargetGhost) {
+	if wc.Target != nil && (wc.Target.Kind == int(spacecraft.TargetGhost) || wc.Target.Kind == int(spacecraft.TargetCraft)) {
 		wc.Target = nil
 	}
 	for i := range wc.Nodes {
-		if wc.Nodes[i].TargetGhostOwner != "" {
+		if wc.Nodes[i].TargetCraftID != 0 {
 			wc.Nodes[i].TargetGhostOwner = ""
 			wc.Nodes[i].TargetCraftID = 0
 		}
 	}
-	if wc.ActiveBurn != nil && wc.ActiveBurn.TargetGhostOwner != "" {
+	if wc.ActiveBurn != nil && wc.ActiveBurn.TargetCraftID != 0 {
 		wc.ActiveBurn.TargetGhostOwner = ""
 		wc.ActiveBurn.TargetCraftID = 0
 	}
@@ -377,6 +386,26 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			PlaneChangeRad:   wc.ActiveBurn.PlaneChangeRad,
 			BurnDirUnit:      vec3To(wc.ActiveBurn.BurnDirUnit),
 			TargetGhostOwner: wc.ActiveBurn.TargetGhostOwner, // #294 review finding 5
+		}
+		// #294 review round 3 (finding D): defensive load-time teardown for
+		// an ActiveBurn that is target-relative in Mode but carries no
+		// target at all (TargetCraftID==0, ownerless). This is exactly the
+		// shape a pre-round-3 give-up used to leave behind (it stripped the
+		// ref but kept the burn "alive") — and, independently, exactly the
+		// shape a v9 save (schema < 10, before CraftToWire started
+		// preserving ghost refs) carries for a craft that was saved
+		// mid-ghost-burn: the old wire form dropped the ref unconditionally
+		// while keeping the burn. migrateV9PayloadToV10 is an identity
+		// transform, so that shape reaches here unchanged on load. Either
+		// way, nodeTargetRelState refuses unconditionally for craftID==0,
+		// so a target-relative burn with no ref can never resolve, never
+		// thrust, and never tear itself down (burnExhausted's fuel-present-
+		// but-EndTime-never-reached hold is permanent) — a zombie burn that
+		// wedges canKeplerStep's per-craft gate and clamps warp ≤10× for
+		// the rest of the session. Tear it down here instead of letting it
+		// load in that state.
+		if spacecraft.IsTargetRelativeMode(c.ActiveBurn.Mode) && c.ActiveBurn.TargetCraftID == 0 {
+			c.ActiveBurn = nil
 		}
 	}
 	// v0.9.3 polish: per-craft Target. Pre-polish saves omit the field; nil

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -180,6 +180,41 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 	return wc
 }
 
+// CraftToWireForTransfer projects one live craft onto its serialisable
+// form exactly like CraftToWire, then strips every ghost ref (Target,
+// planted nodes, the active burn) before returning it. #294 review
+// finding 3: a ghost ref is a (owner fingerprint, remote craft ID) pair
+// meaningful only within the player's OWN world — relay.GhostsFor never
+// emits a player's own craft as a ghost to itself, so the pair can never
+// resolve anywhere else. CraftToWire round-tripping it is correct for a
+// session save/reconnect, which stays within that same world. It is
+// wrong for the dock ledger's parcel/return/transfer payloads (ADR
+// 0040, internal/relay/dock_persist.go): those are delivered into a
+// DIFFERENT player's world, where the ref can never resolve and — worse
+// — can alias the RECIPIENT's own fingerprint (a guest craft carrying a
+// node targeted at the HOST's ghost, transferred into the host's own
+// world, now holds the host's own fingerprint as a "remote" ref). Local
+// craft refs (TargetGhostOwner == "") are untouched — those are a
+// different craft in the SAME world and resolve or refuse exactly as
+// any local ref already does.
+func CraftToWireForTransfer(c *spacecraft.Spacecraft) Craft {
+	wc := CraftToWire(c)
+	if wc.Target != nil && wc.Target.Kind == int(spacecraft.TargetGhost) {
+		wc.Target = nil
+	}
+	for i := range wc.Nodes {
+		if wc.Nodes[i].TargetGhostOwner != "" {
+			wc.Nodes[i].TargetGhostOwner = ""
+			wc.Nodes[i].TargetCraftID = 0
+		}
+	}
+	if wc.ActiveBurn != nil && wc.ActiveBurn.TargetGhostOwner != "" {
+		wc.ActiveBurn.TargetGhostOwner = ""
+		wc.ActiveBurn.TargetCraftID = 0
+	}
+	return wc
+}
+
 // CraftFromWire rehydrates one wire craft against the loaded systems. It
 // is the exact per-craft body worldFromPayload runs, including every
 // backfill older envelopes rely on (RCS loadout, single-stage migration,

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -20,10 +20,14 @@ import (
 
 // CraftToWire projects one live craft onto its serialisable form. It is
 // the exact per-craft body payloadFromWorld runs, so anything a save
-// carries a Parcel carries too. Ghost refs on nodes / the active burn are
-// dropped (their owner fingerprint is not persisted and their craft IDs
-// are remote), and a ghost Target normalises to no-target — both on
-// copies, so the live craft is untouched.
+// carries a Parcel carries too. Ghost refs on nodes, the active burn, and
+// the craft's Target all round-trip (#294 review finding 5 retired the
+// old drop-on-save behavior below the Nodes/ActiveBurn loops — see the
+// comment there and on Target below): the owner fingerprint IS meaningful
+// within the session it was set in, and a reconnect that re-latches
+// Craft.Target back onto a ghost should re-latch a planted node's or a
+// running burn's ref onto the same ghost too, not leave them silently
+// zeroed while the standing lock recovers around them.
 func CraftToWire(c *spacecraft.Spacecraft) Craft {
 	if c == nil {
 		return Craft{}
@@ -95,43 +99,56 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 		if !n.TriggerTime.IsZero() {
 			trigNano = n.TriggerTime.UnixNano()
 		}
-		// v0.28 S4: a node planted against a ghost (remote player's craft)
-		// drops its ghost ref on save — the owner fingerprint isn't
-		// persisted, and its TargetCraftID is a REMOTE id that would collide
-		// with a local id on load. DropGhostRef zeroes both while keeping the
-		// burn geometry. No-op for local / untargeted nodes. Mirrors the
-		// ghost-target normalisation below. n is a copy, so this doesn't
-		// mutate the live world.
-		n.DropGhostRef()
+		// #294 review finding 5: a node planted against a ghost (remote
+		// player's craft) used to drop its ghost ref unconditionally on
+		// save (DropGhostRef, v0.28 S4) — reasoned at the time that the
+		// owner fingerprint was session-local and the TargetCraftID a
+		// REMOTE id that could collide with a local id on load. That
+		// reasoning is exactly what #294 already overturned for
+		// Craft.Target (see below): the fingerprint round-trips fine
+		// within the session it was bound in, and TargetCraftID was
+		// never at risk of a local collision — ghost refs are only ever
+		// resolved by (owner, craftID) pair (World.ghostByRef), never by
+		// craftID alone, so a same-numbered LOCAL craft ID is never
+		// confused with one. Dropping the ref here left a stale-but-
+		// silent gap: Craft.Target re-latches onto the peer after a
+		// reconnect, but a node planted at that same target fires with
+		// TargetGhostOwner=="" and a now-locally-meaningless
+		// TargetCraftID — nodeTargetRelState's owner!="" branch never
+		// even runs, so it falls to the local craftByID branch and
+		// (almost always) fails to find a matching local craft, ok=false.
+		// See executeDueNodesFor below for the refuse-to-fire guard that
+		// makes that failure safe rather than a burn against a zero state.
 		wc.Nodes = append(wc.Nodes, Node{
-			ID:              n.ID,
-			TriggerTimeNano: trigNano,
-			Mode:            int(n.Mode),
-			DV:              n.DV,
-			DurationNano:    int64(n.Duration),
-			PrimaryID:       n.PrimaryID,
-			Event:           int(n.Event),
-			Throttle:        n.Throttle,
-			TargetCraftID:   n.TargetCraftID,
-			PlaneChangeRad:  n.PlaneChangeRad,
-			BurnDirUnit:     vec3From(n.BurnDirUnit),
-			AdvisoryKey:     n.AdvisoryKey,
+			ID:               n.ID,
+			TriggerTimeNano:  trigNano,
+			Mode:             int(n.Mode),
+			DV:               n.DV,
+			DurationNano:     int64(n.Duration),
+			PrimaryID:        n.PrimaryID,
+			Event:            int(n.Event),
+			Throttle:         n.Throttle,
+			TargetCraftID:    n.TargetCraftID,
+			PlaneChangeRad:   n.PlaneChangeRad,
+			BurnDirUnit:      vec3From(n.BurnDirUnit),
+			AdvisoryKey:      n.AdvisoryKey,
+			TargetGhostOwner: n.TargetGhostOwner,
 		})
 	}
 	if c.ActiveBurn != nil {
-		// v0.28 S4: drop a ghost ref on a running burn for the same reason as
-		// nodes above — the copy keeps the live burn intact.
+		// #294 review finding 5: preserve the running burn's ghost ref too,
+		// for the same reason as nodes above.
 		ab := *c.ActiveBurn
-		ab.DropGhostRef()
 		wc.ActiveBurn = &ActiveBurn{
-			Mode:           int(ab.Mode),
-			DVRemaining:    ab.DVRemaining,
-			EndTimeNano:    ab.EndTime.UnixNano(),
-			PrimaryID:      ab.PrimaryID,
-			Throttle:       ab.Throttle,
-			TargetCraftID:  ab.TargetCraftID,
-			PlaneChangeRad: ab.PlaneChangeRad,
-			BurnDirUnit:    vec3From(ab.BurnDirUnit),
+			Mode:             int(ab.Mode),
+			DVRemaining:      ab.DVRemaining,
+			EndTimeNano:      ab.EndTime.UnixNano(),
+			PrimaryID:        ab.PrimaryID,
+			Throttle:         ab.Throttle,
+			TargetCraftID:    ab.TargetCraftID,
+			PlaneChangeRad:   ab.PlaneChangeRad,
+			BurnDirUnit:      vec3From(ab.BurnDirUnit),
+			TargetGhostOwner: ab.TargetGhostOwner,
 		}
 	}
 	// v0.9.3 polish: per-craft Target. Skip serialising when the craft has
@@ -299,30 +316,32 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			trig = time.Unix(0, n.TriggerTimeNano).UTC()
 		}
 		c.Nodes = append(c.Nodes, sim.ManeuverNode{
-			ID:             n.ID,
-			TriggerTime:    trig,
-			Mode:           spacecraft.BurnMode(n.Mode),
-			DV:             n.DV,
-			Duration:       time.Duration(n.DurationNano),
-			PrimaryID:      n.PrimaryID,
-			Event:          sim.TriggerEvent(n.Event),
-			Throttle:       n.Throttle,
-			TargetCraftID:  n.TargetCraftID,
-			PlaneChangeRad: n.PlaneChangeRad,
-			BurnDirUnit:    vec3To(n.BurnDirUnit),
-			AdvisoryKey:    n.AdvisoryKey,
+			ID:               n.ID,
+			TriggerTime:      trig,
+			Mode:             spacecraft.BurnMode(n.Mode),
+			DV:               n.DV,
+			Duration:         time.Duration(n.DurationNano),
+			PrimaryID:        n.PrimaryID,
+			Event:            sim.TriggerEvent(n.Event),
+			Throttle:         n.Throttle,
+			TargetCraftID:    n.TargetCraftID,
+			PlaneChangeRad:   n.PlaneChangeRad,
+			BurnDirUnit:      vec3To(n.BurnDirUnit),
+			AdvisoryKey:      n.AdvisoryKey,
+			TargetGhostOwner: n.TargetGhostOwner, // #294 review finding 5
 		})
 	}
 	if wc.ActiveBurn != nil {
 		c.ActiveBurn = &sim.ActiveBurn{
-			Mode:           spacecraft.BurnMode(wc.ActiveBurn.Mode),
-			DVRemaining:    wc.ActiveBurn.DVRemaining,
-			EndTime:        time.Unix(0, wc.ActiveBurn.EndTimeNano).UTC(),
-			PrimaryID:      wc.ActiveBurn.PrimaryID,
-			Throttle:       wc.ActiveBurn.Throttle,
-			TargetCraftID:  wc.ActiveBurn.TargetCraftID,
-			PlaneChangeRad: wc.ActiveBurn.PlaneChangeRad,
-			BurnDirUnit:    vec3To(wc.ActiveBurn.BurnDirUnit),
+			Mode:             spacecraft.BurnMode(wc.ActiveBurn.Mode),
+			DVRemaining:      wc.ActiveBurn.DVRemaining,
+			EndTime:          time.Unix(0, wc.ActiveBurn.EndTimeNano).UTC(),
+			PrimaryID:        wc.ActiveBurn.PrimaryID,
+			Throttle:         wc.ActiveBurn.Throttle,
+			TargetCraftID:    wc.ActiveBurn.TargetCraftID,
+			PlaneChangeRad:   wc.ActiveBurn.PlaneChangeRad,
+			BurnDirUnit:      vec3To(wc.ActiveBurn.BurnDirUnit),
+			TargetGhostOwner: wc.ActiveBurn.TargetGhostOwner, // #294 review finding 5
 		}
 	}
 	// v0.9.3 polish: per-craft Target. Pre-polish saves omit the field; nil

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -206,22 +206,13 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 // it — the node then resolves against, and fires at, a craft the player
 // never chose. Both kinds of ref are equally meaningless once the craft
 // leaves the world it was planned in, so both are stripped.
+//
+// The stripping itself is spacecraft.StripCrossOwnerTargetRefs — shared with
+// the live (no-restart) dock-ledger delivery path in internal/relay, so the
+// persisted and live paths can't drift apart on which refs count as
+// target-relative.
 func CraftToWireForTransfer(c *spacecraft.Spacecraft) Craft {
-	wc := CraftToWire(c)
-	if wc.Target != nil && (wc.Target.Kind == int(spacecraft.TargetGhost) || wc.Target.Kind == int(spacecraft.TargetCraft)) {
-		wc.Target = nil
-	}
-	for i := range wc.Nodes {
-		if wc.Nodes[i].TargetCraftID != 0 {
-			wc.Nodes[i].TargetGhostOwner = ""
-			wc.Nodes[i].TargetCraftID = 0
-		}
-	}
-	if wc.ActiveBurn != nil && wc.ActiveBurn.TargetCraftID != 0 {
-		wc.ActiveBurn.TargetGhostOwner = ""
-		wc.ActiveBurn.TargetCraftID = 0
-	}
-	return wc
+	return CraftToWire(spacecraft.StripCrossOwnerTargetRefs(c))
 }
 
 // CraftFromWire rehydrates one wire craft against the loaded systems. It

--- a/internal/save/craft_wire_transfer_test.go
+++ b/internal/save/craft_wire_transfer_test.go
@@ -95,15 +95,24 @@ func TestCraftToWireForTransferStripsGhostRefs(t *testing.T) {
 	}
 }
 
-// TestCraftToWireForTransferLeavesLocalRefsAlone — a LOCAL craft ref
-// (no ghost owner) is a different craft in the SAME world; the
-// transfer sanitizer must not touch it.
-func TestCraftToWireForTransferLeavesLocalRefsAlone(t *testing.T) {
+// TestCraftToWireForTransferStripsLocalRefsToo — #294 review round 3
+// finding G. A LOCAL craft ref (no ghost owner) is just as unsafe to
+// carry across a dock-ledger transfer as a ghost ref, for a different
+// reason: w.AdoptCraft remaps only the TRANSFERRED craft's own id, not
+// the TargetCraftID a node (or the active burn) on it points at. A node
+// planted against the sender's SISTER craft transfers with that
+// sender-local id intact, and in the recipient's world the same numeric
+// id belongs to whatever unrelated vessel happens to hold it — the
+// node then fires at a craft the player never chose. The sanitizer must
+// strip local refs (Target, nodes, active burn) exactly like ghost
+// refs, leaving the burn geometry (Δv, mode) untouched.
+func TestCraftToWireForTransferStripsLocalRefsToo(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	c := w.ActiveCraft()
+	c.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: 12345}
 	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
 		Mode:          spacecraft.BurnTargetPrograde,
 		DV:            10,
@@ -111,10 +120,65 @@ func TestCraftToWireForTransferLeavesLocalRefsAlone(t *testing.T) {
 		PrimaryID:     c.Primary.ID,
 		TargetCraftID: 12345, // local ref, no ghost owner
 	})
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DVRemaining:   20,
+		EndTime:       w.Clock.SimTime.Add(30 * time.Second),
+		PrimaryID:     c.Primary.ID,
+		Throttle:      1,
+		TargetCraftID: 12345, // local ref
+	}
 
 	wc := CraftToWireForTransfer(c)
 
-	if len(wc.Nodes) != 1 || wc.Nodes[0].TargetCraftID != 12345 {
-		t.Errorf("local node ref touched by the ghost sanitizer: %+v", wc.Nodes)
+	if wc.Target != nil {
+		t.Errorf("transfer wire Target = %+v, want nil (local target dropped too)", wc.Target)
+	}
+	if len(wc.Nodes) != 1 {
+		t.Fatalf("transfer wire lost the node itself, not just its ref: %+v", wc.Nodes)
+	}
+	if wc.Nodes[0].TargetCraftID != 0 || wc.Nodes[0].TargetGhostOwner != "" {
+		t.Errorf("local node ref survived the transfer sanitizer: %+v", wc.Nodes[0])
+	}
+	if wc.Nodes[0].DV != 10 || wc.Nodes[0].Mode != int(spacecraft.BurnTargetPrograde) {
+		t.Errorf("transfer wire node lost its burn geometry: %+v", wc.Nodes[0])
+	}
+	if wc.ActiveBurn == nil {
+		t.Fatal("transfer wire lost the active burn itself, not just its ref")
+	}
+	if wc.ActiveBurn.TargetCraftID != 0 || wc.ActiveBurn.TargetGhostOwner != "" {
+		t.Errorf("local ActiveBurn ref survived the transfer sanitizer: %+v", wc.ActiveBurn)
+	}
+	if wc.ActiveBurn.DVRemaining != 20 {
+		t.Errorf("transfer wire ActiveBurn lost its DVRemaining: %+v", wc.ActiveBurn)
+	}
+}
+
+// TestCraftToWireForTransferLeavesUntargetedFieldsAlone — the
+// sanitizer must be surgical: a craft carrying no target-relative refs
+// at all round-trips through the transfer path exactly like the plain
+// session path, and an untargeted node's non-target fields are
+// untouched.
+func TestCraftToWireForTransferLeavesUntargetedFieldsAlone(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: 1}
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          10,
+		TriggerTime: w.Clock.SimTime.Add(time.Minute),
+		PrimaryID:   c.Primary.ID,
+	})
+
+	wc := CraftToWireForTransfer(c)
+
+	if wc.Target == nil || wc.Target.Kind != int(spacecraft.TargetBody) || wc.Target.BodyIdx != 1 {
+		t.Errorf("untargeted-relative body target dropped by the transfer sanitizer: %+v", wc.Target)
+	}
+	if len(wc.Nodes) != 1 || wc.Nodes[0].DV != 10 || wc.Nodes[0].Mode != int(spacecraft.BurnPrograde) {
+		t.Errorf("non-target node altered by the transfer sanitizer: %+v", wc.Nodes)
 	}
 }

--- a/internal/save/craft_wire_transfer_test.go
+++ b/internal/save/craft_wire_transfer_test.go
@@ -1,0 +1,120 @@
+package save
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// ghostBoundCraft builds a craft carrying a ghost ref on all three
+// surfaces CraftToWire round-trips: Target, a planted node, and the
+// active burn. Shared by the transfer-sanitize tests below.
+func ghostBoundCraft(t *testing.T) *spacecraft.Spacecraft {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Target = spacecraft.Target{Kind: spacecraft.TargetGhost, CraftID: 987654, GhostOwner: "SHA256:gern"}
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		Mode:             spacecraft.BurnTarget,
+		DV:               42,
+		TriggerTime:      w.Clock.SimTime.Add(time.Minute),
+		PrimaryID:        c.Primary.ID,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	})
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      15,
+		EndTime:          w.Clock.SimTime.Add(30 * time.Second),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	return c
+}
+
+// TestCraftToWireKeepsGhostRefsForSession is the control: the plain
+// session save/reconnect path (CraftToWire) preserves every ghost ref,
+// as #294 review finding 5 already established and ghost_node_ref_test.go
+// / ghost_target_test.go cover end to end via Save/Load. Restated here,
+// side by side with the transfer variant below, so the two paths' actual
+// divergence is visible in one place.
+func TestCraftToWireKeepsGhostRefsForSession(t *testing.T) {
+	c := ghostBoundCraft(t)
+	wc := CraftToWire(c)
+
+	if wc.Target == nil || wc.Target.Kind != int(spacecraft.TargetGhost) || wc.Target.GhostOwner != "SHA256:gern" {
+		t.Errorf("session wire Target = %+v, want the ghost ref kept", wc.Target)
+	}
+	if len(wc.Nodes) != 1 || wc.Nodes[0].TargetGhostOwner != "SHA256:gern" || wc.Nodes[0].TargetCraftID != 987654 {
+		t.Errorf("session wire node ref = %+v, want the ghost ref kept", wc.Nodes)
+	}
+	if wc.ActiveBurn == nil || wc.ActiveBurn.TargetGhostOwner != "SHA256:gern" || wc.ActiveBurn.TargetCraftID != 987654 {
+		t.Errorf("session wire ActiveBurn ref = %+v, want the ghost ref kept", wc.ActiveBurn)
+	}
+}
+
+// TestCraftToWireForTransferStripsGhostRefs — #294 review finding 3. A
+// dock-ledger parcel/return/transfer payload is delivered into a
+// DIFFERENT player's world, where a ghost ref (owner fingerprint +
+// remote craft ID) can never resolve and can even alias the
+// RECIPIENT's own fingerprint. The sanitized wrapper must drop the
+// ghost Target outright and strip the ghost ref from every node and
+// the active burn — while leaving everything else (burn geometry, Δv,
+// mode) untouched.
+func TestCraftToWireForTransferStripsGhostRefs(t *testing.T) {
+	c := ghostBoundCraft(t)
+	wc := CraftToWireForTransfer(c)
+
+	if wc.Target != nil {
+		t.Errorf("transfer wire Target = %+v, want nil (ghost target dropped outright)", wc.Target)
+	}
+	if len(wc.Nodes) != 1 {
+		t.Fatalf("transfer wire lost the node itself, not just its ref: %+v", wc.Nodes)
+	}
+	if wc.Nodes[0].TargetGhostOwner != "" || wc.Nodes[0].TargetCraftID != 0 {
+		t.Errorf("transfer wire node ref = %+v, want the ghost ref stripped", wc.Nodes[0])
+	}
+	if wc.Nodes[0].DV != 42 || wc.Nodes[0].Mode != int(spacecraft.BurnTarget) {
+		t.Errorf("transfer wire node lost its burn geometry: %+v", wc.Nodes[0])
+	}
+	if wc.ActiveBurn == nil {
+		t.Fatal("transfer wire lost the active burn itself, not just its ref")
+	}
+	if wc.ActiveBurn.TargetGhostOwner != "" || wc.ActiveBurn.TargetCraftID != 0 {
+		t.Errorf("transfer wire ActiveBurn ref = %+v, want the ghost ref stripped", wc.ActiveBurn)
+	}
+	if wc.ActiveBurn.DVRemaining != 15 {
+		t.Errorf("transfer wire ActiveBurn lost its DVRemaining: %+v", wc.ActiveBurn)
+	}
+}
+
+// TestCraftToWireForTransferLeavesLocalRefsAlone — a LOCAL craft ref
+// (no ghost owner) is a different craft in the SAME world; the
+// transfer sanitizer must not touch it.
+func TestCraftToWireForTransferLeavesLocalRefsAlone(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            10,
+		TriggerTime:   w.Clock.SimTime.Add(time.Minute),
+		PrimaryID:     c.Primary.ID,
+		TargetCraftID: 12345, // local ref, no ghost owner
+	})
+
+	wc := CraftToWireForTransfer(c)
+
+	if len(wc.Nodes) != 1 || wc.Nodes[0].TargetCraftID != 12345 {
+		t.Errorf("local node ref touched by the ghost sanitizer: %+v", wc.Nodes)
+	}
+}

--- a/internal/save/craft_wire_zombie_burn_test.go
+++ b/internal/save/craft_wire_zombie_burn_test.go
@@ -1,0 +1,128 @@
+package save
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestCraftFromWireTearsDownOwnerlessTargetRelativeBurn — #294 review
+// round 3 finding D (second half). A v9 save (schema < 10, written
+// before CraftToWire started preserving ghost refs) saved mid-ghost-burn
+// carries an ActiveBurn whose Mode is target-relative but whose
+// TargetCraftID / TargetGhostOwner were dropped by the old
+// drop-on-save behavior — migrateV9PayloadToV10 is an identity
+// transform (save_migrate_v9_to_v10.go), so that shape reaches
+// CraftFromWire completely unchanged on load. The same shape is also
+// exactly what a pre-round-3 reconcileTargetLock give-up used to leave
+// behind (strip the ref, keep the burn "alive"). Either way, a
+// target-relative burn with no ref can never resolve, thrust, or tear
+// itself down again — nodeTargetRelState refuses unconditionally for
+// craftID==0, so activeBurnTargetReady never returns true, burnExhausted
+// never fires, and the zombie burn wedges canKeplerStep's per-craft gate
+// (warp stays clamped ≤10× for the rest of the session). CraftFromWire
+// must tear it down defensively at load instead of letting it load in
+// that state.
+func TestCraftFromWireTearsDownOwnerlessTargetRelativeBurn(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	wc := CraftToWire(c)
+	wc.ActiveBurn = &ActiveBurn{
+		Mode:        int(spacecraft.BurnTarget), // target-relative
+		DVRemaining: 100,
+		EndTimeNano: w.Clock.SimTime.Add(time.Minute).UnixNano(),
+		PrimaryID:   c.Primary.ID,
+		Throttle:    1,
+		// TargetCraftID / TargetGhostOwner both zero — the exact shape
+		// the old drop-on-save behavior (and a pre-round-3 give-up) left
+		// behind.
+	}
+
+	loaded, err := CraftFromWire(wc, systems)
+	if err != nil {
+		t.Fatalf("CraftFromWire: %v", err)
+	}
+	if loaded.ActiveBurn != nil {
+		t.Errorf("ownerless target-relative burn survived load: %+v", loaded.ActiveBurn)
+	}
+}
+
+// TestCraftFromWireKeepsResolvableTargetRelativeBurn — the defensive
+// teardown above must be surgical: a target-relative burn that DOES
+// carry a bound ref (local or ghost) loads unchanged.
+func TestCraftFromWireKeepsResolvableTargetRelativeBurn(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	wc := CraftToWire(c)
+	wc.ActiveBurn = &ActiveBurn{
+		Mode:          int(spacecraft.BurnTarget),
+		DVRemaining:   100,
+		EndTimeNano:   w.Clock.SimTime.Add(time.Minute).UnixNano(),
+		PrimaryID:     c.Primary.ID,
+		Throttle:      1,
+		TargetCraftID: 987654,
+	}
+
+	loaded, err := CraftFromWire(wc, systems)
+	if err != nil {
+		t.Fatalf("CraftFromWire: %v", err)
+	}
+	if loaded.ActiveBurn == nil {
+		t.Fatal("resolvable target-relative burn torn down on load")
+	}
+	if loaded.ActiveBurn.TargetCraftID != 987654 {
+		t.Errorf("TargetCraftID = %d, want 987654", loaded.ActiveBurn.TargetCraftID)
+	}
+}
+
+// TestCraftFromWireLeavesNonTargetBurnAlone — regression guard: a
+// non-target-relative ActiveBurn (e.g. a plain prograde burn) with no
+// ref is entirely ordinary — it must never be torn down by the
+// defensive teardown above, which only fires for target-relative modes.
+func TestCraftFromWireLeavesNonTargetBurnAlone(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	wc := CraftToWire(c)
+	wc.ActiveBurn = &ActiveBurn{
+		Mode:        int(spacecraft.BurnPrograde),
+		DVRemaining: 100,
+		EndTimeNano: w.Clock.SimTime.Add(time.Minute).UnixNano(),
+		PrimaryID:   c.Primary.ID,
+		Throttle:    1,
+	}
+
+	loaded, err := CraftFromWire(wc, systems)
+	if err != nil {
+		t.Fatalf("CraftFromWire: %v", err)
+	}
+	if loaded.ActiveBurn == nil {
+		t.Fatal("ordinary non-target-relative burn torn down on load")
+	}
+}

--- a/internal/save/ghost_node_ref_test.go
+++ b/internal/save/ghost_node_ref_test.go
@@ -11,15 +11,23 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
-// TestGhostNodeRefDropsOnSave — v0.28 S4. A K-nudge node planted against
-// a remote player's craft (a ghost) carries a session-local ghost ref
-// (TargetGhostOwner + a REMOTE TargetCraftID). Ghost refs never persist:
-// the owner fingerprint isn't saved, and the remote craft id would
-// collide with a LOCAL craft id on load. So save drops the whole ref —
-// owner cleared AND craft id zeroed — while keeping the burn geometry
-// (mode / Δv / primary / direction). Mirrors the v0.27 ghost-target
-// normalisation. SchemaVersion stays 8 (no schema field added).
-func TestGhostNodeRefDropsOnSave(t *testing.T) {
+// TestGhostNodeRefSurvivesSave — #294 review finding 5. A K-nudge node
+// planted against a remote player's craft (a ghost) carries a session-
+// local ghost ref (TargetGhostOwner + a REMOTE TargetCraftID). v0.28 S4
+// used to drop the whole ref on save (owner cleared, craft id zeroed),
+// mirroring the same normalisation the original #294 fix already
+// reversed for Craft.Target — on the same now-overturned theory that the
+// owner fingerprint couldn't resolve again and the remote craft id would
+// collide with a LOCAL one. Neither holds: ghost refs are only ever
+// resolved by the (owner, craftID) PAIR (World.ghostByRef), never by
+// craftID alone, so a same-numbered local craft can't collide with a
+// remote one. Dropping the ref left a gap: Craft.Target re-latches onto
+// the peer after a reconnect, but a node planted at that same target used
+// to fire with a stale/zeroed ref — see executeDueNodesFor's refuse-to-
+// fire guard for what happens now instead. SchemaVersion stays 9 (no
+// schema field bumped — see save_migrate_v9_to_v10.go for the unrelated
+// v10 bump that DID land, over Target.Kind's widened vocabulary).
+func TestGhostNodeRefSurvivesSave(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -48,12 +56,12 @@ func TestGhostNodeRefDropsOnSave(t *testing.T) {
 	}
 	n := nodes[0]
 
-	// Ghost ref dropped.
-	if n.TargetGhostOwner != "" {
-		t.Errorf("TargetGhostOwner survived save: %q (want dropped)", n.TargetGhostOwner)
+	// Ghost ref preserved.
+	if n.TargetGhostOwner != "SHA256:gern" {
+		t.Errorf("TargetGhostOwner = %q, want %q (survives save)", n.TargetGhostOwner, "SHA256:gern")
 	}
-	if n.TargetCraftID != 0 {
-		t.Errorf("remote TargetCraftID survived save: %d (want dropped — would collide with a local id)", n.TargetCraftID)
+	if n.TargetCraftID != 987654 {
+		t.Errorf("remote TargetCraftID = %d, want 987654 (survives save)", n.TargetCraftID)
 	}
 
 	// Burn geometry kept.
@@ -65,6 +73,48 @@ func TestGhostNodeRefDropsOnSave(t *testing.T) {
 	}
 	if n.PrimaryID != c.Primary.ID {
 		t.Errorf("PrimaryID = %q, want %q", n.PrimaryID, c.Primary.ID)
+	}
+}
+
+// TestGhostActiveBurnRefSurvivesSave — #294 review finding 5, ActiveBurn
+// half. An in-flight finite burn targeted at a ghost used to lose its ref
+// the same way a planted node did; it now round-trips identically.
+func TestGhostActiveBurnRefSurvivesSave(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.ActiveBurn = &sim.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      15,
+		EndTime:          w.Clock.SimTime.Add(30 * time.Second),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetCraftID:    987654,
+		TargetGhostOwner: "SHA256:gern",
+	}
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	ab := got.ActiveCraft().ActiveBurn
+	if ab == nil {
+		t.Fatalf("ActiveBurn lost on save/load")
+	}
+	if ab.TargetGhostOwner != "SHA256:gern" {
+		t.Errorf("ActiveBurn.TargetGhostOwner = %q, want %q (survives save)", ab.TargetGhostOwner, "SHA256:gern")
+	}
+	if ab.TargetCraftID != 987654 {
+		t.Errorf("ActiveBurn.TargetCraftID = %d, want 987654 (survives save)", ab.TargetCraftID)
+	}
+	if ab.Mode != spacecraft.BurnTarget {
+		t.Errorf("ActiveBurn.Mode = %v, want BurnTarget", ab.Mode)
 	}
 }
 

--- a/internal/save/ghost_target_test.go
+++ b/internal/save/ghost_target_test.go
@@ -7,10 +7,18 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
-// Review follow-up: a ghost target (session-local by design) is
-// normalised to no-target on save — never a stuck Kind with a dropped
-// owner, and the persisted Kind vocabulary stays pre-v0.27.
-func TestGhostTargetNormalizedOnSave(t *testing.T) {
+// #294 fix: a ghost target now round-trips through save/load intact
+// (Kind, CraftID, and the owner fingerprint). It used to normalise to
+// no-target on save on the reasoning that the fingerprint was
+// session-local and would never resolve again — which was harmless in
+// single-player (nothing there ever sets a ghost target) but silently
+// dropped a guest's cross-player rendezvous lock on every reconnect
+// that round-trips through the per-player session payload, most
+// visibly the [u] restart-to-adopt flow. The fingerprint IS meaningful
+// within the session it was set in, so it now persists; the deferred
+// re-latch (reportingModel in internal/serve) is what actually
+// resolves it back to a live ghost once the owner's reports resume.
+func TestGhostTargetPersistsOnSave(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -28,10 +36,10 @@ func TestGhostTargetNormalizedOnSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if got.Target.Kind != sim.TargetNone {
-		t.Errorf("loaded Target.Kind = %v, want TargetNone (ghost refs must not persist)", got.Target.Kind)
+	if got.Target.Kind != sim.TargetGhost || got.Target.GhostOwner != "SHA256:x" || got.Target.CraftID != 7 {
+		t.Errorf("loaded Target = %+v, want ghost target at (SHA256:x, 7)", got.Target)
 	}
-	if got.ActiveCraft().Target.Kind != sim.TargetNone {
-		t.Errorf("loaded craft Target.Kind = %v, want TargetNone", got.ActiveCraft().Target.Kind)
+	if ct := got.ActiveCraft().Target; ct.Kind != sim.TargetGhost || ct.GhostOwner != "SHA256:x" || ct.CraftID != 7 {
+		t.Errorf("loaded craft Target = %+v, want ghost target at (SHA256:x, 7)", ct)
 	}
 }

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -114,11 +114,20 @@ type Focus struct {
 // Spacecraft.ID. CraftIdx is the retired pre-v7 0-based slate index,
 // retained only to read v6 saves; migrateV6PayloadToV7 converts it to
 // CraftID. v7 saves write CraftID and leave CraftIdx zero.
+//
+// GhostOwner (#294 fix, additive/omitempty — no schema bump) carries a
+// TargetGhost's remote-player fingerprint. A ghost target used to
+// normalise to no-target on save (the owner fingerprint was never
+// wired onto this struct at all), which was invisible in single-player
+// but meant a guest's cross-player rendezvous lock silently vanished
+// on every reconnect that round-tripped through disk — most visibly
+// the [u] restart-to-adopt flow. See CraftToWire/CraftFromWire.
 type Target struct {
-	Kind     int    `json:"kind"`
-	BodyIdx  int    `json:"body_idx,omitempty"`
-	CraftIdx int    `json:"craft_idx,omitempty"` // pre-v7 (read-only for migration)
-	CraftID  uint64 `json:"craft_id,omitempty"`  // v7+ stable ID
+	Kind       int    `json:"kind"`
+	BodyIdx    int    `json:"body_idx,omitempty"`
+	CraftIdx   int    `json:"craft_idx,omitempty"` // pre-v7 (read-only for migration)
+	CraftID    uint64 `json:"craft_id,omitempty"`  // v7+ stable ID
+	GhostOwner string `json:"ghost_owner,omitempty"`
 }
 
 // Vec3 is the wire form of orbital.Vec3.

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -52,7 +52,20 @@ import (
 // a Mission of ordered Objectives + campaign metadata. The v8→v9 migration
 // re-seeds: it drops the old single-predicate progress so the load path
 // reseeds the new ladder from the catalog; see migrateV8PayloadToV9.
-const SchemaVersion = 9
+// #294 review finding 6 bumps to v10 — Target.Kind's vocabulary
+// widened to include TargetGhost with the fix's fingerprint-preserving
+// GhostOwner field, and the shape those bytes decode to (a live,
+// resolvable-again ghost lock) is new: an older binary that doesn't know
+// TargetGhost would decode the unfamiliar Kind value into whatever its
+// own enum has at that ordinal (or, on ghost_owner: an unrecognised JSON
+// key it silently drops), reconstructing a target it can never resolve
+// and has no code path to explain to the player — exactly the class of
+// "old binary silently mangles new shape" the repo's schema-bump rule
+// exists to prevent. migrateV9PayloadToV10 is an identity transform (the
+// wire shape itself needs no migration — TargetGhost has round-tripped
+// working bytes since the fix landed); the version bump's only job is to
+// make an old binary refuse a v10 envelope instead.
+const SchemaVersion = 10
 
 // File is the on-disk envelope.
 //
@@ -360,6 +373,18 @@ type Node struct {
 	// instead of stacking behind it. Absent → "", the correct value for
 	// every node type that predates this field. No migration.
 	AdvisoryKey string `json:"advisory_key,omitempty"`
+	// TargetGhostOwner (#294 review finding 5, additive omitempty) mirrors
+	// spacecraft.ManeuverNode.TargetGhostOwner — the remote player's
+	// fingerprint a target-relative node was planted against. Used to be
+	// dropped unconditionally on save (DropGhostRef in CraftToWire) on the
+	// same now-reversed theory as Target.GhostOwner: the fingerprint IS
+	// meaningful within the session it was set in, and a reconnect that
+	// re-latches Craft.Target back onto the same ghost should re-latch a
+	// planted node's target too, instead of leaving the node's ref silently
+	// zeroed while the standing target lock recovers around it. Absent → "",
+	// harmless on every save predating this field (a local-craft or
+	// untargeted node's TargetGhostOwner was always "").
+	TargetGhostOwner string `json:"target_ghost_owner,omitempty"`
 }
 
 // DockedComponent mirrors spacecraft.DockedComponent. v0.8.3+.
@@ -423,6 +448,11 @@ type ActiveBurn struct {
 	// plane-change / BurnVector burn reloads with the direction intact.
 	PlaneChangeRad float64 `json:"plane_change_rad,omitempty"`
 	BurnDirUnit    Vec3    `json:"burn_dir_unit,omitempty"`
+	// TargetGhostOwner (#294 review finding 5, additive omitempty) mirrors
+	// the Node field above onto a running burn, for the same reason: a
+	// reconnect mid an in-flight target-relative finite burn should
+	// re-latch the burn's own ref, not just Craft.Target.
+	TargetGhostOwner string `json:"target_ghost_owner,omitempty"`
 }
 
 // Errors returned by Load.
@@ -556,6 +586,15 @@ func Load(path string) (*sim.World, error) {
 	// from the catalog. Payload-only, so it runs here on the wire payload.
 	if f.Version < 9 {
 		migrateV8PayloadToV9(&f.Payload)
+	}
+	// schema v10 (#294 review finding 6): Target.Kind's vocabulary
+	// widened to include TargetGhost; the payload shape itself needs no
+	// transform (see the SchemaVersion doc comment), so this is an
+	// identity pass — its only job is that Load's version gate above now
+	// refuses a pre-v10 binary reading a v10 envelope, matching the repo
+	// rule of bumping + migrating whenever persisted state shape changes.
+	if f.Version < 10 {
+		migrateV9PayloadToV10(&f.Payload)
 	}
 	return worldFromPayload(f.Payload, systems)
 }

--- a/internal/save/save_migrate_v9_to_v10.go
+++ b/internal/save/save_migrate_v9_to_v10.go
@@ -1,0 +1,24 @@
+// #294 review finding 6: schema v9 → v10 migration. Target.Kind's
+// persisted vocabulary widened to include TargetGhost (an already-live
+// value on the wire — see save.go's Target / Node / ActiveBurn
+// GhostOwner / TargetGhostOwner fields, all additive/omitempty), so a
+// v9-declaring envelope written by a pre-fix binary and a v10 envelope
+// written by this one are byte-for-byte identical wherever a ghost
+// isn't targeted, and differ only by the version number and the new
+// ghost_owner / target_ghost_owner keys when one is. Nothing on the
+// wire shape needs transforming — the whole point of the bump is that
+// Load's version gate now refuses an OLDER binary reading a v10
+// envelope, rather than letting it silently drop the unfamiliar keys
+// and reconstruct a permanently-unresolvable ghost target with no code
+// path to explain that to the player (the repo rule: bump the version +
+// add a migration whenever persisted state shape changes).
+
+package save
+
+// migrateV9PayloadToV10 is an identity transform — see the package
+// comment above for why a real field migration isn't needed here.
+// Kept as its own named pass (rather than skipped entirely) to match
+// every other version bump's precedent: a payload's migration history
+// stays a straight line of named functions keyed off f.Version, not a
+// version bump with an implicit no-op hidden in the gate check alone.
+func migrateV9PayloadToV10(p *Payload) {}

--- a/internal/save/save_migrate_v9_to_v10_test.go
+++ b/internal/save/save_migrate_v9_to_v10_test.go
@@ -1,0 +1,110 @@
+package save
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestMigrateV9PayloadToV10IsIdentity — #294 review finding 6. The v9→v10
+// bump exists solely to make Load's version gate refuse an older binary
+// reading a v10 envelope (Target.Kind's vocabulary widened to include
+// TargetGhost, an already-additive/omitempty wire shape); the payload
+// itself needs no field transform. Pin that: migrating a representative
+// payload — including a ghost Target and a ghost-targeted Node/ActiveBurn,
+// the exact shapes finding 6 is about — must leave every field untouched.
+func TestMigrateV9PayloadToV10IsIdentity(t *testing.T) {
+	p := &Payload{
+		SystemIdx:   2,
+		SimTimeNano: 123456789,
+		WarpIdx:     3,
+		NavMode:     2,
+		Target: &Target{
+			Kind:       4, // TargetGhost
+			GhostOwner: "SHA256:gern",
+			CraftID:    99,
+		},
+		Crafts: []Craft{{
+			ID:   1,
+			Name: "Test Craft",
+			Nodes: []Node{{
+				Mode:             1,
+				TargetCraftID:    987654,
+				TargetGhostOwner: "SHA256:gern",
+			}},
+			ActiveBurn: &ActiveBurn{
+				Mode:             1,
+				TargetCraftID:    987654,
+				TargetGhostOwner: "SHA256:gern",
+			},
+		}},
+	}
+	before := *p // shallow copy for comparison; nested pointers/slices below are checked field-by-field
+
+	migrateV9PayloadToV10(p)
+
+	if p.SystemIdx != before.SystemIdx || p.SimTimeNano != before.SimTimeNano ||
+		p.WarpIdx != before.WarpIdx || p.NavMode != before.NavMode {
+		t.Errorf("scalar payload fields changed: got %+v, want unchanged from %+v", p, before)
+	}
+	if p.Target == nil || *p.Target != *before.Target {
+		t.Errorf("Target changed: got %+v, want unchanged %+v", p.Target, before.Target)
+	}
+	if len(p.Crafts) != 1 {
+		t.Fatalf("Crafts count changed: got %d, want 1", len(p.Crafts))
+	}
+	c := p.Crafts[0]
+	if c.ID != 1 || c.Name != "Test Craft" {
+		t.Errorf("Craft identity fields changed: %+v", c)
+	}
+	if len(c.Nodes) != 1 || c.Nodes[0].TargetGhostOwner != "SHA256:gern" || c.Nodes[0].TargetCraftID != 987654 {
+		t.Errorf("Node ghost ref changed: %+v", c.Nodes)
+	}
+	if c.ActiveBurn == nil || c.ActiveBurn.TargetGhostOwner != "SHA256:gern" || c.ActiveBurn.TargetCraftID != 987654 {
+		t.Errorf("ActiveBurn ghost ref changed: %+v", c.ActiveBurn)
+	}
+}
+
+// TestSchemaVersionBumpedToV10 pins the version number itself (#294
+// review finding 6) — a regression here means someone widened
+// Target.Kind's vocabulary again (or otherwise changed persisted shape)
+// without bumping, defeating the whole point of the migration file
+// alongside it.
+func TestSchemaVersionBumpedToV10(t *testing.T) {
+	if SchemaVersion != 10 {
+		t.Errorf("SchemaVersion = %d, want 10", SchemaVersion)
+	}
+}
+
+// TestLoadAcceptsV10Envelope — Load's version gate ([1, SchemaVersion])
+// must accept a freshly-written v10 envelope (Version == SchemaVersion,
+// pinned to 10 above) without routing it through the (identity) v9→v10
+// migration in a way that loses data — exercised here with the exact
+// finding-6 shape, a ghost Target. A real "does an OLD binary refuse a
+// v10 file" check can't run inside this binary (its own SchemaVersion
+// IS 10) — that half of finding 6 is structural: Load's existing
+// `f.Version > SchemaVersion` gate refuses anything above whatever
+// SchemaVersion the reading binary was built with, and
+// TestSchemaVersionBumpedToV10 above pins that a pre-fix binary's
+// SchemaVersion of 9 is now less than a fixed save's 10.
+func TestLoadAcceptsV10Envelope(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.Ghosts = []sim.Ghost{{Owner: "SHA256:gern", CraftID: 7, PrimaryID: c.Primary.ID}}
+	w.SetTargetGhost("SHA256:gern", 7)
+
+	path := t.TempDir() + "/v10.json"
+	if err := Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load a same-version v10 envelope: %v", err)
+	}
+	if got.Target.Kind != sim.TargetGhost || got.Target.GhostOwner != "SHA256:gern" {
+		t.Errorf("loaded Target = %+v, want the ghost lock intact through the v10 envelope", got.Target)
+	}
+}

--- a/internal/serve/dock_flush_test.go
+++ b/internal/serve/dock_flush_test.go
@@ -132,9 +132,17 @@ func TestGuestParkingSurvivesRestart(t *testing.T) {
 	}
 	w.ActiveCraft().ID = guestCraftID
 
-	app, err := tui.New(nil)
+	// #294 review finding 1: withReporting now primes the session (and so
+	// reconciles docking) once at attach, before this test's own explicit
+	// reconcileDocking call below — so app must carry the SAME world as w,
+	// or the priming call's reconcileDocking (running against a mismatched
+	// default world with no craft ID 21) would abandon the DockPending
+	// record outright (relay.DockLedger.reconcileGuest: RemoveCraftByID
+	// fails → "my craft is gone" → record dropped) before the test's own
+	// call ever runs.
+	app, err := tui.NewWithWorld(w)
 	if err != nil {
-		t.Fatalf("tui.New: %v", err)
+		t.Fatalf("tui.NewWithWorld: %v", err)
 	}
 	model := srv.withReporting(app, guestFP)
 	rm, ok := model.(reportingModel)

--- a/internal/serve/inui_hosting_test.go
+++ b/internal/serve/inui_hosting_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/sessiondir"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
@@ -65,6 +66,53 @@ func TestStopHostingClearsCoWarpAndDockGuest(t *testing.T) {
 	}
 	if got := w.EffectiveWarp(); got == 1 {
 		t.Errorf("warp still clamped to 1× after stopHosting — stale co-warp clamp persists")
+	}
+}
+
+// TestStopHostingAbortsGhostRefBurnAndNode — #294 second-round review
+// finding 3(ii): a ghost-ref planted node or in-flight ActiveBurn is
+// unresolvable once hosting stops — no roster left to wait on, no
+// watchdog left running. Left alone the ActiveBurn would hold forever
+// (activeBurnTargetReady never re-resolves outside a session), pinning
+// the craft's warp clamp for the rest of solo play. stopHosting must
+// abort it and cancel any other ghost-bound node, with a one-time
+// notice.
+func TestStopHostingAbortsGhostRefBurnAndNode(t *testing.T) {
+	srv := newOfflineServer(t)
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	m := srv.HostModel(app)
+	w := app.World()
+	c := w.ActiveCraft()
+	c.ActiveBurn = &sim.ActiveBurn{
+		Mode: spacecraft.BurnTarget, DVRemaining: 100,
+		EndTime: w.Clock.SimTime.Add(time.Minute), PrimaryID: c.Primary.ID,
+		Throttle: 1, TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+	}
+	c.Nodes = []sim.ManeuverNode{{
+		Mode: spacecraft.BurnTarget, DV: 50, TriggerTime: w.Clock.SimTime.Add(time.Hour),
+		TargetGhostOwner: "SHA256:someone-else", TargetCraftID: 111,
+	}}
+
+	rm, ok := m.(reportingModel)
+	if !ok {
+		t.Fatalf("model is %T, not reportingModel", m)
+	}
+	stopped, _ := rm.stopHosting()
+	if _, ok := stopped.(reportingModel); !ok {
+		t.Fatalf("stopped model is %T", stopped)
+	}
+
+	if c.ActiveBurn != nil {
+		t.Errorf("stopHosting left a ghost-ref ActiveBurn in place: %+v", c.ActiveBurn)
+	}
+	if len(c.Nodes) != 0 {
+		t.Errorf("stopHosting left a ghost-ref node queued: %+v", c.Nodes)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("no cancellation notice stamped: %+v", w.LastNodeTargetRefusal)
 	}
 }
 

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -152,11 +152,24 @@ func (s *Server) withReporting(app *tui.App, owner string) tea.Model {
 	if note, err := s.store.ConsumePendingNote(owner); err == nil && note != "" {
 		app.Toast(note)
 	}
-	return reportingModel{
+	m := reportingModel{
 		inner: app, app: app,
 		rep: relay.NewReporter(s.relay, owner),
 		srv: s, owner: owner,
 	}
+	// #294 review finding 1: prime w.Session here, before this model ever
+	// sees a tick — mirrors startHosting's own priming call below. Without
+	// this, a reconnecting guest's very first Update dispatches
+	// m.inner.Update(msg) (World.Tick → executeDueNodes) BEFORE any
+	// refreshSession has ever run, so w.Session is still nil and
+	// sessionKnowsOwner reports false for every ghost-ref node — a
+	// reconnecting guest's own due nodes could get cancelled on their very
+	// first tick, with none of the grace the active-target watchdog gives
+	// (targetLockRelatchGrace). Safe to call this early: everything it
+	// touches (ghosts, co-warp, session slate) is transient and either nil
+	// or freshly loaded at this point, never persisted.
+	m.refreshSession(time.Now())
+	return m
 }
 
 func (m reportingModel) Init() tea.Cmd { return m.inner.Init() }
@@ -817,6 +830,17 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// Back to solo: clear the slates the wrapper had been feeding so the
 	// Session screen shows the [h]-start dead-end again.
 	w := m.app.World()
+	// #294 second-round review finding 3(ii): a ghost-ref planted node or
+	// in-flight ActiveBurn is unresolvable outside a hosting session — no
+	// roster to wait on, no watchdog left running, nothing left to
+	// re-latch to (the same "no session" rule executeDueNodesFor's own
+	// fire-time check applies). Left alone, a target-held ActiveBurn would
+	// wedge the craft's warp clamp ≤10× for the rest of solo play; a
+	// queued ghost-ref node would sit refused forever. Aborted here, once,
+	// with a single notice — same shape as CancelGhostNodeRefs, just
+	// applied to every outstanding ref instead of one specific ref whose
+	// own give-up grace expired.
+	w.CancelAllGhostRefs()
 	w.Session, w.Ghosts, w.SessionEvents, w.ChatLines = nil, nil, nil, nil
 	// Clear the multiplayer coupling slates too (v0.28 finding 2): the tick
 	// path that recomputes co-warp / docked-as-guest is gated on m.srv != nil,

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -117,7 +117,7 @@ const localEventTTL = 10 * time.Second
 // long enough to cover the ordinary reconnect skew between two players
 // both dropped by the same [u] restart, short enough that a lock that
 // really is gone doesn't sit silently un-explained for minutes.
-const targetLockRelatchGrace = 45 * time.Second
+const targetLockRelatchGrace = sim.GhostAbsentGrace
 
 // restartExitCode is the dedicated marker the supervising service
 // manager keys on to tell an admin-requested restart from a crash

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -62,19 +62,43 @@ type reportingModel struct {
 	rzInviteHandle  string
 	rzDegraded      bool
 
+	// targetLockOwner / targetLockCraftID identify the specific ghost ref
+	// the watchdog below is tracking (#294 review finding 2) — retargeting
+	// to a different peer mid-grace must start a fresh watch rather than
+	// inherit the old ref's timer and (worst case) chip the wrong peer's
+	// name. A tick that finds w.Target pointing at a different ref than
+	// these (including the very first tick, when both are zero-valued —
+	// "session start" and "player just retargeted" are the same case)
+	// resets targetLockPendingSince and targetLockResolvedOnce below.
+	targetLockOwner   string
+	targetLockCraftID uint64
+
 	// targetLockPendingSince tracks the deferred re-latch of a craft/ghost
 	// target lock across a reconnect (#294): a ghost target now survives
 	// the per-player save round-trip (CraftToWire/CraftFromWire), so a
 	// session that comes up already aimed at one just needs the target
 	// owner's craft reports to resume before ResolveTargetGhost finds it
 	// again — the same tolerance an ordinary momentarily-stale ghost
-	// already has. Zero means "not waiting" (no ghost target, or it
-	// already resolved). Set the tick refreshSession first finds an
-	// unresolved ghost target; cleared on resolution, on the target
-	// changing to something else, or on giving up past
+	// already has. Zero means "not waiting" (no ghost target, the ref
+	// changed, or it already resolved). Set the tick reconcileTargetLock
+	// first finds the current ref unresolved; cleared on resolution, on
+	// the ref changing to something else, or on giving up past
 	// targetLockRelatchGrace (which also fires the loss chip).
 	targetLockPendingSince time.Time
-	targetLockHandle       string // display name captured when pending started
+
+	// targetLockResolvedOnce is set the first time the CURRENTLY TRACKED
+	// ref (targetLockOwner/targetLockCraftID) resolves. #294 review
+	// finding 1: once true, the grace-window watchdog retires permanently
+	// for this ref — a later resolve failure (the viewer browsing to
+	// another system, since relay.GhostsFor only emits ghosts for the
+	// VIEWED system, or the peer landing/transferring for a minute, both
+	// of which drop the ghost out of the slate through no fault of the
+	// lock) reverts to the pre-#294 tolerance: keep the lock, re-latch
+	// silently whenever it resolves again, never clear it and never chip
+	// a loss. Only a ref that has never resolved since it was (re)bound —
+	// freshly restored at session start, or freshly retargeted this
+	// session — runs the 45s countdown at all.
+	targetLockResolvedOnce bool
 }
 
 // localEventTTL matches the chip's on-screen life; pruning here just
@@ -380,44 +404,87 @@ func (m *reportingModel) handleOf(fp string) (string, bool) {
 // target lock across a reconnect (#294). Called every tick after
 // w.Ghosts is refreshed, so ResolveTargetGhost sees this tick's data.
 //
-//   - Target isn't a ghost (never was, changed since, or already cleared
-//     by an earlier tick's timeout): nothing pending, no-op.
-//   - Target is a ghost and resolves: either it never needed re-latching
-//     (ordinary play — the common case, exits immediately below) or the
-//     owner's reports just resumed. Either way clear the pending timer
-//     silently; the player already has the lock they expect, nothing to
-//     announce.
-//   - Target is a ghost, doesn't resolve, and this is the first tick that
-//     was true: start the timer.
-//   - Target is a ghost, still doesn't resolve, and the timer has run
-//     past targetLockRelatchGrace: give up — clear the target and chip
-//     the loss so the drop is legible instead of a silent dangling aim.
+// #294 review (findings 1 + 2) narrowed the scope from "every ghost
+// target, forever" to "a ref that has never resolved since it was
+// (re)bound": the pre-review version ran the 45s countdown on ANY
+// resolve failure, which meant a perfectly healthy established lock
+// got permanently cleared just because the viewer browsed to another
+// system for a minute (relay.GhostsFor only emits ghosts for the
+// VIEWED system) or the peer landed/transferred for a minute (both
+// drop the ghost out of the slate with nothing wrong with the lock).
+// targetLockResolvedOnce is the fix: it's sticky per ref, so the
+// watchdog only ever runs across the window between a ref being bound
+// and its first successful resolve — after that it's retired for good
+// and an unresolved tick just falls through as a no-op (the same
+// tolerance an ordinary momentarily-stale ghost already had before
+// #294 existed).
+//
+//   - Target isn't a ghost: nothing pending, reset tracking, no-op.
+//   - Target names a different ref than the one being tracked
+//     (including the very first tick, session start included, since
+//     the tracked ref starts zero-valued): fresh ref, fresh watch —
+//     never inherit another ref's timer, resolved-once state, or
+//     display handle (finding 2: a cached handle from the old ref
+//     would chip the WRONG peer's name).
+//   - Target resolves: mark this ref resolved-once and clear any
+//     pending timer — either it never needed re-latching (ordinary
+//     play, the common case) or the owner's reports just resumed.
+//     Silent either way; the player already has the lock they expect.
+//   - Target doesn't resolve and has already resolved once before:
+//     old-behavior tolerance (finding 1) — no timer, no clearing, no
+//     chip. Just wait for it to come back.
+//   - Target doesn't resolve and has never resolved since being bound,
+//     and this is the first such tick: start the timer.
+//   - Still unresolved past targetLockRelatchGrace: give up — clear the
+//     target and chip the loss (handle read now, at fire time, per
+//     finding 2 — never cached at timer-start) so the drop is legible
+//     instead of a silent dangling aim.
 func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]string, now time.Time) {
 	if w.Target.Kind != sim.TargetGhost {
+		m.resetTargetLockWatch()
+		return
+	}
+	if w.Target.GhostOwner != m.targetLockOwner || w.Target.CraftID != m.targetLockCraftID {
+		m.targetLockOwner, m.targetLockCraftID = w.Target.GhostOwner, w.Target.CraftID
+		m.targetLockPendingSince = time.Time{}
+		m.targetLockResolvedOnce = false
+	}
+	if _, _, ok := w.ResolveTargetGhost(); ok {
+		m.targetLockResolvedOnce = true
 		m.targetLockPendingSince = time.Time{}
 		return
 	}
-	if _, _, ok := w.ResolveTargetGhost(); ok {
-		m.targetLockPendingSince = time.Time{}
+	if m.targetLockResolvedOnce {
 		return
 	}
 	if m.targetLockPendingSince.IsZero() {
 		m.targetLockPendingSince = now
-		m.targetLockHandle = handles[w.Target.GhostOwner]
 		return
 	}
 	if now.Sub(m.targetLockPendingSince) <= targetLockRelatchGrace {
 		return
 	}
-	// Handle may be "" (the owner left the roster, or their handle
-	// wasn't cached yet when the timer started) — the chip builder
+	// Handle may be "" (the owner left the roster) — the chip builder
 	// renders a handle-less fallback line rather than showing a blank.
+	// Read now, not cached at timer-start (finding 2).
+	handle := handles[w.Target.GhostOwner]
 	w.ClearTarget()
 	m.localEvents = append(m.localEvents, sim.SessionEvent{
-		Kind: sim.SessionEventTargetLockLost, Handle: m.targetLockHandle, At: now,
+		Kind: sim.SessionEventTargetLockLost, Handle: handle, At: now,
 	})
+	m.resetTargetLockWatch()
+}
+
+// resetTargetLockWatch clears every field reconcileTargetLock uses to
+// track its current ref, so the next tick starts from a clean slate —
+// shared by "no ghost target", "gave up past grace", stopHosting
+// (#294 review finding 3: a stale hours-old timer must never survive
+// into the next hosting session and fire an instant false-loss chip on
+// its first tick), and defensively by startHosting.
+func (m *reportingModel) resetTargetLockWatch() {
+	m.targetLockOwner, m.targetLockCraftID = "", 0
 	m.targetLockPendingSince = time.Time{}
-	m.targetLockHandle = ""
+	m.targetLockResolvedOnce = false
 }
 
 // refreshSession rebuilds the world's ghost + session slates from the
@@ -664,6 +731,12 @@ func (m reportingModel) startHosting() (tea.Model, tea.Cmd) {
 	if m.srv != nil {
 		return m, nil
 	}
+	// #294 review finding 3: begin the target-lock watchdog fresh, same
+	// as stopHosting's reset below — defensive here since a value-typed
+	// m should already be zeroed on a first-ever [h], but guarantees a
+	// stale timer from any path can't survive into this session's first
+	// tick and fire an instant false "lost on reconnect" chip.
+	m.resetTargetLockWatch()
 	keyPath, err := DefaultHostKeyPath()
 	if err != nil {
 		m.app.Toast(fmt.Sprintf("can't host: %v", err))
@@ -741,6 +814,14 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	m.coWarp = nil
 	m.meta, m.metaAt = sessiondir.Meta{}, time.Time{}
 	m.localEvents = nil
+	// #294 review finding 3: stopHosting reset every other reporting
+	// field above but not the target-lock watchdog's — the model value
+	// is reused by the next startHosting, so a timer left running from
+	// this session (an hours-old targetLockPendingSince, or a stale
+	// targetLockOwner/CraftID) would fire an instant false "lost on
+	// reconnect" chip on the very first tick of the NEXT hosting
+	// session, for a target that session never even had.
+	m.resetTargetLockWatch()
 	m.app.Toast("hosting stopped")
 	return m, nil
 }

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -95,10 +95,36 @@ type reportingModel struct {
 	// of which drop the ghost out of the slate through no fault of the
 	// lock) reverts to the pre-#294 tolerance: keep the lock, re-latch
 	// silently whenever it resolves again, never clear it and never chip
-	// a loss. Only a ref that has never resolved since it was (re)bound —
-	// freshly restored at session start, or freshly retargeted this
-	// session — runs the 45s countdown at all.
+	// a loss. Only a ref eligible for the countdown at all — see
+	// targetLockEligible — ever runs it.
 	targetLockResolvedOnce bool
+
+	// targetLockTicked marks that reconcileTargetLock has run at least
+	// once THIS HOSTING SESSION — reset at startHosting and stopHosting,
+	// the same two points resetTargetLockWatch's own per-ref reset
+	// already runs at (§ #294 review finding 3), so a ref bound between
+	// hosting sessions can't inherit a countdown meant for a session's
+	// actual first tick.
+	targetLockTicked bool
+
+	// targetLockEligible is sticky per tracked ref (targetLockOwner /
+	// targetLockCraftID): true only when that ref was ALREADY
+	// Craft.Target's value on this hosting session's first tick — i.e.
+	// restored across a save/reconnect, which is the only case the
+	// give-up countdown exists to bound. Set once, when the ref is
+	// (re)bound below, from !targetLockTicked at that moment.
+	//
+	// #294 review finding 4 (round 2, ADR 0038 undock race): every OTHER
+	// ref change is a LIVE SetTargetGhost this same running session made
+	// — a player's own retarget, a Session-screen pick, or ADR 0038's
+	// undock handback (relay/dock.go) aiming the docker at the guest's
+	// departing craft. None of those have anything "restored" to watch
+	// for, and round 1's blanket countdown meant a slow/disconnecting
+	// guest could get the host's brand-new post-undock lock cleared with
+	// a false "lost on reconnect" chip though no reconnect ever
+	// happened. An ineligible ref's unresolved ticks just wait and
+	// re-latch silently, like any ordinary momentarily-stale ghost.
+	targetLockEligible bool
 }
 
 // localEventTTL matches the chip's on-screen life; pruning here just
@@ -419,27 +445,48 @@ func (m *reportingModel) handleOf(fp string) (string, bool) {
 // tolerance an ordinary momentarily-stale ghost already had before
 // #294 existed).
 //
+// #294 review finding 4 (round 2) narrowed it FURTHER: even "a ref that
+// has never resolved since it was (re)bound" ran the countdown on a ref
+// bound by a LIVE SetTargetGhost this same session — including ADR
+// 0038's undock handback, which aims the docker at the guest's
+// departing craft before the guest's next CraftReport can possibly have
+// landed in w.Ghosts. That raced a slow/disconnecting guest into a
+// false "lost on reconnect" chip though no reconnect ever happened.
+// targetLockEligible is the fix: only a ref that was ALREADY
+// Craft.Target's value on this hosting session's very first
+// reconcileTargetLock call — i.e. restored across an actual save/
+// reconnect — is eligible for the countdown at all. Every other ref
+// change just waits and re-latches silently, exactly like the
+// resolved-once tolerance above already does.
+//
 //   - Target isn't a ghost: nothing pending, reset tracking, no-op.
 //   - Target names a different ref than the one being tracked
 //     (including the very first tick, session start included, since
 //     the tracked ref starts zero-valued): fresh ref, fresh watch —
 //     never inherit another ref's timer, resolved-once state, or
 //     display handle (finding 2: a cached handle from the old ref
-//     would chip the WRONG peer's name).
+//     would chip the WRONG peer's name). Eligibility for THIS ref is
+//     decided right here, from whether this is the session's first
+//     tick (finding 4 round 2).
 //   - Target resolves: mark this ref resolved-once and clear any
 //     pending timer — either it never needed re-latching (ordinary
 //     play, the common case) or the owner's reports just resumed.
 //     Silent either way; the player already has the lock they expect.
-//   - Target doesn't resolve and has already resolved once before:
-//     old-behavior tolerance (finding 1) — no timer, no clearing, no
-//     chip. Just wait for it to come back.
-//   - Target doesn't resolve and has never resolved since being bound,
-//     and this is the first such tick: start the timer.
+//   - Target doesn't resolve and has already resolved once before, or
+//     was never eligible in the first place: old-behavior tolerance —
+//     no timer, no clearing, no chip. Just wait for it to come back.
+//   - Target doesn't resolve, is eligible, and has never resolved since
+//     being bound, and this is the first such tick: start the timer.
 //   - Still unresolved past targetLockRelatchGrace: give up — clear the
-//     target and chip the loss (handle read now, at fire time, per
-//     finding 2 — never cached at timer-start) so the drop is legible
-//     instead of a silent dangling aim.
+//     target, strip any matching ghost ref off planted nodes / the
+//     active burn (finding 2's CancelGhostNodeRefs — the watchdog used
+//     to clear only Craft.Target, leaving those wedged), and chip the
+//     loss (handle read now, at fire time, per finding 2 — never cached
+//     at timer-start) so the drop is legible instead of a silent
+//     dangling aim.
 func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]string, now time.Time) {
+	firstTick := !m.targetLockTicked
+	m.targetLockTicked = true
 	if w.Target.Kind != sim.TargetGhost {
 		m.resetTargetLockWatch()
 		return
@@ -448,13 +495,14 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 		m.targetLockOwner, m.targetLockCraftID = w.Target.GhostOwner, w.Target.CraftID
 		m.targetLockPendingSince = time.Time{}
 		m.targetLockResolvedOnce = false
+		m.targetLockEligible = firstTick
 	}
 	if _, _, ok := w.ResolveTargetGhost(); ok {
 		m.targetLockResolvedOnce = true
 		m.targetLockPendingSince = time.Time{}
 		return
 	}
-	if m.targetLockResolvedOnce {
+	if m.targetLockResolvedOnce || !m.targetLockEligible {
 		return
 	}
 	if m.targetLockPendingSince.IsZero() {
@@ -468,7 +516,9 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 	// renders a handle-less fallback line rather than showing a blank.
 	// Read now, not cached at timer-start (finding 2).
 	handle := handles[w.Target.GhostOwner]
+	owner, craftID := w.Target.GhostOwner, w.Target.CraftID
 	w.ClearTarget()
+	w.CancelGhostNodeRefs(owner, craftID)
 	m.localEvents = append(m.localEvents, sim.SessionEvent{
 		Kind: sim.SessionEventTargetLockLost, Handle: handle, At: now,
 	})
@@ -476,15 +526,20 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 }
 
 // resetTargetLockWatch clears every field reconcileTargetLock uses to
-// track its current ref, so the next tick starts from a clean slate —
-// shared by "no ghost target", "gave up past grace", stopHosting
-// (#294 review finding 3: a stale hours-old timer must never survive
-// into the next hosting session and fire an instant false-loss chip on
-// its first tick), and defensively by startHosting.
+// track its CURRENT ref, so the next ref bound starts from a clean
+// slate — shared by "no ghost target" and "gave up past grace". Does
+// NOT touch targetLockTicked: that tracks the hosting SESSION, not the
+// ref, and must survive a ref reset so a live retarget right after a
+// give-up still correctly reads as ineligible (finding 4 round 2) —
+// only startHosting/stopHosting reset it, alongside their own call to
+// this function (#294 review finding 3: a stale hours-old timer must
+// never survive into the next hosting session and fire an instant
+// false-loss chip on its first tick).
 func (m *reportingModel) resetTargetLockWatch() {
 	m.targetLockOwner, m.targetLockCraftID = "", 0
 	m.targetLockPendingSince = time.Time{}
 	m.targetLockResolvedOnce = false
+	m.targetLockEligible = false
 }
 
 // refreshSession rebuilds the world's ghost + session slates from the
@@ -737,6 +792,13 @@ func (m reportingModel) startHosting() (tea.Model, tea.Cmd) {
 	// stale timer from any path can't survive into this session's first
 	// tick and fire an instant false "lost on reconnect" chip.
 	m.resetTargetLockWatch()
+	// #294 review finding 4 (round 2): also begin the SESSION marker
+	// fresh — whatever Craft.Target reads on this new session's first
+	// reconcileTargetLock call is the "restored" ref eligible for the
+	// countdown; without this reset a [h] stop/[h] start cycle would
+	// carry the PRIOR session's targetLockTicked=true forward and wrongly
+	// treat this session's first ref as a live retarget.
+	m.targetLockTicked = false
 	keyPath, err := DefaultHostKeyPath()
 	if err != nil {
 		m.app.Toast(fmt.Sprintf("can't host: %v", err))
@@ -822,6 +884,11 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// reconnect" chip on the very first tick of the NEXT hosting
 	// session, for a target that session never even had.
 	m.resetTargetLockWatch()
+	// #294 review finding 4 (round 2): same reasoning as startHosting's
+	// reset above — the NEXT session's first reconcileTargetLock call
+	// must see targetLockTicked==false so its ref reads as "restored",
+	// not as a live retarget inherited from this session ending.
+	m.targetLockTicked = false
 	m.app.Toast("hosting stopped")
 	return m, nil
 }

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -61,11 +61,33 @@ type reportingModel struct {
 	rzInviteFrom    string // incoming invite's owner last tick ("" = none)
 	rzInviteHandle  string
 	rzDegraded      bool
+
+	// targetLockPendingSince tracks the deferred re-latch of a craft/ghost
+	// target lock across a reconnect (#294): a ghost target now survives
+	// the per-player save round-trip (CraftToWire/CraftFromWire), so a
+	// session that comes up already aimed at one just needs the target
+	// owner's craft reports to resume before ResolveTargetGhost finds it
+	// again — the same tolerance an ordinary momentarily-stale ghost
+	// already has. Zero means "not waiting" (no ghost target, or it
+	// already resolved). Set the tick refreshSession first finds an
+	// unresolved ghost target; cleared on resolution, on the target
+	// changing to something else, or on giving up past
+	// targetLockRelatchGrace (which also fires the loss chip).
+	targetLockPendingSince time.Time
+	targetLockHandle       string // display name captured when pending started
 }
 
 // localEventTTL matches the chip's on-screen life; pruning here just
 // keeps the slice from growing over a long session.
 const localEventTTL = 10 * time.Second
+
+// targetLockRelatchGrace bounds how long a reconnected session waits for
+// an unresolved craft/ghost target lock to come back before giving up and
+// telling the player (#294). Sized like defaultAwayAfter (60s, away.go):
+// long enough to cover the ordinary reconnect skew between two players
+// both dropped by the same [u] restart, short enough that a lock that
+// really is gone doesn't sit silently un-explained for minutes.
+const targetLockRelatchGrace = 45 * time.Second
 
 // restartExitCode is the dedicated marker the supervising service
 // manager keys on to tell an admin-requested restart from a crash
@@ -354,6 +376,50 @@ func (m *reportingModel) handleOf(fp string) (string, bool) {
 	return "", false
 }
 
+// reconcileTargetLock drives the deferred re-latch of a craft/ghost
+// target lock across a reconnect (#294). Called every tick after
+// w.Ghosts is refreshed, so ResolveTargetGhost sees this tick's data.
+//
+//   - Target isn't a ghost (never was, changed since, or already cleared
+//     by an earlier tick's timeout): nothing pending, no-op.
+//   - Target is a ghost and resolves: either it never needed re-latching
+//     (ordinary play — the common case, exits immediately below) or the
+//     owner's reports just resumed. Either way clear the pending timer
+//     silently; the player already has the lock they expect, nothing to
+//     announce.
+//   - Target is a ghost, doesn't resolve, and this is the first tick that
+//     was true: start the timer.
+//   - Target is a ghost, still doesn't resolve, and the timer has run
+//     past targetLockRelatchGrace: give up — clear the target and chip
+//     the loss so the drop is legible instead of a silent dangling aim.
+func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]string, now time.Time) {
+	if w.Target.Kind != sim.TargetGhost {
+		m.targetLockPendingSince = time.Time{}
+		return
+	}
+	if _, _, ok := w.ResolveTargetGhost(); ok {
+		m.targetLockPendingSince = time.Time{}
+		return
+	}
+	if m.targetLockPendingSince.IsZero() {
+		m.targetLockPendingSince = now
+		m.targetLockHandle = handles[w.Target.GhostOwner]
+		return
+	}
+	if now.Sub(m.targetLockPendingSince) <= targetLockRelatchGrace {
+		return
+	}
+	// Handle may be "" (the owner left the roster, or their handle
+	// wasn't cached yet when the timer started) — the chip builder
+	// renders a handle-less fallback line rather than showing a blank.
+	w.ClearTarget()
+	m.localEvents = append(m.localEvents, sim.SessionEvent{
+		Kind: sim.SessionEventTargetLockLost, Handle: m.targetLockHandle, At: now,
+	})
+	m.targetLockPendingSince = time.Time{}
+	m.targetLockHandle = ""
+}
+
 // refreshSession rebuilds the world's ghost + session slates from the
 // store, roster, and presence.
 func (m *reportingModel) refreshSession(now time.Time) {
@@ -372,6 +438,15 @@ func (m *reportingModel) refreshSession(now time.Time) {
 	// Ghosts (S5): everyone else's craft at this world's sim-time.
 	others := m.srv.relay.Snapshot(m.owner)
 	w.Ghosts = relay.GhostsFor(w, others, handles)
+
+	// Deferred re-latch of a craft/ghost target lock (#294). w.Target
+	// arrives here already TargetGhost if it was saved that way (the
+	// save package now persists it, see CraftToWire) — a reconnect right
+	// after a restart lands with the ghost slate still empty, same as
+	// this world's very first tick after connect. Nothing here forces
+	// resolution; it just watches ResolveTargetGhost each tick (now that
+	// w.Ghosts is fresh) and gives up after targetLockRelatchGrace.
+	m.reconcileTargetLock(w, handles, now)
 
 	// Co-warp (v0.28 S1, ADR 0034 §5): couple the viewer's active craft
 	// to any nearby same-subspace player and write the min-over-Effective

--- a/internal/serve/reporting.go
+++ b/internal/serve/reporting.go
@@ -63,13 +63,13 @@ type reportingModel struct {
 	rzDegraded      bool
 
 	// targetLockOwner / targetLockCraftID identify the specific ghost ref
-	// the watchdog below is tracking (#294 review finding 2) — retargeting
-	// to a different peer mid-grace must start a fresh watch rather than
-	// inherit the old ref's timer and (worst case) chip the wrong peer's
-	// name. A tick that finds w.Target pointing at a different ref than
-	// these (including the very first tick, when both are zero-valued —
-	// "session start" and "player just retargeted" are the same case)
-	// resets targetLockPendingSince and targetLockResolvedOnce below.
+	// the give-up countdown below is tracking (#294 review finding 2) —
+	// retargeting to a different peer mid-grace must start a fresh watch
+	// rather than inherit the old ref's timer and (worst case) chip the
+	// wrong peer's name. A tick that finds w.Target pointing at a
+	// different ref than these (including the very first tick, when both
+	// are zero-valued) resets targetLockPendingSince and
+	// targetLockResolvedOnce below.
 	targetLockOwner   string
 	targetLockCraftID uint64
 
@@ -78,53 +78,33 @@ type reportingModel struct {
 	// the per-player save round-trip (CraftToWire/CraftFromWire), so a
 	// session that comes up already aimed at one just needs the target
 	// owner's craft reports to resume before ResolveTargetGhost finds it
-	// again — the same tolerance an ordinary momentarily-stale ghost
-	// already has. Zero means "not waiting" (no ghost target, the ref
-	// changed, or it already resolved). Set the tick reconcileTargetLock
-	// first finds the current ref unresolved; cleared on resolution, on
-	// the ref changing to something else, or on giving up past
-	// targetLockRelatchGrace (which also fires the loss chip).
+	// again.
+	//
+	// #294 review round 3 (presence rule): this timer only ever runs for
+	// an ABSENT owner — one who is not a member of this session's roster
+	// at all (see reconcileTargetLock). A PRESENT owner's unresolved
+	// ghost (landed, viewing a different system, or simply hasn't
+	// reported yet) gets the same tolerance an ordinary momentarily-stale
+	// ghost already has: wait silently, forever if need be, re-latch
+	// whenever it resolves. Zero means "not counting down" (no ghost
+	// target, the ref changed, it already resolved, or the owner is
+	// present). Set the tick reconcileTargetLock first finds the current
+	// ref unresolved AND absent; cleared on resolution, on the ref
+	// changing to something else, on the owner becoming present, or on
+	// giving up past targetLockRelatchGrace (which also fires the loss
+	// chip).
 	targetLockPendingSince time.Time
 
 	// targetLockResolvedOnce is set the first time the CURRENTLY TRACKED
 	// ref (targetLockOwner/targetLockCraftID) resolves. #294 review
-	// finding 1: once true, the grace-window watchdog retires permanently
-	// for this ref — a later resolve failure (the viewer browsing to
-	// another system, since relay.GhostsFor only emits ghosts for the
-	// VIEWED system, or the peer landing/transferring for a minute, both
-	// of which drop the ghost out of the slate through no fault of the
-	// lock) reverts to the pre-#294 tolerance: keep the lock, re-latch
-	// silently whenever it resolves again, never clear it and never chip
-	// a loss. Only a ref eligible for the countdown at all — see
-	// targetLockEligible — ever runs it.
+	// finding 1: once true, the give-up countdown retires permanently for
+	// this ref — a later resolve failure (the viewer browsing to another
+	// system, since relay.GhostsFor only emits ghosts for the VIEWED
+	// system, or the peer landing/transferring for a minute, both of
+	// which drop the ghost out of the slate through no fault of the lock)
+	// reverts to the pre-#294 tolerance: keep the lock, re-latch silently
+	// whenever it resolves again, never clear it and never chip a loss.
 	targetLockResolvedOnce bool
-
-	// targetLockTicked marks that reconcileTargetLock has run at least
-	// once THIS HOSTING SESSION — reset at startHosting and stopHosting,
-	// the same two points resetTargetLockWatch's own per-ref reset
-	// already runs at (§ #294 review finding 3), so a ref bound between
-	// hosting sessions can't inherit a countdown meant for a session's
-	// actual first tick.
-	targetLockTicked bool
-
-	// targetLockEligible is sticky per tracked ref (targetLockOwner /
-	// targetLockCraftID): true only when that ref was ALREADY
-	// Craft.Target's value on this hosting session's first tick — i.e.
-	// restored across a save/reconnect, which is the only case the
-	// give-up countdown exists to bound. Set once, when the ref is
-	// (re)bound below, from !targetLockTicked at that moment.
-	//
-	// #294 review finding 4 (round 2, ADR 0038 undock race): every OTHER
-	// ref change is a LIVE SetTargetGhost this same running session made
-	// — a player's own retarget, a Session-screen pick, or ADR 0038's
-	// undock handback (relay/dock.go) aiming the docker at the guest's
-	// departing craft. None of those have anything "restored" to watch
-	// for, and round 1's blanket countdown meant a slow/disconnecting
-	// guest could get the host's brand-new post-undock lock cleared with
-	// a false "lost on reconnect" chip though no reconnect ever
-	// happened. An ineligible ref's unresolved ticks just wait and
-	// re-latch silently, like any ordinary momentarily-stale ghost.
-	targetLockEligible bool
 }
 
 // localEventTTL matches the chip's on-screen life; pruning here just
@@ -430,63 +410,66 @@ func (m *reportingModel) handleOf(fp string) (string, bool) {
 // target lock across a reconnect (#294). Called every tick after
 // w.Ghosts is refreshed, so ResolveTargetGhost sees this tick's data.
 //
-// #294 review (findings 1 + 2) narrowed the scope from "every ghost
-// target, forever" to "a ref that has never resolved since it was
-// (re)bound": the pre-review version ran the 45s countdown on ANY
-// resolve failure, which meant a perfectly healthy established lock
-// got permanently cleared just because the viewer browsed to another
-// system for a minute (relay.GhostsFor only emits ghosts for the
-// VIEWED system) or the peer landed/transferred for a minute (both
-// drop the ghost out of the slate with nothing wrong with the lock).
-// targetLockResolvedOnce is the fix: it's sticky per ref, so the
-// watchdog only ever runs across the window between a ref being bound
-// and its first successful resolve — after that it's retired for good
-// and an unresolved tick just falls through as a no-op (the same
-// tolerance an ordinary momentarily-stale ghost already had before
-// #294 existed).
+// #294 review round 3 (presence rule) replaced the earlier
+// first-tick-eligibility inference (rounds 1 + 2: targetLockResolvedOnce
+// / targetLockEligible / targetLockTicked) with a simpler test that
+// needs no session-timing bookkeeping at all: the 45s give-up countdown
+// runs ONLY when the ref has never resolved this session AND its owner
+// is ABSENT from the session — not a member of the roster `handles`
+// derives from, at all. Presence, not timing, is what the countdown was
+// always trying to approximate:
 //
-// #294 review finding 4 (round 2) narrowed it FURTHER: even "a ref that
-// has never resolved since it was (re)bound" ran the countdown on a ref
-// bound by a LIVE SetTargetGhost this same session — including ADR
-// 0038's undock handback, which aims the docker at the guest's
-// departing craft before the guest's next CraftReport can possibly have
-// landed in w.Ghosts. That raced a slow/disconnecting guest into a
-// false "lost on reconnect" chip though no reconnect ever happened.
-// targetLockEligible is the fix: only a ref that was ALREADY
-// Craft.Target's value on this hosting session's very first
-// reconcileTargetLock call — i.e. restored across an actual save/
-// reconnect — is eligible for the countdown at all. Every other ref
-// change just waits and re-latches silently, exactly like the
-// resolved-once tolerance above already does.
+//   - An owner who IS present (enrolled in this session) but whose
+//     craft isn't currently resolvable — landed, viewing a different
+//     system (relay.GhostsFor only emits ghosts for the VIEWED system),
+//     or simply hasn't reported yet this tick — is never a countdown
+//     case. The lock waits silently and re-latches the moment it comes
+//     back into view, no matter how long that takes.
+//
+//   - A LIVE SetTargetGhost (a player's own retarget, a Session-screen
+//     pick, or ADR 0038's undock handback aiming the docker at the
+//     guest's departing craft) always points at a PRESENT owner — they
+//     have to be in the roster to have a ghost to aim at in the first
+//     place — so it never starts a countdown either. The old
+//     eligibility flags existed only to approximate this same fact from
+//     session timing; presence gets it directly, and for every case at
+//     once (undock races included), not just the first tick.
+//
+//   - Only a ref whose owner was never enrolled in this session (a
+//     standalone save loaded outside the session it was bound in), or
+//     has since been removed from the roster, is genuinely a "will this
+//     ever come back" question — that's the case the countdown bounds.
 //
 //   - Target isn't a ghost: nothing pending, reset tracking, no-op.
+//
 //   - Target names a different ref than the one being tracked
-//     (including the very first tick, session start included, since
-//     the tracked ref starts zero-valued): fresh ref, fresh watch —
-//     never inherit another ref's timer, resolved-once state, or
-//     display handle (finding 2: a cached handle from the old ref
-//     would chip the WRONG peer's name). Eligibility for THIS ref is
-//     decided right here, from whether this is the session's first
-//     tick (finding 4 round 2).
+//     (including the very first tick, since the tracked ref starts
+//     zero-valued): fresh ref, fresh watch — never inherit another
+//     ref's timer, resolved-once state, or display handle (a cached
+//     handle from the old ref would chip the WRONG peer's name).
+//
 //   - Target resolves: mark this ref resolved-once and clear any
 //     pending timer — either it never needed re-latching (ordinary
 //     play, the common case) or the owner's reports just resumed.
 //     Silent either way; the player already has the lock they expect.
-//   - Target doesn't resolve and has already resolved once before, or
-//     was never eligible in the first place: old-behavior tolerance —
-//     no timer, no clearing, no chip. Just wait for it to come back.
-//   - Target doesn't resolve, is eligible, and has never resolved since
-//     being bound, and this is the first such tick: start the timer.
-//   - Still unresolved past targetLockRelatchGrace: give up — clear the
-//     target, strip any matching ghost ref off planted nodes / the
-//     active burn (finding 2's CancelGhostNodeRefs — the watchdog used
-//     to clear only Craft.Target, leaving those wedged), and chip the
-//     loss (handle read now, at fire time, per finding 2 — never cached
-//     at timer-start) so the drop is legible instead of a silent
-//     dangling aim.
+//
+//   - Target doesn't resolve and has already resolved once before:
+//     old-behavior tolerance — no timer, no clearing, no chip.
+//
+//   - Target doesn't resolve and the owner IS present: no countdown —
+//     clear any timer a prior absence had started (a removed-then-
+//     re-added owner isn't punished for the gap) and wait.
+//
+//   - Target doesn't resolve and the owner is ABSENT: start (or
+//     continue) the timer.
+//
+//   - Still unresolved past targetLockRelatchGrace with the owner
+//     absent throughout: give up — clear the target, abort any
+//     matching planted node / active burn (CancelGhostNodeRefs), and
+//     chip the loss (handle read now, at fire time — never cached at
+//     timer-start) so the drop is legible instead of a silent dangling
+//     aim.
 func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]string, now time.Time) {
-	firstTick := !m.targetLockTicked
-	m.targetLockTicked = true
 	if w.Target.Kind != sim.TargetGhost {
 		m.resetTargetLockWatch()
 		return
@@ -495,14 +478,17 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 		m.targetLockOwner, m.targetLockCraftID = w.Target.GhostOwner, w.Target.CraftID
 		m.targetLockPendingSince = time.Time{}
 		m.targetLockResolvedOnce = false
-		m.targetLockEligible = firstTick
 	}
 	if _, _, ok := w.ResolveTargetGhost(); ok {
 		m.targetLockResolvedOnce = true
 		m.targetLockPendingSince = time.Time{}
 		return
 	}
-	if m.targetLockResolvedOnce || !m.targetLockEligible {
+	if m.targetLockResolvedOnce {
+		return
+	}
+	if _, present := handles[w.Target.GhostOwner]; present {
+		m.targetLockPendingSince = time.Time{}
 		return
 	}
 	if m.targetLockPendingSince.IsZero() {
@@ -514,7 +500,7 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 	}
 	// Handle may be "" (the owner left the roster) — the chip builder
 	// renders a handle-less fallback line rather than showing a blank.
-	// Read now, not cached at timer-start (finding 2).
+	// Read now, not cached at timer-start.
 	handle := handles[w.Target.GhostOwner]
 	owner, craftID := w.Target.GhostOwner, w.Target.CraftID
 	w.ClearTarget()
@@ -527,19 +513,14 @@ func (m *reportingModel) reconcileTargetLock(w *sim.World, handles map[string]st
 
 // resetTargetLockWatch clears every field reconcileTargetLock uses to
 // track its CURRENT ref, so the next ref bound starts from a clean
-// slate — shared by "no ghost target" and "gave up past grace". Does
-// NOT touch targetLockTicked: that tracks the hosting SESSION, not the
-// ref, and must survive a ref reset so a live retarget right after a
-// give-up still correctly reads as ineligible (finding 4 round 2) —
-// only startHosting/stopHosting reset it, alongside their own call to
-// this function (#294 review finding 3: a stale hours-old timer must
-// never survive into the next hosting session and fire an instant
-// false-loss chip on its first tick).
+// slate — shared by "no ghost target" and "gave up past grace". Also
+// called by startHosting/stopHosting (#294 review finding 3) so a stale
+// hours-old timer from one hosting session can never survive into the
+// next and fire an instant false-loss chip on its first tick.
 func (m *reportingModel) resetTargetLockWatch() {
 	m.targetLockOwner, m.targetLockCraftID = "", 0
 	m.targetLockPendingSince = time.Time{}
 	m.targetLockResolvedOnce = false
-	m.targetLockEligible = false
 }
 
 // refreshSession rebuilds the world's ghost + session slates from the
@@ -792,13 +773,6 @@ func (m reportingModel) startHosting() (tea.Model, tea.Cmd) {
 	// stale timer from any path can't survive into this session's first
 	// tick and fire an instant false "lost on reconnect" chip.
 	m.resetTargetLockWatch()
-	// #294 review finding 4 (round 2): also begin the SESSION marker
-	// fresh — whatever Craft.Target reads on this new session's first
-	// reconcileTargetLock call is the "restored" ref eligible for the
-	// countdown; without this reset a [h] stop/[h] start cycle would
-	// carry the PRIOR session's targetLockTicked=true forward and wrongly
-	// treat this session's first ref as a live retarget.
-	m.targetLockTicked = false
 	keyPath, err := DefaultHostKeyPath()
 	if err != nil {
 		m.app.Toast(fmt.Sprintf("can't host: %v", err))
@@ -884,11 +858,6 @@ func (m reportingModel) stopHosting() (tea.Model, tea.Cmd) {
 	// reconnect" chip on the very first tick of the NEXT hosting
 	// session, for a target that session never even had.
 	m.resetTargetLockWatch()
-	// #294 review finding 4 (round 2): same reasoning as startHosting's
-	// reset above — the NEXT session's first reconcileTargetLock call
-	// must see targetLockTicked==false so its ref reads as "restored",
-	// not as a live retarget inherited from this session ending.
-	m.targetLockTicked = false
 	m.app.Toast("hosting stopped")
 	return m, nil
 }

--- a/internal/serve/target_lock_reconnect_test.go
+++ b/internal/serve/target_lock_reconnect_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/jasonfen/terminal-space-program/internal/relay"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
 // #294: a guest's craft/rendezvous target lock on another player's
@@ -219,4 +222,180 @@ func TestTargetLockSurvivesSaveLoadAndReLatchesThroughReportingModel(t *testing.
 		}
 	}
 	_ = m
+}
+
+// #294 review finding 1: the pre-review watchdog ran its 45s countdown on
+// EVERY resolve failure, not just a ref that had never resolved since it
+// was bound. relay.GhostsFor only emits ghosts for the viewer's VIEWED
+// system and skips Landed craft, so a player browsing another system for
+// a minute, or whose peer lands/transfers briefly, would get a perfectly
+// healthy lock silently and permanently cleared. Once a ref has resolved
+// once, the watchdog must retire for it for good — a later resolve
+// failure reverts to the old (pre-#294) tolerance: keep the lock, re-latch
+// silently whenever it resolves again, never clear it, never chip a loss.
+func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.SetTargetGhost(testPeerFP, 99)
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "peer"}
+	now := time.Now()
+
+	// Ordinary play: resolves on the very first tick, same as any live
+	// rendezvous — this is what marks the ref resolved-once.
+	m.reconcileTargetLock(w, handles, now)
+	if !m.targetLockResolvedOnce {
+		t.Fatalf("ref never marked resolved-once after a successful resolve")
+	}
+
+	// The ghost now drops out of the slate for reasons that have nothing
+	// to do with the lock — standing in for "browsing another system" /
+	// "peer landed for a minute" with the blunt instrument of an empty
+	// w.Ghosts, held for far longer than targetLockRelatchGrace.
+	w.Ghosts = nil
+	for i := 1; i <= 10; i++ {
+		m.reconcileTargetLock(w, handles, now.Add(time.Duration(i)*targetLockRelatchGrace))
+	}
+
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Fatalf("established lock cleared despite having resolved once: %+v", w.Target)
+	}
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("watchdog timer started for an already-established lock: %v", m.targetLockPendingSince)
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Errorf("loss chip fired for an established lock that merely went briefly unresolved: %+v", e)
+		}
+	}
+}
+
+// #294 review finding 2: the pending timer used to key only on
+// Kind==TargetGhost, not WHICH ghost — retargeting to a different peer
+// mid-grace inherited the old timer (and, pre-fix, a handle cached at
+// timer-start), clearing the new lock early and naming the wrong peer.
+// The fix keys the watch on (GhostOwner, CraftID): a retarget starts a
+// fresh grace window for the new ref, and the loss chip's handle is read
+// at fire time rather than cached when the timer started.
+func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	const fpA, fpB = "SHA256:peer-a", "SHA256:peer-b"
+	w.SetTargetGhost(fpA, 1)
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{fpA: "alice", fpB: "bob"}
+	now := time.Now()
+
+	// A never resolves — its watchdog timer starts.
+	m.reconcileTargetLock(w, handles, now)
+	if m.targetLockPendingSince.IsZero() {
+		t.Fatalf("watchdog for A never started")
+	}
+	retargetAt := now.Add(targetLockRelatchGrace - time.Second) // deep into A's own grace
+	m.reconcileTargetLock(w, handles, retargetAt)
+
+	// Player retargets to B before A either resolved or timed out — an
+	// ordinary in-session target switch, not a reconnect.
+	w.SetTargetGhost(fpB, 2)
+	m.reconcileTargetLock(w, handles, retargetAt)
+	if m.targetLockOwner != fpB || m.targetLockCraftID != 2 {
+		t.Fatalf("watchdog still tracking the superseded ref: owner=%q craftID=%d", m.targetLockOwner, m.targetLockCraftID)
+	}
+	if w.Target.Kind != sim.TargetGhost {
+		t.Fatalf("retargeting itself cleared the target: %+v", w.Target)
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Fatalf("loss chip fired immediately on retarget — inherited A's near-expired timer: %+v", e)
+		}
+	}
+
+	// B gets its own full grace window measured from the retarget point,
+	// not from whatever was left of A's.
+	m.reconcileTargetLock(w, handles, retargetAt.Add(targetLockRelatchGrace/2))
+	if w.Target.Kind != sim.TargetGhost {
+		t.Fatalf("B cleared before its OWN grace window elapsed: %+v", w.Target)
+	}
+
+	// Past B's own grace: give up, and the chip must name B ("bob") —
+	// read at fire time — never the stale "alice" from A's timer.
+	m.reconcileTargetLock(w, handles, retargetAt.Add(targetLockRelatchGrace+time.Second))
+	if w.Target.Kind != sim.TargetNone {
+		t.Errorf("target not cleared after B's grace elapsed: %+v", w.Target)
+	}
+	var lost *sim.SessionEvent
+	for i, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			lost = &m.localEvents[i]
+		}
+	}
+	if lost == nil {
+		t.Fatalf("no loss chip fired for B; events=%+v", m.localEvents)
+	}
+	if lost.Handle != "bob" {
+		t.Errorf("loss chip named %q, want %q (the CURRENT ref, not the superseded one)", lost.Handle, "bob")
+	}
+}
+
+// #294 review finding 3: stopHosting reset every other reporting field but
+// not the target-lock watchdog's — since the reportingModel value is reused
+// by the next startHosting, a stale hours-old timer would fire an instant
+// false "lost on reconnect" chip on the very next hosting session's first
+// tick, for a target that session never even had.
+func TestStopHostingResetsTargetLockWatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	app, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	var m tea.Model = WrapHost(app, nil, 0)
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 140, Height: 45})
+	m, _ = m.Update(screens.SessionHostMsg{Start: true})
+	srv := hostServer(t, m)
+	if srv == nil {
+		t.Fatal("start failed")
+	}
+
+	rm, ok := m.(reportingModel)
+	if !ok {
+		t.Fatalf("model is %T, not reportingModel", m)
+	}
+	// Simulate a stale watchdog left running from a target lock that
+	// never resolved during this hosting session.
+	rm.targetLockOwner = "SHA256:stale-peer"
+	rm.targetLockCraftID = 42
+	rm.targetLockPendingSince = time.Now().Add(-3 * time.Hour)
+
+	stopped, _ := rm.stopHosting()
+	sm, ok := stopped.(reportingModel)
+	if !ok {
+		t.Fatalf("stopped model is %T", stopped)
+	}
+	if sm.targetLockOwner != "" || sm.targetLockCraftID != 0 || !sm.targetLockPendingSince.IsZero() || sm.targetLockResolvedOnce {
+		t.Errorf("stopHosting left stale watchdog state: owner=%q craftID=%d pendingSince=%v resolvedOnce=%v",
+			sm.targetLockOwner, sm.targetLockCraftID, sm.targetLockPendingSince, sm.targetLockResolvedOnce)
+	}
+
+	// The very next hosting session's first tick must not fire an
+	// instant false loss chip from a stale reset-should-have-cleared timer.
+	var m2 tea.Model = sm
+	m2, _ = m2.Update(screens.SessionHostMsg{Start: true})
+	srv2 := hostServer(t, m2)
+	if srv2 == nil {
+		t.Fatal("restart failed")
+	}
+	t.Cleanup(func() { _ = srv2.ln.Close() })
+	m2 = tick(m2)
+	for _, e := range app.World().SessionEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Errorf("false target-lock-lost chip fired on next session's first tick: %+v", e)
+		}
+	}
 }

--- a/internal/serve/target_lock_reconnect_test.go
+++ b/internal/serve/target_lock_reconnect_test.go
@@ -279,9 +279,18 @@ func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
 // Kind==TargetGhost, not WHICH ghost — retargeting to a different peer
 // mid-grace inherited the old timer (and, pre-fix, a handle cached at
 // timer-start), clearing the new lock early and naming the wrong peer.
-// The fix keys the watch on (GhostOwner, CraftID): a retarget starts a
-// fresh grace window for the new ref, and the loss chip's handle is read
-// at fire time rather than cached when the timer started.
+// The fix (round 1) keyed the watch on (GhostOwner, CraftID): a retarget
+// starts fresh tracking for the new ref rather than inheriting the old
+// one's near-expired timer or cached handle.
+//
+// #294 review finding 4 (round 2) narrowed this further: a retarget is a
+// LIVE SetTargetGhost call, and round 2 scopes the give-up countdown to
+// refs restored at session start only (targetLockEligible) — so B here
+// no longer gets "its own grace window" the way round 1 asserted; it
+// gets no countdown at all and must never chip a loss, no matter how
+// long it stays unresolved. What both rounds agree on: retargeting must
+// never inherit A's state (timer, handle, or eligibility) and must never
+// chip immediately on the switch itself.
 func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -293,10 +302,14 @@ func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 	handles := map[string]string{fpA: "alice", fpB: "bob"}
 	now := time.Now()
 
-	// A never resolves — its watchdog timer starts.
+	// A is this session's very first ref (restored, in the reconnect
+	// sense this fixture stands in for) — eligible, its watchdog starts.
 	m.reconcileTargetLock(w, handles, now)
 	if m.targetLockPendingSince.IsZero() {
 		t.Fatalf("watchdog for A never started")
+	}
+	if !m.targetLockEligible {
+		t.Fatalf("A (this session's first ref) not marked eligible")
 	}
 	retargetAt := now.Add(targetLockRelatchGrace - time.Second) // deep into A's own grace
 	m.reconcileTargetLock(w, handles, retargetAt)
@@ -311,36 +324,29 @@ func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 	if w.Target.Kind != sim.TargetGhost {
 		t.Fatalf("retargeting itself cleared the target: %+v", w.Target)
 	}
+	if m.targetLockEligible {
+		t.Fatalf("B (a LIVE retarget, not a restored ref) wrongly marked eligible for the countdown")
+	}
 	for _, e := range m.localEvents {
 		if e.Kind == sim.SessionEventTargetLockLost {
 			t.Fatalf("loss chip fired immediately on retarget — inherited A's near-expired timer: %+v", e)
 		}
 	}
 
-	// B gets its own full grace window measured from the retarget point,
-	// not from whatever was left of A's.
-	m.reconcileTargetLock(w, handles, retargetAt.Add(targetLockRelatchGrace/2))
-	if w.Target.Kind != sim.TargetGhost {
-		t.Fatalf("B cleared before its OWN grace window elapsed: %+v", w.Target)
+	// B never gets a countdown at all (finding 4 round 2) — it just waits,
+	// silently, no matter how far past what would have been A's grace
+	// window. No pending timer, no chip, target stays locked on B.
+	m.reconcileTargetLock(w, handles, retargetAt.Add(5*targetLockRelatchGrace))
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != fpB || w.Target.CraftID != 2 {
+		t.Errorf("B cleared despite being a live (ineligible) ref: %+v", w.Target)
 	}
-
-	// Past B's own grace: give up, and the chip must name B ("bob") —
-	// read at fire time — never the stale "alice" from A's timer.
-	m.reconcileTargetLock(w, handles, retargetAt.Add(targetLockRelatchGrace+time.Second))
-	if w.Target.Kind != sim.TargetNone {
-		t.Errorf("target not cleared after B's grace elapsed: %+v", w.Target)
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("countdown started for a live retarget: %v", m.targetLockPendingSince)
 	}
-	var lost *sim.SessionEvent
-	for i, e := range m.localEvents {
+	for _, e := range m.localEvents {
 		if e.Kind == sim.SessionEventTargetLockLost {
-			lost = &m.localEvents[i]
+			t.Errorf("loss chip fired for a live retarget that should never get a countdown: %+v", e)
 		}
-	}
-	if lost == nil {
-		t.Fatalf("no loss chip fired for B; events=%+v", m.localEvents)
-	}
-	if lost.Handle != "bob" {
-		t.Errorf("loss chip named %q, want %q (the CURRENT ref, not the superseded one)", lost.Handle, "bob")
 	}
 }
 
@@ -397,5 +403,77 @@ func TestStopHostingResetsTargetLockWatch(t *testing.T) {
 		if e.Kind == sim.SessionEventTargetLockLost {
 			t.Errorf("false target-lock-lost chip fired on next session's first tick: %+v", e)
 		}
+	}
+}
+
+// #294 review finding 4 (round 2): ADR 0038 undock handback
+// (relay/dock.go's SetTargetGhost calls at the docker's release/undock
+// paths) aims the docker at the guest's departing craft before the
+// guest's own next CraftReport can possibly have landed in w.Ghosts —
+// a brand-new ref with an empty ghost slate, which used to be
+// indistinguishable from "restored across a reconnect" and so started
+// the very same 45s give-up countdown. A slow or disconnecting guest
+// then cost the host a false "lost on reconnect" chip though no
+// reconnect ever happened. Fixed two ways: (a) HasRelativeTarget no
+// longer requires a resolve (internal/sim/target.go), so NavTarget
+// survives the momentary gap; (b) the countdown is scoped to refs
+// restored at session start only (targetLockEligible), so a live
+// SetTargetGhost — undock handback included — never starts it at all.
+func TestUndockHandbackLiveSetTargetGhostNeverStartsCountdown(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// The docker was already flying NavTarget before undock — e.g. from
+	// an earlier live rendezvous lock this same session.
+	w.NavMode = sim.NavTarget
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "guest"}
+	now := time.Now()
+
+	// This session has already ticked at least once before the undock —
+	// the undock's fresh ref is emphatically NOT this session's first.
+	m.reconcileTargetLock(w, handles, now)
+
+	// Undock handback: SetTargetGhost fires with an EMPTY ghost slate —
+	// the guest's departing craft hasn't reported in yet.
+	w.SetTargetGhost(testPeerFP, 99)
+	if w.NavMode != sim.NavTarget {
+		t.Fatalf("NavTarget demoted to NavOrbit by a momentarily-unresolved fresh ghost ref: %v", w.NavMode)
+	}
+
+	// The next tick's reconcileTargetLock call (ghost slate still empty)
+	// must not start a countdown for this fresh LIVE ref.
+	m.reconcileTargetLock(w, handles, now.Add(time.Second))
+	if !m.targetLockPendingSince.IsZero() {
+		t.Fatalf("countdown started for a live undock-handback ref: %v", m.targetLockPendingSince)
+	}
+	if m.targetLockEligible {
+		t.Fatalf("undock-handback ref wrongly marked eligible for the give-up countdown")
+	}
+
+	// Even well past what would have been the grace window, still no
+	// chip and the lock is still standing, waiting.
+	m.reconcileTargetLock(w, handles, now.Add(2*targetLockRelatchGrace))
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Fatalf("undock-handback lock cleared despite no reconnect ever happening: %+v", w.Target)
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Fatalf("false 'lost on reconnect' chip fired for a live undock handback: %+v", e)
+		}
+	}
+
+	// The guest's report finally lands: resolves normally, like any
+	// ordinary live target.
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+	m.reconcileTargetLock(w, handles, now.Add(2*targetLockRelatchGrace+time.Second))
+	if !m.targetLockResolvedOnce {
+		t.Errorf("ref never marked resolved-once after the guest's report landed")
+	}
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Errorf("lock lost by the time the guest's report resolved: %+v", w.Target)
 	}
 }

--- a/internal/serve/target_lock_reconnect_test.go
+++ b/internal/serve/target_lock_reconnect_test.go
@@ -28,6 +28,14 @@ import (
 //     after targetLockRelatchGrace and fires a legible
 //     SessionEventTargetLockLost chip.
 //
+// #294 review round 3 replaced the original give-up trigger ("any
+// resolve failure", rounds 1+2's fix: "any resolve failure on a ref
+// eligible from session-start timing") with a PRESENCE rule: the
+// countdown runs only when the ref's owner is ABSENT from this
+// session's roster — not a timing inference at all. See
+// reconcileTargetLock's doc comment in reporting.go for the full
+// reasoning.
+//
 // These tests exercise reconcileTargetLock directly, with synthetic
 // timestamps, so the grace window doesn't have to be slept through.
 
@@ -60,12 +68,13 @@ func TestTargetLockResolvesImmediatelyNoOp(t *testing.T) {
 	}
 }
 
-// The deferred re-latch: a ghost target that lands unresolved (the
-// reconnect case — reports haven't arrived yet) starts a pending timer
-// instead of dropping immediately, and once the owner's report resumes
-// the lock is restored silently — no chip, because the player ends up
-// exactly where they started.
-func TestTargetLockRelatchesSilentlyWhenReportResumes(t *testing.T) {
+// The presence rule's core case: an owner who IS a member of this
+// session (present in the roster `handles` derives from) never starts
+// the give-up countdown at all, no matter how long their ghost stays
+// unresolved — it just waits and re-latches silently once their report
+// resumes, exactly the pre-#294 tolerance an ordinary momentarily-stale
+// ghost always had.
+func TestTargetLockPresentOwnerNeverCountsDownAndReLatches(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -84,20 +93,17 @@ func TestTargetLockRelatchesSilentlyWhenReportResumes(t *testing.T) {
 	if w.Target.Kind != sim.TargetGhost {
 		t.Fatalf("target cleared on the very first unresolved tick: %+v", w.Target)
 	}
-	if m.targetLockPendingSince.IsZero() {
-		t.Fatalf("pending timer did not start for an unresolved ghost target")
+	if !m.targetLockPendingSince.IsZero() {
+		t.Fatalf("countdown started for a present owner: %v", m.targetLockPendingSince)
 	}
 
-	// The peer's report resumes a few seconds later — well inside the
-	// grace window — and the ghost slate now carries their craft.
+	// The peer's report resumes a few seconds later, and the ghost slate
+	// now carries their craft.
 	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
 	m.reconcileTargetLock(w, handles, now.Add(5*time.Second))
 
 	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
 		t.Errorf("target lock not restored once the report resumed: %+v", w.Target)
-	}
-	if !m.targetLockPendingSince.IsZero() {
-		t.Errorf("pending timer not cleared after a successful re-latch")
 	}
 	for _, e := range m.localEvents {
 		if e.Kind == sim.SessionEventTargetLockLost {
@@ -106,10 +112,76 @@ func TestTargetLockRelatchesSilentlyWhenReportResumes(t *testing.T) {
 	}
 }
 
-// Legibility: a ghost target that never resolves within
-// targetLockRelatchGrace is dropped for good and the player is told —
-// not left with a silently dangling aim.
-func TestTargetLockLostChipAfterGraceWindow(t *testing.T) {
+// Finding A's literal motivating case: the peer is present (enrolled in
+// this session) but their craft is Landed — relay.GhostsFor (internal/
+// relay/ghosts.go) filters Landed craft out of the ghost slate
+// entirely, so the ghost never resolves even though nothing is wrong
+// with the lock. The presence rule must survive this indefinitely, not
+// merely for one grace window.
+func TestTargetLockLandedPeerSurvivesAndReLatches(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.SetTargetGhost(testPeerFP, 99)
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "peer"}
+	now := time.Now()
+
+	// Resolve once — an established lock, same as ordinary live play.
+	m.reconcileTargetLock(w, handles, now)
+	if !m.targetLockResolvedOnce {
+		t.Fatalf("ref never marked resolved-once")
+	}
+
+	// The peer lands. GhostsFor filters Landed craft out of the slate —
+	// reproduce that shape directly rather than asserting against
+	// GhostsFor's internals.
+	reports := []relay.CraftReport{{
+		Owner: testPeerFP, SubspaceTime: w.Clock.SimTime,
+		Crafts: []relay.CraftState{{ID: 99, Landed: true, System: w.System().Name, Primary: c.Primary.ID}},
+	}}
+	w.Ghosts = relay.GhostsFor(w, reports, handles)
+	if len(w.Ghosts) != 0 {
+		t.Fatalf("test setup: a Landed craft still produced a ghost: %+v", w.Ghosts)
+	}
+
+	// Reset resolved-once so this run exercises the PRESENCE path on its
+	// own merits, not the (already-covered) resolved-once tolerance.
+	m.targetLockResolvedOnce = false
+	for i := 1; i <= 10; i++ {
+		m.reconcileTargetLock(w, handles, now.Add(time.Duration(i)*targetLockRelatchGrace))
+	}
+
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Fatalf("lock cleared for a landed but PRESENT peer: %+v", w.Target)
+	}
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("countdown started for a present (landed) peer: %v", m.targetLockPendingSince)
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Fatalf("false loss chip fired for a landed but present peer: %+v", e)
+		}
+	}
+
+	// The peer lifts off again — the ghost re-latches normally.
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+	m.reconcileTargetLock(w, handles, now.Add(11*targetLockRelatchGrace))
+	if !m.targetLockResolvedOnce {
+		t.Errorf("ref not marked resolved-once again after re-latching")
+	}
+}
+
+// Legibility: a ghost target whose owner is genuinely ABSENT from this
+// session (never enrolled here — a standalone save loaded outside the
+// session it was bound in, or since removed from the roster) is dropped
+// for good after targetLockRelatchGrace and the player is told — not
+// left with a silently dangling aim.
+func TestTargetLockAbsentOwnerGivesUpAfterGraceWindow(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -117,10 +189,13 @@ func TestTargetLockLostChipAfterGraceWindow(t *testing.T) {
 	w.SetTargetGhost(testPeerFP, 99)
 
 	m := &reportingModel{owner: "SHA256:self"}
-	handles := map[string]string{testPeerFP: "peer"}
+	handles := map[string]string{} // testPeerFP is not a member of this session
 	now := time.Now()
 
 	m.reconcileTargetLock(w, handles, now) // starts the pending timer
+	if m.targetLockPendingSince.IsZero() {
+		t.Fatalf("countdown never started for an absent owner")
+	}
 
 	// Still inside the grace window: keep waiting, no chip yet.
 	m.reconcileTargetLock(w, handles, now.Add(targetLockRelatchGrace/2))
@@ -133,7 +208,7 @@ func TestTargetLockLostChipAfterGraceWindow(t *testing.T) {
 		}
 	}
 
-	// Past grace, still unresolved: give up and say so.
+	// Past grace, still unresolved and still absent: give up and say so.
 	m.reconcileTargetLock(w, handles, now.Add(targetLockRelatchGrace+time.Second))
 
 	if w.Target.Kind != sim.TargetNone {
@@ -147,9 +222,6 @@ func TestTargetLockLostChipAfterGraceWindow(t *testing.T) {
 	}
 	if lost == nil {
 		t.Fatalf("no target-lock-lost chip fired; events=%+v", m.localEvents)
-	}
-	if lost.Handle != "peer" {
-		t.Errorf("loss chip Handle = %q, want %q", lost.Handle, "peer")
 	}
 	if !m.targetLockPendingSince.IsZero() {
 		t.Errorf("pending timer not cleared after giving up")
@@ -192,11 +264,12 @@ func TestTargetLockSurvivesSaveLoadAndReLatchesThroughReportingModel(t *testing.
 	}
 
 	// Bob's report hasn't reached the relay store yet — Alice's session
-	// comes up before Bob's does.
+	// comes up before Bob's does. Bob is still enrolled (present) the
+	// whole time, so this must never start a countdown.
 	m := srv.withReporting(reloaded, fpA)
 	m = tick(m)
 	if w2.Target.Kind != sim.TargetGhost {
-		t.Fatalf("target dropped on the very first tick, before the grace window: %+v", w2.Target)
+		t.Fatalf("target dropped on the very first tick: %+v", w2.Target)
 	}
 
 	// Bob's report now arrives.
@@ -226,13 +299,12 @@ func TestTargetLockSurvivesSaveLoadAndReLatchesThroughReportingModel(t *testing.
 
 // #294 review finding 1: the pre-review watchdog ran its 45s countdown on
 // EVERY resolve failure, not just a ref that had never resolved since it
-// was bound. relay.GhostsFor only emits ghosts for the viewer's VIEWED
-// system and skips Landed craft, so a player browsing another system for
-// a minute, or whose peer lands/transfers briefly, would get a perfectly
-// healthy lock silently and permanently cleared. Once a ref has resolved
-// once, the watchdog must retire for it for good — a later resolve
-// failure reverts to the old (pre-#294) tolerance: keep the lock, re-latch
-// silently whenever it resolves again, never clear it, never chip a loss.
+// was bound. Once a ref has resolved once, the watchdog must retire for
+// it for good — a later resolve failure reverts to the old (pre-#294)
+// tolerance: keep the lock, re-latch silently whenever it resolves
+// again, never clear it, never chip a loss. This holds independently of
+// presence — even an ABSENT owner's already-established lock never
+// expires.
 func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -243,7 +315,7 @@ func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
 	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
 
 	m := &reportingModel{owner: "SHA256:self"}
-	handles := map[string]string{testPeerFP: "peer"}
+	handles := map[string]string{} // absent — resolved-once must still win over presence
 	now := time.Now()
 
 	// Ordinary play: resolves on the very first tick, same as any live
@@ -254,9 +326,7 @@ func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
 	}
 
 	// The ghost now drops out of the slate for reasons that have nothing
-	// to do with the lock — standing in for "browsing another system" /
-	// "peer landed for a minute" with the blunt instrument of an empty
-	// w.Ghosts, held for far longer than targetLockRelatchGrace.
+	// to do with the lock, held for far longer than targetLockRelatchGrace.
 	w.Ghosts = nil
 	for i := 1; i <= 10; i++ {
 		m.reconcileTargetLock(w, handles, now.Add(time.Duration(i)*targetLockRelatchGrace))
@@ -277,21 +347,11 @@ func TestTargetLockEstablishedLockNeverExpiresAfterResolvingOnce(t *testing.T) {
 
 // #294 review finding 2: the pending timer used to key only on
 // Kind==TargetGhost, not WHICH ghost — retargeting to a different peer
-// mid-grace inherited the old timer (and, pre-fix, a handle cached at
+// mid-grace inherited the old timer (and a handle cached at
 // timer-start), clearing the new lock early and naming the wrong peer.
-// The fix (round 1) keyed the watch on (GhostOwner, CraftID): a retarget
-// starts fresh tracking for the new ref rather than inheriting the old
-// one's near-expired timer or cached handle.
-//
-// #294 review finding 4 (round 2) narrowed this further: a retarget is a
-// LIVE SetTargetGhost call, and round 2 scopes the give-up countdown to
-// refs restored at session start only (targetLockEligible) — so B here
-// no longer gets "its own grace window" the way round 1 asserted; it
-// gets no countdown at all and must never chip a loss, no matter how
-// long it stays unresolved. What both rounds agree on: retargeting must
-// never inherit A's state (timer, handle, or eligibility) and must never
-// chip immediately on the switch itself.
-func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
+// The fix keys the watch on (GhostOwner, CraftID): a retarget starts
+// fresh tracking — and its own full grace window — for the new ref.
+func TestTargetLockRetargetMidGraceResetsTimer(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -299,23 +359,17 @@ func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 	const fpA, fpB = "SHA256:peer-a", "SHA256:peer-b"
 	w.SetTargetGhost(fpA, 1)
 	m := &reportingModel{owner: "SHA256:self"}
-	handles := map[string]string{fpA: "alice", fpB: "bob"}
+	handles := map[string]string{} // both absent — both are countdown cases
 	now := time.Now()
 
-	// A is this session's very first ref (restored, in the reconnect
-	// sense this fixture stands in for) — eligible, its watchdog starts.
 	m.reconcileTargetLock(w, handles, now)
 	if m.targetLockPendingSince.IsZero() {
 		t.Fatalf("watchdog for A never started")
 	}
-	if !m.targetLockEligible {
-		t.Fatalf("A (this session's first ref) not marked eligible")
-	}
 	retargetAt := now.Add(targetLockRelatchGrace - time.Second) // deep into A's own grace
 	m.reconcileTargetLock(w, handles, retargetAt)
 
-	// Player retargets to B before A either resolved or timed out — an
-	// ordinary in-session target switch, not a reconnect.
+	// Player retargets to B before A either resolved or timed out.
 	w.SetTargetGhost(fpB, 2)
 	m.reconcileTargetLock(w, handles, retargetAt)
 	if m.targetLockOwner != fpB || m.targetLockCraftID != 2 {
@@ -324,8 +378,12 @@ func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 	if w.Target.Kind != sim.TargetGhost {
 		t.Fatalf("retargeting itself cleared the target: %+v", w.Target)
 	}
-	if m.targetLockEligible {
-		t.Fatalf("B (a LIVE retarget, not a restored ref) wrongly marked eligible for the countdown")
+
+	// A's timer had ~1s left. If B inherited it, this tick (2s later)
+	// would already have given up.
+	m.reconcileTargetLock(w, handles, retargetAt.Add(2*time.Second))
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != fpB {
+		t.Fatalf("B cleared almost immediately — inherited A's near-expired timer: %+v", w.Target)
 	}
 	for _, e := range m.localEvents {
 		if e.Kind == sim.SessionEventTargetLockLost {
@@ -333,20 +391,10 @@ func TestTargetLockRetargetMidGraceResetsTimerAndHandle(t *testing.T) {
 		}
 	}
 
-	// B never gets a countdown at all (finding 4 round 2) — it just waits,
-	// silently, no matter how far past what would have been A's grace
-	// window. No pending timer, no chip, target stays locked on B.
-	m.reconcileTargetLock(w, handles, retargetAt.Add(5*targetLockRelatchGrace))
-	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != fpB || w.Target.CraftID != 2 {
-		t.Errorf("B cleared despite being a live (ineligible) ref: %+v", w.Target)
-	}
-	if !m.targetLockPendingSince.IsZero() {
-		t.Errorf("countdown started for a live retarget: %v", m.targetLockPendingSince)
-	}
-	for _, e := range m.localEvents {
-		if e.Kind == sim.SessionEventTargetLockLost {
-			t.Errorf("loss chip fired for a live retarget that should never get a countdown: %+v", e)
-		}
+	// B gets its OWN full grace window measured from the retarget moment.
+	m.reconcileTargetLock(w, handles, retargetAt.Add(targetLockRelatchGrace+time.Second))
+	if w.Target.Kind != sim.TargetNone {
+		t.Errorf("B not given its own full grace window: %+v", w.Target)
 	}
 }
 
@@ -406,20 +454,17 @@ func TestStopHostingResetsTargetLockWatch(t *testing.T) {
 	}
 }
 
-// #294 review finding 4 (round 2): ADR 0038 undock handback
-// (relay/dock.go's SetTargetGhost calls at the docker's release/undock
-// paths) aims the docker at the guest's departing craft before the
-// guest's own next CraftReport can possibly have landed in w.Ghosts —
-// a brand-new ref with an empty ghost slate, which used to be
-// indistinguishable from "restored across a reconnect" and so started
-// the very same 45s give-up countdown. A slow or disconnecting guest
-// then cost the host a false "lost on reconnect" chip though no
-// reconnect ever happened. Fixed two ways: (a) HasRelativeTarget no
-// longer requires a resolve (internal/sim/target.go), so NavTarget
-// survives the momentary gap; (b) the countdown is scoped to refs
-// restored at session start only (targetLockEligible), so a live
-// SetTargetGhost — undock handback included — never starts it at all.
-func TestUndockHandbackLiveSetTargetGhostNeverStartsCountdown(t *testing.T) {
+// #294 review finding 4 / round 3: ADR 0038 undock handback (relay/
+// dock.go's SetTargetGhost calls at the docker's release/undock paths)
+// aims the docker at the guest's departing craft before the guest's own
+// next CraftReport can possibly have landed in w.Ghosts — a brand-new
+// ref with an empty ghost slate. The guest is always a PRESENT member
+// of this session (they have to be, to have had a stack to undock from
+// in the first place), so the presence rule alone — with no notion of
+// "session's first tick" needed — keeps this from ever starting a
+// countdown, closing the false "lost on reconnect" chip a slow or
+// disconnecting guest used to cost the host.
+func TestUndockHandbackPresentGuestNeverStartsCountdown(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -430,12 +475,8 @@ func TestUndockHandbackLiveSetTargetGhostNeverStartsCountdown(t *testing.T) {
 	w.NavMode = sim.NavTarget
 
 	m := &reportingModel{owner: "SHA256:self"}
-	handles := map[string]string{testPeerFP: "guest"}
+	handles := map[string]string{testPeerFP: "guest"} // the guest is enrolled — present
 	now := time.Now()
-
-	// This session has already ticked at least once before the undock —
-	// the undock's fresh ref is emphatically NOT this session's first.
-	m.reconcileTargetLock(w, handles, now)
 
 	// Undock handback: SetTargetGhost fires with an EMPTY ghost slate —
 	// the guest's departing craft hasn't reported in yet.
@@ -444,21 +485,16 @@ func TestUndockHandbackLiveSetTargetGhostNeverStartsCountdown(t *testing.T) {
 		t.Fatalf("NavTarget demoted to NavOrbit by a momentarily-unresolved fresh ghost ref: %v", w.NavMode)
 	}
 
-	// The next tick's reconcileTargetLock call (ghost slate still empty)
-	// must not start a countdown for this fresh LIVE ref.
-	m.reconcileTargetLock(w, handles, now.Add(time.Second))
+	m.reconcileTargetLock(w, handles, now)
 	if !m.targetLockPendingSince.IsZero() {
 		t.Fatalf("countdown started for a live undock-handback ref: %v", m.targetLockPendingSince)
-	}
-	if m.targetLockEligible {
-		t.Fatalf("undock-handback ref wrongly marked eligible for the give-up countdown")
 	}
 
 	// Even well past what would have been the grace window, still no
 	// chip and the lock is still standing, waiting.
 	m.reconcileTargetLock(w, handles, now.Add(2*targetLockRelatchGrace))
 	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
-		t.Fatalf("undock-handback lock cleared despite no reconnect ever happening: %+v", w.Target)
+		t.Fatalf("undock-handback lock cleared despite the guest being present the whole time: %+v", w.Target)
 	}
 	for _, e := range m.localEvents {
 		if e.Kind == sim.SessionEventTargetLockLost {
@@ -475,5 +511,54 @@ func TestUndockHandbackLiveSetTargetGhostNeverStartsCountdown(t *testing.T) {
 	}
 	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
 		t.Errorf("lock lost by the time the guest's report resolved: %+v", w.Target)
+	}
+}
+
+// #294 review finding B (round 3 redesign): the original round 1/2
+// "eligibility" scheme inferred whether a ref deserved a countdown from
+// SESSION TIMING (was it Craft.Target's value on this hosting session's
+// very first tick?) rather than from anything about the ref itself. A
+// per-craft ghost target promoted to w.Target LATER — a vessel switch
+// (SetActiveCraftIdx) or an F9 quickload swapping a.world without
+// resetting the reportingModel — read as a live retarget under that
+// scheme and pended silently forever, resurrecting the original #294
+// legibility gap. The presence rule fixes this because it has no notion
+// of "session's first tick" at all: it applies whenever the ref is the
+// active target, however long this session has already been running.
+func TestTargetLockLatePromotionGovernedByPresenceNotTiming(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{} // the eventual ghost owner is never enrolled — absent
+	now := time.Now()
+
+	// The session has already ticked many times under no target at all —
+	// standing in for the time elapsed before a vessel switch or
+	// quickload brings a ghost-targeted craft to the front.
+	for i := 0; i < 20; i++ {
+		m.reconcileTargetLock(w, handles, now.Add(time.Duration(i)*time.Second))
+	}
+
+	promoteAt := now.Add(30 * time.Second)
+	w.SetTargetGhost(testPeerFP, 99)
+	m.reconcileTargetLock(w, handles, promoteAt)
+	if m.targetLockPendingSince.IsZero() {
+		t.Fatalf("late-promoted ref with an absent owner never started a countdown")
+	}
+
+	m.reconcileTargetLock(w, handles, promoteAt.Add(targetLockRelatchGrace+time.Second))
+	if w.Target.Kind != sim.TargetNone {
+		t.Errorf("late-promoted ref with an absent owner never gave up: %+v", w.Target)
+	}
+	found := false
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no loss chip fired for the late-promoted absent-owner ref")
 	}
 }

--- a/internal/serve/target_lock_reconnect_test.go
+++ b/internal/serve/target_lock_reconnect_test.go
@@ -1,0 +1,222 @@
+package serve
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/relay"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui"
+)
+
+// #294: a guest's craft/rendezvous target lock on another player's
+// vessel used to be silently dropped across a reconnect (the [u]
+// restart-to-adopt flow, most visibly) while a body target survived
+// the same round-trip untouched. Root cause: CraftToWire normalised
+// any TargetGhost to no-target on save, on the (here, wrong) theory
+// that the owner fingerprint was session-local and could never resolve
+// again. Fixed in two parts:
+//
+//  1. The wire form now preserves the ghost ref (save/craft_wire.go),
+//     so the intent survives the save/load round trip.
+//  2. reportingModel.reconcileTargetLock (reporting.go) watches an
+//     unresolved ghost target every tick and either re-latches it
+//     silently once the owner's craft reports resume, or gives up
+//     after targetLockRelatchGrace and fires a legible
+//     SessionEventTargetLockLost chip.
+//
+// These tests exercise reconcileTargetLock directly, with synthetic
+// timestamps, so the grace window doesn't have to be slept through.
+
+const testPeerFP = "SHA256:peer-target-lock"
+
+// A ghost target that resolves before anyone even notices it was
+// unresolved (the ordinary live-play case, and the "reconnect landed
+// after the peer" case) never starts a pending timer and never chips.
+func TestTargetLockResolvesImmediatelyNoOp(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.SetTargetGhost(testPeerFP, 99)
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "peer"}
+	m.reconcileTargetLock(w, handles, time.Now())
+
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Errorf("target = %+v, want the ghost lock untouched", w.Target)
+	}
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("pending timer started for a target that already resolved")
+	}
+	if len(m.localEvents) != 0 {
+		t.Errorf("unexpected chip(s) for a target that already resolved: %+v", m.localEvents)
+	}
+}
+
+// The deferred re-latch: a ghost target that lands unresolved (the
+// reconnect case — reports haven't arrived yet) starts a pending timer
+// instead of dropping immediately, and once the owner's report resumes
+// the lock is restored silently — no chip, because the player ends up
+// exactly where they started.
+func TestTargetLockRelatchesSilentlyWhenReportResumes(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.SetTargetGhost(testPeerFP, 99)
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "peer"}
+	now := time.Now()
+
+	// Reconnect lands before the peer's report — nothing to resolve
+	// against yet.
+	w.Ghosts = nil
+	m.reconcileTargetLock(w, handles, now)
+	if w.Target.Kind != sim.TargetGhost {
+		t.Fatalf("target cleared on the very first unresolved tick: %+v", w.Target)
+	}
+	if m.targetLockPendingSince.IsZero() {
+		t.Fatalf("pending timer did not start for an unresolved ghost target")
+	}
+
+	// The peer's report resumes a few seconds later — well inside the
+	// grace window — and the ghost slate now carries their craft.
+	w.Ghosts = []sim.Ghost{{Owner: testPeerFP, CraftID: 99, PrimaryID: c.Primary.ID}}
+	m.reconcileTargetLock(w, handles, now.Add(5*time.Second))
+
+	if w.Target.Kind != sim.TargetGhost || w.Target.GhostOwner != testPeerFP || w.Target.CraftID != 99 {
+		t.Errorf("target lock not restored once the report resumed: %+v", w.Target)
+	}
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("pending timer not cleared after a successful re-latch")
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Errorf("loss chip fired despite the target resolving: %+v", e)
+		}
+	}
+}
+
+// Legibility: a ghost target that never resolves within
+// targetLockRelatchGrace is dropped for good and the player is told —
+// not left with a silently dangling aim.
+func TestTargetLockLostChipAfterGraceWindow(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.SetTargetGhost(testPeerFP, 99)
+
+	m := &reportingModel{owner: "SHA256:self"}
+	handles := map[string]string{testPeerFP: "peer"}
+	now := time.Now()
+
+	m.reconcileTargetLock(w, handles, now) // starts the pending timer
+
+	// Still inside the grace window: keep waiting, no chip yet.
+	m.reconcileTargetLock(w, handles, now.Add(targetLockRelatchGrace/2))
+	if w.Target.Kind != sim.TargetGhost {
+		t.Fatalf("target cleared before the grace window elapsed: %+v", w.Target)
+	}
+	for _, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Fatalf("loss chip fired before the grace window elapsed")
+		}
+	}
+
+	// Past grace, still unresolved: give up and say so.
+	m.reconcileTargetLock(w, handles, now.Add(targetLockRelatchGrace+time.Second))
+
+	if w.Target.Kind != sim.TargetNone {
+		t.Errorf("target not cleared after the grace window elapsed: %+v", w.Target)
+	}
+	var lost *sim.SessionEvent
+	for i, e := range m.localEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			lost = &m.localEvents[i]
+		}
+	}
+	if lost == nil {
+		t.Fatalf("no target-lock-lost chip fired; events=%+v", m.localEvents)
+	}
+	if lost.Handle != "peer" {
+		t.Errorf("loss chip Handle = %q, want %q", lost.Handle, "peer")
+	}
+	if !m.targetLockPendingSince.IsZero() {
+		t.Errorf("pending timer not cleared after giving up")
+	}
+}
+
+// Full round trip (#294's actual repro): a guest's world is saved with a
+// ghost target, "restarted" (a fresh App loaded from the persisted
+// payload — the [u] adopt path's shape, minus the network), and the
+// reporting wrapper re-latches the lock once the target owner's craft
+// report reaches the relay store. The body-target sibling case already
+// worked before this fix (payload-level Target always round-tripped);
+// this proves the craft/ghost case now matches it end to end, silently.
+func TestTargetLockSurvivesSaveLoadAndReLatchesThroughReportingModel(t *testing.T) {
+	srv := newOfflineServer(t)
+	const fpA, fpB = "SHA256:alice", "SHA256:bob"
+	enrollDirect(t, srv, fpA, "alice")
+	enrollDirect(t, srv, fpB, "bob")
+
+	// Alice is mid-session, locked onto Bob's vessel (craft ID 99).
+	appA, err := tui.New(nil)
+	if err != nil {
+		t.Fatalf("tui.New: %v", err)
+	}
+	wA := appA.World()
+	wA.SetTargetGhost(fpB, 99)
+	if err := srv.store.SavePlayer(fpA, wA); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	// "Restart": rebuild Alice's App fresh from what was just persisted —
+	// the exact shape newGuestApp takes on a real reconnect.
+	reloaded, err := srv.newGuestApp(fpA)
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	w2 := reloaded.World()
+	if w2.Target.Kind != sim.TargetGhost || w2.Target.GhostOwner != fpB || w2.Target.CraftID != 99 {
+		t.Fatalf("loaded target = %+v, want the ghost lock to have survived the save/load round trip", w2.Target)
+	}
+
+	// Bob's report hasn't reached the relay store yet — Alice's session
+	// comes up before Bob's does.
+	m := srv.withReporting(reloaded, fpA)
+	m = tick(m)
+	if w2.Target.Kind != sim.TargetGhost {
+		t.Fatalf("target dropped on the very first tick, before the grace window: %+v", w2.Target)
+	}
+
+	// Bob's report now arrives.
+	primary := w2.ActiveCraft().Primary.ID
+	srv.relay.Report(relay.CraftReport{
+		Owner:        fpB,
+		SubspaceTime: w2.Clock.SimTime,
+		Crafts: []relay.CraftState{{
+			ID:      99,
+			Name:    "Bobcraft",
+			System:  w2.System().Name,
+			Primary: primary,
+		}},
+	})
+
+	m = tick(m)
+	if w2.Target.Kind != sim.TargetGhost || w2.Target.GhostOwner != fpB || w2.Target.CraftID != 99 {
+		t.Errorf("target lock not re-latched once Bob's report arrived: %+v", w2.Target)
+	}
+	for _, e := range w2.SessionEvents {
+		if e.Kind == sim.SessionEventTargetLockLost {
+			t.Errorf("unexpected target-lock-lost chip: %+v", e)
+		}
+	}
+	_ = m
+}

--- a/internal/serve/target_lock_reconnect_test.go
+++ b/internal/serve/target_lock_reconnect_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/relay"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 	"github.com/jasonfen/terminal-space-program/internal/tui"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
@@ -560,5 +561,51 @@ func TestTargetLockLatePromotionGovernedByPresenceNotTiming(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("no loss chip fired for the late-promoted absent-owner ref")
+	}
+}
+
+// TestWithReportingPrimesSessionBeforeFirstTick — #294 second-round
+// review finding 1: a reconnecting guest's world used to see its first
+// TickMsg dispatched to m.inner.Update (World.Tick → executeDueNodes)
+// BEFORE refreshSession had ever run once, so w.Session was still nil
+// and World.sessionKnowsOwner reported false for every ghost-ref node —
+// a reconnecting guest's own due node could get cancelled outright on
+// the very first tick, with none of the grace targetLockRelatchGrace
+// gives the active target. withReporting now primes the session at
+// attach (mirrors startHosting), so a due ghost-ref node whose target
+// owner IS enrolled and present in the roster must survive the very
+// first tick, held exactly like an ordinary pending-resolvable stall.
+func TestWithReportingPrimesSessionBeforeFirstTick(t *testing.T) {
+	srv := newOfflineServer(t)
+	enrollDirect(t, srv, "SHA256:gern", "gern")
+	enrollDirect(t, srv, testPeerFP, "peer")
+
+	guestApp, err := srv.newGuestApp("SHA256:gern")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	w := guestApp.World()
+	c := w.ActiveCraft()
+	c.Nodes = []sim.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      w.Clock.SimTime, // due immediately
+		TargetGhostOwner: testPeerFP,
+		TargetCraftID:    987654,
+	}}
+
+	guest := srv.withReporting(guestApp, "SHA256:gern")
+	if w.Session == nil {
+		t.Fatal("withReporting did not prime w.Session before the first tick")
+	}
+
+	guest, _ = guest.Update(sim.TickMsg(time.Now()))
+	_ = guest
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("due ghost-ref node cancelled on reconnect's first tick: len(Nodes)=%d, nodes=%+v", len(c.Nodes), c.Nodes)
+	}
+	if w.LastNodeTargetRefusal != nil && w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("first-tick cancellation notice fired despite the target owner being enrolled and present: %+v", w.LastNodeTargetRefusal)
 	}
 }

--- a/internal/sim/active_burn_target_hold_test.go
+++ b/internal/sim/active_burn_target_hold_test.go
@@ -1,0 +1,106 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestActiveBurnHoldsWhenTargetUnresolved — #294 review finding 1. A
+// restored in-flight target-relative ActiveBurn whose ghost ref never
+// re-latches used to slip through attitudeContext's BurnPrograde
+// fallback unnoticed: the MODE degraded, but nothing stopped stepThrust
+// from thrusting (and debiting DVRemaining) along that fallback
+// direction — real fuel spent in a direction nobody commanded. It must
+// instead HOLD: no thrust, no Δv consumed, no fuel burned, EndTime
+// paused (mirrors the fuel-stall pause in burn_pause_resume_test.go),
+// and LastNodeTargetRefusal stamped so the stall is legible.
+func TestActiveBurnHoldsWhenTargetUnresolved(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      500,
+		EndTime:          w.Clock.SimTime.Add(2 * time.Minute),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	w.Ghosts = nil // the ghost never resolves
+	dvBefore := c.ActiveBurn.DVRemaining
+	endBefore := c.ActiveBurn.EndTime
+	fuelBefore := c.ActiveStageFuel()
+
+	for i := 0; i < 10; i++ {
+		w.Tick()
+	}
+
+	if c.ActiveBurn == nil {
+		t.Fatal("held burn was torn down — want it kept alive")
+	}
+	if c.ActiveBurn.DVRemaining != dvBefore {
+		t.Errorf("DVRemaining moved while held: %.3f -> %.3f (want unchanged — no thrust)", dvBefore, c.ActiveBurn.DVRemaining)
+	}
+	if c.ActiveStageFuel() != fuelBefore {
+		t.Errorf("fuel burned while held: %.6f -> %.6f", fuelBefore, c.ActiveStageFuel())
+	}
+	if !c.ActiveBurn.EndTime.After(endBefore) {
+		t.Errorf("EndTime not advanced while held (%v -> %v) — duration window must pause", endBefore, c.ActiveBurn.EndTime)
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Error("LastNodeTargetRefusal not stamped while the burn was held")
+	}
+	if w.LastNodeTargetRefusal != nil && w.LastNodeTargetRefusal.Cancelled {
+		t.Error("a merely-pending hold must not read as Cancelled")
+	}
+}
+
+// TestActiveBurnResumesOnceTargetResolves — the flip side: once the
+// ghost re-latches, the held burn resumes thrusting and its Δv falls
+// normally, proving the hold is a pause, not a silent stall forever.
+func TestActiveBurnResumesOnceTargetResolves(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      500,
+		EndTime:          w.Clock.SimTime.Add(5 * time.Minute),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	w.Ghosts = nil
+	w.Tick()
+	if c.ActiveBurn == nil || c.ActiveBurn.DVRemaining != 500 {
+		t.Fatalf("burn thrust (or vanished) while target unresolved: %+v", c.ActiveBurn)
+	}
+
+	// The ghost's report resumes.
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:gern", CraftID: 987654, PrimaryID: c.Primary.ID,
+		Pos: w.BodyPosition(c.Primary).Add(c.State.R).Add(orbital.Vec3{X: 1e6}),
+		Vel: c.State.V,
+	}}
+
+	done := false
+	for i := 0; i < 20; i++ {
+		w.Tick()
+		if c.ActiveBurn == nil || c.ActiveBurn.DVRemaining != 500 {
+			done = true
+			break
+		}
+	}
+	if !done {
+		t.Fatal("burn never resumed thrusting after the target resolved")
+	}
+	if c.ActiveBurn == nil {
+		t.Fatal("burn vanished right as it resumed — want it to keep running")
+	}
+	if c.ActiveBurn.DVRemaining >= 500 {
+		t.Errorf("DVRemaining did not fall after the target resolved: %.3f", c.ActiveBurn.DVRemaining)
+	}
+}

--- a/internal/sim/active_burn_target_hold_test.go
+++ b/internal/sim/active_burn_target_hold_test.go
@@ -104,3 +104,44 @@ func TestActiveBurnResumesOnceTargetResolves(t *testing.T) {
 		t.Errorf("DVRemaining did not fall after the target resolved: %.3f", c.ActiveBurn.DVRemaining)
 	}
 }
+
+// TestActiveBurnHeldNotExhaustedOnFinalTick — #294 review round 3
+// finding J. burnExhausted used to be evaluated without any knowledge
+// of the target-hold: a hold beginning in the burn's FINAL tick (the
+// ghost drops out of the slate exactly as SimTime reaches EndTime,
+// fuel still aboard, Δv still owed) read as "duration elapsed with fuel
+// to spare" — burnExhausted's own duration check — and tore the burn
+// down as exhausted, silently discarding the remaining committed Δv,
+// instead of holding it (pausing EndTime) the way an unresolved target
+// does on every OTHER tick. The hold must take precedence over
+// exhaustion-by-duration for the SAME tick it first applies.
+func TestActiveBurnHeldNotExhaustedOnFinalTick(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	// EndTime already at (or before) this tick's SimTime — the duration
+	// window has elapsed — while Δv is still owed and the firing stage
+	// still has fuel. Under the old ordering this reads as exhausted the
+	// instant the target-unresolved hold would otherwise begin.
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      500,
+		EndTime:          w.Clock.SimTime,
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	w.Ghosts = nil // the target is unresolved on exactly this tick
+
+	w.Tick()
+
+	if c.ActiveBurn == nil {
+		t.Fatal("burn torn down as exhausted on the hold's first tick — remaining Δv silently discarded")
+	}
+	if c.ActiveBurn.DVRemaining != 500 {
+		t.Errorf("DVRemaining changed while held: got %.3f, want 500 (no thrust while held)", c.ActiveBurn.DVRemaining)
+	}
+	if !c.ActiveBurn.EndTime.After(w.Clock.SimTime.Add(-time.Millisecond)) {
+		t.Errorf("EndTime not pushed out by the hold: %v vs SimTime %v", c.ActiveBurn.EndTime, w.Clock.SimTime)
+	}
+}

--- a/internal/sim/advisory_node_test.go
+++ b/internal/sim/advisory_node_test.go
@@ -87,3 +87,49 @@ func TestReplaceAdvisoryNodeIsNoOpForEmptyKey(t *testing.T) {
 		t.Errorf("replaceAdvisoryNode(\"\") must be a no-op; node count = %d, want 1", got)
 	}
 }
+
+// TestKReplacesEditedNudgeInsteadOfStacking — #294 second-round review
+// finding 6, the "K after edit" half. Before the fix, editing a planted
+// K-nudge through the maneuver form re-planted it with NO AdvisoryKey
+// (tui/screens/maneuver.go's commitCmd never carried it into
+// BurnExecutedMsg, and the message had no field for it at all) — so
+// the edited node could never match replaceAdvisoryNode's key lookup,
+// and a later K press stacked a second node behind it instead of
+// replacing it (#293's ruling). This stands in for "the node an edit
+// produced": same shape commitCmd now emits post-fix (proven at the
+// tui layer by TestEditedAdvisoryNudgeKeepsIdentityAndAutoWarpHonorsIt)
+// — AdvisoryKey present, an arbitrary edited Δv — and confirms a fresh
+// K plant replaces it in place rather than stacking.
+func TestKReplacesEditedNudgeInsteadOfStacking(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	// Stand in for "a nudge that was planted, then edited": AdvisoryKey
+	// carried through (the fix), Δv deliberately NOT what a fresh nudge
+	// would compute, so the test can tell whether it survived.
+	c.Nodes = append(c.Nodes, ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          12345,
+		TriggerTime: w.Clock.SimTime.Add(2 * time.Hour),
+		PrimaryID:   c.Primary.ID,
+		AdvisoryKey: AdvisoryKeyRendezvousNudge,
+	})
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("setup: expected 1 node, got %d", got)
+	}
+
+	_, err := w.PlanRendezvousNudge()
+	if err != nil {
+		if rendezvousGeometryNotUseful(err) {
+			t.Skipf("geometry yielded no useful nudge (%v); not a regression", err)
+		}
+		t.Fatalf("PlanRendezvousNudge: %v", err)
+	}
+
+	if got := len(c.Nodes); got != 1 {
+		t.Fatalf("K after an edit STACKED instead of replacing: len(Nodes)=%d, nodes=%+v", got, c.Nodes)
+	}
+	if c.Nodes[0].DV == 12345 {
+		t.Error("the old edited node is still queued — the fresh K plant did not replace it")
+	}
+}

--- a/internal/sim/burn_pause_resume_test.go
+++ b/internal/sim/burn_pause_resume_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -174,5 +175,74 @@ func TestThrottleCutLeavesRunningBurn(t *testing.T) {
 	w.SetThrottle(0)
 	if c.ActiveBurn == nil {
 		t.Errorf("throttle-cut cancelled a running planted burn — want it left running")
+	}
+}
+
+// TestThrottleCutAbortsTargetHeldBurn — #294 second-round review
+// finding 3(i): before this, only fuel exhaustion (BurnStalled) could
+// ever tear down a held burn — a target-relative burn held on an
+// unresolved craft/ghost ref (fuelled, but activeBurnTargetReady
+// refuses to thrust it) had NO player-facing escape at all. Throttle-
+// cut must abort that hold too, the same way it already aborts a
+// fuel-stalled one.
+func TestThrottleCutAbortsTargetHeldBurn(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      100,
+		EndTime:          w.Clock.SimTime.Add(10 * time.Minute),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	w.Ghosts = nil // the ghost ref never resolves
+	w.Session = nil
+
+	if c.BurnStalled() {
+		t.Fatal("setup: burn must not be fuel-stalled — isolating the target-hold case")
+	}
+	if w.activeBurnTargetReady(c) {
+		t.Fatal("setup: burn should be held on its unresolved target")
+	}
+
+	w.SetThrottle(0)
+
+	if c.ActiveBurn != nil {
+		t.Errorf("throttle-cut left a target-held ActiveBurn in place — want it aborted: %+v", c.ActiveBurn)
+	}
+}
+
+// TestThrottleCutLeavesResolvedTargetBurnRunning — the flip side: a
+// target-relative burn whose target IS resolved is running normally,
+// not held, and throttle-cut must not touch it — same "only the held
+// state is cancellable" contract as TestThrottleCutLeavesRunningBurn.
+func TestThrottleCutLeavesResolvedTargetBurnRunning(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:             spacecraft.BurnTarget,
+		DVRemaining:      100,
+		EndTime:          w.Clock.SimTime.Add(10 * time.Minute),
+		PrimaryID:        c.Primary.ID,
+		Throttle:         1,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:gern", CraftID: 987654, PrimaryID: c.Primary.ID,
+		Pos: w.BodyPosition(c.Primary).Add(c.State.R).Add(orbital.Vec3{X: 1e6}),
+	}}
+	w.Session = sessionWithOwner("SHA256:gern")
+
+	if !w.activeBurnTargetReady(c) {
+		t.Fatal("setup: burn's target should resolve")
+	}
+
+	w.SetThrottle(0)
+
+	if c.ActiveBurn == nil {
+		t.Error("throttle-cut aborted a running, resolved target-relative burn — want it left running")
 	}
 }

--- a/internal/sim/burn_ready_hoist_test.go
+++ b/internal/sim/burn_ready_hoist_test.go
@@ -1,0 +1,104 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestIntegrateOneCraftBurnReadyHoistedAcrossSubSteps is the
+// correctness-preservation test for the performance finding on
+// integrateOneCraft's RK4/Verlet sub-step loop: activeBurnTargetReady
+// used to be re-resolved inside thrustingAt on EVERY sub-step (nSteps
+// capped at 1024) plus twice more post-loop (burnExhausted and the
+// EndTime-pause check) — a ghost-slate scan plus nodeTargetRelState →
+// BodyPositionAt (SolveKepler) at the CONSTANT w.Clock.SimTime, which
+// cannot change within one integrateOneCraft call. The fix hoists that
+// resolve to once per craft per tick, the way `bc` is already hoisted,
+// and threads the result through thrustingAt / burnExhausted instead.
+//
+// This must behave IDENTICALLY to the old per-call-site resolution,
+// because nothing that resolve depends on (w.Ghosts, the local slate,
+// w.Clock.SimTime) changes mid-call. Exercised with enough sim-time in
+// one call to force MULTIPLE sub-steps (maxStep = period/100), so a
+// per-sub-step-vs-once divergence would show up as partial thrust or a
+// mid-call flip, not just a first-sub-step accident.
+func TestIntegrateOneCraftBurnReadyHoistedAcrossSubSteps(t *testing.T) {
+	t.Run("held: unresolved ghost target never thrusts across any sub-step", func(t *testing.T) {
+		w := mustWorld(t)
+		c := w.ActiveCraft()
+		mu := c.Primary.GravitationalParameter()
+		period := orbitalPeriod(c.State, mu)
+		simDelta := time.Duration(period / 10 * float64(time.Second)) // ~10 sub-steps
+
+		c.ActiveBurn = &spacecraft.ActiveBurn{
+			Mode:             spacecraft.BurnTarget,
+			DVRemaining:      100,
+			EndTime:          w.Clock.SimTime.Add(time.Hour),
+			PrimaryID:        c.Primary.ID,
+			Throttle:         1,
+			TargetGhostOwner: "SHA256:gern",
+			TargetCraftID:    987654,
+		}
+		w.Ghosts = nil // never resolves — the burn must HOLD the whole call
+		fuelBefore := c.ActiveStageFuel()
+		endBefore := c.ActiveBurn.EndTime
+
+		w.integrateOneCraft(c, simDelta)
+
+		if c.ActiveBurn == nil {
+			t.Fatal("held burn was torn down — want it kept alive, paused")
+		}
+		if c.ActiveBurn.DVRemaining != 100 {
+			t.Errorf("DVRemaining = %v, want unchanged 100 (never thrust across any sub-step)", c.ActiveBurn.DVRemaining)
+		}
+		if got := c.ActiveStageFuel(); got != fuelBefore {
+			t.Errorf("fuel = %v, want unchanged %v (never thrust across any sub-step)", got, fuelBefore)
+		}
+		if !c.ActiveBurn.EndTime.After(endBefore) {
+			t.Errorf("EndTime = %v, want pushed out past %v (held, not exhausted)", c.ActiveBurn.EndTime, endBefore)
+		}
+	})
+
+	t.Run("thrusting: resolved local target thrusts across every sub-step", func(t *testing.T) {
+		w := mustWorld(t)
+		c := w.ActiveCraft()
+
+		sibling := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+		sibling.Primary = c.Primary
+		sibling.State = c.State
+		sibling.State.R = sibling.State.R.Add(orbital.Vec3{X: 1e6})
+		w.AdoptCraft(sibling, false)
+
+		mu := c.Primary.GravitationalParameter()
+		period := orbitalPeriod(c.State, mu)
+		simDelta := time.Duration(period / 10 * float64(time.Second)) // ~10 sub-steps
+
+		c.ActiveBurn = &spacecraft.ActiveBurn{
+			Mode: spacecraft.BurnTarget,
+			// Far beyond what one call can deliver — isolates "did it
+			// thrust on every sub-step" from "did the burn finish".
+			DVRemaining:   1e6,
+			EndTime:       w.Clock.SimTime.Add(time.Hour),
+			PrimaryID:     c.Primary.ID,
+			Throttle:      1,
+			TargetCraftID: sibling.ID, // local ref, no ghost owner
+		}
+		fuelBefore := c.ActiveStageFuel()
+		dvBefore := c.ActiveBurn.DVRemaining
+
+		w.integrateOneCraft(c, simDelta)
+
+		if c.ActiveBurn == nil {
+			t.Fatal("resolved target-relative burn was torn down unexpectedly")
+		}
+		if c.ActiveBurn.DVRemaining >= dvBefore {
+			t.Errorf("DVRemaining = %v, want it to have DECREASED across the multi-sub-step call (target resolves the whole time)", c.ActiveBurn.DVRemaining)
+		}
+		if got := c.ActiveStageFuel(); got >= fuelBefore {
+			t.Errorf("fuel = %v, want it to have decreased — target resolves the whole time, so every sub-step should thrust", got)
+		}
+	})
+}

--- a/internal/sim/cancel_ghost_node_refs_test.go
+++ b/internal/sim/cancel_ghost_node_refs_test.go
@@ -1,0 +1,90 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestCancelGhostNodeRefsDropsMatchingNode — #294 review finding 2,
+// never-resolvable case (b): reconcileTargetLock's watchdog (internal/
+// serve/reporting.go) gives up on Craft.Target pointing at a ghost ref,
+// and any planted node bound to that SAME ref must be dropped too — not
+// left wedging the queue behind an endless refusal flash the watchdog
+// can no longer clear (it only ever cleared Craft.Target itself).
+func TestCancelGhostNodeRefsDropsMatchingNode(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	c.Nodes = []spacecraft.ManeuverNode{
+		{
+			Mode: spacecraft.BurnTarget, DV: 50, TriggerTime: now.Add(time.Hour),
+			TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+		},
+		{
+			// Same owner, a DIFFERENT craft id — must survive untouched.
+			Mode: spacecraft.BurnTarget, DV: 60, TriggerTime: now.Add(2 * time.Hour),
+			TargetGhostOwner: "SHA256:gern", TargetCraftID: 555,
+		},
+	}
+
+	w.CancelGhostNodeRefs("SHA256:gern", 987654)
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("len(Nodes) = %d, want 1 (only the matching-ref node dropped): %+v", len(c.Nodes), c.Nodes)
+	}
+	if c.Nodes[0].TargetCraftID != 555 {
+		t.Errorf("wrong node survived: %+v", c.Nodes[0])
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestCancelGhostNodeRefsStripsActiveBurnRef — the ActiveBurn half: the
+// ref is stripped, not the burn torn down (the Δv already committed
+// shouldn't be discarded) — world.go's activeBurnTargetReady (finding 1)
+// then holds it permanently instead of merely pending.
+func TestCancelGhostNodeRefsStripsActiveBurnRef(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode: spacecraft.BurnTarget, DVRemaining: 100,
+		EndTime: w.Clock.SimTime.Add(time.Minute), PrimaryID: c.Primary.ID,
+		Throttle: 1, TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+	}
+
+	w.CancelGhostNodeRefs("SHA256:gern", 987654)
+
+	if c.ActiveBurn == nil {
+		t.Fatal("ActiveBurn torn down — want it kept, ref stripped instead")
+	}
+	if c.ActiveBurn.TargetGhostOwner != "" || c.ActiveBurn.TargetCraftID != 0 {
+		t.Errorf("ghost ref not stripped: %+v", c.ActiveBurn)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped for the active-burn strip: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestCancelGhostNodeRefsIgnoresOtherOwners — a give-up for one ref must
+// never touch a node/burn bound to a DIFFERENT ref.
+func TestCancelGhostNodeRefsIgnoresOtherOwners(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode: spacecraft.BurnTarget, DV: 50, TriggerTime: now.Add(time.Hour),
+		TargetGhostOwner: "SHA256:someone-else", TargetCraftID: 987654,
+	}}
+
+	w.CancelGhostNodeRefs("SHA256:gern", 987654)
+
+	if len(c.Nodes) != 1 {
+		t.Errorf("unrelated node touched: %+v", c.Nodes)
+	}
+	if w.LastNodeTargetRefusal != nil {
+		t.Errorf("notice stamped despite no matching ref: %+v", w.LastNodeTargetRefusal)
+	}
+}

--- a/internal/sim/cancel_ghost_node_refs_test.go
+++ b/internal/sim/cancel_ghost_node_refs_test.go
@@ -42,11 +42,19 @@ func TestCancelGhostNodeRefsDropsMatchingNode(t *testing.T) {
 	}
 }
 
-// TestCancelGhostNodeRefsStripsActiveBurnRef — the ActiveBurn half: the
-// ref is stripped, not the burn torn down (the Δv already committed
-// shouldn't be discarded) — world.go's activeBurnTargetReady (finding 1)
-// then holds it permanently instead of merely pending.
-func TestCancelGhostNodeRefsStripsActiveBurnRef(t *testing.T) {
+// TestCancelGhostNodeRefsAbortsActiveBurn — #294 review round 3 finding
+// D: a matching ActiveBurn used to have only its ref stripped, keeping
+// the burn "alive" so its committed Δv wasn't discarded — but with the
+// ref gone (craftID==0), nodeTargetRelState refuses unconditionally, so
+// activeBurnTargetReady never returns true again: the burn holds
+// forever, its EndTime pushed out every tick, burnExhausted never
+// fires, and the zombie burn wedges canKeplerStep's per-craft gate
+// (warp stays clamped ≤10× for the rest of the session). The give-up
+// countdown already ran its full grace window by the time this is
+// called — there is no later resolve to wait for — so the burn is
+// aborted outright instead: torn down cleanly, remaining Δv forfeit,
+// same as any other "this can never fire" case.
+func TestCancelGhostNodeRefsAbortsActiveBurn(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
 	c.ActiveBurn = &spacecraft.ActiveBurn{
@@ -57,14 +65,11 @@ func TestCancelGhostNodeRefsStripsActiveBurnRef(t *testing.T) {
 
 	w.CancelGhostNodeRefs("SHA256:gern", 987654)
 
-	if c.ActiveBurn == nil {
-		t.Fatal("ActiveBurn torn down — want it kept, ref stripped instead")
-	}
-	if c.ActiveBurn.TargetGhostOwner != "" || c.ActiveBurn.TargetCraftID != 0 {
-		t.Errorf("ghost ref not stripped: %+v", c.ActiveBurn)
+	if c.ActiveBurn != nil {
+		t.Fatalf("ActiveBurn kept alive with a stripped ref — want it aborted outright: %+v", c.ActiveBurn)
 	}
 	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
-		t.Errorf("cancellation notice not stamped for the active-burn strip: %+v", w.LastNodeTargetRefusal)
+		t.Errorf("cancellation notice not stamped for the active-burn abort: %+v", w.LastNodeTargetRefusal)
 	}
 }
 

--- a/internal/sim/cancel_ghost_node_refs_test.go
+++ b/internal/sim/cancel_ghost_node_refs_test.go
@@ -93,3 +93,76 @@ func TestCancelGhostNodeRefsIgnoresOtherOwners(t *testing.T) {
 		t.Errorf("notice stamped despite no matching ref: %+v", w.LastNodeTargetRefusal)
 	}
 }
+
+// TestCancelAllGhostRefsDropsEveryGhostBoundNode — #294 second-round
+// review finding 3(ii): called by reportingModel.stopHosting the moment
+// a hosting session ends — every ghost ref becomes unresolvable at
+// once (no roster left, no watchdog left running), not just whichever
+// one ref reconcileTargetLock happened to be tracking. Every ghost-
+// bound node, for ANY owner, must be dropped — a local-ref node must
+// survive untouched.
+func TestCancelAllGhostRefsDropsEveryGhostBoundNode(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	c.Nodes = []spacecraft.ManeuverNode{
+		{Mode: spacecraft.BurnTarget, DV: 50, TriggerTime: now.Add(time.Hour),
+			TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654},
+		{Mode: spacecraft.BurnTarget, DV: 60, TriggerTime: now.Add(2 * time.Hour),
+			TargetGhostOwner: "SHA256:someone-else", TargetCraftID: 111},
+		{Mode: spacecraft.BurnTargetPrograde, DV: 10, TriggerTime: now.Add(3 * time.Hour),
+			TargetCraftID: 424242}, // local ref (no TargetGhostOwner) — must survive
+	}
+
+	w.CancelAllGhostRefs()
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("len(Nodes) = %d, want 1 (only the local-ref node survives): %+v", len(c.Nodes), c.Nodes)
+	}
+	if c.Nodes[0].TargetGhostOwner != "" {
+		t.Errorf("a ghost-bound node survived: %+v", c.Nodes[0])
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestCancelAllGhostRefsAbortsEveryGhostBoundActiveBurn — the ActiveBurn
+// mirror of the node case: any craft's in-flight burn bound to ANY
+// ghost is aborted outright, same as a single-ref give-up already does
+// for its own matching ref.
+func TestCancelAllGhostRefsAbortsEveryGhostBoundActiveBurn(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode: spacecraft.BurnTarget, DVRemaining: 100,
+		EndTime: w.Clock.SimTime.Add(time.Minute), PrimaryID: c.Primary.ID,
+		Throttle: 1, TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+	}
+
+	w.CancelAllGhostRefs()
+
+	if c.ActiveBurn != nil {
+		t.Fatalf("ghost-bound ActiveBurn kept alive — want it aborted outright: %+v", c.ActiveBurn)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped for the active-burn abort: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestCancelAllGhostRefsNoOpWithNothingBound — a no-op call (nothing
+// ghost-bound anywhere) must not stamp a spurious cancellation notice.
+func TestCancelAllGhostRefsNoOpWithNothingBound(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	c.Nodes = []spacecraft.ManeuverNode{{Mode: spacecraft.BurnPrograde, DV: 10, TriggerTime: w.Clock.SimTime.Add(time.Hour)}}
+
+	w.CancelAllGhostRefs()
+
+	if len(c.Nodes) != 1 {
+		t.Errorf("an unrelated local node was touched: %+v", c.Nodes)
+	}
+	if w.LastNodeTargetRefusal != nil {
+		t.Errorf("notice stamped despite nothing ghost-bound: %+v", w.LastNodeTargetRefusal)
+	}
+}

--- a/internal/sim/cancel_ghost_node_refs_test.go
+++ b/internal/sim/cancel_ghost_node_refs_test.go
@@ -166,3 +166,58 @@ func TestCancelAllGhostRefsNoOpWithNothingBound(t *testing.T) {
 		t.Errorf("notice stamped despite nothing ghost-bound: %+v", w.LastNodeTargetRefusal)
 	}
 }
+
+// TestCancelGhostRefsKeepsNonTargetRelativeNodeStripsRef — a node or
+// in-flight burn whose MODE doesn't need the target (a plain prograde
+// circularize planted through the maneuver form while a peer happened to
+// be targeted — the form stamps the binding on every mode so an edited
+// advisory keeps its identity) must survive a ghost give-up and the
+// session-exit sweep alike: its burn is unaffected by the target
+// vanishing. Only the now-meaningless ref is stripped, with no
+// cancellation notice. Dropping it would delete a burn the player made
+// while merely LOOKING at a peer.
+func TestCancelGhostRefsKeepsNonTargetRelativeNodeStripsRef(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode: spacecraft.BurnPrograde, DV: 30, TriggerTime: now.Add(time.Hour),
+		TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+	}}
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode: spacecraft.BurnPrograde, DVRemaining: 100,
+		TargetGhostOwner: "SHA256:gern", TargetCraftID: 987654,
+	}
+
+	w.CancelGhostNodeRefs("SHA256:gern", 987654)
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("prograde node dropped; want kept with ref stripped: %+v", c.Nodes)
+	}
+	if n := c.Nodes[0]; n.TargetGhostOwner != "" || n.TargetCraftID != 0 || n.DV != 30 {
+		t.Errorf("node = %+v, want ref stripped and burn untouched", n)
+	}
+	if c.ActiveBurn == nil {
+		t.Fatal("prograde active burn aborted; want kept with ref stripped")
+	}
+	if c.ActiveBurn.TargetGhostOwner != "" || c.ActiveBurn.TargetCraftID != 0 || c.ActiveBurn.DVRemaining != 100 {
+		t.Errorf("active burn = %+v, want ref stripped and burn untouched", c.ActiveBurn)
+	}
+	if w.LastNodeTargetRefusal != nil {
+		t.Errorf("no cancellation notice expected for a stripped-only ref: %+v", w.LastNodeTargetRefusal)
+	}
+
+	// Same rule for the session-exit sweep.
+	c.Nodes[0].TargetGhostOwner, c.Nodes[0].TargetCraftID = "SHA256:gern", 987654
+	c.ActiveBurn.TargetGhostOwner, c.ActiveBurn.TargetCraftID = "SHA256:gern", 987654
+	w.CancelAllGhostRefs()
+	if len(c.Nodes) != 1 || c.Nodes[0].TargetGhostOwner != "" || c.Nodes[0].TargetCraftID != 0 {
+		t.Errorf("CancelAllGhostRefs: nodes = %+v, want prograde node kept with ref stripped", c.Nodes)
+	}
+	if c.ActiveBurn == nil || c.ActiveBurn.TargetGhostOwner != "" {
+		t.Errorf("CancelAllGhostRefs: active burn = %+v, want kept with ref stripped", c.ActiveBurn)
+	}
+	if w.LastNodeTargetRefusal != nil {
+		t.Errorf("CancelAllGhostRefs: no cancellation notice expected: %+v", w.LastNodeTargetRefusal)
+	}
+}

--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -117,6 +118,14 @@ func TestSortNodesOrdersByBurnStart(t *testing.T) {
 	}
 }
 
+// sessionWithOwner stubs a minimal hosted-session slate naming owner as
+// a roster member — the presence a ghost-ref node needs to HOLD rather
+// than cancel at fire time (#294 review round 3 finding E,
+// World.sessionKnowsOwner).
+func sessionWithOwner(owner string) *SessionInfo {
+	return &SessionInfo{Players: []SessionPlayer{{Fingerprint: owner}}}
+}
+
 // TestExecuteDueNodesRefusesUnresolvedTargetRelativeImpulsive — #294
 // review finding 5. A due impulsive target-relative node whose bound
 // ghost ref doesn't resolve (survived a save/load without a live
@@ -126,7 +135,10 @@ func TestSortNodesOrdersByBurnStart(t *testing.T) {
 // BurnTarget/AntiTarget cases degrade that to a direction aimed at, or
 // away from, the primary's centre — real Δv spent in a bogus
 // direction). The node must stay queued (not popped) and
-// LastNodeTargetRefusal must fire so the player is told.
+// LastNodeTargetRefusal must fire so the player is told. The ghost's
+// owner is present in the session (round 3 finding E) — an absent
+// owner is a cancel, not a hold; see
+// TestExecuteDueNodesCancelsGhostNodeAbsentOwner below.
 func TestExecuteDueNodesRefusesUnresolvedTargetRelativeImpulsive(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
@@ -141,6 +153,7 @@ func TestExecuteDueNodesRefusesUnresolvedTargetRelativeImpulsive(t *testing.T) {
 		TargetCraftID:    987654,
 	}}
 	w.Ghosts = nil // the ghost ref never resolves
+	w.Session = sessionWithOwner("SHA256:gern")
 
 	w.executeDueNodes()
 
@@ -175,6 +188,7 @@ func TestExecuteDueNodesRefusesUnresolvedTargetRelativeFinite(t *testing.T) {
 		TargetCraftID:    987654,
 	}}
 	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:gern")
 
 	w.executeDueNodes()
 
@@ -205,6 +219,7 @@ func TestExecuteDueNodesFiresOnceGhostResolves(t *testing.T) {
 		TargetCraftID:    987654,
 	}}
 	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:gern")
 	w.executeDueNodes()
 	if len(c.Nodes) != 1 {
 		t.Fatalf("node fired/dropped despite an unresolved target: len=%d", len(c.Nodes))
@@ -293,6 +308,7 @@ func TestExecuteDueNodesRefusalStampedOncePerStall(t *testing.T) {
 		TargetCraftID:    987654,
 	}}
 	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:gern")
 
 	w.executeDueNodes()
 	if w.LastNodeTargetRefusal == nil {
@@ -306,5 +322,133 @@ func TestExecuteDueNodesRefusalStampedOncePerStall(t *testing.T) {
 	}
 	if len(c.Nodes) != 1 {
 		t.Fatalf("node dropped or fired despite staying unresolved: len(Nodes)=%d", len(c.Nodes))
+	}
+}
+
+// TestExecuteDueNodesCancelsGhostNodeAbsentOwner — #294 review round 3
+// finding E: reconcileTargetLock's give-up countdown (internal/serve/
+// reporting.go) only ever tracks the world's ACTIVE target — a planted
+// node bound to some OTHER ghost, or evaluated with no hosting session
+// at all (a dock ledger Parcel, a standalone save), never gets a give-up
+// any other way. The fire-time presence rule (World.sessionKnowsOwner)
+// must cancel it outright instead of wedging the queue forever.
+func TestExecuteDueNodesCancelsGhostNodeAbsentOwner(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+	w.Session = nil // no hosting session at all — evaluated outside one
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("ghost-ref node with no session not cancelled: len(Nodes)=%d, nodes=%+v", len(c.Nodes), c.Nodes)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolled — same as above,
+// but WITH a hosting session whose roster simply doesn't include this
+// ref's owner (never enrolled, or since removed) — same give-up.
+func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolled(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:someone-else")
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("ghost-ref node for a not-enrolled owner not cancelled: len(Nodes)=%d", len(c.Nodes))
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancellation notice not stamped: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestExecuteDueNodesHoldsLocalTargetTransientlyOnDifferentPrimary —
+// #294 review round 3 finding F: nodeTargetRelState's own doc names a
+// transient case for a LOCAL target ref — the target craft alive but
+// briefly on a DIFFERENT primary than this node's own frame, mid SOI-
+// transfer. That must HOLD, exactly like a pending-resolvable ghost
+// stall — not be treated as permanently gone the way
+// TestExecuteDueNodesDropsNeverResolvableLocalTarget's genuinely-absent
+// (end-of-flight) case correctly is.
+func TestExecuteDueNodesHoldsLocalTargetTransientlyOnDifferentPrimary(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	sister := w.Crafts[1]
+	w.stampCraftID(sister)
+
+	// Any OTHER body in the system stands in for "mid-SOI-transfer,
+	// briefly on a different primary than the node's own frame."
+	var other bodies.CelestialBody
+	found := false
+	for _, b := range w.System().Bodies {
+		if b.ID != c.Primary.ID {
+			other = b
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("system has no second body to use as the sister's transient primary")
+	}
+	sister.Primary = other
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            50,
+		TriggerTime:   now,
+		PrimaryID:     c.Primary.ID,
+		TargetCraftID: sister.ID,
+	}}
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("transiently-unresolvable local target node dropped instead of held: len(Nodes)=%d", len(c.Nodes))
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Fatal("no stall notice stamped")
+	}
+	if w.LastNodeTargetRefusal.Cancelled {
+		t.Error("transient hold read as Cancelled — must be a pending stall, not a permanent drop")
+	}
+
+	// The sister rebases back onto the shared primary — the node fires
+	// normally on the next tick, proving the hold is a pause.
+	sister.Primary = c.Primary
+	w.executeDueNodes()
+	if len(c.Nodes) != 0 {
+		t.Errorf("node never fired once both craft shared a primary again: len(Nodes)=%d", len(c.Nodes))
 	}
 }

--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -364,7 +364,7 @@ func TestExecuteDueNodesCancelsGhostNodeAbsentOwner(t *testing.T) {
 // player's OWN session having just reconnected before refreshSession
 // ever primed w.Session (fixed at attach in internal/serve), and an
 // owner mid-reconnect must not cost a planted node. The node holds,
-// same as an ordinary pending-resolvable stall, for ghostNodeAbsentGrace
+// same as an ordinary pending-resolvable stall, for GhostAbsentGrace
 // (mirrors reportingModel.targetLockRelatchGrace).
 func TestExecuteDueNodesHoldsGhostNodeOwnerNotEnrolledWithinGrace(t *testing.T) {
 	w := mustWorld(t)
@@ -398,7 +398,7 @@ func TestExecuteDueNodesHoldsGhostNodeOwnerNotEnrolledWithinGrace(t *testing.T) 
 }
 
 // TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolledPastGrace — the
-// flip side: once ghostNodeAbsentGrace has genuinely elapsed with the
+// flip side: once GhostAbsentGrace has genuinely elapsed with the
 // owner still missing from the roster, the node is cancelled, same as
 // before this finding's fix (just deferred instead of instant).
 func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolledPastGrace(t *testing.T) {
@@ -412,7 +412,7 @@ func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolledPastGrace(t *testing.T) 
 		TriggerTime:      now,
 		TargetGhostOwner: "SHA256:gern",
 		TargetCraftID:    987654,
-		GhostAbsentSince: time.Now().Add(-(ghostNodeAbsentGrace + time.Second)),
+		GhostAbsentSince: time.Now().Add(-(GhostAbsentGrace + time.Second)),
 	}}
 	w.Ghosts = nil
 	w.Session = sessionWithOwner("SHA256:someone-else")
@@ -596,7 +596,7 @@ func TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldLocalTarget(t *testing.T)
 // shape as the local-target case above, for a ghost ref: the node
 // holds (owner present, ghost unresolved) at least once, stamping
 // RefusalNoticed, then the owner drops out of the roster and
-// ghostNodeAbsentGrace expires. The cancel must still fire a notice —
+// GhostAbsentGrace expires. The cancel must still fire a notice —
 // not be swallowed by the RefusalNoticed flag the earlier hold set.
 func TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldGhostTarget(t *testing.T) {
 	w := mustWorld(t)
@@ -620,7 +620,7 @@ func TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldGhostTarget(t *testing.T)
 	w.LastNodeTargetRefusal = nil // simulate the HUD consuming the earlier hold flash
 
 	// The owner drops out of the roster and grace has already expired.
-	c.Nodes[0].GhostAbsentSince = time.Now().Add(-(ghostNodeAbsentGrace + time.Second))
+	c.Nodes[0].GhostAbsentSince = time.Now().Add(-(GhostAbsentGrace + time.Second))
 	w.Session = sessionWithOwner("SHA256:someone-else")
 
 	w.executeDueNodes()

--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -357,10 +357,16 @@ func TestExecuteDueNodesCancelsGhostNodeAbsentOwner(t *testing.T) {
 	}
 }
 
-// TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolled — same as above,
-// but WITH a hosting session whose roster simply doesn't include this
-// ref's owner (never enrolled, or since removed) — same give-up.
-func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolled(t *testing.T) {
+// TestExecuteDueNodesHoldsGhostNodeOwnerNotEnrolledWithinGrace — #294
+// second-round review finding 1: a session that simply doesn't (yet)
+// list this ref's owner in its roster must NOT cancel the node on the
+// very first tick it notices — that is exactly the shape of this
+// player's OWN session having just reconnected before refreshSession
+// ever primed w.Session (fixed at attach in internal/serve), and an
+// owner mid-reconnect must not cost a planted node. The node holds,
+// same as an ordinary pending-resolvable stall, for ghostNodeAbsentGrace
+// (mirrors reportingModel.targetLockRelatchGrace).
+func TestExecuteDueNodesHoldsGhostNodeOwnerNotEnrolledWithinGrace(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
 	now := w.Clock.SimTime
@@ -377,11 +383,78 @@ func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolled(t *testing.T) {
 
 	w.executeDueNodes()
 
+	if len(c.Nodes) != 1 {
+		t.Fatalf("ghost-ref node for a not-(yet)-enrolled owner cancelled within grace: len(Nodes)=%d", len(c.Nodes))
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Fatal("no hold notice stamped")
+	}
+	if w.LastNodeTargetRefusal.Cancelled {
+		t.Error("within-grace absence read as Cancelled — must be a pending hold, not a permanent drop")
+	}
+	if c.Nodes[0].GhostAbsentSince.IsZero() {
+		t.Error("GhostAbsentSince not stamped once the owner was first found absent")
+	}
+}
+
+// TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolledPastGrace — the
+// flip side: once ghostNodeAbsentGrace has genuinely elapsed with the
+// owner still missing from the roster, the node is cancelled, same as
+// before this finding's fix (just deferred instead of instant).
+func TestExecuteDueNodesCancelsGhostNodeOwnerNotEnrolledPastGrace(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+		GhostAbsentSince: time.Now().Add(-(ghostNodeAbsentGrace + time.Second)),
+	}}
+	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:someone-else")
+
+	w.executeDueNodes()
+
 	if len(c.Nodes) != 0 {
-		t.Fatalf("ghost-ref node for a not-enrolled owner not cancelled: len(Nodes)=%d", len(c.Nodes))
+		t.Fatalf("ghost-ref node past grace not cancelled: len(Nodes)=%d", len(c.Nodes))
 	}
 	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
 		t.Errorf("cancellation notice not stamped: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestExecuteDueNodesGhostAbsenceTimerResetsOnceOwnerPresent — the
+// absence timer must not survive the owner becoming a roster member
+// again: a later, unrelated absence must start its own fresh grace
+// window rather than inherit an old one and cancel immediately.
+func TestExecuteDueNodesGhostAbsenceTimerResetsOnceOwnerPresent(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:someone-else")
+	w.executeDueNodes()
+	if c.Nodes[0].GhostAbsentSince.IsZero() {
+		t.Fatal("absence timer never stamped")
+	}
+
+	// Owner reappears in the roster (e.g. reconnects).
+	w.Session = sessionWithOwner("SHA256:gern")
+	w.executeDueNodes()
+	if !c.Nodes[0].GhostAbsentSince.IsZero() {
+		t.Error("absence timer not cleared once the owner was seen present")
 	}
 }
 
@@ -450,5 +523,112 @@ func TestExecuteDueNodesHoldsLocalTargetTransientlyOnDifferentPrimary(t *testing
 	w.executeDueNodes()
 	if len(c.Nodes) != 0 {
 		t.Errorf("node never fired once both craft shared a primary again: len(Nodes)=%d", len(c.Nodes))
+	}
+}
+
+// TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldLocalTarget — #294
+// second-round review finding 5. Both cancel branches used to be
+// gated behind `if !n.RefusalNoticed`, but the HOLD branches set that
+// SAME flag and nothing ever clears it once a node moves from holding
+// to cancelling — so a node that held at least once (a transient
+// different-primary stall, here) and later becomes genuinely
+// unresolvable (its target leaves the slate for good) was dropped with
+// NO notice at all, silently. The cancel must fire unconditionally.
+func TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldLocalTarget(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	sister := w.Crafts[1]
+	w.stampCraftID(sister)
+
+	var other bodies.CelestialBody
+	found := false
+	for _, b := range w.System().Bodies {
+		if b.ID != c.Primary.ID {
+			other = b
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("system has no second body to use as the sister's transient primary")
+	}
+	sister.Primary = other
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            50,
+		TriggerTime:   now,
+		PrimaryID:     c.Primary.ID,
+		TargetCraftID: sister.ID,
+	}}
+
+	// First tick: transient stall — holds, stamps RefusalNoticed.
+	w.executeDueNodes()
+	if len(c.Nodes) != 1 || !c.Nodes[0].RefusalNoticed {
+		t.Fatalf("setup: expected the node to hold with RefusalNoticed set: %+v", c.Nodes)
+	}
+	w.LastNodeTargetRefusal = nil // simulate the HUD consuming the earlier hold flash
+
+	// The sister craft is now gone from the slate for good (end-flight)
+	// — a permanent loss, not a transient stall.
+	w.Crafts = []*spacecraft.Spacecraft{c}
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("node not cancelled once its target left the slate for good: %+v", c.Nodes)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancel notice silently swallowed by the prior hold's RefusalNoticed flag: %+v", w.LastNodeTargetRefusal)
+	}
+}
+
+// TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldGhostTarget — same
+// shape as the local-target case above, for a ghost ref: the node
+// holds (owner present, ghost unresolved) at least once, stamping
+// RefusalNoticed, then the owner drops out of the roster and
+// ghostNodeAbsentGrace expires. The cancel must still fire a notice —
+// not be swallowed by the RefusalNoticed flag the earlier hold set.
+func TestExecuteDueNodesCancelNoticeFiresAfterPriorHoldGhostTarget(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+	w.Session = sessionWithOwner("SHA256:gern") // owner present — ordinary pending hold
+
+	w.executeDueNodes()
+	if len(c.Nodes) != 1 || !c.Nodes[0].RefusalNoticed {
+		t.Fatalf("setup: expected the node to hold with RefusalNoticed set: %+v", c.Nodes)
+	}
+	w.LastNodeTargetRefusal = nil // simulate the HUD consuming the earlier hold flash
+
+	// The owner drops out of the roster and grace has already expired.
+	c.Nodes[0].GhostAbsentSince = time.Now().Add(-(ghostNodeAbsentGrace + time.Second))
+	w.Session = sessionWithOwner("SHA256:someone-else")
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("node not cancelled past grace: %+v", c.Nodes)
+	}
+	if w.LastNodeTargetRefusal == nil || !w.LastNodeTargetRefusal.Cancelled {
+		t.Errorf("cancel notice silently swallowed by the prior hold's RefusalNoticed flag: %+v", w.LastNodeTargetRefusal)
 	}
 }

--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -113,5 +114,109 @@ func TestSortNodesOrdersByBurnStart(t *testing.T) {
 	}
 	if nodes[0].DV != 20 {
 		t.Errorf("node[0].DV = %.0f, want 20 (the earlier-BurnStart finite node B)", nodes[0].DV)
+	}
+}
+
+// TestExecuteDueNodesRefusesUnresolvedTargetRelativeImpulsive — #294
+// review finding 5. A due impulsive target-relative node whose bound
+// ghost ref doesn't resolve (survived a save/load without a live
+// serve session to re-latch it, or hasn't re-latched yet post-
+// reconnect) must refuse to fire rather than burn against
+// nodeTargetRelState's zero-value fallback (DirectionUnitTarget's
+// BurnTarget/AntiTarget cases degrade that to a direction aimed at, or
+// away from, the primary's centre — real Δv spent in a bogus
+// direction). The node must stay queued (not popped) and
+// LastNodeTargetRefusal must fire so the player is told.
+func TestExecuteDueNodesRefusesUnresolvedTargetRelativeImpulsive(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+	startFuel := c.ActiveStageFuel()
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now, // due now
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil // the ghost ref never resolves
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 1 {
+		t.Fatalf("len(Nodes) = %d after refused fire, want 1 (node stays queued)", len(c.Nodes))
+	}
+	if c.ActiveStageFuel() != startFuel {
+		t.Errorf("fuel changed on a refused fire: before=%.6f after=%.6f", startFuel, c.ActiveStageFuel())
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Fatal("LastNodeTargetRefusal not set on a refused fire")
+	}
+	if w.LastNodeTargetRefusal.CraftName != c.Name {
+		t.Errorf("LastNodeTargetRefusal.CraftName = %q, want %q", w.LastNodeTargetRefusal.CraftName, c.Name)
+	}
+}
+
+// TestExecuteDueNodesRefusesUnresolvedTargetRelativeFinite — same as
+// above for a finite (Duration>0) target-relative node: it must not
+// start c.ActiveBurn against an unresolved target.
+func TestExecuteDueNodesRefusesUnresolvedTargetRelativeFinite(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTargetPrograde,
+		DV:               100,
+		TriggerTime:      now.Add(10 * time.Second),
+		Duration:         60 * time.Second, // BurnStart = now-20s, already due
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+
+	w.executeDueNodes()
+
+	if c.ActiveBurn != nil {
+		t.Fatalf("ActiveBurn started against an unresolved target: %+v", c.ActiveBurn)
+	}
+	if len(c.Nodes) != 1 {
+		t.Errorf("len(Nodes) = %d after refused fire, want 1 (node stays queued)", len(c.Nodes))
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Error("LastNodeTargetRefusal not set on a refused finite-burn fire")
+	}
+}
+
+// TestExecuteDueNodesFiresOnceGhostResolves — the flip side: once the
+// bound ghost resolves, the previously-refused node fires normally on
+// the next tick, proving the refusal is a hold, not a silent drop.
+func TestExecuteDueNodesFiresOnceGhostResolves(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+	w.executeDueNodes()
+	if len(c.Nodes) != 1 {
+		t.Fatalf("node fired/dropped despite an unresolved target: len=%d", len(c.Nodes))
+	}
+
+	// The ghost's report resumes.
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:gern", CraftID: 987654, PrimaryID: c.Primary.ID,
+		Pos: w.BodyPosition(c.Primary).Add(c.State.R).Add(orbital.Vec3{X: 1e6}),
+	}}
+	w.executeDueNodes()
+	if len(c.Nodes) != 0 {
+		t.Errorf("node did not fire once its target resolved: len(Nodes)=%d", len(c.Nodes))
 	}
 }

--- a/internal/sim/due_node_dispatch_test.go
+++ b/internal/sim/due_node_dispatch_test.go
@@ -220,3 +220,91 @@ func TestExecuteDueNodesFiresOnceGhostResolves(t *testing.T) {
 		t.Errorf("node did not fire once its target resolved: len(Nodes)=%d", len(c.Nodes))
 	}
 }
+
+// TestExecuteDueNodesDropsNeverResolvableLocalTarget — #294 review
+// finding 2, never-resolvable case (a): a node bound to a LOCAL craft
+// (no TargetGhostOwner) whose target was removed from the slate (e.g.
+// end-flight) can never come back the way a ghost might re-latch. The
+// old unconditional `break` wedged the queue behind it forever with an
+// every-tick refusal flash; it must instead be dropped in place with a
+// one-time cancellation notice.
+func TestExecuteDueNodesDropsNeverResolvableLocalTarget(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:          spacecraft.BurnTargetPrograde,
+		DV:            50,
+		TriggerTime:   now,
+		TargetCraftID: 424242, // no TargetGhostOwner — local ref to a craft that isn't in the slate
+	}}
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("never-resolvable local-target node not dropped: len(Nodes)=%d, nodes=%+v", len(c.Nodes), c.Nodes)
+	}
+	if w.LastNodeTargetRefusal == nil {
+		t.Fatal("no cancellation notice stamped")
+	}
+	if !w.LastNodeTargetRefusal.Cancelled {
+		t.Error("notice not marked Cancelled — a never-resolvable drop must read differently than a pending hold")
+	}
+}
+
+// TestExecuteDueNodesNeverResolvableUnblocksQueue — dropping a never-
+// resolvable node must free the rest of the queue to dispatch on the
+// SAME tick, not wait for the next one. Pre-fix, the unconditional
+// break meant an ordinary due node behind a doomed one never fired
+// either.
+func TestExecuteDueNodesNeverResolvableUnblocksQueue(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{
+		{Mode: spacecraft.BurnTargetPrograde, DV: 50, TriggerTime: now.Add(-2 * time.Second), TargetCraftID: 424242},
+		{Mode: spacecraft.BurnPrograde, DV: 10, TriggerTime: now.Add(-time.Second)},
+	}
+	sortNodes(c.Nodes)
+
+	w.executeDueNodes()
+
+	if len(c.Nodes) != 0 {
+		t.Fatalf("ordinary node behind the dropped one did not fire: len(Nodes)=%d, nodes=%+v", len(c.Nodes), c.Nodes)
+	}
+}
+
+// TestExecuteDueNodesRefusalStampedOncePerStall — #294 review finding 2:
+// the HUD flash for a pending-resolvable (ghost) refusal must fire once
+// per stall, not every tick the node sits wedged at the front of the
+// queue.
+func TestExecuteDueNodesRefusalStampedOncePerStall(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	now := w.Clock.SimTime
+
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:             spacecraft.BurnTarget,
+		DV:               100,
+		TriggerTime:      now,
+		TargetGhostOwner: "SHA256:gern",
+		TargetCraftID:    987654,
+	}}
+	w.Ghosts = nil
+
+	w.executeDueNodes()
+	if w.LastNodeTargetRefusal == nil {
+		t.Fatal("first stall did not stamp a refusal")
+	}
+	w.LastNodeTargetRefusal = nil // simulate app.go consuming + clearing the flash
+
+	w.executeDueNodes() // same node, still unresolved — same stall
+	if w.LastNodeTargetRefusal != nil {
+		t.Errorf("refusal restamped for the SAME stall — want once, not every tick: %+v", w.LastNodeTargetRefusal)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("node dropped or fired despite staying unresolved: len(Nodes)=%d", len(c.Nodes))
+	}
+}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2420,6 +2420,24 @@ func (w *World) executeDueNodes() {
 // so a never-resolvable node can be dropped in place — freeing the
 // nodes behind it to fire this same tick — while a pending-resolvable
 // one still holds the queue exactly as before.
+//
+// #294 review round 3 sharpened both branches further:
+//
+//   - Finding F: a LOCAL ref used to treat ANY resolve failure as
+//     permanent, but nodeTargetRelState's own doc names a transient
+//     case — the target craft alive but briefly on a different primary
+//     mid-SOI-transfer. Existence (craftByID) and resolvability
+//     (nodeTargetRelState) are checked separately now: still-in-the-
+//     slate holds like a pending stall, gone-from-the-slate cancels.
+//   - Finding E: a GHOST ref used to hold forever with no give-up
+//     outside reconcileTargetLock's watchdog (internal/serve/
+//     reporting.go), which only ever tracks the world's ACTIVE
+//     target — a node bound to some OTHER ghost, or evaluated with no
+//     hosting session at all (a dock ledger Parcel, a standalone save),
+//     never got a give-up any other way. A simple fire-time presence
+//     rule (World.sessionKnowsOwner) subsumes that dependency: no
+//     session, or the owner isn't part of this one, cancels; owner
+//     present holds, same as before.
 func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 	kept := c.Nodes[:0]
 	held := false
@@ -2470,12 +2488,28 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 				// away from, the primary's centre — a real Δv expenditure
 				// in a bogus direction, not a display glitch).
 				if n.TargetGhostOwner == "" {
-					// Local craft ref: never resolvable. A deleted local
-					// craft (end-flight) never comes back the way a ghost
-					// might re-latch — drop this ONE node, notice once,
-					// and keep dispatching the rest of the queue instead
-					// of wedging everything behind a burn that will never
-					// fire (finding 2, never-resolvable case (a)).
+					// Local craft ref (finding F): distinguish EXISTENCE
+					// from RESOLVABILITY. A target craft still in the
+					// slate but on a different primary right now — mid-
+					// SOI-transfer, the exact case nodeTargetRelState's
+					// own doc names — is a transient stall, not a
+					// permanent loss: hold it exactly like an ordinary
+					// pending stall, and it may resolve on a later tick
+					// once both craft share a primary again.
+					if _, _, stillExists := w.craftByID(n.TargetCraftID); stillExists {
+						if !n.RefusalNoticed {
+							w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
+							n.RefusalNoticed = true
+						}
+						held = true
+						kept = append(kept, n)
+						continue
+					}
+					// Gone from the slate for good (end-flight): that ref
+					// can never come back — drop this ONE node, notice
+					// once, and keep dispatching the rest of the queue
+					// instead of wedging everything behind a burn that
+					// will never fire.
 					if !n.RefusalNoticed {
 						w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
 							When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
@@ -2483,15 +2517,25 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 					}
 					continue // dropped — not appended to kept
 				}
-				// Ghost ref, not (yet) resolved: pending-resolvable —
-				// reconcileTargetLock's own watchdog owns the give-up
-				// call for this case (CancelGhostNodeRefs strips the ref
-				// once it does, which then falls into the local-ref
-				// branch above on a later tick). Until then, leave the
-				// node queued (don't pop it) and hold the rest of the
-				// queue behind it exactly like the !IsResolved()/
-				// ActiveBurn-busy gates above — but stamp the HUD flash
-				// only once per stall, not every tick (finding 2).
+				// Ghost ref, not (yet) resolved (finding E): give up right
+				// here when there is no session at all, or this owner
+				// isn't part of it — reconcileTargetLock's watchdog can
+				// never reach this node (it only ever tracks the world's
+				// ACTIVE target), so nothing else ever will. An owner who
+				// IS a member of this session gets the ordinary pending-
+				// resolvable tolerance: leave the node queued (don't pop
+				// it) and hold the rest of the queue behind it exactly
+				// like the !IsResolved()/ActiveBurn-busy gates above —
+				// stamping the HUD flash only once per stall, not every
+				// tick.
+				if !w.sessionKnowsOwner(n.TargetGhostOwner) {
+					if !n.RefusalNoticed {
+						w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+							When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
+						}
+					}
+					continue // dropped — not appended to kept
+				}
 				if !n.RefusalNoticed {
 					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
 					n.RefusalNoticed = true
@@ -2538,27 +2582,37 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 	c.Nodes = kept
 }
 
-// CancelGhostNodeRefs cancels every planted node — and strips any
-// craft's in-flight ActiveBurn's ref — matching (owner, craftID),
-// across every craft in the slate. Called by
-// reportingModel.reconcileTargetLock (internal/serve/reporting.go) the
-// moment its 45s watchdog gives up on Craft.Target pointing at this
-// same ref (#294 review finding 2, never-resolvable case (b)): the
-// watchdog only ever cleared Craft.Target itself, leaving a planted
-// node's or the active burn's own copy of the ref dangling —
-// executeDueNodesFor would keep re-finding a matching due node
-// unresolved forever, wedging the rest of the queue behind an endless
-// refusal flash that not even retargeting to someone else could clear
-// (that only reset the WATCHDOG's tracked ref, never the node's).
+// CancelGhostNodeRefs cancels every planted node — and aborts any
+// craft's in-flight ActiveBurn — matching (owner, craftID), across
+// every craft in the slate. Called by reportingModel.reconcileTargetLock
+// (internal/serve/reporting.go) the moment its give-up countdown gives
+// up on Craft.Target pointing at this same ref: the watchdog only ever
+// cleared Craft.Target itself, leaving a planted node's or the active
+// burn's own copy of the ref dangling — executeDueNodesFor would keep
+// re-finding a matching due node unresolved forever, wedging the rest
+// of the queue behind an endless refusal flash that not even
+// retargeting to someone else could clear (that only reset the
+// WATCHDOG's tracked ref, never the node's).
 //
 // A matching NODE is dropped from the queue outright — same shape as
 // executeDueNodesFor's own never-resolvable-local-ref branch, just
-// applied proactively instead of waiting for the node to come due. A
-// matching ActiveBurn is NOT torn down: only its ref is stripped, since
-// the Δv already committed shouldn't be discarded. world.go's
-// activeBurnTargetReady (finding 1) already holds a target-relative
-// burn whose ref never resolves — stripping the ref (owner="",
-// craftID=0) just makes that hold permanent instead of merely pending.
+// applied proactively instead of waiting for the node to come due.
+//
+// #294 review round 3 (finding D): a matching ActiveBurn used to have
+// only its ref stripped (owner="", craftID=0), keeping the burn "alive"
+// so its committed Δv wasn't discarded. That backfired: with the ref
+// gone, nodeTargetRelState refuses unconditionally for craftID==0 (it
+// can't tell "no target" from "target just cancelled"), so
+// activeBurnTargetReady never returns true again — the burn holds
+// forever, its EndTime pushed out every tick, burnExhausted never fires,
+// SetThrottle(0) can't abort it (only fuel exhaustion can), and the
+// stuck ActiveBurn wedges canKeplerStep's per-craft gate for the rest of
+// the session (warp stays clamped ≤10×). The target really is gone —
+// the give-up countdown just ran its full grace window — so there is no
+// later resolve to wait for. Abort the burn outright instead: tear it
+// down cleanly, same as any other "this can never fire" case, and let
+// the one-time notice say so. The remaining Δv is forfeit, same as a
+// player-initiated StopManualBurn mid-flight.
 //
 // Stamps LastNodeTargetRefusal once for the whole call (not once per
 // matching node/burn) so a give-up that touches several queued nodes
@@ -2591,13 +2645,9 @@ func (w *World) CancelGhostNodeRefs(owner string, craftID uint64) {
 		}
 		c.Nodes = kept
 		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner == owner && ab.TargetCraftID == craftID {
-			// The burn itself is kept — only the ref is stripped. Unlike a
-			// queued node, an ActiveBurn already has Δv committed; dropping
-			// it outright would discard that. Stripping the ref instead
-			// makes world.go's activeBurnTargetReady (finding 1) hold it
-			// permanently rather than merely pending, the closest thing to
-			// "cancel" that doesn't throw away the in-flight state.
-			ab.DropGhostRef()
+			// Abort outright (finding D) — a stripped-ref zombie burn can
+			// never resolve, thrust, or tear itself down again.
+			c.ActiveBurn = nil
 			notice(c.Name)
 		}
 	}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2409,14 +2409,34 @@ func (w *World) executeDueNodes() {
 // Impulsive nodes (Duration==0) apply their Δv inline; finite nodes
 // start the craft's ActiveBurn. Both popped from the craft's own
 // Nodes slice. v0.8.1+.
+//
+// #294 review finding 2: a due target-relative node whose bound target
+// doesn't resolve used to always `break` — correct for a ghost ref that
+// might still re-latch (pending-resolvable), but wrong for a LOCAL
+// target craft removed from the slate for good (end-flight): that ref
+// can never come back, yet the unconditional break wedged the rest of
+// the queue behind an every-tick refusal flash forever. This walks the
+// queue with an explicit filter instead of the old fired-prefix count,
+// so a never-resolvable node can be dropped in place — freeing the
+// nodes behind it to fire this same tick — while a pending-resolvable
+// one still holds the queue exactly as before.
 func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
-	fired := 0
+	kept := c.Nodes[:0]
+	held := false
 	for _, n := range c.Nodes {
+		if held {
+			kept = append(kept, n)
+			continue
+		}
 		if !n.IsResolved() {
-			break
+			held = true
+			kept = append(kept, n)
+			continue
 		}
 		if n.BurnStart().After(w.Clock.SimTime) {
-			break
+			held = true
+			kept = append(kept, n)
+			continue
 		}
 		// A finite burn occupies the craft exclusively: only one
 		// ActiveBurn can integrate at a time. If one is already in
@@ -2427,7 +2447,9 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 		// tick would overwrite c.ActiveBurn and its Δv would be popped
 		// and silently dropped (GH #88).
 		if c.ActiveBurn != nil {
-			break
+			held = true
+			kept = append(kept, n)
+			continue
 		}
 		// v0.9.3+: resolve target snapshot for target-relative nodes
 		// at fire time. Bound via n.TargetCraftID (captured at plant,
@@ -2440,22 +2462,43 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 			var ok bool
 			rT, vT, ok = w.nodeTargetRelState(n.TargetGhostOwner, n.TargetCraftID, c.Primary)
 			if !ok {
-				// #294 review finding 5: a target-relative node whose bound
-				// target doesn't resolve at fire time must refuse to fire,
-				// not burn against nodeTargetRelState's zero-value fallback
-				// (DirectionUnitTarget's BurnTarget/AntiTarget cases degrade
-				// that to a direction aimed at, or away from, the primary's
-				// centre — a real Δv expenditure in a bogus direction, not a
-				// display glitch). Most reachable via a ghost-targeted node
-				// whose ref survived a save/load (#294) but hasn't re-latched
-				// yet. Leave the node queued (don't pop it, don't advance
-				// `fired`) so a later re-latch — or the player re-planting —
-				// can still fire it; break rather than continue so a stuck
-				// due node blocks the rest of this tick's dispatch exactly
-				// like the existing !IsResolved()/ActiveBurn-busy gates above,
-				// instead of silently skipping past it to a later node.
-				w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
-				break
+				// #294 review finding 5 / finding 2: a target-relative node
+				// whose bound target doesn't resolve at fire time must
+				// refuse to fire, not burn against nodeTargetRelState's
+				// zero-value fallback (DirectionUnitTarget's BurnTarget/
+				// AntiTarget cases degrade that to a direction aimed at, or
+				// away from, the primary's centre — a real Δv expenditure
+				// in a bogus direction, not a display glitch).
+				if n.TargetGhostOwner == "" {
+					// Local craft ref: never resolvable. A deleted local
+					// craft (end-flight) never comes back the way a ghost
+					// might re-latch — drop this ONE node, notice once,
+					// and keep dispatching the rest of the queue instead
+					// of wedging everything behind a burn that will never
+					// fire (finding 2, never-resolvable case (a)).
+					if !n.RefusalNoticed {
+						w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+							When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
+						}
+					}
+					continue // dropped — not appended to kept
+				}
+				// Ghost ref, not (yet) resolved: pending-resolvable —
+				// reconcileTargetLock's own watchdog owns the give-up
+				// call for this case (CancelGhostNodeRefs strips the ref
+				// once it does, which then falls into the local-ref
+				// branch above on a later tick). Until then, leave the
+				// node queued (don't pop it) and hold the rest of the
+				// queue behind it exactly like the !IsResolved()/
+				// ActiveBurn-busy gates above — but stamp the HUD flash
+				// only once per stall, not every tick (finding 2).
+				if !n.RefusalNoticed {
+					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
+					n.RefusalNoticed = true
+				}
+				held = true
+				kept = append(kept, n)
+				continue
 			}
 		}
 		if n.Duration == 0 {
@@ -2490,10 +2533,73 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 		// soft-landing doesn't trip the ViewLaunch auto-route.
 		c.Landed = false
 		c.OnPad = false
-		fired++
+		// fired — not appended to kept.
 	}
-	if fired > 0 {
-		c.Nodes = c.Nodes[fired:]
+	c.Nodes = kept
+}
+
+// CancelGhostNodeRefs cancels every planted node — and strips any
+// craft's in-flight ActiveBurn's ref — matching (owner, craftID),
+// across every craft in the slate. Called by
+// reportingModel.reconcileTargetLock (internal/serve/reporting.go) the
+// moment its 45s watchdog gives up on Craft.Target pointing at this
+// same ref (#294 review finding 2, never-resolvable case (b)): the
+// watchdog only ever cleared Craft.Target itself, leaving a planted
+// node's or the active burn's own copy of the ref dangling —
+// executeDueNodesFor would keep re-finding a matching due node
+// unresolved forever, wedging the rest of the queue behind an endless
+// refusal flash that not even retargeting to someone else could clear
+// (that only reset the WATCHDOG's tracked ref, never the node's).
+//
+// A matching NODE is dropped from the queue outright — same shape as
+// executeDueNodesFor's own never-resolvable-local-ref branch, just
+// applied proactively instead of waiting for the node to come due. A
+// matching ActiveBurn is NOT torn down: only its ref is stripped, since
+// the Δv already committed shouldn't be discarded. world.go's
+// activeBurnTargetReady (finding 1) already holds a target-relative
+// burn whose ref never resolves — stripping the ref (owner="",
+// craftID=0) just makes that hold permanent instead of merely pending.
+//
+// Stamps LastNodeTargetRefusal once for the whole call (not once per
+// matching node/burn) so a give-up that touches several queued nodes
+// still produces a single notice.
+func (w *World) CancelGhostNodeRefs(owner string, craftID uint64) {
+	if owner == "" || craftID == 0 {
+		return
+	}
+	stamped := false
+	notice := func(craftName string) {
+		if stamped {
+			return
+		}
+		w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+			When: w.Clock.SimTime, CraftName: craftName, Cancelled: true,
+		}
+		stamped = true
+	}
+	for _, c := range w.Crafts {
+		if c == nil {
+			continue
+		}
+		kept := c.Nodes[:0]
+		for _, n := range c.Nodes {
+			if n.TargetGhostOwner == owner && n.TargetCraftID == craftID {
+				notice(c.Name)
+				continue // dropped outright — see the node/burn split below
+			}
+			kept = append(kept, n)
+		}
+		c.Nodes = kept
+		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner == owner && ab.TargetCraftID == craftID {
+			// The burn itself is kept — only the ref is stripped. Unlike a
+			// queued node, an ActiveBurn already has Δv committed; dropping
+			// it outright would discard that. Stripping the ref instead
+			// makes world.go's activeBurnTargetReady (finding 1) hold it
+			// permanently rather than merely pending, the closest thing to
+			// "cancel" that doesn't throw away the in-flight state.
+			ab.DropGhostRef()
+			notice(c.Name)
+		}
 	}
 }
 

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -117,10 +117,18 @@ func (w *World) ToggleManualBurn() {
 // it to the active craft. Setting throttle to 0 also stops the
 // active craft's in-flight manual burn so the "x = cut" muscle
 // memory works in one keypress; a normally-running planted burn keeps
-// running, but a STALLED planted burn (paused waiting for a stage,
-// producing no thrust) is aborted — that's the only way to abandon a
-// transfer the spent stage couldn't finish, and without it the dangling
-// burn would block StartManualBurn (v0.12.x pause-and-resume).
+// running, but a STALLED planted burn is aborted — either paused for
+// want of fuel (BurnStalled) or paused for want of a resolvable
+// target (a target-relative burn activeBurnTargetReady refuses to
+// thrust — #294 second-round review finding 3: before this, only fuel
+// exhaustion could ever tear a held burn down, so a craft/ghost target
+// that never came back — the peer landing, changing systems, or the
+// session ending mid-burn — left the player with NO way to abandon the
+// transfer short of staging it dry). Either stall is the only way to
+// abandon a transfer that can't finish, and without aborting it here
+// the dangling burn would block StartManualBurn (v0.12.x
+// pause-and-resume) and keep the craft's warp clamp pinned ≤10× for
+// good.
 func (w *World) SetThrottle(t float64) {
 	c := w.ActiveCraft()
 	if c == nil {
@@ -140,7 +148,7 @@ func (w *World) SetThrottle(t float64) {
 	c.Throttle = t
 	if t == 0 {
 		w.StopManualBurn()
-		if c.BurnStalled() {
+		if c.BurnStalled() || (c.ActiveBurn != nil && !w.activeBurnTargetReady(c)) {
 			c.ActiveBurn = nil
 		}
 	}
@@ -2391,6 +2399,15 @@ func (w *World) DeleteNode(idx int) {
 	c.Nodes = append(c.Nodes[:idx], c.Nodes[idx+1:]...)
 }
 
+// ghostNodeAbsentGrace mirrors reportingModel.targetLockRelatchGrace
+// (internal/serve/reporting.go, 45s) — the SAME wall-clock tolerance a
+// due ghost-ref node gets before executeDueNodesFor gives up on its
+// target owner being absent from the current session's roster (#294
+// second-round review finding 1). Duplicated rather than imported: sim
+// sits below serve in the dependency graph (physics → orbital →
+// planner/spacecraft → sim → tui/serve) and must never import upward.
+const ghostNodeAbsentGrace = 45 * time.Second
+
 // executeDueNodes fires every craft's due nodes onto themselves.
 // Called from Tick after sim-time advances. Each craft's nodes are
 // independent — a planted burn fires on the craft it was planted
@@ -2510,32 +2527,83 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 					// once, and keep dispatching the rest of the queue
 					// instead of wedging everything behind a burn that
 					// will never fire.
-					if !n.RefusalNoticed {
-						w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
-							When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
-						}
+					//
+					// #294 second-round review finding 5: this stamp must
+					// be UNCONDITIONAL, not gated behind !n.RefusalNoticed.
+					// A node that held earlier (the transient different-
+					// primary stall above, which DOES set RefusalNoticed to
+					// mute its own every-tick flash) already carries the
+					// flag by the time it reaches a cancel — gating the
+					// cancel notice on the same flag silently swallowed it,
+					// so the node vanished from the queue with no HUD flash
+					// at all. Cancellation is a one-time terminal event for
+					// this node (it's dropped right after), so there is no
+					// "once per stall" concern to protect here the way the
+					// hold branches have.
+					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+						When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
 					}
 					continue // dropped — not appended to kept
 				}
 				// Ghost ref, not (yet) resolved (finding E): give up right
-				// here when there is no session at all, or this owner
-				// isn't part of it — reconcileTargetLock's watchdog can
-				// never reach this node (it only ever tracks the world's
-				// ACTIVE target), so nothing else ever will. An owner who
-				// IS a member of this session gets the ordinary pending-
-				// resolvable tolerance: leave the node queued (don't pop
-				// it) and hold the rest of the queue behind it exactly
-				// like the !IsResolved()/ActiveBurn-busy gates above —
-				// stamping the HUD flash only once per stall, not every
-				// tick.
-				if !w.sessionKnowsOwner(n.TargetGhostOwner) {
-					if !n.RefusalNoticed {
-						w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
-							When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
-						}
+				// here when there is no session at all — reconcileTargetLock's
+				// watchdog can never reach this node (it only ever tracks the
+				// world's ACTIVE target), and with no session nothing will
+				// ever populate a roster for it to wait on (solo play, or a
+				// craft evaluated outside any hosting session, e.g. a dock
+				// ledger Parcel), so waiting here would just wedge the queue
+				// forever.
+				if w.Session == nil {
+					// Unconditional stamp — see finding 5's note above; a
+					// node held earlier under a live session (RefusalNoticed
+					// already true) must not go silent just because the
+					// session it was waiting on is now gone entirely.
+					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+						When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
 					}
 					continue // dropped — not appended to kept
 				}
+				// #294 second-round review finding 1: in a session, but this
+				// owner isn't (yet) a roster member. Most often the shape of
+				// THIS player's own session reconnecting — a guest's first
+				// tick after connect used to race sessionKnowsOwner against
+				// refreshSession priming w.Session (now fixed at attach, see
+				// withReporting in internal/serve/reporting.go) — or a
+				// roster snapshot momentarily lagging a restart. Give the
+				// SAME wall-clock tolerance reconcileTargetLock's watchdog
+				// gives the world's ACTIVE target before it gives up: an
+				// owner mid-reconnect must not cost a planted node.
+				if !w.sessionKnowsOwner(n.TargetGhostOwner) {
+					now := time.Now()
+					if n.GhostAbsentSince.IsZero() {
+						n.GhostAbsentSince = now
+					}
+					if now.Sub(n.GhostAbsentSince) < ghostNodeAbsentGrace {
+						if !n.RefusalNoticed {
+							w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
+							n.RefusalNoticed = true
+						}
+						held = true
+						kept = append(kept, n)
+						continue
+					}
+					// Unconditional stamp (finding 5): this node has almost
+					// certainly held at least once already (RefusalNoticed
+					// set by the branch just above, every tick within
+					// grace) — gating the cancel on that same flag would
+					// silently drop the node the instant grace expired,
+					// with no notice at all.
+					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+						When: w.Clock.SimTime, CraftName: c.Name, Cancelled: true,
+					}
+					continue // dropped — not appended to kept
+				}
+				// Owner present: an ordinary pending-resolvable ghost (landed,
+				// viewing a different system, hasn't reported yet) gets the
+				// tolerance it always had — hold silently, and clear any
+				// absence timer left over from an earlier stretch of the
+				// owner being away from the roster.
+				n.GhostAbsentSince = time.Time{}
 				if !n.RefusalNoticed {
 					w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
 					n.RefusalNoticed = true
@@ -2647,6 +2715,57 @@ func (w *World) CancelGhostNodeRefs(owner string, craftID uint64) {
 		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner == owner && ab.TargetCraftID == craftID {
 			// Abort outright (finding D) — a stripped-ref zombie burn can
 			// never resolve, thrust, or tear itself down again.
+			c.ActiveBurn = nil
+			notice(c.Name)
+		}
+	}
+}
+
+// CancelAllGhostRefs cancels every planted node bound to ANY ghost
+// (TargetGhostOwner != "") — and aborts any craft's in-flight ghost-
+// ref ActiveBurn — across every craft in the slate, regardless of
+// which peer they name. #294 second-round review finding 3(ii): called
+// by reportingModel.stopHosting (internal/serve/reporting.go) the
+// moment a hosting session ends. Unlike CancelGhostNodeRefs (one
+// specific ref, called mid-session once its own give-up grace
+// expires), leaving the session entirely means NO ghost ref can ever
+// resolve again — there is no roster left to wait on, no watchdog left
+// running, nothing to re-latch to. Left alone, a ghost-bound
+// ActiveBurn would hold forever (activeBurnTargetReady never
+// re-resolves outside a session), wedging the craft's warp clamp for
+// good; a queued ghost-ref node would sit refused every tick it came
+// due. Same shape as executeDueNodesFor's own no-session branch, just
+// applied proactively to every ref at once instead of waiting for each
+// node to come due.
+//
+// Stamps LastNodeTargetRefusal once for the whole call (not once per
+// matching node/burn) so leaving with several ghost refs outstanding
+// still produces a single notice.
+func (w *World) CancelAllGhostRefs() {
+	stamped := false
+	notice := func(craftName string) {
+		if stamped {
+			return
+		}
+		w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
+			When: w.Clock.SimTime, CraftName: craftName, Cancelled: true,
+		}
+		stamped = true
+	}
+	for _, c := range w.Crafts {
+		if c == nil {
+			continue
+		}
+		kept := c.Nodes[:0]
+		for _, n := range c.Nodes {
+			if n.TargetGhostOwner != "" {
+				notice(c.Name)
+				continue // dropped outright
+			}
+			kept = append(kept, n)
+		}
+		c.Nodes = kept
+		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner != "" {
 			c.ActiveBurn = nil
 			notice(c.Name)
 		}

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2437,7 +2437,26 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 		if n.IsTargetRelative() {
 			// v0.28 S4: resolves a local craft ref or a remote ghost ref
 			// (owner + remote id) against the ghost slate.
-			rT, vT, _ = w.nodeTargetRelState(n.TargetGhostOwner, n.TargetCraftID, c.Primary)
+			var ok bool
+			rT, vT, ok = w.nodeTargetRelState(n.TargetGhostOwner, n.TargetCraftID, c.Primary)
+			if !ok {
+				// #294 review finding 5: a target-relative node whose bound
+				// target doesn't resolve at fire time must refuse to fire,
+				// not burn against nodeTargetRelState's zero-value fallback
+				// (DirectionUnitTarget's BurnTarget/AntiTarget cases degrade
+				// that to a direction aimed at, or away from, the primary's
+				// centre — a real Δv expenditure in a bogus direction, not a
+				// display glitch). Most reachable via a ghost-targeted node
+				// whose ref survived a save/load (#294) but hasn't re-latched
+				// yet. Leave the node queued (don't pop it, don't advance
+				// `fired`) so a later re-latch — or the player re-planting —
+				// can still fire it; break rather than continue so a stuck
+				// due node blocks the rest of this tick's dispatch exactly
+				// like the existing !IsResolved()/ActiveBurn-busy gates above,
+				// instead of silently skipping past it to a later node.
+				w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
+				break
+			}
 		}
 		if n.Duration == 0 {
 			// A BurnPlaneChange or BurnVector node degrades to impulsive
@@ -2507,7 +2526,20 @@ func (w *World) nodeLeadActive(c *spacecraft.Spacecraft) (orbital.Vec3, bool) {
 	var rT, vT orbital.Vec3
 	if n.IsTargetRelative() {
 		// v0.28 S4: local craft ref or remote ghost ref (via ghost slate).
-		rT, vT, _ = w.nodeTargetRelState(n.TargetGhostOwner, n.TargetCraftID, c.Primary)
+		ok := false
+		rT, vT, ok = w.nodeTargetRelState(n.TargetGhostOwner, n.TargetCraftID, c.Primary)
+		// #294 review finding 5 (same shape as the navball marker guard
+		// below): an unresolved target-relative node has no direction to
+		// lead-compensate toward. rT=vT=0 doesn't necessarily give
+		// BurnDirectionForBurn a zero-norm result (BurnTarget's
+		// unit(0 − rA) is a perfectly valid-looking unit vector aimed at
+		// the primary's centre) — the dir.Norm()==0 check below can't
+		// catch it, so check ok explicitly rather than let the craft
+		// pre-emptively slew its nose toward the planet ahead of a burn
+		// that (per executeDueNodesFor) will refuse to fire anyway.
+		if !ok {
+			return orbital.Vec3{}, false
+		}
 	}
 	dir := c.BurnDirectionForBurn(n.Mode, rT, vT, n.PlaneChangeRad, n.BurnDirUnit)
 	if dir.Norm() == 0 {

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2399,14 +2399,13 @@ func (w *World) DeleteNode(idx int) {
 	c.Nodes = append(c.Nodes[:idx], c.Nodes[idx+1:]...)
 }
 
-// ghostNodeAbsentGrace mirrors reportingModel.targetLockRelatchGrace
-// (internal/serve/reporting.go, 45s) — the SAME wall-clock tolerance a
-// due ghost-ref node gets before executeDueNodesFor gives up on its
-// target owner being absent from the current session's roster (#294
-// second-round review finding 1). Duplicated rather than imported: sim
-// sits below serve in the dependency graph (physics → orbital →
-// planner/spacecraft → sim → tui/serve) and must never import upward.
-const ghostNodeAbsentGrace = 45 * time.Second
+// GhostAbsentGrace is the wall-clock tolerance a ghost ref gets before the
+// sim gives up on its owner being absent from the session roster: the
+// SAME value for a due ghost-ref node here (executeDueNodesFor) and for
+// the world's active target lock in reportingModel's watchdog
+// (internal/serve/reporting.go, which references this constant so the two
+// can't drift). #294.
+const GhostAbsentGrace = 45 * time.Second
 
 // executeDueNodes fires every craft's due nodes onto themselves.
 // Called from Tick after sim-time advances. Each craft's nodes are
@@ -2578,7 +2577,7 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 					if n.GhostAbsentSince.IsZero() {
 						n.GhostAbsentSince = now
 					}
-					if now.Sub(n.GhostAbsentSince) < ghostNodeAbsentGrace {
+					if now.Sub(n.GhostAbsentSince) < GhostAbsentGrace {
 						if !n.RefusalNoticed {
 							w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
 							n.RefusalNoticed = true
@@ -2689,36 +2688,7 @@ func (w *World) CancelGhostNodeRefs(owner string, craftID uint64) {
 	if owner == "" || craftID == 0 {
 		return
 	}
-	stamped := false
-	notice := func(craftName string) {
-		if stamped {
-			return
-		}
-		w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{
-			When: w.Clock.SimTime, CraftName: craftName, Cancelled: true,
-		}
-		stamped = true
-	}
-	for _, c := range w.Crafts {
-		if c == nil {
-			continue
-		}
-		kept := c.Nodes[:0]
-		for _, n := range c.Nodes {
-			if n.TargetGhostOwner == owner && n.TargetCraftID == craftID {
-				notice(c.Name)
-				continue // dropped outright — see the node/burn split below
-			}
-			kept = append(kept, n)
-		}
-		c.Nodes = kept
-		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner == owner && ab.TargetCraftID == craftID {
-			// Abort outright (finding D) — a stripped-ref zombie burn can
-			// never resolve, thrust, or tear itself down again.
-			c.ActiveBurn = nil
-			notice(c.Name)
-		}
-	}
+	w.cancelGhostRefsMatching(func(o string, id uint64) bool { return o == owner && id == craftID })
 }
 
 // CancelAllGhostRefs cancels every planted node bound to ANY ghost
@@ -2742,6 +2712,24 @@ func (w *World) CancelGhostNodeRefs(owner string, craftID uint64) {
 // matching node/burn) so leaving with several ghost refs outstanding
 // still produces a single notice.
 func (w *World) CancelAllGhostRefs() {
+	w.cancelGhostRefsMatching(func(o string, _ uint64) bool { return o != "" })
+}
+
+// cancelGhostRefsMatching is the shared body of CancelGhostNodeRefs and
+// CancelAllGhostRefs. What happens to a matching ref depends on whether
+// the burn actually NEEDS the target:
+//   - a target-relative-MODE node (BurnTarget* — its direction is
+//     meaningless without the target state) is dropped outright, and an
+//     in-flight target-relative ActiveBurn is aborted; one cancellation
+//     notice per call.
+//   - a node/burn whose MODE is not target-relative (prograde, radial, …)
+//     merely CARRIED the binding — the maneuver form stamps it on every
+//     mode while a craft/ghost is targeted so an edited advisory keeps its
+//     identity, and PlanRendezvousNudge binds every axis — and its burn is
+//     unaffected by the target vanishing. It keeps the node/burn and only
+//     strips the now-meaningless ref, silently: dropping it would delete
+//     a planted circularize the player made while merely LOOKING at a peer.
+func (w *World) cancelGhostRefsMatching(match func(owner string, craftID uint64) bool) {
 	stamped := false
 	notice := func(craftName string) {
 		if stamped {
@@ -2758,16 +2746,23 @@ func (w *World) CancelAllGhostRefs() {
 		}
 		kept := c.Nodes[:0]
 		for _, n := range c.Nodes {
-			if n.TargetGhostOwner != "" {
-				notice(c.Name)
-				continue // dropped outright
+			if n.TargetGhostOwner != "" && match(n.TargetGhostOwner, n.TargetCraftID) {
+				if n.IsTargetRelative() {
+					notice(c.Name)
+					continue // dropped outright
+				}
+				n.TargetGhostOwner, n.TargetCraftID = "", 0
 			}
 			kept = append(kept, n)
 		}
 		c.Nodes = kept
-		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner != "" {
-			c.ActiveBurn = nil
-			notice(c.Name)
+		if ab := c.ActiveBurn; ab != nil && ab.TargetGhostOwner != "" && match(ab.TargetGhostOwner, ab.TargetCraftID) {
+			if spacecraft.IsTargetRelativeMode(ab.Mode) {
+				c.ActiveBurn = nil
+				notice(c.Name)
+			} else {
+				ab.TargetGhostOwner, ab.TargetCraftID = "", 0
+			}
 		}
 	}
 }

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -113,20 +113,31 @@ func (w *World) NavballBasis() (NavballBasis, bool) {
 	var eX orbital.Vec3
 	switch nav {
 	case NavTarget:
-		_, vT, ok := w.TargetStateRelativeToActivePrimary()
-		if !ok {
-			return NavballBasis{}, false
+		if _, vT, ok := w.TargetStateRelativeToActivePrimary(); ok {
+			// KSP convention: target-prograde = unit(v_active − v_target),
+			// the direction of motion relative to the target. The navball
+			// re-centres on that axis so when SAS holds target-prograde
+			// the marker sits at the disk centre.
+			dv := v.Sub(vT)
+			if n := dv.Norm(); n != 0 {
+				eX = dv.Scale(1 / n)
+				break
+			}
 		}
-		// KSP convention: target-prograde = unit(v_active − v_target),
-		// the direction of motion relative to the target. The navball
-		// re-centres on that axis so when SAS holds target-prograde
-		// the marker sits at the disk centre.
-		dv := v.Sub(vT)
-		n := dv.Norm()
-		if n == 0 {
-			return NavballBasis{}, false
-		}
-		eX = dv.Scale(1 / n)
+		// #294 review round 3 (finding H): a persisted NavTarget mode
+		// whose target-relative state doesn't resolve — most visibly a
+		// TargetGhost ref still mid re-latch after a reconnect, or one
+		// with no live session at all to re-latch it — used to blank the
+		// WHOLE navball (return ok=false here), not just the target-
+		// relative markers, for as long as the gap lasted: indefinitely,
+		// for a solo-loaded save. HasRelativeTarget() deliberately keeps
+		// NavMode at NavTarget through a resolve gap (see its doc), so
+		// this can't fall back to NavOrbit above — it has to fall back
+		// HERE, to the same orbit-frame prograde basis the default case
+		// below computes, so the ball is never simply blank. The
+		// degenerate dv.Norm()==0 case (target resolved, but with
+		// exactly matched velocity) falls through the same way.
+		fallthrough
 	default:
 		vN := v.Norm()
 		if vN == 0 {

--- a/internal/sim/navball.go
+++ b/internal/sim/navball.go
@@ -277,7 +277,7 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 	if !ok {
 		return nil
 	}
-	rT, vT, _ := w.TargetStateRelativeToActivePrimary()
+	rT, vT, targetOK := w.TargetStateRelativeToActivePrimary()
 
 	// Per-mode glyph + color per intent. Only the radial pair
 	// re-skins per mode — prograde / retrograde / normal± keep their
@@ -288,10 +288,18 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 		glyph  rune
 		color  lipgloss.Color
 	}
+	// targetRelevant is when ResolveAttitudeIntent rebinds
+	// Prograde/Retrograde/RadialOut/RadialIn to a target-relative BurnMode
+	// (mirrors its own NavTarget case). HasRelativeTarget() is true
+	// whenever a craft/ghost target is BOUND, independent of whether it
+	// currently RESOLVES — a persisted TargetGhost ref mid re-latch after
+	// a reconnect, or one with nobody live to re-latch it, is bound but
+	// unresolved. targetOK is the resolve itself.
+	targetRelevant := w.NavMode == NavTarget && w.HasRelativeTarget()
 	radialOutGlyph := NavballGlyphRadialOut
 	radialInGlyph := NavballGlyphRadialIn
 	radialColor := render.ColorNavballMarkerRadial
-	if w.NavMode == NavTarget && w.HasRelativeTarget() {
+	if targetRelevant {
 		radialOutGlyph = NavballGlyphTarget
 		radialInGlyph = NavballGlyphAntiTarget
 		radialColor = render.ColorNavballMarkerTarget
@@ -307,6 +315,19 @@ func (w *World) NavballMarkers() []render.NavballMarker {
 
 	out := make([]render.NavballMarker, 0, len(entries)+len(active.Nodes))
 	for _, e := range entries {
+		// Suppress the four target-relative cardinals when the target is
+		// bound but doesn't resolve — matching NavballBasis's own fallback
+		// to an orbit-prograde frame, and attitudeContext's resolve-ok
+		// guard (world.go). Without this, DirectionUnitTarget's BurnTarget
+		// case degrades (rT, vT)=(0, 0) to unit(0 − rA): a genuine unit
+		// vector pointing at the primary's centre, so the toward-target
+		// glyph would draw confidently there while SAS actually holds
+		// prograde.
+		if targetRelevant && !targetOK &&
+			(e.intent == IntentPrograde || e.intent == IntentRetrograde ||
+				e.intent == IntentRadialOut || e.intent == IntentRadialIn) {
+			continue
+		}
 		mode := w.ResolveAttitudeIntent(e.intent)
 		dir := active.BurnDirectionWithTarget(mode, rT, vT)
 		if dir.Norm() == 0 {

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -581,3 +581,80 @@ func TestNavballBasisGhostTargetResolvesUsesTargetRelative(t *testing.T) {
 		t.Errorf("EX = %v, want target-relative retrograde %v (not plain orbit prograde %v)", basis.EX, retrogradeUnit, progradeUnit)
 	}
 }
+
+// TestNavballMarkersUnresolvedGhostTargetSuppressesTargetRelative —
+// review finding following #294 review finding H and the node-marker /
+// nodeLeadActive resolve-ok guards from this same PR. NavballMarkers used
+// to discard TargetStateRelativeToActivePrimary's ok, so an unresolved
+// ghost target (bound via HasRelativeTarget — which deliberately stays
+// "relative" through a resolve gap — but with nothing in the ghost slate
+// to resolve against) fed zero (rT, vT) into BurnDirectionWithTarget. For
+// BurnTarget that degrades to unit(0 − rA): a genuine unit vector
+// pointing at the primary's centre, so the toward-target glyph drew
+// confidently there while SAS (attitudeContext, which DOES check ok) was
+// actually holding prograde — the glyph and the held attitude disagreed.
+// The four target-relative cardinals (prograde/retrograde/radial±) must
+// be suppressed entirely when the target doesn't resolve, matching
+// NavballBasis's own fallback; normal+/- are target-independent and must
+// still draw.
+func TestNavballMarkersUnresolvedGhostTargetSuppressesTargetRelative(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavTarget
+	w.SetTargetGhost("SHA256:peer", 99)
+	w.Ghosts = nil // never latched — the reconnect / no-session case
+
+	got := w.NavballMarkers()
+	if got == nil {
+		t.Fatal("NavballMarkers returned nil — want the orbit-fallback basis markers (normal+/-), not a blank navball")
+	}
+	byGlyph := map[rune]bool{}
+	for _, m := range got {
+		byGlyph[m.Glyph] = true
+	}
+	if byGlyph[NavballGlyphTarget] || byGlyph[NavballGlyphAntiTarget] {
+		t.Errorf("target glyph present despite an unresolved target: %+v", got)
+	}
+	if byGlyph[NavballGlyphPrograde] || byGlyph[NavballGlyphRetrograde] {
+		t.Errorf("prograde/retrograde marker present despite an unresolved target-relative NavMode: %+v", got)
+	}
+	if !byGlyph[NavballGlyphNormalPlus] || !byGlyph[NavballGlyphNormalMinus] {
+		t.Errorf("target-independent normal+/- markers missing: %+v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("marker count = %d, want 2 (normal+/- only): %+v", len(got), got)
+	}
+}
+
+// TestNavballMarkersGhostTargetResolvesKeepsTargetRelative — the flip
+// side: once the ghost resolves, the target-relative cardinals draw
+// normally, proving the suppression above is a hold, not a permanent
+// demotion.
+func TestNavballMarkersGhostTargetResolvesKeepsTargetRelative(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.NavMode = NavTarget
+	w.SetTargetGhost("SHA256:peer", 99)
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:peer", CraftID: 99, PrimaryID: c.Primary.ID,
+		Pos: w.BodyPosition(c.Primary).Add(c.State.R).Add(orbital.Vec3{X: 1e6}),
+		Vel: c.State.V.Scale(2),
+	}}
+
+	got := w.NavballMarkers()
+	byGlyph := map[rune]bool{}
+	for _, m := range got {
+		byGlyph[m.Glyph] = true
+	}
+	if !byGlyph[NavballGlyphTarget] || !byGlyph[NavballGlyphAntiTarget] {
+		t.Errorf("target/anti-target markers missing once the target resolves: %+v", got)
+	}
+	if len(got) != 6 {
+		t.Errorf("marker count = %d, want 6 (all six cardinals) once the target resolves: %+v", len(got), got)
+	}
+}

--- a/internal/sim/navball_test.go
+++ b/internal/sim/navball_test.go
@@ -517,3 +517,67 @@ func TestNavballBasisTargetMissingFallsBackToOrbit(t *testing.T) {
 		t.Errorf("EX = %v, want orbit-mode prograde %v", basis.EX, progradeUnit)
 	}
 }
+
+// TestNavballBasisGhostTargetUnresolvedFallsBackToOrbit — #294 review
+// round 3 finding H. A persisted NavTarget mode whose ghost ref hasn't
+// (yet) re-latched — mid reconnect, or with no live session at all —
+// resolves via HasRelativeTarget() to TargetGhost (which deliberately
+// stays "relative" through a resolve gap; see HasRelativeTarget's own
+// doc), so nav never demotes to NavOrbit above. But
+// TargetStateRelativeToActivePrimary itself has nothing to show. The
+// basis must fall back to ordinary orbit-frame prograde here instead of
+// returning ok=false and blanking the WHOLE navball — not just the
+// target-relative markers — for as long as the gap lasts (indefinitely,
+// for a solo-loaded save).
+func TestNavballBasisGhostTargetUnresolvedFallsBackToOrbit(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.NavMode = NavTarget
+	w.SetTargetGhost("SHA256:peer", 99)
+	w.Ghosts = nil // never latched — the reconnect / no-session case
+
+	basis, ok := w.NavballBasis()
+	if !ok {
+		t.Fatal("NavballBasis: ok=false for an unresolved ghost target — want the orbit-frame fallback")
+	}
+	c := w.ActiveCraft()
+	progradeUnit := c.State.V.Scale(1 / c.State.V.Norm())
+	if !vec3Eq(basis.EX, progradeUnit) {
+		t.Errorf("EX = %v, want orbit-mode prograde %v", basis.EX, progradeUnit)
+	}
+}
+
+// TestNavballBasisGhostTargetResolvesUsesTargetRelative — the flip
+// side of the fallback above: once the ghost resolves, the basis goes
+// back to target-relative prograde, proving the fallback is a hold, not
+// a permanent demotion to orbit mode.
+func TestNavballBasisGhostTargetResolvesUsesTargetRelative(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	w.NavMode = NavTarget
+	w.SetTargetGhost("SHA256:peer", 99)
+	// Ghost velocity (primary-relative, same frame as c.State.V here
+	// since they share a primary) deliberately set to 2x the active
+	// craft's own velocity, so target-relative dv = v - vT = -v: exactly
+	// retrograde, unmistakably different from plain orbit prograde.
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:peer", CraftID: 99, PrimaryID: c.Primary.ID,
+		Pos: w.BodyPosition(c.Primary).Add(c.State.R),
+		Vel: c.State.V.Scale(2),
+	}}
+
+	basis, ok := w.NavballBasis()
+	if !ok {
+		t.Fatal("NavballBasis: ok=false for a resolved ghost target")
+	}
+	progradeUnit := c.State.V.Scale(1 / c.State.V.Norm())
+	retrogradeUnit := progradeUnit.Scale(-1)
+	if !vec3Eq(basis.EX, retrogradeUnit) {
+		t.Errorf("EX = %v, want target-relative retrograde %v (not plain orbit prograde %v)", basis.EX, retrogradeUnit, progradeUnit)
+	}
+}

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -155,6 +155,16 @@ const (
 	// while this player's own session ran unattended — local only, and
 	// the only event carrying Elapsed.
 	SessionEventResumed
+
+	// SessionEventTargetLockLost (#294): a craft/ghost target lock that
+	// survived a reconnect (persisted per §CraftToWire) never resolved —
+	// the target owner's craft reports never resumed within the grace
+	// window, or the referenced craft is genuinely gone. Local only: the
+	// deferred re-latch in internal/serve gives up and clears the target
+	// before firing this, so by the time it renders the player really is
+	// back at TargetNone, not merely waiting. Addressed at the player who
+	// had the lock; Handle names the peer it was aimed at.
+	SessionEventTargetLockLost
 )
 
 // SessionEvent is a transient session moment (join / leave / sync —

--- a/internal/sim/session_info.go
+++ b/internal/sim/session_info.go
@@ -218,3 +218,30 @@ func (w *World) DockOwnerOnline() bool {
 	}
 	return false
 }
+
+// sessionKnowsOwner reports whether owner is a member of the current
+// multiplayer session's roster — present regardless of online/away/
+// landed/other-system status, the same "enrollment slate" presence
+// reportingModel.reconcileTargetLock's give-up countdown keys off
+// (internal/serve/reporting.go). False when there is no session at all
+// (solo play, or a craft evaluated outside any hosting session — a dock
+// ledger Parcel, for instance) or the roster has no matching row (never
+// enrolled, or since removed).
+//
+// #294 review round 3 finding E: a persisted ghost-ref NODE that isn't
+// the world's ACTIVE target never gets a give-up from
+// reconcileTargetLock at all — that watchdog only ever tracks
+// w.Target. executeDueNodesFor uses this directly, at fire time, so a
+// node belonging to some OTHER ghost still gets a give-up rule of its
+// own instead of wedging the queue forever.
+func (w *World) sessionKnowsOwner(owner string) bool {
+	if w.Session == nil {
+		return false
+	}
+	for _, p := range w.Session.Players {
+		if p.Fingerprint == owner {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -241,8 +241,30 @@ func (w *World) ghostByRef(owner string, craftID uint64) (Ghost, bool) {
 // review follow-up). Every gate that used to spell Kind==TargetCraft
 // for "can I do target-relative work" goes through here so ghost
 // targets light up the same surfaces.
+//
+// #294 review finding 4: a ghost target must actually RESOLVE to count
+// here — a stale ref (owner never came back after a save/load outside
+// any live serve session, or hasn't re-latched yet post-reconnect) used
+// to read as relative-target-available just because Kind==TargetGhost,
+// which defeated every "stale NavTarget should never produce a zero-
+// direction SAS hold" guard downstream (ResolveAttitudeIntent,
+// CycleNavMode, reconcileNavMode): NavTarget stayed selectable/sticky
+// and the live SAS mode got set to a target-relative BurnMode that then
+// had nothing to aim at. The Kind itself is left untouched on
+// w.Target — this only changes what counts as "usable for nav right
+// now", so the stored lock is still there for reconcileTargetLock (or
+// simply the ghost reappearing) to re-latch onto later; TargetName /
+// TargetGhost-branch readers still see Kind==TargetGhost and can show
+// the pending state (see TargetName, orbit_chip_builders.go).
 func (w *World) HasRelativeTarget() bool {
-	return w.Target.Kind == TargetCraft || w.Target.Kind == TargetGhost
+	switch w.Target.Kind {
+	case TargetCraft:
+		return true
+	case TargetGhost:
+		_, ok := w.ghostByRef(w.Target.GhostOwner, w.Target.CraftID)
+		return ok
+	}
+	return false
 }
 
 // ResolveTargetGhost resolves a ghost target to its slate entry and
@@ -517,6 +539,34 @@ func (w *World) TargetName() string {
 				return g.Handle + "'s " + g.Name
 			}
 			return g.Name
+		}
+		// #294 review finding 4: an unresolved ghost still HOLDS the lock
+		// (Kind stays TargetGhost — see HasRelativeTarget) — returning ""
+		// here made the TARGET chip vanish outright, indistinguishable
+		// from TargetNone / a cleared target. Show the pending state
+		// instead, using the roster handle when a live session has one
+		// (GhostOwnerHandle), so the player can tell "still locked, just
+		// waiting to resolve" from "not locked at all".
+		if h := w.GhostOwnerHandle(w.Target.GhostOwner); h != "" {
+			return h + "'s vessel (pending)"
+		}
+		return "pending target lock"
+	}
+	return ""
+}
+
+// GhostOwnerHandle resolves a ghost owner fingerprint to a display
+// handle via the live session roster (#294 review finding 4) — nil
+// w.Session (solo play, or a session whose roster hasn't refreshed yet)
+// or no matching row both return "". Same lookup shape as
+// DockOwnerOnline (session_info.go).
+func (w *World) GhostOwnerHandle(owner string) string {
+	if w.Session == nil || owner == "" {
+		return ""
+	}
+	for _, p := range w.Session.Players {
+		if p.Fingerprint == owner {
+			return p.Handle
 		}
 	}
 	return ""

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -226,6 +226,17 @@ func (w *World) nodeTargetRelState(owner string, craftID uint64, primary bodies.
 	return tc.State.R, tc.State.V, true
 }
 
+// TargetRelState is the exported door onto nodeTargetRelState for
+// callers outside the sim package (internal/tui/screens's maneuver form,
+// #294 review round 3 finding I): resolves a captured (owner, craftID)
+// target-relative ref — local craft (owner=="") or remote ghost — to its
+// state in the given primary's relative frame, exactly as a planted
+// node or the active burn resolves its own bound target at fire time.
+// ok=false when the ref is empty or doesn't resolve.
+func (w *World) TargetRelState(owner string, craftID uint64, primary bodies.CelestialBody) (rT, vT orbital.Vec3, ok bool) {
+	return w.nodeTargetRelState(owner, craftID, primary)
+}
+
 // ghostByRef finds a ghost by owner + craft ID in the transient slate.
 func (w *World) ghostByRef(owner string, craftID uint64) (Ghost, bool) {
 	for _, g := range w.Ghosts {

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -242,27 +242,24 @@ func (w *World) ghostByRef(owner string, craftID uint64) (Ghost, bool) {
 // for "can I do target-relative work" goes through here so ghost
 // targets light up the same surfaces.
 //
-// #294 review finding 4: a ghost target must actually RESOLVE to count
-// here — a stale ref (owner never came back after a save/load outside
-// any live serve session, or hasn't re-latched yet post-reconnect) used
-// to read as relative-target-available just because Kind==TargetGhost,
-// which defeated every "stale NavTarget should never produce a zero-
-// direction SAS hold" guard downstream (ResolveAttitudeIntent,
-// CycleNavMode, reconcileNavMode): NavTarget stayed selectable/sticky
-// and the live SAS mode got set to a target-relative BurnMode that then
-// had nothing to aim at. The Kind itself is left untouched on
-// w.Target — this only changes what counts as "usable for nav right
-// now", so the stored lock is still there for reconcileTargetLock (or
-// simply the ghost reappearing) to re-latch onto later; TargetName /
-// TargetGhost-branch readers still see Kind==TargetGhost and can show
-// the pending state (see TargetName, orbit_chip_builders.go).
+// #294 review finding 4 (round 2) REVERTED round 1's "a ghost target
+// must actually RESOLVE to count here": that version made a docker
+// flying NavTarget through ADR 0038 undock/proximity ops get demoted
+// to NavOrbit mid-op the instant the ghost slate went briefly empty
+// (reconcileNavMode runs off this every tick), even though the lock
+// itself was fine and about to re-latch — the comment on SetTargetGhost
+// ("ghost targets keep NavTarget valid") stopped being true. The
+// zero-direction-SAS-hold hazard round 1 was guarding against doesn't
+// need HasRelativeTarget's help: attitudeContext (world.go) already
+// falls back to an orbit-frame hold whenever a target-relative mode's
+// (rT, vT) resolve fails, independently of NavMode or this function —
+// see TestAttitudeContextFallsBackWhenGhostUnresolved. So Kind alone is
+// enough here again: a ghost target counts as relative whether or not
+// it currently resolves, exactly like a local craft target always has.
 func (w *World) HasRelativeTarget() bool {
 	switch w.Target.Kind {
-	case TargetCraft:
+	case TargetCraft, TargetGhost:
 		return true
-	case TargetGhost:
-		_, ok := w.ghostByRef(w.Target.GhostOwner, w.Target.CraftID)
-		return ok
 	}
 	return false
 }

--- a/internal/sim/target_ghost_nav_test.go
+++ b/internal/sim/target_ghost_nav_test.go
@@ -57,17 +57,20 @@ func TestNavTargetWorksAgainstGhost(t *testing.T) {
 	}
 }
 
-// Review follow-up: ghost targets are session-local — a save with a
-// ghost targeted round-trips to no target, never a stuck Kind.
-func TestGhostTargetNotPersisted(t *testing.T) {
+// #294 fix: a ghost target now persists through the save round trip
+// (save package's CraftToWire/CraftFromWire) instead of normalising to
+// no-target — the fingerprint is meaningful within the session it was
+// set in, and a reconnect that lands before it resolves again is
+// handled by the serve layer's deferred re-latch, not by dropping the
+// intent here. This test asserts the mirror invariant the save package
+// relies on: the active craft carries the ghost target so save sees
+// it. The round-trip itself is covered by save.TestGhostTargetPersistsOnSave.
+func TestGhostTargetMirroredToActiveCraft(t *testing.T) {
 	w := ghostWorld(t)
 	if w.Target.Kind != TargetGhost {
 		t.Fatal("fixture lost its ghost target")
 	}
 	_ = orbital.Vec3{} // keep the import for the fixture
-	// The save round-trip lives in the save package; here assert the
-	// mirror invariant it relies on: the active craft carries the
-	// ghost target (so save sees it) — save_test covers the drop.
 	if w.ActiveCraft().Target.Kind != TargetGhost {
 		t.Error("ghost target not mirrored to the active craft")
 	}

--- a/internal/sim/target_ghost_nav_test.go
+++ b/internal/sim/target_ghost_nav_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // ghostWorld builds a world with one live ghost targeted.
@@ -73,5 +74,60 @@ func TestGhostTargetMirroredToActiveCraft(t *testing.T) {
 	_ = orbital.Vec3{} // keep the import for the fixture
 	if w.ActiveCraft().Target.Kind != TargetGhost {
 		t.Error("ghost target not mirrored to the active craft")
+	}
+}
+
+// #294 review finding 4: a live target-relative SAS mode whose ghost
+// target stops resolving mid-session must not command a direction
+// derived from the zero-value (rT, vT) — attitudeContext falls back to
+// an orbit-frame hold (BurnPrograde) instead of feeding
+// BurnDirectionForBurn a target snapshot that doesn't exist. Without the
+// fallback, DirectionUnitTarget's BurnTarget case degrades to
+// unit(0 − rA): the nose gets pinned at the primary's centre — a live,
+// continuously-recomputed SAS command, not a one-time glitch.
+func TestAttitudeContextFallsBackWhenGhostUnresolved(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// Ghost offset along the orbit-normal (R × V) — guaranteed
+	// perpendicular to both R and V for a non-degenerate orbit, so the
+	// resolved BurnTarget direction is unambiguously distinct from BOTH
+	// BurnPrograde (~V) and the old buggy "aim at primary centre" (~ -R)
+	// answer, ruling out a coincidental match hiding a real failure.
+	h := c.State.R.Cross(c.State.V)
+	offset := h.Scale(2e6 / h.Norm())
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:gern", CraftID: 42, Handle: "gern", Name: "Aloft",
+		PrimaryID: c.Primary.ID,
+		Pos:       w.BodyPosition(c.Primary).Add(c.State.R).Add(offset),
+		Vel:       c.State.V,
+	}}
+	w.SetTargetGhost("SHA256:gern", 42)
+	c.AttitudeMode = spacecraft.BurnTarget // "toward target" — target-relative
+
+	progradeDir := spacecraft.DirectionUnit(spacecraft.BurnPrograde, c.State.R, c.State.V)
+	rNorm := c.State.R.Norm()
+	badDir := c.State.R.Scale(-1 / rNorm) // the old buggy "aim at planet centre" answer
+
+	// Resolved: aims along the orbit normal (toward the ghost's offset),
+	// not at BurnPrograde or the planet-centre direction — proves the
+	// fixture actually exercises the target-relative branch.
+	dirResolved := w.commandedDirFor(c)
+	if dirResolved.Sub(progradeDir).Norm() < 1e-6 || dirResolved.Sub(badDir).Norm() < 1e-6 {
+		t.Fatalf("fixture didn't exercise a distinct BurnTarget direction: got %+v", dirResolved)
+	}
+
+	// Unresolved: must fall back to the orbit-frame hold (BurnPrograde),
+	// never the old unit(0 − rA) planet-centre pin.
+	w.Ghosts = nil
+	dirUnresolved := w.commandedDirFor(c)
+	if d := dirUnresolved.Sub(progradeDir).Norm(); d > 1e-9 {
+		t.Errorf("unresolved BurnTarget direction = %+v, want the BurnPrograde fallback %+v (diff %g)",
+			dirUnresolved, progradeDir, d)
+	}
+	if d := dirUnresolved.Sub(badDir).Norm(); d < 1e-6 {
+		t.Error("unresolved BurnTarget still aims at the primary's centre")
 	}
 }

--- a/internal/sim/target_ghost_test.go
+++ b/internal/sim/target_ghost_test.go
@@ -56,8 +56,15 @@ func TestTargetGhostResolution(t *testing.T) {
 	if w.Target.Kind != TargetGhost {
 		t.Errorf("stale ghost target lost its Kind: %+v, want it to stay TargetGhost for later re-latch", w.Target)
 	}
-	if w.HasRelativeTarget() {
-		t.Error("HasRelativeTarget true for an unresolved ghost — nav paths would compute a zero-value direction")
+	// #294 review finding 4 (round 2): HasRelativeTarget went back to
+	// Kind-only — a ghost target counts as relative whether or not it
+	// currently resolves (round 1's resolve requirement demoted a docker
+	// off NavTarget mid-proximity-ops the instant the ghost slate briefly
+	// emptied). The zero-direction hazard round 1 guarded against is
+	// covered independently by attitudeContext's own fallback — see
+	// TestAttitudeContextFallsBackWhenGhostUnresolved.
+	if !w.HasRelativeTarget() {
+		t.Error("HasRelativeTarget false for an unresolved ghost — NavTarget/rendezvous surfaces would wrongly hide")
 	}
 }
 

--- a/internal/sim/target_ghost_test.go
+++ b/internal/sim/target_ghost_test.go
@@ -44,7 +44,47 @@ func TestTargetGhostResolution(t *testing.T) {
 	if _, ok := w.TargetState(); ok {
 		t.Error("stale ghost target still resolves")
 	}
-	if name := w.TargetName(); name != "" {
-		t.Errorf("stale ghost TargetName = %q, want empty", name)
+	// #294 review finding 4: the lock itself is NOT the same as
+	// TargetNone — Kind stays TargetGhost so a later resolve can
+	// re-latch it (see reportingModel.reconcileTargetLock), so
+	// TargetName reports a pending state rather than "" (which used to
+	// read exactly like an untargeted craft — the TARGET chip vanished
+	// outright instead of showing "still locked, just waiting").
+	if name := w.TargetName(); name != "pending target lock" {
+		t.Errorf("stale ghost TargetName = %q, want the pending-lock label", name)
+	}
+	if w.Target.Kind != TargetGhost {
+		t.Errorf("stale ghost target lost its Kind: %+v, want it to stay TargetGhost for later re-latch", w.Target)
+	}
+	if w.HasRelativeTarget() {
+		t.Error("HasRelativeTarget true for an unresolved ghost — nav paths would compute a zero-value direction")
+	}
+}
+
+// #294 review finding 4: GhostOwnerHandle backs TargetName's pending
+// label with the roster handle when a live session has one, so the
+// player sees "who", not just "something", while a lock is pending.
+func TestGhostOwnerHandleFromSession(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if h := w.GhostOwnerHandle("SHA256:gern"); h != "" {
+		t.Errorf("GhostOwnerHandle with no session = %q, want empty", h)
+	}
+	w.Session = &SessionInfo{Players: []SessionPlayer{
+		{Fingerprint: "SHA256:gern", Handle: "gern"},
+	}}
+	if h := w.GhostOwnerHandle("SHA256:gern"); h != "gern" {
+		t.Errorf("GhostOwnerHandle = %q, want %q", h, "gern")
+	}
+	if h := w.GhostOwnerHandle("SHA256:someone-else"); h != "" {
+		t.Errorf("GhostOwnerHandle for an unknown owner = %q, want empty", h)
+	}
+
+	w.SetTargetGhost("SHA256:gern", 42)
+	w.Ghosts = nil // unresolved — pending
+	if name := w.TargetName(); name != "gern's vessel (pending)" {
+		t.Errorf("TargetName = %q, want the roster handle in the pending label", name)
 	}
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -907,6 +907,14 @@ type LocalReArmRefusalEvent struct {
 type NodeTargetRefusalEvent struct {
 	When      time.Time
 	CraftName string
+	// Cancelled marks a NEVER-resolvable refusal (#294 review finding 2):
+	// a due node's LOCAL target craft is gone from the slate for good
+	// (end-flight), or a node's/burn's ghost ref matched one
+	// reconcileTargetLock's watchdog already gave up on — as opposed to
+	// an ordinary pending-resolvable stall that might still re-latch.
+	// The HUD message differs ("node cancelled" vs "burn held off") so
+	// the player knows whether to keep waiting or replan.
+	Cancelled bool
 }
 
 // DockEvent records the latest fuse for HUD-side messaging. v0.8.3+.
@@ -1655,7 +1663,12 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	if c.ActiveBurn != nil {
 		if w.burnExhausted(c) {
 			c.ActiveBurn = nil
-		} else if c.ActiveStageFuel() <= 0 {
+		} else if c.ActiveStageFuel() <= 0 || !w.activeBurnTargetReady(c) {
+			// #294 review finding 1: an unresolved target-relative burn is
+			// held exactly like a fuel-stalled one — its EndTime is pushed
+			// out by this tick's span so the duration window pauses rather
+			// than timing out (and getting torn down as "exhausted") while
+			// nobody ever thrust.
 			c.ActiveBurn.EndTime = c.ActiveBurn.EndTime.Add(simDelta)
 		}
 	}
@@ -1682,10 +1695,48 @@ func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt fl
 		if c.ActiveBurn.DVRemaining <= 0 {
 			return false
 		}
+		// #294 review finding 1: a continuing target-relative burn whose
+		// bound target doesn't resolve must hold — not thrust along
+		// attitudeContext's BurnPrograde fallback, which would spend real
+		// Δv in a direction nobody commanded. Checked here (not just in
+		// the post-loop EndTime-pause below) so no RK4 sub-step this tick
+		// ever fires while held.
+		if !w.activeBurnTargetReady(c) {
+			return false
+		}
 		subStart := tickStart.Add(time.Duration(float64(i) * dt * float64(time.Second)))
 		return subStart.Before(c.ActiveBurn.EndTime)
 	}
 	return c.ManualBurn != nil
+}
+
+// activeBurnTargetReady reports whether c's in-flight ActiveBurn is safe
+// to thrust: true for every non-target-relative burn, and for a target-
+// relative burn only once its bound target (local craft ref or remote
+// ghost ref) actually resolves. #294 review finding 1: a restored
+// in-flight target-relative burn whose ghost never re-latches used to
+// slip through unnoticed — attitudeContext degraded the MODE to
+// BurnPrograde on an unresolved target, but nothing stopped stepThrust
+// from thrusting (and debiting DVRemaining) along that fallback
+// direction, a real fuel expenditure in a direction nobody commanded.
+// HOLD instead: no thrust, no dv burned, until the ref resolves.
+// Stamps LastNodeTargetRefusal once per stall (RefusalNoticed), not
+// every tick, and clears the flag the moment the target resolves so a
+// later stall gets its own fresh notice.
+func (w *World) activeBurnTargetReady(c *spacecraft.Spacecraft) bool {
+	ab := c.ActiveBurn
+	if ab == nil || !spacecraft.IsTargetRelativeMode(ab.Mode) {
+		return true
+	}
+	if _, _, ok := w.nodeTargetRelState(ab.TargetGhostOwner, ab.TargetCraftID, c.Primary); ok {
+		ab.RefusalNoticed = false
+		return true
+	}
+	if !ab.RefusalNoticed {
+		w.LastNodeTargetRefusal = &NodeTargetRefusalEvent{When: w.Clock.SimTime, CraftName: c.Name}
+		ab.RefusalNoticed = true
+	}
+	return false
 }
 
 // stepThrust advances one RK4 sub-step with engine thrust, debits the

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -87,6 +87,19 @@ type World struct {
 	// this was retired by ADR 0021 D).
 	LastLaunchReleaseEvent *LaunchReleaseEvent
 
+	// LastNodeTargetRefusal records the most recent due target-relative
+	// node (or in-flight active burn) that refused to fire because its
+	// bound target didn't resolve (#294 review finding 5) — same HUD-
+	// flash pattern as LastLocalReArmRefusal: app.go reads and clears it
+	// once per fire. Without this refusal, executeDueNodesFor would burn
+	// against nodeTargetRelState's zero-value fallback, which
+	// DirectionUnitTarget degrades to a direction aimed at (or away
+	// from) the primary's centre — a real, fuel-burning maneuver in a
+	// bogus direction, not a display glitch. Most reachable via a node
+	// planted against a ghost target whose ref survived a save/load
+	// (#294) but never re-latched.
+	LastNodeTargetRefusal *NodeTargetRefusalEvent
+
 	// Focus selects what the OrbitView canvas is centered on. Zero value
 	// (FocusSystem) matches v0.1.0 behavior.
 	Focus Focus
@@ -884,6 +897,16 @@ type LocalReArmRefusalEvent struct {
 	// when the active vessel is one of the two, else one of the pair
 	// (arbitrarily the second) when neither is active.
 	PartnerName string
+}
+
+// NodeTargetRefusalEvent records the latest target-relative node (or
+// active burn) that refused to fire for want of a resolvable target
+// (#294 review finding 5). CraftName lets the message identify which
+// vessel's plan is stalled when the player isn't currently flying it
+// (executeDueNodesFor walks every craft's own nodes independently).
+type NodeTargetRefusalEvent struct {
+	When      time.Time
+	CraftName string
 }
 
 // DockEvent records the latest fuse for HUD-side messaging. v0.8.3+.
@@ -1699,12 +1722,27 @@ func (w *World) attitudeContext(c *spacecraft.Spacecraft) (mode spacecraft.BurnM
 		planeRad = c.ActiveBurn.PlaneChangeRad
 		burnDir = c.ActiveBurn.BurnDirUnit
 	}
+	var ok bool
 	if c.ActiveBurn != nil && c.ActiveBurn.TargetCraftID != 0 {
 		// v0.28 S4: resolves a local craft ref or a remote ghost ref
 		// (owner + remote id) against the ghost slate each tick.
-		rT, vT, _ = w.nodeTargetRelState(c.ActiveBurn.TargetGhostOwner, c.ActiveBurn.TargetCraftID, c.Primary)
+		rT, vT, ok = w.nodeTargetRelState(c.ActiveBurn.TargetGhostOwner, c.ActiveBurn.TargetCraftID, c.Primary)
 	} else {
-		rT, vT, _ = w.TargetStateRelativeToActivePrimary()
+		rT, vT, ok = w.TargetStateRelativeToActivePrimary()
+	}
+	// #294 review finding 4: a target-relative mode whose target doesn't
+	// resolve (most visibly: a TargetGhost ref persisted across a save/
+	// load with no live serve session to re-latch it, or one still
+	// mid-reconnect) must never command a direction derived from the
+	// zero-value (rT, vT) — DirectionUnitTarget's BurnTarget case
+	// degrades that to unit(0 − rA), pinning the nose at the primary's
+	// centre, and BurnAntiTarget to unit(rA), pointing straight away
+	// from it. Neither is a real "hold" — fall back to an orbit-frame
+	// hold (BurnPrograde) instead of silently aiming at (or away from)
+	// the planet. Non-target modes ignore (rT, vT) entirely, so this
+	// only changes behavior when the mode actually consumes them.
+	if !ok && spacecraft.IsTargetRelativeMode(mode) {
+		mode = spacecraft.BurnPrograde
 	}
 	return mode, rT, vT, planeRad, burnDir
 }

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1602,11 +1602,26 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	// the effective BC the moment the chute fires so the canopy drag
 	// engages for the remaining sub-steps of the tick the deploy fires on.
 	bc := c.EffectiveBallisticCoefficient()
+	// Resolve the active burn's target-relative readiness ONCE per craft
+	// per tick (performance finding, following the v0.36.x idle-CPU work):
+	// activeBurnTargetReady runs a ghost-slate scan plus
+	// nodeTargetRelState → BodyPositionAt (SolveKepler, up to 32 Newton
+	// iterations, recursing per parent body) at w.Clock.SimTime, which is
+	// CONSTANT across this call's whole sub-step loop (nSteps is capped at
+	// 1024) — the loop advances a local `clock`/`dt` for body-position
+	// lookups, never w.Clock.SimTime itself. Pre-fix this ran fresh inside
+	// thrustingAt every sub-step, plus twice more below (burnExhausted and
+	// the EndTime-pause check) — pure added load on exactly the loop the
+	// v0.36.x idle-CPU work optimized. Hoisted the same way `bc` is.
+	burnReady := true
+	if c.ActiveBurn != nil {
+		burnReady = w.activeBurnTargetReady(c)
+	}
 	for i := 0; i < nSteps; i++ {
 		if maybeDeployParachute(c) {
 			bc = c.EffectiveBallisticCoefficient()
 		}
-		if w.thrustingAt(c, tickStart, dt, i) {
+		if w.thrustingAt(c, tickStart, dt, i, burnReady) {
 			w.stepThrust(c, mu, dt)
 		} else {
 			// v0.8.4: drag closure binds the craft's current primary
@@ -1661,9 +1676,9 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	// an Apollo TLI the S-IVB can't finish alone — carries across staging
 	// instead of silently cancelling.
 	if c.ActiveBurn != nil {
-		if w.burnExhausted(c) {
+		if w.burnExhausted(c, burnReady) {
 			c.ActiveBurn = nil
-		} else if c.ActiveStageFuel() <= 0 || !w.activeBurnTargetReady(c) {
+		} else if c.ActiveStageFuel() <= 0 || !burnReady {
 			// #294 review finding 1: an unresolved target-relative burn is
 			// held exactly like a fuel-stalled one — its EndTime is pushed
 			// out by this tick's span so the duration window pauses rather
@@ -1687,7 +1702,14 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 // Either ActiveBurn (planted finite burn) or ManualBurn (v0.7.3+ player-
 // held flight) qualifies; both share the same RK4 thrust path. Fuel
 // must be positive in either case.
-func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt float64, i int) bool {
+//
+// burnReady is the caller's ALREADY-RESOLVED activeBurnTargetReady(c) for
+// this tick (performance finding: the per-craft caller hoists that
+// resolve once, before the sub-step loop, since the answer — a ghost-
+// slate scan plus a Kepler body-position solve — can't change within one
+// call's worth of sub-steps at the constant w.Clock.SimTime). Ignored
+// for a non-target-relative burn or a ManualBurn.
+func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt float64, i int, burnReady bool) bool {
 	if c.ActiveStageFuel() <= 0 {
 		return false
 	}
@@ -1701,7 +1723,7 @@ func (w *World) thrustingAt(c *spacecraft.Spacecraft, tickStart time.Time, dt fl
 		// Δv in a direction nobody commanded. Checked here (not just in
 		// the post-loop EndTime-pause below) so no RK4 sub-step this tick
 		// ever fires while held.
-		if !w.activeBurnTargetReady(c) {
+		if !burnReady {
 			return false
 		}
 		subStart := tickStart.Add(time.Duration(float64(i) * dt * float64(time.Second)))
@@ -1913,14 +1935,19 @@ func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
 // with the same "not exhausted" return the fuel-stall check uses, means
 // a held burn is never reaped as exhausted regardless of which check the
 // caller evaluates first.
-func (w *World) burnExhausted(c *spacecraft.Spacecraft) bool {
+//
+// burnReady is the caller's already-resolved activeBurnTargetReady(c) for
+// this tick (performance finding — see thrustingAt's doc: hoisted once
+// per craft per tick rather than re-resolved here on top of the
+// sub-step loop's own calls).
+func (w *World) burnExhausted(c *spacecraft.Spacecraft, burnReady bool) bool {
 	if c.ActiveBurn.DVRemaining <= 0 {
 		return true
 	}
 	if c.ActiveStageFuel() <= 0 {
 		return false // stalled, not exhausted — kept alive for staging
 	}
-	if !w.activeBurnTargetReady(c) {
+	if !burnReady {
 		return false // held for want of a resolvable target — not exhausted
 	}
 	return !w.Clock.SimTime.Before(c.ActiveBurn.EndTime)

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1895,16 +1895,33 @@ func (w *World) stepThrust(c *spacecraft.Spacecraft, mu, dt float64) {
 
 // burnExhausted reports whether the active burn should be torn down:
 // either its Δv was delivered, or its duration window elapsed while the
-// firing stage still had fuel. v0.12.x: a dry firing stage with Δv still
-// owed is NOT exhausted — it is stalled, and the caller keeps the burn
-// alive (pausing its EndTime) so it resumes after the player stages. Only
-// the fuelled-but-timed-out case terminates on duration.
+// firing stage still had fuel AND a resolvable target. v0.12.x: a dry
+// firing stage with Δv still owed is NOT exhausted — it is stalled, and
+// the caller keeps the burn alive (pausing its EndTime) so it resumes
+// after the player stages. Only the fuelled-but-timed-out case
+// terminates on duration.
+//
+// #294 review round 3 (finding J): a held-for-target burn needs the same
+// precedence the fuel-stall check already had. Before this, the caller
+// (the ONE spot in Tick that both tears down on exhaustion AND pushes
+// EndTime for a hold) checked burnExhausted FIRST and activeBurnTargetReady
+// only in the else branch — so a hold beginning on the exact tick
+// SimTime crosses EndTime (fuel>0, DVRemaining>0, target drops out of
+// the slate that same tick) read as "duration elapsed with fuel to
+// spare," not "held," and tore the burn down with its remaining
+// committed Δv silently discarded. Checking activeBurnTargetReady here,
+// with the same "not exhausted" return the fuel-stall check uses, means
+// a held burn is never reaped as exhausted regardless of which check the
+// caller evaluates first.
 func (w *World) burnExhausted(c *spacecraft.Spacecraft) bool {
 	if c.ActiveBurn.DVRemaining <= 0 {
 		return true
 	}
 	if c.ActiveStageFuel() <= 0 {
 		return false // stalled, not exhausted — kept alive for staging
+	}
+	if !w.activeBurnTargetReady(c) {
+		return false // held for want of a resolvable target — not exhausted
 	}
 	return !w.Clock.SimTime.Before(c.ActiveBurn.EndTime)
 }

--- a/internal/spacecraft/cross_owner.go
+++ b/internal/spacecraft/cross_owner.go
@@ -1,0 +1,52 @@
+package spacecraft
+
+// StripCrossOwnerTargetRefs returns a shallow copy of c with every
+// target-relative reference — Target (when Kind is TargetCraft or
+// TargetGhost), any planted node's TargetCraftID/TargetGhostOwner, and the
+// active burn's TargetCraftID/TargetGhostOwner — cleared. c itself is left
+// untouched; only the copy's Target/Nodes/ActiveBurn are replaced.
+//
+// This is the ONE place that decides which refs are "target-relative" for
+// a craft crossing into a DIFFERENT player's World. save.CraftToWireForTransfer
+// (the dock ledger's persistence path, #294 review finding 3 / finding G)
+// calls this before wire-converting a parked payload; the live (no-restart)
+// cross-player dock-ledger delivery (relay.DockLedger, the finding that
+// followed) calls it directly on the in-memory craft right before handing it
+// to a different owner's World. Both a ghost ref (owner fingerprint + remote
+// craft ID) and a bare local ref are unsafe to carry across: a ghost ref can
+// never resolve in the recipient's World and can even alias the recipient's
+// own fingerprint, and craft IDs are dense per-World small ints, so a local
+// ref can silently resolve against an unrelated craft that happens to hold
+// the same numeric ID on the other side.
+//
+// A craft delivered back into the SAME owner's World (a live undock/release
+// handback, or an abort that returns a guest's own craft) must NOT go
+// through this — every ref on it stayed valid the whole time, and stripping
+// it there would silently break a standing lock the player never lost.
+func StripCrossOwnerTargetRefs(c *Spacecraft) *Spacecraft {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	if cp.Target.Kind == TargetCraft || cp.Target.Kind == TargetGhost {
+		cp.Target = Target{}
+	}
+	if len(cp.Nodes) > 0 {
+		nodes := make([]ManeuverNode, len(cp.Nodes))
+		copy(nodes, cp.Nodes)
+		for i := range nodes {
+			if nodes[i].TargetCraftID != 0 {
+				nodes[i].TargetGhostOwner = ""
+				nodes[i].TargetCraftID = 0
+			}
+		}
+		cp.Nodes = nodes
+	}
+	if cp.ActiveBurn != nil && cp.ActiveBurn.TargetCraftID != 0 {
+		ab := *cp.ActiveBurn
+		ab.TargetGhostOwner = ""
+		ab.TargetCraftID = 0
+		cp.ActiveBurn = &ab
+	}
+	return &cp
+}

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -172,6 +172,13 @@ type ManeuverNode struct {
 	// precedent as ID / TargetCraftID / PlaneChangeRad / BurnDirUnit —
 	// no save-schema migration needed.
 	AdvisoryKey string `json:",omitempty"`
+	// RefusalNoticed (#294 review finding 2) mirrors ActiveBurn's field of
+	// the same name: marks that World has already stamped
+	// LastNodeTargetRefusal for this node refusing to fire (target-
+	// relative, due, bound target not yet resolved) — so the HUD flash
+	// fires once per stall instead of every tick the node sits wedged at
+	// the front of the queue. Runtime-only; excluded from the wire form.
+	RefusalNoticed bool `json:"-"`
 }
 
 // TargetCraftIDValue returns the bound target craft's stable ID and
@@ -305,6 +312,16 @@ type ActiveBurn struct {
 	// in-flight burn so the attitude/thrust path resolves the fixed
 	// BurnVector direction each tick. Zero for non-BurnVector burns.
 	BurnDirUnit orbital.Vec3 `json:",omitempty"`
+	// RefusalNoticed (#294 review finding 1) marks that World has already
+	// stamped LastNodeTargetRefusal for the CURRENT stretch of this burn
+	// being held for want of a resolvable target — so the HUD flash fires
+	// once per stall, not every tick the burn stays held. Reset to false
+	// the moment the target resolves again, so a later stall (the ref
+	// going stale, then coming back, then going stale again) gets its own
+	// fresh notice. Runtime-only session state, deliberately excluded
+	// from the wire form (no save/load meaning — a reloaded burn starts
+	// unnoticed).
+	RefusalNoticed bool `json:"-"`
 }
 
 // TargetCraftIDValue mirrors ManeuverNode.TargetCraftIDValue — returns

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -179,6 +179,19 @@ type ManeuverNode struct {
 	// fires once per stall instead of every tick the node sits wedged at
 	// the front of the queue. Runtime-only; excluded from the wire form.
 	RefusalNoticed bool `json:"-"`
+	// GhostAbsentSince (#294 second-round review finding 1) is the
+	// wall-clock moment a due ghost-ref node first found its target
+	// owner absent from the current session's roster (in a session, but
+	// not a member of it — most often this player's OWN session having
+	// just reconnected, before the very first refreshSession primes
+	// World.Session). Lets executeDueNodesFor give the owner the same
+	// targetLockRelatchGrace tolerance reconcileTargetLock's active-target
+	// watchdog gives (internal/serve/reporting.go) before cancelling the
+	// node outright — an owner mid-reconnect must not cost a planted
+	// node. Reset to zero the moment the owner is seen present again.
+	// Runtime-only; excluded from the wire form (a reloaded node starts
+	// with no absence recorded).
+	GhostAbsentSince time.Time `json:"-"`
 }
 
 // TargetCraftIDValue returns the bound target craft's stable ID and

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -209,19 +209,6 @@ func (n ManeuverNode) TargetGhostRef() (owner string, craftID uint64, ok bool) {
 	return n.TargetGhostOwner, n.TargetCraftID, true
 }
 
-// DropGhostRef clears a ghost target ref (owner + the remote craft id).
-// Called on save so a session-local ghost binding never persists and a
-// remote id can't be reloaded as a local one — the burn geometry
-// (mode / Δv / direction) is untouched. No-op for local-craft or
-// untargeted nodes. v0.28 S4.
-func (n *ManeuverNode) DropGhostRef() {
-	if n.TargetGhostOwner == "" {
-		return
-	}
-	n.TargetGhostOwner = ""
-	n.TargetCraftID = 0
-}
-
 // IsTargetRelative reports whether this node's burn mode requires a
 // target craft state to resolve direction. v0.9.3+.
 func (n ManeuverNode) IsTargetRelative() bool {
@@ -332,18 +319,6 @@ func (b ActiveBurn) TargetCraftIDValue() (uint64, bool) {
 		return 0, false
 	}
 	return b.TargetCraftID, true
-}
-
-// DropGhostRef clears a ghost target ref (owner + the remote craft id)
-// from a running burn, mirroring ManeuverNode.DropGhostRef so a save
-// mid-burn against a ghost never persists a session-local remote id.
-// No-op for local-craft or untargeted burns. v0.28 S4.
-func (b *ActiveBurn) DropGhostRef() {
-	if b.TargetGhostOwner == "" {
-		return
-	}
-	b.TargetGhostOwner = ""
-	b.TargetCraftID = 0
 }
 
 // BurnStalled reports whether a planted burn is paused waiting for the

--- a/internal/spacecraft/target.go
+++ b/internal/spacecraft/target.go
@@ -25,8 +25,13 @@ const (
 	TargetSite
 	// TargetGhost references another player's craft by owner
 	// fingerprint + craft ID (v0.27 S6, ADR 0034). Resolves against
-	// the world's transient ghost slate — a stale ref (owner gone,
-	// craft staged away) resolves to nothing, same as TargetNone.
+	// the world's transient ghost slate — an unresolved ref (owner
+	// gone, craft staged away, or not yet re-latched post-reconnect,
+	// #294) has no relative state to compute with (nav/burn consumers
+	// must check the resolve ok and degrade gracefully — see
+	// World.HasRelativeTarget), but the lock itself is NOT the same as
+	// TargetNone: Kind stays TargetGhost so a later resolve re-latches
+	// it, and TargetName reports a pending state rather than "".
 	TargetGhost
 )
 
@@ -41,8 +46,13 @@ type Target struct {
 	CraftID uint64 // when Kind==TargetCraft or TargetGhost — the target's stable Spacecraft.ID (ADR 0012)
 
 	// GhostOwner names the remote player (key fingerprint) when
-	// Kind==TargetGhost (v0.27 S6, ADR 0034). Session-local by
-	// nature: a save that carries a dangling ghost ref just resolves
-	// to nothing on load.
+	// Kind==TargetGhost (v0.27 S6, ADR 0034). The fingerprint is
+	// meaningful within the session it was set in: #294 preserves it
+	// across save/load (CraftToWire/CraftFromWire) instead of
+	// normalising the target away, so a guest's cross-player rendezvous
+	// lock survives a reconnect. A ref that never resolves against the
+	// live ghost slate (single-player, or a session whose target owner
+	// never came back) just carries a lock that stays pending — see
+	// World.HasRelativeTarget / World.TargetName.
 	GhostOwner string `json:"ghost_owner,omitempty"`
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -329,6 +329,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.statusExpires = time.Now().Add(4 * time.Second)
 			a.world.LastLocalReArmRefusal = nil
 		}
+		// #294 review finding 5: a due target-relative node (or in-flight
+		// burn) refused to fire because its bound target hasn't resolved —
+		// say so instead of leaving the stall silent. Same flash surface,
+		// cleared after one fire.
+		if e := a.world.LastNodeTargetRefusal; e != nil {
+			a.statusMsg = fmt.Sprintf("%s: burn held off — target lock not resolved", e.CraftName)
+			a.statusExpires = time.Now().Add(4 * time.Second)
+			a.world.LastNodeTargetRefusal = nil
+		}
 		return a, sim.TickCmd(a.world.Clock.BaseStep)
 
 	case tea.WindowSizeMsg:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -399,35 +399,40 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// uses. Event is forwarded so resolved-then-edited
 				// event-relative nodes keep their semantic label.
 				a.world.PlanNode(sim.ManeuverNode{
-					ID:            editedID,
-					TriggerTime:   m.TriggerTime,
-					Mode:          m.Mode,
-					DV:            m.DV,
-					Duration:      dur,
-					Event:         m.Event,
-					Throttle:      m.Throttle,
-					TargetCraftID: m.TargetCraftID,
+					ID:               editedID,
+					TriggerTime:      m.TriggerTime,
+					Mode:             m.Mode,
+					DV:               m.DV,
+					Duration:         dur,
+					Event:            m.Event,
+					Throttle:         m.Throttle,
+					TargetCraftID:    m.TargetCraftID,
+					TargetGhostOwner: m.TargetGhostOwner,
 				})
 			case m.Event != sim.TriggerAbsolute:
 				// v0.6.0: event-relative nodes go through PlanNode so
 				// the resolver can freeze TriggerTime against the live
 				// orbit on the next Tick.
 				a.world.PlanNode(sim.ManeuverNode{
-					ID:            editedID,
-					Mode:          m.Mode,
-					DV:            m.DV,
-					Duration:      dur,
-					Event:         m.Event,
-					Throttle:      m.Throttle,
-					TargetCraftID: m.TargetCraftID,
+					ID:               editedID,
+					Mode:             m.Mode,
+					DV:               m.DV,
+					Duration:         dur,
+					Event:            m.Event,
+					Throttle:         m.Throttle,
+					TargetCraftID:    m.TargetCraftID,
+					TargetGhostOwner: m.TargetGhostOwner,
 				})
 			case dur == 0:
 				// v0.9.3+: target-relative impulsive needs the bound
-				// target snapshot for direction resolution. Resolve by
-				// stable ID (ADR 0012).
+				// target snapshot for direction resolution. Resolve a
+				// local ref by stable ID (ADR 0012) or a remote ghost
+				// ref against the ghost slate (#294 review round 3
+				// finding I) via the same resolver a planted node's
+				// fire-time dispatch uses.
 				if m.TargetCraftID != 0 {
-					if tc, _, ok := a.world.CraftByID(m.TargetCraftID); ok && tc.Primary.ID == a.world.ActiveCraft().Primary.ID {
-						a.world.ActiveCraft().ApplyImpulsiveWithTarget(m.Mode, m.DV, tc.State.R, tc.State.V)
+					if rT, vT, ok := a.world.TargetRelState(m.TargetGhostOwner, m.TargetCraftID, a.world.ActiveCraft().Primary); ok {
+						a.world.ActiveCraft().ApplyImpulsiveWithTarget(m.Mode, m.DV, rT, vT)
 						break
 					}
 				}
@@ -438,11 +443,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					effThrottle = 1.0
 				}
 				a.world.ActiveCraft().ActiveBurn = &sim.ActiveBurn{
-					Mode:          m.Mode,
-					DVRemaining:   m.DV,
-					EndTime:       a.world.Clock.SimTime.Add(dur),
-					Throttle:      effThrottle,
-					TargetCraftID: m.TargetCraftID,
+					Mode:             m.Mode,
+					DVRemaining:      m.DV,
+					EndTime:          a.world.Clock.SimTime.Add(dur),
+					Throttle:         effThrottle,
+					TargetCraftID:    m.TargetCraftID,
+					TargetGhostOwner: m.TargetGhostOwner,
 				}
 			}
 		}
@@ -560,8 +566,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case hit.NodeIdx > 0:
 				idx := hit.NodeIdx - 1 // tags are 1-indexed; slice is 0-indexed
 				if idx >= 0 && idx < len(a.world.ActiveCraft().Nodes) {
+					// #294 review round 3 finding I: LoadNode already reads
+					// the node's OWN target binding (local or ghost) — do
+					// NOT follow it with bindManeuverTarget here, which
+					// reflects the CURRENT live World.Target and would
+					// clobber a ghost-bound node's lock the instant the
+					// live target isn't that exact same ghost (a common
+					// case right after a reconnect, before it re-latches).
+					// bindManeuverTarget is for the NEW-node flows only —
+					// see its own doc comment.
 					a.maneuver.LoadNode(idx, a.world.ActiveCraft().Nodes[idx])
-					a.bindManeuverTarget()
 					a.world.Clock.Paused = true
 					a.active = screenManeuver
 				}
@@ -2706,15 +2720,27 @@ func overlayBottomBorder(base, overlay string, border lipgloss.Style) string {
 }
 
 // bindManeuverTarget hands the current World.Target binding to the
-// maneuver form so the four target-relative burn modes and the
-// TriggerNextClosestApproach event are pickable + correctly captured
-// at plant. Bound at form-open time (not per-keypress), so a target
-// switch while the form is open doesn't silently retarget a planted
-// burn — the player closes + reopens to retarget. v0.9.3+.
+// maneuver form for a BRAND-NEW node (`m` on the orbit screen, or the
+// click-an-empty-canvas-point staging flow) so the four target-relative
+// burn modes and the TriggerNextClosestApproach event are pickable +
+// correctly captured at plant. Bound at form-open time (not per-
+// keypress), so a target switch while the form is open doesn't silently
+// retarget a planted burn — the player closes + reopens to retarget.
+//
+// NOT called after LoadNode (click-to-edit an existing node): that path
+// preserves the node's OWN stored binding instead — see LoadNode's and
+// the Maneuver struct's doc comments (#294 review round 3 finding I).
+//
+// v0.9.3+; ghost-aware since #294 review round 3 (previously only
+// TargetCraft was handled here, so opening a NEW node's form while
+// aimed at a ghost silently left it untargeted).
 func (a *App) bindManeuverTarget() {
-	if a.world.Target.Kind == sim.TargetCraft {
-		a.maneuver.SetTargetCraft(true, a.world.Target.CraftID)
-		return
+	switch a.world.Target.Kind {
+	case sim.TargetCraft:
+		a.maneuver.SetTargetCraft(true, "", a.world.Target.CraftID)
+	case sim.TargetGhost:
+		a.maneuver.SetTargetCraft(true, a.world.Target.GhostOwner, a.world.Target.CraftID)
+	default:
+		a.maneuver.SetTargetCraft(false, "", 0)
 	}
-	a.maneuver.SetTargetCraft(false, 0)
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -408,6 +408,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					Throttle:         m.Throttle,
 					TargetCraftID:    m.TargetCraftID,
 					TargetGhostOwner: m.TargetGhostOwner,
+					AdvisoryKey:      m.AdvisoryKey, // #294 second-round review finding 6
 				})
 			case m.Event != sim.TriggerAbsolute:
 				// v0.6.0: event-relative nodes go through PlanNode so
@@ -422,6 +423,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					Throttle:         m.Throttle,
 					TargetCraftID:    m.TargetCraftID,
 					TargetGhostOwner: m.TargetGhostOwner,
+					AdvisoryKey:      m.AdvisoryKey, // #294 second-round review finding 6
 				})
 			case dur == 0:
 				// v0.9.3+: target-relative impulsive needs the bound

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -332,9 +332,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// #294 review finding 5: a due target-relative node (or in-flight
 		// burn) refused to fire because its bound target hasn't resolved —
 		// say so instead of leaving the stall silent. Same flash surface,
-		// cleared after one fire.
+		// cleared after one fire. #294 review finding 2: a never-resolvable
+		// ref (local target craft gone for good, or a ghost ref the
+		// reconnect watchdog already gave up on) gets a distinct message —
+		// the node/burn is cancelled outright, not merely held pending a
+		// re-latch that will never come.
 		if e := a.world.LastNodeTargetRefusal; e != nil {
-			a.statusMsg = fmt.Sprintf("%s: burn held off — target lock not resolved", e.CraftName)
+			if e.Cancelled {
+				a.statusMsg = fmt.Sprintf("%s: node cancelled, target gone", e.CraftName)
+			} else {
+				a.statusMsg = fmt.Sprintf("%s: burn held off — target lock not resolved", e.CraftName)
+			}
 			a.statusExpires = time.Now().Add(4 * time.Second)
 			a.world.LastNodeTargetRefusal = nil
 		}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -428,3 +428,64 @@ func TestHelpOnF1AndTrimResetOnQuestion(t *testing.T) {
 		t.Errorf("`?` did not reset pitch trim (PitchTrim=%v)", c.PitchTrim)
 	}
 }
+
+// TestClickToEditGhostBoundNodePreservesBinding — #294 review round 3
+// finding I. Click-to-edit on a reloaded ghost-targeted node used to
+// silently strip its binding: LoadNode correctly captured the node's
+// own target, but the app always followed it with bindManeuverTarget,
+// which only knew TargetCraft — for a TargetGhost (or, as here, a
+// LIVE target that no longer matches what the node was planted
+// against) it clobbered the freshly-loaded binding down to none. This
+// drives the exact production path (LoadNode, HandleKey's Enter →
+// commitCmd → BurnExecutedMsg, App.Update's re-plant) and asserts the
+// ghost ref survives both the FORM state and the REPLANTED node.
+func TestClickToEditGhostBoundNodePreservesBinding(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := a.world.ActiveCraft()
+	c.Nodes = append(c.Nodes, sim.ManeuverNode{
+		Mode:             spacecraft.BurnTargetPrograde,
+		DV:               42,
+		TriggerTime:      a.world.Clock.SimTime.Add(time.Hour),
+		PrimaryID:        c.Primary.ID,
+		TargetGhostOwner: "SHA256:peer",
+		TargetCraftID:    987654,
+	})
+
+	// The world's CURRENT live target is unrelated to the node being
+	// edited — e.g. the give-up countdown already cleared it, or the
+	// player simply hasn't retargeted since the node was planted.
+	// bindManeuverTarget must never be consulted for an edit.
+	a.world.ClearTarget()
+
+	// Click-to-edit: LoadNode captures the node's OWN binding.
+	a.maneuver.LoadNode(0, c.Nodes[0])
+
+	cmd, ok := a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !ok || cmd == nil {
+		t.Fatal("Enter did not commit")
+	}
+	raw := cmd()
+	msg, ok := raw.(screens.BurnExecutedMsg)
+	if !ok {
+		t.Fatalf("commit produced %T, not BurnExecutedMsg", raw)
+	}
+	if msg.TargetCraftID != 987654 || msg.TargetGhostOwner != "SHA256:peer" {
+		t.Fatalf("edit dropped the ghost binding from the form: TargetCraftID=%d TargetGhostOwner=%q",
+			msg.TargetCraftID, msg.TargetGhostOwner)
+	}
+
+	// Apply the commit through the app, as the real Update loop would,
+	// and confirm the REPLANTED node still carries the ghost ref — not
+	// just the form's transient state.
+	a.Update(msg)
+	nodes := a.world.ActiveCraft().Nodes
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node after commit, got %d: %+v", len(nodes), nodes)
+	}
+	if nodes[0].TargetGhostOwner != "SHA256:peer" || nodes[0].TargetCraftID != 987654 {
+		t.Errorf("replanted node lost its ghost binding: %+v", nodes[0])
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -489,3 +489,180 @@ func TestClickToEditGhostBoundNodePreservesBinding(t *testing.T) {
 		t.Errorf("replanted node lost its ghost binding: %+v", nodes[0])
 	}
 }
+
+// TestClickToEditUntargetedNodeAfterGhostBoundLoadClearsBinding — #294
+// second-round review finding 2. The Maneuver screen is one long-lived
+// value reused across every plant/edit cycle (app.go): LoadNode used to
+// set hasTargetCraft/targetCraftID/targetGhostOwner ONLY inside its
+// `if id, ok := n.TargetCraftIDValue(); ok` branch, with no else. So
+// loading a ghost-bound node, leaving it (Esc, in the real flow), then
+// click-to-editing a later UNTARGETED node left the PRIOR node's
+// binding stamped on the form: it still offered target-relative modes,
+// and commitCmd would stamp the stale refs onto a node that was never
+// targeted.
+func TestClickToEditUntargetedNodeAfterGhostBoundLoadClearsBinding(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := a.world.ActiveCraft()
+	c.Nodes = append(c.Nodes,
+		sim.ManeuverNode{
+			Mode:             spacecraft.BurnTargetPrograde,
+			DV:               42,
+			TriggerTime:      a.world.Clock.SimTime.Add(time.Hour),
+			PrimaryID:        c.Primary.ID,
+			TargetGhostOwner: "SHA256:peer",
+			TargetCraftID:    987654,
+		},
+		sim.ManeuverNode{
+			Mode:        spacecraft.BurnPrograde,
+			DV:          10,
+			TriggerTime: a.world.Clock.SimTime.Add(2 * time.Hour),
+			PrimaryID:   c.Primary.ID,
+			// no target binding
+		},
+	)
+
+	// Open the ghost-bound node (as if clicked), leave it (Esc, in the
+	// real flow), then click-to-edit the SECOND, untargeted node.
+	a.maneuver.LoadNode(0, c.Nodes[0])
+	a.maneuver.LoadNode(1, c.Nodes[1])
+
+	// Cycle the mode field through every non-target-relative entry
+	// (AllBurnModes lists the body-frame six first, the four target-
+	// relative ones appended after). A clean binding must skip straight
+	// past the target-relative block and wrap back to the start; a
+	// binding leaked from node 0's earlier load lets it stop inside
+	// that block instead (advanceMode's own skip-when-untargeted gate).
+	nonTR := 0
+	for _, md := range spacecraft.AllBurnModes {
+		if !spacecraft.IsTargetRelativeMode(md) {
+			nonTR++
+		}
+	}
+	for i := 0; i < nonTR; i++ {
+		if _, done := a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyRight}); done {
+			t.Fatalf("right press %d unexpectedly ended the form", i)
+		}
+	}
+
+	cmd, ok := a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !ok || cmd == nil {
+		t.Fatal("Enter did not commit")
+	}
+	raw := cmd()
+	msg, ok := raw.(screens.BurnExecutedMsg)
+	if !ok {
+		t.Fatalf("commit produced %T, not BurnExecutedMsg", raw)
+	}
+	if spacecraft.IsTargetRelativeMode(msg.Mode) {
+		t.Errorf("mode cycling stopped on a target-relative mode (%v) for a node with no bound target — hasTargetCraft leaked from the earlier ghost-bound LoadNode", msg.Mode)
+	}
+	if msg.TargetCraftID != 0 || msg.TargetGhostOwner != "" {
+		t.Errorf("stale target binding leaked onto an untargeted node's commit: TargetCraftID=%d TargetGhostOwner=%q",
+			msg.TargetCraftID, msg.TargetGhostOwner)
+	}
+}
+
+// TestEditedAdvisoryNudgeKeepsIdentityAndAutoWarpHonorsIt — #294
+// second-round review finding 6. A K-planted rendezvous nudge
+// (PlanRendezvousNudge) stamps AdvisoryKey and a target binding even on
+// a plain velocity-frame mode (BurnPrograde here) — the binding records
+// what the nudge was computed against, not a direction dependency.
+// Before this fix, LoadNode faithfully loaded both, but commitCmd's
+// target-binding stamp was gated on IsTargetRelativeMode (which
+// BurnPrograde never is) and BurnExecutedMsg had no AdvisoryKey field
+// at all — so editing the nudge (here: changing its Δv, which shifts
+// the derived Duration and so BurnStart) silently re-planted it with
+// NEITHER. This drives the exact production path (LoadNode → Enter →
+// commitCmd → BurnExecutedMsg → App.Update's re-plant) and asserts the
+// edited node keeps its AdvisoryKey and target binding, and that
+// Auto-Warp Engage (which resolves by stable node ID, unaffected by
+// AdvisoryKey, but proves the re-plant produced a coherent, still-
+// eligible node) still finds and targets it.
+func TestEditedAdvisoryNudgeKeepsIdentityAndAutoWarpHonorsIt(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := a.world.ActiveCraft()
+	origTrigger := a.world.Clock.SimTime.Add(time.Hour)
+	c.Nodes = append(c.Nodes, sim.ManeuverNode{
+		Mode:             spacecraft.BurnPrograde, // velocity-frame axis, NOT target-relative
+		DV:               20,
+		TriggerTime:      origTrigger,
+		PrimaryID:        c.Primary.ID,
+		TargetCraftID:    c.ID, // stands in for the nudge's computed-against target
+		TargetGhostOwner: "",
+		AdvisoryKey:      sim.AdvisoryKeyRendezvousNudge,
+	})
+	origID := c.Nodes[0].ID
+	if origID == 0 {
+		// EnsureNodeIDs runs at world construction, not on manual
+		// slice appends — stamp one here so AutoWarp has an ID to match.
+		a.world.EnsureNodeIDs()
+		origID = c.Nodes[0].ID
+	}
+
+	// Click-to-edit, then change the Δv (the form's actual editable
+	// numeric field) — a real edit, not a no-op re-commit.
+	a.maneuver.LoadNode(0, c.Nodes[0])
+	// LoadNode focuses the mode field (0); tab twice to reach the Δv
+	// input (2), clear the loaded "20", and type a genuinely different
+	// value.
+	a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyTab})
+	a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyTab})
+	for i := 0; i < 4; i++ {
+		a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	for _, r := range "999" {
+		a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	cmd2, ok2 := a.maneuver.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !ok2 || cmd2 == nil {
+		t.Fatal("Enter did not commit")
+	}
+	raw := cmd2()
+	msg, ok := raw.(screens.BurnExecutedMsg)
+	if !ok {
+		t.Fatalf("commit produced %T, not BurnExecutedMsg", raw)
+	}
+	if msg.AdvisoryKey != sim.AdvisoryKeyRendezvousNudge {
+		t.Errorf("AdvisoryKey dropped by the edit: got %q, want %q", msg.AdvisoryKey, sim.AdvisoryKeyRendezvousNudge)
+	}
+	if msg.TargetCraftID != c.ID {
+		t.Errorf("target binding dropped by the edit on a non-target-relative mode: TargetCraftID=%d, want %d", msg.TargetCraftID, c.ID)
+	}
+
+	a.Update(msg)
+	nodes := a.world.ActiveCraft().Nodes
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node after commit, got %d: %+v", len(nodes), nodes)
+	}
+	edited := nodes[0]
+	if edited.AdvisoryKey != sim.AdvisoryKeyRendezvousNudge {
+		t.Errorf("replanted node lost its AdvisoryKey: %+v", edited)
+	}
+	if edited.TargetCraftID != c.ID {
+		t.Errorf("replanted node lost its target binding: %+v", edited)
+	}
+	if edited.ID != origID {
+		t.Fatalf("replanted node did not keep its stable ID: got %d, want %d", edited.ID, origID)
+	}
+	if edited.DV != 999 {
+		t.Fatalf("edit did not take — DV = %v, want 999 (setup sanity check)", edited.DV)
+	}
+
+	// Auto-Warp Engage must still find and target this exact node —
+	// the edit must not have produced anything soonestEligibleBurn
+	// can't resolve.
+	if !a.world.EngageAutoWarp() {
+		t.Fatal("EngageAutoWarp found no eligible burn after the edit")
+	}
+	if a.world.AutoWarp == nil || a.world.AutoWarp.CraftID != c.ID || a.world.AutoWarp.NodeID != origID {
+		t.Errorf("AutoWarp did not target the edited nudge: %+v (want CraftID=%d NodeID=%d)", a.world.AutoWarp, c.ID, origID)
+	}
+}
+

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -83,6 +83,20 @@ type Maneuver struct {
 	hasTargetCraft   bool
 	targetCraftID    uint64
 	targetGhostOwner string
+
+	// advisoryKey (#294 second-round review finding 6) carries a loaded
+	// node's spacecraft.ManeuverNode.AdvisoryKey through the edit cycle,
+	// mirroring hasTargetCraft/targetCraftID/targetGhostOwner above.
+	// Without this, editing a planted K-nudge (or C-circularize) and
+	// committing re-planted it with NO AdvisoryKey at all — a later
+	// press of the same key could no longer find and replace it (#293's
+	// "replace, don't stack" ruling broke), and the edited node lost its
+	// advisory identity outright. Set unconditionally in LoadNode (so it
+	// correctly clears to "" for a non-advisory node too, same leak this
+	// struct's target-binding fields guard against — finding 2) and
+	// cleared in ResetEditing so a later NEW-node open never inherits a
+	// stale key from whatever was edited last.
+	advisoryKey string
 }
 
 // SetTargetCraft binds (or unbinds) the target — local craft (owner=="")
@@ -167,6 +181,18 @@ type BurnExecutedMsg struct {
 	// an (unresolvable) local ref — the binding survived LoadNode only
 	// to be dropped again at commit.
 	TargetGhostOwner string
+	// AdvisoryKey (#294 second-round review finding 6) mirrors
+	// ManeuverNode.AdvisoryKey through the edit cycle. Before this field
+	// existed, editing a planted single-keystroke advisory node (K's
+	// PlanRendezvousNudge / C's PlanCircularizeAtApoapsis) and committing
+	// re-planted it with no AdvisoryKey at all — the edited node lost its
+	// advisory identity, so a later press of the SAME key could no
+	// longer find and replace it (World.replaceAdvisoryNode matches on
+	// this field) and instead stacked a stale duplicate behind it,
+	// breaking #293's "replace, don't stack" ruling. Empty for every
+	// ordinary (non-advisory) node, same zero-value-omitempty
+	// convention as the field it mirrors.
+	AdvisoryKey string
 }
 
 // NodeDeleteMsg is emitted when the player presses ctrl+d in the
@@ -216,6 +242,12 @@ func NewManeuver(th Theme) *Maneuver {
 func (m *Maneuver) ResetEditing() {
 	m.editingIdx = -1
 	m.loadedTriggerTime = time.Time{}
+	// #294 second-round review finding 6: clear the advisory-key carry
+	// too — every path that opens a NEW node's form (LoadStaged, or
+	// bindManeuverTarget after the `m` quick-plant key) calls this
+	// first, and without clearing it here a stale key from whatever was
+	// last edited would leak onto the new, non-advisory node.
+	m.advisoryKey = ""
 }
 
 // LoadStaged opens the form for a NEW node staged at a specific
@@ -236,6 +268,11 @@ func (m *Maneuver) LoadStaged(triggerTime time.Time) {
 	m.dvInput.SetValue("100")
 	m.throttleInput.SetValue("100")
 	m.focus = 2 // Δv input — player typically wants to set magnitude first
+	// #294 second-round review finding 6: this is a NEW-node entry point
+	// (like ResetEditing, which this doesn't route through) — clear any
+	// advisory key carried over from whatever was last edited, or a
+	// staged plain-click plant would inherit a stale K/C identity.
+	m.advisoryKey = ""
 	m.applyFocus()
 }
 
@@ -283,7 +320,28 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 		m.hasTargetCraft = true
 		m.targetCraftID = id
 		m.targetGhostOwner = n.TargetGhostOwner
+	} else {
+		// #294 second-round review finding 2: the Maneuver screen is one
+		// long-lived value (app.go) reused across every plant/edit, so
+		// without this else-branch clear a PRIOR node's ghost/craft
+		// binding leaks onto a later untargeted node: open a ghost-bound
+		// node, Esc, then click-to-edit an untargeted one — the form
+		// would still offer target-relative modes and commitCmd would
+		// stamp the stale refs onto a node that was never bound to
+		// anything.
+		m.hasTargetCraft = false
+		m.targetCraftID = 0
+		m.targetGhostOwner = ""
 	}
+	// #294 second-round review finding 6: carry the node's own
+	// AdvisoryKey through the edit cycle too, unconditionally (not
+	// gated on the target binding above — a K-nudge's mode is often a
+	// plain velocity-frame axis, not one of the four target-relative
+	// modes, yet it still carries an AdvisoryKey). Assigning n.AdvisoryKey
+	// directly — rather than an if/else — both captures it for an
+	// advisory node and correctly clears it to "" for an ordinary one,
+	// the same leak class finding 2 fixed for the target-binding fields.
+	m.advisoryKey = n.AdvisoryKey
 	m.applyFocus()
 }
 
@@ -443,11 +501,27 @@ func (m *Maneuver) commitCmd() tea.Cmd {
 		EditingIdx:       m.editingIdx,
 		Throttle:         m.parsedThrottle(),
 		IterateForTarget: m.iterateForTarget,
+		// #294 second-round review finding 6: carry the advisory-key
+		// identity straight through — see AdvisoryKey's doc on
+		// BurnExecutedMsg for why an edited K/C node needs this to
+		// survive the re-plant.
+		AdvisoryKey: m.advisoryKey,
 	}
-	// v0.9.3+: capture the bound target craft for target-relative modes
-	// and the TriggerNextClosestApproach event. Bound by stable craft ID
+	// v0.9.3+: capture the bound target craft. Bound by stable craft ID
 	// since v0.14.x (ADR 0012); zero = no target.
-	if m.hasTargetCraft && (spacecraft.IsTargetRelativeMode(mode) || event == sim.TriggerNextClosestApproach) {
+	//
+	// #294 second-round review finding 6: attached for EVERY mode, not
+	// just the target-relative four (+ TriggerNextClosestApproach) —
+	// PlanRendezvousNudge's K plant binds TargetCraftID/TargetGhostOwner
+	// onto velocity-frame axis nodes too (BurnPrograde/Retrograde/
+	// RadialOut/RadialIn — axisLabelToBurnMode's cycle), recording which
+	// target the nudge was actually computed against even though those
+	// modes never read rT/vT for direction. Gating this on mode meant
+	// LoadNode would faithfully load the binding (LoadNode reads it
+	// unconditionally) only for commitCmd to silently drop it again on
+	// re-plant — editing one of those nudges quietly stripped state the
+	// ORIGINAL plant always carried, for no functional reason.
+	if m.hasTargetCraft {
 		msg.TargetCraftID = m.targetCraftID
 		msg.TargetGhostOwner = m.targetGhostOwner
 	}

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -54,30 +54,52 @@ type Maneuver struct {
 	editingIdx        int
 	loadedTriggerTime time.Time
 
-	// hasTargetCraft + targetCraftID carry the World.Target binding
-	// at form-open time, so the four target-relative burn modes and
-	// the TriggerNextClosestApproach event can resolve their
-	// direction / trigger against the captured target. Bound at open
-	// (not at every keypress) so a target switch while the form is
-	// open doesn't silently retarget a planted burn — the player
-	// closes + reopens the form to retarget. v0.9.3+; bound by stable
-	// craft ID since v0.14.x (ADR 0012).
-	hasTargetCraft bool
-	targetCraftID  uint64
+	// hasTargetCraft + targetCraftID + targetGhostOwner carry the bound
+	// target for the form's four target-relative burn modes and the
+	// TriggerNextClosestApproach event to resolve their direction /
+	// trigger against — local craft (targetGhostOwner=="") or a remote
+	// player's ghost (targetGhostOwner!="", v0.28 S4 / ADR 0034).
+	//
+	// Two different callers bind this, with two different intents
+	// (#294 review round 3 finding I):
+	//
+	//   - LoadNode (click-to-edit an existing planted node) reads the
+	//     node's OWN stored binding — preserving it is the point of
+	//     opening the form on an already-target-bound node, so a
+	//     reloaded ghost-bound node doesn't lose its lock just because
+	//     it's being edited.
+	//   - bindManeuverTarget (app.go, called for a brand-NEW node —
+	//     `m` on the orbit screen, or the click-an-empty-canvas-point
+	//     staging flow) reads the CURRENT World.Target instead, since a
+	//     new node has no binding of its own yet to preserve.
+	//
+	// Neither is re-read per keypress: a target switch while the form
+	// is open doesn't silently retarget a planted burn, and — for the
+	// edit case — the only way to point an already-bound node at a
+	// DIFFERENT target is to close the form, retarget, then reopen for
+	// a fresh (now new-node-shaped) bind. v0.9.3+; bound by stable
+	// craft ID since v0.14.x (ADR 0012); ghost-owner-aware since #294
+	// review round 3.
+	hasTargetCraft   bool
+	targetCraftID    uint64
+	targetGhostOwner string
 }
 
-// SetTargetCraft binds (or unbinds) the target craft (by stable ID) the
-// form's planted burn will be aimed at. Called by the app when opening
-// the form so the four target-relative burn modes and the
-// TriggerNextClosestApproach event can resolve at plant + fire time.
-// Pass ok=false to clear (no craft target set / target is a body).
-// v0.9.3+; binds by ID since v0.14.x (ADR 0012).
-func (m *Maneuver) SetTargetCraft(ok bool, id uint64) {
+// SetTargetCraft binds (or unbinds) the target — local craft (owner=="")
+// or remote ghost (owner!="") — the form's planted burn will be aimed
+// at. Called by the app when opening the form for a NEW node so the
+// four target-relative burn modes and the TriggerNextClosestApproach
+// event can resolve at plant + fire time. Pass ok=false to clear (no
+// target set / target is a body). v0.9.3+; binds by ID since v0.14.x
+// (ADR 0012); ghost-owner-aware since #294 review round 3 (finding I).
+func (m *Maneuver) SetTargetCraft(ok bool, owner string, id uint64) {
 	m.hasTargetCraft = ok
 	if ok {
 		m.targetCraftID = id
+		m.targetGhostOwner = owner
 	} else {
 		m.targetCraftID = 0
+		m.targetGhostOwner = ""
 	}
 	// If the currently-selected mode or trigger requires a target
 	// and we no longer have one, snap to safe defaults so the form
@@ -137,6 +159,14 @@ type BurnExecutedMsg struct {
 	// the app passes it straight through. Only populated for target-
 	// relative modes / TriggerNextClosestApproach event.
 	TargetCraftID uint64
+	// TargetGhostOwner (#294 review round 3 finding I) mirrors
+	// ManeuverNode.TargetGhostOwner: non-empty when TargetCraftID names a
+	// REMOTE player's craft rather than a local one. Without this the
+	// form had no way to tell the app a bound target was a ghost, so
+	// committing an edit on a ghost-bound node silently re-planted it as
+	// an (unresolvable) local ref — the binding survived LoadNode only
+	// to be dropped again at commit.
+	TargetGhostOwner string
 }
 
 // NodeDeleteMsg is emitted when the player presses ctrl+d in the
@@ -239,13 +269,20 @@ func (m *Maneuver) LoadNode(idx int, n sim.ManeuverNode) {
 	m.editingIdx = idx
 	m.loadedTriggerTime = n.TriggerTime
 	// v0.9.3+: preserve the node's stored target binding through the
-	// edit cycle so re-planting doesn't drop it. Caller (app) is
-	// expected to follow up with SetTargetCraft to reflect the
-	// CURRENT World.Target if the node's binding is stale, but the
-	// default-load behaviour preserves the original target.
+	// edit cycle so re-planting doesn't drop it — this is authoritative
+	// for the edit flow; unlike the new-node flow, the app does NOT
+	// follow this call with bindManeuverTarget (#294 review round 3
+	// finding I: bindManeuverTarget only knew TargetCraft, so it used to
+	// unconditionally clobber whatever this just loaded the instant the
+	// live World.Target was a ghost, or None, or anything else — most
+	// visibly stripping a reloaded ghost-bound node's lock the moment
+	// the player clicked it to edit, even though nothing about the node
+	// itself had changed). Ghost owner rides along with the ID so a
+	// remote ref survives the edit cycle too, not just a local one.
 	if id, ok := n.TargetCraftIDValue(); ok {
 		m.hasTargetCraft = true
 		m.targetCraftID = id
+		m.targetGhostOwner = n.TargetGhostOwner
 	}
 	m.applyFocus()
 }
@@ -412,6 +449,7 @@ func (m *Maneuver) commitCmd() tea.Cmd {
 	// since v0.14.x (ADR 0012); zero = no target.
 	if m.hasTargetCraft && (spacecraft.IsTargetRelativeMode(mode) || event == sim.TriggerNextClosestApproach) {
 		msg.TargetCraftID = m.targetCraftID
+		msg.TargetGhostOwner = m.targetGhostOwner
 	}
 	return func() tea.Msg { return msg }
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1629,7 +1629,17 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		// sim-time). No DOCK READY: cross-player docking is v0.28.
 		g, gPrimary, ok := w.ResolveTargetGhost()
 		if !ok {
-			return nil
+			// #294 review finding 4: the lock survives an unresolved ghost
+			// (Kind stays TargetGhost so a later resolve re-latches it —
+			// see World.HasRelativeTarget / World.TargetName) — a bare
+			// "return nil" here reads as no target at all, indistinguishable
+			// from TargetNone. Show the pending state instead so the player
+			// can tell "still locked, just waiting" from "lost".
+			return []string{
+				v.theme.Primary.Render("TARGET"),
+				chipRow("ghost:", w.TargetName()),
+				chipRow("status:", "signal not yet resolved"),
+			}
 		}
 		lines := []string{v.theme.Primary.Render("TARGET"), chipRow("ghost:", w.TargetName())}
 		gRel := g.Pos.Sub(w.BodyPosition(gPrimary))

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -291,6 +291,12 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 				row{text: "  they were riding in it and your seat was empty"})
 		case sim.SessionEventDockLost:
 			rows = append(rows, row{text: "⚠ dock with " + e.Handle + " ended — the stack no longer exists", alert: true})
+		case sim.SessionEventTargetLockLost:
+			msg := "⚠ target lock lost on reconnect"
+			if e.Handle != "" {
+				msg = "⚠ target lock on " + e.Handle + " lost on reconnect"
+			}
+			rows = append(rows, row{text: msg, alert: true})
 		case sim.SessionEventRendezvousDegraded:
 			rows = append(rows, row{text: "⚠ rendezvous encounter degraded", alert: true})
 		case sim.SessionEventWentQuiet:


### PR DESCRIPTION
Fixes #294

## Root cause

A guest's craft/rendezvous target lock (`TargetGhost`, aimed at another
player's vessel) was silently dropped on any reconnect that round-trips
through the per-player session payload — most visibly the `[u]`
restart-to-adopt flow. A nav body target (`TargetBody`) on the same
payload was never affected, matching the issue's two-seat observation.

`CraftToWire` (`internal/save/craft_wire.go`) normalised any
`TargetGhost` to no-target on save, on the theory that the remote
owner's fingerprint was session-local and could never resolve again
after a save/load round trip. That reasoning holds for a save file
taken *out* of its session (single-player, or moved elsewhere), but not
for the ordinary case this bug covers: the same session's own guest
reconnecting, where the fingerprint is exactly as meaningful as it was
before the restart.

## Fix

1. **Persist the intent.** `save.Target` gains an additive
   `GhostOwner` field (omitempty, no `SchemaVersion` bump — same
   precedent as other additive fields like `PitchTrim`/`NextNodeID`).
   `CraftToWire`/`CraftFromWire` now preserve `TargetGhost` (Kind +
   CraftID + GhostOwner) instead of dropping it.

2. **Re-latch automatically, or say so.** A ghost target that lands
   unresolved (the ghost slate hasn't repopulated from peer reports
   yet — the ordinary shape of "just reconnected") already degrades
   gracefully everywhere it's consumed (`ResolveTargetGhost`,
   `TargetState`, burn/rendezvous math) — that tolerance already
   existed for a momentarily-stale ghost mid-session. The new bit is
   `reportingModel.reconcileTargetLock` (`internal/serve/reporting.go`),
   which watches an unresolved ghost target every tick after the ghost
   slate refreshes:
   - Resolves within the grace window (target owner's reports resume)
     → silently restored, nothing to announce — the player is back
     where they were.
   - Never resolves within `targetLockRelatchGrace` (45s) → the target
     is cleared and a new `SessionEventTargetLockLost` chip tells the
     player ("target lock lost on reconnect"), instead of leaving a
     silently dangling aim.

## Save schema

No `SchemaVersion` bump. `GhostOwner` is a new `omitempty` field; an
old save/session payload without it just decodes to `""`, which was
already the only value it could ever be (ghost targets never wrote a
non-empty owner before this fix).

## Tests

- `internal/save/ghost_target_test.go` — `TestGhostTargetPersistsOnSave`
  (flips the old "normalised away" assertion to "round-trips intact")
- `internal/sim/target_ghost_nav_test.go` — renamed/updated
  `TestGhostTargetMirroredToActiveCraft` to match
- `internal/serve/target_lock_reconnect_test.go` (new):
  - `TestTargetLockResolvesImmediatelyNoOp`
  - `TestTargetLockRelatchesSilentlyWhenReportResumes`
  - `TestTargetLockLostChipAfterGraceWindow`
  - `TestTargetLockSurvivesSaveLoadAndReLatchesThroughReportingModel`
    (end-to-end: save → simulated restart reload → reporting-model
    re-latch once the peer's report arrives)

`go vet ./...` and `go test ./... -race -count=1` both pass.

## Test plan

- [ ] Two-seat tailnet playtest across an actual `[u]` restart-to-adopt:
      guest A holds a craft lock on guest B's vessel, guest B holds a
      body target; after restart, confirm A's lock silently returns
      once B reconnects, and B's body target is unaffected as before.