### PR TITLE
fix: Meeting Planner review findings (AchievableCA gate, direction/timing, crossing anchor)

### DIFF
--- a/internal/planner/meeting.go
+++ b/internal/planner/meeting.go
@@ -83,6 +83,10 @@ type MeetingBurnOption struct {
 	// (unburned) holder out to TArrival — not read off the closed-form
 	// solve directly — so a derivation bug shows up as a nonzero
 	// AchievableCA rather than being silently trusted away.
+	// meetingLadderCore gates Ok on this being within
+	// meetingAchievableCATolFrac of r0mag — a row whose own propagated
+	// check doesn't land close is never Ok=true (see that constant's
+	// doc comment).
 	AchievableCA float64 // m, separation at the propagated meeting time
 	ArrivalSpeed float64 // m/s, |v_rel| at that same instant
 }
@@ -111,6 +115,29 @@ var meetingCandidateLaps = []int{2, 3, 5, 10, 20}
 // explicitly narrows scope to coplanar (#398 "out of scope: the plane
 // rung").
 const meetingPlaneTolDeg = 1.0
+
+// meetingAchievableCATolFrac gates Ok on the row's own AchievableCA
+// (review finding: "Ok never consults AchievableCA"). meetingLadderCore
+// models the holder as sweeping at a uniform angular rate to derive t0
+// — exact for a circular holder, a first-order approximation for an
+// eccentric one (see meetingLadderCore's doc comment) — so a row can
+// pass every other gate (r0 in [holderPeri, holderApo], periapsis
+// safety, affordability) while the burn it actually prices misses the
+// holder by a large fraction of the orbit. AchievableCA is already the
+// row's own propagate-and-check number (both craft advanced via
+// physics.KeplerStep to TArrival); this constant is what turns that
+// number into a gate instead of a display-only field.
+//
+// 1% of r0mag is generous next to the near-machine-precision residual
+// a genuinely circular holder produces (TestRecommendMeetingLadder_
+// TheirOrbit_PhaseOffsetConverges asserts <5 km on a 6.87e6 m orbit,
+// several orders of magnitude under this bound) but far tighter than
+// the miss an eccentric holder's uniform-sweep approximation actually
+// produces: measured on a perigee 6771 km / apogee 12000 km orbit
+// (e≈0.28) with two co-orbital craft 1/6 period apart, every row's
+// AchievableCA came out ≈6,563,744 m against r0mag≈6.77e6 m — 97% of
+// r0mag, not a rounding error.
+const meetingAchievableCATolFrac = 0.01
 
 var (
 	// ErrMeetingPlaneMismatch: the two orbital planes differ by more
@@ -209,12 +236,46 @@ func RecommendMeetingLadder(
 		if crossingSearchHorizon <= 0 {
 			return MeetingLadder{}, errMeetingInvalidInput
 		}
-		if _, _, _, err := NextClosestApproach(stateA, stateB, primary, mu, crossingSearchHorizon); err != nil {
+		tCA, _, _, err := NextClosestApproach(stateA, stateB, primary, mu, crossingSearchHorizon)
+		if err != nil {
 			return MeetingLadder{}, ErrMeetingNoCrossing
 		}
-		rows, err := meetingLadderCore(stateA, stateB, primary, mu, moverRemainingDV)
+		// Finding 3 (review): this used to run meetingLadderCore on
+		// stateA/stateB exactly as MeetingTheirOrbit does — the anchor
+		// search above was an existence check only, never fed into the
+		// solve, so the two Places produced byte-identical ladders.
+		//
+		// Anchor properly: Kepler-propagate BOTH craft forward (unburned)
+		// to the natural crossing instant tCA found above, then run the
+		// SAME tangential-return solve anchored THERE instead of at
+		// "now" — mover and holder are already close at tCA (that's what
+		// makes it a crossing), so the correction Δv this produces is
+		// typically small, matching the doc comment's "cheapest when a
+		// close approach already exists." Genuinely different math from
+		// MeetingTheirOrbit whenever tCA isn't ~0 (mover's position at
+		// the crossing instant differs from its position now), which is
+		// the ordinary case.
+		moverAtTCA, mok := physics.KeplerStep(physics.StateVector{R: stateA.R, V: stateA.V}, mu, tCA)
+		holderAtTCA, hok := physics.KeplerStep(physics.StateVector{R: stateB.R, V: stateB.V}, mu, tCA)
+		if !mok || !hok {
+			return MeetingLadder{}, ErrMeetingNoCrossing
+		}
+		rows, err := meetingLadderCore(
+			orbital.Vec3State{R: moverAtTCA.R, V: moverAtTCA.V},
+			orbital.Vec3State{R: holderAtTCA.R, V: holderAtTCA.V},
+			primary, mu, moverRemainingDV)
 		if err != nil {
 			return MeetingLadder{}, err
+		}
+		// meetingLadderCore's TArrival is relative to the epoch of the
+		// states it was given — here, tCA, not "now". Re-anchor to "now"
+		// (add tCA back) so MeetingBurnOption.TArrival keeps its
+		// documented "seconds from now" meaning for every Place, not
+		// just the two that solve directly off stateA/stateB.
+		for i := range rows {
+			if rows[i].TArrival > 0 {
+				rows[i].TArrival += tCA
+			}
 		}
 		return MeetingLadder{Place: place, MoverIsA: true, Rows: rows}, nil
 	}
@@ -353,9 +414,10 @@ func meetingLadderCore(moverState, holderState orbital.Vec3State, primary bodies
 		mRaw := (float64(n)*pMoverOrig - t0) / pHolder
 		mFloor := math.Floor(mRaw)
 		var best MeetingBurnOption
+		var bestSafeFlag, bestAchievableFlag bool
 		bestFound := false
-		var bestSafe MeetingBurnOption
-		bestSafeFound := false
+		var bestGood MeetingBurnOption
+		bestGoodFound := false
 		for _, m := range [...]float64{mFloor, mFloor + 1} {
 			if m < 0 {
 				continue
@@ -389,12 +451,14 @@ func meetingLadderCore(moverState, holderState orbital.Vec3State, primary bodies
 				ArrivalSpeed: vRelAtT.Norm(),
 			}
 			safe := orbitSafetyGate(r0, v0, r0, newV, primary, mu)
+			achievable := cand.AchievableCA <= meetingAchievableCATolFrac*r0mag
 
 			if !bestFound || cand.DV < best.DV {
 				best, bestFound = cand, true
+				bestSafeFlag, bestAchievableFlag = safe, achievable
 			}
-			if safe && (!bestSafeFound || cand.DV < bestSafe.DV) {
-				bestSafe, bestSafeFound = cand, true
+			if safe && achievable && (!bestGoodFound || cand.DV < bestGood.DV) {
+				bestGood, bestGoodFound = cand, true
 			}
 		}
 		if !bestFound {
@@ -403,15 +467,27 @@ func meetingLadderCore(moverState, holderState orbital.Vec3State, primary bodies
 		}
 
 		chosen := best
-		chosenSafe := bestSafeFound
-		if bestSafeFound {
-			chosen = bestSafe
+		chosenSafe := bestSafeFlag
+		chosenAchievable := bestAchievableFlag
+		if bestGoodFound {
+			chosen = bestGood
+			chosenSafe, chosenAchievable = true, true
 		}
 
 		affordable := moverRemainingDV < 0 || chosen.DV <= moverRemainingDV
 		switch {
 		case !chosenSafe:
 			chosen.Reason = "burn drops periapsis unsafely"
+		case !chosenAchievable:
+			// The row's own propagate-and-check (AchievableCA) landed
+			// outside meetingAchievableCATolFrac of r0mag — the
+			// uniform-angular-rate holder model (see this function's
+			// doc comment) doesn't hold for this geometry, so the
+			// solved burn doesn't actually deliver a meeting. Same
+			// reason text as the "no bracket converged at all" case
+			// above: both mean "this lap count has no usable meeting
+			// solution", just discovered at a different stage.
+			chosen.Reason = "no meeting solution"
 		case !affordable:
 			chosen.Reason = "unaffordable"
 		default:

--- a/internal/planner/meeting_test.go
+++ b/internal/planner/meeting_test.go
@@ -77,6 +77,59 @@ func TestRecommendMeetingLadder_TheirOrbit_PhaseOffsetConverges(t *testing.T) {
 	}
 }
 
+// TestRecommendMeetingLadder_EccentricHolder_UnachievableRefused —
+// review Finding 1: "Ok never consults AchievableCA." meetingLadderCore's
+// t0 derivation sweeps the holder at a uniform angular rate, exact only
+// for a circular holder; on an eccentric one the model is wrong and the
+// row it prices doesn't actually deliver a meeting, yet every other gate
+// (r0 in [holderPeri, holderApo], periapsis safety, affordability) still
+// passes because both craft sit on the SAME eccentric orbit.
+//
+// Reproduces the reviewer's exact measured scenario: a periapsis 6771 km
+// / apoapsis 12000 km orbit (e≈0.28), two co-orbital craft 1/6 period
+// apart (built by Kepler-stepping one craft's own state forward P/6 —
+// the literal "co-orbital, offset in time" geometry, not just a linear
+// phase offset). Before the fix every row here reported Ok=true with
+// AchievableCA≈6,563,744 m against r0mag≈6.77e6 m (a ~97%-of-orbit
+// miss); this asserts no row is allowed to claim Ok=true when its own
+// propagated check misses this badly.
+func TestRecommendMeetingLadder_EccentricHolder_UnachievableRefused(t *testing.T) {
+	mu := muEarth
+	rp := 6.771e6
+	ra := 12.000e6
+	e := (ra - rp) / (ra + rp)
+	k := math.Sqrt(1 + e) // eccentricStateAtRadius's periapsis-speed multiplier for this e
+
+	stateA := eccentricStateAtRadius(rp, 0, k, mu)
+	period := orbitalPeriod(physics.StateVector{R: stateA.R, V: stateA.V}, mu)
+	svB, ok := physics.KeplerStep(physics.StateVector{R: stateA.R, V: stateA.V}, mu, period/6)
+	if !ok {
+		t.Fatalf("setup: KeplerStep failed advancing the co-orbital partner by P/6")
+	}
+	stateB := orbital.Vec3State{R: svB.R, V: svB.V}
+
+	ladder, err := RecommendMeetingLadder(stateA, stateB, bodies.CelestialBody{}, mu, MeetingTheirOrbit, 4*3600, -1)
+	if err != nil {
+		t.Fatalf("RecommendMeetingLadder err: %v", err)
+	}
+	if len(ladder.Rows) == 0 {
+		t.Fatalf("expected rows")
+	}
+	for _, row := range ladder.Rows {
+		if row.Ok {
+			t.Errorf("laps=%d: Ok=true with AchievableCA=%.0f m (r0≈%.0f m) — a %.0f%% miss must not be offered as a meeting",
+				row.Laps, row.AchievableCA, rp, 100*row.AchievableCA/rp)
+		}
+		// The row is still RETURNED with its real numbers (ADR 0045 §2:
+		// "unaffordable rows are shown but not plantable") — only Ok
+		// flips, AchievableCA itself must stay the honest propagated
+		// value, not get hidden or zeroed.
+		if row.AchievableCA <= 0 {
+			t.Errorf("laps=%d: AchievableCA=%.0f, want the real (large) propagated miss, not zeroed", row.Laps, row.AchievableCA)
+		}
+	}
+}
+
 // TestRecommendMeetingLadder_MoreLapsCostsLess — the doctrine's own
 // wait-vs-Δv lever (ADR 0045 §2's ladder example: 2 laps/630 m/s vs
 // 5 laps/250 m/s vs 20 laps/60 m/s — monotonically cheaper with more
@@ -286,6 +339,73 @@ func TestRecommendMeetingLadder_Crossing_HappyPath(t *testing.T) {
 	}
 	if !sawOk {
 		t.Fatalf("expected at least one Ok row: %+v", ladder.Rows)
+	}
+}
+
+// TestRecommendMeetingLadder_Crossing_DiffersFromTheirOrbit — review
+// Finding 3: "MeetingCrossing is inert." Before the fix, the anchor
+// search (NextClosestApproach) ran as an existence check only and was
+// never fed into the solve — meetingLadderCore always ran on
+// stateA/stateB exactly as MeetingTheirOrbit does, so the two Places
+// produced byte-identical ladders (TestRecommendMeetingLadder_Crossing_
+// HappyPath's own matched-circular fixture doesn't catch this: for
+// perfectly phase-locked circular orbits the natural crossing IS "now",
+// so the two Places legitimately coincide there).
+//
+// This fixture avoids that degeneracy: two craft on the SAME mildly
+// eccentric orbit (so meetingLadderCore's own r0-reachability gate
+// stays satisfied at any anchor instant — both always sit within their
+// shared [periapsis, apoapsis] band) but offset by 1/8 orbital PERIOD
+// in time (via Kepler-propagation, not a periapsis-direction rotation —
+// a rotated-periapsis fixture keeps the natural crossing pinned at each
+// shared periapsis pass, i.e. still at t≈0, for reasons worked out
+// against NextClosestApproach directly before writing this test). The
+// natural crossing here sits measurably later than "now" (verified
+// below), so if MeetingCrossing anchors there while MeetingTheirOrbit
+// anchors at "now", their rows must differ.
+func TestRecommendMeetingLadder_Crossing_DiffersFromTheirOrbit(t *testing.T) {
+	r := meetingCalibrationRadius
+	mu := muEarth
+	k := 1.02 // mild eccentricity (e≈0.04) — keeps meetingLadderCore's holder-sweep model close enough to exact that Finding 1's AchievableCA gate isn't the thing under test here
+	target := eccentricStateAtRadius(r, 0, k, mu)
+	period := orbitalPeriod(physics.StateVector{R: target.R, V: target.V}, mu)
+	svB, ok := physics.KeplerStep(physics.StateVector{R: target.R, V: target.V}, mu, period/8)
+	if !ok {
+		t.Fatalf("setup: KeplerStep failed advancing the co-orbital partner by P/8")
+	}
+	chaser := orbital.Vec3State{R: svB.R, V: svB.V}
+
+	// Non-vacuous precondition: the natural crossing must sit measurably
+	// later than "now", or this fixture doesn't stress the bug either.
+	tCA, _, _, err := NextClosestApproach(chaser, target, bodies.CelestialBody{}, mu, 4*3600)
+	if err != nil {
+		t.Fatalf("setup: NextClosestApproach err: %v", err)
+	}
+	if tCA < 60 {
+		t.Fatalf("setup: tCA = %.1f s, want > 60 s — this fixture must anchor somewhere other than \"now\" to test the fix", tCA)
+	}
+
+	crossing, err := RecommendMeetingLadder(chaser, target, bodies.CelestialBody{}, mu, MeetingCrossing, 4*3600, -1)
+	if err != nil {
+		t.Fatalf("crossing err: %v", err)
+	}
+	theirs, err := RecommendMeetingLadder(chaser, target, bodies.CelestialBody{}, mu, MeetingTheirOrbit, 4*3600, -1)
+	if err != nil {
+		t.Fatalf("their orbit err: %v", err)
+	}
+	if len(crossing.Rows) != len(theirs.Rows) {
+		t.Fatalf("row count mismatch: crossing=%d theirs=%d", len(crossing.Rows), len(theirs.Rows))
+	}
+	identical := true
+	for i := range crossing.Rows {
+		if crossing.Rows[i].DV != theirs.Rows[i].DV || crossing.Rows[i].TArrival != theirs.Rows[i].TArrival {
+			identical = false
+			break
+		}
+	}
+	if identical {
+		t.Errorf("MeetingCrossing produced a byte-identical ladder to MeetingTheirOrbit (tCA=%.1f s from now) — "+
+			"the crossing anchor isn't being fed into the solve: crossing=%+v theirs=%+v", tCA, crossing.Rows, theirs.Rows)
 	}
 }
 

--- a/internal/sim/meeting.go
+++ b/internal/sim/meeting.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -152,10 +153,33 @@ type MeetingPlan struct {
 // PlanMeetingBurn commits the Lap Ladder row with the given lap count
 // for the given MeetingPlace. Mirrors PlanRendezvousNudge /
 // PlanVesselPlaneMatch's single-keystroke-planter shape: gather state,
-// ask the planner, plant a BurnVector node (the same arbitrary-3D-
-// direction mechanism the fused-Lambert departure planter uses,
-// spacecraft.BurnVector — a Meeting Burn is a raw tangential Δv, not
-// one of the eight discrete prograde/retrograde/normal/radial axes).
+// ask the planner, plant a maneuver node.
+//
+// The row returned by the preview ladder (w.RecommendMeetingLadder) is
+// solved as a tangential burn at the craft's position NOW — but the
+// node it plants doesn't fire until leadBuffer later (the same slew-
+// lead pattern PlanRendezvousNudge uses). Review finding 2: planting
+// that row as a BurnVector node (a FROZEN inertial direction, see
+// spacecraft.NodeBurnDirection) fires the frozen "tangential at now"
+// direction at a position where it is no longer tangential, and
+// MeetingArrivalSec re-anchored by subtracting leadBuffer from
+// TArrival doesn't land on the resulting closest approach either
+// (measured: rendezvousTwoCraftWorld at 30° phase lag reported
+// AchievableCA=0 while the planted node actually produced 974.9 m at
+// the committed τ, true minimum 46.3 m ten seconds later).
+//
+// Fix: re-solve the ladder from the state BOTH craft will actually be
+// at TriggerTime (Kepler-propagated forward by leadBuffer, no burn
+// applied — the craft is coasting, not thrusting, until the node
+// fires), then plant BurnPrograde/BurnRetrograde — re-derived at fire
+// time from the craft's ACTUAL (r, v) via NodeBurnDirection/
+// DirectionUnit, exactly like every other tangential-style node — so
+// the direction is correct at the instant it actually applies.
+// MeetingArrivalSec is the fresh row's own TArrival directly: since
+// that row was solved AT TriggerTime, TArrival is already "seconds
+// from TriggerTime to the meeting" — no re-anchoring subtraction
+// needed (see rendezvousCommitFromPlantedMeetingNode, which reads
+// MeetingArrivalSec as exactly that).
 //
 // A second call replaces the craft's own previously-planted, still
 // unfired Meeting Burn (AdvisoryKeyMeetingBurn) rather than stacking a
@@ -194,7 +218,58 @@ func (w *World) PlanMeetingBurn(place planner.MeetingPlace, laps int) (*MeetingP
 		return &MeetingPlan{MeetingBurnOption: row, ForActive: false}, nil
 	}
 
+	// leadBuffer only needs an approximate burn axis to size the slew
+	// angle — the preview row's "tangential at now" direction is close
+	// enough for that estimate even though it isn't used for the plant
+	// itself below.
 	leadBuffer := w.rendezvousLeadBuffer(active, row.BurnDir)
+	triggerTime := w.Clock.SimTime.Add(leadBuffer)
+
+	mu := active.Primary.GravitationalParameter()
+	moverAtTrigger, mok := physics.KeplerStep(active.State, mu, leadBuffer.Seconds())
+	if !mok {
+		return nil, ErrRendezvousNoImprovement
+	}
+	rT, vT, tok := w.TargetStateRelativeToActivePrimary()
+	if !tok {
+		return nil, ErrRendezvousNoTarget
+	}
+	holderAtTrigger, hok := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, leadBuffer.Seconds())
+	if !hok {
+		return nil, ErrRendezvousNoImprovement
+	}
+
+	moverRemainingDV := w.meetingMoverRemainingDV(place, active)
+	freshLadder, err := planner.RecommendMeetingLadder(
+		orbital.Vec3State{R: moverAtTrigger.R, V: moverAtTrigger.V},
+		orbital.Vec3State{R: holderAtTrigger.R, V: holderAtTrigger.V},
+		active.Primary, mu, place, rendezvousCommitHorizonSec, moverRemainingDV)
+	if err != nil {
+		return nil, meetingStructuralErr(err)
+	}
+	var freshRow planner.MeetingBurnOption
+	freshFound := false
+	for _, r := range freshLadder.Rows {
+		if r.Laps == laps {
+			freshRow, freshFound = r, true
+			break
+		}
+	}
+	if !freshFound {
+		return nil, ErrMeetingNoSuchLap
+	}
+	if !freshRow.Ok {
+		return nil, meetingRowReasonToErr(freshRow.Reason)
+	}
+
+	// The fresh row's BurnDir is ± the mover's OWN velocity unit at
+	// TriggerTime (meetingLadderCore's tangential-burn construction) —
+	// compare against it to pick prograde vs. retrograde rather than
+	// carrying a frozen direction vector.
+	mode := spacecraft.BurnPrograde
+	if freshRow.BurnDir.Dot(moverAtTrigger.V.Unit()) < 0 {
+		mode = spacecraft.BurnRetrograde
+	}
 
 	// #293 precedent: a second press replaces its own previous unfired
 	// Meeting Burn instead of stacking behind it — every ladder row is
@@ -202,37 +277,28 @@ func (w *World) PlanMeetingBurn(place planner.MeetingPlace, laps int) (*MeetingP
 	// would fire against an orbit it was never computed for.
 	w.replaceAdvisoryNode(active, AdvisoryKeyMeetingBurn)
 
-	// ADR 0045 S7 (#400): carry the plan's own arrival onto the node so a
-	// later Engage can commit to it directly (see ManeuverNode's own doc
-	// comment). row.TArrival is measured from PLANT time (now); the node
-	// actually fires leadBuffer later, so the offset stored is
-	// re-anchored to TriggerTime. A row whose TArrival doesn't clear the
-	// lead buffer (never expected off meetingCandidateLaps' shortest lap,
-	// but not proven impossible) leaves MeetingArrivalSec at its zero
-	// value — rendezvousCommitFromPlantedMeetingNode treats that as "no
-	// plan info", falling back to the current-course search exactly like
-	// a node that predates this field.
-	var arrivalSec float64
-	if a := row.TArrival - leadBuffer.Seconds(); a > 0 {
-		arrivalSec = a
-	}
-
 	node := ManeuverNode{
-		Mode:              spacecraft.BurnVector,
-		DV:                row.DV,
-		Duration:          active.BurnTimeForDV(row.DV),
-		Event:             spacecraft.TriggerAbsolute,
-		TriggerTime:       w.Clock.SimTime.Add(leadBuffer),
-		PrimaryID:         active.Primary.ID,
-		Throttle:          1.0,
-		TargetCraftID:     w.Target.CraftID,
-		TargetGhostOwner:  w.Target.GhostOwner,
-		AdvisoryKey:       AdvisoryKeyMeetingBurn,
-		BurnDirUnit:       row.BurnDir,
-		MeetingArrivalSec: arrivalSec,
+		Mode:     mode,
+		DV:       freshRow.DV,
+		Duration: active.BurnTimeForDV(freshRow.DV),
+		Event:    spacecraft.TriggerAbsolute,
+
+		TriggerTime:      triggerTime,
+		PrimaryID:        active.Primary.ID,
+		Throttle:         1.0,
+		TargetCraftID:    w.Target.CraftID,
+		TargetGhostOwner: w.Target.GhostOwner,
+		AdvisoryKey:      AdvisoryKeyMeetingBurn,
+		// ADR 0045 S7 (#400): carry the plan's own arrival onto the node
+		// so a later Engage can commit to it directly (see
+		// rendezvousCommitFromPlantedMeetingNode). freshRow was solved
+		// FROM the state at TriggerTime, so its own TArrival already
+		// means "seconds from TriggerTime to the meeting" — stored
+		// as-is, no lead-buffer re-anchoring needed.
+		MeetingArrivalSec: freshRow.TArrival,
 		MeetingPlaceLabel: place.String(),
 		MeetingLaps:       laps,
 	}
 	w.PlanNode(node)
-	return &MeetingPlan{MeetingBurnOption: row, ForActive: true}, nil
+	return &MeetingPlan{MeetingBurnOption: freshRow, ForActive: true}, nil
 }

--- a/internal/sim/meeting_test.go
+++ b/internal/sim/meeting_test.go
@@ -12,7 +12,15 @@ import (
 // TestPlanMeetingBurn_PlantsOneNode — the happy path for the sim-layer
 // planter: MeetingTheirOrbit on a near-matched-orbit two-craft world
 // (rendezvousSmallLagWorld, the same fixture family K's own nudge
-// tests use) plants exactly one BurnVector node on the ACTIVE craft.
+// tests use) plants exactly one node on the ACTIVE craft.
+//
+// Review finding 2: the node plants as BurnPrograde/BurnRetrograde, not
+// BurnVector — a fixed inertial BurnVector direction solved "now" is no
+// longer tangential by the time the node actually fires (leadBuffer
+// later); BurnPrograde/Retrograde re-derive the tangential direction at
+// fire time from the craft's actual (r, v) instead (see
+// PlanMeetingBurn's own doc comment). BurnDirUnit stays zero — it's
+// populated only for BurnVector nodes (ManeuverNode's own doc comment).
 func TestPlanMeetingBurn_PlantsOneNode(t *testing.T) {
 	w := rendezvousSmallLagWorld(t)
 	c := w.ActiveCraft()
@@ -47,8 +55,8 @@ func TestPlanMeetingBurn_PlantsOneNode(t *testing.T) {
 		t.Fatalf("expected 1 node planted, got %d", len(c.Nodes))
 	}
 	n := c.Nodes[0]
-	if n.Mode != spacecraft.BurnVector {
-		t.Errorf("Mode = %v, want BurnVector", n.Mode)
+	if n.Mode != spacecraft.BurnPrograde && n.Mode != spacecraft.BurnRetrograde {
+		t.Errorf("Mode = %v, want BurnPrograde or BurnRetrograde", n.Mode)
 	}
 	if n.AdvisoryKey != AdvisoryKeyMeetingBurn {
 		t.Errorf("AdvisoryKey = %q, want %q", n.AdvisoryKey, AdvisoryKeyMeetingBurn)
@@ -56,8 +64,11 @@ func TestPlanMeetingBurn_PlantsOneNode(t *testing.T) {
 	if math.Abs(n.DV-plan.DV) > 1e-6 {
 		t.Errorf("node DV = %.3f, want %.3f (plan.DV)", n.DV, plan.DV)
 	}
-	if n.BurnDirUnit.Norm() == 0 {
-		t.Errorf("BurnDirUnit is zero — expected the ladder row's burn direction")
+	if n.BurnDirUnit.Norm() != 0 {
+		t.Errorf("BurnDirUnit = %+v, want zero — populated only for BurnVector nodes, and this node is Prograde/Retrograde", n.BurnDirUnit)
+	}
+	if n.MeetingArrivalSec <= 0 {
+		t.Errorf("MeetingArrivalSec = %.1f, want > 0", n.MeetingArrivalSec)
 	}
 	if !n.TriggerTime.After(w.Clock.SimTime) {
 		t.Errorf("TriggerTime not in the future")

--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -488,10 +488,10 @@ func (w *World) rendezvousCommitFromPlantedNode(active *spacecraft.Spacecraft, n
 //
 // ok=false for the same reasons as the sibling (past-due node, a
 // degenerate Kepler step, an SOI crossing before the burn fires, an
-// unresolvable direction), plus a node with no MeetingArrivalSec — either
-// a non-Meeting-Burn node reaching this by construction error, or one
-// whose row.TArrival didn't clear the lead buffer at plant time (see
-// PlanMeetingBurn) — treated as "no plan info", not zero wait.
+// unresolvable direction), plus a node with no MeetingArrivalSec — a
+// non-Meeting-Burn node reaching this by construction error, or a node
+// planted before ADR 0045 S7 added the field — treated as "no plan
+// info", not zero wait.
 func (w *World) rendezvousCommitFromPlantedMeetingNode(active *spacecraft.Spacecraft, node spacecraft.ManeuverNode, rT, vT orbital.Vec3, mu float64) (time.Time, float64, bool) {
 	if node.MeetingArrivalSec <= 0 {
 		return time.Time{}, 0, false

--- a/internal/sim/rendezvous_meeting_commit_test.go
+++ b/internal/sim/rendezvous_meeting_commit_test.go
@@ -18,17 +18,136 @@ import (
 
 // TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon is the
 // #400 acceptance test: "Engage commits to a planted Meeting Planner
-// node's arrival 8h out." Plants a real Meeting Burn via PlanMeetingBurn
-// (so BurnDirUnit/DV/TriggerTime all come from the actual solver), then
-// overrides the node's MeetingArrivalSec to exactly 8h — well past
-// rendezvousCommitHorizonSec (4h) — for a deterministic scenario
-// regardless of which lap row the small-lag fixture happens to solve.
-// RendezvousCommitWithPlan must commit to TriggerTime+8h directly: if it
+// node's arrival [well] out [past the 4h horizon]." Plants a real
+// Meeting Burn via PlanMeetingBurn, picking the LARGEST-lap Ok row on
+// the small-lag fixture: more laps means a smaller Δv spread over more
+// holder periods (ADR 0045 §2's own wait-vs-Δv ladder), so on a ~90 min
+// LEO period even the smallest such fixture's highest lap count
+// (meetingCandidateLaps' own 20) naturally waits tens of hours — no
+// need to force the scenario by hand.
+//
+// Review finding 2 (this test previously overwrote MeetingArrivalSec by
+// hand to exactly 8h, so nothing pinned the field's NATURAL value — a
+// vacuous test the reviewer flagged specifically): this version reads
+// MeetingArrivalSec straight off the planted node and asserts
+// RendezvousCommitWithPlan commits to TriggerTime + that natural value,
+// with a non-vacuous precondition guard that it is actually beyond the
+// 4h horizon (so the test still exercises the "beyond horizon" property
+// it's named for, without hand-editing the field under test).
+//
+// RendezvousCommitWithPlan must commit to that arrival directly: if it
 // instead ran rendezvousCommitFromPlantedNode's horizon-bounded search
-// (the trim-nudge sibling's behaviour), an encounter 8h out — double the
-// 4h window — could never be found, and the commit would refuse.
+// (the trim-nudge sibling's behaviour), an encounter well past the 4h
+// window could never be found, and the commit would refuse.
 func TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon(t *testing.T) {
 	w := rendezvousSmallLagWorld(t)
+	c := w.ActiveCraft()
+
+	ladder, err := w.RecommendMeetingLadder(planner.MeetingTheirOrbit)
+	if err != nil {
+		t.Fatalf("RecommendMeetingLadder err: %v", err)
+	}
+	// Pick the LARGEST-lap Ok row (rows are appended in meetingCandidateLaps'
+	// own ascending order, so the last Ok row is the largest), not the
+	// first — the whole point is a wait that clears the 4h horizon.
+	var pick int
+	found := false
+	for _, row := range ladder.Rows {
+		if row.Ok {
+			pick, found = row.Laps, true
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one Ok row: %+v", ladder.Rows)
+	}
+	if _, err := w.PlanMeetingBurn(planner.MeetingTheirOrbit, pick); err != nil {
+		t.Fatalf("PlanMeetingBurn err: %v", err)
+	}
+	if len(c.Nodes) != 1 {
+		t.Fatalf("expected 1 planted node, got %d", len(c.Nodes))
+	}
+	node := c.Nodes[0]
+
+	// Non-vacuous precondition: the NATURAL MeetingArrivalSec this specific
+	// lap row solved to must already exceed rendezvousCommitHorizonSec, or
+	// this test isn't exercising the "beyond horizon" property it claims to.
+	if node.MeetingArrivalSec <= rendezvousCommitHorizonSec {
+		t.Fatalf("setup: node.MeetingArrivalSec = %.1f s, want > %.1f s (the 4h horizon) — laps=%d didn't naturally wait long enough to stress the bound",
+			node.MeetingArrivalSec, rendezvousCommitHorizonSec, pick)
+	}
+	wantTau := node.TriggerTime.Add(time.Duration(node.MeetingArrivalSec * float64(time.Second)))
+
+	plan, ok := w.RendezvousCommitWithPlan()
+	if !ok {
+		t.Fatal("RendezvousCommitWithPlan: ok=false, want true (structural gates all pass)")
+	}
+	if plan.Tau.IsZero() {
+		t.Fatal("plan.Tau is zero — the planted Meeting Burn node was not honored")
+	}
+	if diff := plan.Tau.Sub(wantTau); diff < -time.Second || diff > time.Second {
+		t.Errorf("plan.Tau = %v, want %v (node.TriggerTime + its own MeetingArrivalSec) — got a difference of %v; "+
+			"a horizon-bounded search would have refused entirely rather than land near this", plan.Tau, wantTau, diff)
+	}
+	if plan.CommittedCA <= 0 {
+		t.Errorf("plan.CommittedCA = %.3f, want > 0", plan.CommittedCA)
+	}
+	if plan.MeetingPlaceLabel != planner.MeetingTheirOrbit.String() {
+		t.Errorf("plan.MeetingPlaceLabel = %q, want %q", plan.MeetingPlaceLabel, planner.MeetingTheirOrbit.String())
+	}
+	if plan.MeetingLaps != pick {
+		t.Errorf("plan.MeetingLaps = %d, want %d", plan.MeetingLaps, pick)
+	}
+}
+
+// rendezvousPhaseLagWorld mirrors rendezvousSmallLagWorld (rendezvous_test.go)
+// but takes the lag angle as a parameter — the small-lag fixture's fixed
+// -0.5° is too close to co-orbital for Finding 2's bug to show measurably
+// (a tangential burn frozen at "now" is still nearly tangential a few tens
+// of seconds later at a nearly-identical point on a nearly-matched orbit).
+func rendezvousPhaseLagWorld(t *testing.T, angle float64) *World {
+	t.Helper()
+	w := rendezvousTwoCraftWorld(t)
+	active := w.Crafts[0]
+	target := w.Crafts[1]
+	h := active.State.R.Cross(active.State.V)
+	axis := h.Unit()
+	target.State.R = rotateAboutAxis(active.State.R, axis, angle)
+	target.State.V = rotateAboutAxis(active.State.V, axis, angle)
+	target.Primary = active.Primary
+	return w
+}
+
+// TestPlanMeetingBurn_CommittedArrivalMatchesTrueClosestApproach is
+// review Finding 2's own regression test, reproducing the reviewer's
+// exact measured scenario: rendezvousTwoCraftWorld with a 30° phase lag.
+//
+// Before the fix, PlanMeetingBurn solved the burn tangentially at the
+// craft's position NOW but planted it as a BurnVector node — a FROZEN
+// inertial direction (spacecraft.NodeBurnDirection) — that fires
+// leadBuffer later at a different point on the orbit, where the frozen
+// direction is no longer tangential; MeetingArrivalSec was then
+// re-anchored by subtracting leadBuffer from the "solved at now" row's
+// TArrival, which doesn't land on the resulting closest approach either.
+// Measured on this exact fixture: the row/commit reported
+// AchievableCA/CommittedCA = 0.0 m, but propagating the planted node
+// exactly as rendezvousCommitFromPlantedMeetingNode does gave 974.9 m at
+// the committed τ, with the TRUE minimum separation of 46.3 m occurring
+// ten seconds later — a burn advertised as a meeting that actually
+// misses by very roughly a kilometer at the wrong instant.
+//
+// After the fix (BurnPrograde/Retrograde re-derived at fire time, solved
+// from the state at TriggerTime — see PlanMeetingBurn's own doc
+// comment), the committed plan's CommittedCA must be small AND must sit
+// at the actual local-minimum separation — verified here by an
+// independent fine-grained scan around the committed arrival using the
+// SAME post-burn state rendezvousCommitFromPlantedMeetingNode derives,
+// so this test cannot pass merely because the solver's own prediction
+// agrees with itself (the self-consistency trap the planner package's
+// own TestMeetingLadder_IterateSelfConsistent doc comment warns about —
+// this scan uses the node's ACTUAL fire-time direction, not the
+// solver's stored one).
+func TestPlanMeetingBurn_CommittedArrivalMatchesTrueClosestApproach(t *testing.T) {
+	w := rendezvousPhaseLagWorld(t, -30*math.Pi/180)
 	c := w.ActiveCraft()
 
 	ladder, err := w.RecommendMeetingLadder(planner.MeetingTheirOrbit)
@@ -52,32 +171,65 @@ func TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon(t *testing.T)
 	if len(c.Nodes) != 1 {
 		t.Fatalf("expected 1 planted node, got %d", len(c.Nodes))
 	}
-
-	// Override to an 8h wait, deterministic and well past the 4h horizon
-	// regardless of what lap row the solver actually picked above.
-	const eightHours = 8 * 3600.0
-	c.Nodes[0].MeetingArrivalSec = eightHours
-	wantTau := c.Nodes[0].TriggerTime.Add(time.Duration(eightHours * float64(time.Second)))
+	node := c.Nodes[0]
 
 	plan, ok := w.RendezvousCommitWithPlan()
-	if !ok {
-		t.Fatal("RendezvousCommitWithPlan: ok=false, want true (structural gates all pass)")
+	if !ok || plan.Tau.IsZero() {
+		t.Fatalf("RendezvousCommitWithPlan: ok=%v Tau=%v, want a committed plan", ok, plan.Tau)
 	}
-	if plan.Tau.IsZero() {
-		t.Fatal("plan.Tau is zero — the planted Meeting Burn node was not honored")
+
+	// Independent scan: rebuild the SAME post-burn state
+	// rendezvousCommitFromPlantedMeetingNode itself derives (target
+	// Kepler-propagated to TriggerTime, then the node's OWN direction
+	// mode applied via postBurnStateWithTarget — BurnPrograde/Retrograde
+	// re-resolved at that state, not a stored vector), then sweep a
+	// ±60 s window around the node's own MeetingArrivalSec looking for
+	// the TRUE local-minimum separation.
+	rT, vT, tok := w.TargetStateRelativeToActivePrimary()
+	if !tok {
+		t.Fatal("TargetStateRelativeToActivePrimary: ok=false")
 	}
-	if diff := plan.Tau.Sub(wantTau); diff < -time.Second || diff > time.Second {
-		t.Errorf("plan.Tau = %v, want %v (node.TriggerTime + 8h) — got a difference of %v; "+
-			"a horizon-bounded search would have refused entirely (8h > 4h) rather than land near this", plan.Tau, wantTau, diff)
+	mu := c.Primary.GravitationalParameter()
+	dt := node.TriggerTime.Sub(w.Clock.SimTime).Seconds()
+	targetAtTrigger, tok2 := physics.KeplerStep(physics.StateVector{R: rT, V: vT}, mu, dt)
+	if !tok2 {
+		t.Fatal("KeplerStep (target to TriggerTime) failed")
 	}
-	if plan.CommittedCA <= 0 {
-		t.Errorf("plan.CommittedCA = %.3f, want > 0", plan.CommittedCA)
+	postState, _, pok := w.postBurnStateWithTarget(node, targetAtTrigger.R, targetAtTrigger.V)
+	if !pok {
+		t.Fatal("postBurnStateWithTarget failed")
 	}
-	if plan.MeetingPlaceLabel != planner.MeetingTheirOrbit.String() {
-		t.Errorf("plan.MeetingPlaceLabel = %q, want %q", plan.MeetingPlaceLabel, planner.MeetingTheirOrbit.String())
+	trueMin := math.Inf(1)
+	trueMinOffset := 0.0
+	for offset := -60.0; offset <= 60.0; offset += 1.0 {
+		tArr := node.MeetingArrivalSec + offset
+		if tArr <= 0 {
+			continue
+		}
+		moverArr, mok := physics.KeplerStep(postState, mu, tArr)
+		holderArr, hok := physics.KeplerStep(targetAtTrigger, mu, tArr)
+		if !mok || !hok {
+			continue
+		}
+		if d := moverArr.R.Sub(holderArr.R).Norm(); d < trueMin {
+			trueMin, trueMinOffset = d, offset
+		}
 	}
-	if plan.MeetingLaps != pick {
-		t.Errorf("plan.MeetingLaps = %d, want %d", plan.MeetingLaps, pick)
+	if math.IsInf(trueMin, 1) {
+		t.Fatal("scan: no offset produced a valid Kepler propagation")
+	}
+
+	const smallCAM = 5_000.0 // 5 km — same "small" family as the planner's own calibration bound
+	if plan.CommittedCA > smallCAM {
+		t.Errorf("plan.CommittedCA = %.1f m, want small (<%.0f m) — a mismatched frozen burn direction would report the honest large miss instead", plan.CommittedCA, smallCAM)
+	}
+	if trueMin > smallCAM {
+		t.Errorf("independently-scanned true minimum = %.1f m at offset %.1fs from the committed arrival, want small (<%.0f m)", trueMin, trueMinOffset, smallCAM)
+	}
+	if math.Abs(trueMinOffset) > 5 {
+		t.Errorf("true minimum occurs %.1fs from the committed arrival, want within a few seconds — "+
+			"the committed τ should already sit at the actual closest approach, not miss it by a fixed offset "+
+			"(finding 2's bug landed the true minimum 10s after the reported one)", trueMinOffset)
 	}
 }
 

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -185,11 +185,15 @@ type ManeuverNode struct {
 	// window bounds a search, not a plan").
 	//
 	// MeetingArrivalSec is seconds from THIS NODE'S OWN TriggerTime to the
-	// meeting instant (planner.MeetingBurnOption.TArrival, which is
-	// measured from plant time, re-anchored here by subtracting the same
-	// lead buffer already folded into TriggerTime) so the absolute arrival
-	// is recovered as TriggerTime.Add(MeetingArrivalSec) with no extra
-	// state. MeetingPlaceLabel is planner.MeetingPlace.String() ("their
+	// meeting instant, so the absolute arrival is recovered as
+	// TriggerTime.Add(MeetingArrivalSec) with no extra state. It is
+	// planner.MeetingBurnOption.TArrival from a ladder row solved AT the
+	// (Kepler-propagated) state the craft will actually be in at
+	// TriggerTime — not the row solved at plant time re-anchored by
+	// subtracting the lead buffer (the plant-time row's own TArrival
+	// isn't relative to TriggerTime; PlanMeetingBurn re-solves the whole
+	// ladder from the TriggerTime state instead, see its own doc
+	// comment). MeetingPlaceLabel is planner.MeetingPlace.String() ("their
 	// orbit" / "your orbit" / "the crossing") — a plain string, not the
 	// planner.MeetingPlace enum itself, again because spacecraft cannot
 	// import planner (sibling packages, ADR — see axisLabelToBurnMode's


### PR DESCRIPTION
## Summary

Fixes three verified findings from the ADR 0045 arc's adversarial code review (all in the Meeting Planner, `internal/planner/meeting.go` + `internal/sim/meeting.go`).

### Finding 1 (HIGH) — `MeetingBurnOption.Ok` never consulted `AchievableCA`

`meetingLadderCore` models the holder as sweeping at a uniform angular rate — exact for a circular holder, a first-order approximation for an eccentric one — so a row could pass every other gate (`r0mag ∈ [holderPeri, holderApo]`, periapsis safety, affordability) while its own propagate-and-check number showed the burn misses by a large fraction of the orbit.

Fix: gate `Ok` on `AchievableCA <= 1% of r0mag` (`meetingAchievableCATolFrac`).

Measured (reviewer's scenario: periapsis 6771 km / apoapsis 12000 km, e≈0.28, two co-orbital craft 1/6 period apart):
- Before: every lap row `Ok=true`, `AchievableCA≈6,563,744 m`, `ArrivalSpeed≈6.1–6.2 km/s` (matches the review report exactly).
- After: every row `Ok=false`, `Reason="no meeting solution"`, `AchievableCA` still reported honestly (not hidden/zeroed).

### Finding 2 (HIGH) — solved tangential-at-now, planted as a frozen inertial `BurnVector`

`PlanMeetingBurn` solved the burn tangentially at the craft's position *now* but planted it as `spacecraft.BurnVector` — a direction frozen at plant time — which fires `leadBuffer` later at a different point on the orbit, where it's no longer tangential. `MeetingArrivalSec` was then re-anchored by subtracting `leadBuffer` from a `TArrival` that was never relative to `TriggerTime` in the first place.

Fix: Kepler-propagate both craft to `TriggerTime` (still coasting, no burn applied), re-solve the whole ladder from that state, and plant `BurnPrograde`/`BurnRetrograde` — re-derived at fire time from the craft's actual `(r, v)` via the existing `NodeBurnDirection`/`DirectionUnit` machinery, same as every other tangential-style node. `MeetingArrivalSec` is the fresh row's own `TArrival` directly (no re-anchoring subtraction needed, since it was solved at `TriggerTime`'s epoch).

Measured (`rendezvousTwoCraftWorld`, 30° phase lag — the reviewer's exact scenario):
- Before: row/commit reported `AchievableCA`/`CommittedCA = 0.0 m`; the node's actual propagated closest approach was **974.9 m** at the committed τ, true minimum **46.3 m** ten seconds later (matches the review report exactly).
- After: `CommittedCA` and an independently-scanned true local minimum both land small (< 5 km bound used in the test) and within a couple seconds of each other.

`TestRendezvousCommitWithPlan_MeetingNode_ArrivalBeyondHorizon` no longer hand-overwrites `MeetingArrivalSec` to force an 8h scenario — it now picks the largest-lap `Ok` row (which naturally waits far past 4h on any realistic LEO period) and pins the *natural* value, with a non-vacuous precondition guard.

### Finding 3 (MEDIUM) — `MeetingCrossing` was inert (byte-identical to `MeetingTheirOrbit`)

`MeetingCrossing` ran `NextClosestApproach` purely as an existence check, then called the identical `meetingLadderCore(stateA, stateB, ...)` that `MeetingTheirOrbit` calls.

**Chose option (a): implemented the anchor properly**, rather than just making the duplication honest. It turned out tractable: Kepler-propagate both craft (unburned) forward to the natural crossing instant found by `NextClosestApproach`, run the same tangential-return solve anchored *there* instead of at "now", then re-anchor `TArrival` back to "now" so the field keeps its documented meaning for every `MeetingPlace`. This is genuinely different math whenever the natural crossing isn't at `t≈0` (the ordinary case) — verified with a same-orbit, time-offset fixture where the previous code produced byte-identical rows and the fixed code doesn't. The existing `_HappyPath` test's matched-circular-orbit fixture is unaffected: for phase-locked circular orbits the natural crossing legitimately *is* "now", so the two Places correctly coincide there — not a regression.

## Verification

Each fix verified non-vacuously per the task's standard: reverted that specific fix in isolation, confirmed its dedicated test fails, restored.

- Finding 1: `TestRecommendMeetingLadder_EccentricHolder_UnachievableRefused` fails without the `meetingAchievableCATolFrac` gate (all rows `Ok=true`), passes with it.
- Finding 2: `TestPlanMeetingBurn_CommittedArrivalMatchesTrueClosestApproach` fails without the fix (true minimum lands 10s after the committed arrival — exactly the reviewer's 46.3m/974.9m/10s numbers), passes with it.
- Finding 3: `TestRecommendMeetingLadder_Crossing_DiffersFromTheirOrbit` fails without the anchor fix (byte-identical rows), passes with it.

```
go vet ./...                       # clean
go test ./... -race -count=1       # all packages ok
```

No files outside `internal/planner/meeting.go`, `internal/sim/meeting.go`, and their tests were touched for logic changes — `internal/sim/rendezvous.go` and `internal/spacecraft/maneuver.go` got doc-comment-only corrections to `rendezvousCommitFromPlantedMeetingNode`'s and `ManeuverNode.MeetingArrivalSec`'s comments, which described the old (now-removed) lead-buffer-subtraction re-anchoring.