### PR TITLE
fix: rendezvous review batch — accepter plan adoption, invite fabrication, pace flag, reset invariant

### DIFF
--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -491,6 +491,7 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 	w.RendezvousPaced = false
 	w.RendezvousPaceWarp = 0
 	w.RendezvousPartnerAway = false
+	w.RendezvousMutualUnplanned = false
 	arm := w.RendezvousArm
 	if arm == nil {
 		if w.rendezvousWarpEngaged() {
@@ -645,17 +646,32 @@ func (w *World) driveRendezvousCoast(peers []CoWarpPeer) {
 		}
 		if arm.Tau.IsZero() {
 			// ADR 0045 S7 (#400): mutual, but no committed encounter yet —
-			// there is nothing for the driver to chase. The pair is still
-			// coupled (ComputeCoWarp's `armed` branch couples on the arm
-			// alone, unconditional on Tau) and rides ordinary min-wins
-			// until a plan lands and Engage is pressed again (see
-			// EngageRendezvousWarpAs's "replaces any prior arm" doc — a
-			// planted Meeting Burn plus a fresh Engage promotes the arm out
-			// of this state). Deliberately narrower than ADR 0037 §2's
-			// full seat-governed "initiator flies the clock" for the
-			// planned/terminal phase — a documented scope decision for
-			// #400, not an oversight; see the PR description.
-			return
+			// there is nothing for the driver to chase YET. The pair is
+			// still coupled (ComputeCoWarp's `armed` branch couples on the
+			// arm alone, unconditional on Tau) and rides ordinary min-wins
+			// until a plan lands.
+			//
+			// Finding 1 (batch review): nothing on the ACCEPTER's side ever
+			// writes to this arm's Tau once it's set — PlanMeetingBurn only
+			// ever touches the arm-holder's own RendezvousArm, and
+			// refreshRendezvousInvite never surfaces a fresh invite while
+			// w.RendezvousArm is non-nil (an accepter has one from the
+			// moment they join). So when the INITIATOR plants a Meeting
+			// Burn and re-Engages — the ordinary "K then Engage" flow the
+			// chip itself prompts for — their own arm.Tau updates and
+			// relays, but the accepter's zero Tau would sit stuck forever
+			// with no other path back short of a manual cancel or
+			// re-arming as initiator (which breaks the ADR 0037 seat
+			// split). Adopt the partner's committed waypoint here, exactly
+			// like the min-τ block above (same min-lead floor), so it
+			// reaches the accepter before the driver has ever engaged —
+			// then fall through to start the coast on it.
+			if partner.RendezvousTau.IsZero() || !partner.RendezvousTau.After(w.Clock.SimTime.Add(rendezvousWaypointMinLead)) {
+				return
+			}
+			arm.Tau, arm.CommittedCA = partner.RendezvousTau, partner.RendezvousCA
+			arm.MeetingPlaceLabel, arm.MeetingLaps = partner.RendezvousMeetingPlace, partner.RendezvousMeetingLaps
+			arm.degradeBaseSet = false // a new waypoint means a new baseline (#251 interaction)
 		}
 		handle := partner.Handle
 		if handle == "" {
@@ -745,6 +761,23 @@ func (w *World) holdRendezvousLeader(partner *CoWarpPeer) {
 	ahead := w.Clock.SimTime.Sub(partner.SubspaceTime).Seconds()
 	if partner.Paused && ahead >= 0 {
 		w.RendezvousHold = true
+		return
+	}
+	// Finding 3 (batch review): relay reports are always at least one
+	// tick stale, so `ahead` is positive on essentially every coasting
+	// tick even when nothing is genuinely diverging — and
+	// rendezvousPaceMaxWarp's ramp is "active" (returns a ceiling below
+	// subspaceStepCap()) for ANY ahead > 0, however small. Reporting
+	// Paced for a sliver that small stood up the "coasting Nx — paced to
+	// X" line during completely ordinary coasting, a regression against
+	// #395's intent (replace a flickering readout with a steady HONEST
+	// one, not an always-on one). Below rendezvousWaypointMinLead this
+	// reads as measurement staleness, not a genuine divergence worth
+	// reporting — the same "too fresh to act on" judgment the τ-adoption
+	// code above makes about a relayed waypoint — so the ceiling isn't
+	// applied at all below it, leaving the ordinary subspace-step cap in
+	// charge and RendezvousPaced false.
+	if ahead <= rendezvousWaypointMinLead.Seconds() {
 		return
 	}
 	if warp, active := w.rendezvousPaceMaxWarp(ahead); active {

--- a/internal/sim/rendezvous_mutual_unplanned_reset_test.go
+++ b/internal/sim/rendezvous_mutual_unplanned_reset_test.go
@@ -1,0 +1,41 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestRendezvousMutualUnplanned_ResetOnArmClear is finding 4 (batch
+// review, LOW): RendezvousMutualUnplanned is assigned inside
+// driveRendezvousCoast (arm.Tau.IsZero() && partner != nil) but, unlike
+// RendezvousHold / RendezvousPaced / RendezvousPartnerAway, was not
+// reset at the top of the function — so the arm==nil early return left
+// it stale at whatever it was on the tick the arm was cleared. Currently
+// latent (every reader is behind RendezvousUnplanned(), which requires a
+// non-nil arm) but it breaks the single-writer/reset-at-top invariant
+// the surrounding flags document.
+func TestRendezvousMutualUnplanned_ResetOnArmClear(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, true) {
+		t.Fatal("Engage should succeed")
+	}
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if !w.RendezvousMutualUnplanned {
+		t.Fatal("precondition: mutual unplanned should be true once the partner has armed back")
+	}
+
+	// Cancel the arm, then drive a tick with no partner report at all —
+	// the arm==nil early return in driveRendezvousCoast must not leave
+	// RendezvousMutualUnplanned stuck true.
+	w.DisengageRendezvousWarp()
+	w.DriveRendezvousWarp(nil)
+
+	if w.RendezvousMutualUnplanned {
+		t.Error("RendezvousMutualUnplanned stayed true after the arm cleared — reset-at-top invariant broken")
+	}
+}

--- a/internal/sim/rendezvous_pace_binding_test.go
+++ b/internal/sim/rendezvous_pace_binding_test.go
@@ -1,0 +1,119 @@
+package sim
+
+import (
+	"testing"
+	"time"
+)
+
+// pacedLeaderWorld returns a World with an engaged rendezvous coast
+// (initiator seat, a far-future τ so nothing else — approach ramp, node
+// ramp, burn cap — clamps the rate in these tests) so holdRendezvousLeader
+// can be exercised directly against hand-built `ahead` values.
+func pacedLeaderWorld(t *testing.T) *World {
+	t.Helper()
+	w := mustWorld(t)
+	farFuture := w.Clock.SimTime.Add(200 * time.Hour)
+	w.RendezvousArm = &RendezvousArm{
+		TargetOwner: harnessOwnerB, Handle: "bob",
+		Tau: farFuture, CommittedCA: 1000,
+		Initiator: true, BrakeIdx: rendezvousFollowing,
+	}
+	w.AutoWarp = &AutoWarpTarget{
+		T: farFuture, Rendezvous: true,
+		RendezvousOwner: harnessOwnerB, RendezvousHandle: "bob",
+	}
+	w.Clock.Paused = false
+	return w
+}
+
+// TestHoldRendezvousLeader_TinyAheadDoesNotPace is finding 3 (batch
+// review, MEDIUM): relay reports are always at least one tick stale, so
+// `ahead` is positive on essentially every coasting tick even when
+// nothing is genuinely diverging. Before the fix, holdRendezvousLeader
+// set RendezvousPaced whenever the ramp was merely "active" (ahead > 0),
+// regardless of magnitude — a sliver of a tick's worth of staleness,
+// well under rendezvousWaypointMinLead, must not stand up the
+// "coasting Nx — paced to bob" chip line.
+func TestHoldRendezvousLeader_TinyAheadDoesNotPace(t *testing.T) {
+	w := pacedLeaderWorld(t)
+	partner := &CoWarpPeer{
+		Owner: harnessOwnerB, Handle: "bob",
+		SubspaceTime: w.Clock.SimTime.Add(-50 * time.Millisecond), // one tick's worth of staleness
+	}
+	// Mirror driveRendezvousCoast's top-of-tick reset, which the real
+	// caller always performs before holdRendezvousLeader runs.
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+
+	w.holdRendezvousLeader(partner)
+
+	if w.RendezvousPaced {
+		t.Errorf("RendezvousPaced = true for a %v stale report — that's within rendezvousWaypointMinLead, ordinary staleness, not genuine divergence (RendezvousPaceWarp=%v)",
+			w.Clock.SimTime.Sub(partner.SubspaceTime), w.RendezvousPaceWarp)
+	}
+}
+
+// TestHoldRendezvousLeader_JustBelowAndAboveDeadband pins the exact
+// boundary the finding 3 fix introduces: ahead == rendezvousWaypointMinLead
+// must not pace (the guard is `ahead <= ...`), one second past it must.
+func TestHoldRendezvousLeader_JustBelowAndAboveDeadband(t *testing.T) {
+	w := pacedLeaderWorld(t)
+	partner := &CoWarpPeer{Owner: harnessOwnerB, Handle: "bob"}
+
+	partner.SubspaceTime = w.Clock.SimTime.Add(-rendezvousWaypointMinLead)
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+	w.holdRendezvousLeader(partner)
+	if w.RendezvousPaced {
+		t.Error("RendezvousPaced = true exactly at the deadband — want false (guard is <=)")
+	}
+
+	partner.SubspaceTime = w.Clock.SimTime.Add(-rendezvousWaypointMinLead - time.Second)
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+	w.holdRendezvousLeader(partner)
+	if !w.RendezvousPaced {
+		t.Error("RendezvousPaced = false one second past the deadband — want true")
+	}
+}
+
+// TestHoldRendezvousLeader_LargeAheadPaces is the flip side: once the
+// leader has genuinely pulled ahead — most of the way to
+// rendezvousPaceCeilingSec — the ceiling is well below the unpaced rate
+// and the flag must still stand up (the fix must narrow the flag, not
+// disable pacing altogether).
+func TestHoldRendezvousLeader_LargeAheadPaces(t *testing.T) {
+	w := pacedLeaderWorld(t)
+	partner := &CoWarpPeer{
+		Owner: harnessOwnerB, Handle: "bob",
+		SubspaceTime: w.Clock.SimTime.Add(-time.Duration(rendezvousPaceCeilingSec-1) * time.Second),
+	}
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+
+	w.holdRendezvousLeader(partner)
+
+	if !w.RendezvousPaced {
+		t.Fatal("RendezvousPaced = false for a leader nearly at the pace ceiling — genuine pacing must still report")
+	}
+	if w.RendezvousPaceWarp <= 0 {
+		t.Errorf("RendezvousPaceWarp = %v, want > 0 while genuinely paced", w.RendezvousPaceWarp)
+	}
+}
+
+// TestHoldRendezvousLeader_AtCeilingHoldsToZero: ahead beyond the ceiling
+// still reports Paced (with PaceWarp effectively 0, the old freeze) —
+// unaffected by the finding 3 fix, since 0 is always < any unpaced rate.
+func TestHoldRendezvousLeader_AtCeilingHoldsToZero(t *testing.T) {
+	w := pacedLeaderWorld(t)
+	partner := &CoWarpPeer{
+		Owner: harnessOwnerB, Handle: "bob",
+		SubspaceTime: w.Clock.SimTime.Add(-time.Duration(rendezvousPaceCeilingSec+30) * time.Second),
+	}
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+
+	w.holdRendezvousLeader(partner)
+
+	if !w.RendezvousPaced {
+		t.Fatal("RendezvousPaced = false beyond the pace ceiling")
+	}
+	if w.RendezvousPaceWarp != 0 {
+		t.Errorf("RendezvousPaceWarp = %v, want 0 beyond the ceiling", w.RendezvousPaceWarp)
+	}
+}

--- a/internal/sim/rendezvous_unplanned_adoption_test.go
+++ b/internal/sim/rendezvous_unplanned_adoption_test.go
@@ -1,0 +1,103 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+)
+
+// TestUnplannedAgreement_AccepterAdoptsInitiatorsLaterPlan is finding 1
+// (batch review, HIGH): an accepter who joins a zero-τ ("agreed, no plan
+// yet") agreement was stuck permanently — refreshRendezvousInvite never
+// surfaces a fresh invite while w.RendezvousArm is non-nil, and nothing
+// on the accepter's side ever writes arm.Tau once the arm exists
+// (PlanMeetingBurn only touches the arm-holder's own arm). So when the
+// INITIATOR later plants a Meeting Burn and re-Engages — the exact flow
+// the chip itself prompts for ("no plan yet — pick a Meeting Place [K],
+// then Engage to commit") — the accepter's own arm never adopted it and
+// the coast never started for them.
+//
+// This drives the accepter's World through DriveRendezvousWarp with a
+// peer report that now carries a real, future RendezvousTau (mirroring
+// the initiator's post-replan relay report) and asserts the accepter's
+// own arm adopts it and the shared coast starts.
+func TestUnplannedAgreement_AccepterAdoptsInitiatorsLaterPlan(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, false) {
+		t.Fatal("Engage (as accepter) should succeed")
+	}
+	if w.RendezvousArm.Initiator {
+		t.Fatal("precondition: accepter seat")
+	}
+
+	// First tick: partner armed back, but still no plan on either side —
+	// must not start the coast (mirrors TestUnplannedAgreement_MutualDoesNotStartCoast).
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+	if w.rendezvousWarpEngaged() {
+		t.Fatal("precondition: coast must not start before a plan lands")
+	}
+
+	// The initiator plants a Meeting Burn and re-Engages: their relayed
+	// report now carries a real, future τ + committed CA + a Meeting
+	// Place. Nothing about the ACCEPTER's own seat or arm identity
+	// changes — only the partner's report.
+	committedTau := w.Clock.SimTime.Add(3 * time.Hour)
+	peer.RendezvousTau = committedTau
+	peer.RendezvousCA = 750
+	peer.RendezvousMeetingPlace = "LEO node"
+	peer.RendezvousMeetingLaps = 2
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+
+	if !w.rendezvousWarpEngaged() {
+		t.Fatal("accepter never adopted the initiator's later plan — still stuck unplanned")
+	}
+	if w.RendezvousArm == nil {
+		t.Fatal("arm cleared unexpectedly")
+	}
+	if !w.RendezvousArm.Tau.Equal(committedTau) {
+		t.Errorf("arm.Tau = %v, want adopted %v", w.RendezvousArm.Tau, committedTau)
+	}
+	if w.RendezvousArm.CommittedCA != 750 {
+		t.Errorf("arm.CommittedCA = %v, want 750 (adopted from partner)", w.RendezvousArm.CommittedCA)
+	}
+	if w.RendezvousArm.MeetingPlaceLabel != "LEO node" || w.RendezvousArm.MeetingLaps != 2 {
+		t.Errorf("Meeting Place not adopted: label=%q laps=%d", w.RendezvousArm.MeetingPlaceLabel, w.RendezvousArm.MeetingLaps)
+	}
+	if w.RendezvousArm.Initiator {
+		t.Error("adoption flipped the seat — accepter must stay accepter (ADR 0037 seat split)")
+	}
+	if w.AutoWarp == nil || !w.AutoWarp.Rendezvous || !w.AutoWarp.T.Equal(committedTau) {
+		t.Fatalf("driver not started on the adopted τ: AutoWarp=%+v", w.AutoWarp)
+	}
+	if w.RendezvousUnplanned() {
+		t.Error("RendezvousUnplanned() still true after adopting a real plan")
+	}
+}
+
+// TestUnplannedAgreement_AccepterIgnoresSubMinLeadPartnerTau mirrors the
+// min-τ adoption block's own min-lead floor (#252 review, finding 4):
+// a partner τ inside rendezvousWaypointMinLead of now must not be
+// adopted — it would be crossed on the very next tick, forcing an
+// immediate spurious waypoint resolution.
+func TestUnplannedAgreement_AccepterIgnoresSubMinLeadPartnerTau(t *testing.T) {
+	w, primary, st := anchorWorld(t)
+	if !w.EngageRendezvousWarpAs("SHA256:gern", "gern", time.Time{}, 0, false) {
+		t.Fatal("Engage (as accepter) should succeed")
+	}
+	peer := peerAt(w, primary, st, 3, orbital.Vec3{X: 50_000}, orbital.Vec3{}, "gern")
+	peer.ArmedTowardViewer = true
+	peer.RendezvousTau = w.Clock.SimTime.Add(1 * time.Second) // inside rendezvousWaypointMinLead (5s)
+
+	w.DriveRendezvousWarp([]CoWarpPeer{peer})
+
+	if w.rendezvousWarpEngaged() {
+		t.Error("adopted a sub-min-lead partner τ — should have waited")
+	}
+	if !w.RendezvousArm.Tau.IsZero() {
+		t.Errorf("arm.Tau = %v, want still zero", w.RendezvousArm.Tau)
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -522,9 +522,8 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			lines := []string{
 				v.theme.Primary.Render("RENDEZVOUS"),
 				v.theme.Dim.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous — " + gap),
-				chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
-				chipRow("CA:", formatRangeM(inv.CA)),
 			}
+			lines = append(lines, rendezvousInviteEncounterLines(inv, now)...)
 			if line := rendezvousMeetingLine(inv.MeetingPlaceLabel, inv.MeetingLaps); line != "" {
 				lines = append(lines, line)
 			}
@@ -533,9 +532,8 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		lines := []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			v.theme.Warning.Render("  ◇ " + inv.Handle + CraftTag(inv.CraftName) + " wants to rendezvous"),
-			chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
-			chipRow("CA:", formatRangeM(inv.CA)),
 		}
+		lines = append(lines, rendezvousInviteEncounterLines(inv, now)...)
 		if line := rendezvousMeetingLine(inv.MeetingPlaceLabel, inv.MeetingLaps); line != "" {
 			lines = append(lines, line)
 		}
@@ -555,6 +553,24 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 // after — see SetRendezvousMeeting). "" (render nothing) whenever the
 // commit's source wasn't a planted Meeting Burn node — including the
 // whole agreed-no-plan state, which never had one.
+// rendezvousInviteEncounterLines renders the invite's τ/CA rows — nil
+// (render nothing) when inv.Tau is zero (finding 2, batch review):
+// refreshRendezvousInvite now surfaces a zero-τ invite for ADR 0045 S7's
+// "agreed, no plan yet" state (#400), and compactDuration clamps a
+// negative duration to zero, so rendering these rows unconditionally
+// showed a fabricated "τ in: 0s / CA: 0 m" — an imminent zero-metre
+// encounter that was never computed — to the player deciding whether to
+// accept.
+func rendezvousInviteEncounterLines(inv *sim.RendezvousInvite, now time.Time) []string {
+	if inv.Tau.IsZero() {
+		return nil
+	}
+	return []string{
+		chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
+		chipRow("CA:", formatRangeM(inv.CA)),
+	}
+}
+
 func rendezvousMeetingLine(placeLabel string, laps int) string {
 	if placeLabel == "" {
 		return ""

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -647,3 +647,84 @@ func TestRendezvousChipUnplannedRendersAt80x24(t *testing.T) {
 		}
 	}
 }
+
+// TestRendezvousChipInviteZeroTauNoFabricatedEncounter is finding 2
+// (batch review): refreshRendezvousInvite now surfaces a zero-τ invite
+// for ADR 0045 S7's "agreed, no plan yet" state (#400) — before this
+// fix the invite's τ/CA rows rendered unconditionally, and
+// compactDuration clamps a negative duration to zero, so a zero-τ
+// invite showed a fabricated "τ in: 0s / CA: 0 m": an imminent
+// zero-metre encounter that was never computed, to the one player
+// deciding whether to accept.
+func TestRendezvousChipInviteZeroTauNoFabricatedEncounter(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:guest", Handle: "gern",
+		Tau: time.Time{}, CA: 0,
+	}
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	if strings.Contains(joined, "τ in:") {
+		t.Errorf("zero-τ invite fabricated a τ row:\n%s", joined)
+	}
+	if strings.Contains(joined, "CA:") {
+		t.Errorf("zero-τ invite fabricated a CA row:\n%s", joined)
+	}
+	for _, want := range []string{"gern wants to rendezvous", "[y] join"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("zero-τ invite chip missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+// TestRendezvousChipInviteBlockedZeroTauNoFabricatedEncounter is finding
+// 2's Blocked-variant twin (the same rows at :525-526 in the original
+// finding) — a subspace-diverged peer's zero-τ invite must not fabricate
+// an encounter either.
+func TestRendezvousChipInviteBlockedZeroTauNoFabricatedEncounter(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:guest", Handle: "gern",
+		Tau: time.Time{}, CA: 0,
+		Blocked: true, AheadBy: -3 * time.Minute,
+	}
+	joined := strings.Join(v.buildRendezvousChip(w), "\n")
+	if strings.Contains(joined, "τ in:") {
+		t.Errorf("blocked zero-τ invite fabricated a τ row:\n%s", joined)
+	}
+	if strings.Contains(joined, "CA:") {
+		t.Errorf("blocked zero-τ invite fabricated a CA row:\n%s", joined)
+	}
+	if !strings.Contains(joined, "gern wants to rendezvous") {
+		t.Errorf("blocked zero-τ invite chip missing attribution:\n%s", joined)
+	}
+}
+
+// TestRendezvousChipInviteZeroTauRendersAt80x24 pins the zero-τ invite's
+// rendering at the narrow floor, same pattern as
+// TestRendezvousChipUnplannedRendersAt80x24.
+func TestRendezvousChipInviteZeroTauRendersAt80x24(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := rendezvousChipWorld(t)
+	w.RendezvousInvite = &sim.RendezvousInvite{
+		Owner: "SHA256:guest", Handle: "gern",
+		Tau: time.Time{}, CA: 0,
+	}
+	lines := v.buildRendezvousChip(w)
+	if lines == nil {
+		t.Fatal("zero-tau invite chip rendered nil")
+	}
+	assertChipCellWidthConsistent(t, "zero-tau invite chip", lines)
+
+	out := v.composeChips(blankCanvas(80, 24), 80, 24, 0, 0, 0,
+		[]builtChip{{corner: cornerBottomLeft, lines: lines}})
+	if !strings.Contains(out, "gern wants to rendezvous") {
+		t.Errorf("invite line missing from the 80×24 composited canvas:\n%s", out)
+	}
+	for _, row := range strings.Split(out, "\n") {
+		if w := lenRunes(row); w != 80 {
+			t.Errorf("composited row width = %d, want 80 (narrow-terminal overflow): %q", w, row)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Four verified code-review findings against ADR 0045 S7 (#400), in `internal/sim/auto_warp.go` and `internal/tui/screens/orbit_chip_builders.go`.

1. **(HIGH)** An accepter who joined a zero-τ ("agreed, no plan yet") agreement could never adopt the initiator's later plan — `refreshRendezvousInvite` never surfaces a fresh invite once `RendezvousArm` is non-nil, and nothing on the accepter's side ever wrote `arm.Tau` once set. `driveRendezvousCoast` now adopts the partner's committed waypoint (mirroring the existing min-τ adoption block, same min-lead floor) before starting the coast, without touching the ADR 0037 seat split.
2. **(MEDIUM)** The RENDEZVOUS chip's invite prompt rendered `τ in:` / `CA:` rows unconditionally, fabricating "τ in: 0s / CA: 0 m" for a zero-τ invite. Both the joinable and Blocked variants now suppress those rows when the invite has no committed encounter yet.
3. **(MEDIUM)** `holdRendezvousLeader` set `RendezvousPaced` whenever the pace ramp was merely "active" (`ahead > 0`), which relay staleness alone satisfies on essentially every coasting tick. Gated behind `rendezvousWaypointMinLead` as a deadband — the same "too fresh to act on" floor already used for waypoint adoption.
4. **(LOW)** `RendezvousMutualUnplanned` was assigned but never reset at the top of `driveRendezvousCoast`, unlike its sibling flags — fixed to restore the single-writer/reset-at-top invariant.

`ComputeCoWarp`'s clamp-exemption ordering was **not** touched by this batch.

## Test plan
- [x] Each finding has a dedicated test; verified non-vacuously (reverted the specific fix, confirmed the paired test fails, restored) for all four.
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`

https://claude.ai/code/session_01HsrrpUr6dLcW4G8nmV9SRN