### PR TITLE
Launch pad guidance: call to action, engine-lit, warp, staging flash, crash alert

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -307,16 +307,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// v0.8.3+: surface docking events as a status flash. Cleared
 		// here so a single fusion only flashes once.
 		if e := a.world.LastDockEvent; e != nil {
-			a.statusMsg = fmt.Sprintf("● DOCKED — composite: %s", e.CompositeName)
-			a.statusExpires = time.Now().Add(4 * time.Second)
+			a.flash(fmt.Sprintf("● DOCKED — composite: %s", e.CompositeName))
 			a.world.LastDockEvent = nil
 		}
 		// v0.11.0+: ViewLaunch switch-end release toast (ADR 0021 D
 		// retired the apoapsis-floor auto-release). Same flash
 		// surface as docking; cleared after one fire.
 		if e := a.world.LastLaunchReleaseEvent; e != nil {
-			a.statusMsg = fmt.Sprintf("ORBIT READY — returning to %s", e.PrevView)
-			a.statusExpires = time.Now().Add(4 * time.Second)
+			a.flash(fmt.Sprintf("ORBIT READY — returning to %s", e.PrevView))
 			a.world.LastLaunchReleaseEvent = nil
 		}
 		// #372: a same-World dock checkDocking refused because of a live
@@ -324,9 +322,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// only ever stamped once for the life of a given latch; see
 		// raiseLocalReArmRefusal). Same flash surface, cleared after one fire.
 		if e := a.world.LastLocalReArmRefusal; e != nil {
-			a.statusMsg = fmt.Sprintf("docking held off — press %s to re-arm, or back %.0f m clear of %s",
-				a.keys.ReArmDock.Help().Key, sim.ReArmDistM, e.PartnerName)
-			a.statusExpires = time.Now().Add(4 * time.Second)
+			a.flash(fmt.Sprintf("docking held off — press %s to re-arm, or back %.0f m clear of %s",
+				a.keys.ReArmDock.Help().Key, sim.ReArmDistM, e.PartnerName))
 			a.world.LastLocalReArmRefusal = nil
 		}
 		// #294 review finding 5: a due target-relative node (or in-flight
@@ -339,11 +336,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// re-latch that will never come.
 		if e := a.world.LastNodeTargetRefusal; e != nil {
 			if e.Cancelled {
-				a.statusMsg = fmt.Sprintf("%s: node cancelled, target gone", e.CraftName)
+				a.flash(fmt.Sprintf("%s: node cancelled, target gone", e.CraftName))
 			} else {
-				a.statusMsg = fmt.Sprintf("%s: burn held off — target lock not resolved", e.CraftName)
+				a.flash(fmt.Sprintf("%s: burn held off — target lock not resolved", e.CraftName))
 			}
-			a.statusExpires = time.Now().Add(4 * time.Second)
 			a.world.LastNodeTargetRefusal = nil
 		}
 		return a, sim.TickCmd(a.world.Clock.BaseStep)
@@ -467,12 +463,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			if overBudget {
-				// Same statusExpires flash mechanism as every other
-				// planner outcome — ADR 0047 §2 deliberately reuses
-				// this rather than introducing a new announcement
-				// helper (that's a later issue's scope).
-				a.statusMsg = fmt.Sprintf("plan exceeds Δv budget by %.0f m/s", overBy)
-				a.statusExpires = time.Now().Add(4 * time.Second)
+				// Same flash mechanism as every other planner outcome
+				// (ADR 0048 §1 — the one announcement helper).
+				a.flash(fmt.Sprintf("plan exceeds Δv budget by %.0f m/s", overBy))
 			}
 		}
 		a.closeManeuverToOrbit()
@@ -767,8 +760,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch s {
 			case "y", "Y":
 				if a.world.EndFlightActive() {
-					a.statusMsg = "● END FLIGHT — wreckage removed"
-					a.statusExpires = time.Now().Add(3 * time.Second)
+					a.flash("● END FLIGHT — wreckage removed")
 				}
 				a.endFlightConfirm = false
 			case "n", "N", "esc":
@@ -810,8 +802,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// so the player can add parts instead of silently
 				// getting a round-robin default.
 				if a.spawn.CustomStackEmpty() {
-					a.statusMsg = "custom stack is empty — add a part with [a]"
-					a.statusExpires = time.Now().Add(3 * time.Second)
+					a.flash("custom stack is empty — add a part with [a]")
 					return a, nil
 				}
 				spec := sim.SpawnSpec{
@@ -828,13 +819,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					LongitudeOffset: a.spawn.SelectedLongitudeEastDeg(),
 				}
 				if c, err := a.world.SpawnCraft(spec); err == nil {
-					a.statusMsg = fmt.Sprintf("spawned vessel %d (%s)", a.world.ActiveCraftIdx+1, c.Name)
-					a.statusExpires = time.Now().Add(3 * time.Second)
+					a.flash(fmt.Sprintf("spawned vessel %d (%s)", a.world.ActiveCraftIdx+1, c.Name))
 				} else {
 					// Surface the failure instead of silently returning to
 					// orbit — a swallowed error reads as "nothing happens".
-					a.statusMsg = fmt.Sprintf("spawn failed: %v", err)
-					a.statusExpires = time.Now().Add(3 * time.Second)
+					a.flash(fmt.Sprintf("spawn failed: %v", err))
 				}
 				a.active = screenOrbit
 			case screens.SpawnActionCancel:
@@ -1462,11 +1451,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.world.CycleRCSPulseScale()
 			if c := a.world.ActiveCraft(); c != nil {
 				if c.EngineMode == spacecraft.EngineRCS {
-					a.statusMsg = fmt.Sprintf("rcs pulse %g m/s", c.RCSPulseDV())
+					a.flash(fmt.Sprintf("rcs pulse %g m/s", c.RCSPulseDV()))
 				} else {
-					a.statusMsg = fmt.Sprintf("rcs pulse %g m/s (press r for rcs)", c.RCSPulseDV())
+					a.flash(fmt.Sprintf("rcs pulse %g m/s (press r for rcs)", c.RCSPulseDV()))
 				}
-				a.statusExpires = time.Now().Add(3 * time.Second)
 			}
 			return a, nil
 		case key.Matches(m, a.keys.NextCraft):
@@ -1501,12 +1489,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// GuestReleaseRefusal says so and names the two-step.
 			if active := a.world.ActiveCraft(); sim.StackHasGuest(active) {
 				if reason := a.world.GuestReleaseRefusal(a.world.ActiveCraftIdx); reason != "" {
-					a.statusMsg = reason
-					a.statusExpires = time.Now().Add(3 * time.Second)
+					a.flash(reason)
 					return a, nil
 				}
-				a.statusMsg = "releasing your partner's vessel…"
-				a.statusExpires = time.Now().Add(3 * time.Second)
+				a.flash("releasing your partner's vessel…")
 				return a, func() tea.Msg { return ReleaseGuestMsg{} }
 			}
 			// #308: say why when it refuses. The key is bound and the stack is
@@ -1515,12 +1501,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// on. UndockRefusal is exhaustive over Undock's false paths, so
 			// there is no third branch that falls through in silence.
 			if reason := a.world.UndockRefusal(a.world.ActiveCraftIdx); reason != "" {
-				a.statusMsg = reason
+				a.flash(reason)
 			} else if a.world.Undock(a.world.ActiveCraftIdx) {
-				a.statusMsg = fmt.Sprintf("undocked into %d components", len(a.world.Crafts))
+				a.flash(fmt.Sprintf("undocked into %d components", len(a.world.Crafts)))
 				a.world.RecordAction(missions.ActionUndock) // ADR 0025 §7
 			}
-			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.ReArmDock):
 			// #372: the explicit "yes, I meant it" for a same-World docking
@@ -1530,14 +1515,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// both proximity gates fuses on the very next tick once the
 			// latch clears, exactly as an un-latched approach would.
 			if partners, ok := a.world.ReArmDocking(); ok {
-				a.statusMsg = "re-armed docking with " + strings.Join(partners, ", ")
+				a.flash("re-armed docking with " + strings.Join(partners, ", "))
 			} else {
 				// A press with no latch held must say so rather than no-op
 				// silently — a dead keypress reads as a broken key (v0.30
 				// lesson).
-				a.statusMsg = "docking: no re-arm latch held"
+				a.flash("docking: no re-arm latch held")
 			}
-			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.TransferControl):
 			// v0.28 S5, ADR 0034 §6: hand a cross-player stack I own to the
@@ -1554,19 +1538,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if active := a.world.ActiveCraft(); active != nil && sim.StackHasGuest(active) {
 				return a, func() tea.Msg { return TransferControlMsg{} }
 			}
-			a.statusMsg = "transfer: not flying a cross-player stack"
-			a.statusExpires = time.Now().Add(3 * time.Second)
+			a.flash("transfer: not flying a cross-player stack")
 			return a, nil
 		case key.Matches(m, a.keys.Deploy):
 			// v0.23 / ADR 0028: release the top carried payload, keep flying the
 			// carrier (drop-and-continue). World.Deploy self-records the deploy
 			// action (so any caller emits it) — no second RecordAction here.
 			if a.world.Deploy(a.world.ActiveCraftIdx) {
-				a.statusMsg = fmt.Sprintf("deployed payload — %d vessels on the slate", len(a.world.Crafts))
+				a.flash(fmt.Sprintf("deployed payload — %d vessels on the slate", len(a.world.Crafts)))
 			} else {
-				a.statusMsg = "deploy: no payload to release (carrier carries no docked payload)"
+				a.flash("deploy: no payload to release (carrier carries no docked payload)")
 			}
-			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.Transpose):
 			// v0.12 / ADR 0009: one-shot Apollo transposition. Reorders
@@ -1575,13 +1557,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch err := a.world.Transpose(a.world.ActiveCraftIdx); {
 			case err == nil:
 				a.world.RecordAction(missions.ActionTranspose) // ADR 0025 §7
-				a.statusMsg = "transposed: SM is firing core — press U to release the LM"
+				a.flash("transposed: SM is firing core — press U to release the LM")
 			case errors.Is(err, sim.ErrTransposeNotReady):
-				a.statusMsg = "transpose: drop the launch vehicle first (stack must be Descent/Ascent/SM/CM)"
+				a.flash("transpose: drop the launch vehicle first (stack must be Descent/Ascent/SM/CM)")
 			default:
-				a.statusMsg = fmt.Sprintf("transpose failed: %v", err)
+				a.flash(fmt.Sprintf("transpose failed: %v", err))
 			}
-			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.CycleTarget):
 			a.world.CycleTarget(true)
@@ -1594,13 +1575,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.CycleNavMode):
 			nav := a.world.CycleNavMode()
 			a.world.RecordAction(missions.ActionCycleNavMode) // ADR 0025 §7
-			a.statusMsg = fmt.Sprintf("nav: %s", nav)
-			a.statusExpires = time.Now().Add(2 * time.Second)
+			a.flash(fmt.Sprintf("nav: %s", nav))
 			return a, nil
 		case key.Matches(m, a.keys.ToggleInstantSAS):
 			a.world.ToggleInstantSAS()
-			a.statusMsg = fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS))
-			a.statusExpires = time.Now().Add(2 * time.Second)
+			a.flash(fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS)))
 			return a, nil
 		case key.Matches(m, a.keys.AttitudeSurfacePrograde):
 			a.handleAttitudeKey(spacecraft.BurnSurfacePrograde)
@@ -1628,12 +1607,35 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Inside the maneuver form, space is the iterate-toggle
 			// (v0.8.6.3) — that path doesn't reach here because the
 			// maneuver form intercepts keys before app.update.
-			_, jettIdx, err := a.world.StageActive(a.world.ActiveCraftIdx)
+			//
+			// #427 / ADR 0048: name the DROPPED STAGE in the Event Flash,
+			// not the jettisoned wreckage craft's disambiguated slate name
+			// (nextCraftName always appends "-N", so "S-IC" would read
+			// "S-IC-1", "S-IC-2", ... across a playthrough — the loadout's
+			// bare stage name is stable and matches the issue's own
+			// example, "dropped S-IC — 2 stages left"). Captured before
+			// the call since StageActive reslices Stages out from under
+			// the pre-drop bottom entry.
+			droppedName := ""
+			if c := a.world.ActiveCraft(); c != nil && len(c.Stages) > 0 {
+				droppedName = c.Stages[0].Name
+			}
+			_, _, err := a.world.StageActive(a.world.ActiveCraftIdx)
 			switch {
 			case err == nil:
 				a.world.RecordAction(missions.ActionStage) // ADR 0025 §7
-				name := a.world.Crafts[jettIdx].Name
-				a.statusMsg = fmt.Sprintf("staged: %s jettisoned", name)
+				// The number that matters is how many stages remain to
+				// fly, not the jettisoned craft's rename (the review's
+				// "renames the vessel with no message" finding).
+				remaining := 0
+				if c := a.world.ActiveCraft(); c != nil {
+					remaining = len(c.Stages)
+				}
+				stageWord := "stages"
+				if remaining == 1 {
+					stageWord = "stage"
+				}
+				a.flash(fmt.Sprintf("dropped %s — %d %s left", droppedName, remaining, stageWord))
 				// v0.12 / ADR 0009: surface the transposition hint the
 				// moment a stage drop leaves the Apollo stack in the
 				// pre-transposition shape [Descent, Ascent, SM, CM] — the
@@ -1641,7 +1643,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// (or stage once more to drop the LM for a manual flip).
 				// Without this the wrong-engine state is silent.
 				if sim.TransposeReady(a.world.ActiveCraft()) {
-					a.statusMsg = "TRANSPOSE READY — press D to flip (SM → firing core; LM becomes nose payload)"
+					a.flash("TRANSPOSE READY — press D to flip (SM → firing core; LM becomes nose payload)")
 				}
 			case errors.Is(err, sim.ErrStageOnlyOne):
 				// v0.12 Slice 3 (ADR 0008): once the vessel is reduced to
@@ -1650,14 +1652,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// action," no new keybinding. Falls through to the normal
 				// no-op flash when there's no stowed chute to arm.
 				if c := a.world.ActiveCraft(); c != nil && c.ArmParachute() {
-					a.statusMsg = "parachute ARMED — auto-deploys in atmosphere"
+					a.flash("parachute ARMED — auto-deploys in atmosphere")
 				} else {
-					a.statusMsg = "stage: cannot drop the only remaining stage"
+					a.flash("stage: cannot drop the only remaining stage")
 				}
 			default:
-				a.statusMsg = fmt.Sprintf("stage failed: %v", err)
+				a.flash(fmt.Sprintf("stage failed: %v", err))
 			}
-			a.statusExpires = time.Now().Add(3 * time.Second)
 			return a, nil
 		case key.Matches(m, a.keys.TiltUp), key.Matches(m, a.keys.TiltDown):
 			// v0.10.6+: nudge ViewTilted's polar tilt θ ±5°. No-op when
@@ -1672,8 +1673,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delta = -sim.ViewTiltThetaStep
 			}
 			theta := a.world.NudgeViewTiltTheta(delta)
-			a.statusMsg = fmt.Sprintf("view: tilted %g°", theta)
-			a.statusExpires = time.Now().Add(1500 * time.Millisecond)
+			a.flash(fmt.Sprintf("view: tilted %g°", theta))
 			return a, nil
 		case key.Matches(m, a.keys.YawLeft), key.Matches(m, a.keys.YawRight):
 			// ADR 0021 G: nudge ViewTilted's yaw φ ±5°, wrapping at
@@ -1689,8 +1689,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delta = -sim.ViewTiltPhiStep
 			}
 			phi := a.world.NudgeViewTiltPhi(delta)
-			a.statusMsg = fmt.Sprintf("view: yaw %g°", phi)
-			a.statusExpires = time.Now().Add(1500 * time.Millisecond)
+			a.flash(fmt.Sprintf("view: yaw %g°", phi))
 			return a, nil
 		}
 	}
@@ -1893,8 +1892,7 @@ func (a *App) dispatchNavballControl(ctrl screens.NavballControlID) {
 	switch ctrl {
 	case screens.NavballControlMode:
 		nav := a.world.CycleNavMode()
-		a.statusMsg = fmt.Sprintf("nav: %s", nav)
-		a.statusExpires = time.Now().Add(2 * time.Second)
+		a.flash(fmt.Sprintf("nav: %s", nav))
 	case screens.NavballControlPrograde:
 		a.handleAttitudeIntent(sim.IntentPrograde)
 	case screens.NavballControlRetrograde:
@@ -1913,12 +1911,10 @@ func (a *App) dispatchNavballControl(ctrl screens.NavballControlID) {
 		if a.world.RCSActive() {
 			state = "on"
 		}
-		a.statusMsg = fmt.Sprintf("RCS: %s", state)
-		a.statusExpires = time.Now().Add(2 * time.Second)
+		a.flash(fmt.Sprintf("RCS: %s", state))
 	case screens.NavballControlSAS:
 		a.world.ToggleInstantSAS()
-		a.statusMsg = fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS))
-		a.statusExpires = time.Now().Add(2 * time.Second)
+		a.flash(fmt.Sprintf("SAS: %s", sasModeLabel(a.world.InstantSAS)))
 	case screens.NavballControlTargetPlus:
 		a.handleAttitudeKey(spacecraft.BurnTarget)
 	case screens.NavballControlTargetMinus:
@@ -2256,8 +2252,7 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		a.active = screenOrbit
 	case screens.SessionCmdTargetGhost:
 		a.world.SetTargetGhost(cmd.Owner, cmd.CraftID)
-		a.statusMsg = fmt.Sprintf("target: %s's vessel", cmd.Handle)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("target: %s's vessel", cmd.Handle))
 		a.active = screenOrbit
 	case screens.SessionCmdSpectate:
 		// Spectate (v0.28 S6 / ADR 0034): camera-follow a remote player's
@@ -2265,19 +2260,17 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		// alike. Fits once to the ghost's drawn orbit extent (Framing Event)
 		// then tracks it; [f]/[g] return to own-craft framing.
 		a.world.SpectateGhost(cmd.Owner, cmd.CraftID)
-		a.statusMsg = fmt.Sprintf("spectating %s — [f] to return", cmd.Handle)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("spectating %s — [f] to return", cmd.Handle))
 		a.active = screenOrbit
 	case screens.SessionCmdSync:
 		// Sync-to (v0.27 S7 / ADR 0034): Auto-Warp to the player's
 		// subspace time. The screen already refused backward targets;
 		// this guard covers a slate that moved between frames.
 		if a.world.EngageSyncWarp(cmd.Time, cmd.Owner, cmd.Handle) {
-			a.statusMsg = fmt.Sprintf("syncing to %s — auto-warp engaged", cmd.Handle)
+			a.flash(fmt.Sprintf("syncing to %s — auto-warp engaged", cmd.Handle))
 		} else {
-			a.statusMsg = fmt.Sprintf("can't sync — %s is no longer ahead", cmd.Handle)
+			a.flash(fmt.Sprintf("can't sync — %s is no longer ahead", cmd.Handle))
 		}
-		a.statusExpires = time.Now().Add(3 * time.Second)
 		a.active = screenOrbit
 	case screens.SessionCmdRendezvous:
 		// Rendezvous Warp initiate (v0.29 S2 / ADR 0034 v0.29 addendum;
@@ -2306,7 +2299,7 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 		switch {
 		case !ok:
 			a.world.RestoreTarget(prevTarget, prevNav)
-			a.statusMsg = fmt.Sprintf("can't rendezvous with %s — no reported position", cmd.Handle)
+			a.flash(fmt.Sprintf("can't rendezvous with %s — no reported position", cmd.Handle))
 		// The seat is fixed here (ADR 0037 §2): proposing the rendezvous
 		// makes you pilot-in-command of the pair's time once the terminal
 		// phase begins.
@@ -2322,20 +2315,18 @@ func (a *App) applySessionCommand(cmd screens.SessionCommand) (tea.Model, tea.Cm
 			// catch a wrong-vessel arm before the invitation goes out.
 			craftTag := screens.CraftTag(a.world.RendezvousArm.CraftName)
 			if plan.Tau.IsZero() {
-				a.statusMsg = fmt.Sprintf("rendezvous agreed with %s%s — no plan yet, waiting for them to join",
-					cmd.Handle, craftTag)
+				a.flash(fmt.Sprintf("rendezvous agreed with %s%s — no plan yet, waiting for them to join",
+					cmd.Handle, craftTag))
 			} else {
-				a.statusMsg = fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join%s",
-					cmd.Handle, craftTag, rendezvousGapNoteSuffix(a.world, plan.CommittedCA))
+				a.flash(fmt.Sprintf("rendezvous armed toward %s%s — waiting for them to join%s",
+					cmd.Handle, craftTag, rendezvousGapNoteSuffix(a.world, plan.CommittedCA)))
 			}
 		default:
-			a.statusMsg = fmt.Sprintf("can't arm rendezvous with %s — encounter is in the past", cmd.Handle)
+			a.flash(fmt.Sprintf("can't arm rendezvous with %s — encounter is in the past", cmd.Handle))
 		}
-		a.statusExpires = time.Now().Add(3 * time.Second)
 		a.active = screenOrbit
 	case screens.SessionCmdToast:
-		a.statusMsg = cmd.Message
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(cmd.Message)
 	case screens.SessionCmdStartHost:
 		// In-UI hosting (v0.28 S3 / ADR 0034). Host-only by
 		// construction: a guest session carries a guestSave sink, so it
@@ -2552,9 +2543,14 @@ func (a *App) commitInspect() {
 	a.toast(fmt.Sprintf("target: %s", name))
 }
 
+// toast is the pre-#427 name for flash, kept as a thin alias — it has
+// ~30 call sites in this file plus the exported Toast below, which
+// internal/serve calls across the App boundary to surface hosting/
+// dock/reporting outcomes. Both now share flash's one voice and one
+// lifetime (ADR 0048) rather than carrying a second copy of the same
+// two-line body.
 func (a *App) toast(msg string) {
-	a.statusMsg = msg
-	a.statusExpires = time.Now().Add(3 * time.Second)
+	a.flash(msg)
 }
 
 // Toast flashes msg in the HUD footer — the exported door for the
@@ -2575,8 +2571,7 @@ func (a *App) toggleChip(c settings.Chip) {
 	s.SetChip(c, !s.ChipEnabled(c))
 	a.orbitView.SetSettings(s)
 	if err := settings.Save(s); err != nil {
-		a.statusMsg = fmt.Sprintf("settings save failed: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("settings save failed: %v", err))
 	}
 }
 
@@ -2610,8 +2605,7 @@ func (a *App) toggleMissionProgram(tutorial bool) {
 	a.orbitView.SetSettings(s)
 	a.world.SetEnabledMissionPrograms(enabledProgramsFromSettings(s))
 	if err := settings.Save(s); err != nil {
-		a.statusMsg = fmt.Sprintf("settings save failed: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("settings save failed: %v", err))
 	}
 }
 
@@ -2627,8 +2621,7 @@ func (a *App) cycleAutosaveInterval() {
 	s.SetAutosaveIntervalMin(settings.NextAutosaveIntervalMin(s.AutosaveIntervalMinutes()))
 	a.orbitView.SetSettings(s)
 	if err := settings.Save(s); err != nil {
-		a.statusMsg = fmt.Sprintf("settings save failed: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("settings save failed: %v", err))
 	}
 }
 
@@ -2645,9 +2638,29 @@ func (a *App) cycleLayout() {
 	s.KeyboardLayout = string(a.layout)
 	a.orbitView.SetSettings(s)
 	if err := settings.Save(s); err != nil {
-		a.statusMsg = fmt.Sprintf("settings save failed: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("settings save failed: %v", err))
 	}
+}
+
+// flashLifetime is the one lifetime every Event Flash lives for (ADR
+// 0048 decision 1). Pre-#427 call sites disagreed — 1.5s / 2s / 3s / 4s
+// / 6s depending on which corner of app.go set statusExpires — with no
+// single owner. flash below is now that owner.
+const flashLifetime = 3 * time.Second
+
+// flash writes one Event Flash to the HUD footer: the transient border
+// line for something that is already over the moment it happens (a burn
+// fired, a stage dropped, a refusal) as opposed to a Standing Alert,
+// which persists while its state still holds (see standingAlert /
+// VESSEL DESTROYED). Every call site in this file goes through flash so
+// the voice and the lifetime can't drift call site to call site (ADR
+// 0048): one verb, what happened, and the number that matters —
+// "node 1 burned — 3054 m/s, 2 remaining", "dropped S-IC — 2 stages
+// left". text is the finished line; callers format their own message
+// (fmt.Sprintf or a literal) and hand it here.
+func (a *App) flash(text string) {
+	a.statusMsg = text
+	a.statusExpires = time.Now().Add(flashLifetime)
 }
 
 // refuse writes a one-phrase "<label>: <reason>" refusal to the HUD
@@ -2658,10 +2671,10 @@ func (a *App) cycleLayout() {
 // which pins that the label appears exactly once). Generalised into one
 // helper so every guarded key speaks with the same voice. label should
 // name the action ("end flight", "rendezvous"), not repeat itself in
-// reason.
+// reason. Refusals are Event Flashes too (ADR 0048), so this is a thin
+// wrapper over flash.
 func (a *App) refuse(label, reason string) {
-	a.statusMsg = fmt.Sprintf("%s: %s", label, reason)
-	a.statusExpires = time.Now().Add(3 * time.Second)
+	a.flash(fmt.Sprintf("%s: %s", label, reason))
 }
 
 // flashStatus writes a transient message to the HUD footer. The
@@ -2669,12 +2682,11 @@ func (a *App) refuse(label, reason string) {
 // (v0.26 / ADR 0033 §D).
 func (a *App) flashStatus(op string, err error) {
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("%s failed: %v", op, err)
-	} else {
-		dir, _ := save.SavesDir()
-		a.statusMsg = fmt.Sprintf("%s ok — %s", op, filepath.Join(dir, save.QuicksaveID))
+		a.flash(fmt.Sprintf("%s failed: %v", op, err))
+		return
 	}
-	a.statusExpires = time.Now().Add(3 * time.Second)
+	dir, _ := save.SavesDir()
+	a.flash(fmt.Sprintf("%s ok — %s", op, filepath.Join(dir, save.QuicksaveID)))
 }
 
 // handlePlanRendezvousKey is K's modal body (ADR 0045 S6, #399), called
@@ -2687,8 +2699,7 @@ func (a *App) flashStatus(op string, err error) {
 func (a *App) handlePlanRendezvousKey() {
 	out, err := a.world.PlanRendezvousOrOpenMeeting()
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("rendezvous: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("rendezvous: %v", err))
 		return
 	}
 	switch {
@@ -2699,9 +2710,8 @@ func (a *App) handlePlanRendezvousKey() {
 		// (#290 found this invisible at plan time: a "successful" plant
 		// that in fact arrived 4.6 m/s under the lock gate, with nothing
 		// on screen warning the player before they committed).
-		a.statusMsg = fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs, arriving ~%.0f m/s",
-			adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival, adv.ArrivalSpeed)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs, arriving ~%.0f m/s",
+			adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival, adv.ArrivalSpeed))
 		a.world.RecordAction(missions.ActionPlanRendezvous) // ADR 0025 §7
 	case out.OpenPicker:
 		// The picker is a chip on the orbit MAP (ADR 0045 §2) — switch
@@ -2710,8 +2720,7 @@ func (a *App) handlePlanRendezvousKey() {
 		// summoned is actually visible.
 		a.active = screenOrbit
 		a.orbitView.OpenMeetingPicker(out.Place, out.Ladder, out.LadderErr)
-		a.statusMsg = "meeting plan: too far apart to nudge — walk the Lap Ladder [←→↑↓], Enter to plant, Esc to cancel"
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash("meeting plan: too far apart to nudge — walk the Lap Ladder [←→↑↓], Enter to plant, Esc to cancel")
 	}
 }
 
@@ -2766,21 +2775,19 @@ func (a *App) planMeetingPickerSelection() {
 	place := a.orbitView.MeetingPickerPlace()
 	plan, err := a.world.PlanMeetingBurn(place, laps)
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("meeting: %v", err)
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash(fmt.Sprintf("meeting: %v", err))
 		return
 	}
 	if plan.ForActive {
-		a.statusMsg = fmt.Sprintf("meeting burn planted: %.1f m/s → CA %.0f m, arriving ~%.0f m/s",
-			plan.DV, plan.AchievableCA, plan.ArrivalSpeed)
+		a.flash(fmt.Sprintf("meeting burn planted: %.1f m/s → CA %.0f m, arriving ~%.0f m/s",
+			plan.DV, plan.AchievableCA, plan.ArrivalSpeed))
 		a.world.RecordAction(missions.ActionPlanRendezvous) // ADR 0025 §7
 	} else {
 		// MeetingYourOrbit: the PARTNER is the mover. #399 out of scope —
 		// carrying this plan to them over the wire is a later slice.
-		a.statusMsg = fmt.Sprintf("meeting plan (their burn): %.1f m/s → CA %.0f m, arriving ~%.0f m/s",
-			plan.DV, plan.AchievableCA, plan.ArrivalSpeed)
+		a.flash(fmt.Sprintf("meeting plan (their burn): %.1f m/s → CA %.0f m, arriving ~%.0f m/s",
+			plan.DV, plan.AchievableCA, plan.ArrivalSpeed))
 	}
-	a.statusExpires = time.Now().Add(3 * time.Second)
 	a.orbitView.CloseMeetingPicker()
 }
 
@@ -2982,12 +2989,10 @@ func (a *App) doPlanTransfer() {
 		// "match plane [I], circularize, then [H]" advisory).
 		// Non-intra-primary plants leave the comparison empty.
 		if cmp := a.world.LastTransfer.Format(); cmp != "" {
-			a.statusMsg = cmp
-			a.statusExpires = time.Now().Add(6 * time.Second)
+			a.flash(cmp)
 		}
 	case sim.TargetCraft:
-		a.statusMsg = "H targets bodies — for vessels, plan via [m]"
-		a.statusExpires = time.Now().Add(3 * time.Second)
+		a.flash("H targets bodies — for vessels, plan via [m]")
 	default:
 		// #428 mechanical fix: this used to be a deliberate silent
 		// no-op (there was "genuinely nothing to name" for TargetNone)
@@ -3028,16 +3033,15 @@ func (a *App) doPlanPlaneMatch() {
 		plan, err = a.world.PlanInclinationChange(0)
 	}
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("inclination: %v", err)
+		a.flash(fmt.Sprintf("inclination: %v", err))
 	} else {
 		nodeLabel := "DN"
 		if plan.AtAN {
 			nodeLabel = "AN"
 		}
-		a.statusMsg = fmt.Sprintf("inclination plan — %.1f m/s at next %s",
-			plan.DV, nodeLabel)
+		a.flash(fmt.Sprintf("inclination plan — %.1f m/s at next %s",
+			plan.DV, nodeLabel))
 	}
-	a.statusExpires = time.Now().Add(3 * time.Second)
 	a.world.RecordAction(missions.ActionPlanIncl) // ADR 0025 §7
 }
 
@@ -3052,12 +3056,11 @@ func (a *App) doPlanCircularize() {
 	}
 	plan, err := a.world.PlanCircularizeAtApoapsis()
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("circularize: %v", err)
+		a.flash(fmt.Sprintf("circularize: %v", err))
 	} else {
-		a.statusMsg = fmt.Sprintf("circularize @ apoapsis (%.0f km) → +%.0f m/s prograde",
-			plan.ApoAltM/1000, plan.DV)
+		a.flash(fmt.Sprintf("circularize @ apoapsis (%.0f km) → +%.0f m/s prograde",
+			plan.ApoAltM/1000, plan.DV))
 	}
-	a.statusExpires = time.Now().Add(3 * time.Second)
 	a.world.RecordAction(missions.ActionPlanCircularize) // ADR 0025 §7
 }
 
@@ -3107,10 +3110,9 @@ func (a *App) doRefinePlan() {
 	}
 	corr, arr, err := a.world.RefinePlan()
 	if err != nil {
-		a.statusMsg = fmt.Sprintf("refine failed: %v", err)
+		a.flash(fmt.Sprintf("refine failed: %v", err))
 	} else {
-		a.statusMsg = fmt.Sprintf("refined — correction %.1f m/s, arrival %.1f m/s", corr, arr)
+		a.flash(fmt.Sprintf("refined — correction %.1f m/s, arrival %.1f m/s", corr, arr))
 	}
-	a.statusExpires = time.Now().Add(3 * time.Second)
 	a.world.RecordAction(missions.ActionRefinePlan) // ADR 0025 §7
 }

--- a/internal/tui/app_flash_test.go
+++ b/internal/tui/app_flash_test.go
@@ -1,0 +1,104 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestFlashSetsOneLifetime pins the ADR 0048 contract: every Event Flash
+// goes through the one flash helper, which sets exactly one lifetime
+// (flashLifetime, 3s) regardless of caller. Pre-#427 call sites disagreed
+// (1.5s/2s/3s/4s/6s) — this is the regression guard against that drift
+// coming back.
+func TestFlashSetsOneLifetime(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	before := time.Now()
+	a.flash("node 1 burned — 3054 m/s, 2 remaining")
+	after := time.Now()
+
+	if a.statusMsg != "node 1 burned — 3054 m/s, 2 remaining" {
+		t.Errorf("statusMsg = %q", a.statusMsg)
+	}
+	wantMin := before.Add(flashLifetime)
+	wantMax := after.Add(flashLifetime)
+	if a.statusExpires.Before(wantMin) || a.statusExpires.After(wantMax) {
+		t.Errorf("statusExpires = %v, want within [%v, %v] (flashLifetime = %v)",
+			a.statusExpires, wantMin, wantMax, flashLifetime)
+	}
+	if flashLifetime != 3*time.Second {
+		t.Errorf("flashLifetime = %v, want 3s (test above assumes this)", flashLifetime)
+	}
+}
+
+// TestFlashOverwritesPriorMessage: a second flash replaces the first in
+// full — text and expiry both — so an old Flash can never linger past a
+// new one's shorter/longer life. (All lifetimes are equal today, but the
+// overwrite behavior itself is the thing under test.)
+func TestFlashOverwritesPriorMessage(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.flash("first")
+	a.flash("second")
+	if a.statusMsg != "second" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "second")
+	}
+}
+
+// TestRefuseIsAFlash: refuse (used by every guarded-key refusal, #282)
+// shares flash's voice and lifetime rather than carrying its own copy.
+func TestRefuseIsAFlash(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	before := time.Now()
+	a.refuse("end flight", "vessel is not wreckage")
+	if a.statusMsg != "end flight: vessel is not wreckage" {
+		t.Errorf("statusMsg = %q", a.statusMsg)
+	}
+	if a.statusExpires.Before(before.Add(flashLifetime)) {
+		t.Errorf("refuse did not apply flashLifetime: statusExpires = %v", a.statusExpires)
+	}
+}
+
+// TestStagingFlashNamesDroppedStageAndRemainingCount pins the #427 Event
+// Flash text for a stage drop: "dropped <name> — <n> stages left" (the
+// issue's own example, "dropped S-IC — 2 stages left"), replacing the
+// old "staged: <name> jettisoned" wording that named the newly-spawned
+// passive craft with no sense of how much rocket is left.
+func TestStagingFlashNamesDroppedStageAndRemainingCount(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	saturn := spacecraft.NewFromLoadout(spacecraft.LoadoutSaturnVID)
+	if len(saturn.Stages) < 3 {
+		t.Fatalf("Saturn V loadout has %d stages, want >= 3", len(saturn.Stages))
+	}
+	saturn.Primary = a.world.Crafts[0].Primary
+	saturn.State = a.world.Crafts[0].State
+	// Crew-tend the bottom stage so canCommand passes without a comms rig
+	// (mirrors internal/sim's crewTendActive test helper).
+	saturn.Stages[len(saturn.Stages)-1].CommandSource = spacecraft.CommandCrewed
+	saturn.SyncFields()
+	a.world.Crafts[0] = saturn
+	a.world.ActiveCraftIdx = 0
+
+	pressKey(a, ' ')
+
+	const want = "dropped S-IC — 2 stages left"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, want)
+	}
+	if !strings.Contains(a.statusMsg, "S-IC") {
+		t.Errorf("flash %q doesn't name the dropped stage", a.statusMsg)
+	}
+}

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -193,7 +193,24 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	if craft != nil {
 		craftName = craft.Name
 	}
-	title := v.theme.Title.Render(fmt.Sprintf("LAUNCH — %s", craftName))
+	// #427 / ADR 0048 §3: carry the warp rate into the launch title bar,
+	// right-aligned the same way the map title bar's clock chip sits —
+	// warpRateText is the exact field renderTitleBar uses, so the number
+	// can never drift between the two screens. Pre-#427 this title held
+	// only the vessel name, so `.`/`,` kept warping with no on-screen
+	// change at all (one reviewer lost ten sim-days tapping `.` on the
+	// pad before noticing on the map).
+	titleLeft := fmt.Sprintf("LAUNCH — %s", craftName)
+	titleRight := warpRateText(w)
+	titlePad := totalCols - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
+	if titlePad < 1 {
+		titlePad = 1
+	}
+	titleRightRendered := v.theme.Dim.Render(titleRight)
+	if w.AutoWarpEngaged() {
+		titleRightRendered = v.theme.Primary.Render(titleRight)
+	}
+	title := v.theme.Title.Render(titleLeft) + strings.Repeat(" ", titlePad) + titleRightRendered
 
 	// The descent half (ADR 0043 §3): one forecast per frame, shared by
 	// the scene (dashed arc + ground marker) and the corridor chip, so
@@ -1391,6 +1408,18 @@ func (v *LaunchView) drawTrail(w *sim.World, body bodies.CelestialBody, bodyPos,
 func (v *LaunchView) composeHUDLine(w *sim.World, c *spacecraft.Spacecraft) string {
 	if c == nil {
 		return ""
+	}
+	// #427 / ADR 0048 §3: the pad's call to action. Landed with the
+	// engine off is exactly the silent state the review found — no
+	// ignite prompt, no mention of `b`, no countdown, no throttle cue
+	// anywhere. Replaces the T+/v_z/downrange/Q line rather than sitting
+	// beside it: pre-ignition every one of those numbers reads a flat
+	// zero (TestFormatLaunchHUDPadIdle), so the line was noise standing
+	// in the way of the one thing that actually matters here. The
+	// moment ignition clears Landed (StartManualBurn, synchronously —
+	// no tick delay) this line reverts to the real telemetry.
+	if c.Landed && c.ManualBurn == nil && c.ActiveBurn == nil {
+		return v.theme.Primary.Render("[b] ignite · [space] stage · [z/x] throttle")
 	}
 	tPlus := time.Duration(0)
 	if w.LaunchSessionActive && !w.LaunchT0.IsZero() {

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -182,6 +183,102 @@ func TestLaunchViewRenderTitle(t *testing.T) {
 	// is the keybinding reference) and its row given to the scene.
 	if strings.Contains(out, "[?]help") {
 		t.Errorf("expected no keybind footer after its removal, got:\n%s", out)
+	}
+}
+
+// TestLaunchViewTitleShowsWarpRate — #427 / ADR 0048 §3: the launch view's
+// title bar used to hold only "LAUNCH — <vessel>", so the warp keys
+// (`.`/`,`) stayed live with nothing on screen to show for it. The title
+// must now carry the same warp field the map title bar's clock chip
+// shows (warpRateText), and it must track a live warp change made while
+// the launch view is up — not just whatever the default was at spawn.
+func TestLaunchViewTitleShowsWarpRate(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	out := v.Render(w, 140, 40)
+	if !strings.Contains(out, "warp 1x") {
+		t.Errorf("expected the default 'warp 1x' in the launch title, got:\n%s", out)
+	}
+
+	// Drive the same warp-up key the pad leaves live (`.`), then confirm
+	// the title's warp field actually moved — not just present once.
+	for i := 0; i < 3; i++ {
+		w.Clock.WarpUp()
+	}
+	out = v.Render(w, 140, 40)
+	got := w.Clock.Warp()
+	if got <= 1 {
+		t.Fatalf("WarpUp x3 left Clock.Warp() = %v, want > 1", got)
+	}
+	wantSubstr := fmt.Sprintf("warp %.0fx", got)
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("launch title didn't track the live warp change: want %q in:\n%s", wantSubstr, out)
+	}
+	if strings.Contains(out, "warp 1x") {
+		t.Errorf("launch title still showed the stale 'warp 1x' after WarpUp:\n%s", out)
+	}
+}
+
+// TestLaunchHUDLineShowsIgnitionHintOnPad — #427 / ADR 0048 §3: the pad's
+// call to action. While Landed with the engine off, the status-area line
+// (bottom border, normally T+/v_z/downrange/Q) becomes the ignite/stage/
+// throttle hint instead — the review's own finding was that nothing on
+// screen told a first-time player to press `b`. The moment the engine
+// lights, the line reverts to real telemetry.
+func TestLaunchHUDLineShowsIgnitionHintOnPad(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: spawned pad craft is not Landed")
+	}
+
+	hud := v.composeHUDLine(w, c)
+	const want = "[b] ignite · [space] stage · [z/x] throttle"
+	if !strings.Contains(hud, want) {
+		t.Errorf("composeHUDLine on the pad = %q, want it to contain %q", hud, want)
+	}
+	if strings.Contains(hud, "T+") {
+		t.Errorf("pad HUD line still showed the zeroed T+/v_z/downrange telemetry: %q", hud)
+	}
+
+	// Full Render must carry the hint too (through overlayHUDStrip).
+	out := v.Render(w, 140, 40)
+	if !strings.Contains(out, want) {
+		t.Errorf("full Render on the pad missing the ignition hint:\n%s", out)
+	}
+
+	// Ignite: the hint must disappear, replaced by real telemetry.
+	w.ToggleManualBurn()
+	if c.ManualBurn == nil {
+		t.Fatal("setup: ToggleManualBurn did not arm ManualBurn")
+	}
+	hud = v.composeHUDLine(w, c)
+	if strings.Contains(hud, "ignite") {
+		t.Errorf("ignition hint lingered after ignition: %q", hud)
+	}
+	if !strings.Contains(hud, "T+") {
+		t.Errorf("post-ignition HUD line lost the T+ telemetry: %q", hud)
 	}
 }
 

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1499,6 +1499,30 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 // right-aligned `[Menu]` and `[Missions]` clickable buttons. Stores
 // the cell ranges of each button so HitMenuButton / HitMissionsButton
 // can map subsequent clicks back to a screen action. v0.7.4+.
+// warpRateText renders the live warp readout — the exact field the map
+// title bar's clock chip carries (v0.10.3+ / ADR 0016), factored out so
+// the launch view's title bar (#427 / ADR 0048 §3) can show the same
+// number rather than hiding it: pre-#427 LAUNCH — <vessel> dropped warp
+// entirely, so `.`/`,` kept working on the pad with nothing on screen to
+// show for it (one reviewer warped ten sim-days by idly tapping `.`).
+// While Auto-Warp is engaged this morphs to "AUTO →<effective>x
+// <time-to-target>"; otherwise "warp <requested>x", or
+// "warp <requested>x→<effective>x" when the integrator clamps the
+// requested rate (e.g. ≤10x during a burn) so the player sees the actual
+// propagation speed. Does not include the "T+<date>" prefix the map
+// title bar prepends — callers that want it add their own.
+func warpRateText(w *sim.World) string {
+	if secs, ok := w.AutoWarpSecondsToTarget(); ok {
+		dur := time.Duration(secs * float64(time.Second))
+		return fmt.Sprintf("AUTO →%.0fx  %s", w.EffectiveWarp(), compactDuration(dur))
+	}
+	reqWarp := w.Clock.Warp()
+	if eff := w.EffectiveWarp(); eff < reqWarp {
+		return fmt.Sprintf("warp %.0fx→%.0fx", reqWarp, eff)
+	}
+	return fmt.Sprintf("warp %.0fx", reqWarp)
+}
+
 func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols int) string {
 	left := fmt.Sprintf("terminal-space-program — %s — %s", version.Version, systemName)
 	// v0.13: the "focus:" readout moved here from the canvas top-left
@@ -1517,23 +1541,12 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 	// Warp shows the effective rate when the integrator clamps it
 	// (e.g. ≤10x during burns) so the player sees the actual
 	// propagation speed, not the requested one.
-	clockChip := "T+" + w.Clock.SimTime.Format("2006-01-02") + "  "
 	// v0.16 / ADR 0016: while Auto-Warp is engaged the warp readout morphs
 	// to AUTO → <effective>x  <time-to-target> so the player sees the
 	// driver and the live rate, not the untouched Selected Warp. The chip
 	// stays emoji-free (single-width runes only) so the rune-counted
 	// button hit-tests below stay aligned.
-	if secs, ok := w.AutoWarpSecondsToTarget(); ok {
-		dur := time.Duration(secs * float64(time.Second))
-		clockChip += fmt.Sprintf("AUTO →%.0fx  %s", w.EffectiveWarp(), compactDuration(dur))
-	} else {
-		reqWarp := w.Clock.Warp()
-		if eff := w.EffectiveWarp(); eff < reqWarp {
-			clockChip += fmt.Sprintf("warp %.0fx→%.0fx", reqWarp, eff)
-		} else {
-			clockChip += fmt.Sprintf("warp %.0fx", reqWarp)
-		}
-	}
+	clockChip := "T+" + w.Clock.SimTime.Format("2006-01-02") + "  " + warpRateText(w)
 	clockChipRendered := v.theme.Dim.Render(clockChip)
 	if w.AutoWarpEngaged() {
 		clockChipRendered = v.theme.Primary.Render(clockChip)

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1283,6 +1283,24 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 			twrLabel = v.theme.Alert.Render(twrLabel + " (will not lift)")
 		}
 	}
+	// #427 / ADR 0048 §3: an ignition indicator beside twr:. The launch
+	// view had no engine-lit state at all — ATTITUDE (the map's own
+	// engine:/manual: rows) uses assembleChips' plain `add`, so it has no
+	// Compact Form and drops outright, silently, the instant the SURFACE
+	// + VESSEL stack (already ~20 rows during ascent) overflows the
+	// top-left column's Graceful Shrink budget — exactly the case the
+	// review captured (gameplay-system-workflows-09.txt: SURFACE/VESSEL/
+	// STAGES/SOI PASS on screen, ATTITUDE nowhere). Folding the readout
+	// into SURFACE instead of trying to keep ATTITUDE alive guarantees it
+	// shows for as long as the ascent HUD itself does (same shouldShowLaunchHUD
+	// gate at the top of this function). Lit iff the engine is actually
+	// producing thrust right now — a manual burn or a firing maneuver
+	// node — not the `throttle:` setting on the VESSEL chip, which stays
+	// at its loadout default whether or not anything is burning.
+	engineLabel := v.theme.Dim.Render("○ off")
+	if c.ActiveBurn != nil || c.ManualBurn != nil {
+		engineLabel = v.theme.Primary.Render("● LIT")
+	}
 	altAGL := c.Altitude()
 	altLabel := fmt.Sprintf("%.0f m", nzero(altAGL, 0))
 	if altAGL >= 1000 {
@@ -1309,7 +1327,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		fmt.Sprintf("  v_horiz:    %.0f m/s (surface-rel)", vHoriz),
 		fmt.Sprintf("  fpa:        %s", fpaLabel),
 		fmt.Sprintf("  fpa_orbit:  %s", fpaOrbitLabel),
-		fmt.Sprintf("  twr:        %s", twrLabel),
+		fmt.Sprintf("  twr:        %s  engine: %s", twrLabel, engineLabel),
 		fmt.Sprintf("  sas:        %s", sasLabel),
 		fmt.Sprintf("  trim:       %s", trimLabel),
 	}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -43,6 +43,20 @@ func (v *OrbitView) assembleChips(w *sim.World) []builtChip {
 	if lines := v.buildVesselChip(w); lines != nil {
 		chips = append(chips, builtChip{corner: cornerTopLeft, lines: lines, compact: v.buildVesselChipCompact(w), priority: chipPriorityCore})
 	}
+	// VESSEL DESTROYED (#427 / ADR 0048): the game's first Standing
+	// Alert — an alert-coloured chip that persists for as long as the
+	// active craft's Crashed state holds, not a transient Event Flash.
+	// Pre-#427 a crash's entire notice was the VESSEL chip's name gaining
+	// a dim "[CR] " prefix (crashedVesselNameLabel) while every other
+	// readout kept reading as if pre-launch — the review's own finding.
+	// Bypasses chipEnabled entirely (no Settings id — there's nothing to
+	// toggle, the exits are non-optional) and survives F2 declutter the
+	// same way the live-burn NODES chip does, because a destroyed vessel
+	// with no visible way out is exactly the "safety/continuity fact the
+	// player has no other way to see" chipPriorityForced exists for.
+	if lines := v.buildVesselDestroyedChip(w); lines != nil {
+		chips = append(chips, builtChip{corner: cornerTopLeft, lines: lines, priority: chipPriorityForced})
+	}
 	// MEETING PLAN (ADR 0045 S6, #399): the picker holds keyboard focus
 	// while open (app.go's key intercept claims ←/→/↑/↓/Enter/Esc before
 	// they can reach camera pan or anything else), so unlike every other

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -686,6 +686,31 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	return lines
 }
 
+// buildVesselDestroyedChip is the VESSEL DESTROYED Standing Alert (#427 /
+// ADR 0048 decision 1): renders only while the active craft is Crashed,
+// naming both exits — [E] end flight (removes the wreckage) and [F9]
+// quickload (the fastest way back to a flying vessel). Already
+// chip-sized (title + one row), so it carries no separate Compact Form —
+// layoutChipsBySide treats a nil compact as "full IS compact".
+//
+// Callers append it OUTSIDE the assembleChips add/addC/addPriority
+// helpers (like the live-burn NODES chip) so it bypasses chipEnabled —
+// and therefore both the Settings toggle (moot: there is nothing to
+// toggle here) and F2 Declutter — entirely. A destroyed vessel with no
+// other on-screen notice is precisely the case a Standing Alert exists
+// for: CONTEXT.md's own rule is "a Flash must never be the only notice
+// of a state that persists."
+func (v *OrbitView) buildVesselDestroyedChip(w *sim.World) []string {
+	c := w.ActiveCraft()
+	if c == nil || !c.Crashed || !w.CraftVisibleHere() {
+		return nil
+	}
+	return []string{
+		v.theme.Alert.Render("VESSEL DESTROYED"),
+		"  [E] end flight  [F9] quickload",
+	}
+}
+
 // buildVesselChipCompact is VESSEL's Compact Form (ADR 0046 / #422): name
 // plus the two figures a pilot needs at a glance mid-emergency — fuel and
 // Δv budget — dropping mass, throttle, monoprop and RCS Δv. Mirrors

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -260,3 +260,75 @@ func TestLaunchChipSteadyOnPad(t *testing.T) {
 		t.Errorf("LAUNCH chip on the pad lost twr/sas rows:\n%s", strings.Join(lines, "\n"))
 	}
 }
+
+// TestLaunchChipEngineLitIndicator — #427 / ADR 0048 §3: the launch HUD
+// had no engine-lit state at all (the review's own finding: after
+// pressing z then b there was no way to tell from the screen whether the
+// engine fired). The twr: row now carries an ignition indicator that
+// reads "off" before ignition and "LIT" once the engine is actually
+// producing thrust (a live ManualBurn or ActiveBurn) — not the
+// throttle: setting, which sits at its loadout default whether or not
+// anything is burning.
+func TestLaunchChipEngineLitIndicator(t *testing.T) {
+	v := NewOrbitView(Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle(),
+	})
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+
+	// Pre-ignition: engine reads off even though throttle is at its
+	// loadout default (100%) — the point of the fix is that ignition, not
+	// throttle setting, is what "LIT" answers.
+	lines := v.buildLaunchChip(w)
+	twrRow := ""
+	for _, l := range lines {
+		if strings.Contains(l, "twr:") {
+			twrRow = l
+			break
+		}
+	}
+	if twrRow == "" {
+		t.Fatalf("no twr: row in LAUNCH chip:\n%s", strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(twrRow, "engine:") || !strings.Contains(twrRow, "off") {
+		t.Errorf("pre-ignition twr: row should show the engine off, got %q", twrRow)
+	}
+	if strings.Contains(twrRow, "LIT") {
+		t.Errorf("pre-ignition twr: row already reads LIT: %q", twrRow)
+	}
+
+	// Ignite (mirrors the `b` key: ToggleManualBurn) — the same row must
+	// now read LIT.
+	w.ToggleManualBurn()
+	if c.ManualBurn == nil {
+		t.Fatal("setup: ToggleManualBurn did not arm ManualBurn")
+	}
+	lines = v.buildLaunchChip(w)
+	twrRow = ""
+	for _, l := range lines {
+		if strings.Contains(l, "twr:") {
+			twrRow = l
+			break
+		}
+	}
+	if !strings.Contains(twrRow, "LIT") {
+		t.Errorf("after ignition the twr: row should read LIT, got %q", twrRow)
+	}
+}

--- a/internal/tui/screens/orbit_vessel_destroyed_test.go
+++ b/internal/tui/screens/orbit_vessel_destroyed_test.go
@@ -1,0 +1,83 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/settings"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestVesselDestroyedChipAppearsOnCrashAndSurvivesDeclutter is #427's
+// Standing Alert test: VESSEL DESTROYED renders the moment the active
+// craft is Crashed, names both exits, and — like the live-burn NODES
+// chip (TestOrbitMetricsAlwaysOnAndLiveBurnForceShows) — survives BOTH
+// every Chip toggled off AND F2 Declutter, because it bypasses
+// chipEnabled entirely rather than merely defaulting on.
+func TestVesselDestroyedChipAppearsOnCrashAndSurvivesDeclutter(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+
+	// A live (non-crashed) vessel must not show the alert.
+	out := v.Render(w, 0, 120, 40)
+	if strings.Contains(out, "VESSEL DESTROYED") {
+		t.Fatalf("a live vessel must not show VESSEL DESTROYED:\n%s", out)
+	}
+
+	// Disable every toggleable Chip AND declutter — the same setup the
+	// NODES force-show test uses — to prove this doesn't merely default
+	// on, it actually bypasses both gates.
+	s := settings.Default()
+	for _, chipID := range settings.AllChips {
+		s.SetChip(chipID, false)
+	}
+	v.SetSettings(s)
+	v.SetDeclutter(true)
+
+	c.Crashed = true
+	out = v.Render(w, 0, 120, 40)
+	if !strings.Contains(out, "VESSEL DESTROYED") {
+		t.Errorf("a crashed vessel must show VESSEL DESTROYED even with every chip disabled and declutter on:\n%s", out)
+	}
+	if !strings.Contains(out, "[E] end flight") || !strings.Contains(out, "[F9] quickload") {
+		t.Errorf("VESSEL DESTROYED must name both exits ([E] end flight, [F9] quickload):\n%s", out)
+	}
+
+	// End Flight clears Crashed → the alert must clear with it (it names
+	// a currently-true state, not a one-shot notice).
+	c.Crashed = false
+	out = v.Render(w, 0, 120, 40)
+	if strings.Contains(out, "VESSEL DESTROYED") {
+		t.Errorf("VESSEL DESTROYED lingered after Crashed cleared:\n%s", out)
+	}
+}
+
+// TestBuildVesselDestroyedChipNilWhenNotVisibleHere: the builder itself
+// (unit-level, no render) must return nil rather than a stale alert when
+// the active craft isn't in the camera's current system — mirrors
+// buildVesselChip's own CraftVisibleHere gate.
+func TestBuildVesselDestroyedChipNilWhenNotVisibleHere(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+	c.Crashed = true
+	c.SystemIdx = w.SystemIdx + 1 // parked in a different system than the camera
+
+	if lines := v.buildVesselDestroyedChip(w); lines != nil {
+		t.Errorf("buildVesselDestroyedChip returned %v for a craft not visible here, want nil", lines)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #427 (ADR 0048 decisions 1 and 3): the launch pad had no call to action, no way to tell whether the engine had fired, and no warp indicator, and a crash was announced only by a dim `[CR]` name prefix.

- **One announcement helper.** `internal/tui/app.go` had a `toast(msg)` helper (3s) plus ~14 raw `a.statusMsg`/`a.statusExpires` pairs with 1.5s/2s/3s/4s/6s lifetimes and no single owner. Introduces `flash(text string)` as the one primitive (`flashLifetime = 3s`); `refuse`, `flashStatus`, and `toast`/`Toast` (the latter an exported cross-package door `internal/serve` calls, kept as a 1-line alias) all delegate to it. Every raw assignment migrated — refusal texts kept verbatim.
- **Standing Alert.** New `buildVesselDestroyedChip`: an alert-coloured chip reading `VESSEL DESTROYED` / `[E] end flight  [F9] quickload` while the active craft is Crashed. Bypasses `chipEnabled` entirely (appended outside the assembleChips add/addC/addPriority helpers) so it survives F2 Declutter the same way the live-burn NODES chip does. Already chip-sized, no separate Compact Form needed.
- **Launch view mechanics:**
  - Pad hint line: the bottom-border status line becomes `[b] ignite · [space] stage · [z/x] throttle` while Landed with the engine off, replacing the all-zero T+/v_z/downrange/Q telemetry it was showing pre-ignition.
  - Engine-lit indicator: SURFACE chip's `twr:` row gains `engine: ● LIT` / `engine: ○ off`, lit only by an actual `ManualBurn`/`ActiveBurn` (not the `throttle:` setting, which sits at its loadout default regardless). Folded into SURFACE rather than trying to keep ATTITUDE's own `engine:`/`manual:` rows alive — ATTITUDE has no Compact Form and was dropping outright once SURFACE+VESSEL filled the top-left column's Graceful Shrink budget, exactly what the review's own capture showed.
  - Warp rate in the launch title bar: extracted `warpRateText(w)` out of the map title bar's clock-chip logic so both screens read the identical live field; the launch title now shows it right-aligned, same as the map bar.
- **Event Flash reword:** the staging flash is now `"dropped S-IC — 2 stages left"` (was `"staged: S-IC-1 jettisoned"`, which named the disambiguated wreckage craft rather than the stage, and said nothing about how much rocket is left).

**Left out, documented in notes:** burn-started/finished Flash (task item 4) — the completion hook lives deep in `World`'s shared per-craft physics tick loop (runs for every craft including remote players'/ghosts' in MP), would need new `World`-level one-shot event state plus a way to report delivered Δv that isn't currently carried past node-fire time. Also not part of ADR 0048 decision 3's five committed pad-scope items. A second Standing Alert (`NO SIGNAL` for CommNet) was checked and found to already exist pre-#427 (`buildCommsChip`) in the ordinary case; making it *fully* Declutter-proof (unlike VESSEL DESTROYED, it has a real Settings toggle) is a design call, not a trivial fix, so left alone.

Full implementation notes (including the render-and-look transcript): `designdocs/terminal-space-program/ux-reviews/20260902-1059/triage/impl-notes/427.md`.

## Test plan

```
go vet ./...
go test ./... -race -count=1
```
All 18 packages pass. New tests:
- `internal/tui/app_flash_test.go`: `flash` sets one lifetime + text, overwrites cleanly, `refuse` shares its voice; staging flash names the dropped stage + remaining count.
- `internal/tui/screens/orbit_vessel_destroyed_test.go`: VESSEL DESTROYED appears only while Crashed, survives every Chip disabled + F2 Declutter, clears when Crashed clears; nil when the craft isn't visible in the current system.
- `internal/tui/screens/orbit_launch_hud_test.go`: engine-lit indicator off pre-ignition (even at 100% throttle) and LIT after `ToggleManualBurn`.
- `internal/tui/screens/launch_test.go`: title bar shows and tracks a live warp change; pad hint line present/absent correctly around ignition, including through full `Render()`.

Manually verified the real binary in a 140×40 tmux session (Saturn V spawned on the pad, warp toggled, ignited, staged, crashed the S-II, toggled F2) — transcript in the notes file linked above.

Closes #427