### PR TITLE
Stop the F1 overlay naming keys that do something else

### DIFF
--- a/internal/tui/help_keymap_test.go
+++ b/internal/tui/help_keymap_test.go
@@ -1,0 +1,150 @@
+package tui
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+
+	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
+)
+
+// rawKeyDisplay maps a bubbletea key string to the token a player reads on
+// the F1 overlay (and sees on their keycaps). Only keys whose wire
+// spelling differs from what the overlay prints need an entry.
+var rawKeyDisplay = map[string]string{
+	"left": "←", "right": "→", "up": "↑", "down": "↓",
+	"shift+left": "shift+←", "shift+right": "shift+→",
+	"shift+up": "shift+↑", "shift+down": "shift+↓",
+	" ":  "space",
+	"f1": "F1", "f2": "F2", "f4": "F4", "f5": "F5", "f9": "F9",
+}
+
+func displayKey(raw string) string {
+	if d, ok := rawKeyDisplay[raw]; ok {
+		return d
+	}
+	return raw
+}
+
+// unadvertised lists the bindings the F1 overlay deliberately does not
+// name, keyed by Keymap field. Each needs a reason: the overlay is the
+// project's source of truth for keybindings, so an omission is a decision,
+// not an oversight.
+var unadvertised = map[string]string{
+	"BossKey": "deliberately hidden — advertising the panic key defeats it (see the BossKey comment in input.go)",
+}
+
+// unadvertisedAlias lists individual keys that are bound as a convenience
+// alias of an advertised key and are intentionally left off the overlay,
+// keyed "Field:key". Anything not listed here must appear in the overlay.
+var unadvertisedAlias = map[string]string{
+	"ZoomIn:=":  "unshifted alias of + on US layouts",
+	"ZoomOut:_": "shifted alias of -",
+	// CraftSlot binds the nine digits individually; the overlay
+	// advertises them collectively on one "1-9" row.
+	"CraftSlot:1": "covered by the 1-9 row", "CraftSlot:2": "covered by the 1-9 row",
+	"CraftSlot:3": "covered by the 1-9 row", "CraftSlot:4": "covered by the 1-9 row",
+	"CraftSlot:5": "covered by the 1-9 row", "CraftSlot:6": "covered by the 1-9 row",
+	"CraftSlot:7": "covered by the 1-9 row", "CraftSlot:8": "covered by the 1-9 row",
+	"CraftSlot:9": "covered by the 1-9 row",
+}
+
+// TestHelpOverlayCoversKeymap pins the project convention that the F1
+// overlay is the source of truth for keybindings (#423): every binding in
+// DefaultKeymap must appear in helpSections under a key token that is
+// actually one of the keys it is bound to. Without this, the overlay drifts
+// silently — it told players `q` quits long after `q` became radial+.
+func TestHelpOverlayCoversKeymap(t *testing.T) {
+	tokens := screens.HelpKeyTokens()
+	km := reflect.ValueOf(DefaultKeymap())
+	kt := km.Type()
+
+	for i := 0; i < km.NumField(); i++ {
+		field := kt.Field(i).Name
+		b, ok := km.Field(i).Interface().(key.Binding)
+		if !ok {
+			continue
+		}
+		keys := b.Keys()
+		if len(keys) == 0 {
+			continue // retired binding kept for compile stability
+		}
+		if why, skip := unadvertised[field]; skip {
+			t.Logf("%s: not in the overlay by design (%s)", field, why)
+			continue
+		}
+
+		token := b.Help().Key
+		if token == "" {
+			t.Errorf("%s: bound to %v but has no help token", field, keys)
+			continue
+		}
+		if !tokens[token] {
+			t.Errorf("%s: keymap advertises %q but the F1 overlay never names it (bound to %v)", field, token, keys)
+		}
+
+		// The advertised token must be one of the keys actually bound,
+		// or the overlay is naming a key that does nothing.
+		if !advertises(token, keys) {
+			t.Errorf("%s: help token %q is not one of its bound keys %v", field, token, keys)
+		}
+
+		// Every other bound key is either also named, or listed as a
+		// deliberate alias.
+		for _, k := range keys {
+			d := displayKey(k)
+			if d == token || tokens[d] {
+				continue
+			}
+			if _, ok := unadvertisedAlias[field+":"+k]; ok {
+				continue
+			}
+			t.Errorf("%s: key %q (%q) is bound but never named in the overlay — document it or add it to unadvertisedAlias with a reason", field, k, d)
+		}
+	}
+}
+
+// advertises reports whether token names one of keys, allowing the "1-9"
+// range shorthand for a binding that takes every digit it spans.
+func advertises(token string, keys []string) bool {
+	for _, k := range keys {
+		if displayKey(k) == token {
+			return true
+		}
+	}
+	if lo, hi, ok := strings.Cut(token, "-"); ok && len(lo) == 1 && len(hi) == 1 {
+		want := map[string]bool{}
+		for c := lo[0]; c <= hi[0]; c++ {
+			want[string(c)] = true
+		}
+		for _, k := range keys {
+			delete(want, k)
+		}
+		return len(want) == 0
+	}
+	return false
+}
+
+// TestHelpKeyTokensSplitsCompoundRows guards the accessor the coverage test
+// leans on: an empty or over-eager split would make the check above pass
+// vacuously.
+func TestHelpKeyTokensSplitsCompoundRows(t *testing.T) {
+	tokens := screens.HelpKeyTokens()
+	for _, want := range []string{"z", "x", "↑", "↓", "←", "→", "/", "space", "1-9", "ctrl+c"} {
+		if !tokens[want] {
+			t.Errorf("HelpKeyTokens missing %q — the row splitter dropped a key", want)
+		}
+	}
+	if tokens[""] {
+		t.Error("HelpKeyTokens produced an empty token")
+	}
+	var got []string
+	for k := range tokens {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	t.Logf("%d tokens: %s", len(got), strings.Join(got, " "))
+}

--- a/internal/tui/screens/bodyinfo.go
+++ b/internal/tui/screens/bodyinfo.go
@@ -89,6 +89,9 @@ func (b *BodyInfo) Render(w *sim.World, selectedIdx, cols, rows int) string {
 		)
 	}
 
-	footer := b.theme.Footer.Render("[esc] back  [←/→] prev/next body  [q] quit")
+	// h/l are the keys that actually step the body cursor here
+	// (Keymap.PrevBody / NextBody). ←/→ pan the map behind this panel and
+	// q is radial+, so neither belongs in this footer (#423).
+	footer := b.theme.Footer.Render("[esc] back  [h/l] prev/next body")
 	return strings.Join(sections, "\n") + "\n\n" + footer
 }

--- a/internal/tui/screens/bodyinfo_test.go
+++ b/internal/tui/screens/bodyinfo_test.go
@@ -1,0 +1,35 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestBodyInfoFooterNamesLiveKeys (#423): the footer used to advertise
+// [←/→] prev/next body and [q] quit. On this screen ←/→ pan the map behind
+// the panel (Keymap.PanLeft/PanRight) and `q` is radial+; the keys that
+// actually walk the body cursor are h/l (Keymap.PrevBody/NextBody).
+func TestBodyInfoFooterNamesLiveKeys(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	out := NewBodyInfo(chipTestTheme()).Render(w, 0, 100, 40)
+	footer := out[strings.LastIndex(out, "\n")+1:]
+	t.Logf("body info footer: %q", footer)
+
+	if !strings.Contains(footer, "[h/l]") {
+		t.Errorf("footer does not name h/l, the keys that actually step the body cursor: %q", footer)
+	}
+	if strings.Contains(footer, "←/→") {
+		t.Errorf("footer still advertises ←/→, which pan the map behind this screen: %q", footer)
+	}
+	if strings.Contains(footer, "[q]") {
+		t.Errorf("footer still advertises [q] quit; q is radial+ here: %q", footer)
+	}
+	if !strings.Contains(footer, "[esc]") {
+		t.Errorf("footer lost the [esc] back exit: %q", footer)
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -39,8 +39,13 @@ var helpSections = []helpSection{
 		{"F1", "toggle this help"},
 		{"esc", "back / close (or save/load/build/settings/controls/quit menu on home)"},
 		{"F5 / F9", "quicksave / quickload"},
-		{"q", "quit (confirm + autosave)"},
 		{"ctrl+c", "quit immediately"},
+	}},
+	// `q` quits only inside the pause menu — in flight it is radial+
+	// (Keymap.AttitudeRadialOut), so it gets a menu-scoped section of its
+	// own rather than a line in GENERAL (#423).
+	{"PAUSE MENU (esc from the map)", [][2]string{
+		{"q", "quit (confirm + autosave) — menu only; in flight q is radial+"},
 	}},
 	{"SAVES (menu → Save / Load Game)", [][2]string{
 		{"↑ / ↓", "move the save cursor"},
@@ -57,8 +62,8 @@ var helpSections = []helpSection{
 		{"V", "launch / surface view — chase-cam on your active vessel (press again to return)"},
 		{"o", "proximity view — close-range picture of your target vessel (press again to return)"},
 		{"↑ ↓ ← →", "pan the view — displaces the tracked center; [g] or any refocus clears it"},
-		{"shift+↑ / ↓", "tilt the 3D view up / down (tilted view only)"},
-		{"shift+← / →", "yaw the 3D view left / right, wraps 360° (tilted view only)"},
+		{"shift+↑ / shift+↓", "tilt the 3D view up / down (tilted view only)"},
+		{"shift+← / shift+→", "yaw the 3D view left / right, wraps 360° (tilted view only)"},
 		{"F2", "declutter — hide chips + navball (core column stays)"},
 	}},
 	{"NAVIGATION", [][2]string{
@@ -121,13 +126,13 @@ var helpSections = []helpSection{
 		{"a / d", "attitude normal+ / normal- (rcs: pulse-fire)"},
 		{"q / e", "attitude radial+ / radial- (rcs: pulse-fire)"},
 		{"W / S", "attitude surface prograde / retrograde (locks to ground)"},
-		{"< / >", "pitch trim ±5° east off the active mode"},
+		{"< / >", "pitch trim 5° west / east off the active mode"},
 		{"?", "reset pitch trim to 0"},
 		{"b", "engage / cut the manual burn (main engine)"},
 		{"r", "engine: main / rcs"},
 		{"p", "rcs pulse step: 0.1 / 0.01 / 0.001 m/s (fine trim)"},
 		{"k", "SAS model: slew / instant"},
-		{";", "NavMode cycle: Orbit → Surface → Target"},
+		{";", "NavMode cycle: Orbit → Surface → Target (skips Target when none is set)"},
 	}},
 	{"VESSEL", [][2]string{
 		{"n", "open spawn form (loadout / position / parent / altitude / dir)"},
@@ -140,6 +145,7 @@ var helpSections = []helpSection{
 		{"D", "transpose: SM → firing core, LM → releasable nose payload"},
 		{"t / T", "cycle / clear the target"},
 		{"space", "decouple bottom stage (bare chute capsule: arm the chute)"},
+		{"E", "end flight — clear a crashed vessel from the slate (y/n confirm)"},
 	}},
 	{"VEHICLE ASSEMBLY (VAB)", [][2]string{
 		{"esc → b", "open the VAB from the pause menu (Build)"},
@@ -298,4 +304,69 @@ func maxInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// helpTokenConnectors are the words-between-keys used in a row's left
+// column ("z / x", "esc → b"). HelpKeyTokens splits on these rather than
+// on bare whitespace so a connector is never mistaken for a key, while the
+// pan row ("↑ ↓ ← →") still yields four separate arrow tokens.
+var helpTokenConnectors = []string{" / ", " → "}
+
+// HelpKeyTokens returns every key token the overlay names in its left
+// column, split out of the compound rows ("z / x" → "z", "x"; "↑ ↓ ← →" →
+// four arrows). The keymap-coverage test in package tui reads it to prove
+// the overlay still names every binding in DefaultKeymap, so helpSections
+// itself can stay unexported. Tokens are the QWERTY spellings authored in
+// helpSections, before any keylayout.DisplayToken translation.
+func HelpKeyTokens() map[string]bool {
+	tokens := map[string]bool{}
+	for _, s := range helpSections {
+		for _, r := range s.rows {
+			for _, tok := range splitHelpToken(r[0]) {
+				tokens[tok] = true
+			}
+		}
+	}
+	return tokens
+}
+
+// splitHelpToken breaks one left-column cell into the individual keys it
+// names. A cell that is itself a key ("/") is returned whole.
+func splitHelpToken(cell string) []string {
+	cell = strings.TrimSpace(cell)
+	if cell == "" {
+		return nil
+	}
+	pieces := []string{cell}
+	for _, sep := range helpTokenConnectors {
+		var next []string
+		for _, p := range pieces {
+			next = append(next, strings.Split(p, sep)...)
+		}
+		pieces = next
+	}
+	var out []string
+	for _, p := range pieces {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// A space-separated run of short glyphs is a key list ("↑ ↓ ← →");
+		// anything with a word in it is one label ("click body").
+		if fields := strings.Fields(p); len(fields) > 1 && allShort(fields) {
+			out = append(out, fields...)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func allShort(fields []string) bool {
+	for _, f := range fields {
+		if len([]rune(f)) > 3 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/tui/screens/help_rows_test.go
+++ b/internal/tui/screens/help_rows_test.go
@@ -1,0 +1,80 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+// helpRow returns the description the overlay prints for a key token,
+// searching the authored sections rather than the rendered frame so the
+// assertion doesn't depend on scroll position.
+func helpRow(t *testing.T, token string) (section, desc string) {
+	t.Helper()
+	for _, s := range helpSections {
+		for _, r := range s.rows {
+			if r[0] == token {
+				return s.header, r[1]
+			}
+		}
+	}
+	t.Fatalf("no help row for token %q", token)
+	return "", ""
+}
+
+// TestHelpQuitRowIsMenuScoped (#423): `q` is AttitudeRadialOut on the
+// flight screen — it only quits inside the pause menu (menu.go). The
+// overlay used to open with "q — quit (confirm + autosave)" in GENERAL,
+// which is the first line a player reads and the one that misleads worst.
+func TestHelpQuitRowIsMenuScoped(t *testing.T) {
+	for _, s := range helpSections {
+		if s.header != "GENERAL" {
+			continue
+		}
+		for _, r := range s.rows {
+			if r[0] == "q" {
+				t.Errorf("GENERAL still lists a bare `q` row (%q) — on the flight screen q is radial+, not quit", r[1])
+			}
+		}
+	}
+	section, desc := helpRow(t, "q")
+	if !strings.Contains(strings.ToLower(section), "menu") {
+		t.Errorf("the quit `q` row sits under %q; it must be in a clearly menu-scoped section", section)
+	}
+	if !strings.Contains(desc, "quit") {
+		t.Errorf("menu-scoped `q` row no longer describes quit: %q", desc)
+	}
+}
+
+// TestHelpPitchTrimNamesBothDirections (#423): `<` is west, `>` is east.
+// The row named only "east" while showing the keys in west-then-east order.
+func TestHelpPitchTrimNamesBothDirections(t *testing.T) {
+	_, desc := helpRow(t, "< / >")
+	west := strings.Index(desc, "west")
+	east := strings.Index(desc, "east")
+	if west < 0 || east < 0 {
+		t.Fatalf("pitch trim row names only one direction: %q", desc)
+	}
+	if west > east {
+		t.Errorf("pitch trim row reads east-before-west (%q) but the keys are `<` west then `>` east", desc)
+	}
+}
+
+// TestHelpNavModeStatesSkipRule (#423): the `;` cycle skips Target when no
+// vessel target is bound, so a player watching it toggle Orbit⇄Surface with
+// a body targeted otherwise concludes the key is broken. docs/controls.md
+// already says this.
+func TestHelpNavModeStatesSkipRule(t *testing.T) {
+	_, desc := helpRow(t, ";")
+	if !strings.Contains(strings.ToLower(desc), "skip") {
+		t.Errorf("NavMode row omits the skip-Target rule: %q", desc)
+	}
+}
+
+// TestHelpDocumentsEndFlight (#423): `E` is the only way to clear a crashed
+// vessel and was absent from the overlay entirely.
+func TestHelpDocumentsEndFlight(t *testing.T) {
+	_, desc := helpRow(t, "E")
+	if !strings.Contains(strings.ToLower(desc), "end flight") && !strings.Contains(strings.ToLower(desc), "crashed") {
+		t.Errorf("`E` row does not describe ending the flight of a crashed vessel: %q", desc)
+	}
+}


### PR DESCRIPTION
Closes #423

## What was wrong

The F1 overlay is the project's source of truth for keybindings, and it drifted in exactly the spots a player reaches for it.

| Row | Overlay said | Reality (`internal/tui/input.go`) |
|---|---|---|
| `q` (GENERAL, first block) | quit (confirm + autosave) | `AttitudeRadialOut` — silently swings the vessel to radial+. `q` quits only inside the pause menu (`menu.go`) |
| `E` | absent | `EndFlight`, the only way to clear a crashed vessel; `docs/controls.md:204` already documents it |
| `< / >` | "pitch trim ±5° east" | `<` is west (`PitchTrimWest`), `>` is east |
| `;` | "Orbit → Surface → Target" | Target is skipped when no vessel target is bound |
| `shift+↑ / ↓`, `shift+← / →` | abbreviated second key | `↓` / `→` alone are pan, not tilt/yaw |

Body info footer (`bodyinfo.go`) read `[esc] back  [←/→] prev/next body  [q] quit`. On that screen `←/→` pan the map behind the panel and `q` is radial+; the keys that walk the body cursor are `h`/`l`.

## What changed

- `help.go`: `q` moved out of GENERAL into a `PAUSE MENU (esc from the map)` section that says it is menu-only; added the `E` row; fixed the `< / >` direction pairing, the `;` skip rule, and the two shift rows.
- `bodyinfo.go`: footer is now `[esc] back  [h/l] prev/next body`.
- New `HelpKeyTokens()` accessor + `internal/tui/help_keymap_test.go`: every binding in `DefaultKeymap` must be named in `helpSections` under a token that is actually one of its bound keys. Deliberate omissions need an entry with a reason — currently the boss key (hidden by design), the `=` / `_` zoom aliases, and the nine vessel-slot digits (advertised collectively as `1-9`).
- `docs/controls.md` and `README.md` were already accurate against the code; neither changed. README carries no key table, only a pointer to F1 and controls.md.

## Test plan

TDD: the coverage test was written first and failed on the real drift (`EndFlight`, `TiltDown`, `YawRight` unnamed); the four wording tests and the bodyinfo footer test failed on the current strings before the fix.

```
$ go vet ./...
(no output, exit 0)

$ go test ./... -race -count=1
ok  	github.com/jasonfen/terminal-space-program/internal/sim	45.060s
ok  	github.com/jasonfen/terminal-space-program/internal/spacecraft	1.332s
ok  	github.com/jasonfen/terminal-space-program/internal/tui	6.062s
ok  	github.com/jasonfen/terminal-space-program/internal/tui/screens	33.055s
ok  	github.com/jasonfen/terminal-space-program/internal/tui/widgets	1.597s
?   	github.com/jasonfen/terminal-space-program/internal/version	[no test files]
```
(all 18 packages `ok`; tail shown)

Render check in a 120x36 tmux pane against the built binary:

```
GENERAL
  F1                  toggle this help
  esc                 back / close (or save/load/build/settings/controls/quit menu on home)
  F5 / F9             quicksave / quickload
  ctrl+c              quit immediately

PAUSE MENU (esc from the map)
  q                   quit (confirm + autosave) — menu only; in flight q is radial+
...
  shift+↑ / shift+↓   tilt the 3D view up / down (tilted view only)
  shift+← / shift+→   yaw the 3D view left / right, wraps 360° (tilted view only)
...
  < / >               pitch trim 5° west / east off the active mode
  ;                   NavMode cycle: Orbit → Surface → Target (skips Target when none is set)
...
  E                   end flight — clear a crashed vessel from the slate (y/n confirm)
```

Body info screen: footer renders `[esc] back  [h/l] prev/next body`; pressing `l` stepped Sun → Mercury, while `←`/`→` left the body unchanged — the footer's old claim was dead, the new one is live.

## Not in scope

Only the rows the issue named plus the two shift rows the coverage test surfaced (their abbreviated second key named a pan key). No other screens, keys, or behaviour touched. Per the issue comment, this lands before #425.

https://claude.ai/code/session_01RCTKxtZi9g9qEgQgozVhyJ