### PR TITLE
Dock gate readout, third ring colour, auto-fuse flash, TARGET hold label

### DIFF
--- a/internal/sim/docking.go
+++ b/internal/sim/docking.go
@@ -679,6 +679,12 @@ func (w *World) checkDocking() (int, int, bool) {
 //
 // ActiveCraftIdx is adjusted so the player keeps flying the
 // composite (the active partner's slate position).
+//
+// #421: also stashes World.LastDockEvent (partner name + resulting
+// component count included) for the HUD's auto-fuse announcement.
+// Captured here, before fuseComposite drops the partner's slot, because
+// by the time a caller further up (World.Tick) could look for it the
+// slate has already changed shape and the dropped identity is gone.
 func (w *World) DockCrafts(idxA, idxB int) {
 	if idxA == idxB {
 		return
@@ -696,7 +702,26 @@ func (w *World) DockCrafts(idxA, idxB int) {
 	if idxB == w.ActiveCraftIdx {
 		lead, drop = idxB, idxA
 	}
-	w.fuseComposite(lead, drop)
+	partnerName := ""
+	if c := w.Crafts[drop]; c != nil {
+		partnerName = c.Name
+	}
+	composite, newLead, ok := w.fuseComposite(lead, drop)
+	if !ok || composite == nil {
+		return
+	}
+	var when time.Time
+	if w.Clock != nil {
+		when = w.Clock.SimTime
+	}
+	w.LastDockEvent = &DockEvent{
+		When:           when,
+		CraftIdx:       newLead,
+		PartnerIdx:     drop,
+		CompositeName:  composite.Name,
+		PartnerName:    partnerName,
+		ComponentCount: len(composite.DockedComponents),
+	}
 }
 
 // fuseComposite fuses the craft at dropIdx into the craft at leadIdx,

--- a/internal/sim/docking_test.go
+++ b/internal/sim/docking_test.go
@@ -56,6 +56,55 @@ func TestDockingFusesCloseSlowCraft(t *testing.T) {
 	}
 }
 
+// TestDockingAutoFuseStampsPartnerNameAndComponentCount (#421): a
+// proximity auto-fuse must record the folded-in partner's name and the
+// resulting composite's total Docked Component count on LastDockEvent —
+// app.go's flash reads both to announce the fusion in the same voice
+// Undock already uses ("docked with <partner> — now 1 vessel, N
+// components"). Captured inside DockCrafts (before the drop slot is
+// gone), not reconstructed by the caller afterward.
+func TestDockingAutoFuseStampsPartnerNameAndComponentCount(t *testing.T) {
+	w, _ := NewWorld()
+	earth := w.Systems[0].FindBody("Earth")
+
+	a := w.Crafts[0]
+	a.State.R = orbital.Vec3{X: earth.RadiusMeters() + 500e3}
+	v := math.Sqrt(earth.GravitationalParameter() / a.State.R.Norm())
+	a.State.V = orbital.Vec3{Y: v}
+
+	// Named distinctly from the default active craft (w.Crafts[0] is
+	// itself named "S-IVB-1" by its default loadout) so PartnerName
+	// below can't pass by coincidentally matching the WRONG craft.
+	b := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	b.Name = "Tug-1"
+	b.Primary = *earth
+	b.State = physics.StateVector{
+		R: a.State.R.Add(orbital.Vec3{X: 10}),
+		V: a.State.V,
+		M: b.TotalMass(),
+	}
+	w.Crafts = append(w.Crafts, b)
+
+	if w.LastDockEvent != nil {
+		t.Fatal("precondition: LastDockEvent already set before any dock")
+	}
+	if _, _, ok := w.checkDocking(); !ok {
+		t.Fatal("expected docking match, got none")
+	}
+	if w.LastDockEvent == nil {
+		t.Fatal("checkDocking fused the pair but did not stamp LastDockEvent")
+	}
+	if w.LastDockEvent.PartnerName != "Tug-1" {
+		t.Errorf("LastDockEvent.PartnerName = %q, want %q", w.LastDockEvent.PartnerName, "Tug-1")
+	}
+	if w.LastDockEvent.ComponentCount != 2 {
+		t.Errorf("LastDockEvent.ComponentCount = %d, want 2 (two plain craft fused)", w.LastDockEvent.ComponentCount)
+	}
+	if w.LastDockEvent.CompositeName == "" {
+		t.Error("LastDockEvent.CompositeName is empty")
+	}
+}
+
 // TestDockingSkipsFarApart: craft beyond DockingDistM mustn't fuse.
 func TestDockingSkipsFarApart(t *testing.T) {
 	w, _ := NewWorld()

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -882,15 +882,12 @@ func (w *World) Tick() {
 		// + node dispatch so two craft converging under a planted
 		// rendezvous burn can fuse on the same tick the maneuver
 		// completes. The result (success / which partners) is
-		// stashed on World.LastDockEvent for the HUD flash.
-		if a, b, ok := w.checkDocking(); ok {
-			w.LastDockEvent = &DockEvent{
-				When:          w.Clock.SimTime,
-				CraftIdx:      a,
-				PartnerIdx:    b,
-				CompositeName: w.ActiveCraft().Name,
-			}
-		}
+		// stashed on World.LastDockEvent for the HUD flash — DockCrafts
+		// populates it directly (#421) rather than this caller
+		// reconstructing it here, since by this point the slate has
+		// already changed shape and the dropped partner's identity is
+		// gone.
+		w.checkDocking()
 	}
 	// Mission eval runs every tick — even with an empty slate — so the event
 	// sink is drained each tick regardless of crafts (ADR 0025 §6). It
@@ -955,6 +952,16 @@ type DockEvent struct {
 	CraftIdx      int    // active partner's index (becomes the composite slot)
 	PartnerIdx    int    // index of the partner that was removed
 	CompositeName string // name of the resulting composite craft
+	// PartnerName / ComponentCount (#421) name the identity that just got
+	// folded in and the resulting composite's total Docked Component count,
+	// so app.go can announce an auto-fuse in the same voice Undock already
+	// uses ("docked with S-IVB-1 — now 1 vessel, 2 components") instead of
+	// the bare "composite: <name>" the flash carried before. Captured in
+	// DockCrafts (before the drop slot is gone) rather than re-derived
+	// here — by the time World.Tick reads LastDockEvent back the slate has
+	// already changed shape.
+	PartnerName    string
+	ComponentCount int
 }
 
 // evaluateMissions steps each mission against the live craft state.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -305,9 +305,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// so warp can't accelerate it.
 		a.maybeAutosave(time.Time(m))
 		// v0.8.3+: surface docking events as a status flash. Cleared
-		// here so a single fusion only flashes once.
+		// here so a single fusion only flashes once. #421 / ADR 0048 §2:
+		// same voice Undock already uses ("undocked into N components") —
+		// verb, what, the number that matters — rather than the old bare
+		// "composite: <name>", so an auto-fuse (the "alongside active"
+		// spawn case chief among them) never welds two vessels together
+		// in total silence.
 		if e := a.world.LastDockEvent; e != nil {
-			a.statusMsg = fmt.Sprintf("● DOCKED — composite: %s", e.CompositeName)
+			a.statusMsg = fmt.Sprintf("docked with %s — now 1 vessel, %d components", e.PartnerName, e.ComponentCount)
 			a.statusExpires = time.Now().Add(4 * time.Second)
 			a.world.LastDockEvent = nil
 		}

--- a/internal/tui/app_dock_flash_test.go
+++ b/internal/tui/app_dock_flash_test.go
@@ -1,0 +1,61 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestAutoFuseFlashesInUndockVoice (#421 / ADR 0048 §2): spawning
+// "alongside active" (or any other proximity auto-fuse) must raise an
+// Event Flash in the same voice `U`/undock already uses — a player must
+// never lose track of which vessel they're flying in total silence, the
+// #301/#421 "docking swallows its own announcement" family. Reproduces
+// the auto-fuse directly (place a second craft inside both docking
+// gates and let the real Tick path run checkDocking) rather than going
+// through the spawn form, so the test pins the announcement itself, not
+// the spawn flow.
+func TestAutoFuseFlashesInUndockVoice(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	active := a.world.ActiveCraft()
+	if active == nil {
+		t.Fatal("setup: no active craft")
+	}
+	// Named distinctly from the default active craft (itself "S-IVB-1",
+	// the default loadout's name) so the assertions below can't pass by
+	// coincidentally matching the WRONG craft's name.
+	partner := spacecraft.NewFromLoadout(spacecraft.LoadoutICPSID)
+	partner.Name = "Tug-1"
+	partner.Primary = active.Primary
+	partner.State = physics.StateVector{
+		R: active.State.R.Add(orbital.Vec3{X: 10}), // inside DockingDistM (50 m)
+		V: active.State.V,                          // matched — inside DockingVMS (0.1 m/s)
+		M: partner.TotalMass(),
+	}
+	a.world.Crafts = append(a.world.Crafts, partner)
+	if len(a.world.Crafts) != 2 {
+		t.Fatalf("setup: expected 2 vessels before the fuse, got %d", len(a.world.Crafts))
+	}
+
+	tickAt(a, time.Now())
+
+	if len(a.world.Crafts) != 1 {
+		t.Fatalf("expected the pair to auto-fuse into 1 composite, got %d craft", len(a.world.Crafts))
+	}
+	if !strings.Contains(a.statusMsg, "docked with Tug-1") {
+		t.Errorf("statusMsg = %q, want it to name the partner in undock's voice (\"docked with Tug-1\")", a.statusMsg)
+	}
+	if !strings.Contains(a.statusMsg, "now 1 vessel") || !strings.Contains(a.statusMsg, "2 components") {
+		t.Errorf("statusMsg = %q, want the vessel/component counts (\"now 1 vessel, 2 components\")", a.statusMsg)
+	}
+	if a.statusExpires.Before(time.Now()) {
+		t.Error("statusExpires already elapsed — the flash won't render")
+	}
+}

--- a/internal/tui/screens/orbit_attitude_chip_test.go
+++ b/internal/tui/screens/orbit_attitude_chip_test.go
@@ -1,0 +1,115 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// holdRow returns the ATTITUDE chip's "  hold:    ..." row, or "" if the
+// chip has fewer than 3 rows (title, nav, hold).
+func holdRow(t *testing.T, chip []string) string {
+	t.Helper()
+	if len(chip) < 3 {
+		t.Fatalf("buildAttitudeChip returned %d rows, want at least 3 (title, nav, hold)", len(chip))
+	}
+	return chip[2]
+}
+
+// TestAttitudeHoldLabelOrbitModeUnaffected: the baseline — NavOrbit with a
+// plain orbit-frame hold reads exactly as it always has. Not a #421
+// scenario; pins that the fix doesn't touch the common case.
+func TestAttitudeHoldLabelOrbitModeUnaffected(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 1_000})
+	w.NavMode = sim.NavOrbit
+	c := w.ActiveCraft()
+	c.AttitudeMode = spacecraft.BurnPrograde
+
+	v := newProximityTestView(t, 80, 24)
+	row := holdRow(t, v.buildAttitudeChip(w))
+	if !strings.Contains(row, "Prograde") || strings.Contains(row, "Target") {
+		t.Errorf("hold row = %q, want plain %q under NavOrbit", row, "Prograde")
+	}
+}
+
+// TestAttitudeHoldLabelNamesTargetFrame is the #421 acceptance test: the
+// six-lane UX review's reproduction was `;;` (nav → TARGET) then `q`
+// (an RCS pulse — internal/sim/rcs.go never touches AttitudeMode), which
+// leaves AttitudeMode sitting at whatever the orbit-frame hold was before
+// the switch while `nav:` already reads TARGET. The hold: row must name
+// the SAME frame the nav: row does once NavMode is NavTarget and a
+// relative target actually resolves, for every base axis that has a
+// target-relative counterpart.
+func TestAttitudeHoldLabelNamesTargetFrame(t *testing.T) {
+	cases := []struct {
+		name    string
+		stale   spacecraft.BurnMode // what AttitudeMode is stuck at (RCS never updated it)
+		want    string
+		mustNot string
+	}{
+		{"prograde", spacecraft.BurnPrograde, "Target Prograde", ""},
+		{"retrograde", spacecraft.BurnRetrograde, "Target Retrograde", ""},
+		{"radial-out", spacecraft.BurnRadialOut, "Target", "Radial"},
+		{"radial-in", spacecraft.BurnRadialIn, "Anti-Target", "Radial"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := proximityWorld(t, orbital.Vec3{X: 1_000})
+			w.NavMode = sim.NavTarget
+			c := w.ActiveCraft()
+			c.AttitudeMode = tc.stale
+
+			v := newProximityTestView(t, 80, 24)
+			row := holdRow(t, v.buildAttitudeChip(w))
+			if !strings.Contains(row, tc.want) {
+				t.Errorf("hold row = %q, want it to contain %q under nav:TARGET", row, tc.want)
+			}
+			if tc.mustNot != "" && strings.Contains(row, tc.mustNot) {
+				t.Errorf("hold row = %q, must not contain the stale orbital label %q", row, tc.mustNot)
+			}
+		})
+	}
+}
+
+// TestAttitudeHoldLabelNormalHasNoTargetCounterpart: NormalPlus/Minus
+// have no target-relative equivalent — ResolveAttitudeIntent itself
+// leaves them orbit-frame under NavTarget too, so the display must match
+// rather than inventing a label that no keypress could ever produce.
+func TestAttitudeHoldLabelNormalHasNoTargetCounterpart(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 1_000})
+	w.NavMode = sim.NavTarget
+	c := w.ActiveCraft()
+	c.AttitudeMode = spacecraft.BurnNormalPlus
+
+	v := newProximityTestView(t, 80, 24)
+	row := holdRow(t, v.buildAttitudeChip(w))
+	if !strings.Contains(row, "Normal+") {
+		t.Errorf("hold row = %q, want it to stay %q (no target-relative counterpart)", row, "Normal+")
+	}
+}
+
+// TestAttitudeHoldLabelNoRelativeTargetStaysOrbitFrame: NavMode can only
+// read NavTarget while HasRelativeTarget is true in ordinary play
+// (CycleNavMode / reconcileNavMode both guard it), but the display must
+// not misname the hold if that invariant is ever bypassed — falls back to
+// the plain orbit-frame label exactly like ResolveAttitudeIntent's own
+// NavTarget-without-a-target guard.
+func TestAttitudeHoldLabelNoRelativeTargetStaysOrbitFrame(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 1_000})
+	w.NavMode = sim.NavTarget
+	w.Target = sim.Target{} // no craft target bound
+	c := w.ActiveCraft()
+	c.AttitudeMode = spacecraft.BurnPrograde
+
+	v := newProximityTestView(t, 80, 24)
+	row := holdRow(t, v.buildAttitudeChip(w))
+	if strings.Contains(row, "Target") {
+		t.Errorf("hold row = %q, must not claim a target frame with no relative target bound", row)
+	}
+	if !strings.Contains(row, "Prograde") {
+		t.Errorf("hold row = %q, want it to fall back to plain %q", row, "Prograde")
+	}
+}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1044,6 +1044,45 @@ func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 	return v.missionChipLinesCompact(flash, flashing, w.ActiveMission())
 }
 
+// attitudeHoldLabel names the ATTITUDE chip's hold: row in whichever
+// frame the nav: row above it is actually reading against (#421). A
+// held BurnMode is fixed in its own frame at the moment it's set
+// (BurnPrograde always means orbit-frame prograde, never target-frame —
+// see BurnDirectionWithTarget), and while EngineRCS is active a w/s/a/d
+// pulse never touches AttitudeMode at all (internal/sim/rcs.go: "RCS is
+// a 6-axis translation tool"), so a player who cycles nav: to TARGET and
+// starts pulsing toward the other vessel keeps seeing whatever the SAS
+// was last explicitly set to hold — commonly the plain orbit-frame
+// "Prograde" from before the switch, disagreeing with the nav: row right
+// above it (six-lane UX review, 2026-09-02).
+//
+// This remaps the four base axis-equivalent orbit-frame modes
+// (Prograde / Retrograde / RadialOut / RadialIn) onto their
+// NavTarget-vocabulary counterparts — mirroring ResolveAttitudeIntent's
+// own (intent, NavMode) → BurnMode mapping in reverse — whenever
+// NavMode is NavTarget and a relative target actually resolves, so the
+// two rows can never name different frames. Already-Target-relative
+// modes, NormalPlus/Minus (no target-frame counterpart:
+// ResolveAttitudeIntent leaves them orbit-frame under NavTarget too),
+// and every non-axis mode (Surface*, PlaneChange, Vector) pass through
+// unchanged. Display-only — never mutates the craft's actual held
+// AttitudeMode or its physical nose direction.
+func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
+	if w.NavMode == sim.NavTarget && w.HasRelativeTarget() {
+		switch mode {
+		case spacecraft.BurnPrograde:
+			mode = spacecraft.BurnTargetPrograde
+		case spacecraft.BurnRetrograde:
+			mode = spacecraft.BurnTargetRetrograde
+		case spacecraft.BurnRadialOut:
+			mode = spacecraft.BurnTarget
+		case spacecraft.BurnRadialIn:
+			mode = spacecraft.BurnAntiTarget
+		}
+	}
+	return mode.String()
+}
+
 // buildAttitudeChip surfaces the held attitude / nav mode / engine mode /
 // manual-burn state. Always relevant for a visible craft (the old block
 // dropped the hold row during ascent to save column height; a corner chip
@@ -1061,7 +1100,7 @@ func (v *OrbitView) buildAttitudeChip(w *sim.World) []string {
 	return []string{
 		v.theme.Primary.Render("ATTITUDE"),
 		fmt.Sprintf("  nav:     %s", w.NavMode),
-		fmt.Sprintf("  hold:    %s", c.AttitudeMode.String()),
+		fmt.Sprintf("  hold:    %s", attitudeHoldLabel(w, c.AttitudeMode)),
 		fmt.Sprintf("  engine:  %s", c.EngineMode.String()),
 		fmt.Sprintf("  manual:  %s", manualState),
 	}

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -420,14 +420,14 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // — the one ring whose COLOR carries state rather than just its
 // presence, in four states:
 //
-//  1. dim — outside the distance gate (or inside it but not yet closing
-//     fast enough to matter, see #4).
-//  2. render.ColorAlert (red, #421) — inside DockingDistM but the
-//     closing rate is over DockingVMS: the readout's own "too fast"
-//     warning (proximityClosingGateSuffix), given a place on the ring
-//     rather than only a chip suffix a player might not be reading.
-//     Distinct from the #343 amber latch below — over-speed is
-//     something the PILOT can fix by braking; a latch is not.
+//  1. dim — outside the distance gate.
+//  2. render.ColorAlert (red, #421) — inside DockingDistM but |v_rel| is
+//     at or over DockingVMS: the SAME (RangeM, VRelMS) predicate
+//     checkDocking's auto-fuse itself refuses on (proximityOverSpeed),
+//     given a place on the ring rather than only a chip row a player
+//     might not be reading. Distinct from the #343 amber latch below —
+//     over-speed is something the PILOT can fix by braking; a latch is
+//     not.
 //  3. amber (ColorWarning) — inside BOTH DockingDistM and DockingVMS but
 //     a same-World re-arm latch (#343) is holding the pair apart.
 //  4. ColorTarget (green) — exactly when sim.ProximityDockGateReady
@@ -446,13 +446,17 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // carries the "there is something to learn here" cue that the `c`
 // re-arm key exists (issue #372 §2's "worth considering").
 //
-// #421: the over-speed state (2) keys off ClosingMS — the same number
-// the closing: row shows — rather than the raw |v_rel| the latch branch
-// (3) and ProximityDockGateReady use, so the ring's red state and the
-// readout's "(need < …)" suffix can never disagree about when they fire
-// (ClosingMS <= |v_rel| always, so this is strictly narrower than "the
-// raw velocity gate failed" — a fast lateral pass that isn't actually
-// closing the range doesn't light it up).
+// #421 (revised): the over-speed state (2) originally keyed off
+// ClosingMS (the closing: row's own number) rather than the raw
+// |v_rel| checkDocking's gate actually uses. That was a narrower — and
+// wrong — proxy: a pair sliding past laterally at |v_rel| 0.50 m/s while
+// closing at only 0.05 m/s sits inside the distance gate, never docks
+// (checkDocking refuses on the full |v_rel|), yet the ring stayed dim
+// and no row said why — exactly the silent failure #421 exists to fix,
+// just on the other axis. proximityOverSpeed now matches checkDocking's
+// own (RangeM, VRelMS) predicate exactly, so the ring can't disagree
+// with the game's actual refusal for ANY approach geometry, not only a
+// head-on one.
 //
 // No separate DOCK READY text callout is added alongside the green
 // state: the ready state is inherently momentary (checkDocking
@@ -464,7 +468,7 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // arrives, and it simply changes colour when the moment does. The amber
 // latched state has no such flicker risk — a latch persists for
 // ReArmDistM/ReArmCeiling's worth of time, not one tick; the red
-// over-speed state is exactly as continuous as the closing rate itself.
+// over-speed state is exactly as continuous as |v_rel| itself.
 func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 	const gateRadius = sim.DockingDistM
 	if !v.proximityRingVisible(st, gateRadius) {
@@ -480,10 +484,10 @@ func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 		// re-arm latch (the only way ProximityDockGateReady can say false
 		// here; see its own doc comment).
 		color = render.ColorWarning
-	case proximityClosingTooFast(st):
-		// Inside the distance gate, but the closing rate alone already
-		// exceeds DockingVMS — the readout's own gate, given a place on
-		// the ring (#421).
+	case proximityOverSpeed(st):
+		// Inside the distance gate, but |v_rel| alone already meets or
+		// exceeds DockingVMS — the exact predicate checkDocking's
+		// auto-fuse refuses on, given a place on the ring (#421).
 		color = render.ColorAlert
 	}
 	pts := proximityRingPoints(st.TargetWorld, st.Frame.AlongTrack, st.Frame.RadialOut, gateRadius)
@@ -754,25 +758,36 @@ func clampInt(x, lo, hi int) int {
 	return x
 }
 
-// proximityClosingTooFast reports whether the pair sits inside the
-// distance gate (sim.DockingDistM) but the CLOSING RATE alone already
-// exceeds the velocity gate (sim.DockingVMS) — issue #421: the failure
-// mode a textbook approach can hit with zero on-screen explanation
-// (checkDocking refuses the auto-fuse on the exact same threshold, just
-// checking the full |v_rel| rather than its closing component; see the
-// doc comment on drawProximityDockGate for why the narrower ClosingMS
-// read is deliberate here).
-func proximityClosingTooFast(st sim.ProximityState) bool {
-	return st.RangeM < sim.DockingDistM && st.ClosingMS >= sim.DockingVMS
+// proximityOverSpeed reports whether the pair sits inside the distance
+// gate (sim.DockingDistM) with |v_rel| at or over the velocity gate
+// (sim.DockingVMS) — the EXACT predicate checkDocking's auto-fuse
+// refuses on (see its dv.Norm() > DockingVMS check), not a narrower
+// proxy. issue #421 (revised): an earlier version of this keyed off the
+// CLOSING RATE (the radial component of v_rel) instead, which meant a
+// pair sliding past laterally — closing 0.05 m/s but |v_rel| 0.50 m/s —
+// sat inside the distance gate, never docked, and got no ring colour and
+// no readout suffix at all: the exact silent failure #421 exists to fix,
+// just missed on the lateral axis. Matching checkDocking's own
+// (RangeM, VRelMS) predicate exactly means the ring and the readout can
+// never disagree with the game's actual refusal, for any approach
+// geometry.
+func proximityOverSpeed(st sim.ProximityState) bool {
+	return st.RangeM < sim.DockingDistM && st.VRelMS >= sim.DockingVMS
 }
 
-// proximityClosingGateSuffix returns the "(need < 0.10)" reminder for
-// the closing: row exactly when proximityClosingTooFast holds, empty
-// otherwise — so the plain rate stands alone the rest of the time.
-// Reads sim.DockingVMS live rather than hard-coding it, so the readout
-// can never drift from the gate checkDocking actually enforces.
-func proximityClosingGateSuffix(st sim.ProximityState) string {
-	if !proximityClosingTooFast(st) {
+// proximityOverSpeedSuffix returns the "(need < 0.10)" reminder for the
+// |v_rel|: row exactly when proximityOverSpeed holds, empty otherwise —
+// so the plain number stands alone the rest of the time. Reads
+// sim.DockingVMS live rather than hard-coding it, so the readout can
+// never drift from the gate checkDocking actually enforces.
+//
+// Deliberately NOT also applied to the closing: row: |v_rel| is the
+// number literally being compared against DockingVMS, but closing can
+// read well under 0.10 while docking still fails (the lateral-pass
+// case above) — tagging closing: with the same reminder there would
+// misname the reason the gate is holding.
+func proximityOverSpeedSuffix(st sim.ProximityState) string {
+	if !proximityOverSpeed(st) {
 		return ""
 	}
 	return fmt.Sprintf("  (need < %.2f)", sim.DockingVMS)
@@ -803,15 +818,15 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 	// a row of its own, because every row this chip spends is a row
 	// admitChipsByBudget takes off the chip below it at 80×24.
 	//
-	// #421: closing: carries the gate itself ("+0.96 m/s (need < 0.10)")
+	// #421: |v_rel|: carries the gate itself ("0.50 m/s (need < 0.10)")
 	// exactly when the pair is inside the distance gate but over the
-	// velocity gate — the failure a textbook approach can hit with no
-	// other on-screen explanation.
+	// velocity gate — the failure a textbook (or a lateral-pass) approach
+	// can hit with no other on-screen explanation.
 	return []string{
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
 		chipRow("range:", formatRangeM(st.RangeM)),
-		chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)),
-		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)+proximityClosingGateSuffix(st)),
+		chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)+proximityOverSpeedSuffix(st)),
+		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)),
 	}
 }
 
@@ -823,13 +838,12 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 // get out" row rather than dropping it: a chip that can't show the view
 // it opened for must still leave a way out, shrunk or not.
 //
-// #421: the one exception to "closing drops in Compact Form" is the same
+// #421: the one exception to "|v_rel| drops in Compact Form" is the same
 // gate the full chip carries — when the pair is inside the distance gate
-// but over the closing-rate gate, that row survives the shrink too. A
-// pilot at the Playable Floor is exactly as capable of blowing the
-// approach as one at Design Size, and Graceful Shrink's own contract
-// (CONTEXT.md) is "shrinks before it vanishes," not "safety-critical
-// rows vanish first."
+// but over the velocity gate, that row survives the shrink too. A pilot
+// at the Playable Floor is exactly as capable of blowing the approach as
+// one at Design Size, and Graceful Shrink's own contract (CONTEXT.md) is
+// "shrinks before it vanishes," not "safety-critical rows vanish first."
 func (v *OrbitView) buildProximityChipCompact(w *sim.World) []string {
 	if w.ViewMode != sim.ViewProximity {
 		return nil
@@ -845,8 +859,8 @@ func (v *OrbitView) buildProximityChipCompact(w *sim.World) []string {
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
 		chipRow("range:", formatRangeM(st.RangeM)),
 	}
-	if suffix := proximityClosingGateSuffix(st); suffix != "" {
-		lines = append(lines, chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)+suffix))
+	if suffix := proximityOverSpeedSuffix(st); suffix != "" {
+		lines = append(lines, chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)+suffix))
 	}
 	return lines
 }

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -418,14 +418,24 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 
 // drawProximityDockGate draws the 50 m dock-gate ring (sim.DockingDistM)
 // — the one ring whose COLOR carries state rather than just its
-// presence: dim while outside either raw gate, amber (ColorWarning) when
-// inside BOTH DockingDistM and DockingVMS but a same-World re-arm latch
-// (#343) is holding the pair apart, and ColorTarget green exactly when
-// sim.ProximityDockGateReady reports the pair actually ready to fuse —
-// the same predicate checkDocking's auto-fuse uses (plus the latch,
-// #372), so the ring's green threshold and the game's actual "you are
-// about to dock" threshold can never drift apart. This is issue #348
-// §1's "DOCK READY becomes a place on screen."
+// presence, in four states:
+//
+//  1. dim — outside the distance gate (or inside it but not yet closing
+//     fast enough to matter, see #4).
+//  2. render.ColorAlert (red, #421) — inside DockingDistM but the
+//     closing rate is over DockingVMS: the readout's own "too fast"
+//     warning (proximityClosingGateSuffix), given a place on the ring
+//     rather than only a chip suffix a player might not be reading.
+//     Distinct from the #343 amber latch below — over-speed is
+//     something the PILOT can fix by braking; a latch is not.
+//  3. amber (ColorWarning) — inside BOTH DockingDistM and DockingVMS but
+//     a same-World re-arm latch (#343) is holding the pair apart.
+//  4. ColorTarget (green) — exactly when sim.ProximityDockGateReady
+//     reports the pair actually ready to fuse, the same predicate
+//     checkDocking's auto-fuse uses (plus the latch, #372), so the
+//     ring's green threshold and the game's actual "you are about to
+//     dock" threshold can never drift apart. This is issue #348 §1's
+//     "DOCK READY becomes a place on screen."
 //
 // #372: before the latch was folded into ProximityDockGateReady, a
 // latched pair sitting inside both raw gates had nowhere to read that —
@@ -436,6 +446,14 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // carries the "there is something to learn here" cue that the `c`
 // re-arm key exists (issue #372 §2's "worth considering").
 //
+// #421: the over-speed state (2) keys off ClosingMS — the same number
+// the closing: row shows — rather than the raw |v_rel| the latch branch
+// (3) and ProximityDockGateReady use, so the ring's red state and the
+// readout's "(need < …)" suffix can never disagree about when they fire
+// (ClosingMS <= |v_rel| always, so this is strictly narrower than "the
+// raw velocity gate failed" — a fast lateral pass that isn't actually
+// closing the range doesn't light it up).
+//
 // No separate DOCK READY text callout is added alongside the green
 // state: the ready state is inherently momentary (checkDocking
 // auto-fuses the pair the very next tick it holds true), so a chip
@@ -445,7 +463,8 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // place, not a popup: it's already there, faint, before the moment
 // arrives, and it simply changes colour when the moment does. The amber
 // latched state has no such flicker risk — a latch persists for
-// ReArmDistM/ReArmCeiling's worth of time, not one tick.
+// ReArmDistM/ReArmCeiling's worth of time, not one tick; the red
+// over-speed state is exactly as continuous as the closing rate itself.
 func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 	const gateRadius = sim.DockingDistM
 	if !v.proximityRingVisible(st, gateRadius) {
@@ -461,6 +480,11 @@ func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 		// re-arm latch (the only way ProximityDockGateReady can say false
 		// here; see its own doc comment).
 		color = render.ColorWarning
+	case proximityClosingTooFast(st):
+		// Inside the distance gate, but the closing rate alone already
+		// exceeds DockingVMS — the readout's own gate, given a place on
+		// the ring (#421).
+		color = render.ColorAlert
 	}
 	pts := proximityRingPoints(st.TargetWorld, st.Frame.AlongTrack, st.Frame.RadialOut, gateRadius)
 	v.canvas.PlotPolylineClass(pts, color, widgets.ClassScenery)
@@ -730,6 +754,30 @@ func clampInt(x, lo, hi int) int {
 	return x
 }
 
+// proximityClosingTooFast reports whether the pair sits inside the
+// distance gate (sim.DockingDistM) but the CLOSING RATE alone already
+// exceeds the velocity gate (sim.DockingVMS) — issue #421: the failure
+// mode a textbook approach can hit with zero on-screen explanation
+// (checkDocking refuses the auto-fuse on the exact same threshold, just
+// checking the full |v_rel| rather than its closing component; see the
+// doc comment on drawProximityDockGate for why the narrower ClosingMS
+// read is deliberate here).
+func proximityClosingTooFast(st sim.ProximityState) bool {
+	return st.RangeM < sim.DockingDistM && st.ClosingMS >= sim.DockingVMS
+}
+
+// proximityClosingGateSuffix returns the "(need < 0.10)" reminder for
+// the closing: row exactly when proximityClosingTooFast holds, empty
+// otherwise — so the plain rate stands alone the rest of the time.
+// Reads sim.DockingVMS live rather than hard-coding it, so the readout
+// can never drift from the gate checkDocking actually enforces.
+func proximityClosingGateSuffix(st sim.ProximityState) string {
+	if !proximityClosingTooFast(st) {
+		return ""
+	}
+	return fmt.Sprintf("  (need < %.2f)", sim.DockingVMS)
+}
+
 // buildProximityChip is the readout block: the three numbers a pilot
 // flies the last kilometres on. Only ever built inside Proximity View —
 // on the map the TARGET chip already carries them, and two chips saying
@@ -754,11 +802,16 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 	// Three rows, not four: the target's name rides the header rather than
 	// a row of its own, because every row this chip spends is a row
 	// admitChipsByBudget takes off the chip below it at 80×24.
+	//
+	// #421: closing: carries the gate itself ("+0.96 m/s (need < 0.10)")
+	// exactly when the pair is inside the distance gate but over the
+	// velocity gate — the failure a textbook approach can hit with no
+	// other on-screen explanation.
 	return []string{
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
 		chipRow("range:", formatRangeM(st.RangeM)),
 		chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)),
-		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)),
+		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)+proximityClosingGateSuffix(st)),
 	}
 }
 
@@ -769,6 +822,14 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 // picture whenever it has room). The refusal branch keeps its "how to
 // get out" row rather than dropping it: a chip that can't show the view
 // it opened for must still leave a way out, shrunk or not.
+//
+// #421: the one exception to "closing drops in Compact Form" is the same
+// gate the full chip carries — when the pair is inside the distance gate
+// but over the closing-rate gate, that row survives the shrink too. A
+// pilot at the Playable Floor is exactly as capable of blowing the
+// approach as one at Design Size, and Graceful Shrink's own contract
+// (CONTEXT.md) is "shrinks before it vanishes," not "safety-critical
+// rows vanish first."
 func (v *OrbitView) buildProximityChipCompact(w *sim.World) []string {
 	if w.ViewMode != sim.ViewProximity {
 		return nil
@@ -780,10 +841,14 @@ func (v *OrbitView) buildProximityChipCompact(w *sim.World) []string {
 			"  [t] target a vessel · [o] back to the map",
 		}
 	}
-	return []string{
+	lines := []string{
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
 		chipRow("range:", formatRangeM(st.RangeM)),
 	}
+	if suffix := proximityClosingGateSuffix(st); suffix != "" {
+		lines = append(lines, chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)+suffix))
+	}
+	return lines
 }
 
 // buildProximityHintChip tells the player the view exists at the one

--- a/internal/tui/screens/orbit_proximity_test.go
+++ b/internal/tui/screens/orbit_proximity_test.go
@@ -576,6 +576,150 @@ func TestProximityDockGateColorLatched(t *testing.T) {
 	}
 }
 
+// proximityOverspeedWorld builds the pair with relPos inside the distance
+// gate but a purely-radial closing rate of closingMS toward the target —
+// the #421 scene: "closing: +0.96 m/s" counting down inside 50 m with no
+// dock. Perturbs only the target's (Crafts[1]) velocity so the active
+// vessel's velocity used elsewhere in a scene stays the plain matched-orbit
+// baseline proximityWorld already sets up.
+func proximityOverspeedWorld(t *testing.T, relPos orbital.Vec3, closingMS float64) *sim.World {
+	t.Helper()
+	w := proximityWorld(t, relPos)
+	active := w.ActiveCraft()
+	dir := relPos.Scale(1 / relPos.Norm())
+	w.Crafts[1].State.V = active.State.V.Sub(dir.Scale(closingMS))
+	return w
+}
+
+// TestProximityClosingGateReadoutSuffix (#421): the closing: row must
+// carry the "(need < 0.10)" gate reminder exactly when the pair sits
+// inside the distance gate but the closing rate alone already exceeds
+// sim.DockingVMS — the failure a textbook approach can hit ("closing:
+// +0.96 m/s" counting down to 2 m with zero explanation) — and must NOT
+// carry it once ready to dock, once truly out of range, or while merely
+// receding.
+func TestProximityClosingGateReadoutSuffix(t *testing.T) {
+	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96) // inside 50 m, closing 0.96 m/s > 0.10 m/s
+	overspeedV := newProximityTestView(t, 80, 24)
+	overspeedW.ViewMode = sim.ViewProximity
+	chip := overspeedV.buildProximityChip(overspeedW)
+	if len(chip) < 4 {
+		t.Fatalf("buildProximityChip returned %d rows, want at least 4", len(chip))
+	}
+	closingRow := chip[3]
+	if !strings.Contains(closingRow, "need < 0.10") {
+		t.Errorf("closing row = %q, want it to carry the gate reminder (need < %.2f)", closingRow, sim.DockingVMS)
+	}
+	if !strings.Contains(closingRow, "+0.96") {
+		t.Errorf("closing row = %q, want the plain rate to still read +0.96 m/s", closingRow)
+	}
+
+	readyW := proximityWorld(t, orbital.Vec3{X: 30}) // inside 50 m, matched v — actually ready, no gate to reminds about
+	readyV := newProximityTestView(t, 80, 24)
+	readyW.ViewMode = sim.ViewProximity
+	readyChip := readyV.buildProximityChip(readyW)
+	if len(readyChip) < 4 {
+		t.Fatalf("buildProximityChip (ready) returned %d rows, want at least 4", len(readyChip))
+	}
+	if strings.Contains(readyChip[3], "need <") {
+		t.Errorf("ready-case closing row = %q, must not carry the gate reminder", readyChip[3])
+	}
+
+	farW := proximityOverspeedWorld(t, orbital.Vec3{X: 100}, 0.96) // outside 50 m even though closing fast
+	farV := newProximityTestView(t, 80, 24)
+	farW.ViewMode = sim.ViewProximity
+	farChip := farV.buildProximityChip(farW)
+	if len(farChip) < 4 {
+		t.Fatalf("buildProximityChip (far) returned %d rows, want at least 4", len(farChip))
+	}
+	if strings.Contains(farChip[3], "need <") {
+		t.Errorf("out-of-range closing row = %q, must not carry the gate reminder", farChip[3])
+	}
+}
+
+// TestProximityClosingGateSurvivesCompactForm (#421): the Compact Form
+// normally drops the closing: row entirely (ADR 0046 / #422), but the
+// over-speed gate reminder is safety-critical the same way the amber
+// re-arm latch on the ring is — Graceful Shrink's contract is "shrinks
+// before it vanishes," not "the warning vanishes first." When the gate
+// isn't firing, Compact stays at its usual 2 rows (name + range only).
+func TestProximityClosingGateSurvivesCompactForm(t *testing.T) {
+	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96)
+	overspeedV := newProximityTestView(t, 80, 24)
+	overspeedW.ViewMode = sim.ViewProximity
+	compact := overspeedV.buildProximityChipCompact(overspeedW)
+	if len(compact) != 3 {
+		t.Fatalf("Compact Form over the gate returned %d rows, want 3 (name, range, closing)", len(compact))
+	}
+	if !strings.Contains(compact[2], "need < 0.10") || !strings.Contains(compact[2], "+0.96") {
+		t.Errorf("Compact closing row = %q, want the same gate-suffixed row the full chip carries", compact[2])
+	}
+
+	readyW := proximityWorld(t, orbital.Vec3{X: 30})
+	readyV := newProximityTestView(t, 80, 24)
+	readyW.ViewMode = sim.ViewProximity
+	readyCompact := readyV.buildProximityChipCompact(readyW)
+	if len(readyCompact) != 2 {
+		t.Fatalf("Compact Form outside the gate returned %d rows, want 2 (name, range only)", len(readyCompact))
+	}
+}
+
+// TestProximityDockGateColorOverspeed (#421) is the acceptance test for
+// the ring's third state: inside the distance gate but closing too fast
+// must render a DISTINCT colour (render.ColorAlert) from ready (green),
+// latched (amber), and plain dim (out of range / not yet closing) — so
+// "you're miles out" and "you're 2 m away but too fast" stop rendering
+// identically (the issue's own #348 finding).
+func TestProximityDockGateColorOverspeed(t *testing.T) {
+	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96)
+	overspeedV := newProximityTestView(t, 80, 24)
+	overspeedW.ViewMode = sim.ViewProximity
+	overspeedV.Render(overspeedW, 0, 80, 24)
+	overspeedSt, ok := overspeedW.ProximityState()
+	if !ok {
+		t.Fatal("ProximityState refused (overspeed case)")
+	}
+	if overspeedW.ProximityDockGateReady(overspeedSt) {
+		t.Fatal("precondition: overspeed case reports ready")
+	}
+	if overspeedSt.RangeM >= sim.DockingDistM {
+		t.Fatalf("precondition: overspeed case outside the distance gate (range=%.2f)", overspeedSt.RangeM)
+	}
+	if overspeedSt.ClosingMS < sim.DockingVMS {
+		t.Fatalf("precondition: overspeed case not actually over the closing-rate gate (closing=%.4f)", overspeedSt.ClosingMS)
+	}
+	if !overspeedV.proximityRingVisible(overspeedSt, sim.DockingDistM) {
+		t.Fatal("precondition: gate ring not visible in the overspeed scene")
+	}
+
+	readyW := proximityWorld(t, orbital.Vec3{X: 30})
+	readyV := newProximityTestView(t, 80, 24)
+	readyW.ViewMode = sim.ViewProximity
+	readyV.Render(readyW, 0, 80, 24)
+
+	latchedW := proximityLatchedWorld(t, orbital.Vec3{X: 30})
+	latchedV := newProximityTestView(t, 80, 24)
+	latchedW.ViewMode = sim.ViewProximity
+	latchedV.Render(latchedW, 0, 80, 24)
+
+	notReadyW := proximityWorld(t, orbital.Vec3{X: 100})
+	notReadyV := newProximityTestView(t, 80, 24)
+	notReadyW.ViewMode = sim.ViewProximity
+	notReadyV.Render(notReadyW, 0, 80, 24)
+
+	overspeedAlert := overspeedV.canvas.CountColor(render.ColorAlert)
+	readyAlert := readyV.canvas.CountColor(render.ColorAlert)
+	latchedAlert := latchedV.canvas.CountColor(render.ColorAlert)
+	notReadyAlert := notReadyV.canvas.CountColor(render.ColorAlert)
+	if overspeedAlert == 0 {
+		t.Error("no ColorAlert cells in the overspeed scene — the ring should render distinctly, not plain dim")
+	}
+	if readyAlert != 0 || latchedAlert != 0 || notReadyAlert != 0 {
+		t.Errorf("ColorAlert cells leaked into a non-overspeed scene: ready=%d, latched=%d, not-ready=%d, want 0 in all three",
+			readyAlert, latchedAlert, notReadyAlert)
+	}
+}
+
 // TestProximityDriftPathDrawsPlannedClass: the drift path reaches the
 // canvas as ClassPlanned (dashed) ink in render.ColorPlannedNode — the
 // end-to-end wiring check that drawProximityDriftPath actually calls

--- a/internal/tui/screens/orbit_proximity_test.go
+++ b/internal/tui/screens/orbit_proximity_test.go
@@ -577,82 +577,117 @@ func TestProximityDockGateColorLatched(t *testing.T) {
 }
 
 // proximityOverspeedWorld builds the pair with relPos inside the distance
-// gate but a purely-radial closing rate of closingMS toward the target —
-// the #421 scene: "closing: +0.96 m/s" counting down inside 50 m with no
-// dock. Perturbs only the target's (Crafts[1]) velocity so the active
-// vessel's velocity used elsewhere in a scene stays the plain matched-orbit
-// baseline proximityWorld already sets up.
-func proximityOverspeedWorld(t *testing.T, relPos orbital.Vec3, closingMS float64) *sim.World {
+// gate, a closing rate of closingMS toward the target, and a total
+// |v_rel| of vRelMS — closingMS and vRelMS can differ (a lateral pass:
+// low closing rate, high |v_rel|), which is exactly the #421 scene the
+// gate keys on. Derivation: with dir = unit(relPos) and perp orthogonal
+// to it (Z, since every relPos used here is pure-X), setting
+// relV = closingMS*dir + lateral*perp with
+// lateral = sqrt(max(vRelMS^2 - closingMS^2, 0)) gives EXACTLY
+// ClosingMS == closingMS and VRelMS == vRelMS in the resolved
+// ProximityState (ClosingMS is the component of relV along dir; VRelMS
+// is |relV|). Perturbs only the target's (Crafts[1]) velocity so the
+// active vessel's velocity used elsewhere in a scene stays the plain
+// matched-orbit baseline proximityWorld already sets up.
+func proximityOverspeedWorld(t *testing.T, relPos orbital.Vec3, closingMS, vRelMS float64) *sim.World {
 	t.Helper()
 	w := proximityWorld(t, relPos)
 	active := w.ActiveCraft()
 	dir := relPos.Scale(1 / relPos.Norm())
-	w.Crafts[1].State.V = active.State.V.Sub(dir.Scale(closingMS))
+	perp := orbital.Vec3{Z: 1}
+	lateralSq := vRelMS*vRelMS - closingMS*closingMS
+	if lateralSq < 0 {
+		lateralSq = 0
+	}
+	lateral := math.Sqrt(lateralSq)
+	relV := dir.Scale(closingMS).Add(perp.Scale(lateral))
+	w.Crafts[1].State.V = active.State.V.Sub(relV)
 	return w
 }
 
-// TestProximityClosingGateReadoutSuffix (#421): the closing: row must
-// carry the "(need < 0.10)" gate reminder exactly when the pair sits
-// inside the distance gate but the closing rate alone already exceeds
-// sim.DockingVMS — the failure a textbook approach can hit ("closing:
-// +0.96 m/s" counting down to 2 m with zero explanation) — and must NOT
-// carry it once ready to dock, once truly out of range, or while merely
-// receding.
-func TestProximityClosingGateReadoutSuffix(t *testing.T) {
-	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96) // inside 50 m, closing 0.96 m/s > 0.10 m/s
-	overspeedV := newProximityTestView(t, 80, 24)
-	overspeedW.ViewMode = sim.ViewProximity
-	chip := overspeedV.buildProximityChip(overspeedW)
+// TestProximityOverSpeedReadoutSuffix (#421, revised): the |v_rel|: row
+// must carry the "(need < 0.10)" gate reminder exactly when the pair
+// sits inside the distance gate but |v_rel| alone already meets or
+// exceeds sim.DockingVMS — including the LATERAL-PASS case the gate
+// originally missed (closing only 0.05 m/s, but |v_rel| 0.50 m/s: the
+// pair is sliding past, not closing, yet checkDocking still refuses on
+// the raw |v_rel| and the readout must say so) — and must NOT carry it
+// once ready to dock or once truly out of range. The closing: row never
+// carries the suffix: closing can read well under 0.10 in the very
+// scene the gate is firing, and tagging it there would misname why
+// docking is failing.
+func TestProximityOverSpeedReadoutSuffix(t *testing.T) {
+	headOnW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96, 0.96) // inside 50 m, head-on 0.96 m/s
+	headOnV := newProximityTestView(t, 80, 24)
+	headOnW.ViewMode = sim.ViewProximity
+	chip := headOnV.buildProximityChip(headOnW)
 	if len(chip) < 4 {
 		t.Fatalf("buildProximityChip returned %d rows, want at least 4", len(chip))
 	}
-	closingRow := chip[3]
-	if !strings.Contains(closingRow, "need < 0.10") {
-		t.Errorf("closing row = %q, want it to carry the gate reminder (need < %.2f)", closingRow, sim.DockingVMS)
+	vRelRow, closingRow := chip[2], chip[3]
+	if !strings.Contains(vRelRow, "need < 0.10") {
+		t.Errorf("|v_rel| row = %q, want it to carry the gate reminder (need < %.2f)", vRelRow, sim.DockingVMS)
 	}
-	if !strings.Contains(closingRow, "+0.96") {
-		t.Errorf("closing row = %q, want the plain rate to still read +0.96 m/s", closingRow)
+	if !strings.Contains(vRelRow, "0.96") {
+		t.Errorf("|v_rel| row = %q, want the plain magnitude to still read 0.96 m/s", vRelRow)
+	}
+	if strings.Contains(closingRow, "need <") {
+		t.Errorf("closing row = %q, must never carry the gate reminder", closingRow)
 	}
 
-	readyW := proximityWorld(t, orbital.Vec3{X: 30}) // inside 50 m, matched v — actually ready, no gate to reminds about
+	lateralW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.05, 0.50) // lateral pass: closing slow, |v_rel| fast
+	lateralV := newProximityTestView(t, 80, 24)
+	lateralW.ViewMode = sim.ViewProximity
+	lateralChip := lateralV.buildProximityChip(lateralW)
+	if len(lateralChip) < 4 {
+		t.Fatalf("buildProximityChip (lateral) returned %d rows, want at least 4", len(lateralChip))
+	}
+	if !strings.Contains(lateralChip[2], "need < 0.10") {
+		t.Errorf("lateral-pass |v_rel| row = %q, want it to carry the gate reminder even though closing is slow", lateralChip[2])
+	}
+	if strings.Contains(lateralChip[3], "need <") {
+		t.Errorf("lateral-pass closing row = %q, must not carry the reminder (closing rate itself is under the limit)", lateralChip[3])
+	}
+
+	readyW := proximityWorld(t, orbital.Vec3{X: 30}) // inside 50 m, matched v — actually ready, no gate to remind about
 	readyV := newProximityTestView(t, 80, 24)
 	readyW.ViewMode = sim.ViewProximity
 	readyChip := readyV.buildProximityChip(readyW)
 	if len(readyChip) < 4 {
 		t.Fatalf("buildProximityChip (ready) returned %d rows, want at least 4", len(readyChip))
 	}
-	if strings.Contains(readyChip[3], "need <") {
-		t.Errorf("ready-case closing row = %q, must not carry the gate reminder", readyChip[3])
+	if strings.Contains(readyChip[2], "need <") {
+		t.Errorf("ready-case |v_rel| row = %q, must not carry the gate reminder", readyChip[2])
 	}
 
-	farW := proximityOverspeedWorld(t, orbital.Vec3{X: 100}, 0.96) // outside 50 m even though closing fast
+	farW := proximityOverspeedWorld(t, orbital.Vec3{X: 100}, 0.96, 0.96) // outside 50 m even though fast
 	farV := newProximityTestView(t, 80, 24)
 	farW.ViewMode = sim.ViewProximity
 	farChip := farV.buildProximityChip(farW)
 	if len(farChip) < 4 {
 		t.Fatalf("buildProximityChip (far) returned %d rows, want at least 4", len(farChip))
 	}
-	if strings.Contains(farChip[3], "need <") {
-		t.Errorf("out-of-range closing row = %q, must not carry the gate reminder", farChip[3])
+	if strings.Contains(farChip[2], "need <") {
+		t.Errorf("out-of-range |v_rel| row = %q, must not carry the gate reminder", farChip[2])
 	}
 }
 
-// TestProximityClosingGateSurvivesCompactForm (#421): the Compact Form
-// normally drops the closing: row entirely (ADR 0046 / #422), but the
+// TestProximityOverSpeedSurvivesCompactForm (#421): the Compact Form
+// normally drops the |v_rel|: row entirely (ADR 0046 / #422), but the
 // over-speed gate reminder is safety-critical the same way the amber
 // re-arm latch on the ring is — Graceful Shrink's contract is "shrinks
 // before it vanishes," not "the warning vanishes first." When the gate
 // isn't firing, Compact stays at its usual 2 rows (name + range only).
-func TestProximityClosingGateSurvivesCompactForm(t *testing.T) {
-	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96)
+func TestProximityOverSpeedSurvivesCompactForm(t *testing.T) {
+	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.05, 0.50) // lateral pass
 	overspeedV := newProximityTestView(t, 80, 24)
 	overspeedW.ViewMode = sim.ViewProximity
 	compact := overspeedV.buildProximityChipCompact(overspeedW)
 	if len(compact) != 3 {
-		t.Fatalf("Compact Form over the gate returned %d rows, want 3 (name, range, closing)", len(compact))
+		t.Fatalf("Compact Form over the gate returned %d rows, want 3 (name, range, |v_rel|)", len(compact))
 	}
-	if !strings.Contains(compact[2], "need < 0.10") || !strings.Contains(compact[2], "+0.96") {
-		t.Errorf("Compact closing row = %q, want the same gate-suffixed row the full chip carries", compact[2])
+	if !strings.Contains(compact[2], "need < 0.10") || !strings.Contains(compact[2], "0.50") {
+		t.Errorf("Compact |v_rel| row = %q, want the same gate-suffixed row the full chip carries", compact[2])
 	}
 
 	readyW := proximityWorld(t, orbital.Vec3{X: 30})
@@ -665,13 +700,16 @@ func TestProximityClosingGateSurvivesCompactForm(t *testing.T) {
 }
 
 // TestProximityDockGateColorOverspeed (#421) is the acceptance test for
-// the ring's third state: inside the distance gate but closing too fast
-// must render a DISTINCT colour (render.ColorAlert) from ready (green),
-// latched (amber), and plain dim (out of range / not yet closing) — so
-// "you're miles out" and "you're 2 m away but too fast" stop rendering
-// identically (the issue's own #348 finding).
+// the ring's third state: inside the distance gate but |v_rel| over the
+// limit must render a DISTINCT colour (render.ColorAlert) from ready
+// (green), latched (amber), and plain dim (out of range) — so "you're
+// miles out" and "you're 2 m away but too fast" stop rendering
+// identically (the issue's own #348 finding). Uses the lateral-pass
+// geometry (closing slow, |v_rel| fast) specifically, since that is the
+// case the ring's ORIGINAL (ClosingMS-keyed) implementation missed
+// entirely.
 func TestProximityDockGateColorOverspeed(t *testing.T) {
-	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.96)
+	overspeedW := proximityOverspeedWorld(t, orbital.Vec3{X: 30}, 0.05, 0.50)
 	overspeedV := newProximityTestView(t, 80, 24)
 	overspeedW.ViewMode = sim.ViewProximity
 	overspeedV.Render(overspeedW, 0, 80, 24)
@@ -685,8 +723,11 @@ func TestProximityDockGateColorOverspeed(t *testing.T) {
 	if overspeedSt.RangeM >= sim.DockingDistM {
 		t.Fatalf("precondition: overspeed case outside the distance gate (range=%.2f)", overspeedSt.RangeM)
 	}
-	if overspeedSt.ClosingMS < sim.DockingVMS {
-		t.Fatalf("precondition: overspeed case not actually over the closing-rate gate (closing=%.4f)", overspeedSt.ClosingMS)
+	if overspeedSt.VRelMS < sim.DockingVMS {
+		t.Fatalf("precondition: overspeed case not actually over the velocity gate (|v_rel|=%.4f)", overspeedSt.VRelMS)
+	}
+	if overspeedSt.ClosingMS >= sim.DockingVMS {
+		t.Fatalf("precondition: overspeed case is closing fast too (closing=%.4f) — not the lateral-pass scene this test wants", overspeedSt.ClosingMS)
 	}
 	if !overspeedV.proximityRingVisible(overspeedSt, sim.DockingDistM) {
 		t.Fatal("precondition: gate ring not visible in the overspeed scene")


### PR DESCRIPTION
## Summary

Implements ADR 0048 decision 2 (issue #421): the docking gate now speaks
through the readout instead of failing in total silence.

- **PROXIMITY chip `closing:` row** carries the gate itself
  (`closing: +0.96 m/s  (need < 0.10)`) exactly when the pair is inside
  the distance gate (`sim.DockingDistM`) but the closing rate alone
  exceeds the velocity gate (`sim.DockingVMS`) — both read live, never
  hard-coded. The Compact Form (#422/#437) normally drops the closing
  row entirely; when the gate is firing it grows a third row to carry
  the same suffixed text, since Graceful Shrink's contract is "shrinks
  before it vanishes," not "the warning goes first."
- **Dock-gate ring** gains a fourth state: `render.ColorAlert` (red) for
  "inside distance, closing too fast," alongside the existing
  green (ready) / amber (#343 re-arm latch) / dim (out of range) states.
  Keys off the same `ClosingMS` the readout shows (not the raw
  `|v_rel|` `checkDocking`'s gate uses) so the ring and the readout can
  never disagree about when they fire.
- **Auto-fuse now announces itself** in the same voice `U`/undock
  already uses: `docked with S-IVB-1 — now 1 vessel, 2 components`.
  `DockCrafts` now stamps `LastDockEvent.PartnerName`/`ComponentCount`
  before the dropped partner's slot is gone (previously the event was
  reconstructed after the slate had already changed shape, so the
  partner's identity was unrecoverable). Covers every proximity
  auto-dock through `checkDocking`, including the "alongside active"
  spawn case. Cross-player docking (`docking_guest.go`) is untouched —
  out of scope, different mechanism/reporting path.
- **ATTITUDE chip `hold:` row** now names the active nav frame: while
  `nav: TARGET` is set and a relative target resolves, the four base
  axis-equivalent orbit-frame holds (Prograde/Retrograde/RadialOut/
  RadialIn) display as their target-relative counterparts (`Target
  Prograde`, `Target Retrograde`, `Target`, `Anti-Target`), mirroring
  `ResolveAttitudeIntent`'s own `(intent, NavMode) → BurnMode` mapping
  in reverse. Root cause: RCS pulses never touch `AttitudeMode`
  (`internal/sim/rcs.go`), so after `;;` + `q` the hold row kept
  showing the stale orbit-frame label while `nav:` already read TARGET.
  Display-only remap — doesn't touch the underlying held mode or the
  vessel's physical nose direction. `NormalPlus`/`NormalMinus` (no
  target-relative counterpart) and no-relative-target pass through
  unchanged.

## Test plan

```
$ go vet ./...
(clean)

$ go test ./... -race -count=1
ok  	.../cmd/terminal-space-program
ok  	.../internal/bodies
ok  	.../internal/keylayout
ok  	.../internal/missions
ok  	.../internal/orbital
ok  	.../internal/physics
ok  	.../internal/planner
ok  	.../internal/relay
ok  	.../internal/render
ok  	.../internal/save
ok  	.../internal/serve
ok  	.../internal/sessiondir
ok  	.../internal/settings
ok  	.../internal/sim
ok  	.../internal/spacecraft
ok  	.../internal/tui
ok  	.../internal/tui/screens
ok  	.../internal/tui/widgets
?   	.../internal/version	[no test files]
```

All new tests confirmed red-before / green-after individually (verified
via `git stash` on just the implementation file, re-run, `stash pop`):

- `internal/sim/docking_test.go`:
  `TestDockingAutoFuseStampsPartnerNameAndComponentCount`
- `internal/tui/app_dock_flash_test.go`: `TestAutoFuseFlashesInUndockVoice`
- `internal/tui/screens/orbit_proximity_test.go`:
  `TestProximityClosingGateReadoutSuffix`,
  `TestProximityClosingGateSurvivesCompactForm`,
  `TestProximityDockGateColorOverspeed`
- `internal/tui/screens/orbit_attitude_chip_test.go` (new):
  `TestAttitudeHoldLabelOrbitModeUnaffected`,
  `TestAttitudeHoldLabelNamesTargetFrame` (4 subtests),
  `TestAttitudeHoldLabelNormalHasNoTargetCounterpart`,
  `TestAttitudeHoldLabelNoRelativeTargetStaysOrbitFrame`

Also driven end-to-end in a real 140×40 tmux session: `n` → alongside
spawn → auto-fuse flash confirmed → `U` → `t` → `o` → `c` → `r` → `;;`
→ repeated `q` closing from 76 m to 8 m. Confirmed `nav:`/`hold:`
agreement, the `closing:` gate suffix appearing/disappearing at the 50 m
boundary, the pair never docking (over-speed the whole approach,
matching the issue's own reported trace), and — via
`tmux capture-pane -e` — the ring's red `#FF5F5F` ANSI pixels present
distinct from the dim `#5F5F5F` pixels on the same ring.

Closes #421