### PR TITLE
ADR 0045 S4: [I] matches a vessel's plane, not just a body's

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1103,6 +1103,127 @@ func (w *World) PlanPlaneMatch(targetIdx int) (*planner.InclinationPlan, error) 
 	}, nil
 }
 
+// PlanVesselPlaneMatch plants a single BurnPlaneChange node that
+// rotates the active craft's orbital plane to coincide with the
+// orbital plane of the bound VESSEL target — a local craft
+// (TargetCraft) or a remote player's ghost (TargetGhost) — same
+// primary only. ADR 0045 §4 (#397): completes the plane rung `[I]`
+// was missing for rendezvous. PlanInclinationChange takes a scalar
+// inclination magnitude and PlanPlaneMatch(bodyIdx) reads a body's
+// catalog orbit; neither can express "match THAT VESSEL's plane" —
+// two vessels can read the same inclination magnitude and still sit
+// in completely different planes (different RAAN), and until this
+// slice there was no vessel-relative plane match anywhere in the
+// game.
+//
+// Mirrors PlanPlaneMatch's geometry exactly, with one substitution:
+// the target's own relative angular momentum (rT × vT, in the active
+// craft's primary-relative frame) stands in for a body's catalog-
+// derived orbit normal (orbital.OrbitNormalWorld). This is the same
+// substitution TargetPlaneNodePositions already makes for the map's
+// ◇/◆ node markers — see that function's comment for why reusing
+// TimeToNodeCrossing this way is valid. No equatorial/ecliptic
+// rotation is needed here (unlike the scalar PlanInclinationChange):
+// c.State.R/V and (rT, vT) are already expressed in the same
+// primary-relative Cartesian frame by TargetStateRelativeToActivePrimary,
+// and comparing two orbit normals directly is frame-invariant as long
+// as both come from that same base frame — see CLAUDE.md's frame
+// boundary note (internal/orbital/frame.go).
+//
+// Errors:
+//   - errNoCraftForTransfer: no active craft.
+//   - ErrRendezvousNoTarget: no craft/ghost target bound, or the bound
+//     ref doesn't resolve (stale craft ID / vanished ghost).
+//   - ErrRendezvousDifferentPrimaries: target orbits a different
+//     primary than the active craft (same-primary only, per #397).
+//   - errPlaneMatchDegenerateTarget: the target's relative state has
+//     no defined orbital plane (rT × vT == 0).
+//   - planner.ErrInclinationNoOp: the two orbits are already coplanar
+//     (or TimeToNodeCrossing finds no crossing within its own
+//     equatorial tolerance) — nothing to do.
+//
+// v0.39+ / #397.
+func (w *World) PlanVesselPlaneMatch() (*planner.InclinationPlan, error) {
+	c := w.ActiveCraft()
+	if c == nil {
+		return nil, errNoCraftForTransfer
+	}
+	if !w.HasRelativeTarget() {
+		return nil, ErrRendezvousNoTarget
+	}
+	targetPrimary, ok := w.rendezvousTargetPrimary()
+	if !ok {
+		return nil, ErrRendezvousNoTarget
+	}
+	if targetPrimary.EnglishName != c.Primary.EnglishName {
+		return nil, ErrRendezvousDifferentPrimaries
+	}
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return nil, ErrRendezvousNoTarget
+	}
+	nTarget := rT.Cross(vT)
+	if nTarget.Norm() == 0 {
+		return nil, errPlaneMatchDegenerateTarget
+	}
+	nTargetHat := nTarget.Unit()
+	primary := c.Primary
+	mu := primary.GravitationalParameter()
+
+	// Time to the next crossing of the target's plane — an AN/DN
+	// crossing in a frame whose Z axis is the target's relative orbit
+	// normal. Identical shape to PlanPlaneMatch's body-target case.
+	planeFrame := orbital.FrameFromNormal(nTarget)
+	stateTF := orbital.Vec3State{
+		R: planeFrame.FromWorld(c.State.R),
+		V: planeFrame.FromWorld(c.State.V),
+	}
+	tAN := orbital.TimeToNodeCrossing(stateTF, mu, true)
+	tDN := orbital.TimeToNodeCrossing(stateTF, mu, false)
+	dt := -1.0
+	atAN := false
+	if tAN >= 0 && (tDN < 0 || tAN <= tDN) {
+		dt, atAN = tAN, true
+	} else if tDN >= 0 {
+		dt, atAN = tDN, false
+	}
+	if dt < 0 {
+		// No crossing — the craft is already coplanar with the target.
+		return nil, planner.ErrInclinationNoOp
+	}
+
+	// Propagate to the crossing and derive the burn geometrically. At
+	// the crossing the radial axis lies along the two planes' mutual
+	// node line, so a rotation of the craft's orbit normal about r̂
+	// onto the target normal aligns the planes exactly.
+	post := w.propagateCraft(dt)
+	rHat := post.R.Unit()
+	hHat := post.R.Cross(post.V).Unit()
+	theta := math.Atan2(hHat.Cross(nTargetHat).Dot(rHat), hHat.Dot(nTargetHat))
+	vHor := post.V.Sub(rHat.Scale(post.V.Dot(rHat)))
+	dv := 2 * vHor.Norm() * math.Sin(math.Abs(theta)/2)
+	if dv == 0 {
+		return nil, planner.ErrInclinationNoOp
+	}
+	now := w.Clock.SimTime
+	w.PlanNode(ManeuverNode{
+		TriggerTime:    now.Add(time.Duration(dt * float64(time.Second))),
+		Mode:           spacecraft.BurnPlaneChange,
+		DV:             dv,
+		Duration:       c.BurnTimeForDV(dv),
+		PrimaryID:      primary.ID,
+		PlaneChangeRad: theta,
+	})
+	return &planner.InclinationPlan{
+		PrimaryID:      primary.ID,
+		DV:             dv,
+		OffsetTime:     time.Duration(dt * float64(time.Second)),
+		NormalSign:     int(math.Copysign(1, theta)),
+		PlaneChangeRad: theta,
+		AtAN:           atAN,
+	}, nil
+}
+
 // CircularizePlan summarises a planted circularize-at-apoapsis node
 // for the caller's status flash. v0.9.4+.
 type CircularizePlan struct {
@@ -2355,6 +2476,14 @@ var (
 	errNoCraftForTransfer    = transferError("no vessel to plan transfer for")
 	errNoRefineTarget        = transferError("no pending transfer to refine")
 	errSamePrimaryUseHohmann = transferError("target shares vessel's primary — use [H] auto-Hohmann instead of porkchop")
+
+	// errPlaneMatchDegenerateTarget: PlanVesselPlaneMatch (ADR 0045 S4,
+	// #397) can't derive a target plane from a degenerate relative
+	// state (rT × vT == 0 — the target sits exactly radial from, or
+	// coincident with, the active craft). Distinct from
+	// planner.ErrInclinationNoOp, which means the two planes ARE
+	// well-defined and already coincide.
+	errPlaneMatchDegenerateTarget = transferError("target's relative orbit is degenerate — no plane to match")
 
 	// PlanCircularizeAtApoapsis errors. Exported so app.go's status
 	// flash can switch on them with errors.Is. v0.9.4+.

--- a/internal/sim/vessel_plane_match_test.go
+++ b/internal/sim/vessel_plane_match_test.go
@@ -1,0 +1,198 @@
+package sim
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+)
+
+// planeAngleDeg is the angle between two orbit-normal (or any) vectors,
+// in degrees. Shared shape with TestPlanPlaneMatchCoplanarWithMoon's
+// local helper of the same name.
+func planeAngleDeg(a, b orbital.Vec3) float64 {
+	c := a.Dot(b) / (a.Norm() * b.Norm())
+	if c > 1 {
+		c = 1
+	} else if c < -1 {
+		c = -1
+	}
+	return math.Acos(c) * 180 / math.Pi
+}
+
+// circularStateAtIncRAAN builds a circular-orbit (R, V) pair at radius
+// r, inclination incDeg and RAAN raanDeg (both in degrees, measured in
+// the given primary's reference frame), expressed in the world-aligned
+// Cartesian frame maneuver.go's craft states use. Mirrors the inline
+// builder in TestPlanPlaneMatchCoplanarWithMoon.
+func circularStateAtIncRAAN(frame orbital.BodyFrame, mu, r, incDeg, raanDeg float64) (orbital.Vec3, orbital.Vec3) {
+	inc := incDeg * math.Pi / 180
+	raan := raanDeg * math.Pi / 180
+	v := math.Sqrt(mu / r)
+	rB := orbital.Vec3{X: r * math.Cos(raan), Y: r * math.Sin(raan)}
+	vB := orbital.Vec3{
+		X: -v * math.Cos(inc) * math.Sin(raan),
+		Y: v * math.Cos(inc) * math.Cos(raan),
+		Z: v * math.Sin(inc),
+	}
+	return frame.ToWorld(rB), frame.ToWorld(vB)
+}
+
+// TestPlanVesselPlaneMatchLocalCraftSameInclinationDifferentRAAN is the
+// ADR 0045 S4 (#397) headline case: two vessels reading the SAME
+// inclination magnitude (51.6°) but different RAAN (0° vs 90°) sit in
+// genuinely different planes — the old scalar PlanInclinationChange(51.6°)
+// could never fix this for a vessel target, since it only ever drops the
+// craft to a fixed magnitude in the primary's frame, ignoring RAAN
+// entirely. PlanVesselPlaneMatch must actually bring the two orbit
+// normals into agreement.
+func TestPlanVesselPlaneMatchLocalCraftSameInclinationDifferentRAAN(t *testing.T) {
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 350e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 0
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	if active.Primary.ID != target.Primary.ID {
+		t.Fatalf("test setup: crafts don't share a primary")
+	}
+
+	mu := active.Primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(active.Primary)
+	rActive := active.Primary.RadiusMeters() + 300e3
+	rTarget := active.Primary.RadiusMeters() + 350e3
+
+	const incDeg = 51.6
+	active.State.R, active.State.V = circularStateAtIncRAAN(frame, mu, rActive, incDeg, 0)
+	target.State.R, target.State.V = circularStateAtIncRAAN(frame, mu, rTarget, incDeg, 90)
+	active.Nodes = nil
+	target.Nodes = nil
+
+	// Sanity: same inclination magnitude, but the planes are genuinely
+	// different — exactly the case the old scalar match couldn't touch.
+	nActive := active.State.R.Cross(active.State.V)
+	nTarget := target.State.R.Cross(target.State.V)
+	if ang := planeAngleDeg(nActive, nTarget); ang < 20 {
+		t.Fatalf("test setup: planes only %.1f° apart, want a real RAAN split", ang)
+	}
+
+	w.SetTargetCraft(1)
+
+	plan, err := w.PlanVesselPlaneMatch()
+	if err != nil {
+		t.Fatalf("PlanVesselPlaneMatch: %v", err)
+	}
+	if plan.DV <= 0 {
+		t.Fatalf("plan.DV = %.2f, want > 0", plan.DV)
+	}
+	if len(active.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node, got %d", len(active.Nodes))
+	}
+
+	post, _ := w.PostBurnState(active.Nodes[0])
+	// The target's own orbital plane is time-invariant (Keplerian, no
+	// perturbations), so target.State's normal is still valid at the
+	// burn's later trigger time.
+	nTargetHat := target.State.R.Cross(target.State.V)
+	if ang := planeAngleDeg(post.R.Cross(post.V), nTargetHat); ang > 0.5 {
+		t.Errorf("post-burn plane %.2f° off the target vessel's, want ~0° (dv=%.1f m/s)", ang, plan.DV)
+	}
+	// Plane-change burn preserves |v| → orbit stays ~circular.
+	if el := orbital.ElementsFromState(post.R, post.V, mu); el.E > 5e-3 {
+		t.Errorf("post-burn e=%.4f, want ~0", el.E)
+	}
+}
+
+// TestPlanVesselPlaneMatchGhostTarget mirrors the local-craft case
+// against a remote player's ghost (TargetGhost, v0.27/ADR 0034) — the
+// acceptance criterion that a vessel plane match works against a ghost,
+// not just a local craft.
+func TestPlanVesselPlaneMatchGhostTarget(t *testing.T) {
+	w := mustWorld(t)
+	active := w.ActiveCraft()
+	mu := active.Primary.GravitationalParameter()
+	frame := orbital.ReferenceFrameForPrimary(active.Primary)
+	r := active.Primary.RadiusMeters() + 300e3
+
+	const incDeg = 28.5
+	active.State.R, active.State.V = circularStateAtIncRAAN(frame, mu, r, incDeg, 0)
+	active.Nodes = nil
+
+	ghostR, ghostV := circularStateAtIncRAAN(frame, mu, r, incDeg, 120)
+	primaryPos := w.BodyPosition(active.Primary)
+	w.Ghosts = []Ghost{{
+		Owner: "SHA256:peer", CraftID: 42, PrimaryID: active.Primary.ID,
+		Pos: primaryPos.Add(ghostR),
+		Vel: ghostV,
+	}}
+	w.SetTargetGhost("SHA256:peer", 42)
+
+	nActive := active.State.R.Cross(active.State.V)
+	nGhost := ghostR.Cross(ghostV)
+	if ang := planeAngleDeg(nActive, nGhost); ang < 20 {
+		t.Fatalf("test setup: planes only %.1f° apart, want a real RAAN split", ang)
+	}
+
+	plan, err := w.PlanVesselPlaneMatch()
+	if err != nil {
+		t.Fatalf("PlanVesselPlaneMatch (ghost): %v", err)
+	}
+	if len(active.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node, got %d", len(active.Nodes))
+	}
+
+	post, _ := w.PostBurnState(active.Nodes[0])
+	if ang := planeAngleDeg(post.R.Cross(post.V), nGhost); ang > 0.5 {
+		t.Errorf("post-burn plane %.2f° off the ghost's, want ~0° (dv=%.1f m/s)", ang, plan.DV)
+	}
+}
+
+// TestPlanVesselPlaneMatchRefusals covers the issue's explicit refusal
+// list: no vessel target bound, orbits already coplanar (nothing to
+// do), and a degenerate target relative state (no defined plane).
+func TestPlanVesselPlaneMatchRefusals(t *testing.T) {
+	t.Run("no target", func(t *testing.T) {
+		w := mustWorld(t)
+		w.ClearTarget()
+		if _, err := w.PlanVesselPlaneMatch(); !errors.Is(err, ErrRendezvousNoTarget) {
+			t.Errorf("err = %v, want ErrRendezvousNoTarget", err)
+		}
+	})
+
+	t.Run("already coplanar", func(t *testing.T) {
+		w := mustWorld(t)
+		if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3}); err != nil {
+			t.Fatalf("SpawnCraft: %v", err)
+		}
+		w.ActiveCraftIdx = 0
+		// Both crafts spawn equatorial by default — same plane already.
+		w.SetTargetCraft(1)
+		if _, err := w.PlanVesselPlaneMatch(); !errors.Is(err, planner.ErrInclinationNoOp) {
+			t.Errorf("err = %v, want planner.ErrInclinationNoOp", err)
+		}
+	})
+
+	t.Run("degenerate target relative state", func(t *testing.T) {
+		w := mustWorld(t)
+		active := w.ActiveCraft()
+		primaryPos := w.BodyPosition(active.Primary)
+		// Ghost sits exactly on top of the active craft's own position
+		// with zero relative velocity — rT × vT is the zero vector, no
+		// defined target plane.
+		w.Ghosts = []Ghost{{
+			Owner: "SHA256:peer", CraftID: 7, PrimaryID: active.Primary.ID,
+			Pos: primaryPos.Add(active.State.R),
+			Vel: orbital.Vec3{},
+		}}
+		w.SetTargetGhost("SHA256:peer", 7)
+		if _, err := w.PlanVesselPlaneMatch(); !errors.Is(err, errPlaneMatchDegenerateTarget) {
+			t.Errorf("err = %v, want errPlaneMatchDegenerateTarget", err)
+		}
+	})
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1211,7 +1211,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// inclination AND the node line, so a following Hohmann
 			// departs coplanar); None → drop to the equatorial plane
 			// of the craft's primary (the equatorial inclination
-			// match shipped with v0.7.4); TargetCraft is deferred.
+			// match shipped with v0.7.4); TargetCraft/TargetGhost
+			// (ADR 0045 S4, #397) → match the OTHER VESSEL's plane
+			// (relative angular momentum rT × vT gives the node line
+			// and rotation angle), not a scalar tilt number — two
+			// vessels can share an inclination magnitude and still sit
+			// in different planes (different RAAN), which the old
+			// scalar match could never fix.
 			//
 			// Pre-v0.9 this block read App.selectedBody, the implicit
 			// body cursor driven by ←/→. selectedBody now drives only
@@ -1221,10 +1227,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch a.world.Target.Kind {
 			case sim.TargetBody:
 				plan, err = a.world.PlanPlaneMatch(a.world.Target.BodyIdx)
-			case sim.TargetCraft:
-				a.statusMsg = "I targets bodies — for vessels, plan via [m]"
-				a.statusExpires = time.Now().Add(3 * time.Second)
-				return a, nil
+			case sim.TargetCraft, sim.TargetGhost:
+				plan, err = a.world.PlanVesselPlaneMatch()
 			default:
 				plan, err = a.world.PlanInclinationChange(0)
 			}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -85,7 +85,7 @@ type Keymap struct {
 	// in a later cleanup.
 	ClearNodes   key.Binding
 	PlanTransfer key.Binding
-	PlanIncl     key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none).
+	PlanIncl     key.Binding // v0.7.4+: plane rotation toward selected body's inclination (or equatorial when none); ADR 0045 S4 (#397) added a vessel-target mode that matches a craft/ghost's actual plane (RAAN included) instead of a scalar tilt.
 	// PlanCircularize (v0.9.4+) plants a prograde burn at the active
 	// craft's next apoapsis sized to circularise the orbit there. The
 	// "single keystroke for the natural last step of an ascent"
@@ -371,7 +371,7 @@ func DefaultKeymap() Keymap {
 		SpawnCraft:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "spawn vessel (sister copy of active)")),
 		ClearNodes:      key.NewBinding(), // v0.8.6: dropped — see ClearNodes field comment.
 		PlanTransfer:    key.NewBinding(key.WithKeys("H"), key.WithHelp("H", "plant transfer to selected body (plane-aware)")),
-		PlanIncl:        key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant inclination match (selected body / equatorial)")),
+		PlanIncl:        key.NewBinding(key.WithKeys("I"), key.WithHelp("I", "plant plane match (body / vessel / equatorial)")),
 		PlanCircularize: key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "plant circularize burn at next apoapsis")),
 		PlanRendezvous:  key.NewBinding(key.WithKeys("K"), key.WithHelp("K", "plant rendezvous nudge to target vessel")),
 		Porkchop:        key.NewBinding(key.WithKeys("P"), key.WithHelp("P", "porkchop plot for selected body")),

--- a/internal/tui/plan_incl_vessel_test.go
+++ b/internal/tui/plan_incl_vessel_test.go
@@ -1,0 +1,94 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestPlanInclBodyTargetUnchanged is the ADR 0045 S4 (#397) regression
+// guard for app.go's `[I]` dispatch: adding a vessel-target branch to
+// the sim.TargetCraft/sim.TargetGhost switch must leave the pre-existing
+// sim.TargetBody path untouched. It presses `I` with a body target
+// bound through the ordinary app.go input path and checks the result
+// against calling world.PlanPlaneMatch directly on an identically
+// set-up world — the two must plant byte-identical nodes, proving the
+// TUI dispatch still routes a body target through the unmodified
+// PlanPlaneMatch function rather than the new PlanVesselPlaneMatch.
+func TestPlanInclBodyTargetUnchanged(t *testing.T) {
+	setup := func(t *testing.T) (*App, int) {
+		t.Helper()
+		a, err := New(nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		sys := a.world.System()
+		moonIdx := -1
+		for i, b := range sys.Bodies {
+			if b.EnglishName == "Moon" {
+				moonIdx = i
+			}
+		}
+		if moonIdx < 0 {
+			t.Skip("Moon not in loaded Sol system")
+		}
+		a.active = screenOrbit
+		return a, moonIdx
+	}
+
+	// Reference: call PlanPlaneMatch directly on a freshly built world —
+	// this is the function app.go called for TargetBody before #397 and
+	// still must call unchanged after.
+	refApp, moonIdx := setup(t)
+	refPlan, refErr := refApp.world.PlanPlaneMatch(moonIdx)
+	if refErr != nil {
+		t.Fatalf("reference PlanPlaneMatch: %v", refErr)
+	}
+
+	// Under test: press `I` with the same body targeted via the normal
+	// app.go input path (a fresh, identically-constructed world).
+	a, _ := setup(t)
+	a.world.SetTargetBody(moonIdx)
+	pressKey(a, 'I')
+
+	got := a.world.ActiveCraft().Nodes
+	if len(got) != 1 {
+		t.Fatalf("expected 1 planted node via [I], got %d", len(got))
+	}
+	if got[0].DV != refPlan.DV || got[0].PlaneChangeRad != refPlan.PlaneChangeRad {
+		t.Errorf("[I]-planted node = {DV:%.6f, PlaneChangeRad:%.6f}, want byte-identical to direct PlanPlaneMatch {DV:%.6f, PlaneChangeRad:%.6f}",
+			got[0].DV, got[0].PlaneChangeRad, refPlan.DV, refPlan.PlaneChangeRad)
+	}
+	if got[0].TriggerTime != refApp.world.Clock.SimTime.Add(refPlan.OffsetTime) {
+		t.Errorf("[I]-planted TriggerTime = %v, want %v", got[0].TriggerTime, refApp.world.Clock.SimTime.Add(refPlan.OffsetTime))
+	}
+}
+
+// TestPlanInclCraftTargetDispatchesVesselPlaneMatch is a thin app.go
+// wiring check (#397): pressing `I` with a craft target bound must
+// route through PlanVesselPlaneMatch, not fall through to the
+// equatorial-drop default or the retired "plan via [m]" refusal.
+func TestPlanInclCraftTargetDispatchesVesselPlaneMatch(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := a.world.SpawnCraft(sim.SpawnSpec{AltitudeM: 350e3, Inclination: 51.6}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(a.world.Crafts) < 2 {
+		t.Fatalf("expected 2 crafts after spawn, got %d", len(a.world.Crafts))
+	}
+	a.world.ActiveCraftIdx = 0
+	a.world.SetTargetCraft(1)
+	a.active = screenOrbit
+
+	pressKey(a, 'I')
+
+	if got := a.world.ActiveCraft().Nodes; len(got) != 1 {
+		t.Fatalf("expected 1 planted node via [I] against a craft target, got %d (statusMsg=%q)", len(got), a.statusMsg)
+	}
+	if a.statusMsg == "" || a.statusMsg == "I targets bodies — for vessels, plan via [m]" {
+		t.Errorf("statusMsg = %q, want an inclination-plan flash, not the retired vessel refusal", a.statusMsg)
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -99,7 +99,7 @@ var helpSections = []helpSection{
 		{"ctrl+d", "delete the node being edited (in planner)"},
 		{"c / C", "clear ALL planned nodes for the active vessel (in planner)"},
 		{"H", "plant transfer to [t] target body (plane-aware)"},
-		{"I", "plant inclination match ([t] target / equatorial)"},
+		{"I", "plant plane match ([t] target body / vessel / equatorial)"},
 		{"C", "plant circularize burn at next apoapsis"},
 		{"K", "plant rendezvous nudge to the target vessel"},
 		{"R", "refine plan (re-Lambert the arrival)"},


### PR DESCRIPTION
## Summary

- `PlanInclinationChange` (scalar magnitude, ignores RAAN) and `PlanPlaneMatch` (body target, catalog orbit normal) left no way to plant a plane-match burn against another **vessel** — two vessels reading the same inclination could sit in completely different planes and `[I]` had no answer.
- New `World.PlanVesselPlaneMatch` derives the burn from the target vessel/ghost's **relative angular momentum** (`rT × vT`) standing in for a body's catalog orbit normal — same node-crossing/rotation geometry `PlanPlaneMatch` already uses, substituting the source of the plane normal. Same-primary only; refuses honestly on no target, a different primary, a degenerate target relative state, or orbits already coplanar.
- `[I]` now dispatches `TargetCraft`/`TargetGhost` to `PlanVesselPlaneMatch` instead of the old "plan via `[m]`" refusal. `TargetBody` still routes through the untouched `PlanPlaneMatch` — pinned by a byte-identical regression test.
- Help text (`internal/tui/input.go`, `internal/tui/screens/help.go`) updated so `[I]`'s description matches what it now does.

## Test plan

- `TestPlanVesselPlaneMatchLocalCraftSameInclinationDifferentRAAN`: two local craft at the same 51.6° inclination magnitude but 0°/90° RAAN — planes ~20°+ apart before, post-burn orbit normals agree within 0.5°, orbit stays circular (e < 5e-3).
- `TestPlanVesselPlaneMatchGhostTarget`: same shape against a remote-player ghost target (not just a local craft).
- `TestPlanVesselPlaneMatchRefusals`: no target / already-coplanar / degenerate target relative state.
- `TestPlanInclBodyTargetUnchanged`: pressing `[I]` with a body target produces a byte-identical planted node (`DV`, `PlaneChangeRad`, `TriggerTime`) to calling `PlanPlaneMatch` directly — proves the body-target path is untouched.
- `TestPlanInclCraftTargetDispatchesVesselPlaneMatch`: app.go wiring check that a craft target actually routes to the new planner.
- `go vet ./...` and `go test ./... -race -count=1` green.

Out of scope per the issue: the Meeting Planner (S5, #398) — this slice only completes the plane rung.

Closes #397

https://claude.ai/code/session_01HsrrpUr6dLcW4G8nmV9SRN