### PR TITLE
ADR 0045 S7: Engage becomes the agreement to meet, carries the Meeting Place

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -242,7 +242,7 @@ docking, chat) are in [multiplayer.md](multiplayer.md). The keys:
 | `t` | roster | Target a player's vessel (expands to a picker when they have several in your system; `esc` backs out) |
 | `v` | roster | Spectate: fit the camera to their ghost orbit and follow it. `f` returns to your own vessel |
 | `s` | roster | Sync-warp forward to a player's time (forward only; a player behind you syncs to you) |
-| `w` | roster | Arm a rendezvous warp toward your predicted closest approach; they answer `y` on their main screen |
+| `w` | roster | Agree to a rendezvous warp with them — commits to an encounter when one's found (a planted node's own arrival, or the current course inside 4 h), otherwise arms with no plan yet; they answer `y` on their main screen |
 | `y` | flight view | Accept a rendezvous warp |
 | `/` | flight view | Cancel a rendezvous warp (either side) |
 | `h` | roster | Host: start hosting from single-player in place, or stop hosting (drops guests, keeps progress) |

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -53,10 +53,17 @@ From that roster:
 ## Rendezvous warp
 
 Closing the distance takes orbits of coasting, so warp there *together*.
-`w` on a player's roster row arms a **rendezvous warp** toward your predicted
-closest approach with them. They get a persistent prompt on their main screen
-(`y` joins), and from that moment your warps are rate-locked all the way to
-the encounter, planted burns firing en route.
+`w` on a player's roster row **agrees to meet them** — you don't need a
+predicted encounter first. If K's rendezvous nudge or the Meeting Planner
+already has a burn queued toward them, `w` commits to where it leads,
+however far out; otherwise it commits to whatever the current courses
+turn up inside the next 4 hours; and if neither finds anything, it still
+arms — a standing agreement with no plan yet. They get a persistent
+prompt on their main screen (`y` joins), and from that moment your warps
+are rate-locked. Once there's a committed encounter, warping runs the
+pair all the way to it, planted burns firing en route; the `RENDEZVOUS`
+block names the Meeting Place when one was planted (their orbit / your
+orbit / the crossing) and how many laps.
 
 Either side cancels with `/`, and only with `/`: the manual warp keys and the
 auto-warp toggle (`G` / `[»Burn]`) are inert while the coast runs (it owns the

--- a/internal/relay/cowarp_peers.go
+++ b/internal/relay/cowarp_peers.go
@@ -87,6 +87,8 @@ func CoWarpPeersFrom(w *sim.World, reports []CraftReport, handles map[string]str
 			p.ArmedTowardViewer = true
 			p.RendezvousTau = rep.RendezvousTau
 			p.RendezvousCA = rep.RendezvousCA
+			p.RendezvousMeetingPlace = rep.RendezvousMeetingPlace
+			p.RendezvousMeetingLaps = rep.RendezvousMeetingLaps
 			// Seat + published rate (ADR 0037 §2). Gated with the arm on
 			// purpose: a dead session's frozen report must not keep clamping
 			// the survivor's clock any more than it keeps their arm alive.

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -70,6 +70,16 @@ type CraftReport struct {
 	RendezvousTau    time.Time `json:"rendezvous_tau,omitempty"`
 	RendezvousCA     float64   `json:"rendezvous_ca,omitempty"` // committed predicted approach at τ (m) — the responder's adopted baseline
 
+	// RendezvousMeetingPlace / RendezvousMeetingLaps (ADR 0045 S7, #400)
+	// carry the reporter's chosen Meeting Place + lap count alongside
+	// RendezvousTau/CA, when their commit came from a planted Meeting
+	// Burn node — agreement state the accepter's chip names (and cannot
+	// change; see sim.RendezvousArm's doc comment). Empty/zero otherwise,
+	// including the whole "agreed, no plan yet" state (RendezvousTau the
+	// zero time), which by definition never had one.
+	RendezvousMeetingPlace string `json:"rendezvous_meeting_place,omitempty"`
+	RendezvousMeetingLaps  int    `json:"rendezvous_meeting_laps,omitempty"`
+
 	// RendezvousInitiator / RendezvousRate / RendezvousBurning carry the
 	// reporter's SEAT and its contribution to the pair's rate in a
 	// rendezvous agreement's terminal phase (ADR 0037 §2). The initiator

--- a/internal/relay/rendezvous_meeting_place_seam_test.go
+++ b/internal/relay/rendezvous_meeting_place_seam_test.go
@@ -1,0 +1,84 @@
+package relay
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRendezvousMeetingPlaceThroughSeam is the ADR 0045 S7 (#400)
+// acceptance test: "the accepter's chip names the Meeting Place and the
+// initiator's selection, and the accepter cannot change it." Exercises
+// the full wire path — SetRendezvousMeeting on the initiator's arm,
+// through the reporter, through CoWarpPeersFrom, into the accepter's
+// invite, and finally adopted verbatim onto the accepter's OWN arm on
+// join — mirroring TestRendezvousArmThroughSeam's shape for Tau/CA.
+func TestRendezvousMeetingPlaceThroughSeam(t *testing.T) {
+	store := NewStore()
+	wA, wB := newWorld(t), newWorld(t)
+	wB.Clock.SimTime = wA.Clock.SimTime // same subspace
+
+	const ownerA, ownerB = "SHA256:alice", "SHA256:bob"
+	handles := map[string]string{ownerB: "bob", ownerA: "alice"}
+	tau := wA.Clock.SimTime.Add(8 * time.Hour)
+	const committedCA = 5000.0
+	const place, laps = "their orbit", 5
+
+	// B Engages toward A and stamps the Meeting Place it committed from —
+	// exactly the sequence app.go's SessionCmdRendezvous handler runs
+	// (EngageRendezvousWarpAs then SetRendezvousMeeting).
+	if !wB.EngageRendezvousWarp(ownerA, "alice", tau, committedCA) {
+		t.Fatal("B failed to engage")
+	}
+	wB.SetRendezvousMeeting(place, laps)
+	NewReporter(store, ownerB).Tick(wB, time.Now())
+
+	// A adapts B's report — the Meeting Place rides alongside τ/CA.
+	peers := CoWarpPeersFrom(wA, store.Snapshot(ownerA), handles, ownerA, live(ownerB), nil)
+	if len(peers) != 1 {
+		t.Fatalf("got %d peers, want 1", len(peers))
+	}
+	if peers[0].RendezvousMeetingPlace != place {
+		t.Errorf("RendezvousMeetingPlace = %q, want %q", peers[0].RendezvousMeetingPlace, place)
+	}
+	if peers[0].RendezvousMeetingLaps != laps {
+		t.Errorf("RendezvousMeetingLaps = %d, want %d", peers[0].RendezvousMeetingLaps, laps)
+	}
+
+	// A's own invite slate carries it too (refreshRendezvousInvite reads
+	// straight off the peer set built above).
+	wA.DriveRendezvousWarp(peers)
+	inv := wA.RendezvousInvite
+	if inv == nil {
+		t.Fatal("A has no invite from B despite a live armed report")
+	}
+	if inv.MeetingPlaceLabel != place || inv.MeetingLaps != laps {
+		t.Errorf("invite Meeting Place = %q/%d, want %q/%d", inv.MeetingPlaceLabel, inv.MeetingLaps, place, laps)
+	}
+
+	// A joins, adopting the Meeting Place verbatim (mirrors app.go's [y]
+	// handler: EngageRendezvousWarpAs then SetRendezvousMeeting(inv...)).
+	if !wA.EngageRendezvousWarpAs(inv.Owner, inv.Handle, inv.Tau, inv.CA, false) {
+		t.Fatal("A failed to join")
+	}
+	wA.SetRendezvousMeeting(inv.MeetingPlaceLabel, inv.MeetingLaps)
+	if wA.RendezvousArm.MeetingPlaceLabel != place || wA.RendezvousArm.MeetingLaps != laps {
+		t.Errorf("A's arm Meeting Place = %q/%d after join, want %q/%d",
+			wA.RendezvousArm.MeetingPlaceLabel, wA.RendezvousArm.MeetingLaps, place, laps)
+	}
+
+	// "The accepter cannot change it": nothing in the picker/planner path
+	// (PlanMeetingBurn, PlanRendezvousNudge) ever touches RendezvousArm —
+	// only SetRendezvousMeeting does, and A's only call to it was the join
+	// above. Simulate A independently running their own Meeting Planner
+	// (as a copilot idly exploring the tool) and confirm the arm's Place
+	// is untouched by it.
+	if _, err := wA.PlanMeetingBurn(0 /* MeetingCrossing */, 2); err == nil {
+		// Whether or not this particular plan succeeds on A's fixture
+		// geometry is irrelevant to the property under test.
+		_ = err
+	}
+	if wA.RendezvousArm.MeetingPlaceLabel != place || wA.RendezvousArm.MeetingLaps != laps {
+		t.Errorf("A's arm Meeting Place changed after A ran the Meeting Planner locally: got %q/%d, want unchanged %q/%d",
+			wA.RendezvousArm.MeetingPlaceLabel, wA.RendezvousArm.MeetingLaps, place, laps)
+	}
+}

--- a/internal/relay/reporter.go
+++ b/internal/relay/reporter.go
@@ -41,12 +41,20 @@ type Reporter struct {
 	lastWall     time.Time
 	lastKeys     []craftKey
 	lastEffWarp  float64
-	lastRzTarget string    // last-reported Rendezvous Warp target (v0.29 S1) — a change forces a report
-	lastRzTau    time.Time // last-reported committed τ — a re-commit toward the SAME partner must also propagate promptly (v0.29 review)
-	lastPaused   bool      // last-reported pause state — the partner's hold-the-leader keys on it (v0.29 review)
-	lastRzRate   float64   // last-reported seat rate (ADR 0037 §2) — the partner clamps to it, so a change must not wait for the heartbeat
-	lastRzSeat   bool      // last-reported initiator seat — cheap, and a re-arm can flip it
-	lastActiveID uint64    // last-reported active craft (#288) — a switch moves no orbit, so nothing else would trigger a report
+	lastRzTarget string // last-reported Rendezvous Warp target (v0.29 S1) — a change forces a report
+	// lastRzTau is the last-reported committed τ — a re-commit toward the
+	// SAME partner must also propagate promptly (v0.29 review).
+	lastRzTau time.Time
+	// lastRzMeetingPlace is the last-reported Meeting Place label (ADR
+	// 0045 S7, #400) — a plant-then-re-Engage that happens to land the
+	// SAME τ (unlikely, but not provably impossible: two different
+	// Meeting Places can coincide on arrival time) must still propagate
+	// promptly, not wait for the heartbeat.
+	lastRzMeetingPlace string
+	lastPaused         bool    // last-reported pause state — the partner's hold-the-leader keys on it (v0.29 review)
+	lastRzRate         float64 // last-reported seat rate (ADR 0037 §2) — the partner clamps to it, so a change must not wait for the heartbeat
+	lastRzSeat         bool    // last-reported initiator seat — cheap, and a re-arm can flip it
+	lastActiveID       uint64  // last-reported active craft (#288) — a switch moves no orbit, so nothing else would trigger a report
 }
 
 // effWarpRelTol is the relative change in Effective warp that forces a
@@ -85,10 +93,14 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 	var rzTarget string
 	var rzTau time.Time
 	var rzCA float64
+	var rzMeetingPlace string
+	var rzMeetingLaps int
 	if w.RendezvousArm != nil {
 		rzTarget = w.RendezvousArm.TargetOwner
 		rzTau = w.RendezvousArm.Tau
 		rzCA = w.RendezvousArm.CommittedCA
+		rzMeetingPlace = w.RendezvousArm.MeetingPlaceLabel
+		rzMeetingLaps = w.RendezvousArm.MeetingLaps
 	}
 	// Seat + rate (ADR 0037 §2): in the terminal phase the partner's clock
 	// is a function of this number, so it has to travel as promptly as the
@@ -110,7 +122,7 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 	due := r.lastWall.IsZero() || now.Sub(r.lastWall) >= Heartbeat ||
 		r.lastRzTarget != rzTarget || !r.lastRzTau.Equal(rzTau) || r.lastPaused != paused ||
 		r.lastActiveID != activeID ||
-		r.lastRzRate != rzRate || r.lastRzSeat != rzSeat
+		r.lastRzRate != rzRate || r.lastRzSeat != rzSeat || r.lastRzMeetingPlace != rzMeetingPlace
 	if !due && keysEqual(r.lastKeys, keys) && !effWarpChanged(r.lastEffWarp, effWarp) {
 		return
 	}
@@ -119,6 +131,7 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 	r.lastEffWarp = effWarp
 	r.lastRzTarget = rzTarget
 	r.lastRzTau = rzTau
+	r.lastRzMeetingPlace = rzMeetingPlace
 	r.lastPaused = paused
 	r.lastActiveID = activeID
 	r.lastRzRate, r.lastRzSeat = rzRate, rzSeat
@@ -131,6 +144,9 @@ func (r *Reporter) Tick(w *sim.World, now time.Time) {
 		RendezvousTarget: rzTarget,
 		RendezvousTau:    rzTau,
 		RendezvousCA:     rzCA,
+
+		RendezvousMeetingPlace: rzMeetingPlace,
+		RendezvousMeetingLaps:  rzMeetingLaps,
 
 		RendezvousInitiator: rzSeat,
 		RendezvousRate:      rzRate,

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -120,19 +120,22 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 		// See executeDueNodesFor below for the refuse-to-fire guard that
 		// makes that failure safe rather than a burn against a zero state.
 		wc.Nodes = append(wc.Nodes, Node{
-			ID:               n.ID,
-			TriggerTimeNano:  trigNano,
-			Mode:             int(n.Mode),
-			DV:               n.DV,
-			DurationNano:     int64(n.Duration),
-			PrimaryID:        n.PrimaryID,
-			Event:            int(n.Event),
-			Throttle:         n.Throttle,
-			TargetCraftID:    n.TargetCraftID,
-			PlaneChangeRad:   n.PlaneChangeRad,
-			BurnDirUnit:      vec3From(n.BurnDirUnit),
-			AdvisoryKey:      n.AdvisoryKey,
-			TargetGhostOwner: n.TargetGhostOwner,
+			ID:                n.ID,
+			TriggerTimeNano:   trigNano,
+			Mode:              int(n.Mode),
+			DV:                n.DV,
+			DurationNano:      int64(n.Duration),
+			PrimaryID:         n.PrimaryID,
+			Event:             int(n.Event),
+			Throttle:          n.Throttle,
+			TargetCraftID:     n.TargetCraftID,
+			PlaneChangeRad:    n.PlaneChangeRad,
+			BurnDirUnit:       vec3From(n.BurnDirUnit),
+			AdvisoryKey:       n.AdvisoryKey,
+			TargetGhostOwner:  n.TargetGhostOwner,
+			MeetingArrivalSec: n.MeetingArrivalSec,
+			MeetingPlaceLabel: n.MeetingPlaceLabel,
+			MeetingLaps:       n.MeetingLaps,
 		})
 	}
 	if c.ActiveBurn != nil {
@@ -351,19 +354,22 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			trig = time.Unix(0, n.TriggerTimeNano).UTC()
 		}
 		c.Nodes = append(c.Nodes, sim.ManeuverNode{
-			ID:               n.ID,
-			TriggerTime:      trig,
-			Mode:             spacecraft.BurnMode(n.Mode),
-			DV:               n.DV,
-			Duration:         time.Duration(n.DurationNano),
-			PrimaryID:        n.PrimaryID,
-			Event:            sim.TriggerEvent(n.Event),
-			Throttle:         n.Throttle,
-			TargetCraftID:    n.TargetCraftID,
-			PlaneChangeRad:   n.PlaneChangeRad,
-			BurnDirUnit:      vec3To(n.BurnDirUnit),
-			AdvisoryKey:      n.AdvisoryKey,
-			TargetGhostOwner: n.TargetGhostOwner, // #294 review finding 5
+			ID:                n.ID,
+			TriggerTime:       trig,
+			Mode:              spacecraft.BurnMode(n.Mode),
+			DV:                n.DV,
+			Duration:          time.Duration(n.DurationNano),
+			PrimaryID:         n.PrimaryID,
+			Event:             sim.TriggerEvent(n.Event),
+			Throttle:          n.Throttle,
+			TargetCraftID:     n.TargetCraftID,
+			PlaneChangeRad:    n.PlaneChangeRad,
+			BurnDirUnit:       vec3To(n.BurnDirUnit),
+			AdvisoryKey:       n.AdvisoryKey,
+			TargetGhostOwner:  n.TargetGhostOwner, // #294 review finding 5
+			MeetingArrivalSec: n.MeetingArrivalSec,
+			MeetingPlaceLabel: n.MeetingPlaceLabel,
+			MeetingLaps:       n.MeetingLaps,
 		})
 	}
 	if wc.ActiveBurn != nil {

--- a/internal/save/meeting_burn_fields_test.go
+++ b/internal/save/meeting_burn_fields_test.go
@@ -1,0 +1,72 @@
+package save_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestRoundtripMeetingBurnFields (ADR 0045 S7, #400) — a planted Meeting
+// Burn node's MeetingArrivalSec / MeetingPlaceLabel / MeetingLaps must
+// survive a save/load round-trip so a reloaded save's node still carries
+// what RendezvousCommitWithPlan needs to commit to its arrival directly.
+// Additive zero-value-omitempty, same precedent as AdvisoryKey
+// (TestRoundtripAdvisoryKey) and BurnDirUnit: no schema bump — an
+// ordinary node with none of these set round-trips as the zero value,
+// and save.SchemaVersion is asserted unchanged from the value this test
+// was written against (10) so a bump elsewhere doesn't silently make
+// this test's own claim stale.
+func TestRoundtripMeetingBurnFields(t *testing.T) {
+	if save.SchemaVersion != 10 {
+		t.Fatalf("save.SchemaVersion = %d, want 10 — ADR 0045 S7 (#400) claims no schema bump was needed; if one landed since, update this pin and confirm the claim still holds", save.SchemaVersion)
+	}
+
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	base := w.Clock.SimTime
+	w.ActiveCraft().Nodes = []sim.ManeuverNode{
+		{
+			TriggerTime:       base.Add(time.Minute),
+			DV:                10,
+			Mode:              spacecraft.BurnVector,
+			AdvisoryKey:       "meeting-burn",
+			MeetingArrivalSec: 8 * 3600,
+			MeetingPlaceLabel: "their orbit",
+			MeetingLaps:       5,
+		},
+		{TriggerTime: base.Add(2 * time.Minute), DV: 20, Mode: spacecraft.BurnPrograde},
+	}
+	w.EnsureNodeIDs()
+
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := save.Save(w, path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := save.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	nodes := got.ActiveCraft().Nodes
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].MeetingArrivalSec != 8*3600 {
+		t.Errorf("MeetingArrivalSec lost in round-trip: got %v, want %v", nodes[0].MeetingArrivalSec, 8*3600)
+	}
+	if nodes[0].MeetingPlaceLabel != "their orbit" {
+		t.Errorf("MeetingPlaceLabel lost in round-trip: got %q, want %q", nodes[0].MeetingPlaceLabel, "their orbit")
+	}
+	if nodes[0].MeetingLaps != 5 {
+		t.Errorf("MeetingLaps lost in round-trip: got %d, want %d", nodes[0].MeetingLaps, 5)
+	}
+	if nodes[1].MeetingArrivalSec != 0 || nodes[1].MeetingPlaceLabel != "" || nodes[1].MeetingLaps != 0 {
+		t.Errorf("ordinary node picked up non-zero Meeting Burn fields after round-trip: %+v", nodes[1])
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -385,6 +385,17 @@ type Node struct {
 	// harmless on every save predating this field (a local-craft or
 	// untargeted node's TargetGhostOwner was always "").
 	TargetGhostOwner string `json:"target_ghost_owner,omitempty"`
+	// MeetingArrivalSec / MeetingPlaceLabel / MeetingLaps (ADR 0045 S7,
+	// #400, additive omitempty) mirror spacecraft.ManeuverNode's fields of
+	// the same name — the Meeting Planner plan a planted Meeting Burn
+	// node carries, so a reloaded save's node still lets Engage commit to
+	// the plan's own arrival (RendezvousCommitWithPlan's Source 2)
+	// instead of losing it. Absent → the zero value, correct for every
+	// node type that predates this field (including every non-Meeting-
+	// Burn node). No migration.
+	MeetingArrivalSec float64 `json:"meeting_arrival_sec,omitempty"`
+	MeetingPlaceLabel string  `json:"meeting_place_label,omitempty"`
+	MeetingLaps       int     `json:"meeting_laps,omitempty"`
 }
 
 // DockedComponent mirrors spacecraft.DockedComponent. v0.8.3+.

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -175,8 +175,16 @@ func (w *World) EngageRendezvousWarp(partner, handle string, tau time.Time, comm
 // plain EngageRendezvousWarp wrapper above does. Roles are fixed here, at
 // invite time, and relayed, so neither side can drift into disagreeing
 // about who flies the clock.
+//
+// ADR 0045 S7 (#400): a zero tau (time.Time{}) is now accepted — the
+// "agreed, no plan yet" state (see RendezvousUnplanned) — and skips the
+// forward-only gate entirely; only a NON-zero tau still has to clear it.
+// A real, once-committed tau can never legitimately be the zero time (the
+// sim clock starts at J2000, millennia after year 1), so the two cases
+// can't collide. This is additive: every existing caller already passes
+// a real future tau and sees no behavioural change.
 func (w *World) EngageRendezvousWarpAs(partner, handle string, tau time.Time, committedCA float64, initiator bool) bool {
-	if !tau.After(w.Clock.SimTime) {
+	if !tau.IsZero() && !tau.After(w.Clock.SimTime) {
 		return false
 	}
 	// The acting craft is captured here for the same reason the handle is
@@ -194,6 +202,25 @@ func (w *World) EngageRendezvousWarpAs(partner, handle string, tau time.Time, co
 		BrakeIdx:  rendezvousFollowing,
 	}
 	return true
+}
+
+// SetRendezvousMeeting stamps the Meeting Place + lap count onto the
+// CURRENT arm (ADR 0045 S7, #400): called right after a successful
+// EngageRendezvousWarpAs when the commit's source was a planted Meeting
+// Burn node (RendezvousCommitWithPlan's Source 2, or the invite's own
+// carried fields on the accepter's join), so the initiator's choice
+// becomes visible agreement state on both sides' RENDEZVOUS chip. A
+// separate call rather than extra EngageRendezvousWarpAs parameters —
+// that function's 5-argument signature has dozens of existing call
+// sites (production and test) that pass no Meeting Place at all; this
+// keeps it additive. No-op when there is no live arm (defensive; both
+// call sites always Engage first in the same sequence).
+func (w *World) SetRendezvousMeeting(placeLabel string, laps int) {
+	if w.RendezvousArm == nil {
+		return
+	}
+	w.RendezvousArm.MeetingPlaceLabel = placeLabel
+	w.RendezvousArm.MeetingLaps = laps
 }
 
 // rendezvousFollowing is RendezvousArm.BrakeIdx's "no brake" value — the
@@ -236,6 +263,24 @@ func (w *World) rendezvousApproachPhase() bool {
 // semantics both fork on it.
 func (w *World) RendezvousApproachPhase() bool { return w.rendezvousApproachPhase() }
 
+// rendezvousUnplanned reports whether the standing agreement has no
+// committed encounter yet (ADR 0045 S7, #400): Engaged, but at commit
+// time neither a planted node nor the 4h current-course search found
+// anything (RendezvousCommitWithPlan's zero-Tau result) — "we are going
+// to meet", agreed, with nothing to chase. Distinct from
+// rendezvousApproachPhase: that state is a DEMOTION from a real coast;
+// this one never had a coast to demote from, and Approach is never set
+// for it.
+func (w *World) rendezvousUnplanned() bool {
+	arm := w.RendezvousArm
+	return arm != nil && !arm.Approach && arm.Tau.IsZero()
+}
+
+// RendezvousUnplanned is the exported form for the tui — the RENDEZVOUS
+// chip's fifth state forks on it, ahead of RendezvousApproachPhase /
+// RendezvousWarpEngaged in the switch (buildRendezvousChip).
+func (w *World) RendezvousUnplanned() bool { return w.rendezvousUnplanned() }
+
 // rendezvousRateGoverned reports whether the agreement itself is setting
 // the pair's rate — the shared coast pre-τ (τ-derived on both sides) or
 // the initiator's clock in the terminal phase (ADR 0037 §2). Either way
@@ -267,8 +312,15 @@ type RendezvousInvite struct {
 	Owner     string    // partner fingerprint — EngageRendezvousWarp's target on respond
 	Handle    string    // display name for the prompt/chip
 	CraftName string    // the vessel the initiator armed (#295) — empty when their report carries no marker
-	Tau       time.Time // the initiator's committed encounter sim-time
+	Tau       time.Time // the initiator's committed encounter sim-time — zero means the initiator Engaged with no plan yet (ADR 0045 S7, #400)
 	CA        float64   // m — the initiator's committed predicted approach
+
+	// MeetingPlaceLabel / MeetingLaps (ADR 0045 S7, #400) carry the
+	// initiator's chosen Meeting Place alongside Tau/CA, when their
+	// commit came from a planted Meeting Burn node. Empty when it didn't
+	// — including whenever Tau is zero, which by definition never had one.
+	MeetingPlaceLabel string
+	MeetingLaps       int
 
 	// Blocked marks an invite from a subspace-diverged peer (#250): the
 	// intent is live, but the coast could never start across the gap, so
@@ -284,10 +336,12 @@ type RendezvousInvite struct {
 
 // refreshRendezvousInvite rebuilds the invite slate from this tick's
 // peer set (v0.29 S2). At most one invite surfaces: the first armed
-// peer with a still-future τ, and only while the viewer has no outgoing
-// arm — once mutually armed (or armed elsewhere) there is nothing to
-// respond to. A past-τ arm is dropped here rather than surfaced, since
-// Engage would refuse it (forward-only).
+// peer with a still-future τ (or ADR 0045 S7/#400: a zero τ — "agreed,
+// no plan yet" never expires this way, see the IsZero exemption below),
+// and only while the viewer has no outgoing arm — once mutually armed
+// (or armed elsewhere) there is nothing to respond to. A past-τ arm is
+// dropped here rather than surfaced, since Engage would refuse it
+// (forward-only).
 //
 // A subspace-diverged peer's arm is kept but Blocked (#250) rather than
 // dropped: Engage would succeed yet the coast could never start, so the
@@ -302,13 +356,14 @@ func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 	var blocked *RendezvousInvite
 	for i := range peers {
 		p := &peers[i]
-		if !p.ArmedTowardViewer || !p.RendezvousTau.After(w.Clock.SimTime) {
+		if !p.ArmedTowardViewer || (!p.RendezvousTau.IsZero() && !p.RendezvousTau.After(w.Clock.SimTime)) {
 			continue
 		}
 		if sameSubspace(w.Clock.SimTime, p.SubspaceTime) {
 			w.RendezvousInvite = &RendezvousInvite{
 				Owner: p.Owner, Handle: p.Handle, CraftName: p.ActiveCraftName,
 				Tau: p.RendezvousTau, CA: p.RendezvousCA,
+				MeetingPlaceLabel: p.RendezvousMeetingPlace, MeetingLaps: p.RendezvousMeetingLaps,
 			}
 			return
 		}
@@ -316,6 +371,7 @@ func (w *World) refreshRendezvousInvite(peers []CoWarpPeer) {
 			blocked = &RendezvousInvite{
 				Owner: p.Owner, Handle: p.Handle, CraftName: p.ActiveCraftName,
 				Tau: p.RendezvousTau, CA: p.RendezvousCA,
+				MeetingPlaceLabel: p.RendezvousMeetingPlace, MeetingLaps: p.RendezvousMeetingLaps,
 				Blocked: true, AheadBy: w.Clock.SimTime.Sub(p.SubspaceTime),
 			}
 		}
@@ -447,8 +503,12 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	// so holding it would freeze the state machine (stuck "waiting" chip,
 	// all future invites suppressed). A DEMOTED arm is exempt (ADR 0037 §1):
 	// its τ is deliberately in the past — the handoff happened there — and
-	// the terminal phase it now stands for has no time bound at all.
-	if !w.rendezvousWarpEngaged() && !arm.Approach && !arm.Tau.After(w.Clock.SimTime) {
+	// the terminal phase it now stands for has no time bound at all. An
+	// UNPLANNED arm is exempt too (ADR 0045 S7, #400): its zero Tau is
+	// never "After" anything, so without this it would expire on the very
+	// next tick after Engage — the whole point of the "agreed, no plan
+	// yet" state is that it has no time bound either, same as Approach.
+	if !w.rendezvousWarpEngaged() && !arm.Approach && !arm.Tau.IsZero() && !arm.Tau.After(w.Clock.SimTime) {
 		w.RendezvousArm = nil
 		return
 	}
@@ -497,6 +557,14 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	// mirroring after that return would blank the away line in precisely
 	// its motivating scenario (#253).
 	w.RendezvousPartnerAway = partner != nil && partner.Away
+	// Mutual-but-unplanned (ADR 0045 S7, #400): the RENDEZVOUS chip's
+	// unplanned state needs to tell "agreed, still waiting for them to
+	// join back" from "mutual, holding for a plan" apart — refreshRendezvous-
+	// Wait can't answer that here (its own catch-all always reports
+	// RendezvousWaitPartner while no coast is running, mutual or not; see
+	// its doc comment), so this is derived fresh from the SAME partner
+	// match just above rather than overloading that classifier.
+	w.RendezvousMutualUnplanned = arm.Tau.IsZero() && partner != nil
 	// Terminal phase (ADR 0037 §1): the agreement is demoted, not ended —
 	// no driver, no waypoints, no τ. All that is left to drive is its
 	// lifetime (retract / dropout grace) and the leader hold that keeps the
@@ -573,6 +641,20 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 			return
 		}
 		if !sameSubspace(w.Clock.SimTime, partner.SubspaceTime) {
+			return
+		}
+		if arm.Tau.IsZero() {
+			// ADR 0045 S7 (#400): mutual, but no committed encounter yet —
+			// there is nothing for the driver to chase. The pair is still
+			// coupled (ComputeCoWarp's `armed` branch couples on the arm
+			// alone, unconditional on Tau) and rides ordinary min-wins
+			// until a plan lands and Engage is pressed again (see
+			// EngageRendezvousWarpAs's "replaces any prior arm" doc — a
+			// planted Meeting Burn plus a fresh Engage promotes the arm out
+			// of this state). Deliberately narrower than ADR 0037 §2's
+			// full seat-governed "initiator flies the clock" for the
+			// planned/terminal phase — a documented scope decision for
+			// #400, not an oversight; see the PR description.
 			return
 		}
 		handle := partner.Handle

--- a/internal/sim/cowarp.go
+++ b/internal/sim/cowarp.go
@@ -216,6 +216,14 @@ type CoWarpPeer struct {
 	// authoritative baseline, not its own staler recompute (v0.29 S1).
 	RendezvousCA float64
 
+	// RendezvousMeetingPlace / RendezvousMeetingLaps (ADR 0045 S7, #400)
+	// carry the peer's chosen Meeting Place + lap count alongside
+	// RendezvousTau/CA, when their commit came from a planted Meeting
+	// Burn node. Empty/zero otherwise — including the whole "agreed, no
+	// plan yet" state, which has no Place to carry.
+	RendezvousMeetingPlace string
+	RendezvousMeetingLaps  int
+
 	// RendezvousInitiator is this peer's SEAT in the mutual agreement (ADR
 	// 0037 §2) — true when they proposed the rendezvous and therefore fly
 	// the pair's clock through the terminal phase. Meaningful only
@@ -280,8 +288,23 @@ type RendezvousArm struct {
 	TargetOwner string    // fingerprint of the partner Engaged toward
 	Handle      string    // partner display name, captured at Engage (chips/HUD never fall back to a raw fingerprint)
 	CraftName   string    // the vessel that armed — captured at Engage (#295), so a wrong-vessel arm is visible from the arming seat
-	Tau         time.Time // the current waypoint's absolute encounter sim-time
+	Tau         time.Time // the current waypoint's absolute encounter sim-time — zero means "agreed, no plan yet" (ADR 0045 S7, #400): see RendezvousUnplanned.
 	CommittedCA float64   // m — the predicted approach at Tau, re-derived per waypoint (HUD "committed" row)
+
+	// MeetingPlaceLabel / MeetingLaps (ADR 0045 S7, #400) name the
+	// initiator's chosen Meeting Place + lap count when Tau was committed
+	// from a planted Meeting Burn node (RendezvousCommitWithPlan's Source
+	// 2) — agreement state, carried onto the wire (relay.CraftReport /
+	// CoWarpPeer) and adopted verbatim by the accepter via
+	// SetRendezvousMeeting, exactly like Tau/CommittedCA. Empty when the
+	// commit's source was the trim-rung nudge or the current-course
+	// search — neither has a Place to name — including the whole
+	// "agreed, no plan yet" state (Tau.IsZero()), which by definition
+	// never had a Source 2 commit. The accepter has no code path that
+	// writes these fields — PlanMeetingBurn never touches RendezvousArm —
+	// so once set, only a fresh Engage (initiator side) can change them.
+	MeetingPlaceLabel string
+	MeetingLaps       int
 
 	// Initiator is this side's SEAT in the agreement (ADR 0037 §2), fixed
 	// at invite time: the player who proposed the rendezvous is

--- a/internal/sim/meeting.go
+++ b/internal/sim/meeting.go
@@ -202,18 +202,36 @@ func (w *World) PlanMeetingBurn(place planner.MeetingPlace, laps int) (*MeetingP
 	// would fire against an orbit it was never computed for.
 	w.replaceAdvisoryNode(active, AdvisoryKeyMeetingBurn)
 
+	// ADR 0045 S7 (#400): carry the plan's own arrival onto the node so a
+	// later Engage can commit to it directly (see ManeuverNode's own doc
+	// comment). row.TArrival is measured from PLANT time (now); the node
+	// actually fires leadBuffer later, so the offset stored is
+	// re-anchored to TriggerTime. A row whose TArrival doesn't clear the
+	// lead buffer (never expected off meetingCandidateLaps' shortest lap,
+	// but not proven impossible) leaves MeetingArrivalSec at its zero
+	// value — rendezvousCommitFromPlantedMeetingNode treats that as "no
+	// plan info", falling back to the current-course search exactly like
+	// a node that predates this field.
+	var arrivalSec float64
+	if a := row.TArrival - leadBuffer.Seconds(); a > 0 {
+		arrivalSec = a
+	}
+
 	node := ManeuverNode{
-		Mode:             spacecraft.BurnVector,
-		DV:               row.DV,
-		Duration:         active.BurnTimeForDV(row.DV),
-		Event:            spacecraft.TriggerAbsolute,
-		TriggerTime:      w.Clock.SimTime.Add(leadBuffer),
-		PrimaryID:        active.Primary.ID,
-		Throttle:         1.0,
-		TargetCraftID:    w.Target.CraftID,
-		TargetGhostOwner: w.Target.GhostOwner,
-		AdvisoryKey:      AdvisoryKeyMeetingBurn,
-		BurnDirUnit:      row.BurnDir,
+		Mode:              spacecraft.BurnVector,
+		DV:                row.DV,
+		Duration:          active.BurnTimeForDV(row.DV),
+		Event:             spacecraft.TriggerAbsolute,
+		TriggerTime:       w.Clock.SimTime.Add(leadBuffer),
+		PrimaryID:         active.Primary.ID,
+		Throttle:          1.0,
+		TargetCraftID:     w.Target.CraftID,
+		TargetGhostOwner:  w.Target.GhostOwner,
+		AdvisoryKey:       AdvisoryKeyMeetingBurn,
+		BurnDirUnit:       row.BurnDir,
+		MeetingArrivalSec: arrivalSec,
+		MeetingPlaceLabel: place.String(),
+		MeetingLaps:       laps,
 	}
 	w.PlanNode(node)
 	return &MeetingPlan{MeetingBurnOption: row, ForActive: true}, nil

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -260,10 +260,64 @@ func (w *World) RendezvousNeedsBurnToClose(ca float64) bool {
 	return ca >= rendezvousGapNoteBar
 }
 
-func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
+// RendezvousPlan is RendezvousCommitWithPlan's result (ADR 0045 S7,
+// #400): everything Engage needs to form the agreement — the same τ/CA
+// RendezvousCommit returns, plus the Meeting Place + lap count when the
+// commit's source was a planted Meeting Burn node. MeetingPlaceLabel is
+// "" whenever the source was the trim-rung nudge or the current-course
+// search — neither has a Place to name. A zero Tau (Tau.IsZero()) means
+// "agreed, no plan yet": Engage no longer refuses on this (see
+// RendezvousCommitWithPlan's doc comment) — it commits the agreement
+// with nothing to chase.
+type RendezvousPlan struct {
+	Tau               time.Time
+	CommittedCA       float64
+	MeetingPlaceLabel string
+	MeetingLaps       int
+}
+
+// RendezvousCommitWithPlan is RendezvousCommit's meeting-aware sibling
+// (ADR 0045 S7, #400): the SAME structural gates and the SAME two
+// (now three) search sources, but it never refuses on "no encounter
+// found" — only on a genuinely structural failure (no active craft, no
+// resolvable relative target, cross-primary). ok=false means Engage
+// itself has nothing to act on at all; ok=true with a zero-Tau Plan means
+// the agreement forms with no committed encounter — neither a planted
+// node nor the 4h current-course search found one — which used to be
+// Engage's outright refusal ("no closable encounter... plant a nudge [K]
+// first") and is now the "agreed, no plan yet" state instead: the whole
+// point of this slice is that Engage stops meaning "we found an
+// encounter" and starts meaning "we are going to meet".
+//
+// Kept alongside RendezvousCommit (which now just delegates here and
+// folds a zero-Tau Plan back into its own ok=false) rather than replacing
+// it — changing RendezvousCommit's 3-value signature would touch every
+// existing call site for no behavioural gain outside Engage itself.
+//
+// Three sources, tried in this order:
+//
+//  1. A PLANTED rendezvous nudge (K's trim rung) — unchanged from
+//     RendezvousCommit's old Source 1, see rendezvousCommitFromPlantedNode.
+//  2. A PLANTED Meeting Burn node (K's meeting rung / the picker's Enter,
+//     PlanMeetingBurn) — new in this slice. Tried second, after the trim
+//     rung: the two AdvisoryKeys never collide (K plants exactly one of
+//     them per press, PlanRendezvousOrOpenMeeting's whole point), so in
+//     practice at most one of Source 1/2 ever has anything to find: this
+//     ordering is precedence for the rare case both somehow exist, not a
+//     load-bearing choice. See rendezvousCommitFromPlantedMeetingNode for
+//     why this source does NOT re-search within the 4h horizon the way
+//     Source 1 does.
+//  3. The current-course fallback (no burn assumed) — unchanged from
+//     RendezvousCommit's old Source 2, see rendezvousCommitCurrentCourse.
+//     Still bounded by rendezvousCommitHorizonSec: this is a SEARCH, not
+//     a plan.
+//
+// ok=true with a zero Tau when none of the three sources found anything —
+// the agreed-no-plan state.
+func (w *World) RendezvousCommitWithPlan() (RendezvousPlan, bool) {
 	active := w.ActiveCraft()
 	if active == nil || !w.HasRelativeTarget() {
-		return time.Time{}, 0, false
+		return RendezvousPlan{}, false
 	}
 	// Shared-primary gate (#261): the fallback below Kepler-propagates the
 	// target's state around the ACTIVE craft's primary. For a target
@@ -277,11 +331,11 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	// search and, when that too is empty, to idle-and-retry with the
 	// degrade warning up (armedPartnerLacksLocalCraft).
 	if primary, pok := w.rendezvousTargetPrimary(); !pok || primary.ID != active.Primary.ID {
-		return time.Time{}, 0, false
+		return RendezvousPlan{}, false
 	}
 	rT, vT, rok := w.TargetStateRelativeToActivePrimary()
 	if !rok {
-		return time.Time{}, 0, false
+		return RendezvousPlan{}, false
 	}
 	mu := active.Primary.GravitationalParameter()
 
@@ -297,12 +351,51 @@ func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
 	// planted one wins.
 	if node, nok := plantedAdvisoryNode(active, AdvisoryKeyRendezvousNudge, w.Target.CraftID, w.Target.GhostOwner); nok {
 		if t, c, cok := w.rendezvousCommitFromPlantedNode(active, node, rT, vT, mu); cok {
-			return t, c, true
+			return RendezvousPlan{Tau: t, CommittedCA: c}, true
 		}
 	}
 
-	// Source 2: the current-course fallback (no burn assumed).
-	return w.rendezvousCommitCurrentCourse(active, rT, vT, mu)
+	// Source 2: a planted Meeting Burn node (ADR 0045 S7, #400).
+	if node, nok := plantedAdvisoryNode(active, AdvisoryKeyMeetingBurn, w.Target.CraftID, w.Target.GhostOwner); nok {
+		if t, c, cok := w.rendezvousCommitFromPlantedMeetingNode(active, node, rT, vT, mu); cok {
+			return RendezvousPlan{
+				Tau: t, CommittedCA: c,
+				MeetingPlaceLabel: node.MeetingPlaceLabel,
+				MeetingLaps:       node.MeetingLaps,
+			}, true
+		}
+	}
+
+	// Source 3: the current-course fallback (no burn assumed). Its own
+	// ok=false is no longer Engage's refusal — it's the agreed-no-plan
+	// state (zero-value Plan), still reported as RendezvousCommitWithPlan
+	// ok=true since every structural gate above already passed.
+	if t, c, cok := w.rendezvousCommitCurrentCourse(active, rT, vT, mu); cok {
+		return RendezvousPlan{Tau: t, CommittedCA: c}, true
+	}
+	return RendezvousPlan{}, true
+}
+
+// RendezvousCommit returns the encounter the initiator commits a
+// Rendezvous Warp to (v0.29 S2, ADR 0034 v0.29 addendum): the absolute
+// τ and its predicted approach against the current relative target.
+// ok=false when no encounter can be found at all: no relative target,
+// cross-primary, or no approach inside the horizon.
+//
+// ADR 0045 S7 (#400): this signature and its "nothing found ⇒ ok=false"
+// behaviour are UNCHANGED — every pre-existing caller keeps working
+// exactly as before. Delegates to RendezvousCommitWithPlan above, which
+// folds a zero-Tau Plan (the new "agreed, no plan yet" outcome) back into
+// ok=false here. Engage itself (app.go's SessionCmdRendezvous handling)
+// calls RendezvousCommitWithPlan directly, since it now DOES act on the
+// zero-Tau case instead of refusing — see that function's doc comment
+// for the full source list and the behavioural change.
+func (w *World) RendezvousCommit() (tau time.Time, ca float64, ok bool) {
+	plan, pok := w.RendezvousCommitWithPlan()
+	if !pok || plan.Tau.IsZero() {
+		return time.Time{}, 0, false
+	}
+	return plan.Tau, plan.CommittedCA, true
 }
 
 // rendezvousCommitCurrentCourse searches for a closest approach on the
@@ -373,6 +466,56 @@ func (w *World) rendezvousCommitFromPlantedNode(active *spacecraft.Spacecraft, n
 		return time.Time{}, 0, false
 	}
 	return node.TriggerTime.Add(time.Duration(tCA * float64(time.Second))), distCA, true
+}
+
+// rendezvousCommitFromPlantedMeetingNode computes the encounter a planted
+// Meeting Burn node (AdvisoryKeyMeetingBurn) actually leads to — the
+// meeting-aware sibling of rendezvousCommitFromPlantedNode just above,
+// called only from RendezvousCommitWithPlan's Source 2 (ADR 0045 S7,
+// #400). Shares its sibling's first two steps (Kepler-propagate the
+// target's current relative state to the node's TriggerTime, then apply
+// the node's burn against that same propagated snapshot via
+// postBurnStateWithTarget) but then DIVERGES: instead of running
+// NextClosestApproach over rendezvousCommitHorizonSec, it propagates BOTH
+// the post-burn mover and the (unburned) holder straight to
+// node.MeetingArrivalSec past TriggerTime — no SEARCH. The Meeting
+// Planner's tangential solve (planner.meetingLadderCore) already aimed
+// this exact burn at this exact instant; re-searching within the 4h
+// window the way the trim-rung sibling does would miss any wait longer
+// than that window entirely, which is the ordinary case for more than a
+// couple of laps (ADR 0045 §5 — "the 4h window bounds a search, not a
+// plan").
+//
+// ok=false for the same reasons as the sibling (past-due node, a
+// degenerate Kepler step, an SOI crossing before the burn fires, an
+// unresolvable direction), plus a node with no MeetingArrivalSec — either
+// a non-Meeting-Burn node reaching this by construction error, or one
+// whose row.TArrival didn't clear the lead buffer at plant time (see
+// PlanMeetingBurn) — treated as "no plan info", not zero wait.
+func (w *World) rendezvousCommitFromPlantedMeetingNode(active *spacecraft.Spacecraft, node spacecraft.ManeuverNode, rT, vT orbital.Vec3, mu float64) (time.Time, float64, bool) {
+	if node.MeetingArrivalSec <= 0 {
+		return time.Time{}, 0, false
+	}
+	dt := node.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	if dt <= 0 {
+		return time.Time{}, 0, false
+	}
+	targetState, tok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
+	if !tok {
+		return time.Time{}, 0, false
+	}
+	postState, primaryID, pok := w.postBurnStateWithTarget(node, targetState.R, targetState.V)
+	if !pok || primaryID != active.Primary.ID {
+		return time.Time{}, 0, false
+	}
+	moverArr, mok := physics.KeplerStep(postState, mu, node.MeetingArrivalSec)
+	holderArr, hok := physics.KeplerStep(targetState, mu, node.MeetingArrivalSec)
+	if !mok || !hok {
+		return time.Time{}, 0, false
+	}
+	arrival := node.TriggerTime.Add(time.Duration(node.MeetingArrivalSec * float64(time.Second)))
+	dist := moverArr.R.Sub(holderArr.R).Norm()
+	return arrival, dist, true
 }
 
 // rendezvousWaypointMinLead is the minimum forward distance a newly

--- a/internal/sim/rendezvous_meeting_commit_test.go
+++ b/internal/sim/rendezvous_meeting_commit_test.go
@@ -1,0 +1,222 @@
+package sim
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// ADR 0045 S7 (#400) acceptance tests: Engage becomes the agreement to
+// meet, and a planted Meeting Planner node's own arrival — however far
+// out — is what it commits to, never a re-search within the 4h window
+// that bounds the current-course fallback.
+
+// TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon is the
+// #400 acceptance test: "Engage commits to a planted Meeting Planner
+// node's arrival 8h out." Plants a real Meeting Burn via PlanMeetingBurn
+// (so BurnDirUnit/DV/TriggerTime all come from the actual solver), then
+// overrides the node's MeetingArrivalSec to exactly 8h — well past
+// rendezvousCommitHorizonSec (4h) — for a deterministic scenario
+// regardless of which lap row the small-lag fixture happens to solve.
+// RendezvousCommitWithPlan must commit to TriggerTime+8h directly: if it
+// instead ran rendezvousCommitFromPlantedNode's horizon-bounded search
+// (the trim-nudge sibling's behaviour), an encounter 8h out — double the
+// 4h window — could never be found, and the commit would refuse.
+func TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	ladder, err := w.RecommendMeetingLadder(planner.MeetingTheirOrbit)
+	if err != nil {
+		t.Fatalf("RecommendMeetingLadder err: %v", err)
+	}
+	var pick int
+	found := false
+	for _, row := range ladder.Rows {
+		if row.Ok {
+			pick, found = row.Laps, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one Ok row: %+v", ladder.Rows)
+	}
+	if _, err := w.PlanMeetingBurn(planner.MeetingTheirOrbit, pick); err != nil {
+		t.Fatalf("PlanMeetingBurn err: %v", err)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node, got %d", len(c.Nodes))
+	}
+
+	// Override to an 8h wait, deterministic and well past the 4h horizon
+	// regardless of what lap row the solver actually picked above.
+	const eightHours = 8 * 3600.0
+	c.Nodes[0].MeetingArrivalSec = eightHours
+	wantTau := c.Nodes[0].TriggerTime.Add(time.Duration(eightHours * float64(time.Second)))
+
+	plan, ok := w.RendezvousCommitWithPlan()
+	if !ok {
+		t.Fatal("RendezvousCommitWithPlan: ok=false, want true (structural gates all pass)")
+	}
+	if plan.Tau.IsZero() {
+		t.Fatal("plan.Tau is zero — the planted Meeting Burn node was not honored")
+	}
+	if diff := plan.Tau.Sub(wantTau); diff < -time.Second || diff > time.Second {
+		t.Errorf("plan.Tau = %v, want %v (node.TriggerTime + 8h) — got a difference of %v; "+
+			"a horizon-bounded search would have refused entirely (8h > 4h) rather than land near this", plan.Tau, wantTau, diff)
+	}
+	if plan.CommittedCA <= 0 {
+		t.Errorf("plan.CommittedCA = %.3f, want > 0", plan.CommittedCA)
+	}
+	if plan.MeetingPlaceLabel != planner.MeetingTheirOrbit.String() {
+		t.Errorf("plan.MeetingPlaceLabel = %q, want %q", plan.MeetingPlaceLabel, planner.MeetingTheirOrbit.String())
+	}
+	if plan.MeetingLaps != pick {
+		t.Errorf("plan.MeetingLaps = %d, want %d", plan.MeetingLaps, pick)
+	}
+}
+
+// TestRendezvousCommitWithPlan_MeetingNode_NoMeetingArrivalFallsThrough
+// is a companion to the test above: a node carrying AdvisoryKeyMeetingBurn
+// but no MeetingArrivalSec (the "predates this field" / "didn't clear the
+// lead buffer" case PlanMeetingBurn's own doc comment names) must not be
+// treated as a zero-wait commit — it should read as "no plan info" and
+// let RendezvousCommitWithPlan fall through to Source 3 exactly as if
+// nothing had been planted.
+func TestRendezvousCommitWithPlan_MeetingNode_NoMeetingArrivalFallsThrough(t *testing.T) {
+	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+	if _, err := w.PlanMeetingBurn(planner.MeetingTheirOrbit, ladderFirstOkLap(t, w)); err != nil {
+		t.Fatalf("PlanMeetingBurn err: %v", err)
+	}
+	c.Nodes[0].MeetingArrivalSec = 0 // simulate a pre-#400 node
+
+	// This geometry is the zero-relative-drift stalemate (rendezvousSmallLagWorld's
+	// own doc comment / TestRendezvousCommitMatchedOrbitsRefusesPhantomNudge):
+	// Source 3's current-course search finds nothing either, so falling
+	// through correctly still yields ok=true with a ZERO Tau (agreed, no
+	// plan), never a phantom commit to "now".
+	plan, ok := w.RendezvousCommitWithPlan()
+	if !ok {
+		t.Fatal("RendezvousCommitWithPlan: ok=false, want true (structural gates pass)")
+	}
+	if !plan.Tau.IsZero() {
+		t.Errorf("plan.Tau = %v, want zero — a MeetingArrivalSec<=0 node must not commit to a zero-second wait", plan.Tau)
+	}
+}
+
+// ladderFirstOkLap is a small helper: the first Ok row's lap count from a
+// MeetingTheirOrbit ladder on w, or a fatal test failure.
+func ladderFirstOkLap(t *testing.T, w *World) int {
+	t.Helper()
+	ladder, err := w.RecommendMeetingLadder(planner.MeetingTheirOrbit)
+	if err != nil {
+		t.Fatalf("RecommendMeetingLadder err: %v", err)
+	}
+	for _, row := range ladder.Rows {
+		if row.Ok {
+			return row.Laps
+		}
+	}
+	t.Fatalf("expected at least one Ok row: %+v", ladder.Rows)
+	return 0
+}
+
+// rendezvousBeyondFourHourWorld mirrors rendezvousBeyondTwoHourWorld
+// (rendezvous_horizon_test.go) but widens the phase offset so the true
+// first closest approach sits PAST rendezvousCommitHorizonSec (4h)
+// instead of merely past the old 2h K cap — the geometry
+// rendezvousCommitCurrentCourse's own horizon bound needs to be tested
+// against directly.
+func rendezvousBeyondFourHourWorld(t *testing.T) (*World, orbital.Vec3State, orbital.Vec3State) {
+	t.Helper()
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	earth := w.Systems[0].FindBody("Earth")
+	if earth == nil {
+		t.Fatal("setup: Earth missing from Sol")
+	}
+	mu := earth.GravitationalParameter()
+
+	rA := earth.RadiusMeters() + 500e3
+	vA := math.Sqrt(mu / rA)
+	a := w.Crafts[0]
+	a.Primary = *earth
+	a.State.R = orbital.Vec3{X: rA}
+	a.State.V = orbital.Vec3{Y: vA}
+
+	const phaseDeg = 80.0
+	th := phaseDeg * math.Pi / 180
+	rB := earth.RadiusMeters() + 650e3
+	vB := math.Sqrt(mu / rB)
+	b := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	b.Primary = *earth
+	b.State = physics.StateVector{
+		R: orbital.Vec3{X: rB * math.Cos(th), Y: rB * math.Sin(th)},
+		V: orbital.Vec3{X: -vB * math.Sin(th), Y: vB * math.Cos(th)},
+		M: b.TotalMass(),
+	}
+	w.Crafts = append(w.Crafts, b)
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+
+	stateA := orbital.Vec3State{R: a.State.R, V: a.State.V}
+	stateB := orbital.Vec3State{R: b.State.R, V: b.State.V}
+	return w, stateA, stateB
+}
+
+// TestRendezvousCommitCurrentCourse_BoundedToFourHours is the #400
+// acceptance test: "a test that rendezvousCommitCurrentCourse still
+// refuses beyond 4h (the search window is untouched)." Source 3 (the
+// current-course fallback) is a SEARCH restricted to
+// rendezvousCommitHorizonSec, unlike Source 2's Meeting-Planner commit
+// above, which happily committed to 8h. This scenario's TRUE first
+// closest approach — confirmed via a generous 10x horizon — sits well
+// past 4h (planner.NextClosestApproach's own documented edge-snap
+// behaviour for a still-converging window that hasn't reached its
+// minimum: it returns the WINDOW EDGE with ok=true rather than an error,
+// see rendezvous_horizon_test.go's TestRendezvousAdvisoryMatchesTargetChipHorizon
+// for the same behaviour pinned at the 2h/4h boundary). So "refuses
+// beyond 4h" is verified here as "never commits to a τ past the 4h
+// horizon", which is the load-bearing property either way the search
+// resolves: a regression that widened or removed the bound would let
+// this test's τ jump out to the TRUE ~11h encounter instead of staying
+// capped at the window edge.
+func TestRendezvousCommitCurrentCourse_BoundedToFourHours(t *testing.T) {
+	w, stateA, stateB := rendezvousBeyondFourHourWorld(t)
+	earth := w.Crafts[0].Primary
+	mu := earth.GravitationalParameter()
+
+	// Non-vacuous guard: confirm the TRUE closest approach sits well past
+	// the 4h horizon under test — a wide, generous search window (10x)
+	// stands in for "no bound at all".
+	const wideHorizonSec = 10 * rendezvousCommitHorizonSec
+	wideTCA, _, _, err := planner.NextClosestApproach(stateA, stateB, earth, mu, wideHorizonSec)
+	if err != nil {
+		t.Fatalf("setup: wide-horizon NextClosestApproach: %v", err)
+	}
+	if wideTCA <= 2*rendezvousCommitHorizonSec {
+		t.Fatalf("setup: true tCA = %.0f s, want > %.0f s (double the 4h horizon, comfortable margin) — test wouldn't stress the bound", wideTCA, 2*rendezvousCommitHorizonSec)
+	}
+
+	active := w.ActiveCraft()
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		t.Fatal("TargetStateRelativeToActivePrimary: ok=false")
+	}
+	tau, _, cok := w.rendezvousCommitCurrentCourse(active, rT, vT, mu)
+	if !cok {
+		t.Fatal("rendezvousCommitCurrentCourse: ok=false — expected the edge-snap result, not an outright refusal")
+	}
+	if got := tau.Sub(w.Clock.SimTime).Seconds(); got > rendezvousCommitHorizonSec+1 {
+		t.Errorf("committed τ is %.0f s out, want <= %.0f s (the 4h horizon) — the true encounter at %.0f s must not have been found",
+			got, rendezvousCommitHorizonSec, wideTCA)
+	}
+}

--- a/internal/sim/rendezvous_unplanned_test.go
+++ b/internal/sim/rendezvous_unplanned_test.go
@@ -1,0 +1,181 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// ADR 0045 S7 (#400): Engage becomes the agreement to meet. These tests
+// cover the "agreed, no plan yet" state — RendezvousArm with a zero Tau
+// — directly at the sim layer: it must not expire on its own (unlike a
+// real, bounded τ), it must not start an Auto-Warp coast (there is
+// nothing to chase), and it must still end on an explicit cancel from
+// either side.
+
+// TestEngageRendezvousWarpAs_ZeroTauFormsUnplannedAgreement is the #400
+// acceptance test: "Engage succeeds with no encounter inside 4h and no
+// planted node." At this layer that is EngageRendezvousWarpAs accepting
+// a zero (unset) tau — app.go's SessionCmdRendezvous handler is what
+// actually computes and passes that zero tau via RendezvousCommitWithPlan,
+// covered end-to-end by the tui-layer tests
+// (TestEngageRendezvousNoEncounterFormsUnplannedAgreement,
+// TestEngageRendezvousSmallLagFormsUnplannedAgreement).
+func TestEngageRendezvousWarpAs_ZeroTauFormsUnplannedAgreement(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage with a zero tau should succeed (agreed, no plan yet)")
+	}
+	if w.RendezvousArm == nil {
+		t.Fatal("RendezvousArm not set")
+	}
+	if !w.RendezvousArm.Tau.IsZero() {
+		t.Errorf("Tau = %v, want zero", w.RendezvousArm.Tau)
+	}
+	if !w.RendezvousUnplanned() {
+		t.Error("RendezvousUnplanned() = false, want true")
+	}
+	if w.RendezvousApproachPhase() {
+		t.Error("RendezvousApproachPhase() = true — the unplanned state must never set Approach, it never demoted from a coast")
+	}
+}
+
+// TestUnplannedAgreement_DoesNotExpireAcrossTicks: a real committed τ
+// eventually passes and the arm-expiry check drops it (v0.29 review);
+// an unplanned arm has no τ to pass and must survive indefinitely —
+// only an explicit cancel or a partner retract while mutual ends it.
+// Drives several ticks with no partner present at all (the ordinary
+// "still waiting to be joined" case) and confirms the arm survives.
+func TestUnplannedAgreement_DoesNotExpireAcrossTicks(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	for i := 0; i < 5; i++ {
+		w.Clock.SimTime = w.Clock.SimTime.Add(time.Hour)
+		w.DriveRendezvousWarp(nil)
+		if w.RendezvousArm == nil {
+			t.Fatalf("arm expired after %d hour(s) of no partner report — an unplanned arm has no time bound", i+1)
+		}
+	}
+}
+
+// TestUnplannedAgreement_MutualDoesNotStartCoast: even once the partner
+// has Engaged back (mutual), a zero-Tau arm must not start the Auto-Warp
+// driver — there is nothing to chase. The pair still couples via
+// ComputeCoWarp's `armed` branch (proven separately, see
+// TestComputeCoWarp_UnplannedMutualArmCouples), but no AutoWarp target is
+// ever created for it.
+func TestUnplannedAgreement_MutualDoesNotStartCoast(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+
+	if w.rendezvousWarpEngaged() {
+		t.Error("Auto-Warp engaged for an unplanned mutual arm — there is no τ to chase")
+	}
+	if !w.RendezvousMutualUnplanned {
+		t.Error("RendezvousMutualUnplanned = false, want true once the partner has armed back")
+	}
+	if w.RendezvousArm == nil {
+		t.Fatal("arm cleared unexpectedly")
+	}
+}
+
+// TestUnplannedAgreement_SelfCancelEnds is the #400 acceptance test's
+// self-cancel half: "a test that cancel still ends the agreement from
+// either side." DisengageRendezvousWarp (the [/] key's action on both
+// the initiator and accepter side — app.go routes both through it) must
+// clear an unplanned arm exactly like a planned one.
+func TestUnplannedAgreement_SelfCancelEnds(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	w.DisengageRendezvousWarp()
+	if w.RendezvousArm != nil {
+		t.Error("cancel did not clear an unplanned arm")
+	}
+	if w.RendezvousUnplanned() {
+		t.Error("RendezvousUnplanned() still true after cancel")
+	}
+}
+
+// TestUnplannedAgreement_AccepterSelfCancelEnds mirrors the test above
+// from the ACCEPTER's seat (initiator=false, the [y]-join path) — the
+// same [/] cancel action, the other seat.
+func TestUnplannedAgreement_AccepterSelfCancelEnds(t *testing.T) {
+	w, _, _ := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, false) {
+		t.Fatal("Engage (as accepter) should succeed")
+	}
+	if w.RendezvousArm.Initiator {
+		t.Fatal("precondition: accepter seat")
+	}
+	w.DisengageRendezvousWarp()
+	if w.RendezvousArm != nil {
+		t.Error("cancel did not clear an unplanned accepter arm")
+	}
+}
+
+// TestComputeCoWarp_UnplannedMutualArmCouples pins ADR 0045 S7 (#400)'s
+// documented scope decision, load-bearing for the ComputeCoWarp
+// clamp-exemption ordering the PR review flags as hand-verified-once
+// (v0.33): a MUTUAL unplanned arm still couples via the `armed` branch
+// (unconditional on Tau — this is unchanged, pre-existing behaviour),
+// but it does NOT claim the #248 clamp exemption (that stays keyed on
+// rendezvousWarpEngaged/rendezvousSeatWith, both false here since the
+// coast never started and Approach was never set) — ordinary min-wins
+// applies until a plan lands. A regression that accidentally widened the
+// exemption to cover the unplanned state would flip this test's MinWarp
+// assertion from "capped at the peer's EffWarp" to "0 / uncapped".
+func TestComputeCoWarp_UnplannedMutualArmCouples(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+
+	res := w.ComputeCoWarp([]CoWarpPeer{peer}, nil)
+	if !res.State.Coupled {
+		t.Fatal("mutual unplanned arm did not couple — the `armed` branch should couple regardless of Tau")
+	}
+	if res.State.MinWarp != peer.EffWarp {
+		t.Errorf("MinWarp = %v, want %v (peer's EffWarp) — an unplanned mutual arm unexpectedly claimed the #248 clamp exemption", res.State.MinWarp, peer.EffWarp)
+	}
+}
+
+// TestRefreshRendezvousDegrade_UnplannedNeverTrips verifies watch-point
+// 3 rather than assuming it (ADR 0045 S7, #400): the degrade watchdog
+// (refreshRendezvousDegrade) gates on rendezvousWarpEngaged() — the
+// AutoWarp coast actually running — which an unplanned arm never
+// reaches (TestUnplannedAgreement_MutualDoesNotStartCoast). It must stay
+// silent across ticks even while mutually armed.
+func TestRefreshRendezvousDegrade_UnplannedNeverTrips(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+
+	for i := 0; i < 5; i++ {
+		w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	}
+	if w.RendezvousDegraded {
+		t.Error("RendezvousDegraded = true for an unplanned agreement — there is no τ to predict an approach at")
+	}
+	if w.RendezvousApproachM != 0 {
+		t.Errorf("RendezvousApproachM = %v, want 0 (never computed while unplanned)", w.RendezvousApproachM)
+	}
+	if !w.RendezvousUnplanned() {
+		t.Fatal("precondition: still unplanned after driving")
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -358,6 +358,16 @@ type World struct {
 	RendezvousDegraded  bool
 	RendezvousApproachM float64
 
+	// RendezvousMutualUnplanned mirrors whether the partner has Engaged
+	// back while the standing agreement has no plan yet (ADR 0045 S7,
+	// #400 — Tau.IsZero(), see RendezvousUnplanned): the RENDEZVOUS chip's
+	// unplanned state uses this to say "mutual, holding for a plan"
+	// instead of "waiting for them to join" once they have. Set each tick
+	// by DriveRendezvousWarp; false whenever the arm has a real plan (Tau
+	// non-zero), is in the terminal phase (Approach), or doesn't exist.
+	// Transient, serve-written like RendezvousHold.
+	RendezvousMutualUnplanned bool
+
 	// Session and SessionEvents are the multiplayer roster slate and
 	// recent join/leave/sync moments (v0.27 S6) — same contract as
 	// Ghosts: serve-layer written, screen read, transient, nil/empty

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -172,6 +172,36 @@ type ManeuverNode struct {
 	// precedent as ID / TargetCraftID / PlaneChangeRad / BurnDirUnit —
 	// no save-schema migration needed.
 	AdvisoryKey string `json:",omitempty"`
+	// MeetingArrivalSec / MeetingPlaceLabel / MeetingLaps (ADR 0045 S7,
+	// #400) are set only on a planted Meeting Burn (AdvisoryKey ==
+	// "meeting-burn", internal/sim's AdvisoryKeyMeetingBurn — spacecraft
+	// can't reference that constant, it lives in the sim package one layer
+	// up) — the sim layer's own copy of the Meeting Planner row it
+	// plants, carried on the node so a LATER Engage press can commit to
+	// the plan's own arrival directly (rendezvousCommitFromPlantedMeetingNode)
+	// instead of re-searching within the 4h horizon rendezvousCommitFromPlantedNode
+	// (the plain trim-nudge sibling) still does: a multi-lap meeting can
+	// land its arrival well past that window (ADR 0045 §5 — "the 4h
+	// window bounds a search, not a plan").
+	//
+	// MeetingArrivalSec is seconds from THIS NODE'S OWN TriggerTime to the
+	// meeting instant (planner.MeetingBurnOption.TArrival, which is
+	// measured from plant time, re-anchored here by subtracting the same
+	// lead buffer already folded into TriggerTime) so the absolute arrival
+	// is recovered as TriggerTime.Add(MeetingArrivalSec) with no extra
+	// state. MeetingPlaceLabel is planner.MeetingPlace.String() ("their
+	// orbit" / "your orbit" / "the crossing") — a plain string, not the
+	// planner.MeetingPlace enum itself, again because spacecraft cannot
+	// import planner (sibling packages, ADR — see axisLabelToBurnMode's
+	// doc comment in internal/sim/rendezvous.go for the mirror-image
+	// constraint). MeetingLaps is the chosen Lap Ladder row's lap count.
+	//
+	// All three are zero for every node but a planted Meeting Burn.
+	// Additive, same zero-value-omitempty precedent as PlaneChangeRad /
+	// BurnDirUnit / AdvisoryKey above — no save-schema migration.
+	MeetingArrivalSec float64 `json:",omitempty"`
+	MeetingPlaceLabel string  `json:",omitempty"`
+	MeetingLaps       int     `json:",omitempty"`
 	// RefusalNoticed (#294 review finding 2) mirrors ActiveBurn's field of
 	// the same name: marks that World has already stamped
 	// LastNodeTargetRefusal for this node refusing to fire (target-

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1027,8 +1027,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// the moment the seat is taken — it is the only point where the
 			// asymmetry is a choice rather than a surprise.
 			if a.world.EngageRendezvousWarpAs(inv.Owner, inv.Handle, inv.Tau, inv.CA, false) {
-				a.toast(fmt.Sprintf("rendezvous with %s — coasting together; you fly copilot ([,] brakes the pair, [/] cancels)%s",
-					inv.Handle, rendezvousGapNoteSuffix(a.world, inv.CA)))
+				// ADR 0045 S7 (#400): adopt the initiator's Meeting Place
+				// verbatim, same as Tau/CA above — the accepter has no code
+				// path that can change it (see RendezvousArm's doc comment).
+				a.world.SetRendezvousMeeting(inv.MeetingPlaceLabel, inv.MeetingLaps)
+				if inv.Tau.IsZero() {
+					a.toast(fmt.Sprintf("rendezvous agreed with %s — no plan yet; you fly copilot ([,] brakes the pair, [/] cancels)", inv.Handle))
+				} else {
+					a.toast(fmt.Sprintf("rendezvous with %s — coasting together; you fly copilot ([,] brakes the pair, [/] cancels)%s",
+						inv.Handle, rendezvousGapNoteSuffix(a.world, inv.CA)))
+				}
 			} else {
 				a.toast(fmt.Sprintf("can't join %s — the encounter time has passed", inv.Handle))
 			}
@@ -2062,7 +2070,7 @@ func (a *App) closeSavesToOrbit() {
 // capturing; the Saves browser only during name entry (Save-As/rename);
 // the Spawn screen only while its ALTITUDE typed-edit box is open (ADR
 // 0044 / S4 — review finding #5: this comment's own "extend here" note
-// was not followed when that box landed, so `` ` `` mid-digit swapped the
+// was not followed when that box landed, so “ ` “ mid-digit swapped the
 // whole screen to the boss shell instead of typing a backtick nobody
 // wanted). Extend here as future free-text surfaces (VAB, search) land.
 func (a *App) capturingText() bool {
@@ -2308,43 +2316,54 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		a.statusExpires = time.Now().Add(3 * time.Second)
 		a.active = screenOrbit
 	case screens.SessionCmdRendezvous:
-		// Rendezvous Warp initiate (v0.29 S2 / ADR 0034 v0.29 addendum):
-		// target the partner's ghost (the advisory + TARGET chip context),
-		// commit the encounter — a planted rendezvous-nudge node's
-		// post-burn course when one exists, else the current-course
-		// closest approach (#276: never the K-nudge ADVISORY's unfired
-		// preview) — and arm toward them. The coast starts only when they
-		// respond (mutual arm); the screen already gated same-subspace and
-		// ghost presence.
+		// Rendezvous Warp initiate (v0.29 S2 / ADR 0034 v0.29 addendum;
+		// ADR 0045 S7, #400: Engage IS the agreement now). Target the
+		// partner's ghost (the advisory + TARGET chip context), commit
+		// whatever encounter is available — a planted Meeting Burn node's
+		// own arrival, a planted trim-rung nudge's post-burn course, else
+		// the current-course closest approach (#276: never the K-nudge
+		// ADVISORY's unfired preview) — and arm toward them regardless of
+		// whether anything was found. The coast starts only when they
+		// respond (mutual arm), and only once there IS a plan; the screen
+		// already gated same-subspace and ghost presence.
 		//
-		// PR #392 review finding 2: SetTargetGhost runs before the commit
-		// gate, so a refusal below must not leave the switch behind —
-		// capture the prior target/NavMode and restore them on !ok. Without
-		// this a refused Engage silently stole whatever the player was
-		// targeting before (mid-transfer TargetBody Moon, say), flipped
-		// NavMode along with it, and left the stale ghost ref to persist
-		// into the next save.
+		// PR #392 review finding 2: SetTargetGhost runs before the commit,
+		// so a refusal below must not leave the switch behind — capture
+		// the prior target/NavMode and restore them on !ok. Without this a
+		// refused Engage silently stole whatever the player was targeting
+		// before (mid-transfer TargetBody Moon, say), flipped NavMode
+		// along with it, and left the stale ghost ref to persist into the
+		// next save. ADR 0045 S7 narrows when !ok can even fire: only the
+		// genuinely structural gates (no target resolvable, cross-primary)
+		// refuse now — "no encounter found" no longer does.
 		prevTarget, prevNav := a.world.Target, a.world.NavMode
 		a.world.SetTargetGhost(cmd.Owner, cmd.CraftID)
-		tau, ca, ok := a.world.RendezvousCommit()
+		plan, ok := a.world.RendezvousCommitWithPlan()
 		switch {
 		case !ok:
 			a.world.RestoreTarget(prevTarget, prevNav)
-			// #276's own remedy, restored (finding 1): RendezvousCommit now
-			// honors an actually-planted rendezvous nudge, so "plant a
-			// nudge [K] first" is a real next step again, not the dead end
-			// ADR 0039 S2 papered over by pointing at the doctrine's
-			// generic phasing-coach line instead.
-			a.statusMsg = fmt.Sprintf("no closable encounter with %s — plant a rendezvous nudge [K] first", cmd.Handle)
+			a.statusMsg = fmt.Sprintf("can't rendezvous with %s — no reported position", cmd.Handle)
 		// The seat is fixed here (ADR 0037 §2): proposing the rendezvous
 		// makes you pilot-in-command of the pair's time once the terminal
 		// phase begins.
-		case a.world.EngageRendezvousWarpAs(cmd.Owner, cmd.Handle, tau, ca, true):
+		case a.world.EngageRendezvousWarpAs(cmd.Owner, cmd.Handle, plan.Tau, plan.CommittedCA, true):
+			// Meeting Place (ADR 0045 S7, #400): stamped after Engage
+			// succeeds, so a re-Engage that plants nothing new (plan has no
+			// Place) clears whatever the PREVIOUS arm carried — the arm was
+			// just replaced wholesale above, so this keeps the two in sync
+			// rather than accidentally carrying stale Place text forward.
+			a.world.SetRendezvousMeeting(plan.MeetingPlaceLabel, plan.MeetingLaps)
 			// Name the acting craft (#295): arming acts on whatever slot is
 			// active, and a player who cycled it earlier has no other way to
 			// catch a wrong-vessel arm before the invitation goes out.
-			a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join%s",
-				cmd.Handle, screens.CraftTag(a.world.RendezvousArm.CraftName), rendezvousGapNoteSuffix(a.world, ca))
+			craftTag := screens.CraftTag(a.world.RendezvousArm.CraftName)
+			if plan.Tau.IsZero() {
+				a.statusMsg = fmt.Sprintf("rendezvous agreed with %s%s — no plan yet, waiting for them to join",
+					cmd.Handle, craftTag)
+			} else {
+				a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join%s",
+					cmd.Handle, craftTag, rendezvousGapNoteSuffix(a.world, plan.CommittedCA))
+			}
 		default:
 			a.statusMsg = fmt.Sprintf("can't arm rendezvous with %s — encounter is in the past", cmd.Handle)
 		}

--- a/internal/tui/app_rendezvous_engage_test.go
+++ b/internal/tui/app_rendezvous_engage_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
-// TestEngageRendezvousNoEncounterCoachesPhasingBurn — PR #392 review
-// finding 1 supersedes ADR 0039 S2 / #277 for this refusal: a genuinely
-// stalemated geometry (matched circular orbit, opposite phase — zero
-// relative drift, an encounter can never form on the current courses,
-// #276) with NO rendezvous nudge planted must refuse Engage with #276's
-// own requested remedy, "plant a rendezvous nudge [K] first" — no
-// longer a dead end now that RendezvousCommit actually honors a planted
-// node (finding 1), so pointing at K is a real next step again instead
-// of the generic phasing-coach line ADR 0039 S2 substituted when it
-// wasn't.
-func TestEngageRendezvousNoEncounterCoachesPhasingBurn(t *testing.T) {
+// TestEngageRendezvousNoEncounterFormsUnplannedAgreement (ADR 0045 S7,
+// #400 — supersedes the PR #392 review finding 1 contract this test used
+// to pin, where Engage refused outright on a stalemated geometry) — a
+// genuinely stalemated geometry (matched circular orbit, opposite phase —
+// zero relative drift, an encounter can never form on the current
+// courses, #276) with NO rendezvous nudge planted must now SUCCEED:
+// Engage stops meaning "we found an encounter" and starts meaning "we
+// are going to meet" (ADR 0045 §5). The agreement forms with no
+// committed τ — RendezvousArm is set, RendezvousUnplanned() is true, and
+// the status message names the new state rather than refusing.
+func TestEngageRendezvousNoEncounterFormsUnplannedAgreement(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -48,7 +48,16 @@ func TestEngageRendezvousNoEncounterCoachesPhasingBurn(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if !strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
-		t.Errorf("refusal %q missing the #276 remedy (plant a rendezvous nudge [K] first)", app.statusMsg)
+	if !strings.Contains(app.statusMsg, "no plan yet") {
+		t.Errorf("status %q missing the agreed-no-plan wording", app.statusMsg)
+	}
+	if app.world.RendezvousArm == nil {
+		t.Fatal("Engage did not form an agreement (ADR 0045 S7, #400: it should have — no encounter is no longer a refusal)")
+	}
+	if !app.world.RendezvousArm.Tau.IsZero() {
+		t.Errorf("Tau = %v, want zero (no encounter was found to commit to)", app.world.RendezvousArm.Tau)
+	}
+	if !app.world.RendezvousUnplanned() {
+		t.Error("RendezvousUnplanned() = false, want true")
 	}
 }

--- a/internal/tui/app_rendezvous_matched_orbit_test.go
+++ b/internal/tui/app_rendezvous_matched_orbit_test.go
@@ -7,17 +7,21 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
-// TestEngageRendezvousSmallLagRefusesPhantomArm (#276, wording updated
-// for PR #392 review finding 1): a small co-orbital phase lag (same
-// circular orbit, differing only by -0.5°) is the geometry
-// TestEngageRendezvousCloseCANoGapNote already documents as one where
-// the K-nudge advisory finds a real, plantable burn (~43 km post-burn
-// CA). But the player here has not pressed K — no burn has been made
-// or planted, and matched orbits never close on their own. Engage must
-// refuse (pointing at K, #276's own remedy — now a real next step since
-// RendezvousCommit honors an actually-planted node), not silently arm
-// toward the advisory's unfired preview.
-func TestEngageRendezvousSmallLagRefusesPhantomArm(t *testing.T) {
+// TestEngageRendezvousSmallLagFormsUnplannedAgreement (ADR 0045 S7, #400
+// — supersedes the PR #392 review finding 1 contract this test used to
+// pin, where Engage refused a "phantom" arm outright): a small
+// co-orbital phase lag (same circular orbit, differing only by -0.5°) is
+// the geometry TestEngageRendezvousCloseCANoGapNote already documents as
+// one where the K-nudge advisory finds a real, plantable burn (~43 km
+// post-burn CA) — but the player here has not pressed K, so
+// RendezvousCommitWithPlan's current-course search (Source 3) is what
+// runs, and a slow phase lag on matched circular orbits doesn't close
+// inside the 4h search window. Engage now SUCCEEDS anyway (ADR 0045 §5:
+// the 4h window bounds a search, not the agreement) — forming the
+// agreed-no-plan state rather than the old outright refusal. The
+// commit's own gates are unchanged: this still isn't a real committed
+// encounter, so Tau stays zero and there is no Meeting Place to name.
+func TestEngageRendezvousSmallLagFormsUnplannedAgreement(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -35,10 +39,16 @@ func TestEngageRendezvousSmallLagRefusesPhantomArm(t *testing.T) {
 	if app.statusMsg == "" {
 		t.Fatal("Engage produced no status message")
 	}
-	if !strings.Contains(app.statusMsg, "plant a rendezvous nudge") {
-		t.Errorf("Engage armed on a phantom encounter instead of refusing: %q", app.statusMsg)
+	if !strings.Contains(app.statusMsg, "no plan yet") {
+		t.Errorf("status %q missing the agreed-no-plan wording", app.statusMsg)
 	}
-	if app.world.RendezvousArm != nil {
-		t.Error("RendezvousArm set despite no encounter on the current courses (#276)")
+	if app.world.RendezvousArm == nil {
+		t.Fatal("Engage did not form an agreement (ADR 0045 S7, #400)")
+	}
+	if !app.world.RendezvousArm.Tau.IsZero() {
+		t.Errorf("Tau = %v, want zero — no node was planted and the current-course search doesn't close inside 4h", app.world.RendezvousArm.Tau)
+	}
+	if app.world.RendezvousArm.MeetingPlaceLabel != "" {
+		t.Errorf("MeetingPlaceLabel = %q, want empty — nothing was planted to name a Place from", app.world.RendezvousArm.MeetingPlaceLabel)
 	}
 }

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -76,7 +76,7 @@ var helpSections = []helpSection{
 		{"t", "target their ghost vessel — 2+ vessels opens a picker ([esc] backs out)"},
 		{"v", "spectate — fit + camera-follow their ghost's orbit ([f] to return)"},
 		{"s", "sync-warp forward to a player ahead of you (forward only)"},
-		{"w", "rendezvous warp — arm a rate-locked coast to your encounter with them"},
+		{"w", "rendezvous warp — agree to meet them; commits to an encounter when one's found, otherwise arms with no plan yet"},
 		{"RANGE column", "live distance to them; warps lock inside 35 km at under 100 m/s closing"},
 		{"h", "start / stop hosting — accept ssh guests (stop confirms, drops guests)"},
 		{"i / r / x", "host + admins: mint invite / revoke code / remove player"},

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -429,6 +429,8 @@ func (v *OrbitView) buildChatChip(w *sim.World) []string {
 func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 	now := w.Clock.SimTime
 	switch {
+	case w.RendezvousUnplanned():
+		return v.rendezvousUnplannedLines(w)
 	case w.RendezvousApproachPhase():
 		return v.rendezvousApproachLines(w)
 	case w.RendezvousWarpEngaged():
@@ -440,6 +442,9 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		}
 		if arm := w.RendezvousArm; arm != nil {
 			lines = append(lines, chipRow("committed:", formatRangeM(arm.CommittedCA)))
+			if line := rendezvousMeetingLine(arm.MeetingPlaceLabel, arm.MeetingLaps); line != "" {
+				lines = append(lines, line)
+			}
 			// ADR 0039 S3 / #281: the trend across waypoint re-derivations —
 			// distinct from the degrade warning below, which compares
 			// against a baseline that re-bases every waypoint and so can
@@ -492,13 +497,16 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			// Own the wait instead of blaming them or advising a Sync.
 			status = v.theme.Warning.Render("  your Auto-Warp is running — coast starts when it releases")
 		}
-		return []string{
+		lines := []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			status,
 			chipRow("τ in:", compactDuration(arm.Tau.Sub(now))),
 			chipRow("CA:", formatRangeM(arm.CommittedCA)),
-			v.theme.Dim.Render("  [/] cancel"),
 		}
+		if line := rendezvousMeetingLine(arm.MeetingPlaceLabel, arm.MeetingLaps); line != "" {
+			lines = append(lines, line)
+		}
+		return append(lines, v.theme.Dim.Render("  [/] cancel"))
 	case w.RendezvousInvite != nil:
 		inv := w.RendezvousInvite
 		if inv.Blocked {
@@ -511,25 +519,78 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			if inv.AheadBy > 0 {
 				gap = "subspace gap, they must Sync to you"
 			}
-			return []string{
+			lines := []string{
 				v.theme.Primary.Render("RENDEZVOUS"),
 				v.theme.Dim.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous — " + gap),
 				chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 				chipRow("CA:", formatRangeM(inv.CA)),
 			}
+			if line := rendezvousMeetingLine(inv.MeetingPlaceLabel, inv.MeetingLaps); line != "" {
+				lines = append(lines, line)
+			}
+			return lines
 		}
-		return []string{
+		lines := []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			v.theme.Warning.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous"),
 			chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 			chipRow("CA:", formatRangeM(inv.CA)),
-			// Name the seat at the moment it is taken (ADR 0037 §2): roles
-			// are fixed at invite time, so this prompt is the only place the
-			// asymmetry is a choice rather than a later surprise.
-			v.theme.Warning.Render("  [y] join as copilot — " + inv.Handle + " sets the pair's warp"),
 		}
+		if line := rendezvousMeetingLine(inv.MeetingPlaceLabel, inv.MeetingLaps); line != "" {
+			lines = append(lines, line)
+		}
+		// Name the seat at the moment it is taken (ADR 0037 §2): roles
+		// are fixed at invite time, so this prompt is the only place the
+		// asymmetry is a choice rather than a later surprise.
+		return append(lines, v.theme.Warning.Render("  [y] join as copilot — "+inv.Handle+" sets the pair's warp"))
 	}
 	return nil
+}
+
+// rendezvousMeetingLine renders the Meeting Place + lap count row (ADR
+// 0045 S7, #400) — agreement state named on both sides' RENDEZVOUS chip,
+// carried verbatim from whichever side committed it (RendezvousArm.
+// MeetingPlaceLabel on the initiator, RendezvousInvite.MeetingPlaceLabel
+// on the accepter before joining, RendezvousArm.MeetingPlaceLabel again
+// after — see SetRendezvousMeeting). "" (render nothing) whenever the
+// commit's source wasn't a planted Meeting Burn node — including the
+// whole agreed-no-plan state, which never had one.
+func rendezvousMeetingLine(placeLabel string, laps int) string {
+	if placeLabel == "" {
+		return ""
+	}
+	return chipRow("meeting:", fmt.Sprintf("%s — %d laps", placeLabel, laps))
+}
+
+// rendezvousUnplannedLines is the RENDEZVOUS chip's fifth state (ADR
+// 0045 S7, #400): Engaged, but neither a planted node nor the 4h
+// current-course search found an encounter to commit to at Engage
+// time — "we are going to meet", agreed, with nothing planned yet.
+// Distinct from rendezvousApproachLines: that state is a demotion FROM a
+// real coast; this agreement never had one to demote from, so it never
+// sets Approach and never renders the seat/rate rows that assume it.
+//
+// Two sub-states once mutual (w.RendezvousMutualUnplanned): the
+// initiator is told to plan (K, then Engage again to commit it — see
+// EngageRendezvousWarpAs's "replaces any prior arm"), the accepter is
+// told they're holding for the initiator's call — ADR 0037's "they do
+// not vote" applies here too. Before mutual, the line is the same
+// "waiting for them to join" every other pre-coast state uses.
+func (v *OrbitView) rendezvousUnplannedLines(w *sim.World) []string {
+	arm := w.RendezvousArm
+	lines := []string{
+		v.theme.Primary.Render("RENDEZVOUS"),
+		"  agreed with " + arm.Handle + CraftTag(arm.CraftName),
+	}
+	switch {
+	case w.RendezvousMutualUnplanned && arm.Initiator:
+		lines = append(lines, v.theme.Dim.Render("  no plan yet — pick a Meeting Place [K], then Engage to commit"))
+	case w.RendezvousMutualUnplanned:
+		lines = append(lines, v.theme.Dim.Render("  no plan yet — holding for "+arm.Handle+"'s call"))
+	default:
+		lines = append(lines, v.theme.Warning.Render("  waiting for them to join"))
+	}
+	return append(lines, v.theme.Dim.Render("  [/] cancel"))
 }
 
 // rendezvousTrendLines renders the CA trend row (ADR 0039 S3 / #281):

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -581,3 +581,69 @@ func lenRunes(s string) int {
 	}
 	return n
 }
+
+// TestRendezvousChipMeetingPlaceRendersAt80x24 is part of the ADR 0045
+// S7 (#400) acceptance test — "chip rendering asserted at 80×24" — for
+// the Meeting Place row the coasting state now carries. Mirrors
+// TestRendezvousChipPacedRendersAt80x24's shape exactly: the same
+// composited-canvas + per-cell-width checks, new text.
+func TestRendezvousChipMeetingPlaceRendersAt80x24(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	tau := w.Clock.SimTime.Add(8 * time.Hour)
+	w.EngageRendezvousWarp("SHA256:guest", "gern", tau, 900)
+	w.AutoWarp = &sim.AutoWarpTarget{
+		T: tau, Rendezvous: true,
+		RendezvousOwner: "SHA256:guest", RendezvousHandle: "gern",
+	}
+	w.RendezvousArm.MeetingPlaceLabel = "your orbit"
+	w.RendezvousArm.MeetingLaps = 5
+
+	lines := v.buildRendezvousChip(w)
+	assertChipCellWidthConsistent(t, "meeting-place rendezvous chip", lines)
+
+	out := v.composeChips(blankCanvas(80, 24), 80, 24, 0, 0, 0,
+		[]builtChip{{corner: cornerBottomLeft, lines: lines}})
+	if !strings.Contains(out, "your orbit — 5 laps") {
+		t.Errorf("meeting place row missing from the 80×24 composited canvas:\n%s", out)
+	}
+	for _, row := range strings.Split(out, "\n") {
+		if w := lenRunes(row); w != 80 {
+			t.Errorf("composited row width = %d, want 80 (narrow-terminal overflow): %q", w, row)
+		}
+	}
+}
+
+// TestRendezvousChipUnplannedRendersAt80x24 covers the same acceptance
+// bullet for the OTHER new surface in this slice — the "agreed, no plan
+// yet" state (RendezvousUnplanned). Confirms both wordings the mutual
+// sub-state can render (initiator vs accepter) survive the real
+// composite at 80×24.
+func TestRendezvousChipUnplannedRendersAt80x24(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:guest", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage with no plan should succeed")
+	}
+	w.RendezvousMutualUnplanned = true
+
+	lines := v.buildRendezvousChip(w)
+	if lines == nil {
+		t.Fatal("unplanned chip rendered nil")
+	}
+	assertChipCellWidthConsistent(t, "unplanned rendezvous chip", lines)
+
+	out := v.composeChips(blankCanvas(80, 24), 80, 24, 0, 0, 0,
+		[]builtChip{{corner: cornerBottomLeft, lines: lines}})
+	if !strings.Contains(out, "agreed with gern") {
+		t.Errorf("unplanned agreement line missing from the 80×24 composited canvas:\n%s", out)
+	}
+	if !strings.Contains(out, "no plan yet") {
+		t.Errorf("no-plan line missing from the 80×24 composited canvas:\n%s", out)
+	}
+	for _, row := range strings.Split(out, "\n") {
+		if w := lenRunes(row); w != 80 {
+			t.Errorf("composited row width = %d, want 80 (narrow-terminal overflow): %q", w, row)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #400. Widest slice of the ADR 0045 arc — amends ADR 0037.

- **Engage no longer refuses on "no encounter"**: `RendezvousCommitWithPlan` (a new sibling of `RendezvousCommit`, which is unchanged for every other caller) only refuses on genuinely structural gates (no target, cross-primary). "Nothing found" now forms the agreement with a zero `Tau` — the new **"agreed, no plan yet"** state (`RendezvousArm.Tau.IsZero()`, `World.RendezvousUnplanned()`), which persists (exempted from the τ-expiry check), couples via the existing `armed` branch, and never starts an Auto-Warp coast (nothing to chase) until a fresh Engage lands a real plan.
- **A planted Meeting Planner node's own arrival is what Engage commits to**, however far out: `rendezvousCommitFromPlantedMeetingNode` propagates straight to `ManeuverNode.MeetingArrivalSec` — no re-search within the 4h horizon the trim-nudge sibling (`rendezvousCommitFromPlantedNode`) still uses for its own honored node. `rendezvousCommitCurrentCourse` (the search-bound fallback) is untouched.
- **The Meeting Place + lap count is agreement state**: carried on `RendezvousArm`/`RendezvousInvite`, over the wire via `CraftReport`/`CoWarpPeer`, and named on the RENDEZVOUS chip on both sides (a new "meeting: their orbit — 5 laps" row). The accepter has no code path that can change it — only `SetRendezvousMeeting`, called from the initiator's Engage and the accepter's own join (adopting the initiator's value verbatim).
- **`ManeuverNode`** gains `MeetingArrivalSec`/`MeetingPlaceLabel`/`MeetingLaps` (additive, zero-value-omitempty, round-trips through save) so a planted Meeting Burn node carries its own plan forward to a later Engage press.

## Watch-points (from the issue)

1. **`rendezvousCommitFromPlantedNode` vs `rendezvousCommitCurrentCourse`**: not conflated. The trim-nudge path is untouched; the new Meeting-node path is a separate function (`rendezvousCommitFromPlantedMeetingNode`) that skips the horizon search entirely.
2. **`ComputeCoWarp`'s clamp-exemption ordering**: **not touched**. The unplanned-mutual state couples (existing `armed` branch, unconditional on Tau) but deliberately does **not** claim the `#248` clamp exemption — that stays keyed on `rendezvousWarpEngaged()`/`rendezvousSeatWith` (both false pre-plan), so ordinary min-wins applies until a plan lands. Pinned by `TestComputeCoWarp_UnplannedMutualArmCouples`, verified non-vacuous by sabotaging the exemption and confirming the test catches it.
3. **Degrade watchdog**: verified, not assumed — `refreshRendezvousDegrade` already gates on the coast actually running (`rendezvousWarpEngaged()`), which the unplanned state never reaches, so it no-ops correctly with no code change. Pinned by `TestRefreshRendezvousDegrade_UnplannedNeverTrips`.

## Scope decision

The unplanned state is deliberately narrower than ADR 0037 §2's full seat-governed "initiator flies the clock" — it does not extend `Approach`-style seat/rate governance to the pre-plan state (that machinery — `rendezvousSeatWith`, `refreshRendezvousRate`, `rendezvousSeatRate` — is entirely untouched). Documented in code and in the PR description; a natural follow-on if wanted.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] Every new/changed test verified non-vacuous (revert-and-confirm-fail, restore) — see session notes
- [x] Save round-trip test for the new `ManeuverNode` fields, no schema bump (`save.SchemaVersion` still 10)
- [x] Chip rendering asserted at 80×24 for both new surfaces (Meeting Place row, agreed-no-plan state)

Claude-Session: https://claude.ai/code/session_01HsrrpUr6dLcW4G8nmV9SRN