### PR TITLE
Launch View: show the [»Burn] Auto-Warp button

### DIFF
--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -201,16 +201,38 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	// only the vessel name, so `.`/`,` kept warping with no on-screen
 	// change at all (one reviewer lost ten sim-days tapping `.` on the
 	// pad before noticing on the map).
+	//
+	// The `[»Burn]` Auto-Warp-to-next-burn button (orbit.go's
+	// renderTitleBar, v0.16 / ADR 0016) never got its launch-view
+	// counterpart: a player who lifts off auto-routes straight into this
+	// screen (ViewLaunch auto-route) and can coast for real minutes with
+	// no visible way to warp to the node they just planted with `C` — the
+	// button that answers exactly that is one screen away. `G` already
+	// works here (App's key switch isn't screen-gated), so this is a
+	// rendering-only parity fix, same color rules as orbit.go: Warning
+	// while engaged, dimmed when no burn is eligible, Primary otherwise.
 	titleLeft := fmt.Sprintf("LAUNCH — %s", craftName)
-	titleRight := warpRateText(w)
+	burnLabel := "[»Burn]"
+	if w.AutoWarpEngaged() {
+		burnLabel = "[■Burn]"
+	}
+	titleRight := warpRateText(w) + "  " + burnLabel
 	titlePad := totalCols - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
 	if titlePad < 1 {
 		titlePad = 1
 	}
-	titleRightRendered := v.theme.Dim.Render(titleRight)
+	warpRendered := v.theme.Dim.Render(warpRateText(w))
 	if w.AutoWarpEngaged() {
-		titleRightRendered = v.theme.Primary.Render(titleRight)
+		warpRendered = v.theme.Primary.Render(warpRateText(w))
 	}
+	burnRendered := v.theme.Primary.Render(burnLabel)
+	switch {
+	case w.AutoWarpEngaged():
+		burnRendered = v.theme.Warning.Render(burnLabel)
+	case !w.AutoWarpEligible():
+		burnRendered = v.theme.Dim.Render(burnLabel)
+	}
+	titleRightRendered := warpRendered + "  " + burnRendered
 	title := v.theme.Title.Render(titleLeft) + strings.Repeat(" ", titlePad) + titleRightRendered
 
 	// The descent half (ADR 0043 §3): one forecast per frame, shared by

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -225,6 +225,45 @@ func TestLaunchViewTitleShowsWarpRate(t *testing.T) {
 	}
 }
 
+// TestLaunchViewTitleShowsBurnButton — a player who lifts off auto-routes
+// into this screen (ViewLaunch auto-route) and can coast for real minutes
+// with no visible way to warp to a planted node: the `[»Burn]` Auto-Warp
+// button existed only in orbit.go's title bar, one screen away. `G` (and
+// the click-equivalent on the map) already worked here since App's key
+// switch isn't screen-gated — this was a missing readout, not a missing
+// control. Mirrors auto_warp_titlebar_test.go's coverage for the map.
+func TestLaunchViewTitleShowsBurnButton(t *testing.T) {
+	th := launchThemeForTest()
+	v := NewLaunchView(th, NewOrbitView(th))
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	idle := v.Render(w, 140, 40)
+	if !strings.Contains(idle, "[»Burn]") {
+		t.Errorf("launch title missing [»Burn] button with no burn planted, got:\n%s", idle)
+	}
+
+	w.PlanNode(sim.ManeuverNode{TriggerTime: w.Clock.SimTime.Add(2 * time.Hour), DV: 10, Mode: spacecraft.BurnPrograde})
+	eligible := v.Render(w, 140, 40)
+	if !strings.Contains(eligible, "[»Burn]") {
+		t.Errorf("launch title missing [»Burn] button with an eligible burn planted, got:\n%s", eligible)
+	}
+
+	if !w.EngageAutoWarp() {
+		t.Fatal("EngageAutoWarp failed with an eligible burn planted")
+	}
+	engaged := v.Render(w, 140, 40)
+	if !strings.Contains(engaged, "[■Burn]") {
+		t.Errorf("launch title missing [■Burn] label once Auto-Warp engaged, got:\n%s", engaged)
+	}
+	if strings.Contains(engaged, "[»Burn]") {
+		t.Errorf("launch title still showed idle [»Burn] once Auto-Warp engaged:\n%s", engaged)
+	}
+}
+
 // TestLaunchHUDLineShowsIgnitionHintOnPad — #427 / ADR 0048 §3: the pad's
 // call to action. While Landed with the engine off, the status-area line
 // (bottom border, normally T+/v_z/downrange/Q) becomes the ignite/stage/


### PR DESCRIPTION
## Summary
- Live-playtesting the Off the Pad Flight School rung, coasting to apoapsis after planting `C` in the chase-cam Launch View surfaced this: liftoff auto-routes into Launch View and there was no visible way to warp to the planted node — the `[»Burn]` Auto-Warp button only ever rendered in the map's Orbit View title bar (Launch View's title only carried the bare `warp Nx` readout, added by #427).
- `G` (and the equivalent click on the map) already worked from Launch View — App's key switch isn't screen-gated — so this is a rendering-only parity fix: same `[»Burn]`/`[■Burn]` label, same color rules (Warning while engaged, dimmed when no burn is eligible, Primary otherwise) as `orbit.go`'s title bar.
- No mouse hit-test added — Launch View has no existing mouse-click handling to hang it on, and `G` already covers keyboard.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1` (full suite green)
- [x] New test `TestLaunchViewTitleShowsBurnButton`: idle/eligible/engaged states, mirrors `auto_warp_titlebar_test.go`'s coverage for the map