### PR TITLE
Flight School: five rungs, Moon-gated credit, e: row, ladder lists and sendoff (#426)

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -33,6 +33,7 @@ behind a one-row `▸ +N hidden` marker rather than overlap each other.
   - [Porkchop plot (`P`)](#porkchop-plot-p)
   - [Meeting Planner (`K`)](#meeting-planner-k)
   - [Vehicle Assembly Building](#vehicle-assembly-building-esc--build-vab)
+  - [Missions ladder (`M`)](#missions-ladder-m)
   - [Saves](#saves-esc--save-game--load-game)
 
 ## Quick tour
@@ -430,6 +431,20 @@ Designs are stored as portable files under
 `$XDG_CONFIG_HOME/terminal-space-program/designs/` (typically
 `~/.config/terminal-space-program/designs/`); copy one into the sibling
 `loadouts/` overlay dir to share it as a mod.
+
+### Missions ladder (`M`)
+
+The active mission (if any) shows as a checklist card on top; below it, two
+headed lists — **Flight School** and **Challenges** — each with their own
+progress count. A locked rung is dimmed with what unlocks it; an available
+rung reads bright; completed and failed rungs are marked. A program that's
+switched off shows a one-key toggle in place of its list.
+
+| Key | Action |
+|---|---|
+| `1` | Turn on Flight School (shown only while it's off) |
+| `2` | Turn on the Challenge ladder (shown only while it's off) |
+| `Esc` | Back to the map |
 
 ### Saves (`Esc → [Save Game]` / `[Load Game]`)
 

--- a/internal/missions/catalog_integrity_test.go
+++ b/internal/missions/catalog_integrity_test.go
@@ -88,3 +88,29 @@ func TestEmbeddedCatalogIntegrity(t *testing.T) {
 		}
 	}
 }
+
+// TestCatalogHasNoCrossProgramRequiresEdge — #426: the two Programs toggle
+// independently (a player can run Flight School without the Challenge
+// ladder, or vice versa), so a challenge rung must never require a tutorial
+// rung (or the reverse) — that would silently strand it behind a Program
+// the player switched off. chal-dock in particular used to require
+// chal-luna-return; it's now a root rung specifically because Flight
+// School teaches docking itself.
+func TestCatalogHasNoCrossProgramRequiresEdge(t *testing.T) {
+	cat, err := DefaultCatalog()
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	programByID := make(map[string]string, len(cat.Missions))
+	for _, m := range cat.Missions {
+		programByID[m.ID] = m.Program
+	}
+	for _, m := range cat.Missions {
+		for _, req := range m.Requires {
+			if reqProgram := programByID[req]; reqProgram != "" && reqProgram != m.Program {
+				t.Errorf("mission %q (program %q) requires %q (program %q) — a mission must never require one from a different program",
+					m.ID, m.Program, req, reqProgram)
+			}
+		}
+	}
+}

--- a/internal/missions/event_gates_test.go
+++ b/internal/missions/event_gates_test.go
@@ -1,0 +1,130 @@
+package missions
+
+import "testing"
+
+// #426 (Flight School content): extends the event objective family with
+// optional gates checked at the moment the Action fired, so a control-
+// teaching step can require more than "the key was pressed at all" — the
+// UX review's finding that pressing [t] once, landing on Mercury, still
+// credited "aim for the Moon".
+
+// TestEventRequireTargetBodyIDGatesOnBoundTarget — cycle_target only credits
+// when the bound Target is the named body, not the first press.
+func TestEventRequireTargetBodyIDGatesOnBoundTarget(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionCycleTarget, RequireTargetBodyID: "moon"}}
+
+	// First press lands on Mercury: action fired, but the bound target isn't
+	// the Moon — must NOT credit.
+	got := o.Evaluate(EvalContext{RecentActions: []Action{ActionCycleTarget}, TargetBodyID: "mercury"})
+	if got != InProgress {
+		t.Fatalf("cycle_target to Mercury: got %v, want InProgress", got)
+	}
+
+	// A later press lands on the Moon: now it credits.
+	got = o.Evaluate(EvalContext{RecentActions: []Action{ActionCycleTarget}, TargetBodyID: "moon"})
+	if got != Passed {
+		t.Fatalf("cycle_target to Moon: got %v, want Passed", got)
+	}
+}
+
+// TestEventRequireTargetBodyIDNoActionStillGated — the action must ALSO have
+// fired; simply having the Moon bound already (with no press this tick)
+// must not credit.
+func TestEventRequireTargetBodyIDNoActionStillGated(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionCycleTarget, RequireTargetBodyID: "moon"}}
+	got := o.Evaluate(EvalContext{TargetBodyID: "moon"})
+	if got != InProgress {
+		t.Fatalf("Moon bound but no cycle_target action fired: got %v, want InProgress", got)
+	}
+}
+
+// TestEventRequireBudgetOKGatesOnOverBudgetNode — plan_transfer only credits
+// when no planted node is over budget (ADR 0047 §2). An over-budget plan
+// still plants (warn-and-allow); it just doesn't teach "you can afford
+// this."
+func TestEventRequireBudgetOKGatesOnOverBudgetNode(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{
+		Action:              ActionPlanTransfer,
+		RequireTargetBodyID: "moon",
+		RequireBudgetOK:     true,
+	}}
+
+	// Planted a 7431 m/s transfer against a 5910 m/s budget (the issue's own
+	// numbers) — over budget, must NOT credit even though it's aimed at the Moon.
+	got := o.Evaluate(EvalContext{
+		RecentActions:     []Action{ActionPlanTransfer},
+		TargetBodyID:      "moon",
+		HasOverBudgetNode: true,
+	})
+	if got != InProgress {
+		t.Fatalf("over-budget Moon transfer: got %v, want InProgress", got)
+	}
+
+	// An affordable Moon transfer credits.
+	got = o.Evaluate(EvalContext{
+		RecentActions:     []Action{ActionPlanTransfer},
+		TargetBodyID:      "moon",
+		HasOverBudgetNode: false,
+	})
+	if got != Passed {
+		t.Fatalf("affordable Moon transfer: got %v, want Passed", got)
+	}
+}
+
+// TestEventRequireTargetBodyIDRejectsNonMoonEvenAffordable — a transfer
+// planted at a body other than the Moon (even a perfectly affordable one)
+// must not credit "plant a transfer to the Moon."
+func TestEventRequireTargetBodyIDRejectsNonMoonEvenAffordable(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{
+		Action:              ActionPlanTransfer,
+		RequireTargetBodyID: "moon",
+		RequireBudgetOK:     true,
+	}}
+	got := o.Evaluate(EvalContext{
+		RecentActions:     []Action{ActionPlanTransfer},
+		TargetBodyID:      "mercury",
+		HasOverBudgetNode: false,
+	})
+	if got != InProgress {
+		t.Fatalf("affordable Mercury transfer: got %v, want InProgress (not the Moon)", got)
+	}
+}
+
+// TestEventRequireSpawnLocationPad — spawn_craft only credits "spawn on the
+// pad" when the newly-active (spawned) craft's OnPad flag is true.
+func TestEventRequireSpawnLocationPad(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionSpawnCraft, RequireSpawnLocation: "pad"}}
+
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionSpawnCraft}, OnPad: false}); got != InProgress {
+		t.Fatalf("spawned in orbit: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionSpawnCraft}, OnPad: true}); got != Passed {
+		t.Fatalf("spawned on pad: got %v, want Passed", got)
+	}
+}
+
+// TestEventRequireSpawnLocationOrbit — the inverse gate for tut-dock's
+// "spawn a partner IN ORBIT" step.
+func TestEventRequireSpawnLocationOrbit(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionSpawnCraft, RequireSpawnLocation: "orbit"}}
+
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionSpawnCraft}, OnPad: true}); got != InProgress {
+		t.Fatalf("spawned on pad: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionSpawnCraft}, OnPad: false}); got != Passed {
+		t.Fatalf("spawned in orbit: got %v, want Passed", got)
+	}
+}
+
+// TestEventRequireTargetCraftGatesOnCraftTarget — tut-dock's "target it"
+// step only credits when the bound Target is a craft, not a body.
+func TestEventRequireTargetCraftGatesOnCraftTarget(t *testing.T) {
+	o := Objective{Kind: KindEvent, Params: Params{Action: ActionCycleTarget, RequireTargetCraft: true}}
+
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionCycleTarget}, TargetIsCraft: false}); got != InProgress {
+		t.Fatalf("target is a body: got %v, want InProgress", got)
+	}
+	if got := o.Evaluate(EvalContext{RecentActions: []Action{ActionCycleTarget}, TargetIsCraft: true}); got != Passed {
+		t.Fatalf("target is a craft: got %v, want Passed", got)
+	}
+}

--- a/internal/missions/missions.go
+++ b/internal/missions/missions.go
@@ -224,6 +224,41 @@ type Params struct {
 	// MinRelays is the number of connected relay-antenna craft
 	// KindRelayCoverage requires (ADR 0027). v0.23+.
 	MinRelays int `json:"min_relays,omitempty"`
+
+	// The following four fields are optional gates on a KindEvent
+	// objective's Action match (#426, Flight School content). All are
+	// checked only in the same tick the Action itself matched — none of
+	// them substitute for the Action match, they narrow it — so a
+	// misconfigured gate with no Action can never pass. Added to teach
+	// controls precisely rather than crediting the first press: the UX
+	// review found that "aim for the Moon" credited the first `t` press
+	// (landing on Mercury), and "plant a transfer" credited an unflyable,
+	// unaffordable plan.
+
+	// RequireTargetBodyID, when set, requires the EvalContext's currently-
+	// bound Target to be a body with this catalog ID at the moment the
+	// Action fired (e.g. "moon" for tut-orient's target-cycle step and
+	// tut-plan's transfer-plant step).
+	RequireTargetBodyID string `json:"require_target_body_id,omitempty"`
+
+	// RequireTargetCraft, when true, requires the EvalContext's currently-
+	// bound Target to be a craft (any craft) at the moment the Action
+	// fired — tut-dock's "target it" step.
+	RequireTargetCraft bool `json:"require_target_craft,omitempty"`
+
+	// RequireBudgetOK, when true, requires that none of the active craft's
+	// currently-planted nodes are an Over-budget Node (ADR 0047 §2) at the
+	// moment the Action fired — tut-plan's "plant a transfer you can
+	// actually afford" step. An over-budget plant still plants (ADR 0047
+	// warn-and-allow); it just earns no credit here.
+	RequireBudgetOK bool `json:"require_budget_ok,omitempty"`
+
+	// RequireSpawnLocation, when set, gates a spawn_craft Action match on
+	// where the newly-spawned (and now active) craft ended up: "pad"
+	// requires OnPad true (tut-launch's "spawn on the launchpad"), "orbit"
+	// requires OnPad false (tut-dock's "spawn a partner in orbit"). Empty
+	// imposes no constraint.
+	RequireSpawnLocation string `json:"require_spawn_location,omitempty"`
 }
 
 // Objective is the atomic pass/fail predicate (the pre-v0.21 Mission).
@@ -319,6 +354,30 @@ type EvalContext struct {
 	// slate currently do. Read by the coverage objectives.
 	ActiveConnected     bool
 	ConnectedRelayCount int
+
+	// The following four fields back the KindEvent Require* gates (#426,
+	// Flight School content). All are snapshotted from World.Target /
+	// ActiveCraft at eval time — the same tick a gated Action fired, since
+	// nothing moves the target or re-plants a node between the UI action and
+	// the next mission-eval tick.
+
+	// TargetBodyID is the catalog ID of the body currently bound as
+	// World.Target, or "" when the bound Target isn't a body (none, a craft,
+	// or a site). Read by RequireTargetBodyID.
+	TargetBodyID string
+	// TargetIsCraft is whether World.Target is currently bound to a craft
+	// (any craft, resolved or not — unlike HasTargetCraft above, which also
+	// requires the target to resolve to a live relative state for the
+	// Rendezvous kind). Read by RequireTargetCraft.
+	TargetIsCraft bool
+	// HasOverBudgetNode is whether ANY node currently planted on the active
+	// craft is an Over-budget Node (ADR 0047 §2, via ManeuverNode.OverBudget
+	// — the missions package doesn't import spacecraft, so this is computed
+	// by the caller). Read by RequireBudgetOK.
+	HasOverBudgetNode bool
+	// OnPad is the active craft's OnPad flag (true between a launchpad spawn
+	// and first liftoff). Read by RequireSpawnLocation.
+	OnPad bool
 }
 
 // Evaluate steps the objective one tick and returns the new status.
@@ -401,20 +460,46 @@ func evalEstablishContact(p Params, ctx EvalContext) Status {
 
 // evalEvent: pass when the objective's Action appears in the since-last-tick
 // action sink (ctx.RecentActions) — i.e. the player triggered that semantic
-// gameplay verb during this tick window. Because the sim drains the sink each
-// tick and Mission ordering only evaluates an objective while it is active, a
-// match here means the action fired while the objective was InProgress. A
-// missing Action param is inert (never matches). v0.21+ (ADR 0025 §6).
+// gameplay verb during this tick window — AND every optional Require* gate
+// the objective declares is also satisfied at that same moment (#426). Because
+// the sim drains the sink each tick and Mission ordering only evaluates an
+// objective while it is active, a match here means the action fired while the
+// objective was InProgress. A missing Action param is inert (never matches).
+// v0.21+ (ADR 0025 §6); Require* gates added #426.
 func evalEvent(p Params, ctx EvalContext) Status {
 	if p.Action == "" {
 		return InProgress
 	}
+	matched := false
 	for _, a := range ctx.RecentActions {
 		if a == p.Action {
-			return Passed
+			matched = true
+			break
 		}
 	}
-	return InProgress
+	if !matched {
+		return InProgress
+	}
+	if p.RequireTargetBodyID != "" && ctx.TargetBodyID != p.RequireTargetBodyID {
+		return InProgress
+	}
+	if p.RequireTargetCraft && !ctx.TargetIsCraft {
+		return InProgress
+	}
+	if p.RequireBudgetOK && ctx.HasOverBudgetNode {
+		return InProgress
+	}
+	switch p.RequireSpawnLocation {
+	case "pad":
+		if !ctx.OnPad {
+			return InProgress
+		}
+	case "orbit":
+		if ctx.OnPad {
+			return InProgress
+		}
+	}
+	return Passed
 }
 
 // failOnTriggered reports whether any of the objective's declared fail

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -266,7 +266,7 @@
       "objectives": [
         {
           "name": "Circular orbit at 800 km",
-          "description": "Fly your carrier into a near-circular orbit at ~800 km altitude.",
+          "description": "Fly your carrier into a near-circular orbit at ~800 km altitude (e ≤ 0.05).",
           "kind": "circularize",
           "params": {
             "primary_id": "earth",

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -13,10 +13,10 @@
           "params": { "action": "cycle_view" }
         },
         {
-          "name": "Pick a target",
-          "description": "Press [t] to cycle the target slot — aim for the Moon. [T] clears it.",
+          "name": "Aim for the Moon",
+          "description": "Press [t] to cycle the target slot until TARGET reads Moon. [T] clears it.",
           "kind": "event",
-          "params": { "action": "cycle_target" }
+          "params": { "action": "cycle_target", "require_target_body_id": "moon" }
         }
       ]
     },
@@ -34,10 +34,14 @@
           "params": { "action": "open_maneuver" }
         },
         {
-          "name": "Plant a transfer",
-          "description": "With the Moon targeted, press [H] to plant a transfer burn toward it.",
+          "name": "Plant a transfer to the Moon",
+          "description": "With the Moon targeted, press [H] to plant a transfer you can afford.",
           "kind": "event",
-          "params": { "action": "plan_transfer" }
+          "params": {
+            "action": "plan_transfer",
+            "require_target_body_id": "moon",
+            "require_budget_ok": true
+          }
         }
       ]
     },
@@ -53,6 +57,84 @@
           "description": "Warp to your burn ([G]) or fire manually ([b]) and raise your altitude past 700 km.",
           "kind": "reach_altitude",
           "params": { "primary_id": "earth", "min_altitude_m": 700000 }
+        }
+      ]
+    },
+    {
+      "id": "tut-launch",
+      "name": "Flight School: Off the Pad",
+      "description": "Launch a Saturn V from the pad and fly it to orbit.",
+      "program": "tutorial",
+      "requires": ["tut-fly"],
+      "objectives": [
+        {
+          "name": "Spawn on the pad",
+          "description": "Press [n], pick Saturn V, and set position to launchpad.",
+          "kind": "event",
+          "params": { "action": "spawn_craft", "require_spawn_location": "pad" }
+        },
+        {
+          "name": "Throttle up",
+          "description": "Press [z] to throttle up to 100%.",
+          "kind": "event",
+          "params": { "action": "throttle_full" }
+        },
+        {
+          "name": "Stage to lift off",
+          "description": "Press [space] to drop the clamps and light the engine.",
+          "kind": "event",
+          "params": { "action": "stage" }
+        },
+        {
+          "name": "Pitch east",
+          "description": "Above 10 km, pitch east with [W] and hold it through the turn.",
+          "kind": "reach_altitude",
+          "params": { "primary_id": "earth", "min_altitude_m": 10000 }
+        },
+        {
+          "name": "Plan the circularising burn",
+          "description": "At ORBIT READY, press [C] to plant the circularising burn.",
+          "kind": "event",
+          "params": { "action": "plan_circularize" }
+        },
+        {
+          "name": "Fly the burn and make orbit",
+          "description": "Warp to the node or fire it manually — settle into orbit.",
+          "kind": "circularize_from_pad",
+          "params": { "primary_id": "earth", "min_periapsis_alt_m": 200000 }
+        }
+      ]
+    },
+    {
+      "id": "tut-dock",
+      "name": "Flight School: Meet & Dock",
+      "description": "Rendezvous with a partner vessel and dock.",
+      "program": "tutorial",
+      "requires": ["tut-launch"],
+      "objectives": [
+        {
+          "name": "Spawn a partner in orbit",
+          "description": "Press [n] to spawn a second vessel in orbit to rendezvous with.",
+          "kind": "event",
+          "params": { "action": "spawn_craft", "require_spawn_location": "orbit" }
+        },
+        {
+          "name": "Target it",
+          "description": "Press [t] to cycle the target slot until TARGET shows the other vessel.",
+          "kind": "event",
+          "params": { "action": "cycle_target", "require_target_craft": true }
+        },
+        {
+          "name": "Plant the meeting burn",
+          "description": "Press [K] to plant a burn toward it.",
+          "kind": "event",
+          "params": { "action": "plan_rendezvous" }
+        },
+        {
+          "name": "Close in and dock",
+          "description": "Match up and dock the two vessels.",
+          "kind": "dock",
+          "params": {}
         }
       ]
     },
@@ -131,7 +213,6 @@
       "name": "Rendezvous & Dock",
       "description": "Bring two vessels together and dock them.",
       "program": "challenge",
-      "requires": ["chal-luna-return"],
       "objectives": [
         {
           "name": "Spawn a partner",
@@ -152,7 +233,7 @@
       "name": "Mars Flyby",
       "description": "Leave Earth's neighbourhood — fly past Mars.",
       "program": "challenge",
-      "requires": ["chal-dock"],
+      "requires": ["chal-luna-capture"],
       "objectives": [
         {
           "name": "Enter Mars' SOI",

--- a/internal/sim/mission_catalog_progression_test.go
+++ b/internal/sim/mission_catalog_progression_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
 // TestEmbeddedTutorialProgression is the automated proxy for playtesting the
-// v0.21 Slice 6 catalog: it drives the seeded tutorial through its intended
-// semantic actions + the requires gating and asserts each rung advances in
-// order, ending with the first challenge surfaced as active. This pins the
-// Slice-6 done-criterion ("a new player can complete the tutorial") so a
-// future catalog edit that strands a rung fails loudly.
+// Flight School catalog (#426, five rungs: tut-orient, tut-plan, tut-fly,
+// tut-launch, tut-dock): it drives the seeded tutorial through its intended
+// semantic actions + world state via the real evaluator and asserts each
+// rung advances in order, ending with the ladder complete. Along the way it
+// pins the two refusals the UX review's own evidence flagged: a target-cycle
+// press that lands on Mercury does NOT credit "aim for the Moon", and an
+// over-budget or non-Moon transfer does NOT credit "plant a transfer".
 func TestEmbeddedTutorialProgression(t *testing.T) {
 	w, err := NewWorld()
 	if err != nil {
@@ -40,44 +43,128 @@ func TestEmbeddedTutorialProgression(t *testing.T) {
 		w.RecordAction(a)
 		w.evaluateMissions()
 	}
+	moonIdx := findBodyIdx(t, w, "moon")
+	mercuryIdx := findBodyIdx(t, w, "mercury")
 
 	// The opening active rung is the first tutorial step.
 	if am := w.ActiveMission(); am == nil || am.ID != "tut-orient" {
 		t.Fatalf("opening active mission = %v, want tut-orient", am)
 	}
 
-	// tut-orient: change view, then target.
+	// tut-orient objective 1: change view.
 	step(missions.ActionCycleView)
+
+	// REFUSAL 1 (issue #426 evidence): the first target-cycle press lands on
+	// Mercury — must NOT credit "aim for the Moon".
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: mercuryIdx}
 	step(missions.ActionCycleTarget)
-	if got := statusByID("tut-orient"); got != missions.Passed {
-		t.Fatalf("tut-orient = %v after view+target, want Passed", got)
+	if got := statusByID("tut-orient"); got == missions.Passed {
+		t.Fatalf("tut-orient passed after targeting Mercury, want still InProgress")
 	}
 
-	// tut-plan unlocks: open the planner, then plant a transfer.
+	// A later press lands on the Moon: now it credits.
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: moonIdx}
+	step(missions.ActionCycleTarget)
+	if got := statusByID("tut-orient"); got != missions.Passed {
+		t.Fatalf("tut-orient = %v after view+Moon target, want Passed", got)
+	}
+
+	// tut-plan unlocks: open the planner.
 	step(missions.ActionOpenManeuver)
+	c := w.ActiveCraft()
+
+	// REFUSAL 2a (issue #426 evidence): an over-budget Moon transfer plants
+	// (ADR 0047 warn-and-allow) but must NOT credit "plant a transfer".
+	c.Nodes = []spacecraft.ManeuverNode{{DV: c.RemainingDeltaV() + 1521}}
+	step(missions.ActionPlanTransfer)
+	if got := statusByID("tut-plan"); got == missions.Passed {
+		t.Fatalf("tut-plan passed on an over-budget Moon transfer, want still InProgress")
+	}
+
+	// REFUSAL 2b: an affordable transfer at the WRONG body (Mercury) must
+	// also not credit.
+	c.Nodes = []spacecraft.ManeuverNode{{DV: 10}}
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: mercuryIdx}
+	step(missions.ActionPlanTransfer)
+	if got := statusByID("tut-plan"); got == missions.Passed {
+		t.Fatalf("tut-plan passed on an affordable Mercury transfer, want still InProgress")
+	}
+
+	// An affordable Moon transfer credits.
+	c.Nodes = []spacecraft.ManeuverNode{{DV: 10}}
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: moonIdx}
 	step(missions.ActionPlanTransfer)
 	if got := statusByID("tut-plan"); got != missions.Passed {
-		t.Fatalf("tut-plan = %v after open+transfer, want Passed", got)
+		t.Fatalf("tut-plan = %v after an affordable Moon transfer, want Passed", got)
 	}
+	c.Nodes = nil
 
 	// tut-fly unlocks: a state objective — climb above 700 km. Pin the craft
 	// above the floor and evaluate (no physics tick needed).
-	c := w.ActiveCraft()
-	r := c.Primary.RadiusMeters() + 800_000 // comfortably above the 700 km floor
-	mu := c.Primary.GravitationalParameter()
-	c.State = physics.StateVector{
-		R: orbital.Vec3{X: r},
-		V: orbital.Vec3{Y: math.Sqrt(mu / r)},
-		M: c.TotalMass(),
-	}
+	setCircularAltitude(c, 800_000)
 	w.evaluateMissions()
 	if got := statusByID("tut-fly"); got != missions.Passed {
 		t.Fatalf("tut-fly = %v after climbing above 700 km, want Passed", got)
 	}
 
-	// Tutorial complete and challenges disabled → no active mission remains
-	// (the challenge ladder is a separate, opted-out program here).
+	// tut-launch unlocks: spawn on the pad, throttle up, stage (liftoff),
+	// pitch east above 10 km, plan the circularising burn, then make orbit.
+	c.OnPad = true
+	step(missions.ActionSpawnCraft)
+	step(missions.ActionThrottleFull)
+	step(missions.ActionStage)
+	c.OnPad = false // liftoff clears OnPad in real play (maneuver.go)
+
+	setCircularAltitude(c, 15_000) // above the 10 km floor
+	w.evaluateMissions()
+	if got := statusByID("tut-launch"); got == missions.Passed {
+		t.Fatalf("tut-launch passed before the circularising burn, want still InProgress")
+	}
+
+	step(missions.ActionPlanCircularize)
+
+	setCircularAltitude(c, 250_000) // periapsis above the 200 km floor, e≈0
+	w.evaluateMissions()
+	if got := statusByID("tut-launch"); got != missions.Passed {
+		t.Fatalf("tut-launch = %v after making orbit, want Passed", got)
+	}
+
+	// tut-dock unlocks: spawn a partner IN ORBIT (not on the pad), target it,
+	// plant the meeting burn, and dock.
+	twin := *c
+	twin.ID = c.ID + 1000
+	w.Crafts = append(w.Crafts, &twin)
+	step(missions.ActionSpawnCraft) // c.OnPad is already false (in orbit)
+	if got := statusByID("tut-dock"); got == missions.Passed {
+		t.Fatalf("tut-dock passed after the spawn step alone, want still InProgress")
+	}
+
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: twin.ID}
+	step(missions.ActionCycleTarget)
+	step(missions.ActionPlanRendezvous)
+
+	c.DockedComponents = append(c.DockedComponents, spacecraft.DockedComponent{})
+	w.evaluateMissions()
+	if got := statusByID("tut-dock"); got != missions.Passed {
+		t.Fatalf("tut-dock = %v after docking, want Passed", got)
+	}
+
+	// Flight School complete and challenges disabled → no active mission
+	// remains (the challenge ladder is a separate, opted-out program here).
 	if am := w.ActiveMission(); am != nil {
-		t.Fatalf("active mission after tutorial = %v, want nil (challenges disabled)", am)
+		t.Fatalf("active mission after Flight School = %v, want nil (challenges disabled)", am)
+	}
+}
+
+// setCircularAltitude pins c's state to a circular orbit at the given
+// altitude (m) above its primary — enough for the reach_altitude and
+// circularize_from_pad kinds to evaluate without a real physics tick.
+func setCircularAltitude(c *spacecraft.Spacecraft, altitudeM float64) {
+	r := c.Primary.RadiusMeters() + altitudeM
+	mu := c.Primary.GravitationalParameter()
+	c.State = physics.StateVector{
+		R: orbital.Vec3{X: r},
+		V: orbital.Vec3{Y: math.Sqrt(mu / r)},
+		M: c.TotalMass(),
 	}
 }

--- a/internal/sim/mission_context_test.go
+++ b/internal/sim/mission_context_test.go
@@ -123,6 +123,114 @@ func TestTickPassesLandAtBody(t *testing.T) {
 	}
 }
 
+// TestMissionEvalContextTargetBodyID — #426: TargetBodyID resolves the
+// bound World.Target body by catalog ID (not the raw body-slice index) so
+// the missions package can gate an event objective on "aimed at the Moon"
+// without duplicating the sys.Bodies[idx] lookup.
+func TestMissionEvalContextTargetBodyID(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	moonIdx := findBodyIdx(t, w, "moon")
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: moonIdx}
+	if got := w.missionEvalContext().TargetBodyID; got != "moon" {
+		t.Errorf("TargetBodyID with Moon bound: got %q, want %q", got, "moon")
+	}
+
+	mercuryIdx := findBodyIdx(t, w, "mercury")
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: mercuryIdx}
+	if got := w.missionEvalContext().TargetBodyID; got != "mercury" {
+		t.Errorf("TargetBodyID with Mercury bound: got %q, want %q", got, "mercury")
+	}
+
+	// No target bound at all: empty.
+	w.Target = spacecraft.Target{}
+	if got := w.missionEvalContext().TargetBodyID; got != "" {
+		t.Errorf("TargetBodyID with no target: got %q, want empty", got)
+	}
+}
+
+// TestMissionEvalContextTargetIsCraft — TargetIsCraft reflects whether the
+// bound Target is a craft, independent of whether it resolves to a relative
+// state (unlike HasTargetCraft, which also requires resolution).
+func TestMissionEvalContextTargetIsCraft(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if w.missionEvalContext().TargetIsCraft {
+		t.Error("TargetIsCraft should start false with no target")
+	}
+	moonIdx := findBodyIdx(t, w, "moon")
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetBody, BodyIdx: moonIdx}
+	if w.missionEvalContext().TargetIsCraft {
+		t.Error("TargetIsCraft should be false when a body is targeted")
+	}
+	active := w.ActiveCraft()
+	twin := *active
+	twin.ID = active.ID + 1000
+	w.Crafts = append(w.Crafts, &twin)
+	w.Target = spacecraft.Target{Kind: spacecraft.TargetCraft, CraftID: twin.ID}
+	if !w.missionEvalContext().TargetIsCraft {
+		t.Error("TargetIsCraft should be true when a craft is targeted")
+	}
+}
+
+// TestMissionEvalContextHasOverBudgetNode — #426: true when ANY node on the
+// active craft exceeds its remaining Δv budget (ADR 0047 §2), false when the
+// queue is empty or every node is affordable. Uses the SAME
+// ManeuverNode.OverBudget predicate the NODES/planner chips use.
+func TestMissionEvalContextHasOverBudgetNode(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if w.missionEvalContext().HasOverBudgetNode {
+		t.Error("empty node queue should not be flagged over-budget")
+	}
+	c.Nodes = []spacecraft.ManeuverNode{{DV: 10}}
+	if w.missionEvalContext().HasOverBudgetNode {
+		t.Error("an affordable node should not be flagged over-budget")
+	}
+	c.Nodes = []spacecraft.ManeuverNode{{DV: c.RemainingDeltaV() + 1521}}
+	if !w.missionEvalContext().HasOverBudgetNode {
+		t.Error("an over-budget node should be flagged")
+	}
+}
+
+// TestMissionEvalContextOnPad — #426: OnPad mirrors the active craft's own
+// OnPad flag, feeding the tut-launch / tut-dock spawn-location gates.
+func TestMissionEvalContextOnPad(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.OnPad = true
+	if !w.missionEvalContext().OnPad {
+		t.Error("OnPad true on the active craft should propagate")
+	}
+	c.OnPad = false
+	if w.missionEvalContext().OnPad {
+		t.Error("OnPad false on the active craft should propagate")
+	}
+}
+
+// findBodyIdx returns the index into w.System().Bodies of the body with the
+// given catalog ID, failing the test if it's not found.
+func findBodyIdx(t *testing.T, w *World, id string) int {
+	t.Helper()
+	for i, b := range w.System().Bodies {
+		if b.ID == id {
+			return i
+		}
+	}
+	t.Fatalf("no body with id %q in the loaded system", id)
+	return -1
+}
+
 // TestStageActiveLatchesStagedFlag — decoupling a stage latches the
 // session staged flag the outcome context reads.
 func TestStageActiveLatchesStagedFlag(t *testing.T) {

--- a/internal/sim/mission_sendoff_test.go
+++ b/internal/sim/mission_sendoff_test.go
@@ -1,0 +1,100 @@
+package sim
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
+
+// #426 item F, decision 9: LadderSendoff drives both the ladder screen's
+// top-card slot and the MISSION chip once a whole Program's rungs are all
+// Passed. Pure function of Mission.Status — no persisted state.
+
+func twoTutorialOneChallenge() []missions.Mission {
+	return []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial, Status: missions.Passed},
+		{ID: "t2", Name: "Fly It", Program: missions.ProgramTutorial, Status: missions.Passed},
+		{ID: "c1", Name: "High Orbit", Program: missions.ProgramChallenge},
+	}
+}
+
+func TestLadderSendoffFlightSchoolCompleteOffersChallengesWhenOff(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = twoTutorialOneChallenge()
+	// Challenge ladder off: Flight School's sendoff offers it.
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+	text, offer, ok := w.LadderSendoff()
+	if !ok || text != "FLIGHT SCHOOL COMPLETE" {
+		t.Fatalf("LadderSendoff = (%q, %v, %v), want (\"FLIGHT SCHOOL COMPLETE\", _, true)", text, offer, ok)
+	}
+	if !offer {
+		t.Error("should offer the Challenge ladder when it's off")
+	}
+}
+
+func TestLadderSendoffFlightSchoolCompleteNoOfferWhenChallengesOn(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = twoTutorialOneChallenge()
+	// Challenges enabled but its own rung is still InProgress and requires
+	// nothing — so it's the active mission, and Sendoff must not fire at
+	// all (ActiveMission takes precedence).
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true, missions.ProgramChallenge: true})
+	if _, _, ok := w.LadderSendoff(); ok {
+		t.Error("LadderSendoff should not fire while a challenge rung is active")
+	}
+}
+
+func TestLadderSendoffChallengeLadderCompleteNoOffer(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial, Status: missions.Passed},
+		{ID: "c1", Name: "High Orbit", Program: missions.ProgramChallenge, Status: missions.Passed},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true, missions.ProgramChallenge: true})
+	text, offer, ok := w.LadderSendoff()
+	if !ok || text != "CHALLENGE LADDER COMPLETE" {
+		t.Fatalf("LadderSendoff = (%q, %v, %v), want (\"CHALLENGE LADDER COMPLETE\", false, true)", text, offer, ok)
+	}
+	if offer {
+		t.Error("challenge-complete sendoff must not offer anything")
+	}
+}
+
+func TestLadderSendoffNoneWhenNothingComplete(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+	if _, _, ok := w.LadderSendoff(); ok {
+		t.Error("LadderSendoff should not fire with an in-progress mission active")
+	}
+}
+
+func TestLadderSendoffSurvivesProgramDisabledAfterCompletion(t *testing.T) {
+	w, err := NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = twoTutorialOneChallenge()
+	// Flight School complete, then the player switches it OFF, challenges
+	// also off — Sendoff must still recognise the completed Program by
+	// Status, independent of the current enabled toggle.
+	w.SetEnabledMissionPrograms(map[string]bool{})
+	text, offer, ok := w.LadderSendoff()
+	if !ok || text != "FLIGHT SCHOOL COMPLETE" || !offer {
+		t.Fatalf("LadderSendoff after disabling = (%q, %v, %v), want (\"FLIGHT SCHOOL COMPLETE\", true, true)", text, offer, ok)
+	}
+}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1206,6 +1206,48 @@ func (w *World) ActiveMission() *missions.Mission {
 	return nil
 }
 
+// LadderSendoff returns the one-line "complete" message the player surface
+// (ladder screen active-card slot + MISSION chip) shows once a whole
+// Program's rungs are all Passed, and whether it should offer a one-key
+// switch to the Challenge ladder (#426 item F, decision 9). Only fires when
+// there's no other active rung to show — ActiveMission() nil — so a
+// still-in-progress Challenge rung always takes precedence over a completed
+// Flight School's sendoff; the Challenge ladder's own completion sendoff
+// takes precedence over Flight School's (finishing everything beats
+// finishing just the tutorial). Purely derived from Mission.Status; no new
+// persisted state.
+func (w *World) LadderSendoff() (text string, offerChallenges bool, ok bool) {
+	if w.ActiveMission() != nil {
+		return "", false, false
+	}
+	if w.programComplete(missions.ProgramChallenge) {
+		return "CHALLENGE LADDER COMPLETE", false, true
+	}
+	if w.programComplete(missions.ProgramTutorial) {
+		return "FLIGHT SCHOOL COMPLETE", !w.MissionProgramEnabled(missions.ProgramChallenge), true
+	}
+	return "", false, false
+}
+
+// programComplete reports whether every mission tagged with the given
+// Program has Passed. False when the catalog carries no mission for that
+// Program at all (nothing to be "complete"). Independent of whether the
+// Program is currently enabled — a player who finished Flight School and
+// then switched it off in Settings should still see it as complete.
+func (w *World) programComplete(program string) bool {
+	any := false
+	for i := range w.Missions {
+		if w.Missions[i].Program != program {
+			continue
+		}
+		any = true
+		if w.Missions[i].Status != missions.Passed {
+			return false
+		}
+	}
+	return any
+}
+
 // nextFiniteBurnTrigger returns the BurnStart sim-time of the soonest
 // pending finite-burn node (Duration > 0), or the zero time if no
 // finite-burn node is queued. v0.5.14+: BurnStart is TriggerTime -

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1108,16 +1108,17 @@ func (w *World) missionEvalContext() missions.EvalContext {
 		HasTarget:      w.Target.Kind != spacecraft.TargetNone,
 		Staged:         w.stagedThisSession,
 		RecentActions:  w.recentActions,
+		// #426: gates for the Flight School event-objective Require* fields.
+		TargetBodyID:      w.boundTargetBodyID(),
+		TargetIsCraft:     w.Target.Kind == spacecraft.TargetCraft,
+		HasOverBudgetNode: activeCraftHasOverBudgetNode(c),
+		OnPad:             c.OnPad,
 	}
 	// v0.23 / ADR 0027: project the CommNet graph down for coverage
 	// objectives (the missions package never imports sim).
 	if w.CommGraph != nil {
 		ctx.ActiveConnected = w.CommGraph.HasConnection(c.ID)
-		for _, oc := range w.Crafts {
-			if oc != nil && oc.AntennaKind == spacecraft.AntennaRelay && w.CommGraph.HasConnection(oc.ID) {
-				ctx.ConnectedRelayCount++
-			}
-		}
+		ctx.ConnectedRelayCount = w.ConnectedRelayCount()
 	}
 	// Target-craft relative state (rendezvous), against the player's
 	// current target slot in the active craft's frame. Only when a craft
@@ -1130,6 +1131,58 @@ func (w *World) missionEvalContext() missions.EvalContext {
 		}
 	}
 	return ctx
+}
+
+// boundTargetBodyID resolves World.Target to a catalog body ID when it's
+// bound to a body, or "" otherwise (no target, a craft, a site, or a stale
+// out-of-range index). #426: the missions package can't do this lookup
+// itself (Target lives on spacecraft/sim, not missions), so World does it
+// once here for the event-objective RequireTargetBodyID gate.
+func (w *World) boundTargetBodyID() string {
+	if w.Target.Kind != spacecraft.TargetBody {
+		return ""
+	}
+	sys := w.System()
+	if w.Target.BodyIdx <= 0 || w.Target.BodyIdx >= len(sys.Bodies) {
+		return ""
+	}
+	return sys.Bodies[w.Target.BodyIdx].ID
+}
+
+// activeCraftHasOverBudgetNode reports whether ANY node currently planted on
+// c is an Over-budget Node (ADR 0047 §2, via ManeuverNode.OverBudget) — the
+// signal #426's RequireBudgetOK event-objective gate reads. Shares the exact
+// predicate the NODES chip and planner list mark with, rather than forking
+// it a third time.
+func activeCraftHasOverBudgetNode(c *spacecraft.Spacecraft) bool {
+	if c == nil {
+		return false
+	}
+	for _, n := range c.Nodes {
+		if _, over := n.OverBudget(c); over {
+			return true
+		}
+	}
+	return false
+}
+
+// ConnectedRelayCount returns how many relay-antenna craft in the slate
+// currently reach a ground station, via the cached CommGraph (v0.23 / ADR
+// 0027). Factored out of missionEvalContext (which feeds the
+// relay_coverage evaluator) so the MISSION chip's live "relays online N/3"
+// row (#426) reads the exact same count rather than re-deriving it. Returns
+// 0 before the first CommGraph build.
+func (w *World) ConnectedRelayCount() int {
+	if w.CommGraph == nil {
+		return 0
+	}
+	n := 0
+	for _, oc := range w.Crafts {
+		if oc != nil && oc.AntennaKind == spacecraft.AntennaRelay && w.CommGraph.HasConnection(oc.ID) {
+			n++
+		}
+	}
+	return n
 }
 
 // ActiveMission returns the first in-progress mission whose requirements are

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -314,6 +314,25 @@ func (n ManeuverNode) BurnEnd() time.Time {
 	return n.TriggerTime.Add(n.Duration / 2)
 }
 
+// OverBudget reports whether this node's planned Δv exceeds c's currently
+// remaining Δv (ADR 0047 §2's Over-budget Node), and the shortfall in m/s
+// (0 when within budget). An over-budget node plants anyway — refuelling,
+// staging, or docking a tug can all legitimately need more than the craft's
+// current fuel state supports — this just flags it. The ONE predicate shared
+// by the NODES/planner-list marker (internal/tui/screens/orbit_chips.go,
+// nextQueuedNodeLine) and the tut-plan Flight School objective (#426); do
+// not fork this formula, extend it here.
+func (n ManeuverNode) OverBudget(c *Spacecraft) (shortfallMs float64, over bool) {
+	if c == nil {
+		return 0, false
+	}
+	shortfall := n.DV - c.RemainingDeltaV()
+	if shortfall > 0 {
+		return shortfall, true
+	}
+	return 0, false
+}
+
 // ActiveBurn is the runtime state of an in-progress finite burn. Set
 // by the dispatcher when a node with Duration>0 fires; cleared when
 // DVRemaining hits zero or SimTime passes EndTime. v0.8.1+: lives on

--- a/internal/spacecraft/maneuver_budget_test.go
+++ b/internal/spacecraft/maneuver_budget_test.go
@@ -1,0 +1,41 @@
+package spacecraft
+
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// TestManeuverNodeOverBudget — ADR 0047 §2: a node's Δv exceeding the
+// craft's currently remaining Δv is the "Over-budget Node" the planner
+// marks with a shortfall, and plants anyway (warn-and-allow, not a
+// refusal). This is the ONE predicate both the NODES/planner chip rows
+// (internal/tui/screens/orbit_chips.go) and the tut-plan Flight School
+// objective (#426) share — factored here so neither forks it.
+func TestManeuverNodeOverBudget(t *testing.T) {
+	systems, _ := bodies.LoadAll()
+	earth := systems[0].FindBody("Earth")
+	sc := NewInLEO(*earth)
+	budget := sc.RemainingDeltaV()
+
+	over := ManeuverNode{DV: budget + 1521}
+	shortfall, isOver := over.OverBudget(sc)
+	if !isOver {
+		t.Fatalf("node at budget+1521 should be over budget")
+	}
+	if shortfall < 1520 || shortfall > 1522 {
+		t.Errorf("shortfall = %.2f, want ~1521", shortfall)
+	}
+
+	affordable := ManeuverNode{DV: 10}
+	if _, isOver := affordable.OverBudget(sc); isOver {
+		t.Errorf("a 10 m/s node against a %.0f m/s budget must not be over budget", budget)
+	}
+
+	// Exactly at budget is NOT over (only a strictly positive shortfall counts,
+	// matching the chip's `> 0` gate).
+	exact := ManeuverNode{DV: budget}
+	if shortfall, isOver := exact.OverBudget(sc); isOver {
+		t.Errorf("a node exactly at budget must not be marked over-budget (shortfall %.2f)", shortfall)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -983,6 +983,24 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
+		// Missions ladder: `1`/`2` turn on Flight School / the Challenge
+		// ladder when the empty-state or per-program offer row is showing
+		// (#426 item F, decision 5) — wired through the same
+		// toggleMissionProgram the Settings screen uses, not a new path.
+		// Sits before the generic switch (like the Porkchop/Help blocks
+		// above) so these raw digits don't also fall through to the
+		// switch's CraftSlot case, which — per the comment on the K case
+		// below — reaches screenMissions same as screenOrbit.
+		if a.active == screenMissions {
+			switch m.String() {
+			case "1":
+				a.toggleMissionProgram(true)
+				return a, nil
+			case "2":
+				a.toggleMissionProgram(false)
+				return a, nil
+			}
+		}
 		switch {
 		case key.Matches(m, a.keys.Help):
 			if a.active == screenHelp {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -991,13 +991,21 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// above) so these raw digits don't also fall through to the
 		// switch's CraftSlot case, which — per the comment on the K case
 		// below — reaches screenMissions same as screenOrbit.
+		// Enable-only: the offer row is shown only while a program is off,
+		// so a digit pressed while it is already on is a stray key, not a
+		// request to switch it off (the F1 row promises "turn on"). Off is
+		// the Settings screen's job.
 		if a.active == screenMissions {
 			switch m.String() {
 			case "1":
-				a.toggleMissionProgram(true)
+				if !a.orbitView.Settings().TutorialOn() {
+					a.toggleMissionProgram(true)
+				}
 				return a, nil
 			case "2":
-				a.toggleMissionProgram(false)
+				if !a.orbitView.Settings().ChallengesEnabled {
+					a.toggleMissionProgram(false)
+				}
 				return a, nil
 			}
 		}

--- a/internal/tui/missions_screen_toggle_test.go
+++ b/internal/tui/missions_screen_toggle_test.go
@@ -1,66 +1,85 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/missions"
+)
 
 // #426 item F, decision 5: the missions ladder screen offers one-key
-// toggles ("[1] turn on Flight School" / "[2] turn on the Challenge
+// enables ("[1] turn on Flight School" / "[2] turn on the Challenge
 // ladder") wired through the SAME toggleMissionProgram Settings uses, not a
-// new path. These pin that pressing 1/2 on screenMissions actually flips
-// the Settings toggle and re-pushes the enabled-program set to World.
+// new path. The keys are enable-only: the offer row is shown only while a
+// program is off, so a digit pressed while it is already on must not switch
+// it off (the F1 row promises "turn on"). These pin that pressing 1/2 on
+// screenMissions flips the persisted Settings toggle on, re-pushes the
+// enabled-program set to World, and is a no-op once on.
 
-func TestMissionsScreenDigitOneTogglesTutorial(t *testing.T) {
+func withProgramsOff(t *testing.T) *App {
+	t.Helper()
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	s := a.orbitView.Settings()
+	s.SetTutorialEnabled(false)
+	s.ChallengesEnabled = false
+	a.orbitView.SetSettings(s)
+	a.world.SetEnabledMissionPrograms(enabledProgramsFromSettings(s))
 	a.active = screenMissions
-	before := a.orbitView.Settings().TutorialEnabled
+	return a
+}
+
+func TestMissionsScreenDigitOneTurnsOnTutorial(t *testing.T) {
+	a := withProgramsOff(t)
 
 	pressKey(a, '1')
 
-	if got := a.orbitView.Settings().TutorialEnabled; got == before {
-		t.Fatalf("TutorialEnabled unchanged after pressing 1 on the missions screen (was %v)", before)
+	if !a.orbitView.Settings().TutorialOn() {
+		t.Fatalf("TutorialOn still false after pressing 1 on the missions screen")
 	}
-	if got := a.world.MissionProgramEnabled("tutorial"); got != a.orbitView.Settings().TutorialEnabled {
-		t.Errorf("World's enabled-program set (tutorial=%v) disagrees with the persisted Settings toggle (%v)", got, a.orbitView.Settings().TutorialEnabled)
+	if !a.world.MissionProgramEnabled(missions.ProgramTutorial) {
+		t.Errorf("World's enabled-program set does not carry the tutorial after the persisted toggle went on")
 	}
 	if a.active != screenMissions {
 		t.Errorf("active screen changed to %v, want to stay on screenMissions", a.active)
 	}
+
+	// Enable-only: a second press must not switch it back off.
+	pressKey(a, '1')
+	if !a.orbitView.Settings().TutorialOn() {
+		t.Fatalf("pressing 1 while Flight School is on switched it off; the key is enable-only")
+	}
 }
 
-func TestMissionsScreenDigitTwoTogglesChallenges(t *testing.T) {
-	a, err := New(nil)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	a.active = screenMissions
-	before := a.orbitView.Settings().ChallengesEnabled
+func TestMissionsScreenDigitTwoTurnsOnChallenges(t *testing.T) {
+	a := withProgramsOff(t)
 
 	pressKey(a, '2')
 
-	if got := a.orbitView.Settings().ChallengesEnabled; got == before {
-		t.Fatalf("ChallengesEnabled unchanged after pressing 2 on the missions screen (was %v)", before)
+	if !a.orbitView.Settings().ChallengesEnabled {
+		t.Fatalf("ChallengesEnabled still false after pressing 2 on the missions screen")
 	}
-	if got := a.world.MissionProgramEnabled("challenge"); got != a.orbitView.Settings().ChallengesEnabled {
-		t.Errorf("World's enabled-program set (challenge=%v) disagrees with the persisted Settings toggle (%v)", got, a.orbitView.Settings().ChallengesEnabled)
+	if !a.world.MissionProgramEnabled(missions.ProgramChallenge) {
+		t.Errorf("World's enabled-program set does not carry challenges after the persisted toggle went on")
+	}
+
+	pressKey(a, '2')
+	if !a.orbitView.Settings().ChallengesEnabled {
+		t.Fatalf("pressing 2 while the Challenge ladder is on switched it off; the key is enable-only")
 	}
 }
 
 // TestMissionsScreenDigitsInertElsewhere — the digit intercept is scoped to
 // screenMissions; from the orbit map, '1' must still do whatever it always
-// did (jump to craft slot 1), not toggle a mission program.
+// did (jump to craft slot 1), not touch a mission program.
 func TestMissionsScreenDigitsInertElsewhere(t *testing.T) {
-	a, err := New(nil)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
+	a := withProgramsOff(t)
 	a.active = screenOrbit
-	before := a.orbitView.Settings().TutorialEnabled
 
 	pressKey(a, '1')
 
-	if got := a.orbitView.Settings().TutorialEnabled; got != before {
-		t.Errorf("pressing 1 on the orbit screen toggled TutorialEnabled (%v -> %v); the intercept must be missions-screen-only", before, got)
+	if a.orbitView.Settings().TutorialOn() {
+		t.Errorf("pressing 1 on the orbit screen turned Flight School on; the intercept must be missions-screen-only")
 	}
 }

--- a/internal/tui/missions_screen_toggle_test.go
+++ b/internal/tui/missions_screen_toggle_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import "testing"
+
+// #426 item F, decision 5: the missions ladder screen offers one-key
+// toggles ("[1] turn on Flight School" / "[2] turn on the Challenge
+// ladder") wired through the SAME toggleMissionProgram Settings uses, not a
+// new path. These pin that pressing 1/2 on screenMissions actually flips
+// the Settings toggle and re-pushes the enabled-program set to World.
+
+func TestMissionsScreenDigitOneTogglesTutorial(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenMissions
+	before := a.orbitView.Settings().TutorialEnabled
+
+	pressKey(a, '1')
+
+	if got := a.orbitView.Settings().TutorialEnabled; got == before {
+		t.Fatalf("TutorialEnabled unchanged after pressing 1 on the missions screen (was %v)", before)
+	}
+	if got := a.world.MissionProgramEnabled("tutorial"); got != a.orbitView.Settings().TutorialEnabled {
+		t.Errorf("World's enabled-program set (tutorial=%v) disagrees with the persisted Settings toggle (%v)", got, a.orbitView.Settings().TutorialEnabled)
+	}
+	if a.active != screenMissions {
+		t.Errorf("active screen changed to %v, want to stay on screenMissions", a.active)
+	}
+}
+
+func TestMissionsScreenDigitTwoTogglesChallenges(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenMissions
+	before := a.orbitView.Settings().ChallengesEnabled
+
+	pressKey(a, '2')
+
+	if got := a.orbitView.Settings().ChallengesEnabled; got == before {
+		t.Fatalf("ChallengesEnabled unchanged after pressing 2 on the missions screen (was %v)", before)
+	}
+	if got := a.world.MissionProgramEnabled("challenge"); got != a.orbitView.Settings().ChallengesEnabled {
+		t.Errorf("World's enabled-program set (challenge=%v) disagrees with the persisted Settings toggle (%v)", got, a.orbitView.Settings().ChallengesEnabled)
+	}
+}
+
+// TestMissionsScreenDigitsInertElsewhere — the digit intercept is scoped to
+// screenMissions; from the orbit map, '1' must still do whatever it always
+// did (jump to craft slot 1), not toggle a mission program.
+func TestMissionsScreenDigitsInertElsewhere(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.active = screenOrbit
+	before := a.orbitView.Settings().TutorialEnabled
+
+	pressKey(a, '1')
+
+	if got := a.orbitView.Settings().TutorialEnabled; got != before {
+		t.Errorf("pressing 1 on the orbit screen toggled TutorialEnabled (%v -> %v); the intercept must be missions-screen-only", before, got)
+	}
+}

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -43,7 +43,7 @@ type helpSection struct {
 // the 13-row MULTIPLAYER section (issue #425 evidence).
 var helpSections = []helpSection{
 	{"GENERAL", [][2]string{
-		{"F1", "toggle this help"},
+		{"F1 / ?", "toggle this help"},
 		{"esc", "back / close (or save/load/build/settings/keyboard layout/help/quit menu on home)"},
 		{"F5 / F9", "quicksave / quickload"},
 		{"ctrl+c", "quit immediately"},
@@ -152,6 +152,10 @@ var helpSections = []helpSection{
 		{"c", "toggle fused decouple (stage drops with the group below)"},
 		{"t", "set a Σ Δv target (a tank row then hints the count to reach it)"},
 		{"s / o", "save the design (name it) / open a saved design"},
+	}},
+	{"MISSIONS (ladder screen — open with M)", [][2]string{
+		{"1", "turn on Flight School (shown when it's off)"},
+		{"2", "turn on the Challenge ladder (shown when it's off)"},
 	}},
 	{"SAVES (menu → Save / Load Game)", [][2]string{
 		{"↑ / ↓", "move the save cursor"},

--- a/internal/tui/screens/help_rows_test.go
+++ b/internal/tui/screens/help_rows_test.go
@@ -95,6 +95,7 @@ func TestHelpSectionOrder(t *testing.T) {
 		"MEETING PLANNER (map chip, opens from K)",
 		"VESSEL",
 		"VEHICLE ASSEMBLY (VAB)",
+		"MISSIONS (ladder screen — open with M)", // #426, screen-scoped, after VAB
 		"SAVES (menu → Save / Load Game)",
 		"MULTIPLAYER (session screen — open with O)",
 		"MOUSE",

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -981,9 +981,10 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		// exceeds the vessel's current remaining budget plants anyway —
 		// warn and allow, never refuse — but every list carrying it
 		// shows the shortfall so the player isn't surprised later. Same
-		// wording as the on-map NODES chip (orbit_chips.go).
-		if over := n.DV - budget; over > 0 {
-			row += "  " + m.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", over))
+		// wording as the on-map NODES chip (orbit_chips.go); the predicate
+		// itself lives on ManeuverNode.OverBudget (#426) so no list forks it.
+		if shortfall, isOver := n.OverBudget(c); isOver {
+			row += "  " + m.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", shortfall))
 		}
 		switch {
 		case i == m.editingIdx:

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/physics"
 	"github.com/jasonfen/terminal-space-program/internal/planner"
@@ -1006,6 +1007,19 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		newRow = m.theme.Dim.Render("  " + newRow)
 	}
 	lines = append(lines, newRow)
+
+	// MISSION reminder (#426): the #426 issue's own evidence was that the
+	// instruction for the step the player is on lived on the screen they
+	// just left — the planner's footer never mentioned H/I/C/K/P/R at all.
+	// One dim line names the active Flight School step here too, without
+	// widening the panel (the ansi.Truncate pass below still clips it to
+	// panelWidth like every other row). Challenge rungs show nothing —
+	// this is Flight School's on-ramp, not a general reminder surface.
+	if am := w.ActiveMission(); am != nil && am.Program == missions.ProgramTutorial {
+		if obj, ok := am.CurrentObjective(); ok {
+			lines = append(lines, "", m.theme.Dim.Render("MISSION ▸ "+obj.Label()))
+		}
+	}
 
 	// QUICK PLANS (ADR 0047 §4 / #428): the one-key planners, legal
 	// right now or dimmed with the reason when a precondition isn't

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -259,6 +260,88 @@ func TestManeuverQuickPlansBlockListsAllSix(t *testing.T) {
 	}
 	if !strings.Contains(out, "no body selected") {
 		t.Errorf("P's no-body-selected reason missing:\n%s", out)
+	}
+}
+
+// TestManeuverShowsMissionReminderDuringTutorial — #426: the issue's own
+// evidence was that the instruction for the step you're on lived on the
+// screen you just left (the mission chip), and the planner's footer never
+// named it. While a Flight School rung is active, the planner now carries
+// one dim "MISSION ▸ <step>" line.
+func TestManeuverShowsMissionReminderDuringTutorial(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:      "tut-orient",
+		Name:    "Flight School: Orientation",
+		Program: missions.ProgramTutorial,
+		Objectives: []missions.Objective{
+			{Kind: missions.KindEvent, Name: "Change your view", Params: missions.Params{Action: missions.ActionCycleView}},
+		},
+	}}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+	m := NewManeuver(Theme{})
+	out := m.Render(w, 120, 40, 0)
+	if !strings.Contains(out, "MISSION ▸ Change your view") {
+		t.Errorf("planner missing the MISSION reminder line during a tutorial rung:\n%s", out)
+	}
+}
+
+// TestManeuverOmitsMissionReminderForChallenges — a challenge-program active
+// mission gets no reminder line; this on-ramp is Flight School's alone.
+func TestManeuverOmitsMissionReminderForChallenges(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:      "chal-high-orbit",
+		Name:    "Make a 1000 km Orbit",
+		Program: missions.ProgramChallenge,
+		Objectives: []missions.Objective{
+			{Kind: missions.KindCircularize, Name: "Circular orbit at 1000 km"},
+		},
+	}}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramChallenge: true})
+	m := NewManeuver(Theme{})
+	out := m.Render(w, 120, 40, 0)
+	if strings.Contains(out, "MISSION ▸") {
+		t.Errorf("planner should not show a MISSION reminder for a challenge rung:\n%s", out)
+	}
+}
+
+// TestManeuverMissionReminderEllipsizesLikeEveryOtherRow — the reminder is
+// truncated by the same ansi.Truncate pass every other panel row gets
+// (formPanelWidth), never left to widen the panel: a long objective label
+// gets cut with an ellipsis at a narrow render, same as the QUICK PLANS
+// reason text TestManeuverEllipsizesNarrowRows already pins.
+func TestManeuverMissionReminderEllipsizesLikeEveryOtherRow(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	longLabel := "This is a deliberately very long objective label meant to test truncation behaviour"
+	w.Missions = []missions.Mission{{
+		ID:      "tut-launch",
+		Name:    "Flight School: Off the Pad",
+		Program: missions.ProgramTutorial,
+		Objectives: []missions.Objective{
+			{Kind: missions.KindEvent, Name: longLabel, Params: missions.Params{Action: missions.ActionSpawnCraft}},
+		},
+	}}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+	m := NewManeuver(Theme{})
+
+	narrow := m.Render(w, 104, 24, 0)
+	if strings.Contains(narrow, longLabel) {
+		t.Errorf("MISSION reminder's full long label survived un-ellipsized at 104 cols (panel width %d):\n%s", formPanelWidth(104), narrow)
+	}
+
+	wide := m.Render(w, 260, 40, 0)
+	if !strings.Contains(wide, longLabel) {
+		t.Errorf("MISSION reminder missing at a wide (260-col) render, where it should fit unellipsized:\n%s", wide)
 	}
 }
 

--- a/internal/tui/screens/missions.go
+++ b/internal/tui/screens/missions.go
@@ -49,20 +49,24 @@ type ladderRow struct {
 	Objectives []missions.Objective
 }
 
-// classifyLadder is the pure render-model for the ladder screen: it buckets
-// each mission and computes locked-rung hints, given the catalog's current
-// per-mission Status. The active rung is the FIRST unlocked InProgress
-// mission — every later unlocked InProgress one is merely available. A
-// mission is locked when any mission ID in its Requires is not yet Passed;
-// its hint names the unmet prerequisites. v0.21 Slice 5 (ADR 0025 §2/§"Locked
-// rungs").
-func classifyLadder(ms []missions.Mission) []ladderRow {
+// classifyLadder is the pure render-model for one program's rung list: it
+// buckets each mission and computes locked-rung hints, given the catalog's
+// current per-mission Status. activeID names the mission the caller has
+// already decided owns the top-of-screen active card (typically
+// World.ActiveMission().ID, computed once across BOTH programs — #426 item
+// F split the single interleaved ladder into a FLIGHT SCHOOL list and a
+// CHALLENGES list, so "the first unlocked InProgress mission in THIS
+// program" is no longer the right notion of active; the caller decides once,
+// globally, and this just marks whichever row matches). A mission is locked
+// when any mission ID in its Requires is not yet Passed; its hint names the
+// unmet prerequisites. v0.21 Slice 5 (ADR 0025 §2/§"Locked rungs"); split by
+// program #426.
+func classifyLadder(ms []missions.Mission, activeID string) []ladderRow {
 	passed := missions.PassedSet(ms)
 	nameByID := make(map[string]string, len(ms))
 	for i := range ms {
 		nameByID[ms[i].ID] = ms[i].Name
 	}
-	activeAssigned := false
 	rows := make([]ladderRow, 0, len(ms))
 	for i := range ms {
 		m := ms[i]
@@ -72,13 +76,12 @@ func classifyLadder(ms []missions.Mission) []ladderRow {
 			row.Category = ladderCompleted
 		case m.Status == missions.Failed:
 			row.Category = ladderFailed
+		case activeID != "" && m.ID == activeID:
+			row.Category = ladderActive
+			row.Objectives = m.Objectives
 		case !m.RequirementsMet(passed):
 			row.Category = ladderLocked
 			row.Hint = lockedHint(m, nameByID, passed)
-		case !activeAssigned:
-			row.Category = ladderActive
-			row.Objectives = m.Objectives
-			activeAssigned = true
 		default:
 			row.Category = ladderAvailable
 		}
@@ -111,6 +114,15 @@ func lockedHint(m missions.Mission, nameByID map[string]string, passed map[strin
 // Render returns the ladder/program screen. width is the terminal width —
 // used to right-align the [Back] button on row 0. Empty-catalog worlds show
 // a placeholder so the player isn't faced with a blank screen.
+//
+// #426 item F reshaped the body: the active mission (if any) still owns a
+// card on top, but the rest of the ladder is now two headed lists — FLIGHT
+// SCHOOL and CHALLENGES — each with its own N/M complete count, instead of
+// one interleaved list gated on both programs being on. A program that's
+// switched off shows one dim offer row under its header (its one-key
+// toggle) instead of its mission list; that offer row is also what a
+// player sees for BOTH programs at once, replacing the old flat "missions
+// off — enable … in Settings" placeholder.
 func (m *Missions) Render(w *sim.World, width int) string {
 	const titleText = "missions"
 	const backLabel = "[Back]"
@@ -135,63 +147,104 @@ func (m *Missions) Render(w *sim.World, width int) string {
 		return b.String()
 	}
 
-	// Only show missions whose program the player has enabled (ADR 0025 §2 /
-	// v0.21 Slice 7). Both programs default off, so a fresh sandbox lands here.
-	var active []missions.Mission
-	for _, ms := range w.Missions {
-		if w.MissionProgramEnabled(ms.Program) {
-			active = append(active, ms)
-		}
+	activeMission := w.ActiveMission()
+	var activeID string
+	if activeMission != nil {
+		activeID = activeMission.ID
 	}
-	if len(active) == 0 {
-		b.WriteString(m.theme.Dim.Render("  (missions off — enable Tutorial or Challenges in [Menu] → Settings)"))
-		b.WriteString("\n\n")
-		b.WriteString(m.theme.Footer.Render("[esc] back to orbit"))
-		return b.String()
-	}
-
-	passed, failed := 0, 0
-	for _, ms := range active {
-		switch ms.Status {
-		case missions.Passed:
-			passed++
-		case missions.Failed:
-			failed++
-		}
-	}
-	summary := fmt.Sprintf("%d/%d complete", passed, len(active))
-	if failed > 0 {
-		summary += fmt.Sprintf("  (%d failed)", failed)
-	}
-	b.WriteString("  " + m.theme.Primary.Render(summary))
-	b.WriteString("\n\n")
-
-	rows := classifyLadder(active)
 
 	// Active card on top (ADR 0025 Slice 5 — Jason's "active card" layout):
 	// the current mission, expanded to its objective checklist with the
 	// current step's hint, framed in the HUD box so it reads as "what now".
-	for _, r := range rows {
-		if r.Category == ladderActive {
-			b.WriteString(m.activeCard(r, width))
+	// With nothing active, a completed Program's Sendoff takes the same
+	// slot instead of leaving it blank (#426 item F, decision 9).
+	switch {
+	case activeMission != nil:
+		row := ladderRow{Name: activeMission.Name, Category: ladderActive, Objectives: activeMission.Objectives}
+		b.WriteString(m.activeCard(row, width))
+		b.WriteString("\n\n")
+	default:
+		if text, offer, ok := w.LadderSendoff(); ok {
+			b.WriteString(m.sendoffCard(text, offer, width))
 			b.WriteString("\n\n")
-			break
 		}
 	}
 
-	// The rest of the ladder lists below the card. The active rung is omitted
-	// here — it already owns the card — so each remaining rung shows once.
-	for _, r := range rows {
-		if r.Category == ladderActive {
-			continue
-		}
-		b.WriteString(m.ladderRowLine(r))
-		b.WriteByte('\n')
-	}
+	b.WriteString(m.programSection("FLIGHT SCHOOL", "Flight School", "1",
+		programMissions(w.Missions, missions.ProgramTutorial),
+		w.MissionProgramEnabled(missions.ProgramTutorial), activeID))
+	b.WriteByte('\n')
+	b.WriteString(m.programSection("CHALLENGES", "the Challenge ladder", "2",
+		programMissions(w.Missions, missions.ProgramChallenge),
+		w.MissionProgramEnabled(missions.ProgramChallenge), activeID))
 
 	b.WriteString("\n")
 	b.WriteString(m.theme.Footer.Render("[esc] back to orbit"))
 	return b.String()
+}
+
+// programMissions filters ms to the ones tagged with the given Program, in
+// catalog order. An untagged mission (Program == "") never appears in
+// either headed list — the shipped catalog tags every mission, so this is a
+// documented simplification for a hypothetical modder catalog entry with no
+// Program tag, not a real-world gap.
+func programMissions(ms []missions.Mission, program string) []missions.Mission {
+	var out []missions.Mission
+	for _, mi := range ms {
+		if mi.Program == program {
+			out = append(out, mi)
+		}
+	}
+	return out
+}
+
+// programSection renders one headed sub-list: the header line with its own
+// "N/M complete" count (computed regardless of whether the program is
+// currently enabled, so a player who switched it off can still see how far
+// they got), then either the classified rung list (the active rung, if any
+// of these missions owns it, is skipped — the card above already shows it)
+// or, when the program is off, one dim offer row naming its one-key toggle
+// (#426 item F, decision 5). heading is the section's all-caps label
+// ("FLIGHT SCHOOL"); label is the lower-case name used in the offer row's
+// "[N] turn on <label>" text; key is that digit ("1" or "2").
+func (m *Missions) programSection(heading, label, key string, ms []missions.Mission, enabled bool, activeID string) string {
+	var b strings.Builder
+	passed := 0
+	for i := range ms {
+		if ms[i].Status == missions.Passed {
+			passed++
+		}
+	}
+	b.WriteString(m.theme.Primary.Render(fmt.Sprintf("%s  %d/%d complete", heading, passed, len(ms))))
+	b.WriteByte('\n')
+	if !enabled {
+		b.WriteString(m.theme.Dim.Render(fmt.Sprintf("  [%s] turn on %s", key, label)))
+		b.WriteByte('\n')
+		return b.String()
+	}
+	for _, r := range classifyLadder(ms, activeID) {
+		if r.Category == ladderActive {
+			continue // owns the card above
+		}
+		b.WriteString(m.ladderRowLine(r))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// sendoffCard renders the whole-Program-complete state in the same box
+// style as activeCard, so it reads as "what now" the same way the active
+// card did (#426 item F, decision 9).
+func (m *Missions) sendoffCard(text string, offerChallenges bool, width int) string {
+	max := width - 4
+	if max < 8 {
+		max = 8
+	}
+	lines := []string{clipLine(m.theme.Primary.Render(text), max)}
+	if offerChallenges {
+		lines = append(lines, clipLine(m.theme.Dim.Render("  [2] turn on the Challenge ladder"), max))
+	}
+	return m.theme.HUDBox.Render(strings.Join(lines, "\n"))
 }
 
 // activeCard renders the highlighted active-mission card: an "ACTIVE: <name>"
@@ -229,9 +282,16 @@ func (m *Missions) activeCard(r ladderRow, width int) string {
 	return m.theme.HUDBox.Render(strings.Join(lines, "\n"))
 }
 
+// lockGlyph marks a locked rung — a single-width dingbat (U+26BF SQUARED
+// KEY) chosen alongside the game's existing single-width HUD glyph set
+// (✓ ✗ ▸ ● ◇ ⚠ ·) rather than an emoji lock (🔒/🔓/⛔ all measure
+// double-width via lipgloss.Width, which would throw off column math
+// elsewhere the way none of the existing glyphs do). #426 item F.
+const lockGlyph = "⚿"
+
 // ladderRowLine renders one non-active rung in the list below the card:
-// completed rungs checked, available rungs as a pending dot, locked rungs
-// dimmed with their requirement hint, failed rungs marked.
+// completed rungs checked, available rungs bright with ▸, locked rungs
+// dimmed with a lock glyph and their requirement hint, failed rungs marked.
 func (m *Missions) ladderRowLine(r ladderRow) string {
 	switch r.Category {
 	case ladderCompleted:
@@ -239,13 +299,13 @@ func (m *Missions) ladderRowLine(r ladderRow) string {
 	case ladderFailed:
 		return m.theme.Alert.Render("  ✗ " + r.Name + "  (failed)")
 	case ladderLocked:
-		line := "  · " + r.Name
+		line := "  " + lockGlyph + " " + r.Name
 		if r.Hint != "" {
 			line += "   " + r.Hint
 		}
 		return m.theme.Dim.Render(line)
 	default: // ladderAvailable
-		return "  · " + r.Name
+		return "  ▸ " + r.Name
 	}
 }
 

--- a/internal/tui/screens/missions_screen_test.go
+++ b/internal/tui/screens/missions_screen_test.go
@@ -8,10 +8,15 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
-// classifyLadder is the pure render-model behind the missions/ladder screen
-// (ADR 0025 / Slice 5): it sorts each mission into completed / active /
-// available / locked / failed and computes the locked-rung "needs:" hint.
-// These pin that classification independent of the layout/box rendering.
+// classifyLadder is the pure render-model behind one program's rung list on
+// the missions/ladder screen (ADR 0025 / Slice 5; split into two lists by
+// program #426): it sorts each mission into completed / active / available
+// / locked / failed and computes the locked-rung "needs:" hint. The caller
+// decides which mission ID (if any) owns the active card — #426 item F
+// split the single interleaved ladder into FLIGHT SCHOOL / CHALLENGES
+// lists, so "first unlocked InProgress in this slice" is no longer the
+// right notion; these tests pass the id explicitly, mirroring what
+// Render() derives once from World.ActiveMission() across both programs.
 
 func TestClassifyLadder(t *testing.T) {
 	ms := []missions.Mission{
@@ -21,7 +26,7 @@ func TestClassifyLadder(t *testing.T) {
 		{ID: "d", Name: "Fourth", Requires: []string{"c"}},
 		{ID: "e", Name: "Fifth", Status: missions.Failed},
 	}
-	rows := classifyLadder(ms)
+	rows := classifyLadder(ms, "b")
 	if len(rows) != 5 {
 		t.Fatalf("rows = %d, want 5", len(rows))
 	}
@@ -29,13 +34,13 @@ func TestClassifyLadder(t *testing.T) {
 		t.Errorf("row 0 (Passed) = %v, want completed", rows[0].Category)
 	}
 	if rows[1].Category != ladderActive {
-		t.Errorf("row 1 (first unlocked InProgress) = %v, want active", rows[1].Category)
+		t.Errorf("row 1 (given activeID) = %v, want active", rows[1].Category)
 	}
 	if len(rows[1].Objectives) != 1 {
 		t.Errorf("active row should carry its objective checklist, got %d", len(rows[1].Objectives))
 	}
 	if rows[2].Category != ladderAvailable {
-		t.Errorf("row 2 (second unlocked InProgress) = %v, want available", rows[2].Category)
+		t.Errorf("row 2 (unlocked, not the active id) = %v, want available", rows[2].Category)
 	}
 	if rows[3].Category != ladderLocked {
 		t.Errorf("row 3 (unmet requires) = %v, want locked", rows[3].Category)
@@ -49,14 +54,14 @@ func TestClassifyLadder(t *testing.T) {
 }
 
 func TestClassifyLadderExactlyOneActive(t *testing.T) {
-	// Several unlocked InProgress missions, but only the first is the active
-	// one (it gets the card); the rest are available.
+	// Several unlocked InProgress missions; only the one matching activeID
+	// is marked active, the rest are available.
 	ms := []missions.Mission{
 		{ID: "a", Name: "A"},
 		{ID: "b", Name: "B"},
 		{ID: "c", Name: "C"},
 	}
-	rows := classifyLadder(ms)
+	rows := classifyLadder(ms, "a")
 	active := 0
 	for _, r := range rows {
 		if r.Category == ladderActive {
@@ -68,13 +73,31 @@ func TestClassifyLadderExactlyOneActive(t *testing.T) {
 	}
 }
 
+func TestClassifyLadderNoActiveIDMarksNoneActive(t *testing.T) {
+	// An empty activeID (e.g. the Sendoff case — nothing is active) marks
+	// no row active; unlocked InProgress missions read as available.
+	ms := []missions.Mission{
+		{ID: "a", Name: "A"},
+		{ID: "b", Name: "B"},
+	}
+	rows := classifyLadder(ms, "")
+	for _, r := range rows {
+		if r.Category == ladderActive {
+			t.Errorf("row %q marked active with no activeID given", r.Name)
+		}
+		if r.Category != ladderAvailable {
+			t.Errorf("row %q = %v, want available", r.Name, r.Category)
+		}
+	}
+}
+
 func TestClassifyLadderUnlockedAfterRequirementPassed(t *testing.T) {
 	// Once the prerequisite passes, the gated rung becomes available, not locked.
 	ms := []missions.Mission{
 		{ID: "c", Name: "Third", Status: missions.Passed},
 		{ID: "d", Name: "Fourth", Requires: []string{"c"}},
 	}
-	rows := classifyLadder(ms)
+	rows := classifyLadder(ms, "d")
 	if rows[1].Category == ladderLocked {
 		t.Errorf("row with a now-passed requirement should not be locked")
 	}
@@ -89,13 +112,14 @@ func TestMissionsRenderSmoke(t *testing.T) {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	w.Missions = []missions.Mission{
-		{ID: "a", Name: "Reach Orbit", Status: missions.Passed},
-		{ID: "b", Name: "Circularize", Objectives: []missions.Objective{
+		{ID: "a", Name: "Reach Orbit", Program: missions.ProgramTutorial, Status: missions.Passed},
+		{ID: "b", Name: "Circularize", Program: missions.ProgramTutorial, Objectives: []missions.Objective{
 			{Name: "reach 100 km", Status: missions.Passed},
 			{Name: "circular orbit", Description: "burn at apoapsis"},
 		}},
-		{ID: "c", Name: "Luna Flyby", Requires: []string{"b"}},
+		{ID: "c", Name: "Luna Flyby", Program: missions.ProgramTutorial, Requires: []string{"b"}},
 	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
 	out := scr.Render(w, 60)
 	for _, want := range []string{"ACTIVE", "Circularize", "circular orbit", "Luna Flyby", "needs:"} {
 		if !strings.Contains(out, want) {
@@ -104,7 +128,38 @@ func TestMissionsRenderSmoke(t *testing.T) {
 	}
 }
 
-func TestMissionsRenderProgramsOff(t *testing.T) {
+// TestMissionsRenderTwoHeadedLists — #426 item F: the ladder is two headed
+// lists, FLIGHT SCHOOL and CHALLENGES, each with its own N/M complete
+// count, replacing the single interleaved list + flat summary line.
+func TestMissionsRenderTwoHeadedLists(t *testing.T) {
+	scr := NewMissions(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial, Status: missions.Passed},
+		{ID: "t2", Name: "Plan a Burn", Program: missions.ProgramTutorial},
+		{ID: "c1", Name: "High Orbit", Program: missions.ProgramChallenge},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true, missions.ProgramChallenge: true})
+	out := scr.Render(w, 70)
+	if !strings.Contains(out, "FLIGHT SCHOOL  1/2 complete") {
+		t.Errorf("missing FLIGHT SCHOOL header with its own count:\n%s", out)
+	}
+	if !strings.Contains(out, "CHALLENGES  0/1 complete") {
+		t.Errorf("missing CHALLENGES header with its own count:\n%s", out)
+	}
+	if !strings.Contains(out, "High Orbit") {
+		t.Errorf("challenge rung missing from the CHALLENGES list:\n%s", out)
+	}
+}
+
+// TestMissionsRenderOffProgramShowsToggleOffer — #426 item F, decision 5: a
+// program that's switched off shows a one-line dim toggle offer under its
+// header instead of its mission list, naming the one-key toggle
+// (toggleMissionProgram is wired in app.go, not this screen).
+func TestMissionsRenderOffProgramShowsToggleOffer(t *testing.T) {
 	scr := NewMissions(chipTestTheme())
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -117,21 +172,79 @@ func TestMissionsRenderProgramsOff(t *testing.T) {
 			Objectives: []missions.Objective{{Kind: missions.KindSOIFlyby, Params: missions.Params{PrimaryID: "moon"}}}},
 	}
 
-	// Both programs off → the screen shows the enable-in-Settings hint.
+	// Both off: both headers show, each with its own offer row — no
+	// generic "enable in Settings" placeholder anymore.
 	w.SetEnabledMissionPrograms(map[string]bool{})
 	out := scr.Render(w, 70)
-	if !strings.Contains(out, "enable") {
-		t.Errorf("all-programs-off should show the enable-in-Settings hint:\n%s", out)
+	if !strings.Contains(out, "[1] turn on Flight School") {
+		t.Errorf("missing Flight School toggle offer with both off:\n%s", out)
+	}
+	if !strings.Contains(out, "[2] turn on the Challenge ladder") {
+		t.Errorf("missing Challenge ladder toggle offer with both off:\n%s", out)
+	}
+	if strings.Contains(out, "TutMission") || strings.Contains(out, "ChalMission") {
+		t.Errorf("no mission list should render for an off program:\n%s", out)
 	}
 
-	// Enabling just the tutorial surfaces it and keeps challenges hidden.
+	// Enabling just the tutorial surfaces its list and keeps the challenge
+	// section as an offer row.
 	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
 	out = scr.Render(w, 70)
 	if !strings.Contains(out, "TutMission") {
 		t.Errorf("tutorial-on should show the tutorial mission:\n%s", out)
 	}
 	if strings.Contains(out, "ChalMission") {
-		t.Errorf("challenges-off should hide challenge missions:\n%s", out)
+		t.Errorf("challenges-off should hide the challenge mission list:\n%s", out)
+	}
+	if !strings.Contains(out, "[2] turn on the Challenge ladder") {
+		t.Errorf("challenges-off should still show its toggle offer:\n%s", out)
+	}
+}
+
+// TestMissionsRenderLockedRungHasLockGlyphAndAvailableIsBright — #426 item
+// F: a locked rung carries a lock glyph (dim, with its "needs:" hint); an
+// available (unlocked, not-yet-active) rung reads with the ▸ marker.
+func TestMissionsRenderLockedRungHasLockGlyphAndAvailableIsBright(t *testing.T) {
+	scr := NewMissions(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "c1", Name: "Active One", Program: missions.ProgramChallenge},
+		{ID: "c2", Name: "Available Two", Program: missions.ProgramChallenge},
+		{ID: "c3", Name: "Locked Three", Program: missions.ProgramChallenge, Requires: []string{"c2"}},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramChallenge: true})
+	out := scr.Render(w, 70)
+	if !strings.Contains(out, lockGlyph+" Locked Three") {
+		t.Errorf("locked rung missing the lock glyph:\n%s", out)
+	}
+	if !strings.Contains(out, "▸ Available Two") {
+		t.Errorf("available rung missing the ▸ marker:\n%s", out)
+	}
+}
+
+// TestMissionsRenderSendoffWhenFlightSchoolComplete — #426 item F, decision
+// 9: once every Flight School rung has Passed and nothing else is active,
+// the active-card slot shows the Sendoff instead of nothing, offering the
+// Challenge ladder when it's off.
+func TestMissionsRenderSendoffWhenFlightSchoolComplete(t *testing.T) {
+	scr := NewMissions(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial, Status: missions.Passed},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+	out := scr.Render(w, 70)
+	if !strings.Contains(out, "FLIGHT SCHOOL COMPLETE") {
+		t.Errorf("missing Sendoff text:\n%s", out)
+	}
+	if !strings.Contains(out, "[2] turn on the Challenge ladder") {
+		t.Errorf("Sendoff missing the Challenge-ladder offer (challenges are off):\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -944,7 +944,7 @@ func (v *OrbitView) anyActiveBurn(w *sim.World) bool {
 // a failed mission isn't safety-critical the way a live burn is).
 func (v *OrbitView) buildMissionsChip(w *sim.World) []string {
 	flash, flashing := w.MissionFailFlash()
-	return v.missionChipLines(flash, flashing, w.ActiveMission())
+	return v.missionChipLines(flash, flashing, w.ActiveMission(), w.ConnectedRelayCount())
 }
 
 // missionChipLines is the pure content selector behind buildMissionsChip,
@@ -983,7 +983,7 @@ func wrapChipText(s string, width int) []string {
 	return out
 }
 
-func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mission) []string {
+func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mission, relayCount int) []string {
 	if flashing {
 		return []string{
 			v.theme.Alert.Render("MISSION"),
@@ -1005,6 +1005,13 @@ func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mi
 		header,
 		fmt.Sprintf("  %s %s  %d/%d", hudNodeMarker, obj.Label(), passed, total),
 	}
+	// #426: a relay_coverage objective's raw progress ("0/1" — one countable
+	// deploy-and-verify goal) doesn't tell the player how close the live
+	// count is to the target, so it gets its own live row alongside the
+	// generic N/M one.
+	if obj.Kind == missions.KindRelayCoverage {
+		lines = append(lines, fmt.Sprintf("  relays online %d/%d", relayCount, obj.Params.MinRelays))
+	}
 	// Tutorial steps surface their instruction ("Press [v] …") in-flight so the
 	// player learns the control without opening the missions screen (Slice 7
 	// playtest feedback). Challenge steps stay the clean one-liner. Wrapped
@@ -1023,9 +1030,9 @@ func (v *OrbitView) missionChipLines(flash string, flashing bool, m *missions.Mi
 // hint condensed to its FIRST wrapped line only (with a trailing "…"
 // when the hint needed more than one) — "objective + key hint wrapped to
 // ≤ 40 cols", not the hint's full multi-line text.
-func (v *OrbitView) missionChipLinesCompact(flash string, flashing bool, m *missions.Mission) []string {
+func (v *OrbitView) missionChipLinesCompact(flash string, flashing bool, m *missions.Mission, relayCount int) []string {
 	if flashing {
-		return v.missionChipLines(flash, flashing, m) // already 2 lines
+		return v.missionChipLines(flash, flashing, m, relayCount) // already 2 lines
 	}
 	if m == nil {
 		return nil
@@ -1039,6 +1046,9 @@ func (v *OrbitView) missionChipLinesCompact(flash string, flashing bool, m *miss
 	lines := []string{
 		header,
 		fmt.Sprintf("  %s %s  %d/%d", hudNodeMarker, obj.Label(), passed, total),
+	}
+	if obj.Kind == missions.KindRelayCoverage {
+		lines = append(lines, fmt.Sprintf("  relays online %d/%d", relayCount, obj.Params.MinRelays))
 	}
 	if m.Program == missions.ProgramTutorial && obj.Description != "" {
 		wrapped := wrapChipText(obj.Description, missionChipWrapWidth)
@@ -1055,7 +1065,7 @@ func (v *OrbitView) missionChipLinesCompact(flash string, flashing bool, m *miss
 
 func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 	flash, flashing := w.MissionFailFlash()
-	return v.missionChipLinesCompact(flash, flashing, w.ActiveMission())
+	return v.missionChipLinesCompact(flash, flashing, w.ActiveMission(), w.ConnectedRelayCount())
 }
 
 // attitudeHoldLabel names the ATTITUDE chip's hold: row in whichever

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1665,6 +1665,11 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	lines = append(lines, chipRow("period:", formatPeriod(period)))
 	lines = append(lines, chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)))
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
+	// #426 (CONTEXT.md Chip entry): eccentricity, always-on, Full form only —
+	// the three eccentricity-graded challenge rungs (chal-high-orbit et al.)
+	// have a number on the HUD to check against instead of grading a value
+	// the chip never showed. The Compact Form stays the Ap/Pe strip.
+	lines = append(lines, chipRow("e:", fmt.Sprintf("%.4f", el.E)))
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
 	}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -944,7 +944,27 @@ func (v *OrbitView) anyActiveBurn(w *sim.World) bool {
 // a failed mission isn't safety-critical the way a live burn is).
 func (v *OrbitView) buildMissionsChip(w *sim.World) []string {
 	flash, flashing := w.MissionFailFlash()
+	if !flashing {
+		if text, offer, ok := w.LadderSendoff(); ok {
+			return v.sendoffChipLines(text, offer)
+		}
+	}
 	return v.missionChipLines(flash, flashing, w.ActiveMission(), w.ConnectedRelayCount())
+}
+
+// sendoffChipLines renders the MISSION chip's whole-Program-complete state
+// (#426 item F, decision 9) — the same one line the ladder screen's
+// active-card slot shows, plus the Challenge-ladder offer when
+// World.LadderSendoff says to carry it.
+func (v *OrbitView) sendoffChipLines(text string, offerChallenges bool) []string {
+	lines := []string{
+		v.theme.Primary.Render("MISSION"),
+		"  " + text,
+	}
+	if offerChallenges {
+		lines = append(lines, v.theme.Dim.Render("  [2] turn on the Challenge ladder"))
+	}
+	return lines
 }
 
 // missionChipLines is the pure content selector behind buildMissionsChip,
@@ -1065,6 +1085,11 @@ func (v *OrbitView) missionChipLinesCompact(flash string, flashing bool, m *miss
 
 func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 	flash, flashing := w.MissionFailFlash()
+	if !flashing {
+		if text, offer, ok := w.LadderSendoff(); ok {
+			return v.sendoffChipLines(text, offer) // already 2-3 lines, same as Full
+		}
+	}
 	return v.missionChipLinesCompact(flash, flashing, w.ActiveMission(), w.ConnectedRelayCount())
 }
 

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -885,9 +885,11 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	n := nc.Nodes[ni]
 	// Over-budget Node (ADR 0047 §2 / #428): same shortfall wording as
 	// the planner list, on both the full and Compact forms of the chip.
+	// The predicate itself lives on ManeuverNode.OverBudget (#426) so this
+	// chip and the tut-plan mission objective share one formula.
 	over := ""
-	if o := n.DV - nc.RemainingDeltaV(); o > 0 {
-		over = "  " + v.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", o))
+	if shortfall, isOver := n.OverBudget(nc); isOver {
+		over = "  " + v.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", shortfall))
 	}
 	label := fmt.Sprintf("#%d", ni+1)
 	if len(w.Crafts) > 1 {

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -744,6 +744,36 @@ func TestOrbitMetricsShowsDirectionIndicator(t *testing.T) {
 	}
 }
 
+// TestOrbitMetricsChipShowsEccentricity — #426 (CONTEXT.md Chip entry): the
+// full-form ORBIT chip always carries an `e:` row so the three
+// eccentricity-graded challenge rungs have a number on the HUD to check
+// against. Full form only; the Compact Form stays the Ap/Pe strip.
+func TestOrbitMetricsChipShowsEccentricity(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("expected an active craft")
+	}
+
+	joined := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if !strings.Contains(joined, chipRow("e:", "")) {
+		t.Fatalf("ORBIT chip missing the e: row at the shared label column:\n%s", joined)
+	}
+
+	// Compact Form stays the Ap/Pe strip — no e: row. (Matching on the
+	// chipRow-prefixed "  e:" rather than bare "e:" so this doesn't
+	// false-positive on "Pe:", which also contains the substring "e:".)
+	compact := strings.Join(v.buildOrbitMetricsChipCompact(w), "\n")
+	if strings.Contains(compact, "  e:") {
+		t.Errorf("Compact Form should not carry the e: row:\n%s", compact)
+	}
+}
+
 // TestProjectedOrbitIsSeparateChip — issue #63 follow-up: the projected
 // post-burn orbit is its own PROJECTED ORBIT chip stacked beneath the
 // always-on ORBIT chip, so planting a node shows the current and
@@ -1107,7 +1137,9 @@ func realisticChipSet(burning bool) []builtChip {
 			lines:   []string{"MISSION  Flight School: Plan a Burn", "  ▸ Warp to the node  0/1", "    Press [G] to auto-warp to the burn."},
 			compact: []string{"MISSION  Flight School: Plan a Burn", "  ▸ Warp to the node  0/1"}},
 		{corner: cornerTopRight, priority: chipPriorityCore,
-			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  t→Ap:      47m", "  Pe:        498.2 km", "  t→Pe:      12m", "  period:    1h34m28s", "  inclin.:   0.00°", "  direction: prograde"},
+			// #426: the Full form grew an `e:` row (eccentricity, always-on,
+			// full form only — the Compact Form stays the Ap/Pe strip below).
+			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  t→Ap:      47m", "  Pe:        498.2 km", "  t→Pe:      12m", "  period:    1h34m28s", "  inclin.:   0.00°", "  direction: prograde", "  e:         0.0004"},
 			compact: []string{"ORBIT", "  Ap: 500.0 km  Pe: 498.2 km"}},
 		{id: settings.ChipTarget, corner: cornerTopRight,
 			lines:   []string{"TARGET", "  body:     Moon", "  Δi:       19.44°", "  range:    371639 km", "  TCA:      4.72h"},

--- a/internal/tui/screens/orbit_mission_chip_test.go
+++ b/internal/tui/screens/orbit_mission_chip_test.go
@@ -193,6 +193,35 @@ func TestBuildMissionsChipReadsLiveRelayCountFromWorld(t *testing.T) {
 	}
 }
 
+// TestBuildMissionsChipShowsSendoff — #426 item F: once every Flight
+// School rung has Passed and nothing else is active, the chip shows the
+// Sendoff line (World.LadderSendoff) instead of going blank, with the
+// Challenge-ladder offer when challenges are off.
+func TestBuildMissionsChipShowsSendoff(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{
+		{ID: "t1", Name: "Orientation", Program: missions.ProgramTutorial, Status: missions.Passed},
+	}
+	w.SetEnabledMissionPrograms(map[string]bool{missions.ProgramTutorial: true})
+
+	full := strings.Join(v.buildMissionsChip(w), "\n")
+	if !strings.Contains(full, "FLIGHT SCHOOL COMPLETE") {
+		t.Errorf("full-form chip missing the Sendoff line:\n%s", full)
+	}
+	if !strings.Contains(full, "[2] turn on the Challenge ladder") {
+		t.Errorf("full-form chip missing the Challenge-ladder offer (challenges are off):\n%s", full)
+	}
+
+	compact := strings.Join(v.buildMissionsChipCompact(w), "\n")
+	if !strings.Contains(compact, "FLIGHT SCHOOL COMPLETE") {
+		t.Errorf("compact-form chip missing the Sendoff line:\n%s", compact)
+	}
+}
+
 // TestMissionChipHintWrapsInsteadOfWideningTheBox (ADR 0046 / #422): a
 // long tutorial hint ("Warp to your burn ([G]) or fire manually ([b])…",
 // 87 columns in the 2026-09-02 UX review's gameplay-flow-progression-09

--- a/internal/tui/screens/orbit_mission_chip_test.go
+++ b/internal/tui/screens/orbit_mission_chip_test.go
@@ -14,6 +14,8 @@ import (
 // mission name, its current objective, and N/M progress — with a transient
 // failure flash when a mission dies. missionChipLines is the pure content
 // selector, exercised here without needing a live World to arm the flash.
+// The trailing relayCount int (#426) only matters for a relay_coverage
+// objective; every other test here passes 0 and ignores it.
 
 func TestMissionChipLinesActive(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
@@ -25,7 +27,7 @@ func TestMissionChipLinesActive(t *testing.T) {
 			{Kind: missions.KindCircularize, Name: "circular orbit"},
 		},
 	}
-	lines := v.missionChipLines("", false, m)
+	lines := v.missionChipLines("", false, m, 0)
 	if lines == nil {
 		t.Fatal("active mission chip = nil, want content")
 	}
@@ -52,7 +54,7 @@ func TestMissionChipLinesFailureFlash(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	// The flash wins even with an active mission present (it just failed).
 	m := &missions.Mission{ID: "next", Name: "Luna Flyby"}
-	lines := v.missionChipLines("Land Test failed: crashed", true, m)
+	lines := v.missionChipLines("Land Test failed: crashed", true, m, 0)
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "✗") {
 		t.Errorf("failure flash missing ✗ marker:\n%s", joined)
@@ -80,7 +82,7 @@ func TestMissionChipLinesTutorialHint(t *testing.T) {
 			Params:      missions.Params{Action: missions.ActionCycleView},
 		}},
 	}
-	lines := v.missionChipLines("", false, m)
+	lines := v.missionChipLines("", false, m, 0)
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "Press [v]") {
 		t.Errorf("tutorial chip should surface the hint instruction:\n%s", joined)
@@ -91,14 +93,14 @@ func TestMissionChipLinesTutorialHint(t *testing.T) {
 
 	// A challenge-program mission keeps the clean one-liner (no hint).
 	m.Program = missions.ProgramChallenge
-	if got := v.missionChipLines("", false, m); len(got) != 2 {
+	if got := v.missionChipLines("", false, m, 0); len(got) != 2 {
 		t.Errorf("challenge chip = %d lines, want 2 (no hint):\n%s", len(got), strings.Join(got, "\n"))
 	}
 }
 
 func TestMissionChipLinesNilWhenIdle(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
-	if got := v.missionChipLines("", false, nil); got != nil {
+	if got := v.missionChipLines("", false, nil, 0); got != nil {
 		t.Errorf("no mission + no flash chip = %v, want nil", got)
 	}
 }
@@ -128,6 +130,69 @@ func TestBuildMissionsChipReadsWorld(t *testing.T) {
 	}
 }
 
+// TestMissionChipShowsLiveRelayCount — #426 (CONTEXT.md Player surface entry):
+// while a relay_coverage objective is the current one, the chip carries a
+// live "relays online N/3" row alongside the generic progress line, in both
+// the Full and Compact forms. World.ConnectedRelayCount() is the same count
+// the evaluator itself uses (evalRelayCoverage via missionEvalContext) — not
+// re-derived here.
+func TestMissionChipShowsLiveRelayCount(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	m := &missions.Mission{
+		ID:      "chal-relay",
+		Name:    "Relay Constellation",
+		Program: missions.ProgramChallenge,
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindRelayCoverage,
+			Name:   "Three relays connected",
+			Params: missions.Params{MinRelays: 3},
+		}},
+	}
+	full := strings.Join(v.missionChipLines("", false, m, 1), "\n")
+	if !strings.Contains(full, "relays online 1/3") {
+		t.Errorf("full-form chip missing live relay count:\n%s", full)
+	}
+	compact := strings.Join(v.missionChipLinesCompact("", false, m, 1), "\n")
+	if !strings.Contains(compact, "relays online 1/3") {
+		t.Errorf("compact-form chip missing live relay count:\n%s", compact)
+	}
+
+	// A non-relay-coverage objective never carries the row, regardless of
+	// what relayCount is passed.
+	other := &missions.Mission{
+		ID: "m2", Name: "Reach Orbit",
+		Objectives: []missions.Objective{{Kind: missions.KindOrbitInsertion, Name: "make orbit"}},
+	}
+	if got := strings.Join(v.missionChipLines("", false, other, 2), "\n"); strings.Contains(got, "relays online") {
+		t.Errorf("non-relay-coverage chip should not show relay count:\n%s", got)
+	}
+}
+
+// TestBuildMissionsChipReadsLiveRelayCountFromWorld is the wiring test:
+// buildMissionsChip pulls the count from World.ConnectedRelayCount() rather
+// than a caller-supplied value.
+func TestBuildMissionsChipReadsLiveRelayCountFromWorld(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Missions = []missions.Mission{{
+		ID:   "chal-relay",
+		Name: "Relay Constellation",
+		Objectives: []missions.Objective{{
+			Kind:   missions.KindRelayCoverage,
+			Name:   "Three relays connected",
+			Params: missions.Params{MinRelays: 3},
+		}},
+	}}
+	// No CommGraph built yet (no Tick run) → ConnectedRelayCount is 0.
+	chip := strings.Join(v.buildMissionsChip(w), "\n")
+	if !strings.Contains(chip, "relays online 0/3") {
+		t.Errorf("chip should read World.ConnectedRelayCount() (0 before any Tick):\n%s", chip)
+	}
+}
+
 // TestMissionChipHintWrapsInsteadOfWideningTheBox (ADR 0046 / #422): a
 // long tutorial hint ("Warp to your burn ([G]) or fire manually ([b])…",
 // 87 columns in the 2026-09-02 UX review's gameplay-flow-progression-09
@@ -149,7 +214,7 @@ func TestMissionChipHintWrapsInsteadOfWideningTheBox(t *testing.T) {
 		}},
 	}
 
-	full := v.missionChipLines("", false, m)
+	full := v.missionChipLines("", false, m, 0)
 	for _, l := range full {
 		if w := lipgloss.Width(l); w > missionChipWrapWidth+4 { // +4 for the "    " hint indent
 			t.Errorf("full-form line exceeds the wrap width (%d): %q (%d cols)", missionChipWrapWidth, l, w)
@@ -159,7 +224,7 @@ func TestMissionChipHintWrapsInsteadOfWideningTheBox(t *testing.T) {
 		t.Fatalf("full form should wrap the long hint across multiple rows, got %d lines:\n%s", len(full), strings.Join(full, "\n"))
 	}
 
-	compact := v.missionChipLinesCompact("", false, m)
+	compact := v.missionChipLinesCompact("", false, m, 0)
 	for _, l := range compact {
 		if w := lipgloss.Width(l); w > missionChipWrapWidth+4 {
 			t.Errorf("compact-form line exceeds the wrap width (%d): %q (%d cols)", missionChipWrapWidth, l, w)


### PR DESCRIPTION
## Summary

Implements the #426 grill decisions (action-plan.md phase-3 section) end to end:

- **Five-rung Flight School** in `internal/missions/missions.json`: keeps `tut-orient`/`tut-plan`/`tut-fly`, adds `tut-launch` (Off the Pad: spawn on pad, throttle, stage, pitch-east altitude, plan circularize, circularize_from_pad@200km) and `tut-dock` (Meet & Dock: spawn in orbit, target a craft, plan rendezvous, dock).
- **Moon-gated credit**: `tut-orient`'s target step and `tut-plan`'s transfer step now require the bound Target to actually be the Moon; the transfer step also requires the plant not be an Over-budget Node (ADR 0047 §2). Implemented as four new optional gates on `KindEvent` objectives (`RequireTargetBodyID`, `RequireTargetCraft`, `RequireBudgetOK`, `RequireSpawnLocation`).
- **`ManeuverNode.OverBudget(c)`** factored out of two forked call sites (the NODES chip marker and the planner's PLANNED NODES list marker) into one shared predicate, now also used by the mission evaluator.
- **Challenge edges**: `chal-dock` is now a root rung (no prerequisite — Flight School teaches docking); `chal-mars-flyby` requires `chal-luna-capture` instead. New catalog test asserts no `requires` edge crosses a Program boundary.
- **`e:` row** on the full-form ORBIT chip (Compact Form unchanged — stays the Ap/Pe strip).
- **Live relay count** ("relays online N/3") on the MISSION chip while a `relay_coverage` objective is current, sourced from a new `World.ConnectedRelayCount()` (factored out of the evaluator's own counting loop).
- **Planner MISSION reminder**: one dim `MISSION ▸ <step>` line above QUICK PLANS while a Flight School rung is active (nothing for challenges).
- **Ladder screen redesign**: two headed lists (FLIGHT SCHOOL / CHALLENGES) with their own N/M counts, replacing the single interleaved list; locked rungs get a lock glyph (`⚿`) + their hint; available rungs read bright with `▸`; a program that's off shows a one-key toggle offer row instead of its list (also the new both-off empty state). Wired through the existing `toggleMissionProgram`.
- **Sendoff**: `World.LadderSendoff()` derives "FLIGHT SCHOOL COMPLETE" / "CHALLENGE LADDER COMPLETE" purely from `Mission.Status` (no schema bump); shown in both the ladder screen's active-card slot and the MISSION chip.
- **Docs**: new "MISSIONS" section in `help.go` (placed after VEHICLE ASSEMBLY per the task's rebase-conflict-avoidance instruction) and a matching `docs/controls.md` subsection + TOC entry.

## Test plan

- `go vet ./...` clean; `go test ./... -race -count=1` green throughout (checked after every commit).
- `internal/sim/mission_catalog_progression_test.go` (`TestEmbeddedTutorialProgression`) walks all five Flight School rungs to Passed through the real evaluator (RecordAction + evaluateMissions), proving both refusals from the issue's own evidence: a Mercury target press does not credit "aim for the Moon", and an over-budget or wrong-body transfer does not credit "plant a transfer".
- New unit tests for the event-objective gates (`internal/missions/event_gates_test.go`), the mission-eval context wiring (`internal/sim/mission_context_test.go`), `ManeuverNode.OverBudget` (`internal/spacecraft/maneuver_budget_test.go`), the `e:` row and MISSION chip relay count / sendoff (`internal/tui/screens/orbit_chips_test.go`, `orbit_mission_chip_test.go`), the planner reminder (`internal/tui/screens/maneuver_test.go`), the ladder screen's two-list rendering and sendoff (`internal/tui/screens/missions_screen_test.go`), and the digit-key wiring (`internal/tui/missions_screen_toggle_test.go`).
- Manual verification: built the real binary and drove it in a 140×40 tmux session with scratch `XDG_CONFIG_HOME`/`XDG_STATE_HOME`, capturing and reading (row by row) the flight screen with the MISSION chip on rung 1, the ladder screen with both headed lists (including the challenge-edge changes visibly reflected — `Rendezvous & Dock` and `Deploy a Payload` both unlocked roots, `Mars Flyby` now needs `Luna Capture`), the ORBIT chip's `e:` row, and the planner's MISSION reminder line. Captures archived in the planning vault alongside the implementation notes.

Closes #426