### PR TITLE
Window the CRAFT TYPE / chip lists; wrap the VAB footer (#373)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2860,11 +2860,11 @@ func (a *App) View() string {
 	case screenMenu:
 		base = a.menu.Render(a.width)
 	case screenSpawn:
-		base = a.spawn.Render(a.width)
+		base = a.spawn.Render(a.width, a.height)
 	case screenMissions:
 		base = a.missions.Render(a.world, a.width)
 	case screenSettings:
-		base = a.settingsScreen.Render(a.orbitView.Settings(), a.width)
+		base = a.settingsScreen.Render(a.orbitView.Settings(), a.width, a.height)
 	case screenControls:
 		base = a.controls.Render(a.layout, a.width)
 	case screenVAB:

--- a/internal/tui/screens/settings.go
+++ b/internal/tui/screens/settings.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/jasonfen/terminal-space-program/internal/settings"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
 // SettingsScreen is the v0.13 slice-3 menu-reached screen that toggles
@@ -123,11 +124,115 @@ func (s *SettingsScreen) HandleClick(col, row int) (SettingsAction, settings.Chi
 	return SettingsActionNone, ""
 }
 
+// settingsRowsBudget is settingsScreen's ceiling on the windowed body's row
+// count, mirroring spawn.go's craftTypeRowBudget (#373 / ADR 0046's
+// Consequences section) — shrunk further by Render when height is tight,
+// never below 1.
+const settingsRowsBudget = 12
+
+// settingsBody flattens the screen's body — the chips / gameplay / saves
+// sections, each a pinnable widgets.WindowLine header followed by its rows
+// (blank lines and descriptions included, exactly as Render used to emit
+// them inline) — into one windowed-list input. rowSelectable is
+// index-aligned with the returned lines: rowSelectable[i] is the cursor
+// index (into settings.AllChips + the gameplay/saves rows) that line i
+// represents, or -1 for a header/blank/description line. cursorLine is the
+// line index the current cursor (s.cursor) sits on.
+func (s *SettingsScreen) settingsBody(prefs settings.Settings) (lines []widgets.WindowLine, rowSelectable []int, cursorLine int) {
+	add := func(text string, isHeader bool, selectable int) {
+		lines = append(lines, widgets.WindowLine{Text: text, IsHeader: isHeader})
+		rowSelectable = append(rowSelectable, selectable)
+		if selectable >= 0 && selectable == s.cursor {
+			cursorLine = len(lines) - 1
+		}
+	}
+
+	add(s.theme.Dim.Render("─── chips ───"), true, -1)
+	add("", false, -1)
+	add(s.theme.Dim.Render("  Default visibility of each orbit-screen chip."), false, -1)
+	add("", false, -1)
+	for i, c := range settings.AllChips {
+		marker := "  "
+		if i == s.cursor {
+			marker = "> "
+		}
+		box := "[ ]"
+		if prefs.ChipEnabled(c) {
+			box = "[x]"
+		}
+		text := box + " " + c.Label()
+		if i == s.cursor {
+			text = s.theme.Primary.Render(text)
+		}
+		add(marker+text, false, i)
+	}
+
+	// Gameplay section: the two built-in mission programs, off by default —
+	// the player opts in here (ADR 0025 §2 / v0.21 Slice 7).
+	add("", false, -1)
+	add(s.theme.Dim.Render("─── gameplay ───"), true, -1)
+	add("", false, -1)
+	add(s.theme.Dim.Render("  Built-in missions. Off by default; opt in to fly them."), false, -1)
+	add("", false, -1)
+	gameplay := []struct {
+		label string
+		on    bool
+	}{
+		{"Tutorial", prefs.TutorialEnabled},
+		{"Challenge ladder", prefs.ChallengesEnabled},
+	}
+	for j, g := range gameplay {
+		idx := len(settings.AllChips) + j
+		marker := "  "
+		if idx == s.cursor {
+			marker = "> "
+		}
+		box := "[ ]"
+		if g.on {
+			box = "[x]"
+		}
+		text := box + " " + g.label
+		if idx == s.cursor {
+			text = s.theme.Primary.Render(text)
+		}
+		add(marker+text, false, idx)
+	}
+
+	// Saves section: the periodic-autosave interval (v0.26 S4 / ADR 0033
+	// §E). A value row rather than a checkbox — space/enter cycles it
+	// through settings.AutosaveIntervalSteps; 0 renders as "off" (the
+	// on-quit autosave still fires regardless).
+	add("", false, -1)
+	add(s.theme.Dim.Render("─── saves ───"), true, -1)
+	add("", false, -1)
+	add(s.theme.Dim.Render("  Periodic autosave into the rotating ring. Off keeps quit-autosave only."), false, -1)
+	add("", false, -1)
+	{
+		idx := len(settings.AllChips) + gameplayRows
+		marker := "  "
+		if idx == s.cursor {
+			marker = "> "
+		}
+		text := "Autosave interval: ‹" + autosaveIntervalLabel(prefs.AutosaveIntervalMinutes()) + "›"
+		if idx == s.cursor {
+			text = s.theme.Primary.Render(text)
+		}
+		add(marker+text, false, idx)
+	}
+
+	return lines, rowSelectable, cursorLine
+}
+
 // Render returns the settings screen for the given visibility state.
 // width is the terminal width — used to right-align [Back] on row 0 the
-// same way the menu / missions screens do, and to size the full-row
-// click targets. The on/off box for each Chip reads prefs.ChipEnabled.
-func (s *SettingsScreen) Render(prefs settings.Settings, width int) string {
+// same way the menu / missions screens do, and to size the full-row click
+// targets. height is the terminal height (#373 / ADR 0046): the body (the
+// chips / gameplay / saves sections) windows itself around the cursor so
+// the title, the active section's header, and the cursor stay on screen;
+// height<=0 disables the windowing clamp (shows the whole body) — handy
+// for tests and any caller with no height budget. The on/off box for each
+// Chip reads prefs.ChipEnabled.
+func (s *SettingsScreen) Render(prefs settings.Settings, width, height int) string {
 	var lines []string
 
 	// Row 0: title + right-aligned [Back] button.
@@ -148,86 +253,53 @@ func (s *SettingsScreen) Render(prefs settings.Settings, width int) string {
 		strings.Repeat(" ", pad)+
 		s.theme.Primary.Render(backLabel))
 
-	lines = append(lines, s.theme.Dim.Render("─── chips ───"))
-	lines = append(lines, "")
-	lines = append(lines, s.theme.Dim.Render("  Default visibility of each orbit-screen chip."))
-	lines = append(lines, "")
+	body, rowSelectable, cursorLine := s.settingsBody(prefs)
 
-	// One row per Chip, in AllChips display order. Record each row as a
-	// full-width click target (index-aligned with AllChips) before
-	// appending it, so buttonRange.row matches the rendered line index.
+	// title(1) + blank(1) + footer(1) — every line Render emits outside the
+	// windowed body.
+	const fixedLines = 3
+	budget := 0 // widgets.Window treats <=0 as "show everything"
+	if height > 0 {
+		budget = height - fixedLines
+		if budget > settingsRowsBudget {
+			budget = settingsRowsBudget
+		}
+		if budget < 1 {
+			budget = 1
+		}
+	}
+	rendered := widgets.Window(body, cursorLine, budget)
+	// Safety net: widgets.Window's pinned header + "N more" markers can add
+	// up to 3 lines on top of budget (documented on Window). Drop those
+	// marker/pin lines first — cheapest to lose — before ever touching a
+	// content row, so the cursor's own row is the last thing trimmed.
+	// Mirrors spawn.go's Render.
+	if height > 0 {
+		if over := fixedLines + len(rendered) - height; over > 0 {
+			trimmed := rendered[:0]
+			dropped := 0
+			for _, r := range rendered {
+				if dropped < over && r.Kind != widgets.LineContent {
+					dropped++
+					continue
+				}
+				trimmed = append(trimmed, r)
+			}
+			rendered = trimmed
+		}
+	}
+
+	// rowBtns for off-window rows stay unset (the zero buttonRange), so a
+	// click can never land on a row that isn't drawn — mirrors saves.go's
+	// windowed-list click-target contract.
 	s.rowBtns = make([]buttonRange, len(settings.AllChips)+gameplayRows+savesRows)
-	for i, c := range settings.AllChips {
-		marker := "  "
-		if i == s.cursor {
-			marker = "> "
+	for _, r := range rendered {
+		if r.Kind == widgets.LineContent {
+			if sel := rowSelectable[r.Index]; sel >= 0 {
+				s.rowBtns[sel] = buttonRange{row: len(lines), colStart: 0, colEnd: width, set: true}
+			}
 		}
-		box := "[ ]"
-		if prefs.ChipEnabled(c) {
-			box = "[x]"
-		}
-		s.rowBtns[i] = buttonRange{row: len(lines), colStart: 0, colEnd: width, set: true}
-
-		text := box + " " + c.Label()
-		if i == s.cursor {
-			text = s.theme.Primary.Render(text)
-		}
-		lines = append(lines, marker+text)
-	}
-
-	// Gameplay section: the two built-in mission programs, off by default —
-	// the player opts in here (ADR 0025 §2 / v0.21 Slice 7).
-	lines = append(lines, "")
-	lines = append(lines, s.theme.Dim.Render("─── gameplay ───"))
-	lines = append(lines, "")
-	lines = append(lines, s.theme.Dim.Render("  Built-in missions. Off by default; opt in to fly them."))
-	lines = append(lines, "")
-	gameplay := []struct {
-		label string
-		on    bool
-	}{
-		{"Tutorial", prefs.TutorialEnabled},
-		{"Challenge ladder", prefs.ChallengesEnabled},
-	}
-	for j, g := range gameplay {
-		idx := len(settings.AllChips) + j
-		marker := "  "
-		if idx == s.cursor {
-			marker = "> "
-		}
-		box := "[ ]"
-		if g.on {
-			box = "[x]"
-		}
-		s.rowBtns[idx] = buttonRange{row: len(lines), colStart: 0, colEnd: width, set: true}
-		text := box + " " + g.label
-		if idx == s.cursor {
-			text = s.theme.Primary.Render(text)
-		}
-		lines = append(lines, marker+text)
-	}
-
-	// Saves section: the periodic-autosave interval (v0.26 S4 / ADR 0033
-	// §E). A value row rather than a checkbox — space/enter cycles it
-	// through settings.AutosaveIntervalSteps; 0 renders as "off" (the
-	// on-quit autosave still fires regardless).
-	lines = append(lines, "")
-	lines = append(lines, s.theme.Dim.Render("─── saves ───"))
-	lines = append(lines, "")
-	lines = append(lines, s.theme.Dim.Render("  Periodic autosave into the rotating ring. Off keeps quit-autosave only."))
-	lines = append(lines, "")
-	{
-		idx := len(settings.AllChips) + gameplayRows
-		marker := "  "
-		if idx == s.cursor {
-			marker = "> "
-		}
-		s.rowBtns[idx] = buttonRange{row: len(lines), colStart: 0, colEnd: width, set: true}
-		text := "Autosave interval: ‹" + autosaveIntervalLabel(prefs.AutosaveIntervalMinutes()) + "›"
-		if idx == s.cursor {
-			text = s.theme.Primary.Render(text)
-		}
-		lines = append(lines, marker+text)
+		lines = append(lines, r.Text)
 	}
 
 	lines = append(lines, "")

--- a/internal/tui/screens/settings_test.go
+++ b/internal/tui/screens/settings_test.go
@@ -12,7 +12,7 @@ import (
 // nothing in the canonical list is silently unlisted.
 func TestSettingsRenderListsEveryChip(t *testing.T) {
 	s := NewSettingsScreen(Theme{})
-	out := s.Render(settings.Default(), 80)
+	out := s.Render(settings.Default(), 80, 0)
 	for _, c := range settings.AllChips {
 		if !strings.Contains(out, c.Label()) {
 			t.Errorf("Render is missing chip %q (label %q)", c, c.Label())
@@ -38,7 +38,7 @@ func TestSettingsRenderReflectsDisabled(t *testing.T) {
 	s := NewSettingsScreen(Theme{})
 	prefs := settings.Default()
 	prefs.SetChip(settings.ChipTarget, false)
-	out := s.Render(prefs, 80)
+	out := s.Render(prefs, 80, 0)
 	// One disabled chip + the two off-by-default gameplay toggles = 3 empty.
 	if got, want := strings.Count(out, "[ ]"), 1+gameplayRows; got != want {
 		t.Errorf("empty-box count = %d, want %d (disabled chip + off gameplay toggles):\n%s", got, want, out)
@@ -116,7 +116,7 @@ func TestSettingsAutosaveIntervalRow(t *testing.T) {
 func TestSettingsRenderShowsAutosaveInterval(t *testing.T) {
 	s := NewSettingsScreen(Theme{})
 
-	out := s.Render(settings.Default(), 80)
+	out := s.Render(settings.Default(), 80, 0)
 	if !strings.Contains(out, "Autosave interval") {
 		t.Errorf("Render is missing the autosave-interval row:\n%s", out)
 	}
@@ -126,7 +126,7 @@ func TestSettingsRenderShowsAutosaveInterval(t *testing.T) {
 
 	prefs := settings.Default()
 	prefs.SetAutosaveIntervalMin(0)
-	out = s.Render(prefs, 80)
+	out = s.Render(prefs, 80, 0)
 	if !strings.Contains(out, "off") {
 		t.Errorf("Render with interval 0 is missing %q:\n%s", "off", out)
 	}
@@ -137,7 +137,7 @@ func TestSettingsRenderShowsAutosaveInterval(t *testing.T) {
 func TestSettingsClickAutosaveRow(t *testing.T) {
 	s := NewSettingsScreen(Theme{})
 	const width = 80
-	out := s.Render(settings.Default(), width)
+	out := s.Render(settings.Default(), width, 0)
 	lines := strings.Split(out, "\n")
 
 	row := -1
@@ -184,7 +184,7 @@ func TestSettingsReset(t *testing.T) {
 func TestSettingsHandleClick(t *testing.T) {
 	s := NewSettingsScreen(Theme{})
 	const width = 80
-	out := s.Render(settings.Default(), width)
+	out := s.Render(settings.Default(), width, 0)
 	lines := strings.Split(out, "\n")
 
 	// Find the rendered row of the third chip by its label, then click it.

--- a/internal/tui/screens/settings_window_test.go
+++ b/internal/tui/screens/settings_window_test.go
@@ -1,0 +1,92 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/settings"
+)
+
+// TestSettingsFitsAndKeepsCursorVisibleAt104x24 is the #373 repro: at
+// 104x24 the pre-fix Render emitted the title, the "chips" section header,
+// and all three sections' rows unconditionally (33 lines), so after two
+// Down presses the cursor scrolled off the top of the pane with no title,
+// no header, and zero ">" markers anywhere in the capture
+// (features-discoverability-19/20-settings-104x24.txt).
+func TestSettingsFitsAndKeepsCursorVisibleAt104x24(t *testing.T) {
+	s := NewSettingsScreen(Theme{})
+	s.HandleKey("down")
+	s.HandleKey("down")
+
+	out := s.Render(settings.Default(), 104, 24)
+	lines := strings.Split(out, "\n")
+	if len(lines) > 24 {
+		t.Errorf("rendered %d lines, want <= 24 (terminal height):\n%s", len(lines), out)
+	}
+	if !strings.Contains(out, "settings") {
+		t.Errorf("title missing from rendered output:\n%s", out)
+	}
+	if !strings.Contains(out, "chips") {
+		t.Errorf("the active section header (\"chips\") is missing from rendered output:\n%s", out)
+	}
+	if !strings.Contains(out, "> ") {
+		t.Errorf("cursor marker (\"> \") missing from rendered output:\n%s", out)
+	}
+	if !strings.Contains(out, settings.AllChips[2].Label()) {
+		t.Errorf("the highlighted chip (%q) is missing from rendered output:\n%s", settings.AllChips[2].Label(), out)
+	}
+	if !strings.Contains(out, "[esc] back") {
+		t.Errorf("footer missing from rendered output:\n%s", out)
+	}
+}
+
+// TestSettingsWindowActuallyHidesRowsAtFloor confirms the body is really
+// windowed (not just short) at the floor: far fewer chip rows render than
+// settings.AllChips holds.
+func TestSettingsWindowActuallyHidesRowsAtFloor(t *testing.T) {
+	s := NewSettingsScreen(Theme{})
+	out := s.Render(settings.Default(), 104, 24)
+	shown := 0
+	for _, c := range settings.AllChips {
+		if strings.Contains(out, c.Label()) {
+			shown++
+		}
+	}
+	if shown >= len(settings.AllChips) {
+		t.Errorf("windowed render shows %d of %d chip labels, want far fewer:\n%s", shown, len(settings.AllChips), out)
+	}
+}
+
+// TestSettingsWindowFollowsCursorIntoGameplaySection checks the pinned
+// section header tracks the cursor across sections: once the cursor walks
+// past the chip rows onto the gameplay toggles, the "gameplay" header
+// (not "chips") must be the one visible.
+func TestSettingsWindowFollowsCursorIntoGameplaySection(t *testing.T) {
+	s := NewSettingsScreen(Theme{})
+	for i := 0; i < len(settings.AllChips); i++ {
+		s.HandleKey("down")
+	}
+	out := s.Render(settings.Default(), 104, 24)
+	if !strings.Contains(out, "gameplay") {
+		t.Errorf("expected the \"gameplay\" section header pinned once the cursor reaches the gameplay rows:\n%s", out)
+	}
+	if !strings.Contains(out, "Tutorial") {
+		t.Errorf("cursor row (Tutorial) missing from rendered output:\n%s", out)
+	}
+}
+
+// TestSettingsRenderUnboundedHeightShowsWholeBody locks in the height<=0
+// escape hatch: every existing settings test renders with height 0 and
+// expects the full body (all chips + gameplay + saves rows) unwindowed.
+func TestSettingsRenderUnboundedHeightShowsWholeBody(t *testing.T) {
+	s := NewSettingsScreen(Theme{})
+	out := s.Render(settings.Default(), 80, 0)
+	for _, c := range settings.AllChips {
+		if !strings.Contains(out, c.Label()) {
+			t.Errorf("chip %q missing from unbounded-height render", c.Label())
+		}
+	}
+	if !strings.Contains(out, "Autosave interval") {
+		t.Errorf("autosave row missing from unbounded-height render:\n%s", out)
+	}
+}

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
 // SpawnCraft is the modal form opened by `n` on the orbit screen.
@@ -914,57 +915,153 @@ func altKmLabel(altM float64) string {
 	return sim.CommaKm(altM) + " km"
 }
 
-// Render returns the modal form. Width is the terminal width.
-func (s *SpawnCraft) Render(width int) string {
-	var lines []string
+// craftTypeRowBudget caps how many CRAFT TYPE rows (including category
+// headers) the windowed catalog list shows around the cursor (#373 / ADR
+// 0046's Consequences section: "about 8 rows around the cursor"). Render
+// shrinks this further when the terminal is too short to give the rest of
+// the form (POSITION/PARENT BODY/ALTITUDE/DIRECTION, the footer) room —
+// see craftTypeRowsFor.
+const craftTypeRowBudget = 8
+
+// craftTypeLines flattens the CRAFT TYPE catalog — category headers (ADR
+// 0031 / S8), the "Custom & Designs" group, the synthetic Custom entry,
+// and any saved designs — into widgets.WindowLines suitable for
+// widgets.Window, plus the line index the cursor (loadoutIdx) sits on.
+// This is exactly the content the pre-#373 Render loop emitted inline;
+// factoring it out is what lets Render window it instead of emitting
+// every line.
+func (s *SpawnCraft) craftTypeLines() (lines []widgets.WindowLine, cursorLine int) {
+	idx := 0
+	for _, g := range s.groupedLoadouts() {
+		lines = append(lines, widgets.WindowLine{Text: "  " + s.theme.Primary.Render(g.label), IsHeader: true})
+		for _, id := range g.ids {
+			l := spacecraft.Loadouts[id]
+			row := fmt.Sprintf("%s %s  %s  %s  — %s",
+				l.Glyph, l.Name, crewTag(l), l.Role, propulsionSummary(l))
+			if idx == s.loadoutIdx {
+				cursorLine = len(lines)
+			}
+			lines = append(lines, widgets.WindowLine{Text: s.craftRow(idx, row)})
+			idx++
+		}
+	}
+	// Trailing "Custom & Designs" group — never filtered (ADR 0031). idx is now
+	// visibleCatalogCount(), so the Custom row lands on the Custom index.
+	lines = append(lines, widgets.WindowLine{Text: "  " + s.theme.Primary.Render("Custom & Designs"), IsHeader: true})
+	if idx == s.loadoutIdx {
+		cursorLine = len(lines)
+	}
+	lines = append(lines, widgets.WindowLine{Text: s.craftRow(idx, "✎ Custom…  build-your-own  — assemble a stage stack")})
+	idx++
+	for _, d := range s.designs {
+		if idx == s.loadoutIdx {
+			cursorLine = len(lines)
+		}
+		lines = append(lines, widgets.WindowLine{Text: s.craftRow(idx,
+			fmt.Sprintf("✎ %s  saved design  — %d stages", d.Name(), len(d.Loadout.Parts)))})
+		idx++
+	}
+	return lines, cursorLine
+}
+
+// craftTypeRowsFor picks the CRAFT TYPE window's row budget for a given
+// terminal height: craftTypeRowBudget when there's room, shrunk to
+// whatever's left after fixedLines (every other line Render emits — the
+// title, VESSEL TYPE header, POSITION/PARENT BODY/ALTITUDE/DIRECTION, the
+// footer, and the STACK editor when Custom is selected) so the rest of the
+// form is never pushed off screen by the catalog window itself. height<=0
+// means "no budget" (tests, and any caller with nothing to fit into) —
+// the catalog renders unwindowed, matching the pre-#373 behavior. Never
+// drops below 1 so the cursor's own row always renders.
+func craftTypeRowsFor(height, fixedLines int) int {
+	if height <= 0 {
+		return 0 // widgets.Window treats <=0 as "show everything"
+	}
+	avail := height - fixedLines
+	if avail > craftTypeRowBudget {
+		avail = craftTypeRowBudget
+	}
+	if avail < 1 {
+		avail = 1
+	}
+	return avail
+}
+
+// Render returns the modal form. width is the terminal width; height is
+// the terminal height (#373 / ADR 0046) — Render windows the CRAFT TYPE
+// catalog to fit height, keeping POSITION/PARENT BODY/ALTITUDE/DIRECTION,
+// the title, the "[f] show all" hint, and the footer on screen. height<=0
+// disables the windowing clamp (shows the whole catalog) — handy for
+// tests and any caller with no height budget.
+func (s *SpawnCraft) Render(width, height int) string {
+	var head []string
 
 	const titleText = "terminal-space-program — spawn vessel"
-	lines = append(lines, s.theme.Title.Render(titleText))
-	lines = append(lines, "")
+	head = append(head, s.theme.Title.Render(titleText))
+	head = append(head, "")
 
-	// Field 0: craft type — catalog loadouts grouped under category headers
-	// (ADR 0031 / S8), then a trailing "Custom & Designs" group with the
-	// synthetic "Custom…" entry and any saved VAB designs. Headers are
-	// non-selectable; the cursor (loadoutIdx) walks only the selectable rows,
-	// which follow groupedLoadouts()'s flattened order — so `idx` below tracks
-	// the running selectable index and the catalog rows end exactly at
-	// visibleCatalogCount() (the Custom index — the filtered count, not
-	// len(LoadoutOrder)), keeping IsCustomSelected / IsDesignSelected in step.
-	lines = append(lines, s.fieldHeader(0, "VESSEL TYPE"))
-	// ADR 0031 / S10: the scale-class system filter note + [f] hint.
+	// Field 0: craft type header + the ADR 0031 / S10 system-filter note.
+	// The catalog rows themselves (category headers, loadouts, Custom &
+	// Designs) are windowed below via craftTypeLines/widgets.Window rather
+	// than emitted inline — see craftTypeRowsFor's doc comment.
+	head = append(head, s.fieldHeader(0, "VESSEL TYPE"))
 	if s.showAll {
-		lines = append(lines, "  "+s.theme.Dim.Render(
+		head = append(head, "  "+s.theme.Dim.Render(
 			"showing all systems' vessels — [f] filter to this system"))
 	} else if hidden := len(spacecraft.LoadoutOrder) - s.visibleCatalogCount(); hidden > 0 {
 		noun := "vessels"
 		if hidden == 1 {
 			noun = "vessel"
 		}
-		lines = append(lines, "  "+s.theme.Dim.Render(fmt.Sprintf(
+		head = append(head, "  "+s.theme.Dim.Render(fmt.Sprintf(
 			"%d %s from other systems hidden — [f] show all", hidden, noun)))
 	}
-	lines = append(lines, "")
-	idx := 0
-	for _, g := range s.groupedLoadouts() {
-		lines = append(lines, "  "+s.theme.Primary.Render(g.label))
-		for _, id := range g.ids {
-			l := spacecraft.Loadouts[id]
-			row := fmt.Sprintf("%s %s  %s  %s  — %s",
-				l.Glyph, l.Name, crewTag(l), l.Role, propulsionSummary(l))
-			lines = append(lines, s.craftRow(idx, row))
-			idx++
+	head = append(head, "")
+
+	var lines []string
+	lines = append(lines, head...)
+
+	tail := s.renderTail(width)
+
+	catalogLines, cursorLine := s.craftTypeLines()
+	budget := craftTypeRowsFor(height, len(head)+len(tail))
+	rendered := widgets.Window(catalogLines, cursorLine, budget)
+	// Safety net: widgets.Window's pinned header + "N more" markers add up
+	// to 3 lines on top of budget (documented on Window), which
+	// craftTypeRowsFor's estimate doesn't account for — a terminal with
+	// almost no room to spare after the fixed head+tail chrome can still
+	// overflow height by that much. Drop marker/pin lines first (cheapest
+	// to lose) before ever touching a content row, so the cursor's own row
+	// is the last thing trimmed — see the loop below.
+	if height > 0 {
+		if over := len(head) + len(rendered) + len(tail) - height; over > 0 {
+			trimmed := rendered[:0]
+			dropped := 0
+			for _, r := range rendered {
+				if dropped < over && r.Kind != widgets.LineContent {
+					dropped++
+					continue
+				}
+				trimmed = append(trimmed, r)
+			}
+			rendered = trimmed
 		}
 	}
-	// Trailing "Custom & Designs" group — never filtered (ADR 0031). idx is now
-	// visibleCatalogCount(), so the Custom row lands on the Custom index.
-	lines = append(lines, "  "+s.theme.Primary.Render("Custom & Designs"))
-	lines = append(lines, s.craftRow(idx, "✎ Custom…  build-your-own  — assemble a stage stack"))
-	idx++
-	for _, d := range s.designs {
-		lines = append(lines, s.craftRow(idx,
-			fmt.Sprintf("✎ %s  saved design  — %d stages", d.Name(), len(d.Loadout.Parts))))
-		idx++
+	for _, r := range rendered {
+		lines = append(lines, r.Text)
 	}
+	lines = append(lines, tail...)
+
+	return strings.Join(lines, "\n")
+}
+
+// renderTail renders everything Render shows AFTER the (possibly
+// windowed) CRAFT TYPE catalog: the STACK editor when Custom is selected,
+// POSITION, PARENT BODY, ALTITUDE/LAUNCH SITE, DIRECTION, and the footer.
+// Factored out of Render so craftTypeRowsFor can measure its length before
+// the catalog window is sized (#373).
+func (s *SpawnCraft) renderTail(width int) []string {
+	var lines []string
 
 	// v0.10.1+ STACK editor — only when Custom is selected. Shows the
 	// working stack bottom→top, the catalog part-picker, and the
@@ -1129,7 +1226,7 @@ func (s *SpawnCraft) Render(width int) string {
 	lines = append(lines, s.theme.Footer.Render(
 		"[tab] field  [←/→] cycle  [f] system filter  [enter] spawn  [esc] cancel"))
 
-	return strings.Join(lines, "\n")
+	return lines
 }
 
 // bandWarning classifies the focused (parent, altitude) against the

--- a/internal/tui/screens/spawn_altitude_test.go
+++ b/internal/tui/screens/spawn_altitude_test.go
@@ -122,13 +122,13 @@ func TestAltitudeArmedHintTellsThePlayerEnterLaunches(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	s.Reset(bandTestBodies(), "earth", nil, "", nil)
 	s.fieldIdx = 3
-	if out := s.Render(80); !strings.Contains(out, "Enter to edit") {
+	if out := s.Render(80, 0); !strings.Contains(out, "Enter to edit") {
 		t.Fatalf("quiet focused ALTITUDE does not offer %q:\n%s", "Enter to edit", out)
 	}
 	enterAltEdit(t, s)
 	typeDigits(s, 900)
 	s.HandleKey("enter")
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "Enter now launches") {
 		t.Errorf("after leaving the box the hint does not say Enter launches:\n%s", out)
 	}
@@ -209,7 +209,7 @@ func TestAltitudeCommitClamps(t *testing.T) {
 	if !strings.Contains(s.altNote, "raised from 60") {
 		t.Errorf("altNote = %q, missing the raised-from-60 clamp sentence", s.altNote)
 	}
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "↳") || !strings.Contains(out, s.altNote) {
 		t.Errorf("rendered form does not show the clamp note verbatim:\n%s", out)
 	}
@@ -425,7 +425,7 @@ func TestAltitudeNoOrbitBodyKeepsEnterDead(t *testing.T) {
 		t.Error("Enter opened the edit box over an Empty Orbit Band — there is nothing to edit")
 	}
 
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "✕") {
 		t.Errorf("rendered form missing the ✕ no-orbit marker:\n%s", out)
 	}
@@ -464,16 +464,16 @@ func TestAltitudeCommitSamplesCommsOnceNotPerKeystroke(t *testing.T) {
 	typeDigits(s, 4400)
 	// Render repeatedly while editing — must never sample.
 	for i := 0; i < 5; i++ {
-		_ = s.Render(80)
+		_ = s.Render(80, 0)
 	}
 	if calls != 0 {
 		t.Fatalf("sampler called %d times while the edit box was open (mid-type), want 0", calls)
 	}
 
 	s.HandleKey("enter") // commit
-	_ = s.Render(80)
-	_ = s.Render(80)
-	_ = s.Render(80)
+	_ = s.Render(80, 0)
+	_ = s.Render(80, 0)
+	_ = s.Render(80, 0)
 	if calls != 1 {
 		t.Errorf("sampler called %d times across commit + repeated renders at the same altitude, want exactly 1 (memoized)", calls)
 	}
@@ -557,7 +557,7 @@ func TestAltitudeRetypedDisplayedValueCountsAsOnStop(t *testing.T) {
 func TestAltitudeFieldRendersAt80Columns(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	s.Reset(bandTestBodies(), "earth", nil, "", nil)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "ALTITUDE") {
 		t.Error("ALTITUDE header missing from an 80-column render")
 	}

--- a/internal/tui/screens/spawn_band_test.go
+++ b/internal/tui/screens/spawn_band_test.go
@@ -45,13 +45,13 @@ func TestSpawnFormFlagsDegradedBand(t *testing.T) {
 	resetWithBand(s, bandStub(map[int]float64{5000: 0.61}))
 
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "degraded comms band") || !strings.Contains(out, "relays advised") {
 		t.Errorf("a degraded preset must be flagged with the relay advice:\n%s", out)
 	}
 
 	setAltitude(t, s, 500)
-	if out := s.Render(80); strings.Contains(out, "degraded comms band") {
+	if out := s.Render(80, 0); strings.Contains(out, "degraded comms band") {
 		t.Errorf("a full-coverage preset must not be flagged:\n%s", out)
 	}
 }
@@ -60,7 +60,7 @@ func TestSpawnFormOutOfReachWording(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	resetWithBand(s, bandStub(map[int]float64{5000: 0}))
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "out of network reach") {
 		t.Errorf("zero coverage is the out-of-range case, not the band:\n%s", out)
 	}
@@ -73,7 +73,7 @@ func TestSpawnFormNoBandWarningWithoutSampler(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	s.Reset(bandTestBodies(), "earth", nil, "", nil)
 	setAltitude(t, s, 5000)
-	if out := s.Render(80); strings.Contains(out, "degraded comms band") {
+	if out := s.Render(80, 0); strings.Contains(out, "degraded comms band") {
 		t.Errorf("no sampler injected → no claim made:\n%s", out)
 	}
 }
@@ -89,7 +89,7 @@ func TestSpawnFormCrewedLoadoutNeverWarned(t *testing.T) {
 	selectCustom(s)
 	s.customStages = []spacecraft.Stage{{Name: "Pod", CommandSource: spacecraft.CommandCrewed}}
 	setAltitude(t, s, 5000)
-	if out := s.Render(80); strings.Contains(out, "degraded comms band") || strings.Contains(out, "out of network reach") {
+	if out := s.Render(80, 0); strings.Contains(out, "degraded comms band") || strings.Contains(out, "out of network reach") {
 		t.Errorf("a crewed craft is never comms-gated — no warning applies:\n%s", out)
 	}
 }
@@ -107,7 +107,7 @@ func TestSpawnFormPassesSelectedAntennaToSampler(t *testing.T) {
 		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
 	}}
 	setAltitude(t, s, 5000)
-	_ = s.Render(80)
+	_ = s.Render(80, 0)
 	if gotRange != spacecraft.AntennaRangeRelayCislunar {
 		t.Errorf("sampler must receive the selected stack's antenna range; got %g", gotRange)
 	}
@@ -144,7 +144,7 @@ func TestClampAndCommsWarningBothRenderAtLowCeilingBody(t *testing.T) {
 		t.Fatalf("setup: Enceladus's Orbit Band did not clamp the 500km Reset default — test premise broken")
 	}
 
-	out := s.Render(80) // the very first render — no arrow keys, no re-focus
+	out := s.Render(80, 0) // the very first render — no arrow keys, no re-focus
 	clampIdx := strings.Index(out, "↳")
 	warnIdx := strings.Index(out, "⚠")
 	if clampIdx < 0 {
@@ -177,7 +177,7 @@ func TestSpawnFormRelayClassDegradedBandIsNeutral(t *testing.T) {
 		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
 	}}
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if strings.Contains(out, "⚠") {
 		t.Errorf("a relay-class craft must not be warned off the deployment that fixes its own band:\n%s", out)
 	}
@@ -198,7 +198,7 @@ func TestSpawnFormNonRelayDegradedBandUnchanged(t *testing.T) {
 		AntennaKind: spacecraft.AntennaDirect, AntennaRangeM: 1e9,
 	}}
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
 		t.Errorf("an ordinary (non-relay) probe below threshold must keep the original warning:\n%s", out)
 	}
@@ -213,7 +213,7 @@ func TestSpawnFormRelayClassCrewedStillNeverWarned(t *testing.T) {
 		AntennaKind: spacecraft.AntennaRelay, AntennaRangeM: spacecraft.AntennaRangeRelayCislunar,
 	}}
 	setAltitude(t, s, 5000)
-	if out := s.Render(80); strings.Contains(out, "⚠") || strings.Contains(out, "coverage from here") {
+	if out := s.Render(80, 0); strings.Contains(out, "⚠") || strings.Contains(out, "coverage from here") {
 		t.Errorf("crewed suppression must still win outright, even for a relay-class craft:\n%s", out)
 	}
 }
@@ -246,7 +246,7 @@ func TestSpawnFormMixedAntennaResolvesDirectNotRelay(t *testing.T) {
 		},
 	}
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
 		t.Errorf("a mixed loadout that resolves to Direct must get the ordinary warning, not the relay-class reframe:\n%s", out)
 	}
@@ -270,7 +270,7 @@ func TestSpawnFormRelayAntennaWithoutCommandSourceIsNotRelayClass(t *testing.T) 
 		},
 	}
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "⚠ degraded comms band") || !strings.Contains(out, "relays advised") {
 		t.Errorf("a relay antenna with no command source is not Controllable and must keep the ordinary warning:\n%s", out)
 	}
@@ -294,7 +294,7 @@ func TestSpawnFormMultiStageGenuineRelayIsNeutral(t *testing.T) {
 		},
 	}
 	setAltitude(t, s, 5000)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if strings.Contains(out, "⚠") {
 		t.Errorf("a genuine multi-stage relay (resolves to relay, controllable) must not be warned off its own deployment:\n%s", out)
 	}

--- a/internal/tui/screens/spawn_filter_test.go
+++ b/internal/tui/screens/spawn_filter_test.go
@@ -141,5 +141,5 @@ func TestEmptyFilterDegradesGracefully(t *testing.T) {
 	if s.SelectedLoadoutID() != "" {
 		t.Errorf("no catalog craft selected, SelectedLoadoutID = %q, want empty", s.SelectedLoadoutID())
 	}
-	_ = s.Render(80) // must not panic
+	_ = s.Render(80, 0) // must not panic
 }

--- a/internal/tui/screens/spawn_group_test.go
+++ b/internal/tui/screens/spawn_group_test.go
@@ -126,7 +126,7 @@ func TestCustomCyclingStillReachesCustomAndDesigns(t *testing.T) {
 // ADR 0031 / S8).
 func TestRenderShowsCategoryHeaders(t *testing.T) {
 	s := formShowAll()
-	out := s.Render(100)
+	out := s.Render(100, 0)
 	for _, g := range s.groupedLoadouts() {
 		if !strings.Contains(out, g.label) {
 			t.Errorf("render missing category header %q", g.label)

--- a/internal/tui/screens/spawn_launch_test.go
+++ b/internal/tui/screens/spawn_launch_test.go
@@ -177,7 +177,7 @@ func TestFilterToggleResnapsLaunchpad(t *testing.T) {
 func TestRenderShowsCrewTags(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	s.Reset([]bodies.CelestialBody{earthLike()}, "earth", nil, "", nil)
-	out := s.Render(120)
+	out := s.Render(120, 0)
 	if !strings.Contains(out, "crewed") {
 		t.Error("render missing a 'crewed' tag (e.g. Apollo Stack)")
 	}

--- a/internal/tui/screens/spawn_test.go
+++ b/internal/tui/screens/spawn_test.go
@@ -210,7 +210,7 @@ func TestSpawnListsSavedDesigns(t *testing.T) {
 	if s.SelectedLoadoutID() != "" {
 		t.Errorf("a design row must blank SelectedLoadoutID, got %q", s.SelectedLoadoutID())
 	}
-	if !strings.Contains(s.Render(80), "Mun Hopper") {
+	if !strings.Contains(s.Render(80, 0), "Mun Hopper") {
 		t.Error("rendered CRAFT TYPE list does not show the saved design")
 	}
 }
@@ -246,7 +246,7 @@ func TestSpawnDockSeamFromCSMLMModule(t *testing.T) {
 	if len(plan) != 1 || plan[0] != 2 {
 		t.Errorf("SelectedNosePayloadPlan = %v, want [2] (the LM as nose payload)", plan)
 	}
-	if !strings.Contains(s.Render(80), "dock seam") {
+	if !strings.Contains(s.Render(80, 0), "dock seam") {
 		t.Error("rendered stack does not show the dock seam divider")
 	}
 }
@@ -297,11 +297,11 @@ func TestSpawnRenderShowsStackEditor(t *testing.T) {
 	s := NewSpawnCraft(Theme{})
 	s.Reset(nil, "", nil, "", nil)
 
-	if strings.Contains(s.Render(80), "STACK (bottom → top)") {
+	if strings.Contains(s.Render(80, 0), "STACK (bottom → top)") {
 		t.Error("STACK editor rendered for a non-custom loadout")
 	}
 	selectCustom(s)
-	out := s.Render(80)
+	out := s.Render(80, 0)
 	if !strings.Contains(out, "Custom…") {
 		t.Error("Custom row missing from CRAFT TYPE list")
 	}
@@ -311,7 +311,7 @@ func TestSpawnRenderShowsStackEditor(t *testing.T) {
 	s.fieldIdx = stackFieldIdx
 	s.HandleKey("a")
 	picked := s.SelectedCustomStages()[0].Name
-	if !strings.Contains(s.Render(80), picked) {
+	if !strings.Contains(s.Render(80, 0), picked) {
 		t.Errorf("rendered stack does not list the added part %q", picked)
 	}
 }

--- a/internal/tui/screens/spawn_window_test.go
+++ b/internal/tui/screens/spawn_window_test.go
@@ -1,0 +1,123 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// spawnFormMidCatalog builds a spawn form with the cursor parked on a
+// vessel in the middle of the CRAFT TYPE catalog — the #373 repro case:
+// deep enough into the list that the pre-fix, unwindowed Render scrolled
+// the cursor, the title, and the footer off the top of a real terminal.
+func spawnFormMidCatalog(t *testing.T) *SpawnCraft {
+	t.Helper()
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "", nil, "", nil)
+	s.showAll = true // full unfiltered catalog — the biggest, most repro-prone list
+	n := s.visibleCatalogCount()
+	if n < 3 {
+		t.Fatalf("catalog too small to test mid-list windowing: %d loadouts", n)
+	}
+	s.loadoutIdx = n / 2
+	return s
+}
+
+// assertSpawnChromeVisible checks the invariants #373 / ADR 0046 require at
+// every terminal size at or above the Playable Floor: the title, the
+// "[f]" filter hint, the cursor marker on the selected CRAFT TYPE row, the
+// always-on fields below it, and the footer must all be present in the
+// rendered output — and the whole thing must fit within height lines, or
+// something upstream of the footer has scrolled off the top of a real
+// terminal (the exact #373 symptom).
+func assertSpawnChromeVisible(t *testing.T, out string, height int) {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	if len(lines) > height {
+		t.Errorf("rendered %d lines, want <= %d (terminal height) — chrome will scroll off the top:\n%s",
+			len(lines), height, out)
+	}
+	if !strings.Contains(out, "spawn vessel") {
+		t.Errorf("title missing from rendered output:\n%s", out)
+	}
+	if !strings.Contains(out, "[f]") {
+		t.Errorf("\"[f]\" system-filter hint missing from rendered output:\n%s", out)
+	}
+	if !strings.Contains(out, "→ ") {
+		t.Errorf("CRAFT TYPE cursor marker (\"→ \") missing from rendered output — the player can't tell which vessel Enter will spawn:\n%s", out)
+	}
+	for _, want := range []string{"POSITION", "PARENT BODY", "ALTITUDE", "DIRECTION"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("field header %q missing from rendered output:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "[esc] cancel") {
+		t.Errorf("footer missing from rendered output:\n%s", out)
+	}
+}
+
+// TestSpawnFormFitsAndKeepsCursorVisibleAt104x24 is the #373 repro at the
+// Playable Floor. Before the windowed-list fix, Render dumped the entire
+// CRAFT TYPE catalog (headers + every loadout) unconditionally, so at
+// 104x24 the title, the cursor, and the footer were routinely pushed off
+// the top of the pane.
+func TestSpawnFormFitsAndKeepsCursorVisibleAt104x24(t *testing.T) {
+	s := spawnFormMidCatalog(t)
+	assertSpawnChromeVisible(t, s.Render(104, 24), 24)
+}
+
+// TestSpawnFormFitsAndKeepsCursorVisibleAt120x36 pins the 2026-09-03
+// reopen evidence directly: the same scrolling failure reproduced at
+// 120x36, well above the size #373 was originally (wrongly) closed
+// against, because the form is 46-52 rows regardless of terminal size.
+func TestSpawnFormFitsAndKeepsCursorVisibleAt120x36(t *testing.T) {
+	s := spawnFormMidCatalog(t)
+	assertSpawnChromeVisible(t, s.Render(120, 36), 36)
+}
+
+// TestSpawnFormFitsAt140x40DesignSize checks the ADR 0046 Design Size
+// too: the form (46-52 rows) still overflows 140x40 on its own, so the
+// windowed catalog must still be doing work even well above the floor.
+func TestSpawnFormFitsAt140x40DesignSize(t *testing.T) {
+	s := spawnFormMidCatalog(t)
+	assertSpawnChromeVisible(t, s.Render(140, 40), 40)
+}
+
+// TestSpawnFormWindowActuallyHidesRowsAtFloor confirms the catalog is
+// ACTUALLY windowed (not just coincidentally short) at the floor: with the
+// cursor mid-list and the full unfiltered catalog selected, far fewer
+// loadout rows render than the catalog actually holds. (At the floor,
+// fitting height takes priority over the "N more" markers themselves —
+// see TestSpawnFormFitsAndKeepsCursorVisibleAt104x24 — so this checks row
+// counts rather than requiring the marker text.)
+func TestSpawnFormWindowActuallyHidesRowsAtFloor(t *testing.T) {
+	s := spawnFormMidCatalog(t)
+	total := s.visibleCatalogCount()
+	out := s.Render(104, 24)
+	shown := strings.Count(out, "➤")
+	if shown >= total {
+		t.Errorf("windowed render shows %d of %d catalog rows, want far fewer:\n%s", shown, total, out)
+	}
+	cursorName := spacecraft.Loadouts[s.orderedLoadoutIDs()[s.loadoutIdx]].Name
+	if !strings.Contains(out, cursorName) {
+		t.Errorf("the cursor's own row (%s) is missing from the windowed render:\n%s", cursorName, out)
+	}
+}
+
+// TestSpawnFormRenderUnboundedHeightShowsWholeCatalog locks in the
+// height<=0 escape hatch existing tests rely on: with no height budget,
+// every catalog loadout still renders (no windowing, no markers) — the
+// pre-#373 behavior, kept for callers with nothing to fit into.
+func TestSpawnFormRenderUnboundedHeightShowsWholeCatalog(t *testing.T) {
+	s := NewSpawnCraft(Theme{})
+	s.Reset(nil, "", nil, "", nil)
+	s.showAll = true
+	out := s.Render(80, 0)
+	for _, id := range spacecraft.LoadoutOrder {
+		l := spacecraft.Loadouts[id]
+		if !strings.Contains(out, l.Name) {
+			t.Errorf("loadout %q missing from unbounded-height render", l.Name)
+		}
+	}
+}

--- a/internal/tui/screens/vab_footer_test.go
+++ b/internal/tui/screens/vab_footer_test.go
@@ -1,0 +1,83 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVABFooterWrapsAndKeepsSaveOpenAt104Columns is the #373 repro for the
+// VAB's second footer row: at 104 columns the un-wrapped 132-char string
+// ("[+/−] qty  ...  [s] save  [o] open  [esc] back") ran off the pane and
+// was cut off mid-token, hiding "[s] save" and "[o] open" entirely — the
+// only on-screen way to learn how to keep a build (features-discoverability
+// -22-vab-104x24.txt). The fix wraps the footer to as many rows as the
+// width needs instead of truncating.
+func TestVABFooterWrapsAndKeepsSaveOpenAt104Columns(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	out := v.Render(104)
+
+	for _, ln := range strings.Split(out, "\n") {
+		if len([]rune(ln)) > 104 {
+			t.Errorf("rendered line exceeds 104 columns (%d): %q", len([]rune(ln)), ln)
+		}
+	}
+	if !strings.Contains(out, "[s] save") {
+		t.Errorf("footer is missing \"[s] save\" at 104 columns:\n%s", out)
+	}
+	if !strings.Contains(out, "[o] open") {
+		t.Errorf("footer is missing \"[o] open\" at 104 columns:\n%s", out)
+	}
+	if !strings.Contains(out, "[esc] back") {
+		t.Errorf("footer is missing \"[esc] back\" at 104 columns:\n%s", out)
+	}
+}
+
+// TestVABFooterFitsOnOneRowWhenWide confirms the wrap is a real word-wrap,
+// not an unconditional split: at a comfortably wide terminal both footer
+// hint rows stay on one physical line each (2 lines total), matching the
+// pre-#373 layout.
+func TestVABFooterFitsOnOneRowWhenWide(t *testing.T) {
+	v := NewVAB(Theme{})
+	v.Reset(testVABComps())
+	out := v.Render(160)
+	lines := strings.Split(out, "\n")
+
+	footerRows := 0
+	for _, ln := range lines {
+		if strings.Contains(ln, "[tab] column") || strings.Contains(ln, "[+/") {
+			footerRows++
+		}
+	}
+	if footerRows != 2 {
+		t.Errorf("got %d footer key-hint rows at width 160, want 2 (one per hint row):\n%s", footerRows, out)
+	}
+}
+
+// TestWrapFooterHintsKeepsHintsWhole checks the wrap unit directly: a hint
+// ("[key] description") must never be split across two lines — only
+// gaps between hints are wrap points.
+func TestWrapFooterHintsKeepsHintsWhole(t *testing.T) {
+	s := "[a] add  [b] bravo  [c] charlie  [d] delta"
+	for _, w := range []int{1, 5, 8, 12, 20, 100} {
+		lines := wrapFooterHints(s, w)
+		joined := strings.Join(lines, "  ")
+		if joined != s {
+			t.Errorf("wrap at width %d dropped or reordered hints: got %q, want %q", w, joined, s)
+		}
+		for _, ln := range lines {
+			if ln == "" {
+				t.Errorf("wrap at width %d produced an empty line", w)
+			}
+		}
+	}
+}
+
+func TestWrapFooterHintsEmptyInput(t *testing.T) {
+	if got := wrapFooterHints("", 80); got != nil {
+		t.Errorf("wrapFooterHints(\"\", 80) = %v, want nil", got)
+	}
+	if got := wrapFooterHints("hi", 0); got != nil {
+		t.Errorf("wrapFooterHints with w<=0 = %v, want nil", got)
+	}
+}

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -254,10 +254,20 @@ func (v *VAB) renderBuild(width int) string {
 		foot = append(foot, "", v.theme.Warning.Render(v.flash))
 	}
 	foot = append(foot, v.theme.Dim.Render(strings.Repeat("─", clampI(width, 40, 100))))
-	foot = append(foot, v.theme.Footer.Render(
-		"[tab] column  [↑/↓] move  [←/→] swap  [PgUp/Dn] section  [a] add  [n] new stage  [x] remove"))
-	foot = append(foot, v.theme.Footer.Render(
-		"[+/−] qty  ['['/']'] reorder  [y] duplicate  [enter] crack part  [d] dock seam  [c] fuse  [t] target  [s] save  [o] open  [esc] back"))
+	// #373: these two key-hint rows used to be single un-wrapped strings —
+	// at 104 columns the second row (132 chars) ran off the right edge and
+	// was cut off mid-token, hiding "[s] save" / "[o] open" entirely (the
+	// only on-screen way to learn how to keep a build). wrapFooterHints
+	// wraps to as many rows as width needs instead, keeping each "[key]
+	// hint" pair whole rather than splitting it across lines.
+	for _, ln := range wrapFooterHints(
+		"[tab] column  [↑/↓] move  [←/→] swap  [PgUp/Dn] section  [a] add  [n] new stage  [x] remove", width) {
+		foot = append(foot, v.theme.Footer.Render(ln))
+	}
+	for _, ln := range wrapFooterHints(
+		"[+/−] qty  ['['/']'] reorder  [y] duplicate  [enter] crack part  [d] dock seam  [c] fuse  [t] target  [s] save  [o] open  [esc] back", width) {
+		foot = append(foot, v.theme.Footer.Render(ln))
+	}
 
 	return strings.Join(head, "\n") + "\n\n" + body + "\n" + strings.Join(foot, "\n")
 }
@@ -573,6 +583,37 @@ func wrapText(s string, w int) []string {
 		default:
 			lines = append(lines, cur)
 			cur = word
+		}
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
+}
+
+// wrapFooterHints word-wraps a footer key-hint row ("[key] description  [key]
+// description  …", hints separated by two spaces) to a column width,
+// returning the lines. Unlike wrapText, the wrap unit is a whole hint —
+// "[s] save", not "[s]" and "save" separately — so a hint's key and its
+// description can never land on different lines. #373: the VAB's second
+// footer row (132 chars) used to be emitted as one un-wrapped string and got
+// cut off mid-token at 104 columns, hiding "[s] save" / "[o] open" outright.
+func wrapFooterHints(s string, w int) []string {
+	if strings.TrimSpace(s) == "" || w <= 0 {
+		return nil
+	}
+	hints := strings.Split(s, "  ")
+	var lines []string
+	var cur string
+	for _, h := range hints {
+		switch {
+		case cur == "":
+			cur = h
+		case lipgloss.Width(cur)+2+lipgloss.Width(h) <= w:
+			cur += "  " + h
+		default:
+			lines = append(lines, cur)
+			cur = h
 		}
 	}
 	if cur != "" {

--- a/internal/tui/widgets/windowed_list.go
+++ b/internal/tui/widgets/windowed_list.go
@@ -1,0 +1,133 @@
+package widgets
+
+import "fmt"
+
+// WindowLine is one line of content in a scrollable list panel: either a
+// pinnable section/category header or an ordinary content row (a
+// selectable item, a blank spacer, a description — anything the caller
+// wants to keep in the scroll).
+//
+// #373: the spawn form and Settings screen each grew a selectable list
+// (the CRAFT TYPE catalog, the chip-toggle rows) tall enough to scroll the
+// cursor, the screen title, or the footer off the top of the terminal with
+// no windowing at all. This is the shared fix (ADR 0046's Consequences
+// section): a list panel windows itself around the cursor instead of
+// emitting every line.
+type WindowLine struct {
+	Text     string
+	IsHeader bool
+}
+
+// LineKind classifies one line of a Window result.
+type LineKind int
+
+const (
+	// LineContent is a line taken directly from the input, at
+	// RenderedLine.Index.
+	LineContent LineKind = iota
+	// LinePinnedHeader is a section header (IsHeader==true in the input, at
+	// RenderedLine.Index) that has itself scrolled out of the visible
+	// window and is pinned as an extra line above it, so the section a
+	// player has scrolled into never loses its label.
+	LinePinnedHeader
+	// LineMoreAbove is a "▲ N more" marker; RenderedLine.Count is N.
+	LineMoreAbove
+	// LineMoreBelow is a "▼ N more" marker; RenderedLine.Count is N.
+	LineMoreBelow
+)
+
+// RenderedLine is one line of a Window result.
+type RenderedLine struct {
+	Text  string
+	Kind  LineKind
+	Index int // input index into the lines Window was called with; valid for LineContent / LinePinnedHeader
+	Count int // hidden-line count; valid for LineMoreAbove / LineMoreBelow
+}
+
+// Bounds returns the [start, end) window into an n-item list that keeps
+// cursor visible, sized to at most rowBudget items — centered on cursor
+// where the list is long enough to need windowing, clamped to the list's
+// ends otherwise. rowBudget <= 0, or a rowBudget that already covers the
+// whole list, returns the full range (0, n). cursor is clamped into
+// [0, n) before computing the window, so any cursor value is safe to pass.
+func Bounds(n, cursor, rowBudget int) (start, end int) {
+	if n <= 0 {
+		return 0, 0
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= n {
+		cursor = n - 1
+	}
+	if rowBudget <= 0 || rowBudget >= n {
+		return 0, n
+	}
+	start = cursor - rowBudget/2
+	if start < 0 {
+		start = 0
+	}
+	end = start + rowBudget
+	if end > n {
+		end = n
+		start = end - rowBudget
+	}
+	if start < 0 {
+		start = 0
+	}
+	return start, end
+}
+
+// Window computes a scrollable list panel's visible content: the
+// [start, end) slice of lines from Bounds, a leading "▲ N more" marker
+// when rows are hidden above, a trailing "▼ N more" marker when rows are
+// hidden below, and — when the header that owns the first visible line has
+// itself scrolled out of view — that header pinned as an extra leading
+// line.
+//
+// cursor is an index into lines (need not itself be a header line); it is
+// clamped the same way Bounds clamps it. An empty lines returns nil.
+func Window(lines []WindowLine, cursor, rowBudget int) []RenderedLine {
+	n := len(lines)
+	if n == 0 {
+		return nil
+	}
+	start, end := Bounds(n, cursor, rowBudget)
+
+	var out []RenderedLine
+	if hdrIdx := ownerHeaderIndex(lines, start); hdrIdx >= 0 && hdrIdx < start {
+		out = append(out, RenderedLine{Text: lines[hdrIdx].Text, Kind: LinePinnedHeader, Index: hdrIdx})
+	}
+	if start > 0 {
+		out = append(out, RenderedLine{Text: fmt.Sprintf("▲ %d more", start), Kind: LineMoreAbove, Count: start})
+	}
+	for i := start; i < end; i++ {
+		out = append(out, RenderedLine{Text: lines[i].Text, Kind: LineContent, Index: i})
+	}
+	if end < n {
+		out = append(out, RenderedLine{Text: fmt.Sprintf("▼ %d more", n-end), Kind: LineMoreBelow, Count: n - end})
+	}
+	return out
+}
+
+// ownerHeaderIndex returns the index of the nearest header line at or
+// before i, or -1 when no header precedes it.
+func ownerHeaderIndex(lines []WindowLine, i int) int {
+	for j := i; j >= 0; j-- {
+		if lines[j].IsHeader {
+			return j
+		}
+	}
+	return -1
+}
+
+// Texts extracts the rendered text of each line, in order — for a caller
+// (like a plain list with no click targets) that only needs the finished
+// lines and not the Kind/Index detail Window otherwise carries.
+func Texts(rendered []RenderedLine) []string {
+	out := make([]string, len(rendered))
+	for i, r := range rendered {
+		out[i] = r.Text
+	}
+	return out
+}

--- a/internal/tui/widgets/windowed_list_test.go
+++ b/internal/tui/widgets/windowed_list_test.go
@@ -1,0 +1,250 @@
+package widgets
+
+import "testing"
+
+func plainLines(n int) []WindowLine {
+	lines := make([]WindowLine, n)
+	for i := range lines {
+		lines[i] = WindowLine{Text: itoa(i)}
+	}
+	return lines
+}
+
+func itoa(i int) string {
+	// Avoid pulling in strconv just for test fixtures.
+	digits := "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{digits[i%10]}, b...)
+		i /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func TestBoundsCursorAtTop(t *testing.T) {
+	start, end := Bounds(20, 0, 6)
+	if start != 0 {
+		t.Fatalf("start = %d, want 0", start)
+	}
+	if end-start != 6 {
+		t.Fatalf("window size = %d, want 6", end-start)
+	}
+	if !(0 >= start && 0 < end) {
+		t.Fatalf("cursor 0 not in [%d,%d)", start, end)
+	}
+}
+
+func TestBoundsCursorInMiddle(t *testing.T) {
+	start, end := Bounds(20, 10, 6)
+	if end-start != 6 {
+		t.Fatalf("window size = %d, want 6", end-start)
+	}
+	if !(10 >= start && 10 < end) {
+		t.Fatalf("cursor 10 not in [%d,%d)", start, end)
+	}
+	// Centered: roughly equal slack on both sides.
+	if start != 7 || end != 13 {
+		t.Fatalf("got [%d,%d), want [7,13) for a centered cursor", start, end)
+	}
+}
+
+func TestBoundsCursorAtBottom(t *testing.T) {
+	start, end := Bounds(20, 19, 6)
+	if end != 20 {
+		t.Fatalf("end = %d, want 20", end)
+	}
+	if end-start != 6 {
+		t.Fatalf("window size = %d, want 6", end-start)
+	}
+	if !(19 >= start && 19 < end) {
+		t.Fatalf("cursor 19 not in [%d,%d)", start, end)
+	}
+}
+
+func TestBoundsWindowLargerThanList(t *testing.T) {
+	start, end := Bounds(5, 2, 50)
+	if start != 0 || end != 5 {
+		t.Fatalf("got [%d,%d), want [0,5) when the budget exceeds the list", start, end)
+	}
+}
+
+func TestBoundsNonPositiveBudgetShowsEverything(t *testing.T) {
+	start, end := Bounds(5, 2, 0)
+	if start != 0 || end != 5 {
+		t.Fatalf("got [%d,%d), want [0,5) for a non-positive budget", start, end)
+	}
+	start, end = Bounds(5, 2, -3)
+	if start != 0 || end != 5 {
+		t.Fatalf("got [%d,%d), want [0,5) for a negative budget", start, end)
+	}
+}
+
+func TestWindowCursorAtTopShowsBelowMarkerOnly(t *testing.T) {
+	rendered := Window(plainLines(20), 0, 6)
+	if rendered[0].Kind != LineContent || rendered[0].Index != 0 {
+		t.Fatalf("first rendered line = %+v, want the cursor's own row first", rendered[0])
+	}
+	last := rendered[len(rendered)-1]
+	if last.Kind != LineMoreBelow {
+		t.Fatalf("last line kind = %v, want LineMoreBelow", last.Kind)
+	}
+	for _, r := range rendered {
+		if r.Kind == LineMoreAbove {
+			t.Fatalf("unexpected LineMoreAbove when cursor is at the top: %+v", rendered)
+		}
+	}
+}
+
+func TestWindowCursorAtBottomShowsAboveMarkerOnly(t *testing.T) {
+	rendered := Window(plainLines(20), 19, 6)
+	first := rendered[0]
+	if first.Kind != LineMoreAbove {
+		t.Fatalf("first line kind = %v, want LineMoreAbove", first.Kind)
+	}
+	for _, r := range rendered {
+		if r.Kind == LineMoreBelow {
+			t.Fatalf("unexpected LineMoreBelow when cursor is at the bottom: %+v", rendered)
+		}
+	}
+	// The cursor's own row must actually be present.
+	found := false
+	for _, r := range rendered {
+		if r.Kind == LineContent && r.Index == 19 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cursor row (index 19) missing from rendered output: %+v", rendered)
+	}
+}
+
+func TestWindowMiddleShowsBothMarkers(t *testing.T) {
+	rendered := Window(plainLines(20), 10, 6)
+	if rendered[0].Kind != LineMoreAbove {
+		t.Fatalf("first line kind = %v, want LineMoreAbove", rendered[0].Kind)
+	}
+	if rendered[len(rendered)-1].Kind != LineMoreBelow {
+		t.Fatalf("last line kind = %v, want LineMoreBelow", rendered[len(rendered)-1].Kind)
+	}
+	found := false
+	for _, r := range rendered {
+		if r.Kind == LineContent && r.Index == 10 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cursor row (index 10) missing from rendered output: %+v", rendered)
+	}
+}
+
+func TestWindowLargerThanListReturnsEverythingUnwindowed(t *testing.T) {
+	lines := plainLines(5)
+	rendered := Window(lines, 2, 50)
+	if len(rendered) != 5 {
+		t.Fatalf("len(rendered) = %d, want 5 (no markers, nothing hidden)", len(rendered))
+	}
+	for i, r := range rendered {
+		if r.Kind != LineContent || r.Index != i {
+			t.Fatalf("rendered[%d] = %+v, want LineContent at index %d", i, r, i)
+		}
+	}
+}
+
+func TestWindowNonPositiveBudgetReturnsEverything(t *testing.T) {
+	lines := plainLines(5)
+	rendered := Window(lines, 2, 0)
+	if len(rendered) != 5 {
+		t.Fatalf("len(rendered) = %d, want 5 for a non-positive budget", len(rendered))
+	}
+}
+
+// TestWindowPinsScrolledOffHeader is the header-pinning case: a category
+// header several rows above the visible window must reappear as a pinned
+// leading line once the window scrolls past it, so a player deep in a
+// long section never loses the label for what they're looking at.
+func TestWindowPinsScrolledOffHeader(t *testing.T) {
+	lines := []WindowLine{
+		{Text: "Header A", IsHeader: true},
+		{Text: "a0"}, {Text: "a1"}, {Text: "a2"}, {Text: "a3"}, {Text: "a4"},
+		{Text: "a5"}, {Text: "a6"}, {Text: "a7"}, {Text: "a8"}, {Text: "a9"},
+	}
+	// cursor deep into the "a" section, window small enough that index 0
+	// (the header) scrolls out of view.
+	rendered := Window(lines, 9, 3)
+	if len(rendered) == 0 {
+		t.Fatalf("got no rendered lines")
+	}
+	first := rendered[0]
+	if first.Kind != LinePinnedHeader || first.Text != "Header A" {
+		t.Fatalf("first line = %+v, want the pinned \"Header A\" header", first)
+	}
+}
+
+// TestWindowNoPinWhenHeaderAlreadyVisible confirms the header is not
+// duplicated when it's already inside the window (cursor near the top of
+// its section).
+func TestWindowNoPinWhenHeaderAlreadyVisible(t *testing.T) {
+	lines := []WindowLine{
+		{Text: "Header A", IsHeader: true},
+		{Text: "a0"}, {Text: "a1"}, {Text: "a2"}, {Text: "a3"},
+	}
+	rendered := Window(lines, 1, 3)
+	pins := 0
+	for _, r := range rendered {
+		if r.Kind == LinePinnedHeader {
+			pins++
+		}
+	}
+	if pins != 0 {
+		t.Fatalf("got %d pinned headers, want 0 when the header is already in the window: %+v", pins, rendered)
+	}
+}
+
+// TestWindowPinFollowsSectionCrossing checks that the pinned header tracks
+// whichever section actually owns the top visible row, not just the first
+// header in the list — the second section's header pins once the window
+// crosses into it.
+func TestWindowPinFollowsSectionCrossing(t *testing.T) {
+	lines := []WindowLine{
+		{Text: "Header A", IsHeader: true},
+		{Text: "a0"}, {Text: "a1"},
+		{Text: "Header B", IsHeader: true},
+		{Text: "b0"}, {Text: "b1"}, {Text: "b2"}, {Text: "b3"}, {Text: "b4"},
+	}
+	// cursor on b3 (index 7), small window entirely inside section B but
+	// past Header B's own line (index 3).
+	rendered := Window(lines, 7, 2)
+	if rendered[0].Kind != LinePinnedHeader || rendered[0].Text != "Header B" {
+		t.Fatalf("first line = %+v, want the pinned \"Header B\" header", rendered[0])
+	}
+}
+
+func TestTextsExtractsRenderedText(t *testing.T) {
+	rendered := Window(plainLines(5), 2, 50)
+	texts := Texts(rendered)
+	want := []string{"0", "1", "2", "3", "4"}
+	if len(texts) != len(want) {
+		t.Fatalf("len(texts) = %d, want %d", len(texts), len(want))
+	}
+	for i := range want {
+		if texts[i] != want[i] {
+			t.Fatalf("texts[%d] = %q, want %q", i, texts[i], want[i])
+		}
+	}
+}
+
+func TestWindowEmptyInput(t *testing.T) {
+	if rendered := Window(nil, 0, 5); rendered != nil {
+		t.Fatalf("Window(nil, ...) = %+v, want nil", rendered)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #373.

The spawn form and Settings screen each emitted their entire selectable list unconditionally with no windowing, so the cursor, the title, the `[f] show all` hint, and the footer routinely scrolled off the top of a real terminal — reproduced at both 104×24 and 120×36 (the 2026-09-03 reopen evidence), and the form (46-52 rows) still doesn't fit the new 140×40 Design Size on its own (ADR 0046's Consequences section, which reframes and resolves this issue). The VAB's second footer row was a single un-wrapped 132-char string cut off mid-token at 104 columns, hiding `[s] save` / `[o] open` entirely.

Per the 2026-09-04 grill decision recorded in ADR 0046: window the CRAFT TYPE list (~8 rows around the cursor, ▲/▼ markers, category header pinned), keep POSITION/PARENT BODY/ALTITUDE/DIRECTION and the footer fixed on screen, give Settings the same windowed-list widget for its chip toggles, and wrap the VAB footer instead of truncating it. Not a whole-form scroll, not a separate picker screen.

## What changed

- **New widget** `internal/tui/widgets/windowed_list.go`: given a line list (each optionally tagged as a pinnable section header) and a cursor index, `Window` returns a cursor-centered slice sized to a row budget, with `▲ N more` / `▼ N more` markers and, when the header owning the visible window's top row has itself scrolled out of view, that header pinned as an extra leading line. `Bounds` is the underlying `[start, end)` computation, exposed separately so a caller that needs per-row click targets (Settings) can build its own output around it. Unit-tested in isolation (`windowed_list_test.go`): cursor at top/middle/bottom, a budget larger than the list, header pinning and un-pinning, and the header tracking across a section boundary.
- **`internal/tui/screens/spawn.go`**: `Render` now takes `(width, height int)` (mirrors `help.go`/`saves.go`). The CRAFT TYPE catalog (category headers + loadouts + "Custom & Designs") is flattened into `widgets.WindowLine`s and windowed to a budget capped at 8 rows and shrunk further when the terminal is short of room for the rest of the form; POSITION/PARENT BODY/ALTITUDE/DIRECTION, the title, the `[f]` hint, and the footer are built as fixed "head"/"tail" content around the window. A trim safety net drops the pinned header / `N more` markers first (never a content row, so the cursor's own row is always the last thing that could be trimmed) if the window's own overhead would still overflow the given height.
- **`internal/tui/screens/settings.go`**: `Render` now takes `(prefs, width, height int)`. The chips/gameplay/saves body (headers, descriptions, blanks, and the toggle rows) is flattened the same way and windowed so the title, the active section's header, and the cursor stay on screen; click-target `rowBtns` are only set for rows that actually rendered (mirrors `saves.go`'s existing windowed-list click contract). Same trim safety net as spawn.
- **`internal/tui/screens/vab_render.go`**: the two footer key-hint rows now go through a new `wrapFooterHints` (word-wraps on the `"  "` hint separator, so a `"[key] description"` pair is never split across lines) instead of being emitted as single un-wrapped strings. Footer rendering only — nothing else in the VAB screen touched.
- **`internal/tui/app.go`**: the two call sites (`a.spawn.Render`, `a.settingsScreen.Render`) now pass `a.height` alongside `a.width`.
- Every pre-existing `spawn_*_test.go` / `settings_test.go` call site updated to pass `height=0` ("no budget" — unwindowed, matching the exact pre-#373 output those tests assert against).

No goldens needed re-baselining — no existing test asserted the old un-wrapped VAB footer text or an un-windowed spawn/settings render at a real height budget.

## Out of scope (per the issue)

- `README.md`, `docs/controls.md`, `orbit_chips.go`, `orbit_chip_builders.go`, `maneuver.go`, `help.go` — untouched, owned by parallel work. If a spawn-form terminal-size line belongs in the docs, that's for the docs pass to add.
- The VAB's STACK editor inside the spawn form (when Custom is selected) is not separately windowed — the issue's decision text scopes the fix to the CRAFT TYPE list specifically.

## Test plan

- [x] `go vet ./...` — clean.
- [x] `go test ./... -race -count=1` — all packages pass:
  ```
  ok  	github.com/jasonfen/terminal-space-program/cmd/terminal-space-program	1.165s
  ok  	github.com/jasonfen/terminal-space-program/internal/bodies	1.212s
  ok  	github.com/jasonfen/terminal-space-program/internal/keylayout	1.098s
  ok  	github.com/jasonfen/terminal-space-program/internal/missions	1.122s
  ok  	github.com/jasonfen/terminal-space-program/internal/orbital	1.163s
  ok  	github.com/jasonfen/terminal-space-program/internal/physics	1.163s
  ok  	github.com/jasonfen/terminal-space-program/internal/planner	1.107s
  ok  	github.com/jasonfen/terminal-space-program/internal/relay	1.887s
  ok  	github.com/jasonfen/terminal-space-program/internal/render	1.252s
  ok  	github.com/jasonfen/terminal-space-program/internal/save	3.235s
  ok  	github.com/jasonfen/terminal-space-program/internal/serve	15.032s
  ok  	github.com/jasonfen/terminal-space-program/internal/sessiondir	2.139s
  ok  	github.com/jasonfen/terminal-space-program/internal/settings	1.082s
  ok  	github.com/jasonfen/terminal-space-program/internal/sim	45.299s
  ok  	github.com/jasonfen/terminal-space-program/internal/spacecraft	1.306s
  ok  	github.com/jasonfen/terminal-space-program/internal/tui	5.713s
  ok  	github.com/jasonfen/terminal-space-program/internal/tui/screens	33.815s
  ok  	github.com/jasonfen/terminal-space-program/internal/tui/widgets	1.538s
  ?   	github.com/jasonfen/terminal-space-program/internal/version	[no test files]
  ```
- [x] New repro-first tests (all failed against the pre-fix code before the windowing/trim logic landed, now pass): `spawn_window_test.go`, `settings_window_test.go`, `vab_footer_test.go`, plus `windowed_list_test.go` for the widget in isolation.
- [x] Render-and-look via tmux at 104×24, 120×36, 140×40 (`XDG_STATE_HOME`/`XDG_CONFIG_HOME` pointed at an isolated scratch dir):
  - Spawn form (`n`), cycling CRAFT TYPE with `←/→`: title, `[f]` hint, cursor `→`, category header pin, `▲/▼ N more` markers, POSITION/PARENT BODY/ALTITUDE/DIRECTION, and the footer all stayed on screen and fit the pane at every size.
  - Settings (menu → `t`), walking `Down` through chips into the gameplay section: title, the active section header (`chips` then `gameplay`), and the `>` cursor all stayed visible and tracked the section correctly at 104×24.
  - VAB (menu → `b`) at 104 columns: the second footer row now wraps onto its own line and `[s] save` / `[o] open` are both fully visible (previously cut off mid-token, per `features-discoverability-22-vab-104x24.txt`).

PR left open per instructions — not merging.