### PR TITLE
fix: gate relay.Store.Earliest on presence, not report existence

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -198,19 +198,36 @@ func (s *Store) Frontier() (time.Time, bool) {
 	return max, ok
 }
 
-// Earliest is the minimum subspace time across every stored (i.e.
-// live) report — where a new player joins (ADR 0034 §7 amendment /
-// ADR 0045 S3, closing #247/#396): joining behind the group is
-// recoverable with Sync, which is forward-only, so joining ahead of
-// anyone actually playing is the trap to avoid, not joining behind.
-// ok is false while the store is empty; the caller falls back to the
-// furthest-behind persisted payload (sessiondir.Store.EarliestSimTime).
-func (s *Store) Earliest() (time.Time, bool) {
+// Earliest is the minimum subspace time across every stored report
+// whose owner satisfies live — where a new player joins (ADR 0034 §7
+// amendment / ADR 0045 S3, closing #247/#396): joining behind the
+// group is recoverable with Sync, which is forward-only, so joining
+// ahead of anyone actually playing is the trap to avoid, not joining
+// behind.
+//
+// Report never evicts on disconnect, so the store keeps every
+// owner's last report indefinitely; Frontier's max-fold tolerates
+// that (a stale entry can't raise a maximum live players have
+// already passed), but a min-fold is dominated by it — a player who
+// played briefly and left would permanently drag every new joiner to
+// their stale clock. live is the caller's liveness check, so a
+// departed owner's lingering report is excluded from the fold; the
+// store itself tracks no notion of "live" (ADR 0034: it stores and
+// relays, nothing else — that bookkeeping belongs to whoever tracks
+// sessions, e.g. serve's presence).
+//
+// ok is false when no report satisfies live; the caller falls back
+// to the furthest-behind persisted payload
+// (sessiondir.Store.EarliestSimTime).
+func (s *Store) Earliest(live func(owner string) bool) (time.Time, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var min time.Time
 	ok := false
-	for _, r := range s.reports {
+	for owner, r := range s.reports {
+		if !live(owner) {
+			continue
+		}
 		if !ok || r.SubspaceTime.Before(min) {
 			min = r.SubspaceTime
 			ok = true

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -129,6 +129,11 @@ func TestFrontierUnderDivergence(t *testing.T) {
 	}
 }
 
+// allLive is the liveness predicate for tests where every stored
+// report is meant to count — Earliest's own liveness gating isn't
+// under test.
+func allLive(string) bool { return true }
+
 // Earliest under divergence: the mirror of Frontier, and the two
 // must not converge on the same value — Frontier backs
 // --reset-fleet's epoch, Earliest backs a new player's join point
@@ -137,7 +142,7 @@ func TestFrontierUnderDivergence(t *testing.T) {
 // laggard, not the leader, sets where newcomers land.
 func TestEarliestUnderDivergence(t *testing.T) {
 	store := NewStore()
-	if _, ok := store.Earliest(); ok {
+	if _, ok := store.Earliest(allLive); ok {
 		t.Fatal("empty store claims an earliest")
 	}
 	wA, wB := newWorld(t), newWorld(t)
@@ -146,7 +151,7 @@ func TestEarliestUnderDivergence(t *testing.T) {
 	NewReporter(store, "SHA256:alice").Tick(wA, time.Now())
 	NewReporter(store, "SHA256:bob").Tick(wB, time.Now())
 
-	e, ok := store.Earliest()
+	e, ok := store.Earliest(allLive)
 	if !ok {
 		t.Fatal("no earliest with two reports stored")
 	}
@@ -160,6 +165,39 @@ func TestEarliestUnderDivergence(t *testing.T) {
 	// Frontier still reports the max — the two must not converge.
 	if f, ok := store.Frontier(); !ok || !f.Equal(wA.Clock.SimTime) {
 		t.Errorf("Frontier = %v/%v, want alice's %v", f, ok, wA.Clock.SimTime)
+	}
+}
+
+// A report whose owner the caller's live predicate rejects is
+// excluded from Earliest's fold entirely — not merely outweighed.
+// Report never evicts on disconnect (nothing in the store deletes a
+// stale entry), so without this exclusion a departed player's old
+// report would dominate every live player's min forever: alice
+// reports a time ten days behind bob and carol, then "disconnects"
+// (the test's live predicate marks her false); Earliest must land on
+// the earliest LIVE time (bob's), not alice's stale one.
+func TestEarliestExcludesReportsLiveRejects(t *testing.T) {
+	store := NewStore()
+	wAlice, wBob, wCarol := newWorld(t), newWorld(t), newWorld(t)
+	wBob.Clock.SimTime = wBob.Clock.SimTime.Add(10 * 24 * time.Hour)
+	wCarol.Clock.SimTime = wCarol.Clock.SimTime.Add(11 * 24 * time.Hour)
+	NewReporter(store, "SHA256:alice").Tick(wAlice, time.Now())
+	NewReporter(store, "SHA256:bob").Tick(wBob, time.Now())
+	NewReporter(store, "SHA256:carol").Tick(wCarol, time.Now())
+
+	live := func(owner string) bool { return owner != "SHA256:alice" }
+	e, ok := store.Earliest(live)
+	if !ok {
+		t.Fatal("no earliest with two live reports stored")
+	}
+	if !e.Equal(wBob.Clock.SimTime) {
+		t.Errorf("earliest = %v, want bob's live %v, not alice's stale %v", e, wBob.Clock.SimTime, wAlice.Clock.SimTime)
+	}
+
+	// Nobody live at all → ok=false, same as an empty store from the
+	// caller's point of view.
+	if _, ok := store.Earliest(func(string) bool { return false }); ok {
+		t.Error("Earliest with no live owners should report ok=false")
 	}
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -510,7 +510,7 @@ func (s *Server) frontier() (time.Time, bool) {
 // a genuinely empty server), in which case the caller's fresh default
 // clock stands.
 func (s *Server) joinTime() (time.Time, bool) {
-	if live, ok := s.relay.Earliest(); ok {
+	if live, ok := s.relay.Earliest(s.presence.isOnline); ok {
 		return live, true
 	}
 	return s.store.EarliestSimTime()

--- a/internal/serve/subspace_test.go
+++ b/internal/serve/subspace_test.go
@@ -47,6 +47,7 @@ func TestJoinAtEarliestLiveClock(t *testing.T) {
 	}
 	behind := wBehind.Clock.SimTime.Add(6 * 24 * time.Hour)
 	wBehind.Clock.SimTime = behind
+	srv.presence.markOnline("SHA256:closer")
 	relay.NewReporter(srv.relay, "SHA256:closer").Tick(wBehind, time.Now())
 
 	wAhead, err := sim.NewWorld()
@@ -55,6 +56,7 @@ func TestJoinAtEarliestLiveClock(t *testing.T) {
 	}
 	ahead := wAhead.Clock.SimTime.Add(10 * 24 * time.Hour)
 	wAhead.Clock.SimTime = ahead
+	srv.presence.markOnline("SHA256:veteran")
 	relay.NewReporter(srv.relay, "SHA256:veteran").Tick(wAhead, time.Now())
 
 	app, err := srv.newGuestApp("SHA256:rookie")
@@ -81,6 +83,7 @@ func TestJoinIgnoresStoredPayloadAhead(t *testing.T) {
 	}
 	live := wLive.Clock.SimTime.Add(6 * 24 * time.Hour)
 	wLive.Clock.SimTime = live
+	srv.presence.markOnline("SHA256:present")
 	relay.NewReporter(srv.relay, "SHA256:present").Tick(wLive, time.Now())
 
 	wOfflineVet, err := sim.NewWorld()
@@ -98,6 +101,55 @@ func TestJoinIgnoresStoredPayloadAhead(t *testing.T) {
 	}
 	if got := app.World().Clock.SimTime; !got.Equal(live) {
 		t.Errorf("new player joined at %v, want the live player's time %v (stored payload must not pull forward)", got, live)
+	}
+}
+
+// A departed player's stale report must not out-vote the live group:
+// Report never evicts on disconnect, so the store keeps alice's old
+// entry indefinitely, and a naive min-fold over "everything stored"
+// would let it dominate forever (a min, unlike Frontier's max, is
+// dragged DOWN by a stale straggler, not merely outweighed). Alice
+// plays briefly and disconnects; Bob and Carol are still online, ten
+// days ahead of her. Dave joining now must land with Bob and Carol,
+// not get pulled ten days behind everyone actually playing.
+func TestJoinIgnoresStaleDisconnectedReport(t *testing.T) {
+	srv := newOfflineServer(t)
+
+	wAlice, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	srv.presence.markOnline("SHA256:alice")
+	relay.NewReporter(srv.relay, "SHA256:alice").Tick(wAlice, time.Now())
+	srv.presence.markOffline("SHA256:alice") // alice disconnects; her report lingers in the store
+
+	wBob, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	bobTime := wBob.Clock.SimTime.Add(10 * 24 * time.Hour)
+	wBob.Clock.SimTime = bobTime
+	srv.presence.markOnline("SHA256:bob")
+	relay.NewReporter(srv.relay, "SHA256:bob").Tick(wBob, time.Now())
+
+	wCarol, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	carolTime := wCarol.Clock.SimTime.Add(11 * 24 * time.Hour)
+	wCarol.Clock.SimTime = carolTime
+	srv.presence.markOnline("SHA256:carol")
+	relay.NewReporter(srv.relay, "SHA256:carol").Tick(wCarol, time.Now())
+
+	app, err := srv.newGuestApp("SHA256:dave")
+	if err != nil {
+		t.Fatalf("newGuestApp: %v", err)
+	}
+	if got := app.World().Clock.SimTime; !got.Equal(bobTime) {
+		t.Errorf("dave joined at %v, want bob's live %v (alice's stale disconnected report must not win the min)", got, bobTime)
+	}
+	if got := app.World().Clock.SimTime; got.Equal(wAlice.Clock.SimTime) {
+		t.Error("dave joined at alice's stale disconnected clock — ten days behind the live group")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Store.Earliest`'s doc comment claimed it folds over "every stored (i.e. live) report" — false. `Store.Report` never deletes on disconnect, so a departed player's last report lingers forever. `Frontier` (max) tolerates that; `Earliest` (added by #396/PR #402, a min) is dominated by it — a player who played briefly and disconnected drags every new joiner's clock back to their stale time, exactly the "join ahead of the group" trap ADR 0045 S3 exists to prevent.
- `relay.Store.Earliest` now takes a `live func(owner string) bool` predicate and excludes any report whose owner fails it. `serve.joinTime()` passes `s.presence.isOnline`.
- The store itself still tracks no notion of liveness (ADR 0034: "it stores and relays, nothing else"). Liveness stays owned by `serve`'s `presence`, one layer up — pushing it into the store was rejected because `Frontier` and `Earliest` legitimately want *different* filtering over the same stored data (Frontier's `--reset-fleet` epoch deliberately wants offline payloads to "hold the frontier too"; only `Earliest` needs live-only). The predicate parameter keeps that policy at the call site instead of baking one interpretation into the store.
- Fixed `Earliest`'s doc comment to describe what the code actually does.

## The `.After(...)` guard (serve.go:428/464)
Both `joinTime()` call sites apply the result only when it's later than the guest's fresh default clock. Assessed and left unchanged: the default clock is a fixed constant (J2000 epoch, adjusted for the lunar transfer window in `tui.New`), and every session's subspace time only ever moves forward from that same shared start. A genuinely live session's earliest time can therefore never be *before* the default — the guard is a no-op safety rail, not a mask over the staleness bug. Before this fix, the bug wasn't hidden by the guard either: a stale disconnected report (e.g. Alice's) is virtually always *after* the default clock (she played for a while before disconnecting), so `.After()` was true and the stale value sailed through.

## Verification
- `go vet ./...` — clean.
- `go test ./... -race -count=1` — all packages pass.
- Non-vacuous check: patched `Earliest` to accept but ignore the `live` predicate (reproducing the pre-fix behavior while keeping the new signature so tests still compile) — both new tests (`TestEarliestExcludesReportsLiveRejects` in `internal/relay`, `TestJoinIgnoresStaleDisconnectedReport` in `internal/serve`) failed as expected. Reverted the patch, reran — both pass, full suite green.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [x] New tests fail against a deliberately-unfixed `Earliest`, pass against the real fix

https://claude.ai/code/session_01HsrrpUr6dLcW4G8nmV9SRN