### PR TITLE
New players join at the earliest live clock, not the frontier

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -168,9 +168,12 @@ func (s *Store) Snapshot(excludeOwner string) []CraftReport {
 	return out
 }
 
-// Frontier is the maximum subspace time across every stored report —
-// where a new player joins (you can never start in someone's past,
-// ADR 0034). ok is false while the store is empty.
+// Frontier is the maximum subspace time across every stored report.
+// It backs --reset-fleet's epoch (internal/serve/resetfleet.go),
+// which wants every clock aligned forward to the furthest-advanced
+// session. It is NOT where a new player joins — see Earliest for
+// that (ADR 0034 §7 amendment / ADR 0045 S3). ok is false while the
+// store is empty.
 func (s *Store) Frontier() (time.Time, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -183,6 +186,27 @@ func (s *Store) Frontier() (time.Time, bool) {
 		}
 	}
 	return max, ok
+}
+
+// Earliest is the minimum subspace time across every stored (i.e.
+// live) report — where a new player joins (ADR 0034 §7 amendment /
+// ADR 0045 S3, closing #247/#396): joining behind the group is
+// recoverable with Sync, which is forward-only, so joining ahead of
+// anyone actually playing is the trap to avoid, not joining behind.
+// ok is false while the store is empty; the caller falls back to the
+// furthest-behind persisted payload (sessiondir.Store.EarliestSimTime).
+func (s *Store) Earliest() (time.Time, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var min time.Time
+	ok := false
+	for _, r := range s.reports {
+		if !ok || r.SubspaceTime.Before(min) {
+			min = r.SubspaceTime
+			ok = true
+		}
+	}
+	return min, ok
 }
 
 // Subscribe returns a channel of future reports and a cancel func.

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -129,6 +129,40 @@ func TestFrontierUnderDivergence(t *testing.T) {
 	}
 }
 
+// Earliest under divergence: the mirror of Frontier, and the two
+// must not converge on the same value — Frontier backs
+// --reset-fleet's epoch, Earliest backs a new player's join point
+// (ADR 0034 §7 amendment / ADR 0045 S3, closing #247/#396). A viewer
+// ahead of it sees it hold, not move: the whole point is that the
+// laggard, not the leader, sets where newcomers land.
+func TestEarliestUnderDivergence(t *testing.T) {
+	store := NewStore()
+	if _, ok := store.Earliest(); ok {
+		t.Fatal("empty store claims an earliest")
+	}
+	wA, wB := newWorld(t), newWorld(t)
+	// A warps 10 days ahead; B stays put — subspaces diverge.
+	wA.Clock.SimTime = wA.Clock.SimTime.Add(10 * 24 * time.Hour)
+	NewReporter(store, "SHA256:alice").Tick(wA, time.Now())
+	NewReporter(store, "SHA256:bob").Tick(wB, time.Now())
+
+	e, ok := store.Earliest()
+	if !ok {
+		t.Fatal("no earliest with two reports stored")
+	}
+	if !e.Equal(wB.Clock.SimTime) {
+		t.Errorf("earliest = %v, want bob's %v (min of subspaces)", e, wB.Clock.SimTime)
+	}
+	if !e.Before(wA.Clock.SimTime) {
+		t.Error("earliest not behind the leader")
+	}
+
+	// Frontier still reports the max — the two must not converge.
+	if f, ok := store.Frontier(); !ok || !f.Equal(wA.Clock.SimTime) {
+		t.Errorf("Frontier = %v/%v, want alice's %v", f, ok, wA.Clock.SimTime)
+	}
+}
+
 // Concurrent report/subscribe/snapshot is race-clean (the -race run
 // is the assertion; the counts just keep the compiler honest).
 func TestConcurrentReportSubscribe(t *testing.T) {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -421,12 +421,12 @@ func (s *Server) sessionHandler(sess ssh.Session) (tea.Model, []tea.ProgramOptio
 	// commits the enrollment.
 	ctx := sess.Context()
 	onEnroll := func(handle string) {
-		// Re-apply the frontier at the COMMIT (review follow-up): the
+		// Re-apply the join time at the COMMIT (review follow-up): the
 		// connect-time sample goes stale while the player sits in the
 		// card/code/handle prompts and other subspaces advance. The
 		// game's tick loop hasn't started yet, so the relabel is safe.
-		if f, ok := s.frontier(); ok && f.After(app.World().Clock.SimTime) {
-			app.World().Clock.SimTime = f
+		if j, ok := s.joinTime(); ok && j.After(app.World().Clock.SimTime) {
+			app.World().Clock.SimTime = j
 		}
 		s.presence.markOnline(fp)
 		s.presence.event(sim.SessionEventJoin, fp, handle, "")
@@ -451,14 +451,18 @@ func (s *Server) newGuestApp(fp string) (*tui.App, error) {
 		if app, err = tui.New(nil); err != nil {
 			return nil, err
 		}
-		// Join at the frontier (v0.27 S4, ADR 0034): a NEW player's
-		// clock starts at the max subspace time across live sessions
-		// and persisted payloads — you can never start in someone's
-		// past. Craft state vectors are time-local, so relabelling
-		// "now" is safe. Reconnects (the branch above) keep their own
-		// stored time instead.
-		if f, ok := s.frontier(); ok && f.After(app.World().Clock.SimTime) {
-			app.World().Clock.SimTime = f
+		// Join at the earliest live clock (ADR 0034 §7 amendment /
+		// ADR 0045 S3, closing #247/#396): a NEW player's clock starts
+		// alongside the furthest-behind player actually online, or —
+		// with nobody online — the furthest-behind persisted payload.
+		// Sync is forward-only, so joining behind the group is
+		// recoverable and joining ahead of it is a permanent trap;
+		// this is the deliberate inverse of frontier(), which stays a
+		// max and backs --reset-fleet's epoch instead. Craft state
+		// vectors are time-local, so relabelling "now" is safe.
+		// Reconnects (the branch above) keep their own stored time.
+		if j, ok := s.joinTime(); ok && j.After(app.World().Clock.SimTime) {
+			app.World().Clock.SimTime = j
 		}
 	default:
 		return nil, err
@@ -470,7 +474,10 @@ func (s *Server) newGuestApp(fp string) (*tui.App, error) {
 }
 
 // frontier combines the live store's max subspace time with the
-// persisted payloads' — offline players hold the frontier too.
+// persisted payloads' — offline players hold the frontier too. This
+// is the epoch --reset-fleet aligns every clock forward to
+// (ResetFleet, resetfleet.go); it is NOT where a new player joins —
+// see joinTime for that.
 func (s *Server) frontier() (time.Time, bool) {
 	live, okLive := s.relay.Frontier()
 	stored, okStored := s.store.LatestSimTime()
@@ -486,6 +493,27 @@ func (s *Server) frontier() (time.Time, bool) {
 		return stored, true
 	}
 	return time.Time{}, false
+}
+
+// joinTime is where a NEW player's clock starts (ADR 0034 §7
+// amendment / ADR 0045 S3, closing #247/#396): the earliest subspace
+// time among live sessions, or — with nobody online — the
+// furthest-behind persisted payload. Deliberately NOT frontier()
+// inverted-and-merged: while anyone is live, offline payloads are
+// ignored entirely, even ones further behind than the live group, so
+// the rule stays "join with whoever is actually playing." Only the
+// empty-server case falls back to stored payloads at all, and even
+// then it's the minimum, not the maximum — a lid-open session that
+// warped for days and persisted on disconnect must not keep pulling
+// new joiners forward after its owner has left. ok is false only when
+// there are no live sessions AND no persisted payloads at all (i.e.
+// a genuinely empty server), in which case the caller's fresh default
+// clock stands.
+func (s *Server) joinTime() (time.Time, bool) {
+	if live, ok := s.relay.Earliest(); ok {
+		return live, true
+	}
+	return s.store.EarliestSimTime()
 }
 
 // persistMiddleware writes the final per-player payload after the

--- a/internal/serve/subspace_test.go
+++ b/internal/serve/subspace_test.go
@@ -31,12 +31,24 @@ func newOfflineServer(t *testing.T) *Server {
 	return srv
 }
 
-// A new player joins at the frontier: the max subspace time across
-// live reports and persisted payloads, never their past.
-func TestJoinAtFrontier(t *testing.T) {
+// A new player joins at the earliest LIVE clock, not the frontier
+// (ADR 0034 §7 amendment / ADR 0045 S3, closing #247/#396): with two
+// players online at different subspace times, the far-ahead one must
+// not pull a rookie forward. Sync is forward-only, so joining behind
+// the group is recoverable and joining ahead of it is a permanent
+// trap — the opposite of the old "you can never start in someone's
+// past" rule this replaces.
+func TestJoinAtEarliestLiveClock(t *testing.T) {
 	srv := newOfflineServer(t)
 
-	// A live session 10 days ahead holds the frontier.
+	wBehind, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	behind := wBehind.Clock.SimTime.Add(6 * 24 * time.Hour)
+	wBehind.Clock.SimTime = behind
+	relay.NewReporter(srv.relay, "SHA256:closer").Tick(wBehind, time.Now())
+
 	wAhead, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -49,23 +61,34 @@ func TestJoinAtFrontier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newGuestApp: %v", err)
 	}
-	if got := app.World().Clock.SimTime; !got.Equal(ahead) {
-		t.Errorf("new player joined at %v, want frontier %v", got, ahead)
+	if got := app.World().Clock.SimTime; !got.Equal(behind) {
+		t.Errorf("new player joined at %v, want earliest live %v", got, behind)
 	}
 }
 
-// Persisted payloads hold the frontier even when nobody is online —
-// an offline veteran's stored time still floors a new join.
-func TestJoinAtFrontierFromStoredPayload(t *testing.T) {
+// A stored (offline) payload far ahead of the live group must not
+// pull a new joiner forward: while anyone is live, offline payloads
+// are ignored entirely for the join point, however far ahead they
+// are. This is the trap #247/#396 exists to close — a lid-open
+// session that warped for days and persisted on disconnect must not
+// keep dropping newcomers into a time nobody is actually at.
+func TestJoinIgnoresStoredPayloadAhead(t *testing.T) {
 	srv := newOfflineServer(t)
 
-	wVet, err := sim.NewWorld()
+	wLive, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
 	}
-	ahead := wVet.Clock.SimTime.Add(30 * 24 * time.Hour)
-	wVet.Clock.SimTime = ahead
-	if err := srv.store.SavePlayer("SHA256:offline-vet", wVet); err != nil {
+	live := wLive.Clock.SimTime.Add(6 * 24 * time.Hour)
+	wLive.Clock.SimTime = live
+	relay.NewReporter(srv.relay, "SHA256:present").Tick(wLive, time.Now())
+
+	wOfflineVet, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	wOfflineVet.Clock.SimTime = wOfflineVet.Clock.SimTime.Add(30 * 24 * time.Hour)
+	if err := srv.store.SavePlayer("SHA256:offline-vet", wOfflineVet); err != nil {
 		t.Fatalf("SavePlayer: %v", err)
 	}
 
@@ -73,8 +96,44 @@ func TestJoinAtFrontierFromStoredPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newGuestApp: %v", err)
 	}
-	if got := app.World().Clock.SimTime; !got.Equal(ahead) {
-		t.Errorf("new player joined at %v, want stored frontier %v", got, ahead)
+	if got := app.World().Clock.SimTime; !got.Equal(live) {
+		t.Errorf("new player joined at %v, want the live player's time %v (stored payload must not pull forward)", got, live)
+	}
+}
+
+// With nobody online, a new player joins alongside the
+// furthest-BEHIND stored payload, not the furthest-ahead one — the
+// minimum, mirroring joinTime's live-session rule onto the offline
+// fallback so an unattended session that ran far ahead can't keep
+// springing the ADR 0034 §7 trap after its owner has disconnected.
+func TestJoinAtFurthestBehindStoredPayloadWhenEmpty(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	wBehind, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	behind := wBehind.Clock.SimTime.Add(5 * 24 * time.Hour)
+	wBehind.Clock.SimTime = behind
+	if err := srv.store.SavePlayer("SHA256:behind-vet", wBehind); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	wAhead, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	wAhead.Clock.SimTime = wAhead.Clock.SimTime.Add(30 * 24 * time.Hour)
+	if err := srv.store.SavePlayer("SHA256:ahead-vet", wAhead); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	app, err := srv.newGuestApp("SHA256:rookie")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	if got := app.World().Clock.SimTime; !got.Equal(behind) {
+		t.Errorf("new player joined at %v, want furthest-behind stored payload %v", got, behind)
 	}
 }
 

--- a/internal/sessiondir/sessiondir.go
+++ b/internal/sessiondir/sessiondir.go
@@ -860,16 +860,39 @@ func (s *Store) HasPayload(fingerprint string) bool {
 }
 
 // LatestSimTime scans every persisted player payload for the maximum
-// stored subspace time — offline players hold the frontier (v0.27 S4,
-// ADR 0034: you can never start in someone's past, online or not).
-// ok is false when no payload parses. Unreadable files are skipped:
-// frontier is a floor, not an integrity check.
+// stored subspace time. It backs --reset-fleet's epoch
+// (internal/serve/resetfleet.go), which wants every clock aligned
+// forward to the furthest-advanced payload. It is NOT where a new
+// player joins — see EarliestSimTime for that (ADR 0034 §7 amendment
+// / ADR 0045 S3). ok is false when no payload parses. Unreadable
+// files are skipped: this scan is a floor, not an integrity check.
 func (s *Store) LatestSimTime() (time.Time, bool) {
+	return s.scanSimTime(func(t, best time.Time) bool { return t.After(best) })
+}
+
+// EarliestSimTime scans every persisted player payload for the
+// minimum stored subspace time — the furthest-behind stored payload,
+// which is where a new player joins when nobody is live (ADR 0034 §7
+// amendment / ADR 0045 S3, closing #247/#396). A lid-open session
+// that ran unattended and persisted a payload days ahead must not be
+// able to keep pulling new joiners forward after its owner
+// disconnects; the furthest-behind payload is the safe (recoverable
+// via forward-only Sync) choice instead. ok is false when no payload
+// parses.
+func (s *Store) EarliestSimTime() (time.Time, bool) {
+	return s.scanSimTime(func(t, best time.Time) bool { return t.Before(best) })
+}
+
+// scanSimTime walks every persisted player payload and folds their
+// stored subspace times with better, which reports whether candidate
+// t improves on the running best. Unreadable or unparsable files are
+// skipped.
+func (s *Store) scanSimTime(better func(t, best time.Time) bool) (time.Time, bool) {
 	entries, err := os.ReadDir(filepath.Join(s.dir, "players"))
 	if err != nil {
 		return time.Time{}, false
 	}
-	var max time.Time
+	var best time.Time
 	found := false
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
@@ -888,10 +911,10 @@ func (s *Store) LatestSimTime() (time.Time, bool) {
 			continue
 		}
 		t := time.Unix(0, probe.Payload.SimTimeNano).UTC()
-		if !found || t.After(max) {
-			max = t
+		if !found || better(t, best) {
+			best = t
 			found = true
 		}
 	}
-	return max, found
+	return best, found
 }

--- a/internal/sessiondir/sessiondir_test.go
+++ b/internal/sessiondir/sessiondir_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/save"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -374,6 +375,49 @@ func TestPlayerPayloadRoundTrip(t *testing.T) {
 	}
 	if len(got.Crafts) > 0 && got.Crafts[0].ID != w.Crafts[0].ID {
 		t.Errorf("craft ID %d, want %d", got.Crafts[0].ID, w.Crafts[0].ID)
+	}
+}
+
+// EarliestSimTime is the minimum stored subspace time, the mirror of
+// LatestSimTime's maximum — LatestSimTime backs --reset-fleet's
+// epoch, EarliestSimTime backs a new player's join point when nobody
+// is live (ADR 0034 §7 amendment / ADR 0045 S3, closing #247/#396).
+func TestEarliestSimTime(t *testing.T) {
+	s := openStore(t)
+	if _, ok := s.EarliestSimTime(); ok {
+		t.Fatal("empty store claims an earliest sim time")
+	}
+
+	wAhead, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	wAhead.Clock.SimTime = wAhead.Clock.SimTime.Add(30 * 24 * time.Hour)
+	if err := s.SavePlayer("SHA256:ahead", wAhead); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	wBehind, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	behind := wBehind.Clock.SimTime.Add(5 * 24 * time.Hour)
+	wBehind.Clock.SimTime = behind
+	if err := s.SavePlayer("SHA256:behind", wBehind); err != nil {
+		t.Fatalf("SavePlayer: %v", err)
+	}
+
+	got, ok := s.EarliestSimTime()
+	if !ok {
+		t.Fatal("no earliest sim time with two payloads stored")
+	}
+	if !got.Equal(behind) {
+		t.Errorf("EarliestSimTime = %v, want the furthest-behind payload %v", got, behind)
+	}
+
+	// LatestSimTime still reports the max — the two must not converge.
+	if latest, ok := s.LatestSimTime(); !ok || !latest.Equal(wAhead.Clock.SimTime) {
+		t.Errorf("LatestSimTime = %v/%v, want the furthest-ahead payload %v", latest, ok, wAhead.Clock.SimTime)
 	}
 }
 


### PR DESCRIPTION
Closes #396. Closes #247.

## Summary

- `relay.Store.Earliest()` and `sessiondir.Store.EarliestSimTime()` add the minimum-time counterparts to the existing `Frontier()` / `LatestSimTime()` maxima.
- `serve.Server.joinTime()` is a new function — min over live reports, falling back to a min over persisted payloads when nobody's online — used at both existing join sites (`newGuestApp`'s fresh branch, `onEnroll`'s commit re-application) in place of `frontier()`.
- `frontier()` itself is untouched: it still keeps its max definition and still backs `--reset-fleet`'s epoch (`resetfleet.go`), which legitimately wants every clock aligned forward.
- `subspace_test.go`'s two frontier-join tests are inverted per the issue's acceptance criteria (comments rewritten, not deleted); a new empty-server test and a "stored payload ahead must not pull forward" test were added, plus direct unit tests for the two new `Earliest*` functions.

## Why

Sync is forward-only (ADR 0034 §4), so a newcomer joining *behind* the group is recoverable but joining *ahead* is a permanent trap. A guest session left warping unattended runs its clock far ahead and — because it persists on disconnect — kept dropping every subsequent newcomer days ahead of everyone actually playing, online or not.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] `TestResetFleetEpochIsStoredFrontier` still green unmodified — confirms `frontier()`/`LatestSimTime()` weren't repurposed.