### PR TITLE
fix: rendezvous pace deadband, Earliest nil guard, orphaned doc comment

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -219,7 +219,18 @@ func (s *Store) Frontier() (time.Time, bool) {
 // ok is false when no report satisfies live; the caller falls back
 // to the furthest-behind persisted payload
 // (sessiondir.Store.EarliestSimTime).
+//
+// live is called once per stored report WHILE s.mu is held (RLock) —
+// it must not touch the store (no Report/Snapshot/Earliest/Frontier
+// call back in, directly or transitively), or a liveness source that
+// itself reads the relay store deadlocks. The only production caller
+// (Server.isOnline) locks presence.mu instead, a separate lock, so
+// this is safe today; a nil live would panic, so one is substituted
+// silently.
 func (s *Store) Earliest(live func(owner string) bool) (time.Time, bool) {
+	if live == nil {
+		live = func(string) bool { return true }
+	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var min time.Time

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -201,6 +201,27 @@ func TestEarliestExcludesReportsLiveRejects(t *testing.T) {
 	}
 }
 
+// TestEarliestNilLiveTreatsEveryoneAsLive is a regression guard for the
+// batch review (finding 2, internal/relay/relay.go:222): a nil live
+// callback used to panic on the first call. Earliest substitutes a
+// default that reports every owner live, matching the pre-callback
+// behaviour (Frontier-style, no exclusion).
+func TestEarliestNilLiveTreatsEveryoneAsLive(t *testing.T) {
+	store := NewStore()
+	wAlice, wBob := newWorld(t), newWorld(t)
+	wBob.Clock.SimTime = wBob.Clock.SimTime.Add(10 * 24 * time.Hour)
+	NewReporter(store, "SHA256:alice").Tick(wAlice, time.Now())
+	NewReporter(store, "SHA256:bob").Tick(wBob, time.Now())
+
+	e, ok := store.Earliest(nil)
+	if !ok {
+		t.Fatal("Earliest(nil) should still find a minimum across both reports")
+	}
+	if !e.Equal(wAlice.Clock.SimTime) {
+		t.Errorf("Earliest(nil) = %v, want alice's %v (nil live must not exclude anyone)", e, wAlice.Clock.SimTime)
+	}
+}
+
 // Concurrent report/subscribe/snapshot is race-clean (the -race run
 // is the assertion; the counts just keep the compiler honest).
 func TestConcurrentReportSubscribe(t *testing.T) {

--- a/internal/sim/auto_warp.go
+++ b/internal/sim/auto_warp.go
@@ -763,28 +763,58 @@ func (w *World) holdRendezvousLeader(partner *CoWarpPeer) {
 		w.RendezvousHold = true
 		return
 	}
-	// Finding 3 (batch review): relay reports are always at least one
-	// tick stale, so `ahead` is positive on essentially every coasting
-	// tick even when nothing is genuinely diverging — and
-	// rendezvousPaceMaxWarp's ramp is "active" (returns a ceiling below
-	// subspaceStepCap()) for ANY ahead > 0, however small. Reporting
-	// Paced for a sliver that small stood up the "coasting Nx — paced to
-	// X" line during completely ordinary coasting, a regression against
-	// #395's intent (replace a flickering readout with a steady HONEST
-	// one, not an always-on one). Below rendezvousWaypointMinLead this
-	// reads as measurement staleness, not a genuine divergence worth
-	// reporting — the same "too fresh to act on" judgment the τ-adoption
-	// code above makes about a relayed waypoint — so the ceiling isn't
-	// applied at all below it, leaving the ordinary subspace-step cap in
-	// charge and RendezvousPaced false.
-	if ahead <= rendezvousWaypointMinLead.Seconds() {
+	// Finding 3 (batch review) / finding 1 (#412 review): relay reports
+	// are always at least one report cycle stale, so `ahead` is positive
+	// on essentially every coasting tick even when nothing is genuinely
+	// diverging. The staleness this deadband must absorb is bounded in
+	// WALL-clock terms (relay.Reporter.Tick's Heartbeat — sim can't
+	// import relay, see rendezvousPaceHeartbeatSec), not sim-clock terms:
+	// a report that is one Heartbeat old is behind by up to Heartbeat
+	// WALL-seconds of the PARTNER's own coast, which is
+	// Heartbeat*partner.EffWarp SIM-seconds — 25-50s at 10x, 250-500s at
+	// 100x. A flat sim-second deadband (the original #412 fix) is inert
+	// at any warp above ~1x: it clears almost immediately, `ahead` keeps
+	// climbing on pure staleness, and once it passes
+	// rendezvousPaceCeilingSec the ramp below asymptotically collapses
+	// the leader's rate to a dead stop — the #279 stall #395 shipped to
+	// kill, reintroduced by staleness alone rather than genuine
+	// divergence. Scaling the deadband by partner.EffWarp (the source of
+	// the staleness) fixes that, but a binary gate isn't enough on its
+	// own: once `ahead` clears the (now warp-scaled) gate, feeding the
+	// RAW ahead into rendezvousPaceMaxWarp still measures against the
+	// same fixed rendezvousPaceCeilingSec, and raw ahead already carries
+	// the whole staleness term — at 100x that alone is 2-5x the ceiling,
+	// so the ramp saturates at 0 immediately past the gate. Subtracting
+	// the deadband before ramping treats it as a baseline offset: the
+	// ramp measures genuine excess beyond plausible staleness, so the
+	// ceiling stays meaningful at any warp instead of being swallowed by
+	// the same staleness the gate was just built to absorb. Floored at
+	// rendezvousWaypointMinLead so a report with EffWarp 0 (a degenerate
+	// or held partner not yet reflected in Paused) keeps the original
+	// minimum deadband rather than collapsing to zero tolerance.
+	deadband := partner.EffWarp * rendezvousPaceHeartbeatSec
+	if deadband < rendezvousWaypointMinLead.Seconds() {
+		deadband = rendezvousWaypointMinLead.Seconds()
+	}
+	if ahead <= deadband {
 		return
 	}
-	if warp, active := w.rendezvousPaceMaxWarp(ahead); active {
+	if warp, active := w.rendezvousPaceMaxWarp(ahead - deadband); active {
 		w.RendezvousPaced = true
 		w.RendezvousPaceWarp = warp
 	}
 }
+
+// rendezvousPaceHeartbeatSec mirrors relay.Heartbeat (internal/relay/
+// reporter.go), the maximum WALL-clock interval between a live coasting
+// reporter's reports. sim cannot import relay (relay imports sim; the
+// dependency graph only runs one way — see CLAUDE.md's "Architecture"),
+// so the value is duplicated here rather than shared. Used by
+// holdRendezvousLeader to size the staleness deadband: a partner's
+// SubspaceTime is stale by up to this many WALL-seconds, which at that
+// partner's own EffWarp is this many wall-seconds times EffWarp of SIM-
+// second staleness in `ahead` — not a genuine divergence.
+const rendezvousPaceHeartbeatSec = 5.0
 
 // rendezvousPaceMaxWarp is the paced ramp itself (#395, ADR 0045 S2, in
 // the same clamp family as clampedWarp's node/Auto-Warp approach terms):

--- a/internal/sim/rendezvous_pace_binding_test.go
+++ b/internal/sim/rendezvous_pace_binding_test.go
@@ -97,6 +97,38 @@ func TestHoldRendezvousLeader_LargeAheadPaces(t *testing.T) {
 	}
 }
 
+// TestHoldRendezvousLeader_DeadbandScalesWithPartnerEffWarp is the
+// finding-1 regression guard (#412 review, auto_warp.go:780): the flat
+// rendezvousWaypointMinLead deadband is inert at any real coast warp —
+// see rendezvous_pace_deadband_test.go's harness for the full mechanism.
+// This pins the boundary directly: at partner.EffWarp = 100, an `ahead`
+// of 400 sim-seconds (100x the OLD flat 5s deadband, and comfortably
+// past rendezvousPaceCeilingSec=90 on its own) is pure plausible
+// staleness — Heartbeat(5s wall) * EffWarp(100) = 500s — and must not
+// pace; one second past the scaled deadband must.
+func TestHoldRendezvousLeader_DeadbandScalesWithPartnerEffWarp(t *testing.T) {
+	w := pacedLeaderWorld(t)
+	partner := &CoWarpPeer{
+		Owner: harnessOwnerB, Handle: "bob", EffWarp: 100,
+		SubspaceTime: w.Clock.SimTime.Add(-400 * time.Second),
+	}
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+	w.holdRendezvousLeader(partner)
+	if w.RendezvousPaced {
+		t.Errorf("RendezvousPaced = true for 400s ahead at partner.EffWarp=100 (deadband=%v) — "+
+			"that's within one relay.Heartbeat of plausible staleness at this warp, not genuine divergence",
+			rendezvousPaceHeartbeatSec*partner.EffWarp)
+	}
+
+	deadband := rendezvousPaceHeartbeatSec * partner.EffWarp // 500
+	partner.SubspaceTime = w.Clock.SimTime.Add(-time.Duration(deadband+1) * time.Second)
+	w.RendezvousHold, w.RendezvousPaced, w.RendezvousPaceWarp = false, false, 0
+	w.holdRendezvousLeader(partner)
+	if !w.RendezvousPaced {
+		t.Errorf("RendezvousPaced = false one second past the scaled deadband (%v) — want true", deadband)
+	}
+}
+
 // TestHoldRendezvousLeader_AtCeilingHoldsToZero: ahead beyond the ceiling
 // still reports Paced (with PaceWarp effectively 0, the old freeze) —
 // unaffected by the finding 3 fix, since 0 is always < any unpaced rate.

--- a/internal/sim/rendezvous_pace_deadband_test.go
+++ b/internal/sim/rendezvous_pace_deadband_test.go
@@ -1,0 +1,169 @@
+package sim
+
+import (
+	"testing"
+	"time"
+)
+
+// #395 review, finding 1 (internal/sim/auto_warp.go:780): the pacing
+// deadband holdRendezvousLeader compares `ahead` against is
+// rendezvousWaypointMinLead — a flat 5 SIM-second constant — but `ahead`
+// is dominated by relay report staleness at any real coast rate: a
+// partner's CoWarpPeer.SubspaceTime is only as fresh as its last
+// relay.Heartbeat (5 WALL-clock seconds), so at effective warp W the
+// staleness alone is up to ~5*W sim-seconds. A flat 5-sim-second deadband
+// clears above ~1x warp and, once `ahead` (pure staleness, no genuine
+// divergence) exceeds rendezvousPaceCeilingSec, rendezvousPaceMaxWarp
+// returns (0, true) — clampedWarp's RendezvousPaced clamp then drives the
+// leader's selection to 0. That is the #279 dead-0x stall #395 shipped to
+// kill, reintroduced by the flat deadband.
+//
+// This harness reproduces the mechanism directly (unlike
+// rendezvous_pace_harness_test.go's twoWorldRendezvousHarness, which
+// always hands DriveRendezvousWarp the partner's freshest in-memory
+// state — no relay staleness at all, so it cannot exercise this bug):
+// world B ticks every iteration (never paused, so its true subspace time
+// keeps advancing), but the CoWarpPeer snapshot fed to world A's
+// DriveRendezvousWarp is only refreshed once every simulated
+// relay.Heartbeat of WALL-clock time — measured via Clock.BaseStep, the
+// real-time-per-tick constant World.Tick already scales by the effective
+// warp (world.go's `simDelta := BaseStep * effWarp`).
+const testHarnessHeartbeatSec = 5.0 // mirrors relay.Heartbeat (internal/relay/reporter.go); sim cannot import relay (cycle)
+
+// throttledPeerHarness pairs two engaged Worlds and feeds A a
+// heartbeat-throttled view of B, reproducing report staleness without
+// simulating the relay transport itself.
+type throttledPeerHarness struct {
+	t    *testing.T
+	a, b *World
+
+	reported     CoWarpPeer // last relayed snapshot of B seen by A
+	wallSinceRep float64    // wall-seconds since `reported` was refreshed
+}
+
+func newThrottledPeerHarness(t *testing.T, tauFromNow time.Duration) *throttledPeerHarness {
+	t.Helper()
+	a, b := mustWorld(t), mustWorld(t)
+	if !a.EngageRendezvousWarp(harnessOwnerB, "bob", a.Clock.SimTime.Add(tauFromNow), 0) {
+		t.Fatal("A: EngageRendezvousWarp failed")
+	}
+	if !b.EngageRendezvousWarp(harnessOwnerA, "alice", b.Clock.SimTime.Add(tauFromNow), 0) {
+		t.Fatal("B: EngageRendezvousWarp failed")
+	}
+	h := &throttledPeerHarness{t: t, a: a, b: b}
+	// First mutual pass on both sides so the coast actually starts,
+	// mirroring twoWorldRendezvousHarness's construction. Both peers here
+	// are necessarily pre-coast snapshots (EffectiveWarp() still the
+	// default 1x — the max-seed only applies once DriveRendezvousWarp has
+	// actually started the coast), so `reported` is re-captured below
+	// AFTER both sides are engaged and running at their real rate —
+	// otherwise the harness would hold a stale EffWarp=1 "report" for a
+	// full heartbeat, exactly reproducing the deadband's OWN bug as a
+	// harness artifact rather than testing it.
+	h.a.DriveRendezvousWarp([]CoWarpPeer{h.peerFromB()})
+	h.b.DriveRendezvousWarp([]CoWarpPeer{h.peerFromA()})
+	h.reported = h.peerFromB()
+	return h
+}
+
+func (h *throttledPeerHarness) peerFromB() CoWarpPeer {
+	return CoWarpPeer{
+		Owner: harnessOwnerB, Handle: "bob",
+		SubspaceTime: h.b.Clock.SimTime, EffWarp: h.b.EffectiveWarp(),
+		Paused: h.b.Clock.Paused, ArmedTowardViewer: true,
+	}
+}
+
+func (h *throttledPeerHarness) peerFromA() CoWarpPeer {
+	return CoWarpPeer{
+		Owner: harnessOwnerA, Handle: "alice",
+		SubspaceTime: h.a.Clock.SimTime, EffWarp: h.a.EffectiveWarp(),
+		Paused: h.a.Clock.Paused, ArmedTowardViewer: true,
+	}
+}
+
+// step advances B a real tick (always fresh to itself, never paused),
+// then advances A against a peer snapshot that only refreshes once a
+// simulated relay.Heartbeat of wall-clock time has elapsed — exactly
+// the cadence relay.Reporter.Tick uses for a steady coast (elements
+// Kepler-constant, EffWarp constant: nothing forces an early report).
+//
+// Ordering matters and mirrors production exactly (internal/serve/
+// reporting.go's Update): World.Tick() runs first each iteration, using
+// whatever RendezvousPaced/RendezvousPaceWarp the PREVIOUS DriveRendezvous-
+// Warp call left set ("clampedWarp reads it on the sim tick that
+// follows" — auto_warp.go's DriveRendezvousWarp doc). DriveRendezvousWarp
+// runs after, recomputing `ahead` from the tick that just happened and
+// setting the pacing for the NEXT tick. That one-tick lag is exactly
+// what lets `ahead` jump past rendezvousPaceCeilingSec in a single step
+// before the ramp reacts — collapsing the harness's two calls into one
+// tight per-tick feedback loop (Drive-then-Tick, same iteration) hides
+// the bug entirely: the ramp gets to react before the SAME tick's
+// advance, so it self-limits smoothly and never overshoots.
+func (h *throttledPeerHarness) step() {
+	h.b.Tick()
+	h.b.DriveRendezvousWarp([]CoWarpPeer{h.peerFromA()})
+
+	h.wallSinceRep += h.a.Clock.BaseStep.Seconds()
+	if h.wallSinceRep >= testHarnessHeartbeatSec {
+		h.reported = h.peerFromB()
+		h.wallSinceRep = 0
+	}
+
+	h.a.Tick()
+	h.a.DriveRendezvousWarp([]CoWarpPeer{h.reported})
+}
+
+// TestRendezvousPaceDeadbandStallsAtHighWarp is the finding-1 regression
+// guard. Revert the fix (restore `if ahead <= rendezvousWaypointMinLead.
+// Seconds() { return }` as the sole guard, feeding raw `ahead` into
+// rendezvousPaceMaxWarp) and this test fails: A's clock goes dead (no
+// tick advances its SimTime at all) on a large fraction of ticks, purely
+// from relay report staleness against a partner that is never paused and
+// never genuinely falls behind. "Dead" is measured directly as
+// SimTime-does-not-advance across a tick, not EffectiveWarp()==0: the
+// continuous ramp's asymptotic approach toward the ceiling can converge
+// a float64 warp down through denormally small values that still round
+// to a nonzero EffectiveWarp() yet, once World.Tick's `time.Duration(
+// BaseStep * effWarp)` truncates below 1ns, produce the exact same
+// player-visible dead stop — measuring the truncated advance is the
+// honest check, matching what a player watching the clock would see.
+func TestRendezvousPaceDeadbandStallsAtHighWarp(t *testing.T) {
+	h := newThrottledPeerHarness(t, 200*time.Hour)
+	if !h.a.RendezvousWarpEngaged() || !h.b.RendezvousWarpEngaged() {
+		t.Fatal("precondition: the mutual coast did not start")
+	}
+	if warp := h.a.EffectiveWarp(); warp < 100 {
+		t.Fatalf("precondition: A's effective warp is %.1f, want >= 100x for this reproduction", warp)
+	}
+	t.Logf("A's steady effective warp: %.1fx", h.a.EffectiveWarp())
+
+	const ticks = 300
+	pacedTransitions := 0
+	prevPaced := h.a.RendezvousPaced
+	deadTicks := 0
+	for i := 0; i < ticks; i++ {
+		before := h.a.Clock.SimTime
+		h.step()
+		if !h.a.RendezvousWarpEngaged() {
+			t.Fatalf("coast dropped mid-run at tick %d", i)
+		}
+		if h.a.RendezvousPaced != prevPaced {
+			pacedTransitions++
+			prevPaced = h.a.RendezvousPaced
+		}
+		if h.a.Clock.SimTime.Equal(before) {
+			deadTicks++
+		}
+	}
+
+	deadFraction := float64(deadTicks) / float64(ticks)
+	t.Logf("pacedTransitions=%d deadTicks=%d/%d (%.0f%%)", pacedTransitions, deadTicks, ticks, deadFraction*100)
+
+	const maxDeadFraction = 0.05
+	if deadFraction > maxDeadFraction {
+		t.Errorf("A's clock went dead on %d/%d ticks (%.0f%%) from pure report staleness "+
+			"(B never paused, never genuinely diverging) — the #279 stall #395 was meant to kill "+
+			"(want <= %.0f%%)", deadTicks, ticks, deadFraction*100, maxDeadFraction*100)
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -553,6 +553,13 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 // after — see SetRendezvousMeeting). "" (render nothing) whenever the
 // commit's source wasn't a planted Meeting Burn node — including the
 // whole agreed-no-plan state, which never had one.
+func rendezvousMeetingLine(placeLabel string, laps int) string {
+	if placeLabel == "" {
+		return ""
+	}
+	return chipRow("meeting:", fmt.Sprintf("%s — %d laps", placeLabel, laps))
+}
+
 // rendezvousInviteEncounterLines renders the invite's τ/CA rows — nil
 // (render nothing) when inv.Tau is zero (finding 2, batch review):
 // refreshRendezvousInvite now surfaces a zero-τ invite for ADR 0045 S7's
@@ -569,13 +576,6 @@ func rendezvousInviteEncounterLines(inv *sim.RendezvousInvite, now time.Time) []
 		chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
 		chipRow("CA:", formatRangeM(inv.CA)),
 	}
-}
-
-func rendezvousMeetingLine(placeLabel string, laps int) string {
-	if placeLabel == "" {
-		return ""
-	}
-	return chipRow("meeting:", fmt.Sprintf("%s — %d laps", placeLabel, laps))
 }
 
 // rendezvousUnplannedLines is the RENDEZVOUS chip's fifth state (ADR


### PR DESCRIPTION
## Summary

Three code-review findings from the #412 review batch.

**Finding 1 (HIGH in effect, reported medium)** — `internal/sim/auto_warp.go`'s `holdRendezvousLeader` pacing deadband was a flat 5 SIM-second constant (`rendezvousWaypointMinLead`), but the relay-report staleness it exists to absorb is bounded in WALL-clock terms: `relay.Reporter.Tick` only fires on its 5s wall-clock `Heartbeat` during a steady coast, so a partner's reported `SubspaceTime` lags their true current subspace time by up to `Heartbeat * partner.EffWarp` sim-seconds — 250-500s at 100x. The flat deadband cleared almost immediately above ~1x warp, and once `ahead` exceeded `rendezvousPaceCeilingSec` (90) from pure staleness, `rendezvousPaceMaxWarp` collapsed the leader's selection toward 0 — the #279 dead-warp stall #395 shipped to kill, reintroduced.

Fix: `deadband := partner.EffWarp * rendezvousPaceHeartbeatSec` (floored at `rendezvousWaypointMinLead` for a degenerate/zero-EffWarp report), **subtracted from `ahead` before feeding the ramp** — a binary gate alone isn't enough, since once `ahead` clears a bigger gate it's still the raw (staleness-dominated) value hitting the fixed ceiling. `rendezvousPaceHeartbeatSec` mirrors `relay.Heartbeat` as a local constant — `sim` can't import `relay` (the dependency only runs one way), so it's duplicated with a comment explaining why.

I chose scaling the deadband (using `partner.EffWarp`, already on `CoWarpPeer`) over extrapolating `SubspaceTime` in `relay.CoWarpPeersFrom` (the reviewer's other candidate) because the latter lives in `internal/relay/cowarp_peers.go`, outside this batch's assigned files (`auto_warp.go`, `relay.go`, `orbit_chip_builders.go`). The chosen fix is fully contained in `auto_warp.go` and grounded in the same mechanism (the partner's own reporting cadence), not a looser tolerance band.

**Finding 2 (LOW)** — `relay.Store.Earliest` panicked on a nil `live` callback and invoked it under `s.mu.RLock()` with no documented discipline. Added a nil guard (defaults to "everyone live") and a doc comment stating the callback must not touch the store.

**Finding 3 (LOW)** — `rendezvousInviteEncounterLines` was inserted between `rendezvousMeetingLine` and its doc comment, so godoc attached both paragraphs to the new function and left `rendezvousMeetingLine` undocumented. Reordered so each function keeps its own comment (verified with `go doc -u`).

## Test plan

- [x] New regression test (`rendezvous_pace_deadband_test.go`) reproduces the finding-1 stall via a heartbeat-throttled two-World harness at 1200x effective warp (>= 100x): **75% dead ticks pre-fix → 0% post-fix over 300 ticks**. Non-vacuous: reverted the `auto_warp.go` fix via `git stash`, confirmed the test fails (75% dead ticks), restored.
- [x] New unit test (`rendezvous_pace_binding_test.go`) pins the deadband-scaling boundary directly against `holdRendezvousLeader` at `partner.EffWarp=100`.
- [x] New test (`relay_test.go`) covers `Earliest(nil)`. Non-vacuous: reverted the `relay.go` fix, confirmed the exact nil-pointer panic, restored.
- [x] Finding 3 verified with `go doc -u` before/after — each function now shows only its own doc paragraph.
- [x] Did **not** touch `ComputeCoWarp` or its clamp-exemption ordering.
- [x] `go vet ./...` clean.
- [x] `go test ./... -race -count=1` — all packages pass.
- [x] Existing rendezvous/co-warp/pace suite (80+ tests) unaffected — ran targeted before committing.

Claude-Session: https://claude.ai/code/session_01HsrrpUr6dLcW4G8nmV9SRN