### PR TITLE
Fix: floating-point throttle residual keeps warp pinned at 10x

### DIFF
--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -113,6 +113,18 @@ func (w *World) ToggleManualBurn() {
 	w.StartManualBurn()
 }
 
+// throttleZeroEpsilon floors a near-zero throttle to exactly 0 before
+// SetThrottle's cut check. AdjustThrottle reaches 0% by repeated ±0.1
+// float additions (the `X`/`Z` -10%/+10% keys); ten of those from 1.0
+// lands on 1.3878e-16, not exactly 0.0 (binary floating point can't
+// represent 0.1 exactly), so the exact-equality cut check below used
+// to silently miss it — the throttle row rounds to a display "0%" but
+// ManualBurn never clears, leaving the engine "on" (anyCraftThrusting)
+// and warp pinned to the 10× burn cap with nothing on screen to say
+// why. Found live: player reported warp stuck at 10× well outside the
+// atmosphere despite reading 0% throttle.
+const throttleZeroEpsilon = 1e-9
+
 // SetThrottle clamps the requested throttle to [0, 1] and applies
 // it to the active craft. Setting throttle to 0 also stops the
 // active craft's in-flight manual burn so the "x = cut" muscle
@@ -137,7 +149,7 @@ func (w *World) SetThrottle(t float64) {
 	if !w.canCommand(c) { // ADR 0027: no new throttle command without a connection
 		return
 	}
-	if t < 0 {
+	if t < throttleZeroEpsilon {
 		t = 0
 	} else if t > 1 {
 		t = 1

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -2317,6 +2317,37 @@ func TestSetThrottleZeroStopsManualBurn(t *testing.T) {
 	}
 }
 
+// TestAdjustThrottleTenStepsDownStopsManualBurn: reaching 0% via ten
+// repeated -10% presses (the `X` key, AdjustThrottle(-0.1) each time)
+// must clear ManualBurn exactly like a direct SetThrottle(0)/`x` cut,
+// even though the accumulated float lands on ~1.39e-16, not exactly
+// 0.0 (0.1 has no exact binary representation). Before the
+// throttleZeroEpsilon floor, SetThrottle's exact `t == 0` check missed
+// this residual: the throttle row rounded to a displayed 0% while
+// ManualBurn stayed set, pinning EffectiveWarp at the 10× burn cap
+// with nothing on screen explaining why. Found live-playtesting.
+func TestAdjustThrottleTenStepsDownStopsManualBurn(t *testing.T) {
+	w, _ := NewWorld()
+	w.ActiveCraft().Throttle = 1.0
+	w.ActiveCraft().AttitudeMode = spacecraft.BurnPrograde
+	w.StartManualBurn()
+	if w.ActiveCraft().ManualBurn == nil {
+		t.Fatal("setup: ManualBurn should be set")
+	}
+	for i := 0; i < 10; i++ {
+		w.AdjustThrottle(-0.1)
+	}
+	if got := w.ActiveCraft().Throttle; got != 0 {
+		t.Errorf("Craft.Throttle = %v, want exactly 0", got)
+	}
+	if w.ActiveCraft().ManualBurn != nil {
+		t.Error("ten -10% steps to 0% should stop the manual burn, same as a direct cut")
+	}
+	if w.anyCraftThrusting() {
+		t.Error("warp should not stay pinned to the burn cap once throttle reads 0%")
+	}
+}
+
 // TestAdjustThrottleClampsToRange: ±10 % steps must clamp to [0, 1]
 // regardless of the requested delta, preserving the throttle invariant.
 func TestAdjustThrottleClampsToRange(t *testing.T) {


### PR DESCRIPTION
## Summary
- Found live-playtesting: warp stayed capped at 10x well outside the atmosphere even after cutting throttle to a displayed 0%.
- Root cause: pressing the `X` (throttle -10%) key ten times from full throttle accumulates via repeated float addition (`AdjustThrottle(-0.1)` x10) and lands on `1.3877787807814457e-16`, not exactly `0.0` — 0.1 has no exact binary representation. `SetThrottle`'s cut check (`if t == 0 { StopManualBurn() }`) is an exact-equality comparison, so it silently misses this residual. The throttle row rounds the tiny value to a displayed "0%", but `ManualBurn` never clears, so `anyCraftThrusting()` stays true and `clampedWarp()` keeps the 10x burn cap in effect — with nothing on screen explaining why.
- Fix: floor any throttle below a `1e-9` epsilon to exactly `0` before the cut check in `SetThrottle` (covers `AdjustThrottle` too, since it routes through `SetThrottle`). A direct `x` cut (`SetThrottle(0)`) was never affected — only the accumulated `X`/`Z` step path.

## Test plan
- [x] New regression test `TestAdjustThrottleTenStepsDownStopsManualBurn`: ten `AdjustThrottle(-0.1)` calls from full throttle must land on exactly `0` and clear `ManualBurn`. Verified it fails without the fix (`Craft.Throttle = 1.3877787807814457e-16, want exactly 0`) and passes with it.
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1` (full suite green)