### PR TITLE
Ladder screen: [1]/[2] turn a program off as well as on (Flight School opt-out)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2470,8 +2470,14 @@ abandoning a rung is deferred (needs persisted state). An in-flight
 plus N/M progress, flashes a Failed Mission for ~4 s before advancing, and
 surfaces the step's instruction inline for tutorial Missions; a countable
 Objective (relay coverage) shows its live count there ("relays online
-1/3"). When both Programs are off, the screen offers the one-key toggles
-rather than pointing at Settings.
+1/3"). Each Program's list carries a one-key row that says what it does:
+"turn on" in place of the list while the Program is off, "turn off" under
+the list while it is on. That "turn off" row is the **Opt-out**: a player
+who would rather fly unguided switches Flight School off in three presses
+(M, 1, esc), and it persists exactly as the Settings toggle does; the
+first rung's text points at it. Nothing on the screen points at Settings.
+_Avoid_: Dismiss (the chip has no dismiss key of its own), Skip tutorial
+(there is no skip; off is off until switched back on).
 _Avoid_: Quest, Achievement; and don't swap the two core terms — the
 inversion is load-bearing (an Objective is one predicate; a Mission bundles
 several ordered Objectives). The pre-v0.21 naming, where a single predicate

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -437,13 +437,16 @@ Designs are stored as portable files under
 The active mission (if any) shows as a checklist card on top; below it, two
 headed lists — **Flight School** and **Challenges** — each with their own
 progress count. A locked rung is dimmed with what unlocks it; an available
-rung reads bright; completed and failed rungs are marked. A program that's
-switched off shows a one-key toggle in place of its list.
+rung reads bright; completed and failed rungs are marked. Each program
+carries a one-key row: `turn on` in place of its list while it's off,
+`turn off` under its list while it's on. Flight School is on by default;
+if you'd rather fly unguided, `M`, `1`, `Esc` switches it off for good
+(the same toggle lives in Settings).
 
 | Key | Action |
 |---|---|
-| `1` | Turn on Flight School (shown only while it's off) |
-| `2` | Turn on the Challenge ladder (shown only while it's off) |
+| `1` | Turn Flight School on / off |
+| `2` | Turn the Challenge ladder on / off |
 | `Esc` | Back to the map |
 
 ### Saves (`Esc → [Save Game]` / `[Load Game]`)

--- a/internal/missions/missions.json
+++ b/internal/missions/missions.json
@@ -8,7 +8,7 @@
       "objectives": [
         {
           "name": "Change your view",
-          "description": "Press [v] to cycle the camera view.",
+          "description": "Press [v] to cycle the camera view. Rather fly solo? [M] then [1] turns Flight School off.",
           "kind": "event",
           "params": { "action": "cycle_view" }
         },

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -991,21 +991,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// above) so these raw digits don't also fall through to the
 		// switch's CraftSlot case, which — per the comment on the K case
 		// below — reaches screenMissions same as screenOrbit.
-		// Enable-only: the offer row is shown only while a program is off,
-		// so a digit pressed while it is already on is a stray key, not a
-		// request to switch it off (the F1 row promises "turn on"). Off is
-		// the Settings screen's job.
+		// A true toggle: the ladder shows "[N] turn on" while a program is
+		// off and "[N] turn off" while it is on, so the key always does
+		// what the row beside it says. The off direction is the fast opt-out
+		// from Flight School (M, 1, esc) for a player who wants to fly
+		// unguided; it persists like the Settings toggle.
 		if a.active == screenMissions {
 			switch m.String() {
 			case "1":
-				if !a.orbitView.Settings().TutorialOn() {
-					a.toggleMissionProgram(true)
-				}
+				a.toggleMissionProgram(true)
 				return a, nil
 			case "2":
-				if !a.orbitView.Settings().ChallengesEnabled {
-					a.toggleMissionProgram(false)
-				}
+				a.toggleMissionProgram(false)
 				return a, nil
 			}
 		}

--- a/internal/tui/missions_screen_toggle_test.go
+++ b/internal/tui/missions_screen_toggle_test.go
@@ -6,14 +6,13 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 )
 
-// #426 item F, decision 5: the missions ladder screen offers one-key
-// enables ("[1] turn on Flight School" / "[2] turn on the Challenge
-// ladder") wired through the SAME toggleMissionProgram Settings uses, not a
-// new path. The keys are enable-only: the offer row is shown only while a
-// program is off, so a digit pressed while it is already on must not switch
-// it off (the F1 row promises "turn on"). These pin that pressing 1/2 on
-// screenMissions flips the persisted Settings toggle on, re-pushes the
-// enabled-program set to World, and is a no-op once on.
+// #426 item F, decision 5, plus the opt-out Jason asked for on
+// 2026-09-04: the missions ladder screen carries a one-key row per program
+// ("[1] turn on Flight School" while off, "[1] turn off Flight School"
+// while on; same for "[2]" and the Challenge ladder) wired through the SAME
+// toggleMissionProgram Settings uses, not a new path. These pin that the
+// digit flips the persisted Settings toggle in BOTH directions and re-pushes
+// the enabled-program set to World, so M, 1, esc is a real opt-out.
 
 func withProgramsOff(t *testing.T) *App {
 	t.Helper()
@@ -30,11 +29,10 @@ func withProgramsOff(t *testing.T) *App {
 	return a
 }
 
-func TestMissionsScreenDigitOneTurnsOnTutorial(t *testing.T) {
+func TestMissionsScreenDigitOneTogglesTutorialBothWays(t *testing.T) {
 	a := withProgramsOff(t)
 
 	pressKey(a, '1')
-
 	if !a.orbitView.Settings().TutorialOn() {
 		t.Fatalf("TutorialOn still false after pressing 1 on the missions screen")
 	}
@@ -45,18 +43,23 @@ func TestMissionsScreenDigitOneTurnsOnTutorial(t *testing.T) {
 		t.Errorf("active screen changed to %v, want to stay on screenMissions", a.active)
 	}
 
-	// Enable-only: a second press must not switch it back off.
+	// The opt-out: a second press switches it off, and World follows.
 	pressKey(a, '1')
-	if !a.orbitView.Settings().TutorialOn() {
-		t.Fatalf("pressing 1 while Flight School is on switched it off; the key is enable-only")
+	if a.orbitView.Settings().TutorialOn() {
+		t.Fatalf("pressing 1 while Flight School is on did not switch it off; M, 1, esc must be a real opt-out")
+	}
+	if a.world.MissionProgramEnabled(missions.ProgramTutorial) {
+		t.Errorf("World still runs the tutorial after the persisted toggle went off")
+	}
+	if a.orbitView.Settings().TutorialEnabled == nil {
+		t.Errorf("opt-out must be recorded as an explicit false, not reset to absent (absent means on)")
 	}
 }
 
-func TestMissionsScreenDigitTwoTurnsOnChallenges(t *testing.T) {
+func TestMissionsScreenDigitTwoTogglesChallengesBothWays(t *testing.T) {
 	a := withProgramsOff(t)
 
 	pressKey(a, '2')
-
 	if !a.orbitView.Settings().ChallengesEnabled {
 		t.Fatalf("ChallengesEnabled still false after pressing 2 on the missions screen")
 	}
@@ -65,8 +68,8 @@ func TestMissionsScreenDigitTwoTurnsOnChallenges(t *testing.T) {
 	}
 
 	pressKey(a, '2')
-	if !a.orbitView.Settings().ChallengesEnabled {
-		t.Fatalf("pressing 2 while the Challenge ladder is on switched it off; the key is enable-only")
+	if a.orbitView.Settings().ChallengesEnabled {
+		t.Fatalf("pressing 2 while the Challenge ladder is on did not switch it off")
 	}
 }
 

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -154,8 +154,8 @@ var helpSections = []helpSection{
 		{"s / o", "save the design (name it) / open a saved design"},
 	}},
 	{"MISSIONS (ladder screen — open with M)", [][2]string{
-		{"1", "turn on Flight School (shown when it's off)"},
-		{"2", "turn on the Challenge ladder (shown when it's off)"},
+		{"1", "turn Flight School on / off (the row under its list says which)"},
+		{"2", "turn the Challenge ladder on / off"},
 	}},
 	{"SAVES (menu → Save / Load Game)", [][2]string{
 		{"↑ / ↓", "move the save cursor"},

--- a/internal/tui/screens/missions.go
+++ b/internal/tui/screens/missions.go
@@ -204,9 +204,13 @@ func programMissions(ms []missions.Mission, program string) []missions.Mission {
 // they got), then either the classified rung list (the active rung, if any
 // of these missions owns it, is skipped — the card above already shows it)
 // or, when the program is off, one dim offer row naming its one-key toggle
-// (#426 item F, decision 5). heading is the section's all-caps label
-// ("FLIGHT SCHOOL"); label is the lower-case name used in the offer row's
-// "[N] turn on <label>" text; key is that digit ("1" or "2").
+// (#426 item F, decision 5). When the program is on, the same key is
+// offered as "[N] turn off <label>" under its list, so a player who wants
+// to play unguided can opt out of Flight School in three presses (M, 1,
+// esc) instead of a trip through Settings (Jason, 2026-09-04). heading is
+// the section's all-caps label ("FLIGHT SCHOOL"); label is the lower-case
+// name used in the offer row's "[N] turn on/off <label>" text; key is that
+// digit ("1" or "2").
 func (m *Missions) programSection(heading, label, key string, ms []missions.Mission, enabled bool, activeID string) string {
 	var b strings.Builder
 	passed := 0
@@ -229,6 +233,8 @@ func (m *Missions) programSection(heading, label, key string, ms []missions.Miss
 		b.WriteString(m.ladderRowLine(r))
 		b.WriteByte('\n')
 	}
+	b.WriteString(m.theme.Dim.Render(fmt.Sprintf("  [%s] turn off %s", key, label)))
+	b.WriteByte('\n')
 	return b.String()
 }
 

--- a/internal/tui/screens/missions_screen_test.go
+++ b/internal/tui/screens/missions_screen_test.go
@@ -199,6 +199,14 @@ func TestMissionsRenderOffProgramShowsToggleOffer(t *testing.T) {
 	if !strings.Contains(out, "[2] turn on the Challenge ladder") {
 		t.Errorf("challenges-off should still show its toggle offer:\n%s", out)
 	}
+	// The on program carries the opposite row under its list, so the key
+	// always does what the row says (the fast opt-out from Flight School).
+	if !strings.Contains(out, "[1] turn off Flight School") {
+		t.Errorf("tutorial-on should offer the turn-off row under its list:\n%s", out)
+	}
+	if strings.Contains(out, "[1] turn on Flight School") {
+		t.Errorf("tutorial-on must not also show the turn-on row:\n%s", out)
+	}
 }
 
 // TestMissionsRenderLockedRungHasLockGlyphAndAvailableIsBright — #426 item


### PR DESCRIPTION
## Summary

Flight School is on by default since #441, but the only way off was Settings (Esc, Settings, cursor past the chip rows, Enter). Jason asked for an immediate opt-out before tagging v0.40.0.

- Each program section on the ladder screen now carries a one-key row that says what it does: `[N] turn on <program>` in place of the list while off (unchanged), `[N] turn off <program>` under the list while on (new).
- `1`/`2` are a true toggle again (the enable-only guard from the #442 rebase is gone, since the row now names the direction). Same `toggleMissionProgram` path as Settings; the choice persists as an explicit false.
- Rung 1's text points at it: "Rather fly solo? [M] then [1] turns Flight School off."
- F1 MISSIONS rows, controls.md and the CONTEXT.md Player surface entry (new **Opt-out** term) updated.

## Test plan

- `go vet ./...` and `go test ./... -race -count=1` green.
- `missions_screen_toggle_test.go` pins both directions and that the off choice is an explicit false (absent means on).
- `missions_screen_test.go` pins the turn-off row under an on program and its absence when off.
- Live at 140x40 in tmux with scratch XDG dirs: M shows `[1] turn off Flight School`; pressing 1 flips the section to `[1] turn on Flight School`; Esc back to the map shows no MISSION chip; settings.json carries `tutorialEnabled: false`.