### PR TITLE
Fix Saturn V pad sprite legibility: axis snap, width floor, separators, colours, ground/sky

### DIFF
--- a/internal/spacecraft/data/parts.json
+++ b/internal/spacecraft/data/parts.json
@@ -15,7 +15,7 @@
       "ballistic_coeff": 0.000008,
       "launch_sprite_rows_px": 24,
       "launch_sprite_width_px": 5,
-      "launch_sprite_color": "#F5EFE0",
+      "launch_sprite_color": "#F0EAD6",
       "fuel_type": "kerolox"
     },
     {
@@ -33,7 +33,7 @@
       "ballistic_coeff": 0.000025,
       "launch_sprite_rows_px": 20,
       "launch_sprite_width_px": 4,
-      "launch_sprite_color": "#E8E8E8",
+      "launch_sprite_color": "#C7D1D9",
       "fuel_type": "hydrolox"
     },
     {
@@ -51,7 +51,7 @@
       "ballistic_coeff": 0.0000625,
       "launch_sprite_rows_px": 12,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#D8D8D8",
+      "launch_sprite_color": "#8C9096",
       "fuel_type": "hydrolox"
     },
     {
@@ -173,7 +173,7 @@
       "isp_s": 311,
       "launch_sprite_rows_px": 5,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#D4C088",
+      "launch_sprite_color": "#8A6B3D",
       "launch_sprite_has_legs": true,
       "fuel_type": "hypergolic",
       "can_soft_land": true
@@ -191,7 +191,7 @@
       "isp_s": 311,
       "launch_sprite_rows_px": 3,
       "launch_sprite_width_px": 2,
-      "launch_sprite_color": "#C8C8B0",
+      "launch_sprite_color": "#D8D4C0",
       "fuel_type": "hypergolic",
       "can_soft_land": true
     },
@@ -240,7 +240,7 @@
       "dry_mass_kg": 5900,
       "launch_sprite_rows_px": 6,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#D8D8E0",
+      "launch_sprite_color": "#EDE6D6",
       "has_parachute": true
     },
     {
@@ -341,7 +341,7 @@
       "isp_s": 311,
       "launch_sprite_rows_px": 5,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#D4C088",
+      "launch_sprite_color": "#8A6B3D",
       "launch_sprite_has_legs": true,
       "fuel_type": "hypergolic",
       "can_soft_land": true
@@ -359,7 +359,7 @@
       "isp_s": 311,
       "launch_sprite_rows_px": 3,
       "launch_sprite_width_px": 2,
-      "launch_sprite_color": "#C8C8B0",
+      "launch_sprite_color": "#D8D4C0",
       "fuel_type": "hypergolic",
       "can_soft_land": true
     },
@@ -375,7 +375,7 @@
       "isp_s": 314,
       "launch_sprite_rows_px": 6,
       "launch_sprite_width_px": 2,
-      "launch_sprite_color": "#C8C8D0",
+      "launch_sprite_color": "#A8ACC0",
       "fuel_type": "hypergolic"
     },
     {
@@ -391,7 +391,7 @@
       "ballistic_coeff": 0.000007,
       "launch_sprite_rows_px": 14,
       "launch_sprite_width_px": 4,
-      "launch_sprite_color": "#D8E6F0",
+      "launch_sprite_color": "#DCEAF5",
       "fuel_type": "kerolox"
     },
     {
@@ -407,7 +407,7 @@
       "ballistic_coeff": 0.000025,
       "launch_sprite_rows_px": 10,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#C8E0F0",
+      "launch_sprite_color": "#7C96AC",
       "fuel_type": "hydrolox"
     },
     {
@@ -438,7 +438,7 @@
       "ballistic_coeff": 0.00005,
       "launch_sprite_rows_px": 6,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#C8C8D0",
+      "launch_sprite_color": "#E8E4D4",
       "has_parachute": true
     },
     {
@@ -589,7 +589,7 @@
       "ballistic_coeff": 0.000007,
       "launch_sprite_rows_px": 16,
       "launch_sprite_width_px": 4,
-      "launch_sprite_color": "#D8E6F0",
+      "launch_sprite_color": "#E2EEF7",
       "fuel_type": "kerolox"
     },
     {
@@ -606,7 +606,7 @@
       "ballistic_coeff": 0.000025,
       "launch_sprite_rows_px": 12,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#C8E0F0",
+      "launch_sprite_color": "#9AB4C8",
       "fuel_type": "hydrolox"
     },
     {
@@ -623,7 +623,7 @@
       "ballistic_coeff": 0.000007,
       "launch_sprite_rows_px": 18,
       "launch_sprite_width_px": 4,
-      "launch_sprite_color": "#D0D8E0",
+      "launch_sprite_color": "#E4E9EE",
       "fuel_type": "solid"
     },
     {
@@ -640,7 +640,7 @@
       "ballistic_coeff": 0.000025,
       "launch_sprite_rows_px": 14,
       "launch_sprite_width_px": 4,
-      "launch_sprite_color": "#B8CCE0",
+      "launch_sprite_color": "#8CA0B4",
       "fuel_type": "hydrolox"
     },
     {
@@ -690,7 +690,7 @@
       "ballistic_coeff": 0.0000625,
       "launch_sprite_rows_px": 8,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#C0D8E8",
+      "launch_sprite_color": "#5E7488",
       "fuel_type": "hydrolox"
     },
     {
@@ -707,7 +707,7 @@
       "ballistic_coeff": 0.0000625,
       "launch_sprite_rows_px": 7,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#B8D0E0",
+      "launch_sprite_color": "#57697A",
       "fuel_type": "hydrolox"
     },
     {
@@ -724,7 +724,7 @@
       "ballistic_coeff": 0.00005,
       "launch_sprite_rows_px": 5,
       "launch_sprite_width_px": 3,
-      "launch_sprite_color": "#A8D8C8",
+      "launch_sprite_color": "#5FA890",
       "launch_sprite_has_legs": true,
       "fuel_type": "hypergolic",
       "can_soft_land": true
@@ -743,7 +743,7 @@
       "ballistic_coeff": 0.00005,
       "launch_sprite_rows_px": 3,
       "launch_sprite_width_px": 2,
-      "launch_sprite_color": "#B0E0D0",
+      "launch_sprite_color": "#D8F0E4",
       "fuel_type": "hypergolic",
       "can_soft_land": true
     },

--- a/internal/spacecraft/loadouts_test.go
+++ b/internal/spacecraft/loadouts_test.go
@@ -25,7 +25,7 @@ func TestNewFromLoadoutResolvedGolden(t *testing.T) {
 		DryMass: 130000, FuelMass: 2160000, FuelCapacity: 2160000, Thrust: 35100000, Isp: 263,
 		MonopropMass: mono, MonopropCap: cap, RCSThrust: thr, RCSIsp: isp,
 		BallisticCoefficient: 8e-6, LaunchSpriteRowsPx: 24, LaunchSpriteWidthPx: 5,
-		LaunchSpriteColor: "#F5EFE0", FuelType: FuelTypeKerolox,
+		LaunchSpriteColor: "#F0EAD6", FuelType: FuelTypeKerolox, // #424 / ADR 0048 §4: widened colour spread
 	}
 	if !reflect.DeepEqual(sv.Stages[0], wantSIC) {
 		t.Errorf("Saturn-V S-IC resolution drift:\n want %+v\n  got %+v", wantSIC, sv.Stages[0])

--- a/internal/spacecraft/stages_catalog_test.go
+++ b/internal/spacecraft/stages_catalog_test.go
@@ -32,7 +32,7 @@ func TestBuildStageGoldenByteIdentical(t *testing.T) {
 		BallisticCoefficient: 6.25e-5,
 		LaunchSpriteRowsPx:   12,
 		LaunchSpriteWidthPx:  3,
-		LaunchSpriteColor:    "#D8D8D8",
+		LaunchSpriteColor:    "#8C9096", // #424 / ADR 0048 §4: widened Saturn V colour spread
 		FuelType:             FuelTypeHydrolox,
 	}
 	if got, ok := BuildStage(StageModuleSIVBID); !ok || !reflect.DeepEqual(got, wantSIVB) {
@@ -111,14 +111,22 @@ func TestBuildStageCarriesFuelType(t *testing.T) {
 // CSM split into SM (silver service module) + CM (pale cone).
 func TestApolloStackSilhouetteIsUnifiedPalette(t *testing.T) {
 	apollo := Loadouts[LoadoutApolloStackID]
+	// #424 / ADR 0048 §4: the pre-fix palette was four shades of
+	// near-white ~13-20 luminance levels apart — indistinguishable on
+	// a terminal (0.299R+0.587G+0.114B computed < 20 apart at every
+	// boundary). Widened so every adjacent pair clears ~20 levels
+	// while staying "white rocket" in spirit: warm ivory booster,
+	// cool light grey sustainer, mid grey interstage/transfer stage,
+	// dark gold LM descent, pale silver LM ascent, cool grey service
+	// module, warm ivory command module cone.
 	want := map[string]string{
-		"S-IC":    "#F5EFE0",
-		"S-II":    "#E8E8E8",
-		"S-IVB":   "#D8D8D8",
-		"Descent": "#D4C088", // v0.12 Slice 2: LM split — descent keeps the gold foil
-		"Ascent":  "#C8C8B0", // pale metal band above the descent
-		"SM":      "#C8C8D0", // bare aluminium service module
-		"CM":      "#D8D8E0", // pale command-module cone
+		"S-IC":    "#F0EAD6",
+		"S-II":    "#C7D1D9",
+		"S-IVB":   "#8C9096",
+		"Descent": "#8A6B3D", // v0.12 Slice 2: LM split — descent keeps the gold foil
+		"Ascent":  "#D8D4C0", // pale metal band above the descent
+		"SM":      "#A8ACC0", // bare aluminium service module
+		"CM":      "#EDE6D6", // pale command-module cone
 	}
 	for _, s := range apollo.Stages {
 		w, ok := want[s.Name]

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -482,8 +483,8 @@ func (v *LaunchView) renderScene(w *sim.World, craft *spacecraft.Spacecraft, cor
 
 	v.canvas.Center(camWorld)
 
-	// Horizon curve + SurfaceColor flood-fill below.
-	v.drawHorizonAndFill(body, bodyCentre)
+	// Horizon band + two-step sky above (v0.40 / #424).
+	v.drawHorizonAndFill(body, bodyCentre, altitudeM)
 
 	// Current-orbit ellipse, rendered exactly as the orbit-map screens
 	// do (same DrawEllipseClass Real-class path + apo/peri markers).
@@ -832,17 +833,133 @@ func (v *LaunchView) chaseHAxis(c *spacecraft.Spacecraft, body bodies.CelestialB
 // drift still steers the camera.
 const chaseHorizSpeedFloorMps = 0.1
 
-// drawHorizonAndFill paints the body's projected silhouette below the
-// horizon with SurfaceColor. In the chase-cam basis (h_axis,
-// local_up), the body sphere projects orthographically to a circle of
-// radius bodyRadius centred at the body's projected position — its
-// upper edge IS the horizon (naturally flat at low altitude, naturally
-// curved at altitude, because the canvas window slices a chord of a
-// large circle). Uses Canvas.FillProjectedSphere so work is bounded by
-// canvas size, not sphere size (planet radius * scale can be millions
-// of cells at low zoom).
-func (v *LaunchView) drawHorizonAndFill(body bodies.CelestialBody, bodyPos orbital.Vec3) {
-	v.canvas.FillProjectedSphere(bodyPos, body.RadiusMeters(), lipgloss.Color(body.SurfaceColorHex()))
+// Horizon-band geometry (issue #424 / ADR 0048 §4). In sub-pixel rows
+// (canvasCellPxH = 4 rows/cell): groundApronRows is a thin, brightened
+// strip right at the horizon (structure/lit ground); groundDimRows is
+// a couple of dimmed rows beneath it. Everything past that stays
+// terminal background — the fix for "ten unbroken rows of green" was
+// to draw LESS, not a different flat colour.
+const (
+	groundApronRows = canvasCellPxH / 2 // half a cell: a thin lit line at the horizon
+	groundDimRows   = canvasCellPxH * 2 // two full cells: "a couple of dim rows"
+)
+
+// Sky-band geometry. Two steps, both shrinking to zero as the vessel
+// climbs past the body's atmosphere (drawHorizonAndFill scales these
+// by altitude/CutoffAltitude) — "thins with altitude" per the ADR.
+// skyGlowRows is the haze-tinted band right at the horizon;
+// skyDeepRows is a darker band further up before space goes to pure
+// black.
+const (
+	skyGlowRows = canvasCellPxH     // one cell of haze tint at the horizon
+	skyDeepRows = canvasCellPxH * 2 // two cells fading toward space
+)
+
+// groundApronLightenFrac / groundDimDarkenFrac / skyDeepDarkenFrac
+// (0..1) are how far each band's colour blends toward white/black
+// from the body's single authored SurfaceColor / atmosphere haze
+// colour — deriving a small gradient from one hex per body rather
+// than hand-authoring a band palette for every body in the catalog.
+const (
+	groundApronLightenFrac = 0.35
+	groundDimDarkenFrac    = 0.45
+	skyDeepDarkenFrac      = 0.55
+)
+
+// drawHorizonAndFill paints a horizon band (ground below, sky above)
+// instead of the old unbroken SurfaceColor disk fill. In the chase-cam
+// basis (h_axis, local_up) the body sphere projects orthographically
+// to a circle of radius bodyRadius centred at the body's projected
+// position — its upper edge IS the horizon (naturally flat at low
+// altitude, naturally curved at altitude, because the canvas window
+// slices a chord of a large circle). Canvas.FillHorizonBands walks
+// that same edge but only paints a bounded run of rows outward from
+// it on each side, so work stays bounded by canvas size (not sphere
+// size) exactly like the FillProjectedSphere precedent it replaces.
+//
+// Ground is always drawn (every body has a SurfaceColor). Sky only
+// draws for bodies with an Atmosphere — an airless body (the Moon)
+// stays pure black above the horizon at any altitude, which is
+// physically correct and needs no special case. altitudeM scales the
+// sky bands down to nothing by the atmosphere's CutoffAltitude.
+func (v *LaunchView) drawHorizonAndFill(body bodies.CelestialBody, bodyPos orbital.Vec3, altitudeM float64) {
+	surface := body.SurfaceColorHex()
+	ground := []widgets.HorizonBand{
+		{Color: lightenHex(surface, groundApronLightenFrac), Rows: groundApronRows},
+		{Color: darkenHex(surface, groundDimDarkenFrac), Rows: groundDimRows},
+	}
+
+	var sky []widgets.HorizonBand
+	if atmo := body.Atmosphere; atmo != nil {
+		frac := 1.0
+		if atmo.CutoffAltitude > 0 {
+			frac = 1.0 - altitudeM/atmo.CutoffAltitude
+		}
+		if frac > 0 {
+			if frac > 1 {
+				frac = 1
+			}
+			haze := atmo.Color
+			if haze == "" {
+				haze = body.Color
+			}
+			glowRows := int(math.Round(float64(skyGlowRows) * frac))
+			deepRows := int(math.Round(float64(skyDeepRows) * frac))
+			if glowRows > 0 {
+				sky = append(sky, widgets.HorizonBand{Color: lipgloss.Color(haze), Rows: glowRows})
+			}
+			if deepRows > 0 {
+				sky = append(sky, widgets.HorizonBand{Color: darkenHex(haze, skyDeepDarkenFrac), Rows: deepRows})
+			}
+		}
+	}
+
+	v.canvas.FillHorizonBands(bodyPos, body.RadiusMeters(), ground, sky)
+}
+
+// lightenHex / darkenHex blend a "#RRGGBB" colour toward white / black
+// by frac (0..1) — deriving the horizon-band palette from a body's
+// single authored SurfaceColor / atmosphere haze colour (issue #424).
+// Malformed input (wrong length, non-hex digits) returns it unchanged:
+// this is cosmetic-only and never worth a panic over catalog data.
+func lightenHex(hex string, frac float64) lipgloss.Color {
+	return blendHex(hex, 255, 255, 255, frac)
+}
+
+func darkenHex(hex string, frac float64) lipgloss.Color {
+	return blendHex(hex, 0, 0, 0, frac)
+}
+
+func blendHex(hex string, tr, tg, tb int, frac float64) lipgloss.Color {
+	r, g, b, ok := parseHexColor(hex)
+	if !ok {
+		return lipgloss.Color(hex)
+	}
+	mix := func(c, t int) int {
+		v := int(math.Round(float64(c) + (float64(t)-float64(c))*frac))
+		if v < 0 {
+			v = 0
+		}
+		if v > 255 {
+			v = 255
+		}
+		return v
+	}
+	return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", mix(r, tr), mix(g, tg), mix(b, tb)))
+}
+
+func parseHexColor(hex string) (r, g, b int, ok bool) {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) != 6 {
+		return 0, 0, 0, false
+	}
+	rv, err1 := strconv.ParseInt(hex[0:2], 16, 32)
+	gv, err2 := strconv.ParseInt(hex[2:4], 16, 32)
+	bv, err3 := strconv.ParseInt(hex[4:6], 16, 32)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return 0, 0, 0, false
+	}
+	return int(rv), int(gv), int(bv), true
 }
 
 // drawOrbitPath plots the active craft's live Keplerian ellipse into
@@ -1242,6 +1359,16 @@ const vesselSubPixelM = 1.5
 // (left-column, right-column). A zero rune ('\x00') means "no glyph
 // at this cell" — used to draw a sparse outline at the crown row
 // (the swing-arm sits in the right column only).
+// launchTowerColor (issue #424 / ADR 0048 §4) is the mobile-launcher
+// silhouette's colour — a cool structural slate distinct in HUE (not
+// just brightness) from every vehicle body tone, so the tower reads
+// as its own thing rather than blending into "dim grey" wherever a
+// stage happens to render dim too. Deliberately its own constant
+// rather than reusing render.ColorDim (kept for the trail / distant-
+// craft fallback dot, and now for the stage separator row — see
+// stageSeparatorColor in launch_sprite.go).
+const launchTowerColor = lipgloss.Color("#6E7C8C")
+
 var lutSprite = [][2]rune{
 	{'╤', 0},
 	{'║', '╤'},
@@ -1313,7 +1440,7 @@ func (v *LaunchView) drawLaunchTower(w *sim.World, craft *spacecraft.Spacecraft,
 				continue
 			}
 			cellWorld := bodyPos.Add(cellFromBody)
-			v.canvas.PlotColored(cellWorld, render.ColorDim)
+			v.canvas.PlotColored(cellWorld, launchTowerColor)
 			v.canvas.SetCellOverlay(cellWorld, glyph)
 		}
 	}

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -635,47 +635,47 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 	if craft.ChuteState == spacecraft.ChuteDeployed {
 		canopy = ComposeCanopy(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM)
 	}
-	// Plot each pixel as a braille sub-cell dot via PlotColoredAnchored
-	// (#424 follow-up), NOT PlotColored(anchorWorld.Add(p.OffsetWorld),
-	// ...): the latter forms an absolute world point by adding a small
-	// sprite offset onto the vessel's large-magnitude world anchor, then
-	// Project immediately subtracts that same anchor back off — an
-	// IEEE754 round trip that doesn't always recover the offset
-	// bit-for-bit, and when the offset's exact value lands on a sub-pixel
-	// rounding tie (it does, routinely — see PlotColoredAnchored's doc
-	// comment), the residual noise flips math.Round's outcome
-	// independently per row, reproducing the exact "half-lit column"
-	// aliasing #424 reported even with the stack axis bit-exact
-	// vertical. PlotColoredAnchored keeps the anchor and offset separate
-	// through to projection, avoiding the round trip entirely.
+	// Fill each sample as its own vesselSubPixelM x vesselSubPixelM tile
+	// via FillRectAnchored (#424 second follow-up), NOT a single plotted
+	// point (PlotColoredAnchored): ComposeLaunchSprite emits one sample
+	// per vesselSubPixelM (1.5 m) step, but the chase-cam's actual
+	// sub-pixel PITCH at a given zoom has no fixed relationship to that
+	// stride — on the pad the pitch is FINER than 1.5 m, so plotting one
+	// point per sample left every other sub-pixel row dark (a periodic
+	// "half-lit stripe", distinct from the column-tie-flipping bug
+	// PlotColoredAnchored/tieBreakBias fixed first). Adjacent samples are
+	// spaced exactly vesselSubPixelM apart by construction (emitRect
+	// steps col/rowAbove by exactly 1 unit), so filling each as its own
+	// full-stride tile reconstructs the stage's true solid rectangle at
+	// ANY zoom — see FillRectAnchored's doc comment for why adjacent
+	// tiles are guaranteed to abut with no gap and no overlap.
 	//
 	// No SetCellOverlay glyph: braille dots are direction-agnostic, so a
 	// tilted rocket renders smoothly at any pitch — the gravity-turn
 	// smear the v0.11.3 ASCII first-cut produced is gone. ClearCellOverlay
-	// after each plot removes the LUT's body-fixed overlay glyphs in
+	// after each fill removes the LUT's body-fixed overlay glyphs in
 	// cells the rocket occupies, so the braille dots show through at the
 	// pad (otherwise the LUT's SetCellOverlay `║ ╤ █` would mask the
-	// rocket) — cell-granularity, so the anchor round-trip's ~10⁻¹⁰ m
-	// noise can never shift it to the wrong cell; no need to route it
-	// through the anchored path too.
+	// rocket) — cell-granularity, so per-sample floating-point noise can
+	// never shift it to the wrong cell.
 	for _, p := range sprite {
-		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.FillRectAnchored(anchorWorld, p.OffsetWorld, vesselSubPixelM, vesselSubPixelM, p.Color)
 		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range bell {
-		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.FillRectAnchored(anchorWorld, p.OffsetWorld, vesselSubPixelM, vesselSubPixelM, p.Color)
 		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range legs {
-		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.FillRectAnchored(anchorWorld, p.OffsetWorld, vesselSubPixelM, vesselSubPixelM, p.Color)
 		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range flame {
-		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.FillRectAnchored(anchorWorld, p.OffsetWorld, vesselSubPixelM, vesselSubPixelM, p.Color)
 		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range canopy {
-		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.FillRectAnchored(anchorWorld, p.OffsetWorld, vesselSubPixelM, vesselSubPixelM, p.Color)
 		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	return true

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -635,38 +635,48 @@ func (v *LaunchView) drawComposedRocket(craft *spacecraft.Spacecraft, anchorWorl
 	if craft.ChuteState == spacecraft.ChuteDeployed {
 		canopy = ComposeCanopy(craft.Stages, craft.CurrentAttitudeDir, basis, vesselSubPixelM)
 	}
-	// Plot each pixel as a braille sub-cell dot via PlotColored.
-	// No SetCellOverlay glyph: braille dots are direction-agnostic,
-	// so a tilted rocket renders smoothly at any pitch — the
-	// gravity-turn smear the v0.11.3 ASCII first-cut produced is
-	// gone. ClearCellOverlay after each plot removes the LUT's
-	// body-fixed overlay glyphs in cells the rocket occupies, so
-	// the braille dots show through at the pad (otherwise the
-	// LUT's SetCellOverlay `║ ╤ █` would mask the rocket).
+	// Plot each pixel as a braille sub-cell dot via PlotColoredAnchored
+	// (#424 follow-up), NOT PlotColored(anchorWorld.Add(p.OffsetWorld),
+	// ...): the latter forms an absolute world point by adding a small
+	// sprite offset onto the vessel's large-magnitude world anchor, then
+	// Project immediately subtracts that same anchor back off — an
+	// IEEE754 round trip that doesn't always recover the offset
+	// bit-for-bit, and when the offset's exact value lands on a sub-pixel
+	// rounding tie (it does, routinely — see PlotColoredAnchored's doc
+	// comment), the residual noise flips math.Round's outcome
+	// independently per row, reproducing the exact "half-lit column"
+	// aliasing #424 reported even with the stack axis bit-exact
+	// vertical. PlotColoredAnchored keeps the anchor and offset separate
+	// through to projection, avoiding the round trip entirely.
+	//
+	// No SetCellOverlay glyph: braille dots are direction-agnostic, so a
+	// tilted rocket renders smoothly at any pitch — the gravity-turn
+	// smear the v0.11.3 ASCII first-cut produced is gone. ClearCellOverlay
+	// after each plot removes the LUT's body-fixed overlay glyphs in
+	// cells the rocket occupies, so the braille dots show through at the
+	// pad (otherwise the LUT's SetCellOverlay `║ ╤ █` would mask the
+	// rocket) — cell-granularity, so the anchor round-trip's ~10⁻¹⁰ m
+	// noise can never shift it to the wrong cell; no need to route it
+	// through the anchored path too.
 	for _, p := range sprite {
-		world := anchorWorld.Add(p.OffsetWorld)
-		v.canvas.PlotColored(world, p.Color)
-		v.canvas.ClearCellOverlay(world)
+		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range bell {
-		world := anchorWorld.Add(p.OffsetWorld)
-		v.canvas.PlotColored(world, p.Color)
-		v.canvas.ClearCellOverlay(world)
+		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range legs {
-		world := anchorWorld.Add(p.OffsetWorld)
-		v.canvas.PlotColored(world, p.Color)
-		v.canvas.ClearCellOverlay(world)
+		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range flame {
-		world := anchorWorld.Add(p.OffsetWorld)
-		v.canvas.PlotColored(world, p.Color)
-		v.canvas.ClearCellOverlay(world)
+		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	for _, p := range canopy {
-		world := anchorWorld.Add(p.OffsetWorld)
-		v.canvas.PlotColored(world, p.Color)
-		v.canvas.ClearCellOverlay(world)
+		v.canvas.PlotColoredAnchored(anchorWorld, p.OffsetWorld, p.Color)
+		v.canvas.ClearCellOverlay(anchorWorld.Add(p.OffsetWorld))
 	}
 	return true
 }

--- a/internal/tui/screens/launch_sprite.go
+++ b/internal/tui/screens/launch_sprite.go
@@ -72,13 +72,31 @@ func flameCoreWidth(w int) int {
 	return (w + 1) / 3
 }
 
+// minRenderedStageWidthPx (issue #424 / ADR 0048 §4) floors every
+// resolved stage width at 4 sub-pixel columns (2 terminal cells).
+// Below that a stage's rectangle was 1-2 sub-pixel columns wide —
+// even snapped vertical (see snapNearVertical) a rectangle that thin
+// reads as a scatter of dots rather than a block once braille packs
+// it 2-per-cell. This is the single resolver every geometry function
+// in this file goes through (body rect, bell throat, taper, legs,
+// composedStackMaxWidth), so a stage that renders 4-wide has its
+// bell/taper/legs sized off that SAME 4-wide throat — not a phantom
+// narrower "as authored" width that would make the ornamentation
+// visually disagree with the body it's attached to.
+const minRenderedStageWidthPx = 4
+
 // stageSpriteWidthPx resolves the width a stage should render at, with
-// the unset-zero fallback to defaultSpriteWidthPx baked in. v0.11.5+.
+// the unset-zero fallback to defaultSpriteWidthPx baked in (v0.11.5+),
+// then floored to minRenderedStageWidthPx (v0.40 / #424).
 func stageSpriteWidthPx(s spacecraft.Stage) int {
-	if s.LaunchSpriteWidthPx <= 0 {
-		return defaultSpriteWidthPx
+	w := s.LaunchSpriteWidthPx
+	if w <= 0 {
+		w = defaultSpriteWidthPx
 	}
-	return s.LaunchSpriteWidthPx
+	if w < minRenderedStageWidthPx {
+		w = minRenderedStageWidthPx
+	}
+	return w
 }
 
 // stageSpriteColor resolves the silhouette colour for a stage:
@@ -323,6 +341,23 @@ func ComposeLaunchSprite(stages []spacecraft.Stage, cmdWorld orbital.Vec3, basis
 			emitRect(rowOffset, 1, taperWidth, color)
 			rowOffset++
 		}
+		// Stage separator (issue #424 / ADR 0048 §4): an UNCONDITIONAL
+		// 1-row dark band at every boundary between two rendered
+		// stages, wide enough to cap both. Unlike the taper above
+		// (gated on taperThreshold, shape-only, painted in the lower
+		// stage's own colour) this exists purely to keep the stack
+		// reading as segmented when colour doesn't carry it — the
+		// Saturn V's four near-white stages were the review's second
+		// finding. Sits right at the seam, after any taper flare.
+		if i+1 < len(stages) && separatorRowBetween(s, stages[i+1]) > 0 {
+			upWidth := stageSpriteWidthPx(stages[i+1])
+			sepWidth := width
+			if upWidth > sepWidth {
+				sepWidth = upWidth
+			}
+			emitRect(rowOffset, 1, sepWidth, stageSeparatorColor())
+			rowOffset++
+		}
 	}
 	if len(pixels) == 0 {
 		return nil
@@ -361,10 +396,41 @@ func taperRowBetween(lower, upper spacecraft.Stage) int {
 	return 0
 }
 
+// stageSeparatorColor (issue #424 / ADR 0048 §4) is the dark boundary
+// line ComposeLaunchSprite paints between every pair of adjacent
+// rendered stages. Reuses render.ColorDim — already the tower/pad
+// "this is inert structure" vocabulary (see drawLaunchTower's former
+// use, now launchTowerColor) — rather than inventing a near-black
+// tone that could round to the terminal's own background under
+// 256-colour quantization and vanish outright. A function, not a
+// cached package var: render.ColorDim is itself a live theme setting
+// (applyUIOverrides can reassign it after this package's vars have
+// already initialized), so caching its value at init time would
+// freeze the separator at the DEFAULT dim colour even when the
+// player's theme overrides "dim" — read it fresh on every call, same
+// as every other render.ColorDim call site in this file.
+func stageSeparatorColor() lipgloss.Color {
+	return render.ColorDim
+}
+
+// separatorRowBetween returns 1 whenever `upper` is itself a rendered
+// stage (LaunchSpriteRowsPx > 0), else 0. Unlike taperRowBetween this
+// is unconditional — every boundary between two drawn stages gets a
+// separator regardless of height — so it's a distinct predicate, not
+// a threshold variant of the taper rule. Shared by ComposeLaunchSprite
+// (emits the row) and composedStackRows (needs only the height) so
+// the two can't drift, same discipline as taperRowBetween.
+func separatorRowBetween(lower, upper spacecraft.Stage) int {
+	if upper.LaunchSpriteRowsPx > 0 {
+		return 1
+	}
+	return 0
+}
+
 // composedStackRows returns the total sub-pixel height of the composed
-// launch sprite, including inter-stage taper rows — mirrors the
-// rowOffset accumulation in ComposeLaunchSprite so ComposeCanopy can
-// anchor itself just above the top stage.
+// launch sprite, including inter-stage taper AND separator rows —
+// mirrors the rowOffset accumulation in ComposeLaunchSprite so
+// ComposeCanopy can anchor itself just above the top stage.
 func composedStackRows(stages []spacecraft.Stage) int {
 	rows := 0
 	for i, s := range stages {
@@ -374,6 +440,7 @@ func composedStackRows(stages []spacecraft.Stage) int {
 		rows += s.LaunchSpriteRowsPx
 		if i+1 < len(stages) {
 			rows += taperRowBetween(s, stages[i+1])
+			rows += separatorRowBetween(s, stages[i+1])
 		}
 	}
 	return rows
@@ -594,10 +661,53 @@ func ComposeFlame(stages []spacecraft.Stage, cmdWorld orbital.Vec3, basis widget
 	return pixels
 }
 
+// nearVerticalSnapDeg (issue #424 / ADR 0048 §4) is the angular
+// tolerance, in degrees off screen-vertical, within which the stack
+// axis snaps to EXACTLY vertical instead of the raw projected
+// direction. A vessel standing "vertical" on the pad is almost never
+// perfectly aligned to the canvas basis — physics jitter and
+// floating-point noise tip CurrentAttitudeDir a fraction of a degree
+// off true. Left unsnapped, that fraction bleeds a small
+// row-dependent horizontal term into every pixel's screen.X
+// (screenSX = rowAbove·pxSize·stackX in emitRect below): row 0 and
+// row 20 land at very slightly different fractional columns, and
+// because Canvas.Project rounds each plotted pixel independently,
+// rows a few sub-pixels apart can round to DIFFERENT absolute
+// columns — the "scattered, half-filled... changes pattern every
+// row" TV-static read #424 reported. Snapping removes the
+// row-dependent term entirely: with stackX forced to 0, screenSX
+// becomes a pure function of the column index and every row's pixel
+// in a given column lands on the identical fractional coordinate, so
+// it rounds identically too. "A couple of degrees" per the ADR.
+const nearVerticalSnapDeg = 2.5
+
+// snapNearVertical returns (0, sign(y)) when the unit vector (x, y)
+// sits within nearVerticalSnapDeg of the screen-vertical axis in
+// EITHER direction (nose up or, degenerately, nose down), else
+// returns (x, y) unchanged. Direction-agnostic by construction: any
+// attitude outside the snap cone renders exactly as before — the
+// original continuous braille sub-pixel rasteriser, untouched — so a
+// vehicle mid gravity-turn keeps smoothly leaning rather than
+// suddenly popping between a "vertical" and a "tilted" renderer (ADR
+// 0048 explicitly rejected a two-renderer split for this reason).
+func snapNearVertical(x, y float64) (float64, float64) {
+	angleDeg := math.Atan2(math.Abs(x), math.Abs(y)) * 180 / math.Pi
+	if angleDeg > nearVerticalSnapDeg {
+		return x, y
+	}
+	if y < 0 {
+		return 0, -1
+	}
+	return 0, 1
+}
+
 // stackDirScreen returns the unit-vector projection of cmdWorld into
 // the chase-cam basis's (X, Y) screen plane. Falls back to (0, 1) —
 // pure vertical stacking — when the projection magnitude is below
-// 1e-9 (cmd parallel to the depth axis, or zero).
+// 1e-9 (cmd parallel to the depth axis, or zero). Near-vertical
+// results are snapped to exactly vertical (see snapNearVertical /
+// nearVerticalSnapDeg) so a standing rocket's stage columns render
+// solid instead of aliasing (#424).
 func stackDirScreen(cmdWorld orbital.Vec3, basis widgets.Basis) (x, y float64) {
 	x = cmdWorld.Dot(basis.X)
 	y = cmdWorld.Dot(basis.Y)
@@ -605,5 +715,5 @@ func stackDirScreen(cmdWorld orbital.Vec3, basis widgets.Basis) (x, y float64) {
 	if mag < 1e-9 {
 		return 0, 1
 	}
-	return x / mag, y / mag
+	return snapNearVertical(x/mag, y/mag)
 }

--- a/internal/tui/screens/launch_sprite_realpath_test.go
+++ b/internal/tui/screens/launch_sprite_realpath_test.go
@@ -24,6 +24,12 @@ import (
 //     v.Render call, so it can only pass if the live render path is
 //     genuinely solid, not if some parallel/idealized computation says
 //     it should be.
+//
+// This checks COLUMN consistency only (every row of a given nominal
+// column lands on the same canvas px). It does NOT catch a row-gap
+// aliasing where the intended column is right but rows in between two
+// samples are simply dark — see
+// TestRealLaunchView_SII_EveryRowInSpanIsLit for that.
 func TestRealLaunchView_SIC_ColumnsAreSolid(t *testing.T) {
 	w, c := spawnSaturnVOnPad(t)
 	for i := 0; i < 5; i++ {
@@ -63,11 +69,6 @@ func TestRealLaunchView_SIC_ColumnsAreSolid(t *testing.T) {
 		t.Fatalf("got %d sprite pixels for S-IC, want %d (rows x width - no taper/separator on a lone stage)", len(sprite), rows*width)
 	}
 
-	// Real path: how drawComposedRocket actually plots (PlotColoredAnchored),
-	// read back via ProjectAnchored's identical projection math, then
-	// cross-checked against the raw drawille bitmap SubPixelSet reads —
-	// so this confirms both "the intended column is consistent" AND
-	// "the canvas that was actually drawn to agrees."
 	badCols := 0
 	for col := 0; col < width; col++ {
 		wantPx, wantPy := -1, -1
@@ -93,5 +94,97 @@ func TestRealLaunchView_SIC_ColumnsAreSolid(t *testing.T) {
 	}
 	if badCols == 0 {
 		t.Logf("all %d columns solid across %d rows on the real chase-cam path (verified against the actual rendered bitmap)", width, rows)
+	}
+}
+
+// TestRealLaunchView_SII_EveryRowInSpanIsLit is the row-gap counterpart
+// to TestRealLaunchView_SIC_ColumnsAreSolid: it doesn't just check that
+// samples land on a consistent column, it checks that EVERY sub-pixel
+// ROW within the stage's vertical span has a lit pixel in the stage's
+// column band — the exact property that failed on the after2 capture
+// (rows 3-16, cols 70-73 alternating a fully-lit cell row with a sparse
+// one: ComposeLaunchSprite samples every vesselSubPixelM = 1.5 m, but
+// the chase-cam's actual sub-pixel pitch on the pad is FINER than that,
+// so a single point per sample left every other sub-pixel row dark).
+//
+// Checked on S-II (Stages[1]), not S-IC: S-IC's base sits right at pad
+// level, close enough to the ground-band fill (issue #424 item 5) that
+// a naive "is ANY pixel lit in this row" check could pass by
+// coincidence from the UNRELATED ground fill rather than the sprite
+// itself. S-II sits a full S-IC (24 rows x 1.5 m = 36 m) above that,
+// comfortably clear of the ground band, so a lit pixel there can only
+// be the rocket.
+func TestRealLaunchView_SII_EveryRowInSpanIsLit(t *testing.T) {
+	w, c := spawnSaturnVOnPad(t)
+	for i := 0; i < 5; i++ {
+		w.Tick()
+	}
+
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Render(w, 140, 40)
+
+	basis := v.canvas.Basis()
+	anchorWorld := v.canvas.CenterWorld()
+	cmd := c.CurrentAttitudeDir
+
+	sii := c.Stages[1]
+	if sii.Name != "S-II" {
+		t.Fatalf("Stages[1] = %q, want S-II", sii.Name)
+	}
+	siiColor := stageSpriteColor(sii)
+
+	// Compose the FULL stack (not S-II alone) so S-II's samples land at
+	// the same rowOffset the real render placed them at — S-IC's rows
+	// plus whatever taper/separator rows sit between S-IC and S-II.
+	full := ComposeLaunchSprite(c.Stages, cmd, basis, vesselSubPixelM)
+
+	var siiSamples []SpritePixel
+	for _, p := range full {
+		if p.Color == siiColor {
+			siiSamples = append(siiSamples, p)
+		}
+	}
+	if len(siiSamples) == 0 {
+		t.Fatal("no S-II-coloured samples found in the composed stack")
+	}
+
+	minPx, maxPx, minPy, maxPy := 1<<30, -(1 << 30), 1<<30, -(1 << 30)
+	for _, p := range siiSamples {
+		px, py, ok := v.canvas.ProjectAnchored(anchorWorld, p.OffsetWorld)
+		if !ok {
+			t.Fatalf("S-II sample projected off-canvas (px=%d py=%d)", px, py)
+		}
+		if px < minPx {
+			minPx = px
+		}
+		if px > maxPx {
+			maxPx = px
+		}
+		if py < minPy {
+			minPy = py
+		}
+		if py > maxPy {
+			maxPy = py
+		}
+	}
+	t.Logf("S-II real column band: px[%d..%d] py[%d..%d] (%d samples)", minPx, maxPx, minPy, maxPy, len(siiSamples))
+
+	darkRows := 0
+	for py := minPy; py <= maxPy; py++ {
+		lit := false
+		for px := minPx; px <= maxPx; px++ {
+			if v.canvas.SubPixelSet(px, py) {
+				lit = true
+				break
+			}
+		}
+		if !lit {
+			darkRows++
+			t.Errorf("REAL PATH row py=%d is completely DARK across S-II's own column band (px %d..%d) — a stripe of the #424 follow-up row-gap aliasing", py, minPx, maxPx)
+		}
+	}
+	if darkRows == 0 {
+		t.Logf("every sub-pixel row in S-II's span (py %d..%d) has a lit pixel — no row-gap striping on the real chase-cam path", minPy, maxPy)
 	}
 }

--- a/internal/tui/screens/launch_sprite_realpath_test.go
+++ b/internal/tui/screens/launch_sprite_realpath_test.go
@@ -1,0 +1,97 @@
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestRealLaunchView_SIC_ColumnsAreSolid reproduces #424's follow-up
+// through the ACTUAL chase-cam path — spawnSaturnVOnPad + real
+// World.Tick() calls (so CurrentAttitudeDir is genuinely initialized the
+// way the live game initializes it, not a synthetic unit vector) + a
+// real LaunchView.Render call — rather than the synthetic basis/cmd
+// TestComposeLaunchSprite_NearVerticalColumnsAreSolid used, which passed
+// even while the real chase-cam still aliased. Two things distinguish
+// this test from that one:
+//
+//  1. It measures the REAL chase-cam basis's angle off vertical on the
+//     pad and logs it, so a future regression that moves the attitude
+//     outside the snap cone shows up as a measured number, not a guess.
+//  2. It reads back the ACTUAL RENDERED CANVAS BITMAP via
+//     Canvas.SubPixelSet — not a re-derived projection — after a real
+//     v.Render call, so it can only pass if the live render path is
+//     genuinely solid, not if some parallel/idealized computation says
+//     it should be.
+func TestRealLaunchView_SIC_ColumnsAreSolid(t *testing.T) {
+	w, c := spawnSaturnVOnPad(t)
+	for i := 0; i < 5; i++ {
+		w.Tick()
+	}
+
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Render(w, 140, 40)
+
+	basis := v.canvas.Basis()
+	anchorWorld := v.canvas.CenterWorld()
+
+	cmd := c.CurrentAttitudeDir
+	if cmd.Norm() == 0 {
+		t.Fatalf("precondition: CurrentAttitudeDir is still the zero vector after 5 ticks — the real init path never ran")
+	}
+	x := cmd.Dot(basis.X)
+	y := cmd.Dot(basis.Y)
+	mag := math.Sqrt(x*x + y*y)
+	angleDeg := math.Atan2(math.Abs(x), math.Abs(y)) * 180 / math.Pi
+	t.Logf("real chase-cam basis at KSC pad: cmd.X=%.9f cmd.Y=%.9f |proj|=%.9f angle-off-vertical=%.6f deg (snap cone = %.1f deg)", x, y, mag, angleDeg, nearVerticalSnapDeg)
+	if angleDeg > nearVerticalSnapDeg {
+		t.Fatalf("real attitude is %.4f deg off vertical - OUTSIDE the %.1f deg snap cone, so snapNearVertical never engages on the pad; the threshold or the basis is the bug, not the anchor", angleDeg, nearVerticalSnapDeg)
+	}
+
+	sic := c.Stages[0]
+	if sic.Name != "S-IC" {
+		t.Fatalf("Stages[0] = %q, want S-IC", sic.Name)
+	}
+	rows := sic.LaunchSpriteRowsPx
+	width := stageSpriteWidthPx(sic)
+	t.Logf("S-IC: rows=%d width=%d anchorWorld=%+v scale=%v", rows, width, anchorWorld, v.canvas.Scale())
+
+	sprite := ComposeLaunchSprite([]spacecraft.Stage{sic}, cmd, basis, vesselSubPixelM)
+	if len(sprite) != rows*width {
+		t.Fatalf("got %d sprite pixels for S-IC, want %d (rows x width - no taper/separator on a lone stage)", len(sprite), rows*width)
+	}
+
+	// Real path: how drawComposedRocket actually plots (PlotColoredAnchored),
+	// read back via ProjectAnchored's identical projection math, then
+	// cross-checked against the raw drawille bitmap SubPixelSet reads —
+	// so this confirms both "the intended column is consistent" AND
+	// "the canvas that was actually drawn to agrees."
+	badCols := 0
+	for col := 0; col < width; col++ {
+		wantPx, wantPy := -1, -1
+		for row := 0; row < rows; row++ {
+			p := sprite[row*width+col]
+			px, py, ok := v.canvas.ProjectAnchored(anchorWorld, p.OffsetWorld)
+			if !ok {
+				t.Fatalf("col %d row %d: pixel projected off-canvas (px=%d py=%d)", col, row, px, py)
+			}
+			if !v.canvas.SubPixelSet(px, py) {
+				t.Errorf("col %d row %d: ProjectAnchored says (px=%d,py=%d) but the real rendered canvas has NO dot there", col, row, px, py)
+			}
+			if row == 0 {
+				wantPx, wantPy = px, py
+				continue
+			}
+			if px != wantPx {
+				badCols++
+				t.Errorf("REAL PATH column %d is NOT solid: row 0 -> canvas col %d, row %d -> canvas col %d (py %d vs %d) - this is the #424 follow-up aliasing on the actual chase-cam render", col, wantPx, row, px, wantPy, py)
+				break
+			}
+		}
+	}
+	if badCols == 0 {
+		t.Logf("all %d columns solid across %d rows on the real chase-cam path (verified against the actual rendered bitmap)", width, rows)
+	}
+}

--- a/internal/tui/screens/launch_sprite_snap_test.go
+++ b/internal/tui/screens/launch_sprite_snap_test.go
@@ -1,0 +1,206 @@
+package screens
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
+)
+
+// angledCmd returns a unit cmdWorld vector tilted degOffVertical
+// degrees off basis.Y (screen-vertical) toward basis.X — the probe
+// vector every test in this file uses to sweep across the #424
+// near-vertical snap threshold.
+func angledCmd(degOffVertical float64) orbital.Vec3 {
+	rad := degOffVertical * math.Pi / 180
+	return orbital.Vec3{X: math.Sin(rad), Y: 0, Z: math.Cos(rad)}
+}
+
+// TestSnapNearVertical_WithinToleranceSnapsExact pins the ADR 0048 §4
+// tolerance ("a couple of degrees"): 0° and 1.5° off vertical both
+// snap to exactly (0, 1).
+func TestSnapNearVertical_WithinToleranceSnapsExact(t *testing.T) {
+	for _, deg := range []float64{0, 1.5} {
+		rad := deg * math.Pi / 180
+		x, y := snapNearVertical(math.Sin(rad), math.Cos(rad))
+		if x != 0 || y != 1 {
+			t.Errorf("at %.1f° off vertical: snapNearVertical = (%v, %v), want (0, 1)", deg, x, y)
+		}
+	}
+}
+
+// TestSnapNearVertical_BeyondToleranceKeepsRawDirection is the other
+// half of the same pin: 3° and 10° off vertical are NOT snapped — the
+// exact continuous direction passes through unchanged, so a
+// gravity-turned vehicle keeps leaning smoothly with no pop at the
+// snap boundary (ADR 0048 explicitly rejected a two-renderer switch).
+func TestSnapNearVertical_BeyondToleranceKeepsRawDirection(t *testing.T) {
+	for _, deg := range []float64{3, 10} {
+		rad := deg * math.Pi / 180
+		wantX, wantY := math.Sin(rad), math.Cos(rad)
+		x, y := snapNearVertical(wantX, wantY)
+		if x != wantX || y != wantY {
+			t.Errorf("at %.1f° off vertical: snapNearVertical = (%v, %v), want unchanged (%v, %v)", deg, x, y, wantX, wantY)
+		}
+	}
+}
+
+// TestComposeLaunchSprite_NearVerticalColumnsAreSolid reproduces the
+// #424 bug directly and proves the fix: at 0° and 1.5° off vertical
+// (inside the snap cone — the angles a player would call "the rocket
+// is standing on the pad"), rasterising a tall multi-row stage through
+// a REAL widgets.Canvas must land every row of the same nominal
+// column on the identical canvas sub-pixel column. Before the snap,
+// this failed at exactly these angles: floating-point drift in
+// screenSX across rows rounded to different absolute columns, which
+// is the "scattered, half-filled... changes pattern every row"
+// TV-static the issue reported. An empty-sprite pass would be
+// vacuous, so this asserts against a real 24-row × 5-wide stage (the
+// Saturn V S-IC's authored dimensions) and fails loudly if the pixel
+// count doesn't match rows×width.
+func TestComposeLaunchSprite_NearVerticalColumnsAreSolid(t *testing.T) {
+	const rows = 24
+	const width = 5
+	basis := widgets.Basis{
+		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
+		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
+	}
+	for _, deg := range []float64{0, 1.5} {
+		stage := spacecraft.Stage{LaunchSpriteRowsPx: rows, LaunchSpriteWidthPx: width, Color: "#F5EFE0"}
+		cmd := angledCmd(deg)
+		pixels := ComposeLaunchSprite([]spacecraft.Stage{stage}, cmd, basis, vesselSubPixelM)
+		if got, want := len(pixels), rows*width; got != want {
+			t.Fatalf("at %.1f°: got %d pixels, want %d (rows×width, single stage — no taper/separator)", deg, got, want)
+		}
+
+		c := widgets.NewCanvas(40, 20)
+		c.SetBasis(basis)
+		c.SetScale(1.0 / launchAutoScale(0, 20))
+		c.Center(orbital.Vec3{})
+
+		for col := 0; col < width; col++ {
+			wantPx := -1
+			for row := 0; row < rows; row++ {
+				p := pixels[row*width+col]
+				px, _, ok := c.Project(p.OffsetWorld)
+				if !ok {
+					t.Fatalf("at %.1f° col %d row %d: pixel projected off-canvas", deg, col, row)
+				}
+				if row == 0 {
+					wantPx = px
+					continue
+				}
+				if px != wantPx {
+					t.Errorf("at %.1f° off vertical, column %d is NOT solid: row 0 rasterises to canvas column %d but row %d rasterises to %d — this is the #424 aliasing", deg, col, wantPx, row, px)
+				}
+			}
+		}
+	}
+}
+
+// TestComposeLaunchSprite_OffVerticalKeepsOriginalRasteriser confirms
+// attitudes outside the snap cone (3°, 10°) are genuinely untouched:
+// column 0's screen.X still DRIFTS row-to-row (the row-dependent term
+// snapNearVertical removes when it fires is still present here), and
+// stackDirScreen returns the raw normalized projection rather than
+// (0, ±1) — the same continuous rasteriser this file has used since
+// v0.11.3, so a gravity-turned vehicle keeps rendering exactly as
+// before the #424 fix.
+func TestComposeLaunchSprite_OffVerticalKeepsOriginalRasteriser(t *testing.T) {
+	basis := widgets.Basis{
+		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
+		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
+	}
+	const rows = 24
+	const width = 5
+	for _, deg := range []float64{3, 10} {
+		cmd := angledCmd(deg)
+		rad := deg * math.Pi / 180
+		wantX, wantY := math.Sin(rad), math.Cos(rad)
+		gotX, gotY := stackDirScreen(cmd, basis)
+		// Two independent paths to the same unit vector (Sin/Cos here
+		// vs. cmd.Dot(basis)/mag in stackDirScreen) can differ in the
+		// last float64 bit — compare with a tight epsilon rather than
+		// exact equality; the point being tested is "not snapped to
+		// (0, ±1)", not bit-identical trig.
+		const eps = 1e-12
+		if math.Abs(gotX-wantX) > eps || math.Abs(gotY-wantY) > eps {
+			t.Fatalf("at %.1f°: stackDirScreen = (%v, %v), want the raw unsnapped direction (%v, %v)", deg, gotX, gotY, wantX, wantY)
+		}
+
+		stage := spacecraft.Stage{LaunchSpriteRowsPx: rows, LaunchSpriteWidthPx: width, Color: "#F5EFE0"}
+		pixels := ComposeLaunchSprite([]spacecraft.Stage{stage}, cmd, basis, vesselSubPixelM)
+		x0 := pixels[0*width+0].OffsetWorld.Dot(basis.X)
+		xLast := pixels[(rows-1)*width+0].OffsetWorld.Dot(basis.X)
+		if x0 == xLast {
+			t.Errorf("at %.1f° off vertical, column 0 shows NO row-dependent drift — the snap appears to be firing where it shouldn't", deg)
+		}
+	}
+}
+
+// TestStageSpriteWidthPx_FloorsBelowMinimum pins stageSpriteWidthPx's
+// resolution order directly: unset (0) falls back to
+// defaultSpriteWidthPx first, THEN both that fallback and any
+// authored width below minRenderedStageWidthPx are floored; an
+// authored width at or above the floor passes through unchanged.
+func TestStageSpriteWidthPx_FloorsBelowMinimum(t *testing.T) {
+	cases := []struct{ authored, want int }{
+		{0, minRenderedStageWidthPx},
+		{1, minRenderedStageWidthPx},
+		{2, minRenderedStageWidthPx},
+		{3, minRenderedStageWidthPx},
+		{4, 4},
+		{5, 5},
+	}
+	for _, c := range cases {
+		got := stageSpriteWidthPx(spacecraft.Stage{LaunchSpriteWidthPx: c.authored})
+		if got != c.want {
+			t.Errorf("stageSpriteWidthPx(authored=%d) = %d, want %d", c.authored, got, c.want)
+		}
+	}
+}
+
+// TestComposeLaunchSprite_SeparatorAtEachBoundary is the direct TDD
+// pin for ADR 0048 §4's third requirement: an unconditional dark
+// separator row at EVERY boundary between two rendered stages,
+// regardless of the (unrelated, height-gated) inter-stage taper.
+// Three stages, all below taperThreshold rows, so no taper rows
+// appear — every non-body pixel found here is a separator pixel.
+func TestComposeLaunchSprite_SeparatorAtEachBoundary(t *testing.T) {
+	s1 := spacecraft.Stage{LaunchSpriteRowsPx: 4, LaunchSpriteWidthPx: 5, Color: "#111111"}
+	s2 := spacecraft.Stage{LaunchSpriteRowsPx: 4, LaunchSpriteWidthPx: 4, Color: "#222222"}
+	s3 := spacecraft.Stage{LaunchSpriteRowsPx: 4, LaunchSpriteWidthPx: 3, Color: "#333333"}
+	basis := widgets.Basis{
+		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
+		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
+	}
+	pixels := ComposeLaunchSprite([]spacecraft.Stage{s1, s2, s3}, orbital.Vec3{Z: 1}, basis, 1.0)
+	if len(pixels) == 0 {
+		t.Fatal("expected sprite pixels, got none")
+	}
+
+	sep := string(stageSeparatorColor())
+	widthAtY := map[int]int{}
+	for _, p := range pixels {
+		if string(p.Color) != sep {
+			continue
+		}
+		y := int(math.Round(p.OffsetWorld.Dot(basis.Y)))
+		widthAtY[y]++
+	}
+	if len(widthAtY) != 2 {
+		t.Fatalf("got separator rows at %d distinct heights, want 2 (one per boundary); rows=%v", len(widthAtY), widthAtY)
+	}
+	// Boundary 1 sits right after s1's 4 body rows (y=0..3) at y=4,
+	// width = max(s1 5, s2 4) = 5. Boundary 2 sits after s2's 4 body
+	// rows (y=5..8) at y=9, width = max(s2 4, s3 3 floored to
+	// minRenderedStageWidthPx 4) = 4.
+	want := map[int]int{4: 5, 9: 4}
+	for y, wantW := range want {
+		if got := widthAtY[y]; got != wantW {
+			t.Errorf("separator row at y=%d has width %d, want %d (full map: %v)", y, got, wantW, widthAtY)
+		}
+	}
+}

--- a/internal/tui/screens/launch_sprite_test.go
+++ b/internal/tui/screens/launch_sprite_test.go
@@ -11,8 +11,10 @@ import (
 )
 
 // TestComposeLaunchSprite_VerticalClimbSingleStage is the tracer:
-// one stage with LaunchSpriteRowsPx = 4 emits a 2-wide × 4-tall
-// rectangle of braille sub-pixels (8 pixels), all with positive
+// one stage with LaunchSpriteRowsPx = 4 and no authored width emits a
+// minRenderedStageWidthPx-wide × 4-tall rectangle of braille
+// sub-pixels — the unset-width fallback (defaultSpriteWidthPx = 2)
+// still floors to the #424 rendering minimum, all with positive
 // screen.Y offset (stack extends UP from the vessel anchor at
 // vertical climb).
 func TestComposeLaunchSprite_VerticalClimbSingleStage(t *testing.T) {
@@ -27,8 +29,8 @@ func TestComposeLaunchSprite_VerticalClimbSingleStage(t *testing.T) {
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{stage}, cmd, basis, 1.0)
 
-	if got, want := len(pixels), 4*defaultSpriteWidthPx; got != want {
-		t.Fatalf("got %d pixels, want %d (rows %d × width %d)", got, want, 4, defaultSpriteWidthPx)
+	if got, want := len(pixels), 4*minRenderedStageWidthPx; got != want {
+		t.Fatalf("got %d pixels, want %d (rows %d × width %d)", got, want, 4, minRenderedStageWidthPx)
 	}
 	for i, p := range pixels {
 		if string(p.Color) != "#FFD93D" {
@@ -42,7 +44,10 @@ func TestComposeLaunchSprite_VerticalClimbSingleStage(t *testing.T) {
 
 // TestComposeLaunchSprite_MultiStageStacksBottomToTop verifies the
 // Stages[0]=bottom convention: every pixel from the bottom stage
-// sits at lower screen.Y than every pixel from the top stage.
+// sits at lower screen.Y than every pixel from the top stage. Two
+// rendered stages also means one boundary, so the #424 stage
+// separator row fires (both stages < taperThreshold, so no taper);
+// its pixels are neither stage's colour and are counted separately.
 func TestComposeLaunchSprite_MultiStageStacksBottomToTop(t *testing.T) {
 	bottom := spacecraft.Stage{LaunchSpriteRowsPx: 4, Color: "#FF0000"}
 	top := spacecraft.Stage{LaunchSpriteRowsPx: 4, Color: "#00FF00"}
@@ -53,12 +58,16 @@ func TestComposeLaunchSprite_MultiStageStacksBottomToTop(t *testing.T) {
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{bottom, top}, cmd, basis, 1.0)
 
-	if got, want := len(pixels), 2*4*defaultSpriteWidthPx; got != want {
-		t.Fatalf("got %d pixels, want %d", got, want)
+	// 4 rows × floored width 4 per stage, plus one 4-wide separator row.
+	wantBody := 4 * minRenderedStageWidthPx
+	wantSep := minRenderedStageWidthPx
+	if got, want := len(pixels), 2*wantBody+wantSep; got != want {
+		t.Fatalf("got %d pixels, want %d (2×%d body + %d separator)", got, want, wantBody, wantSep)
 	}
 
 	maxBottomY := -1e18
 	minTopY := 1e18
+	var sepN int
 	for _, p := range pixels {
 		y := p.OffsetWorld.Dot(basis.Y)
 		switch string(p.Color) {
@@ -70,12 +79,17 @@ func TestComposeLaunchSprite_MultiStageStacksBottomToTop(t *testing.T) {
 			if y < minTopY {
 				minTopY = y
 			}
+		case string(stageSeparatorColor()):
+			sepN++
 		default:
 			t.Errorf("unexpected color %q on pixel", string(p.Color))
 		}
 	}
 	if !(minTopY > maxBottomY) {
 		t.Errorf("top-stage pixels must be above bottom-stage pixels; maxBottomY=%v minTopY=%v", maxBottomY, minTopY)
+	}
+	if sepN != wantSep {
+		t.Errorf("separator pixel count = %d, want %d", sepN, wantSep)
 	}
 }
 
@@ -146,12 +160,12 @@ func TestComposeLaunchSprite_Col0LeftOfCol1(t *testing.T) {
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{stage}, cmd, basis, 1.0)
-	if got := len(pixels); got != defaultSpriteWidthPx {
-		t.Fatalf("got %d pixels for 1 row, want %d", got, defaultSpriteWidthPx)
+	if got := len(pixels); got != minRenderedStageWidthPx {
+		t.Fatalf("got %d pixels for 1 row, want %d", got, minRenderedStageWidthPx)
 	}
 	// Pixels should span the screen.X range symmetrically: minX
 	// must be negative (col 0 is left of centre), maxX positive
-	// (col defaultSpriteWidthPx-1 is right of centre).
+	// (col minRenderedStageWidthPx-1 is right of centre).
 	minX, maxX := 1e18, -1e18
 	for _, p := range pixels {
 		x := p.OffsetWorld.Dot(basis.X)
@@ -205,8 +219,8 @@ func TestComposeLaunchSprite_NoSpriteReturnsNil(t *testing.T) {
 // TestComposeFlame_MidThrottleEmitsMidLength (v0.11.5-followup):
 // throttle 0.5 falls in the middle bin and emits 3 cone-tapered
 // sub-pixel rows. With no bell the top width defaults to the stage
-// width (defaultSpriteWidthPx = 2) tapering to max(1, 2/2) = 1 at the
-// tip, so the cone is 2 + 2 + 1 = 5 pixels.
+// width — floored to minRenderedStageWidthPx (#424) — tapering to
+// max(1, 4/2) = 2 at the tip, so the cone is 4 + 3 + 2 = 9 pixels.
 func TestComposeFlame_MidThrottleEmitsMidLength(t *testing.T) {
 	stage := spacecraft.Stage{LaunchSpriteRowsPx: 4}
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
@@ -215,8 +229,8 @@ func TestComposeFlame_MidThrottleEmitsMidLength(t *testing.T) {
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	pixels := ComposeFlame([]spacecraft.Stage{stage}, cmd, basis, 1.0, 0.5, 0, 0)
-	if got, want := len(pixels), 5; got != want {
-		t.Fatalf("got %d pixels, want %d (mid bin = 3-row cone tapering 2→2→1)", got, want)
+	if got, want := len(pixels), 9; got != want {
+		t.Fatalf("got %d pixels, want %d (mid bin = 3-row cone tapering 4→3→2)", got, want)
 	}
 	for i, p := range pixels {
 		if y := p.OffsetWorld.Dot(basis.Y); y >= 0 {
@@ -257,9 +271,13 @@ func TestComposeFlameTwoColourCore(t *testing.T) {
 		t.Error("wide flame should keep fuel-coloured edges")
 	}
 
-	// Narrow flame: no bell, stage width 2 → every row ≤ 2 wide → no core.
-	narrow := spacecraft.Stage{LaunchSpriteRowsPx: 4, LaunchSpriteWidthPx: 2, Thrust: 1e6, FuelType: spacecraft.FuelTypeKerolox}
-	for _, p := range ComposeFlame([]spacecraft.Stage{narrow}, cmd, basis, 1.0, 1.0, 0, 0) {
+	// Narrow flame: an explicit narrow bellWidth (2) bypasses the
+	// stage-width fallback so every row stays ≤ 2 wide → no core.
+	// (Since #424 floors the un-belled fallback to
+	// minRenderedStageWidthPx = 4, a real stage can no longer produce
+	// a narrow flame this way — bellWidth stays the one path in.)
+	narrow := spacecraft.Stage{LaunchSpriteRowsPx: 4, Thrust: 1e6, FuelType: spacecraft.FuelTypeKerolox}
+	for _, p := range ComposeFlame([]spacecraft.Stage{narrow}, cmd, basis, 1.0, 1.0, 0, 2) {
 		if string(p.Color) == string(flameCoreColor) {
 			t.Errorf("narrow flame (width ≤ 2) should have no hot core")
 		}
@@ -311,11 +329,12 @@ func TestComposeFlame_FrameSwapShiftsPixels(t *testing.T) {
 
 // TestComposeLaunchSpriteUsesPerStageWidth verifies sub-scope 1 of
 // v0.11.5 silhouette polish: each stage paints a rectangle at its own
-// Stage.LaunchSpriteWidthPx width. A 4-wide stage emits 4 pixels per
-// row; a 2-wide stage emits 2 per row; a mixed-width stack composes
-// both honestly.
+// Stage.LaunchSpriteWidthPx width. A 6-wide stage emits 6 pixels per
+// row; a 2-wide stage emits 2 per row — but #424 floors the rendered
+// width at minRenderedStageWidthPx (4), so the 2-wide stage actually
+// composes at 4; a mixed-width stack composes both honestly.
 func TestComposeLaunchSpriteUsesPerStageWidth(t *testing.T) {
-	wide := spacecraft.Stage{LaunchSpriteRowsPx: 2, LaunchSpriteWidthPx: 4, Color: "#FF0000"}
+	wide := spacecraft.Stage{LaunchSpriteRowsPx: 2, LaunchSpriteWidthPx: 6, Color: "#FF0000"}
 	narrow := spacecraft.Stage{LaunchSpriteRowsPx: 2, LaunchSpriteWidthPx: 2, Color: "#00FF00"}
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
 	basis := widgets.Basis{
@@ -332,33 +351,40 @@ func TestComposeLaunchSpriteUsesPerStageWidth(t *testing.T) {
 			narrowN++
 		}
 	}
-	if got, want := wideN, 2*4; got != want {
-		t.Errorf("wide stage pixels = %d, want %d (2 rows × 4 wide)", got, want)
+	if got, want := wideN, 2*6; got != want {
+		t.Errorf("wide stage pixels = %d, want %d (2 rows × 6 wide)", got, want)
 	}
-	if got, want := narrowN, 2*2; got != want {
-		t.Errorf("narrow stage pixels = %d, want %d (2 rows × 2 wide)", got, want)
+	if got, want := narrowN, 2*minRenderedStageWidthPx; got != want {
+		t.Errorf("narrow stage pixels = %d, want %d (2 rows × floored width %d)", got, want, minRenderedStageWidthPx)
 	}
 }
 
 // TestInterStageTaperFiresAboveThreshold (v0.11.5 sub-scope 2):
 // two stages both ≥ taperThreshold rows with different widths produce
 // a synthetic 1-row band at width round((lower + upper) / 2) in the
-// lower stage's colour, sitting between the stage bodies in the stack.
+// lower stage's colour, sitting between the stage bodies in the
+// stack. Widths (6, 4) are both above the #424 rendering floor
+// (minRenderedStageWidthPx = 4) so the taper math this test exercises
+// stays independent of that floor; the boundary also grows the #424
+// stage-separator row (its own, non-lower-coloured pixel), which
+// sits ABOVE the taper.
 func TestInterStageTaperFiresAboveThreshold(t *testing.T) {
-	lower := spacecraft.Stage{LaunchSpriteRowsPx: 10, LaunchSpriteWidthPx: 4, Color: "#FF0000"}
-	upper := spacecraft.Stage{LaunchSpriteRowsPx: 10, LaunchSpriteWidthPx: 2, Color: "#00FF00"}
+	lower := spacecraft.Stage{LaunchSpriteRowsPx: 10, LaunchSpriteWidthPx: 6, Color: "#FF0000"}
+	upper := spacecraft.Stage{LaunchSpriteRowsPx: 10, LaunchSpriteWidthPx: 4, Color: "#00FF00"}
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
 	basis := widgets.Basis{
 		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{lower, upper}, cmd, basis, 1.0)
-	// Expected counts: lower body = 10×4 = 40, upper body = 10×2 = 20,
-	// taper row = round((4+2)/2) = 3 pixels in lower colour.
-	const wantTaper = 3
-	wantTotal := 10*4 + 10*2 + wantTaper
+	// Expected counts: lower body = 10×6 = 60, upper body = 10×4 = 40,
+	// taper row = round((6+4)/2) = 5 pixels in lower colour, separator
+	// row = max(6,4) = 6 pixels in the #424 separator colour.
+	const wantTaper = 5
+	const wantSep = 6
+	wantTotal := 10*6 + 10*4 + wantTaper + wantSep
 	if got := len(pixels); got != wantTotal {
-		t.Fatalf("got %d total pixels, want %d (40 lower + 20 upper + %d taper)", got, wantTotal, wantTaper)
+		t.Fatalf("got %d total pixels, want %d (60 lower + 40 upper + %d taper + %d separator)", got, wantTotal, wantTaper, wantSep)
 	}
 	// Count lower-colour pixels and find the highest-y lower pixel —
 	// that should be a taper-row pixel sitting above the lower body's
@@ -373,11 +399,12 @@ func TestInterStageTaperFiresAboveThreshold(t *testing.T) {
 			}
 		}
 	}
-	if got, want := lowerN, 10*4+wantTaper; got != want {
+	if got, want := lowerN, 10*6+wantTaper; got != want {
 		t.Errorf("lower-colour pixels = %d, want %d (body + taper)", got, want)
 	}
 	// Lower body's top row is at y = 9; taper row at y = 10. So the
-	// max lower-colour y should be at index 10 (the taper row).
+	// max lower-colour y should be at index 10 (the taper row) — the
+	// separator (y = 11, a different colour) doesn't count here.
 	if !(maxLowerY > 9.5) {
 		t.Errorf("taper must sit ABOVE the lower stage body; maxLowerY=%v, expect > 9.5", maxLowerY)
 	}
@@ -385,19 +412,23 @@ func TestInterStageTaperFiresAboveThreshold(t *testing.T) {
 
 // TestInterStageTaperSuppressedBelowThreshold (v0.11.5 sub-scope 2):
 // when one or both stages fall below taperThreshold rows the boundary
-// hard-steps — no synthetic row is inserted.
+// hard-steps — no synthetic taper row is inserted. The #424 stage
+// separator is a SEPARATE, unconditional feature (see
+// TestComposeLaunchSprite_SeparatorAtEachBoundary) and still fires
+// here regardless of the taper threshold.
 func TestInterStageTaperSuppressedBelowThreshold(t *testing.T) {
 	lower := spacecraft.Stage{LaunchSpriteRowsPx: 5, LaunchSpriteWidthPx: 4, Color: "#FF0000"} // 5 < threshold 6
-	upper := spacecraft.Stage{LaunchSpriteRowsPx: 6, LaunchSpriteWidthPx: 2, Color: "#00FF00"}
+	upper := spacecraft.Stage{LaunchSpriteRowsPx: 6, LaunchSpriteWidthPx: 5, Color: "#00FF00"}
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
 	basis := widgets.Basis{
 		X: orbital.Vec3{X: 1, Y: 0, Z: 0},
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{lower, upper}, cmd, basis, 1.0)
-	want := 5*4 + 6*2 // no taper row
+	wantSep := 5 // max(lower width 4, upper width 5)
+	want := 5*4 + 6*5 + wantSep
 	if got := len(pixels); got != want {
-		t.Errorf("got %d pixels, want %d (no taper when lower < threshold)", got, want)
+		t.Errorf("got %d pixels, want %d (no taper when lower < threshold, but the separator still fires)", got, want)
 	}
 }
 
@@ -426,11 +457,13 @@ func TestInterStageTaperColourIsLowerStage(t *testing.T) {
 }
 
 // TestEngineBellFlaresBottomStage (v0.12 Slice 4): a thrust-bearing
-// width-2 bottom stage (mouth = 4) emits a 3-row tapered bell flaring
-// from the throat (stage width 2, nearest the body) out to the mouth
-// (width 4, at the nozzle exit), all in the stage's colour, sitting
-// below the stage base. The multi-row taper replaced the v0.11.5
-// single-row flare.
+// bottom stage emits a 3-row tapered bell flaring from the throat
+// (nearest the body) out to the mouth (at the nozzle exit), all in
+// the stage's colour, sitting below the stage base. The multi-row
+// taper replaced the v0.11.5 single-row flare. Stage width is
+// authored at 2, but #424 floors every resolved stage width at
+// minRenderedStageWidthPx (4) — bell geometry goes through that same
+// resolver, so the throat here is 4, not 2 (see stageSpriteWidthPx).
 func TestEngineBellFlaresBottomStage(t *testing.T) {
 	stage := spacecraft.Stage{
 		LaunchSpriteRowsPx:  6,
@@ -438,8 +471,8 @@ func TestEngineBellFlaresBottomStage(t *testing.T) {
 		Color:               "#FF0000",
 		Thrust:              1e6,
 	}
-	if got, want := EngineBellWidth([]spacecraft.Stage{stage}), 4; got != want {
-		t.Errorf("EngineBellWidth = %d, want %d", got, want)
+	if got, want := EngineBellWidth([]spacecraft.Stage{stage}), 6; got != want {
+		t.Errorf("EngineBellWidth = %d, want %d (floored throat 4 + bellExtraWidth 2)", got, want)
 	}
 	if got, want := EngineBellRows([]spacecraft.Stage{stage}), 3; got != want {
 		t.Errorf("EngineBellRows = %d, want %d (mouth-throat ≥ 2 ⇒ tapered)", got, want)
@@ -450,9 +483,9 @@ func TestEngineBellFlaresBottomStage(t *testing.T) {
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	bell := ComposeEngineBell([]spacecraft.Stage{stage}, cmd, basis, 1.0)
-	// 3 rows: widths 2 + 3 + 4 = 9 pixels.
-	if got, want := len(bell), 9; got != want {
-		t.Fatalf("bell pixel count = %d, want %d (3 rows: 2+3+4)", got, want)
+	// 3 rows: widths 4 + 5 + 6 = 15 pixels.
+	if got, want := len(bell), 15; got != want {
+		t.Fatalf("bell pixel count = %d, want %d (3 rows: 4+5+6)", got, want)
 	}
 	// Bucket by row (y = rowAbove in this basis) → width per row.
 	widthByRow := map[int]int{}
@@ -468,8 +501,8 @@ func TestEngineBellFlaresBottomStage(t *testing.T) {
 	}
 	// Throat (y=-1, nearest the body) is narrowest; mouth (y=-3, nozzle
 	// exit) is widest — a real bell flares toward the exit.
-	if widthByRow[-1] != 2 || widthByRow[-2] != 3 || widthByRow[-3] != 4 {
-		t.Errorf("taper widths by row = %v, want {-1:2, -2:3, -3:4}", widthByRow)
+	if widthByRow[-1] != 4 || widthByRow[-2] != 5 || widthByRow[-3] != 6 {
+		t.Errorf("taper widths by row = %v, want {-1:4, -2:5, -3:6}", widthByRow)
 	}
 }
 
@@ -514,7 +547,13 @@ func TestEngineBellSuppressedNoThrust(t *testing.T) {
 
 // TestFlameColorMatchesFuelType (v0.11.5 sub-scope 4): each FuelType
 // value maps to its catalog-locked palette hex; the bottom stage's
-// FuelType drives every flame pixel's colour.
+// FuelType drives every EDGE flame pixel's colour. Since #424 floors
+// the un-belled fallback width to minRenderedStageWidthPx (4), the
+// flame's wider rows are now wide enough to resolve a two-colour
+// core (v0.12 Slice 4) — flameCoreColor pixels are expected and
+// skipped here; TestComposeFlameTwoColourCore covers the core/edge
+// split itself, this test only needs every non-core pixel to carry
+// the fuel tint.
 func TestFlameColorMatchesFuelType(t *testing.T) {
 	cases := []struct {
 		fuel string
@@ -537,11 +576,19 @@ func TestFlameColorMatchesFuelType(t *testing.T) {
 			t.Errorf("fuel=%q: expected flame pixels, got none", c.fuel)
 			continue
 		}
+		edgeSeen := false
 		for _, p := range pixels {
+			if string(p.Color) == string(flameCoreColor) {
+				continue
+			}
+			edgeSeen = true
 			if string(p.Color) != c.want {
 				t.Errorf("fuel=%q: pixel colour = %q, want %q", c.fuel, string(p.Color), c.want)
 				break
 			}
+		}
+		if !edgeSeen {
+			t.Errorf("fuel=%q: every pixel was core-coloured, no edge pixel to check", c.fuel)
 		}
 	}
 }
@@ -549,6 +596,8 @@ func TestFlameColorMatchesFuelType(t *testing.T) {
 // TestFlameFallsBackToWarningOnUnsetFuelType (v0.11.5 sub-scope 4):
 // stages without a FuelType (pre-v0.11.5 saves, RCS-tug, custom
 // stacks) keep amber `render.ColorWarning` flame — no regression.
+// Core pixels (see TestFlameColorMatchesFuelType) are skipped the
+// same way.
 func TestFlameFallsBackToWarningOnUnsetFuelType(t *testing.T) {
 	stage := spacecraft.Stage{LaunchSpriteRowsPx: 4} // FuelType unset
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
@@ -560,11 +609,19 @@ func TestFlameFallsBackToWarningOnUnsetFuelType(t *testing.T) {
 	if len(pixels) == 0 {
 		t.Fatal("expected flame pixels, got none")
 	}
+	edgeSeen := false
 	for _, p := range pixels {
+		if p.Color == flameCoreColor {
+			continue
+		}
+		edgeSeen = true
 		if p.Color != render.ColorWarning {
 			t.Errorf("unset FuelType: pixel colour = %q, want render.ColorWarning %q", string(p.Color), string(render.ColorWarning))
 			break
 		}
+	}
+	if !edgeSeen {
+		t.Error("every pixel was core-coloured, no edge pixel to check")
 	}
 }
 
@@ -881,11 +938,17 @@ func TestEngineBellInheritsLaunchSpriteColor(t *testing.T) {
 	}
 }
 
-// TestComposeLaunchSpriteDefaultsToTwoWhenWidthZero verifies the
-// pre-v0.11.5 behaviour fallback: a stage with LaunchSpriteWidthPx == 0
-// renders at defaultSpriteWidthPx (= 2), so un-catalogued and pre-
-// v0.11.5 saves keep their original 2-wide rectangle.
-func TestComposeLaunchSpriteDefaultsToTwoWhenWidthZero(t *testing.T) {
+// TestComposeLaunchSpriteWidthZeroFallsBackThenFloors verifies BOTH
+// generations of the width-resolution fallback stack: a stage with
+// LaunchSpriteWidthPx == 0 falls back to defaultSpriteWidthPx (= 2,
+// the pre-v0.11.5 universal width — un-catalogued and pre-v0.11.5
+// saves), which #424 then floors to minRenderedStageWidthPx (4) like
+// every other rendered width. Renamed from
+// …DefaultsToTwoWhenWidthZero, which is no longer literally true.
+func TestComposeLaunchSpriteWidthZeroFallsBackThenFloors(t *testing.T) {
+	if defaultSpriteWidthPx >= minRenderedStageWidthPx {
+		t.Fatalf("precondition: defaultSpriteWidthPx (%d) must be below minRenderedStageWidthPx (%d) for this test to prove the floor fires", defaultSpriteWidthPx, minRenderedStageWidthPx)
+	}
 	stage := spacecraft.Stage{LaunchSpriteRowsPx: 3, Color: "#FFD93D"} // width unset = 0
 	cmd := orbital.Vec3{X: 0, Y: 0, Z: 1}
 	basis := widgets.Basis{
@@ -893,8 +956,8 @@ func TestComposeLaunchSpriteDefaultsToTwoWhenWidthZero(t *testing.T) {
 		Y: orbital.Vec3{X: 0, Y: 0, Z: 1},
 	}
 	pixels := ComposeLaunchSprite([]spacecraft.Stage{stage}, cmd, basis, 1.0)
-	if got, want := len(pixels), 3*defaultSpriteWidthPx; got != want {
-		t.Errorf("got %d pixels, want %d (3 rows × default %d wide)", got, want, defaultSpriteWidthPx)
+	if got, want := len(pixels), 3*minRenderedStageWidthPx; got != want {
+		t.Errorf("got %d pixels, want %d (3 rows × floored width %d)", got, want, minRenderedStageWidthPx)
 	}
 }
 
@@ -940,9 +1003,11 @@ func TestComposeCanopy_SitsAboveStack(t *testing.T) {
 	if minCanopyY <= maxBodyY {
 		t.Errorf("canopy bottom (%.2f) should sit above the body top (%.2f)", minCanopyY, maxBodyY)
 	}
-	// Canopy spans wider than the 3-wide top stage body (±1 sub-pixel).
+	// Canopy spans wider than the top stage body — authored width 3,
+	// floored to minRenderedStageWidthPx (4) by #424 — by a
+	// comfortable margin either way, so this bound holds regardless.
 	if span := maxCanopyX - minCanopyX; span <= 2.0 {
-		t.Errorf("canopy width span %.2f should exceed the 3-wide stage body (2 sub-pixels)", span)
+		t.Errorf("canopy width span %.2f should exceed the top stage body (2 sub-pixels)", span)
 	}
 }
 

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -1279,6 +1279,78 @@ func (c *Canvas) projectRelBiased(rel orbital.Vec3) (int, int, bool) {
 	return px, py, true
 }
 
+// pixelEdge converts a basis-relative (world-minus-centre, already
+// dotted against one basis axis) coordinate to an integer sub-pixel
+// boundary index, applying the same tieBreakBias-guarded rounding
+// projectRelBiased uses. FillRectAnchored calls this on BOTH edges of
+// BOTH axes of every tile it fills — critically, two tiles that share a
+// real-world boundary (adjacent launch-sprite samples, spaced exactly
+// wM/hM apart by construction) compute that shared boundary by calling
+// pixelEdge on the SAME real-world coordinate, so they get the IDENTICAL
+// pixel index and tile with no gap and no overlap. Rounding each tile's
+// own half-width independently instead (centre ± round(halfWidthPx))
+// would NOT have this property: two separate roundings of two
+// expressions that are mathematically but not bit-for-bit equal can
+// disagree by a pixel, which is exactly the kind of gap this function
+// exists to rule out.
+func pixelEdge(rel, scale float64) int {
+	return int(math.Floor(rel*scale + 0.5 + tieBreakBias))
+}
+
+// FillRectAnchored fills a solid wM×hM (world metres) rectangle centred
+// at anchor+centerOffset, computed directly in the canvas's OWN
+// sub-pixel space at the CURRENT zoom — every sub-pixel the rectangle
+// covers gets lit, not just the ones a fixed-stride sample happens to
+// land on (#424 follow-up). The launch sprite plots one SpritePixel
+// sample per vesselSubPixelM (1.5 m) step; at the pad the chase-cam's
+// actual sub-pixel pitch is FINER than that stride, so plotting each
+// sample as a single point left every other sub-pixel row dark — a
+// periodic "half-lit stripe" distinct from (and found after fixing) the
+// column-tie-flipping bug PlotColoredAnchored/tieBreakBias fixed.
+// Filling each sample as its own full wM×hM tile instead reconstructs
+// the stage's true solid rectangle: adjacent samples are spaced exactly
+// wM/hM apart by construction (emitRect steps col and rowAbove by
+// exactly 1 unit = 1×pxSize), so their tiles EXACTLY ABUT via
+// pixelEdge's shared-boundary property, at any zoom — whether the
+// canvas pitch is coarser or finer than the sample stride.
+//
+// Y is flipped like Project: increasing world-Y (relY, hence increasing
+// centerOffset along basis.Y) moves the tile UP the screen (smaller py).
+// A tile is floored at 1 pixel in each dimension so a sample can never
+// vanish at a zoom where wM/hM would otherwise round to 0 sub-pixels.
+func (c *Canvas) FillRectAnchored(anchor, centerOffset orbital.Vec3, wM, hM float64, color lipgloss.Color) {
+	rel := anchor.Sub(c.centerW).Add(centerOffset)
+	relX := rel.X*c.basis.X.X + rel.Y*c.basis.X.Y + rel.Z*c.basis.X.Z
+	relY := rel.X*c.basis.Y.X + rel.Y*c.basis.Y.Y + rel.Z*c.basis.Y.Z
+
+	pxLeft := pixelEdge(relX-wM/2, c.scale) + c.pxW/2
+	pxRight := pixelEdge(relX+wM/2, c.scale) + c.pxW/2
+	if pxRight <= pxLeft {
+		pxRight = pxLeft + 1
+	}
+	// relY+hM/2 is the TOP of the tile (larger world-Y); Project maps
+	// larger relY to SMALLER py, so the top edge gives the smaller py.
+	pyTop := c.pxH/2 - pixelEdge(relY+hM/2, c.scale)
+	pyBottom := c.pxH/2 - pixelEdge(relY-hM/2, c.scale)
+	if pyBottom <= pyTop {
+		pyBottom = pyTop + 1
+	}
+
+	tag := CellTag{Color: color}
+	for py := pyTop; py < pyBottom; py++ {
+		if py < 0 || py >= c.pxH {
+			continue
+		}
+		for px := pxLeft; px < pxRight; px++ {
+			if px < 0 || px >= c.pxW {
+				continue
+			}
+			c.dc.Set(px, py)
+			c.pixelTags.set(px, py, tag)
+		}
+	}
+}
+
 // SubPixelSet reports whether the raw braille dot at sub-pixel (px, py)
 // is lit — a direct read of the underlying drawille bitmap, bypassing
 // String()'s per-cell color aggregation. Exists for tests that need to

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -696,6 +696,87 @@ func (c *Canvas) FillProjectedSphere(center orbital.Vec3, radius float64, color 
 	}
 }
 
+// HorizonBand is one solid-colour strip in a Canvas.FillHorizonBands
+// gradient: Rows sub-pixel rows painted in Color, working outward
+// from the horizon edge. v0.40 / issue #424.
+type HorizonBand struct {
+	Color lipgloss.Color
+	Rows  int
+}
+
+// FillHorizonBands paints a LIMITED horizon strip in place of
+// FillProjectedSphere's unbroken disk flood (v0.40 / issue #424, ADR
+// 0048 §4). The old flood painted the WHOLE silhouette below the
+// horizon one flat shade all the way to the far canvas edge — no
+// horizon line, no scale reference (the UX review's dump at 104×24:
+// "ten unbroken rows of identical... blocks"). This walks the SAME
+// near-flat sphere edge FillProjectedSphere uses (locally flat
+// because planet radius ≫ chase-cam distance) but only paints a
+// bounded run of rows out from that edge on each side: `ground` bands
+// work DOWN from the edge (into the body — a lit apron right at the
+// horizon, a dimmer band beneath it), `sky` bands work UP from the
+// edge (away from the body — a horizon glow fading toward open
+// space). Anything past the given bands is left untouched (terminal
+// background) — that's what turns a flood into a readable STRIP: a
+// player judges scale against the visible ground/sky edge instead of
+// an undifferentiated colour field.
+//
+// Ground bands stay clipped to the sphere's own silhouette (dy² ≤
+// pxR²) so the strip still narrows correctly as the visible arc
+// curves at altitude, matching FillProjectedSphere's existing
+// curvature behaviour. Sky bands have no silhouette to clip against —
+// they paint into open space — so only the canvas bounds gate them;
+// callers shrink the row counts themselves as altitude grows (the ADR's
+// "thins with altitude").
+func (c *Canvas) FillHorizonBands(center orbital.Vec3, radius float64, ground, sky []HorizonBand) {
+	if radius <= 0 {
+		return
+	}
+	cx, cy, _ := c.Project(center)
+	pxR := radius * c.scale
+	pxR2 := pxR * pxR
+	for px := 0; px < c.pxW; px++ {
+		dx := float64(px - cx)
+		dx2 := dx * dx
+		if dx2 > pxR2 {
+			continue // this column never reaches the sphere's edge
+		}
+		edge := float64(cy) - math.Sqrt(pxR2-dx2) // topmost "ground" row here
+
+		row := edge
+		for _, band := range ground {
+			tag := CellTag{Color: band.Color}
+			for i := 0; i < band.Rows; i++ {
+				py := int(math.Round(row))
+				row++
+				if py < 0 || py >= c.pxH {
+					continue
+				}
+				dy := float64(py) - float64(cy)
+				if dy*dy > pxR2 {
+					continue
+				}
+				c.dc.Set(px, py)
+				c.pixelTags.set(px, py, tag)
+			}
+		}
+
+		row = edge - 1
+		for _, band := range sky {
+			tag := CellTag{Color: band.Color}
+			for i := 0; i < band.Rows; i++ {
+				py := int(math.Round(row))
+				row--
+				if py < 0 || py >= c.pxH {
+					continue
+				}
+				c.dc.Set(px, py)
+				c.pixelTags.set(px, py, tag)
+			}
+		}
+	}
+}
+
 // PlotColored sets a single pixel and tags it with the given color.
 // Used by callers that want a tagged dot (e.g. v0.6.1 maneuver-leg
 // preview). v0.6.4+: routed through PlotColoredTagged so tagged

--- a/internal/tui/widgets/canvas.go
+++ b/internal/tui/widgets/canvas.go
@@ -1163,11 +1163,13 @@ func (c *Canvas) ZoomBy(factor float64) {
 	}
 }
 
-// Project converts a world-frame inertial Vec3 to integer pixel coords.
-// Y is flipped so increasing world-Y visually points up. Returns the
-// pixel location and ok=false if the point is off-canvas.
-func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
-	rel := w.Sub(c.centerW)
+// projectRel converts an ALREADY-relative (world-minus-centre) vector to
+// integer pixel coordinates — the shared tail of Project and
+// PlotColoredAnchored. Project computes rel = w.Sub(c.centerW) and hands
+// it here; PlotColoredAnchored computes its own relative vector WITHOUT
+// ever forming an absolute world point (anchor.Add(offset)) first — see
+// that method's doc comment for why the distinction matters.
+func (c *Canvas) projectRel(rel orbital.Vec3) (int, int, bool) {
 	relX := rel.X*c.basis.X.X + rel.Y*c.basis.X.Y + rel.Z*c.basis.X.Z
 	relY := rel.X*c.basis.Y.X + rel.Y*c.basis.Y.Y + rel.Z*c.basis.Y.Z
 	px := int(math.Round(relX*c.scale)) + c.pxW/2
@@ -1176,6 +1178,115 @@ func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
 		return px, py, false
 	}
 	return px, py, true
+}
+
+// Project converts a world-frame inertial Vec3 to integer pixel coords.
+// Y is flipped so increasing world-Y visually points up. Returns the
+// pixel location and ok=false if the point is off-canvas.
+func (c *Canvas) Project(w orbital.Vec3) (int, int, bool) {
+	return c.projectRel(w.Sub(c.centerW))
+}
+
+// PlotColoredAnchored plots a pixel at anchor+offset — e.g. a launch
+// sprite pixel, where `anchor` is the vessel's world position and
+// `offset` is the sprite's small (metre-scale) sub-pixel displacement
+// from it. Numerically DIFFERENT from
+// `PlotColored(anchor.Add(offset), color)`, and deliberately so (#424
+// follow-up): that call forms an absolute world point by adding a tiny
+// offset (~1.5 m) onto a large-magnitude world coordinate (a body-
+// relative launch anchor is ~10^6 m), then Project immediately subtracts
+// the SAME large coordinate back off via w.Sub(c.centerW). IEEE754
+// float64 addition-then-subtraction of a large value does not always
+// recover a small operand bit-for-bit — the residual noise is only
+// ~10^-10 m, negligible for most offsets, but when the offset's exact
+// projected value lands precisely on a X.5 sub-pixel tie (the sprite's
+// width-axis offsets are literally half-integer multiples of
+// vesselSubPixelM for even xPx — see stackDirScreen/emitRect in
+// launch_sprite.go), that noise is enough to flip which side of the tie
+// math.Round lands on, independently per row (each row's full 3D offset
+// differs, so the residual differs) — reproducing the exact "half-lit
+// column that changes pattern every row" aliasing #424 reported, even
+// with the vessel standing bit-exact vertical (angle-off-vertical =
+// 0.000000°, confirmed by TestRealLaunchView_SIC_ColumnsAreSolid before
+// this fix). Computing `anchor.Sub(c.centerW).Add(offset)` instead never
+// forms that absolute point: when anchor == c.centerW (the common case —
+// the active vessel's own sprite, anchored at the same point the canvas
+// is centred on) the subtraction is EXACTLY the zero vector per IEEE754
+// (a-a==0 for any finite a, no rounding possible), so the projected
+// value is `offset` untouched — exact, no tie-flipping. For a passive
+// vessel anchored elsewhere, anchor and c.centerW are both body-relative
+// (similar magnitude), so their subtraction is well-conditioned (nearby
+// same-magnitude values subtract cleanly), and the noise is bounded by
+// that ONE subtraction rather than compounding through an add-then-
+// re-subtract round trip per pixel.
+func (c *Canvas) PlotColoredAnchored(anchor, offset orbital.Vec3, color lipgloss.Color) {
+	rel := anchor.Sub(c.centerW).Add(offset)
+	if px, py, ok := c.projectRelBiased(rel); ok {
+		c.dc.Set(px, py)
+		c.pixelTags.set(px, py, CellTag{Color: color})
+	}
+}
+
+// ProjectAnchored is PlotColoredAnchored's read-only twin: the same
+// numerically-stable anchor+offset projection, without plotting.
+// Callers that need to know WHERE an anchored sprite pixel would land
+// (tests verifying column solidity against the real render path,
+// future hit-testing) use this instead of reconstructing
+// `Project(anchor.Add(offset))`, which reintroduces the precision
+// round trip PlotColoredAnchored's doc comment describes.
+func (c *Canvas) ProjectAnchored(anchor, offset orbital.Vec3) (int, int, bool) {
+	return c.projectRelBiased(anchor.Sub(c.centerW).Add(offset))
+}
+
+// tieBreakBias (#424 follow-up) is added before rounding in
+// projectRelBiased so a value that lands almost exactly on a X.5
+// sub-pixel tie resolves the SAME way every time, regardless of which
+// side of the tie a few ULPs of floating-point noise happen to land on.
+// That noise is real and unavoidable: a launch sprite's per-pixel
+// OffsetWorld is composed as `basis.X.Scale(a).Add(basis.Y.Scale(b))`
+// and later decomposed back via a dot product against basis.X/basis.Y —
+// exact only if basis.X and basis.Y are orthonormal to full float64
+// precision, which a chase-cam basis DERIVED from real-world velocity /
+// radial vectors is not (residual cross-terms measured at 10⁻¹⁶–10⁻¹⁵,
+// growing slightly with the offset's magnitude along the OTHER basis
+// axis — a taller sprite row has more of this leakage). Two rows of the
+// same stage share the identical intended sub-pixel column (their
+// width-axis offset is the same xPx·pxSize), but when that shared value
+// is EXACTLY a half-integer number of sub-pixels (routine — see
+// emitRect in launch_sprite.go, where an even sprite width or a
+// non-integer vesselSubPixelM stride both produce this), the decode
+// noise is enough to flip math.Round's outcome independently per row —
+// reproducing #424's "half-lit column that changes pattern every row"
+// even with the stack axis bit-exact vertical. tieBreakBias (10⁻⁹) is
+// four to five orders of magnitude larger than the measured noise but
+// nine orders of magnitude smaller than one sub-pixel, so it cannot
+// move any position that ISN'T already within a hair of an exact tie.
+const tieBreakBias = 1e-9
+
+// projectRelBiased is projectRel with tieBreakBias applied before
+// rounding — see tieBreakBias's doc comment. Used only by the anchored
+// sprite-plotting path (PlotColoredAnchored / ProjectAnchored); Project
+// and everything built on it keep the plain, unbiased rounding so this
+// fix's blast radius stays inside the launch sprite it was written for.
+func (c *Canvas) projectRelBiased(rel orbital.Vec3) (int, int, bool) {
+	relX := rel.X*c.basis.X.X + rel.Y*c.basis.X.Y + rel.Z*c.basis.X.Z
+	relY := rel.X*c.basis.Y.X + rel.Y*c.basis.Y.Y + rel.Z*c.basis.Y.Z
+	px := int(math.Floor(relX*c.scale+0.5+tieBreakBias)) + c.pxW/2
+	py := c.pxH/2 - int(math.Floor(relY*c.scale+0.5+tieBreakBias))
+	if px < 0 || px >= c.pxW || py < 0 || py >= c.pxH {
+		return px, py, false
+	}
+	return px, py, true
+}
+
+// SubPixelSet reports whether the raw braille dot at sub-pixel (px, py)
+// is lit — a direct read of the underlying drawille bitmap, bypassing
+// String()'s per-cell color aggregation. Exists for tests that need to
+// confirm actual rendered dot state (not just "what would Project
+// compute"), e.g. verifying a launch sprite's columns are genuinely
+// solid in the canvas that was actually drawn to.
+func (c *Canvas) SubPixelSet(px, py int) bool {
+	return c.dc.Get(px, py)
 }
 
 // ProjectClamped is Project with the result pinned inside the canvas


### PR DESCRIPTION
Closes #424

## Summary

Fixes ADR 0048 §4 (all 5 items): the Saturn V on the pad rendered as
scattered braille "TV static" on a flat green wall.

Root cause: `ComposeLaunchSprite`'s stack axis was never snapped to exactly
vertical, so a fraction of a degree of physics jitter bled a row-dependent
horizontal term into every plotted sub-pixel. `Canvas.Project` rounds each
pixel independently, so rows a few sub-pixels apart rounded to *different*
absolute columns — the scattered-glyph read the issue described. This is a
real per-render numerical aliasing bug, not just a palette problem.

- **Axis snap**: `snapNearVertical` forces the stack direction to exactly
  (0, ±1) within ~2.5° of vertical, wired through the one shared
  `stackDirScreen` resolver every sprite feature (body/bell/legs/flame/
  canopy) uses — one renderer, no glyph-sprite switch. Off-cone attitudes
  are untouched.
- **Minimum width**: every rendered stage width floors at 4 sub-pixel
  columns (2 cells).
- **Stage separators**: an unconditional dark row at every stage boundary,
  independent of the existing height-gated inter-stage taper.
- **Colour spread**: widened the near-white palette wherever adjacent
  stages/parts computed under ~20 luminance levels apart (Saturn V, Apollo
  Stack, Kern Stack, Vector V, Raster Launch System, Socket Lander,
  Lander). Full before/after table in the notes file linked below.
- **Ground/sky**: replaced the unbounded green flood-fill with a bounded
  ~2.5-cell horizon strip (bright apron + dim band) and a 2-step sky band
  that shrinks to nothing as altitude approaches the atmosphere's cutoff
  (airless bodies get no sky band — already correct). Launch tower
  recoloured to a distinct hue from the vehicle body tones.

Full write-up (root cause derivation, colour luminance table, verified
before/after colour-code evidence, the "not vacuous" check on the new
tests): `designdocs/terminal-space-program/ux-reviews/20260902-1059/triage/impl-notes/424.md`

## Test plan

`go vet ./...` — clean.

`go test ./... -race -count=1` — all packages pass:

```
ok  	github.com/jasonfen/terminal-space-program/cmd/terminal-space-program	1.243s
ok  	github.com/jasonfen/terminal-space-program/internal/bodies	1.271s
ok  	github.com/jasonfen/terminal-space-program/internal/keylayout	1.165s
ok  	github.com/jasonfen/terminal-space-program/internal/missions	1.148s
ok  	github.com/jasonfen/terminal-space-program/internal/orbital	1.189s
ok  	github.com/jasonfen/terminal-space-program/internal/physics	1.180s
ok  	github.com/jasonfen/terminal-space-program/internal/planner	1.109s
ok  	github.com/jasonfen/terminal-space-program/internal/relay	1.892s
ok  	github.com/jasonfen/terminal-space-program/internal/render	1.260s
ok  	github.com/jasonfen/terminal-space-program/internal/save	3.216s
ok  	github.com/jasonfen/terminal-space-program/internal/serve	14.993s
ok  	github.com/jasonfen/terminal-space-program/internal/sessiondir	2.142s
ok  	github.com/jasonfen/terminal-space-program/internal/settings	1.093s
ok  	github.com/jasonfen/terminal-space-program/internal/sim	43.867s
ok  	github.com/jasonfen/terminal-space-program/internal/spacecraft	1.311s
ok  	github.com/jasonfen/terminal-space-program/internal/tui	5.635s
ok  	github.com/jasonfen/terminal-space-program/internal/tui/screens	33.043s
ok  	github.com/jasonfen/terminal-space-program/internal/tui/widgets	1.563s
```

New TDD regression tests (`launch_sprite_snap_test.go`):
- `TestSnapNearVertical_WithinToleranceSnapsExact` / `_BeyondToleranceKeepsRawDirection` at 0°/1.5°/3°/10°
- `TestComposeLaunchSprite_NearVerticalColumnsAreSolid` — rasterises through a real `widgets.Canvas.Project` at pad-launch scale and asserts every row of a column lands on the identical canvas sub-pixel column
- `TestComposeLaunchSprite_OffVerticalKeepsOriginalRasteriser` — proves 3°/10° attitudes still use the raw, unsnapped, row-drifting rasteriser
- `TestStageSpriteWidthPx_FloorsBelowMinimum`, `TestComposeLaunchSprite_SeparatorAtEachBoundary`

Verified the solid-columns test is not vacuous: temporarily bypassed the
snap (reverted immediately) and reran it — it failed with the expected
column-drift error at 1.5°, passed again after restoring the fix.

Manual render-and-look at 140×40 (`n` → POSITION → launchpad → Saturn V →
Enter, captured at T+2s; then `z` `b` `>`×3 and captured mid-ascent),
before built from an unmodified `main` clone and after from this branch.
Verified by extracting the actual truecolor SGR codes per row (glyph
shapes alone are misleading here — the navball widget is *also* a large
solid-braille circle, unrelated to this fix, and dominates a plain-text
diff):

- Ground fill: `rgb(107,142,78)` (old flat green) painted every row from
  the horizon to the bottom of the canvas before; after, the darkened
  ground band only appears for 2 rows, then nothing.
- New sky bands (`rgb(157,200,255)` / `rgb(71,89,115)`, derived from
  Earth's atmosphere haze colour) appear only after the fix.
- Stage colours moved to the new spread (`rgb(199,209,217)` /
  `rgb(240,234,214)` / `rgb(140,144,150)` replacing the old near-identical
  greys).
- The tower recoloured to `rgb(110,124,140)`, and the stage-separator
  colour (`rgb(95,95,95)`, `render.ColorDim`) now appears at exactly the 2
  stage boundaries of the 3-stage Saturn V instead of scattered across the
  tower's own height.

### On the pad, before (main)

```
LAUNCH — Saturn V-1
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│╭───────────────────────────────────────╮⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠔⡭⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀╭─────────────────────╮│
││VESSEL  Saturn V-1                     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡣⢚⠄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ORBIT                ││
││  fuel: 100% (2160000 kg)  Δv: 3518 m/s│⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣭⢨⡃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│  altitude:  500.0 km││
│╰───────────────────────────────────────╯⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡭⢬⠅⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│  Ap:        500.0 km││
│╭─────────────────────────────────╮⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣚⠰⡃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││SURFACE                          │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣝⢪⡅╤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││  altitude:   0 m                │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣮⠰⡅⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
```
(full 40-line captures at `424-before-140x40.txt` / `.ansi`, `424-before-tipped-140x40.txt` / `.ansi` in the notes directory)

### On the pad, after (this branch)

```
LAUNCH — Saturn V-1
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│╭───────────────────────────────────────╮⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢮⢨⠅⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││VESSEL  Saturn V-1                     │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡳⠰⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││  fuel: 100% (2160000 kg)  Δv: 3518 m/s│⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣭⢘⡃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
│╰───────────────────────────────────────╯⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠶⢬⡅⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
│╭─────────────────────────────────╮⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢟⢐⠆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││SURFACE                          │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣛⢪⡃╤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
││  altitude:   0 m                │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣵⠰⠅⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│
```
(full captures: `424-after-140x40.txt` / `.ansi`, `424-after-tipped-140x40.txt` / `.ansi`)

## Scope / fence

Kept every hunk inside the sprite/ground/sky drawing code
(`launch_sprite.go`, `canvas.go`'s new `FillHorizonBands` addition,
`launch.go`'s `drawHorizonAndFill`/`drawLaunchTower`/one call-site edit in
`renderScene`) plus loadout colour data. Did not touch chips, the title
bar, announcements, or `orbit_*.go` — sibling #427's territory (same
launch view, per the issue's sequencing note).
