### PR TITLE
Burn state visibility: 7 UX fixes from the 2026-09-06 grill

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2757,7 +2757,26 @@ Collapse (bare; say Compact Form), Responsive.
 The momentary "hide all overlays" action (F2) that clears every Chip and
 the Navball to expose a clean orbit view. Transient and unsaved — it does
 not change the persisted Settings, and it never hides the **HUD** column.
+Named twice on screen while it's on (grilled 2026-09-06): the canvas
+footer's view label gets a trailing `· declutter`, and the title bar
+carries a Dim `[F2 declutter]` tag beside the warp readout — both gone
+the instant F2 clears it. The Launch View shares the same state and gets
+the same title-bar tag.
 _Avoid_: Hide UI, clean mode, F2 mode, toggle overlays.
+
+**Engine-lit cue** (grilled 2026-09-06, "burn state is invisible"):
+The set of always-visible signals that an engine is actually producing
+thrust right now, as opposed to merely set to some throttle. Three parts,
+all gated on live thrust (`AnyCraftThrusting`: a live `ActiveBurn` or
+`ManualBurn` on any craft in the slate) and never on the throttle
+*setting*: the **HUD** chip's `throttle:` row carries a trailing `(idle)`
+(Dim) or `● FIRING` (Warning) suffix; the map canvas border (and the
+Launch View's pad canvas border) switches from Primary to Warning; and
+the title bar (both screens) carries a `● BURN` badge in Warning beside
+the warp readout. All three clear the tick thrust stops.
+_Avoid_: "engine on"/"engine off" (ambiguous with the throttle setting),
+LIT (that's the Launch pad's separate pre-ignition `twr:` row indicator,
+ADR 0048 §3, not this cue).
 
 **Announcement** — **Event Flash** / **Standing Alert** (grilled 2026-09-04, #421/#427):
 How the game tells the player something happened, in two tiers by

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -388,6 +388,18 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			PlannedDV:        wc.ActiveBurn.PlannedDV,
 			NodeIndex:        wc.ActiveBurn.NodeIndex,
 		}
+		// #447 review finding 8: a save written before PlannedDV existed
+		// decodes it as the zero value, and app.go's burn-finished flash
+		// would otherwise print "burned — 0 m/s" for a burn that really
+		// delivered thousands of m/s. DVRemaining at save time is the
+		// closest available estimate of what's left to deliver — not
+		// exact (some Δv may already have been spent before the save),
+		// but far closer than a bare, wrong zero. app.go additionally
+		// drops the "— N m/s" clause entirely if this still comes back 0
+		// (an unfired burn saved at the instant of ignition).
+		if c.ActiveBurn.PlannedDV == 0 {
+			c.ActiveBurn.PlannedDV = c.ActiveBurn.DVRemaining
+		}
 		// #294 review round 3 (finding D): defensive load-time teardown for
 		// an ActiveBurn that is target-relative in Mode but carries no
 		// target at all (TargetCraftID==0, ownerless). This is exactly the

--- a/internal/save/craft_wire.go
+++ b/internal/save/craft_wire.go
@@ -152,6 +152,8 @@ func CraftToWire(c *spacecraft.Spacecraft) Craft {
 			PlaneChangeRad:   ab.PlaneChangeRad,
 			BurnDirUnit:      vec3From(ab.BurnDirUnit),
 			TargetGhostOwner: ab.TargetGhostOwner,
+			PlannedDV:        ab.PlannedDV,
+			NodeIndex:        ab.NodeIndex,
 		}
 	}
 	// v0.9.3 polish: per-craft Target. Skip serialising when the craft has
@@ -383,6 +385,8 @@ func CraftFromWire(wc Craft, systems []bodies.System) (*spacecraft.Spacecraft, e
 			PlaneChangeRad:   wc.ActiveBurn.PlaneChangeRad,
 			BurnDirUnit:      vec3To(wc.ActiveBurn.BurnDirUnit),
 			TargetGhostOwner: wc.ActiveBurn.TargetGhostOwner, // #294 review finding 5
+			PlannedDV:        wc.ActiveBurn.PlannedDV,
+			NodeIndex:        wc.ActiveBurn.NodeIndex,
 		}
 		// #294 review round 3 (finding D): defensive load-time teardown for
 		// an ActiveBurn that is target-relative in Mode but carries no

--- a/internal/save/craft_wire_planned_dv_fallback_test.go
+++ b/internal/save/craft_wire_planned_dv_fallback_test.go
@@ -1,0 +1,94 @@
+package save
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// TestCraftFromWireFallsBackPlannedDVWhenAbsent — #447 review finding 8.
+// A save written before ActiveBurn.PlannedDV existed decodes it as the
+// zero value (additive omitempty field). Without a fallback, the
+// burn-finished Event Flash would print "burned — 0 m/s" for a burn
+// that really delivered real Δv — a false statement, not merely a less
+// precise one. CraftFromWire falls back to DVRemaining (the wire form's
+// own remaining-Δv estimate at save time) whenever PlannedDV comes back
+// 0, so the finish flash reports the closest available real figure
+// instead of a fabricated zero.
+func TestCraftFromWireFallsBackPlannedDVWhenAbsent(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	wc := CraftToWire(c)
+	wc.ActiveBurn = &ActiveBurn{
+		Mode:        int(spacecraft.BurnPrograde),
+		DVRemaining: 1800,
+		EndTimeNano: w.Clock.SimTime.Add(time.Minute).UnixNano(),
+		PrimaryID:   c.Primary.ID,
+		Throttle:    1,
+		// PlannedDV / NodeIndex both zero — a pre-#447 save's shape.
+	}
+
+	loaded, err := CraftFromWire(wc, systems)
+	if err != nil {
+		t.Fatalf("CraftFromWire: %v", err)
+	}
+	if loaded.ActiveBurn == nil {
+		t.Fatal("ActiveBurn did not survive load")
+	}
+	if loaded.ActiveBurn.PlannedDV != 1800 {
+		t.Errorf("PlannedDV = %v, want fallback to DVRemaining (1800)", loaded.ActiveBurn.PlannedDV)
+	}
+}
+
+// TestCraftFromWireKeepsExplicitPlannedDV — the fallback above must be
+// surgical: a save written AFTER #447, carrying a real (non-zero)
+// PlannedDV, loads it unchanged rather than being overridden by
+// DVRemaining (which can legitimately differ once a burn has partially
+// delivered its Δv).
+func TestCraftFromWireKeepsExplicitPlannedDV(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	systems, err := bodies.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+
+	wc := CraftToWire(c)
+	wc.ActiveBurn = &ActiveBurn{
+		Mode:        int(spacecraft.BurnPrograde),
+		DVRemaining: 900, // partially delivered — differs from PlannedDV
+		EndTimeNano: w.Clock.SimTime.Add(time.Minute).UnixNano(),
+		PrimaryID:   c.Primary.ID,
+		Throttle:    1,
+		PlannedDV:   3054,
+		NodeIndex:   2,
+	}
+
+	loaded, err := CraftFromWire(wc, systems)
+	if err != nil {
+		t.Fatalf("CraftFromWire: %v", err)
+	}
+	if loaded.ActiveBurn == nil {
+		t.Fatal("ActiveBurn did not survive load")
+	}
+	if loaded.ActiveBurn.PlannedDV != 3054 {
+		t.Errorf("PlannedDV = %v, want the explicit wire value 3054 (not overridden by DVRemaining)", loaded.ActiveBurn.PlannedDV)
+	}
+	if loaded.ActiveBurn.NodeIndex != 2 {
+		t.Errorf("NodeIndex = %v, want 2", loaded.ActiveBurn.NodeIndex)
+	}
+}

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -466,13 +466,19 @@ type ActiveBurn struct {
 	TargetGhostOwner string `json:"target_ghost_owner,omitempty"`
 	// PlannedDV (ADR 0048, additive omitempty) mirrors the spacecraft
 	// field: the firing node's original Δv, kept for the burn-finished
-	// Event Flash's wording. Absent on older saves — a reloaded burn
-	// mid-flight just loses the exact figure on its finish flash, no
-	// migration needed.
+	// Event Flash's wording. Absent (zero) on a save written before this
+	// field existed — CraftFromWire falls back to DVRemaining in that
+	// case (#447 review finding 8: a bare zero here would otherwise read
+	// as "node 1 burned — 0 m/s", a false statement about a burn that
+	// just delivered real Δv, not merely a less precise one), and
+	// app.go's flash drops the "— N m/s" clause entirely if even that
+	// fallback comes back 0. No migration needed either way.
 	PlannedDV float64 `json:"planned_dv,omitempty"`
 	// NodeIndex (ADR 0048, additive omitempty) mirrors the spacecraft
 	// field: the firing node's 0-based ordinal, for the "node #N" wording
-	// on the finish flash.
+	// on the finish flash. Absent (zero) on an older save reads as "node
+	// 1" — a guess, not a migration hazard; nothing downstream trusts
+	// this index for anything but display text.
 	NodeIndex int `json:"node_index,omitempty"`
 }
 

--- a/internal/save/save.go
+++ b/internal/save/save.go
@@ -464,6 +464,16 @@ type ActiveBurn struct {
 	// reconnect mid an in-flight target-relative finite burn should
 	// re-latch the burn's own ref, not just Craft.Target.
 	TargetGhostOwner string `json:"target_ghost_owner,omitempty"`
+	// PlannedDV (ADR 0048, additive omitempty) mirrors the spacecraft
+	// field: the firing node's original Δv, kept for the burn-finished
+	// Event Flash's wording. Absent on older saves — a reloaded burn
+	// mid-flight just loses the exact figure on its finish flash, no
+	// migration needed.
+	PlannedDV float64 `json:"planned_dv,omitempty"`
+	// NodeIndex (ADR 0048, additive omitempty) mirrors the spacecraft
+	// field: the firing node's 0-based ordinal, for the "node #N" wording
+	// on the finish flash.
+	NodeIndex int `json:"node_index,omitempty"`
 }
 
 // Errors returned by Load.

--- a/internal/sim/burn_announce_test.go
+++ b/internal/sim/burn_announce_test.go
@@ -1,0 +1,193 @@
+package sim
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// This file covers decision 4 of the burn-state-visibility batch
+// (grilled 2026-09-06, designdocs/terminal-space-program/ux-reviews/
+// 20260902-1059/triage/action-plan.md; ADR 0048): a planted finite burn
+// firing and finishing in total silence. Modeled on how LastDockEvent
+// (docking_test.go) and LastNodeTargetRefusal are tested — stash-site
+// assertions on World fields, not app.go's flash wording (that's covered
+// by internal/tui/app_test.go, if one exists, or just left to the
+// flash-formatting convention shared with the other Last*Event fields).
+
+// TestExecuteDueNodesStampsBurnFiredEvent — a due finite node igniting
+// (the c.ActiveBurn = &ActiveBurn{...} branch of executeDueNodesFor)
+// must stash LastBurnFiredEvent with the craft's name, the node's DV,
+// and its 0-based NodeIndex (the "node #N" convention) — per craft, not
+// just the active one.
+func TestExecuteDueNodesStampsBurnFiredEvent(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	now := w.Clock.SimTime
+
+	// A held node ahead of it (unresolved) so NodeIndex must read 1, not
+	// 0 — proving the stash names this node's real ordinal, not just "the
+	// first node examined".
+	held := spacecraft.ManeuverNode{
+		Mode: spacecraft.BurnPrograde,
+		DV:   50,
+		// Event-relative, unresolved: TriggerTime stays zero until the
+		// lazy-freeze resolver fires, so this node holds every tick.
+		Event: spacecraft.TriggerNextApo,
+	}
+	firing := spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          3054,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    60 * time.Second, // BurnStart = now - 20s: already due
+	}
+	c.Nodes = []spacecraft.ManeuverNode{held, firing}
+
+	if w.LastBurnFiredEvent != nil {
+		t.Fatal("precondition: LastBurnFiredEvent already set before any burn fired")
+	}
+	w.executeDueNodes()
+
+	// The held node can't resolve/fire, so it stays queued and blocks the
+	// walk (executeDueNodesFor stops dispatching once one node holds) —
+	// rebuild the fixture without it so `firing` is actually reachable.
+	if c.ActiveBurn != nil {
+		t.Fatal("test fixture bug: held node should have blocked the walk")
+	}
+
+	c.Nodes = []spacecraft.ManeuverNode{firing}
+	w.executeDueNodes()
+
+	if c.ActiveBurn == nil {
+		t.Fatal("firing node did not start an ActiveBurn")
+	}
+	if w.LastBurnFiredEvent == nil {
+		t.Fatal("firing node did not stash LastBurnFiredEvent")
+	}
+	e := w.LastBurnFiredEvent
+	if e.CraftName != c.Name {
+		t.Errorf("LastBurnFiredEvent.CraftName = %q, want %q", e.CraftName, c.Name)
+	}
+	if e.DV != 3054 {
+		t.Errorf("LastBurnFiredEvent.DV = %v, want 3054", e.DV)
+	}
+	if e.NodeIndex != 0 {
+		t.Errorf("LastBurnFiredEvent.NodeIndex = %d, want 0 (only node left in the queue)", e.NodeIndex)
+	}
+	// The running burn itself must carry the same figures forward so the
+	// finish event can report them later (DVRemaining drifts as the burn
+	// integrates; PlannedDV/NodeIndex must not).
+	if c.ActiveBurn.PlannedDV != 3054 {
+		t.Errorf("ActiveBurn.PlannedDV = %v, want 3054", c.ActiveBurn.PlannedDV)
+	}
+}
+
+// TestExecuteDueNodesStampsBurnFiredEventNonActiveCraft — decision 4 is
+// explicit that this is a per-craft hook, not just the active vessel's:
+// a burn igniting on a different craft in the slate must still stamp
+// LastBurnFiredEvent, naming that craft.
+func TestExecuteDueNodesStampsBurnFiredEventNonActiveCraft(t *testing.T) {
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	other := w.Crafts[1]
+	other.Name = "Tug-1"
+	now := w.Clock.SimTime
+	other.Nodes = []spacecraft.ManeuverNode{{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          500,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    20 * time.Second,
+	}}
+
+	w.executeDueNodes()
+
+	if other.ActiveBurn == nil {
+		t.Fatal("non-active craft's due node did not fire")
+	}
+	if w.LastBurnFiredEvent == nil {
+		t.Fatal("non-active craft's ignition did not stash LastBurnFiredEvent")
+	}
+	if w.LastBurnFiredEvent.CraftName != "Tug-1" {
+		t.Errorf("LastBurnFiredEvent.CraftName = %q, want %q (non-active craft)", w.LastBurnFiredEvent.CraftName, "Tug-1")
+	}
+}
+
+// TestBurnExhaustionStampsBurnFinishedEvent — the teardown branch in
+// integrateOneCraft (c.ActiveBurn = nil on exhaustion) must stash
+// LastBurnFinishedEvent naming the craft, the node's originally planned
+// Δv (not the ~0 DVRemaining left by exhaustion), the fired node's
+// ordinal, and how many nodes are still queued on that craft afterward.
+func TestBurnExhaustionStampsBurnFinishedEvent(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	// One more node still queued behind the burn under test, so
+	// NodesRemaining has something other than 0 to assert against.
+	c.Nodes = []spacecraft.ManeuverNode{{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          10,
+		TriggerTime: w.Clock.SimTime.Add(24 * time.Hour),
+	}}
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnPrograde,
+		DVRemaining: 3054,
+		PlannedDV:   3054,
+		NodeIndex:   2,               // "node #3" — proves the finish event carries this through, not just 0
+		EndTime:     w.Clock.SimTime, // already due: exhausts on this tick
+		PrimaryID:   c.Primary.ID,
+		Throttle:    1,
+	}
+
+	if w.LastBurnFinishedEvent != nil {
+		t.Fatal("precondition: LastBurnFinishedEvent already set before any burn finished")
+	}
+	_, done := tickUntil(w, 50, func() bool { return c.ActiveBurn == nil })
+	if !done {
+		t.Fatal("burn never tore down as exhausted within 50 ticks")
+	}
+	if w.LastBurnFinishedEvent == nil {
+		t.Fatal("exhausted burn did not stash LastBurnFinishedEvent")
+	}
+	e := w.LastBurnFinishedEvent
+	if e.CraftName != c.Name {
+		t.Errorf("LastBurnFinishedEvent.CraftName = %q, want %q", e.CraftName, c.Name)
+	}
+	if e.DV != 3054 {
+		t.Errorf("LastBurnFinishedEvent.DV = %v, want 3054 (PlannedDV, not the exhausted DVRemaining)", e.DV)
+	}
+	if e.NodeIndex != 2 {
+		t.Errorf("LastBurnFinishedEvent.NodeIndex = %d, want 2", e.NodeIndex)
+	}
+	if e.NodesRemaining != 1 {
+		t.Errorf("LastBurnFinishedEvent.NodesRemaining = %d, want 1 (the still-queued node)", e.NodesRemaining)
+	}
+}
+
+// TestBurnStallDoesNotStampBurnFinishedEvent — a stalled burn (fuel-dry,
+// Δv still owed) is paused, not finished; it must not stamp
+// LastBurnFinishedEvent while stalled.
+func TestBurnStallDoesNotStampBurnFinishedEvent(t *testing.T) {
+	w := mustWorld(t)
+	c := twoStageBurner(t, w, 200)
+	c.ActiveBurn.PlannedDV = 200
+
+	_, ok := tickUntil(w, 200, func() bool { return c.ActiveStageFuel() <= 0 })
+	if !ok {
+		t.Fatal("lower stage never ran dry within 200 ticks")
+	}
+	if c.ActiveBurn == nil {
+		t.Fatal("stalled burn was torn down — want it kept alive")
+	}
+	if w.LastBurnFinishedEvent != nil {
+		t.Errorf("LastBurnFinishedEvent stamped for a merely-stalled burn: %+v", w.LastBurnFinishedEvent)
+	}
+}

--- a/internal/sim/burn_announce_test.go
+++ b/internal/sim/burn_announce_test.go
@@ -13,14 +13,20 @@ import (
 // firing and finishing in total silence. Modeled on how LastDockEvent
 // (docking_test.go) and LastNodeTargetRefusal are tested — stash-site
 // assertions on World fields, not app.go's flash wording (that's covered
-// by internal/tui/app_test.go, if one exists, or just left to the
-// flash-formatting convention shared with the other Last*Event fields).
+// by internal/tui/app_burn_flash_test.go).
+//
+// PendingBurnFiredEvents / PendingBurnFinishedEvents are slices, not
+// single pointers (code-review findings 1 and 2 on the first version of
+// this PR): a single scalar silently clobbered an earlier craft's stash
+// when two crafts ignited or exhausted in the same tick, and the
+// NodeIndex math (len(kept)) undercounted whenever an earlier node in
+// the same call fired impulsively (also never appended to kept).
 
 // TestExecuteDueNodesStampsBurnFiredEvent — a due finite node igniting
 // (the c.ActiveBurn = &ActiveBurn{...} branch of executeDueNodesFor)
-// must stash LastBurnFiredEvent with the craft's name, the node's DV,
-// and its 0-based NodeIndex (the "node #N" convention) — per craft, not
-// just the active one.
+// must append a BurnFiredEvent to PendingBurnFiredEvents with the
+// craft's name, the node's DV, and its 0-based NodeIndex (the "node #N"
+// convention) — per craft, not just the active one.
 func TestExecuteDueNodesStampsBurnFiredEvent(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
@@ -29,54 +35,34 @@ func TestExecuteDueNodesStampsBurnFiredEvent(t *testing.T) {
 	}
 	now := w.Clock.SimTime
 
-	// A held node ahead of it (unresolved) so NodeIndex must read 1, not
-	// 0 — proving the stash names this node's real ordinal, not just "the
-	// first node examined".
-	held := spacecraft.ManeuverNode{
-		Mode: spacecraft.BurnPrograde,
-		DV:   50,
-		// Event-relative, unresolved: TriggerTime stays zero until the
-		// lazy-freeze resolver fires, so this node holds every tick.
-		Event: spacecraft.TriggerNextApo,
-	}
 	firing := spacecraft.ManeuverNode{
 		Mode:        spacecraft.BurnPrograde,
 		DV:          3054,
 		TriggerTime: now.Add(10 * time.Second),
 		Duration:    60 * time.Second, // BurnStart = now - 20s: already due
 	}
-	c.Nodes = []spacecraft.ManeuverNode{held, firing}
-
-	if w.LastBurnFiredEvent != nil {
-		t.Fatal("precondition: LastBurnFiredEvent already set before any burn fired")
-	}
-	w.executeDueNodes()
-
-	// The held node can't resolve/fire, so it stays queued and blocks the
-	// walk (executeDueNodesFor stops dispatching once one node holds) —
-	// rebuild the fixture without it so `firing` is actually reachable.
-	if c.ActiveBurn != nil {
-		t.Fatal("test fixture bug: held node should have blocked the walk")
-	}
-
 	c.Nodes = []spacecraft.ManeuverNode{firing}
+
+	if len(w.PendingBurnFiredEvents) != 0 {
+		t.Fatal("precondition: PendingBurnFiredEvents already non-empty before any burn fired")
+	}
 	w.executeDueNodes()
 
 	if c.ActiveBurn == nil {
 		t.Fatal("firing node did not start an ActiveBurn")
 	}
-	if w.LastBurnFiredEvent == nil {
-		t.Fatal("firing node did not stash LastBurnFiredEvent")
+	if len(w.PendingBurnFiredEvents) != 1 {
+		t.Fatalf("PendingBurnFiredEvents has %d entries, want 1", len(w.PendingBurnFiredEvents))
 	}
-	e := w.LastBurnFiredEvent
+	e := w.PendingBurnFiredEvents[0]
 	if e.CraftName != c.Name {
-		t.Errorf("LastBurnFiredEvent.CraftName = %q, want %q", e.CraftName, c.Name)
+		t.Errorf("CraftName = %q, want %q", e.CraftName, c.Name)
 	}
 	if e.DV != 3054 {
-		t.Errorf("LastBurnFiredEvent.DV = %v, want 3054", e.DV)
+		t.Errorf("DV = %v, want 3054", e.DV)
 	}
 	if e.NodeIndex != 0 {
-		t.Errorf("LastBurnFiredEvent.NodeIndex = %d, want 0 (only node left in the queue)", e.NodeIndex)
+		t.Errorf("NodeIndex = %d, want 0 (only node in the queue)", e.NodeIndex)
 	}
 	// The running burn itself must carry the same figures forward so the
 	// finish event can report them later (DVRemaining drifts as the burn
@@ -86,10 +72,59 @@ func TestExecuteDueNodesStampsBurnFiredEvent(t *testing.T) {
 	}
 }
 
+// TestExecuteDueNodesFiredEventNodeIndexAfterImpulsiveFire — review
+// finding 2's exact repro: an impulsive (Duration==0) plane-change node
+// followed by a finite burn node, both due the same tick. The impulsive
+// node fires and is dropped from kept without ever being appended (same
+// as a finite fire), so a len(kept)-derived NodeIndex undercounted the
+// finite node that follows it as "node #1" when it's really "node #2"
+// (original ordinal 1). NodeIndex must read 1, not 0.
+func TestExecuteDueNodesFiredEventNodeIndexAfterImpulsiveFire(t *testing.T) {
+	w := mustWorld(t)
+	c := w.ActiveCraft()
+	if c == nil {
+		t.Fatal("no active craft")
+	}
+	now := w.Clock.SimTime
+
+	impulsive := spacecraft.ManeuverNode{
+		Mode: spacecraft.BurnPlaneChange,
+		DV:   10,
+		// Duration is zero, so BurnStart() == TriggerTime — already due,
+		// so this fires impulsively (ApplyImpulsiveDir), not via
+		// ActiveBurn, and is never appended to kept — same as a finite
+		// fire.
+		TriggerTime: now.Add(-5 * time.Second),
+	}
+	finite := spacecraft.ManeuverNode{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          3054,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    60 * time.Second, // BurnStart = now - 20s: already due
+	}
+	c.Nodes = []spacecraft.ManeuverNode{impulsive, finite}
+
+	w.executeDueNodes()
+
+	if c.ActiveBurn == nil {
+		t.Fatal("finite node behind the impulsive one did not fire")
+	}
+	if len(w.PendingBurnFiredEvents) != 1 {
+		t.Fatalf("PendingBurnFiredEvents has %d entries, want 1 (only the finite node stamps a fired event)", len(w.PendingBurnFiredEvents))
+	}
+	e := w.PendingBurnFiredEvents[0]
+	if e.NodeIndex != 1 {
+		t.Errorf("NodeIndex = %d, want 1 (this was c.Nodes[1] — the impulsive node ahead of it must still count)", e.NodeIndex)
+	}
+	if c.ActiveBurn.NodeIndex != 1 {
+		t.Errorf("ActiveBurn.NodeIndex = %d, want 1", c.ActiveBurn.NodeIndex)
+	}
+}
+
 // TestExecuteDueNodesStampsBurnFiredEventNonActiveCraft — decision 4 is
 // explicit that this is a per-craft hook, not just the active vessel's:
-// a burn igniting on a different craft in the slate must still stamp
-// LastBurnFiredEvent, naming that craft.
+// a burn igniting on a different craft in the slate must still append a
+// BurnFiredEvent, naming that craft.
 func TestExecuteDueNodesStampsBurnFiredEventNonActiveCraft(t *testing.T) {
 	w := mustWorld(t)
 	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 500e3}); err != nil {
@@ -111,19 +146,69 @@ func TestExecuteDueNodesStampsBurnFiredEventNonActiveCraft(t *testing.T) {
 	if other.ActiveBurn == nil {
 		t.Fatal("non-active craft's due node did not fire")
 	}
-	if w.LastBurnFiredEvent == nil {
-		t.Fatal("non-active craft's ignition did not stash LastBurnFiredEvent")
+	if len(w.PendingBurnFiredEvents) != 1 {
+		t.Fatalf("PendingBurnFiredEvents has %d entries, want 1", len(w.PendingBurnFiredEvents))
 	}
-	if w.LastBurnFiredEvent.CraftName != "Tug-1" {
-		t.Errorf("LastBurnFiredEvent.CraftName = %q, want %q (non-active craft)", w.LastBurnFiredEvent.CraftName, "Tug-1")
+	if w.PendingBurnFiredEvents[0].CraftName != "Tug-1" {
+		t.Errorf("CraftName = %q, want %q (non-active craft)", w.PendingBurnFiredEvents[0].CraftName, "Tug-1")
+	}
+}
+
+// TestExecuteDueNodesStampsBothCraftsFiredEventsSameTick — code-review
+// finding 1's exact repro: two different crafts each have a due finite
+// node. Firing both in the same executeDueNodes() call must not let the
+// second craft's ignition clobber the first's — both must land in
+// PendingBurnFiredEvents, in the order they fired.
+func TestExecuteDueNodesStampsBothCraftsFiredEventsSameTick(t *testing.T) {
+	w := mustWorld(t)
+	first := w.ActiveCraft()
+	if first == nil {
+		t.Fatal("no active craft")
+	}
+	first.Name = "Craft-A"
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	second := w.Crafts[1]
+	second.Name = "Craft-B"
+	now := w.Clock.SimTime
+
+	first.Nodes = []spacecraft.ManeuverNode{{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          111,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    20 * time.Second,
+	}}
+	second.Nodes = []spacecraft.ManeuverNode{{
+		Mode:        spacecraft.BurnPrograde,
+		DV:          222,
+		TriggerTime: now.Add(10 * time.Second),
+		Duration:    20 * time.Second,
+	}}
+
+	w.executeDueNodes()
+
+	if first.ActiveBurn == nil || second.ActiveBurn == nil {
+		t.Fatal("both crafts' due nodes should have fired")
+	}
+	if len(w.PendingBurnFiredEvents) != 2 {
+		t.Fatalf("PendingBurnFiredEvents has %d entries, want 2 (one per craft) — got %+v",
+			len(w.PendingBurnFiredEvents), w.PendingBurnFiredEvents)
+	}
+	names := map[string]bool{}
+	for _, e := range w.PendingBurnFiredEvents {
+		names[e.CraftName] = true
+	}
+	if !names["Craft-A"] || !names["Craft-B"] {
+		t.Errorf("PendingBurnFiredEvents = %+v, want one entry each for Craft-A and Craft-B", w.PendingBurnFiredEvents)
 	}
 }
 
 // TestBurnExhaustionStampsBurnFinishedEvent — the teardown branch in
-// integrateOneCraft (c.ActiveBurn = nil on exhaustion) must stash
-// LastBurnFinishedEvent naming the craft, the node's originally planned
-// Δv (not the ~0 DVRemaining left by exhaustion), the fired node's
-// ordinal, and how many nodes are still queued on that craft afterward.
+// integrateOneCraft (c.ActiveBurn = nil on exhaustion) must append a
+// BurnFinishedEvent naming the craft, the node's originally planned Δv
+// (not the ~0 DVRemaining left by exhaustion), the fired node's ordinal,
+// and how many nodes are still queued on that craft afterward.
 func TestBurnExhaustionStampsBurnFinishedEvent(t *testing.T) {
 	w := mustWorld(t)
 	c := w.ActiveCraft()
@@ -147,34 +232,82 @@ func TestBurnExhaustionStampsBurnFinishedEvent(t *testing.T) {
 		Throttle:    1,
 	}
 
-	if w.LastBurnFinishedEvent != nil {
-		t.Fatal("precondition: LastBurnFinishedEvent already set before any burn finished")
+	if len(w.PendingBurnFinishedEvents) != 0 {
+		t.Fatal("precondition: PendingBurnFinishedEvents already non-empty before any burn finished")
 	}
 	_, done := tickUntil(w, 50, func() bool { return c.ActiveBurn == nil })
 	if !done {
 		t.Fatal("burn never tore down as exhausted within 50 ticks")
 	}
-	if w.LastBurnFinishedEvent == nil {
-		t.Fatal("exhausted burn did not stash LastBurnFinishedEvent")
+	if len(w.PendingBurnFinishedEvents) != 1 {
+		t.Fatalf("PendingBurnFinishedEvents has %d entries, want 1", len(w.PendingBurnFinishedEvents))
 	}
-	e := w.LastBurnFinishedEvent
+	e := w.PendingBurnFinishedEvents[0]
 	if e.CraftName != c.Name {
-		t.Errorf("LastBurnFinishedEvent.CraftName = %q, want %q", e.CraftName, c.Name)
+		t.Errorf("CraftName = %q, want %q", e.CraftName, c.Name)
 	}
 	if e.DV != 3054 {
-		t.Errorf("LastBurnFinishedEvent.DV = %v, want 3054 (PlannedDV, not the exhausted DVRemaining)", e.DV)
+		t.Errorf("DV = %v, want 3054 (PlannedDV, not the exhausted DVRemaining)", e.DV)
 	}
 	if e.NodeIndex != 2 {
-		t.Errorf("LastBurnFinishedEvent.NodeIndex = %d, want 2", e.NodeIndex)
+		t.Errorf("NodeIndex = %d, want 2", e.NodeIndex)
 	}
 	if e.NodesRemaining != 1 {
-		t.Errorf("LastBurnFinishedEvent.NodesRemaining = %d, want 1 (the still-queued node)", e.NodesRemaining)
+		t.Errorf("NodesRemaining = %d, want 1 (the still-queued node)", e.NodesRemaining)
+	}
+}
+
+// TestExecuteOneCraftStampsBothCraftsFinishedEventsSameTick — the
+// finish-side twin of TestExecuteDueNodesStampsBothCraftsFiredEventsSameTick:
+// two crafts' burns both exhaust on the same tick must both land in
+// PendingBurnFinishedEvents.
+func TestExecuteOneCraftStampsBothCraftsFinishedEventsSameTick(t *testing.T) {
+	w := mustWorld(t)
+	first := w.ActiveCraft()
+	if first == nil {
+		t.Fatal("no active craft")
+	}
+	first.Name = "Craft-A"
+	if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	second := w.Crafts[1]
+	second.Name = "Craft-B"
+
+	mk := func(dv float64) *spacecraft.ActiveBurn {
+		return &spacecraft.ActiveBurn{
+			Mode:        spacecraft.BurnPrograde,
+			DVRemaining: dv,
+			PlannedDV:   dv,
+			EndTime:     w.Clock.SimTime, // already due: exhausts on this tick
+			Throttle:    1,
+		}
+	}
+	first.ActiveBurn = mk(111)
+	first.ActiveBurn.PrimaryID = first.Primary.ID
+	second.ActiveBurn = mk(222)
+	second.ActiveBurn.PrimaryID = second.Primary.ID
+
+	_, done := tickUntil(w, 50, func() bool { return first.ActiveBurn == nil && second.ActiveBurn == nil })
+	if !done {
+		t.Fatal("both burns never tore down as exhausted within 50 ticks")
+	}
+	if len(w.PendingBurnFinishedEvents) != 2 {
+		t.Fatalf("PendingBurnFinishedEvents has %d entries, want 2 — got %+v",
+			len(w.PendingBurnFinishedEvents), w.PendingBurnFinishedEvents)
+	}
+	names := map[string]bool{}
+	for _, e := range w.PendingBurnFinishedEvents {
+		names[e.CraftName] = true
+	}
+	if !names["Craft-A"] || !names["Craft-B"] {
+		t.Errorf("PendingBurnFinishedEvents = %+v, want one entry each for Craft-A and Craft-B", w.PendingBurnFinishedEvents)
 	}
 }
 
 // TestBurnStallDoesNotStampBurnFinishedEvent — a stalled burn (fuel-dry,
-// Δv still owed) is paused, not finished; it must not stamp
-// LastBurnFinishedEvent while stalled.
+// Δv still owed) is paused, not finished; it must not append a
+// BurnFinishedEvent while stalled.
 func TestBurnStallDoesNotStampBurnFinishedEvent(t *testing.T) {
 	w := mustWorld(t)
 	c := twoStageBurner(t, w, 200)
@@ -187,7 +320,7 @@ func TestBurnStallDoesNotStampBurnFinishedEvent(t *testing.T) {
 	if c.ActiveBurn == nil {
 		t.Fatal("stalled burn was torn down — want it kept alive")
 	}
-	if w.LastBurnFinishedEvent != nil {
-		t.Errorf("LastBurnFinishedEvent stamped for a merely-stalled burn: %+v", w.LastBurnFinishedEvent)
+	if len(w.PendingBurnFinishedEvents) != 0 {
+		t.Errorf("PendingBurnFinishedEvents non-empty for a merely-stalled burn: %+v", w.PendingBurnFinishedEvents)
 	}
 }

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -2618,7 +2618,18 @@ func (w *World) executeDueNodes() {
 func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 	kept := c.Nodes[:0]
 	held := false
-	for _, n := range c.Nodes {
+	// idx is this node's true 0-based ordinal in the ORIGINAL c.Nodes
+	// slice — used by the BurnFiredEvent stash below (review finding 2).
+	// len(kept) undercounts whenever an earlier node in this same call
+	// fired IMPULSIVELY: an impulsive fire is never appended to kept
+	// either (same as a finite fire), so it silently vanished from a
+	// len(kept)-derived count too. idx is safe to read here even though
+	// kept shares c.Nodes' backing array and mutates it in place: a
+	// filter-in-place only ever writes to indices < the current read
+	// cursor (len(kept) <= idx always), so arr[idx] itself is never
+	// touched by an earlier iteration's compaction before this line reads
+	// it via range.
+	for idx, n := range c.Nodes {
 		if held {
 			kept = append(kept, n)
 			continue
@@ -2795,22 +2806,20 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 				PlaneChangeRad:   n.PlaneChangeRad,
 				BurnDirUnit:      n.BurnDirUnit,
 				PlannedDV:        n.DV,
-				NodeIndex:        len(kept),
+				NodeIndex:        idx,
 			}
 			// ADR 0048 / decision 4: burn state was otherwise invisible — a
-			// node fired and finished in total silence. len(kept) is this
-			// node's 0-based ordinal within c.Nodes at fire time: every
-			// node ahead of it in the walk either already fired earlier in
-			// this same call (and so was never appended to kept) or this
-			// is the first due node, so kept holds exactly the nodes still
-			// queued ahead of it. Per-craft, not just the active craft —
-			// executeDueNodesFor runs once per craft in the slate.
-			w.LastBurnFiredEvent = &BurnFiredEvent{
+			// node fired and finished in total silence. Appended, not
+			// assigned (review finding 1): executeDueNodes walks every
+			// craft's own queue in the same tick, so two crafts igniting
+			// this tick must both survive to app.go rather than the second
+			// overwriting the first's single stashed pointer.
+			w.PendingBurnFiredEvents = append(w.PendingBurnFiredEvents, BurnFiredEvent{
 				When:      w.Clock.SimTime,
 				CraftName: c.Name,
-				NodeIndex: len(kept),
+				NodeIndex: idx,
 				DV:        n.DV,
-			}
+			})
 		}
 		// v0.9.2+: planted-burn ignition releases a Landed craft.
 		// Symmetric with StartManualBurn; not strictly common

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -119,7 +119,7 @@ func (w *World) ToggleManualBurn() {
 // lands on 1.3878e-16, not exactly 0.0 (binary floating point can't
 // represent 0.1 exactly), so the exact-equality cut check below used
 // to silently miss it — the throttle row rounds to a display "0%" but
-// ManualBurn never clears, leaving the engine "on" (anyCraftThrusting)
+// ManualBurn never clears, leaving the engine "on" (AnyCraftThrusting)
 // and warp pinned to the 10× burn cap with nothing on screen to say
 // why. Found live: player reported warp stuck at 10× well outside the
 // atmosphere despite reading 0% throttle.
@@ -2794,6 +2794,22 @@ func (w *World) executeDueNodesFor(c *spacecraft.Spacecraft) {
 				TargetGhostOwner: n.TargetGhostOwner, // v0.28 S4: carry the ghost ref onto the running burn
 				PlaneChangeRad:   n.PlaneChangeRad,
 				BurnDirUnit:      n.BurnDirUnit,
+				PlannedDV:        n.DV,
+				NodeIndex:        len(kept),
+			}
+			// ADR 0048 / decision 4: burn state was otherwise invisible — a
+			// node fired and finished in total silence. len(kept) is this
+			// node's 0-based ordinal within c.Nodes at fire time: every
+			// node ahead of it in the walk either already fired earlier in
+			// this same call (and so was never appended to kept) or this
+			// is the first due node, so kept holds exactly the nodes still
+			// queued ahead of it. Per-craft, not just the active craft —
+			// executeDueNodesFor runs once per craft in the slate.
+			w.LastBurnFiredEvent = &BurnFiredEvent{
+				When:      w.Clock.SimTime,
+				CraftName: c.Name,
+				NodeIndex: len(kept),
+				DV:        n.DV,
 			}
 		}
 		// v0.9.2+: planted-burn ignition releases a Landed craft.

--- a/internal/sim/maneuver_test.go
+++ b/internal/sim/maneuver_test.go
@@ -2343,7 +2343,7 @@ func TestAdjustThrottleTenStepsDownStopsManualBurn(t *testing.T) {
 	if w.ActiveCraft().ManualBurn != nil {
 		t.Error("ten -10% steps to 0% should stop the manual burn, same as a direct cut")
 	}
-	if w.anyCraftThrusting() {
+	if w.AnyCraftThrusting() {
 		t.Error("warp should not stay pinned to the burn cap once throttle reads 0%")
 	}
 }

--- a/internal/sim/rendezvous_seat.go
+++ b/internal/sim/rendezvous_seat.go
@@ -171,7 +171,7 @@ func (w *World) rendezvousSeatRate() (float64, bool) {
 			rate = b
 		}
 	}
-	burning := w.anyCraftThrusting()
+	burning := w.AnyCraftThrusting()
 	if burning && rate > burnWarpCap {
 		rate = burnWarpCap
 	}

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -1870,10 +1870,17 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 			// (PlannedDV), not DVRemaining — which is ~0 by now, the
 			// number a "delivered" figure would read but not "the number
 			// that matters" the ADR's voice calls for. len(c.Nodes) is
-			// this craft's own remaining queue: executeDueNodesFor already
-			// ran earlier this tick and stripped the fired node out.
-			// Per-craft — integrateOneCraft runs once per craft in the
-			// slate, so a non-active craft's burn finishing still flashes.
+			// this craft's own remaining queue AS OF THE START of this
+			// tick's dispatch: Tick() runs integrateOneCraft (here) for
+			// every craft BEFORE executeDueNodes fires this tick's due
+			// nodes (#447 review finding 9 — a prior version of this
+			// comment had the order backwards), so a node that ignites
+			// later in this same tick is still counted here as
+			// "remaining". That undercounts "remaining" by one in the
+			// same-tick chained-burn case, but never overcounts, and the
+			// figure is display-only. Per-craft — integrateOneCraft runs
+			// once per craft in the slate, so a non-active craft's burn
+			// finishing still flashes.
 			// Appended, not assigned (review finding 1): integrateOneCraft
 			// runs once per craft per tick, so two crafts' burns exhausting
 			// the same tick must both survive to app.go.

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -100,20 +100,24 @@ type World struct {
 	// (#294) but never re-latched.
 	LastNodeTargetRefusal *NodeTargetRefusalEvent
 
-	// LastBurnFiredEvent records the most recent planted finite burn to
-	// ignite (ADR 0048 / decision 4: burn state was otherwise invisible —
-	// a node fired and finished in total silence). Stamped by
+	// PendingBurnFiredEvents queues every planted finite burn that ignited
+	// THIS tick (ADR 0048 / decision 4: burn state was otherwise invisible
+	// — a node fired and finished in total silence). Stamped by
 	// executeDueNodesFor at the same site that sets Craft.ActiveBurn, per
-	// craft (not just the active one), so a burn igniting on a vessel the
-	// player isn't currently flying still flashes. app.go reads and
-	// clears it, same one-shot pattern as LastDockEvent.
-	LastBurnFiredEvent *BurnFiredEvent
+	// craft (not just the active one) — a slice, not a single pointer,
+	// because executeDueNodes walks every craft in the slate in one tick,
+	// and two crafts igniting the same tick must both flash rather than
+	// the second silently clobbering the first's stash. app.go drains
+	// (flashes each, in order) and clears the whole slice every TickMsg —
+	// same one-shot-per-event contract as LastDockEvent, just N-wide.
+	PendingBurnFiredEvents []BurnFiredEvent
 
-	// LastBurnFinishedEvent records the most recent finite burn to
-	// exhaust (ADR 0048 / decision 4), stamped by integrateOneCraft right
-	// before it nils Craft.ActiveBurn on the exhausted branch. Same
-	// per-craft, one-shot, app.go-cleared pattern as LastBurnFiredEvent.
-	LastBurnFinishedEvent *BurnFinishedEvent
+	// PendingBurnFinishedEvents queues every finite burn that exhausted
+	// THIS tick (ADR 0048 / decision 4), stamped by integrateOneCraft
+	// right before it nils Craft.ActiveBurn on the exhausted branch. Same
+	// per-tick, per-craft, app.go-drained contract as
+	// PendingBurnFiredEvents.
+	PendingBurnFinishedEvents []BurnFinishedEvent
 
 	// Focus selects what the OrbitView canvas is centered on. Zero value
 	// (FocusSystem) matches v0.1.0 behavior.
@@ -1862,7 +1866,7 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	if c.ActiveBurn != nil {
 		if w.burnExhausted(c, burnReady) {
 			// ADR 0048 / decision 4: the matching finish half of
-			// LastBurnFiredEvent. DV is the node's original planned Δv
+			// PendingBurnFiredEvents. DV is the node's original planned Δv
 			// (PlannedDV), not DVRemaining — which is ~0 by now, the
 			// number a "delivered" figure would read but not "the number
 			// that matters" the ADR's voice calls for. len(c.Nodes) is
@@ -1870,13 +1874,16 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 			// ran earlier this tick and stripped the fired node out.
 			// Per-craft — integrateOneCraft runs once per craft in the
 			// slate, so a non-active craft's burn finishing still flashes.
-			w.LastBurnFinishedEvent = &BurnFinishedEvent{
+			// Appended, not assigned (review finding 1): integrateOneCraft
+			// runs once per craft per tick, so two crafts' burns exhausting
+			// the same tick must both survive to app.go.
+			w.PendingBurnFinishedEvents = append(w.PendingBurnFinishedEvents, BurnFinishedEvent{
 				When:           w.Clock.SimTime,
 				CraftName:      c.Name,
 				NodeIndex:      c.ActiveBurn.NodeIndex,
 				DV:             c.ActiveBurn.PlannedDV,
 				NodesRemaining: len(c.Nodes),
-			}
+			})
 			c.ActiveBurn = nil
 		} else if c.ActiveStageFuel() <= 0 || !burnReady {
 			// #294 review finding 1: an unresolved target-relative burn is

--- a/internal/sim/world.go
+++ b/internal/sim/world.go
@@ -100,6 +100,21 @@ type World struct {
 	// (#294) but never re-latched.
 	LastNodeTargetRefusal *NodeTargetRefusalEvent
 
+	// LastBurnFiredEvent records the most recent planted finite burn to
+	// ignite (ADR 0048 / decision 4: burn state was otherwise invisible —
+	// a node fired and finished in total silence). Stamped by
+	// executeDueNodesFor at the same site that sets Craft.ActiveBurn, per
+	// craft (not just the active one), so a burn igniting on a vessel the
+	// player isn't currently flying still flashes. app.go reads and
+	// clears it, same one-shot pattern as LastDockEvent.
+	LastBurnFiredEvent *BurnFiredEvent
+
+	// LastBurnFinishedEvent records the most recent finite burn to
+	// exhaust (ADR 0048 / decision 4), stamped by integrateOneCraft right
+	// before it nils Craft.ActiveBurn on the exhausted branch. Same
+	// per-craft, one-shot, app.go-cleared pattern as LastBurnFiredEvent.
+	LastBurnFinishedEvent *BurnFinishedEvent
+
 	// Focus selects what the OrbitView canvas is centered on. Zero value
 	// (FocusSystem) matches v0.1.0 behavior.
 	Focus Focus
@@ -946,6 +961,33 @@ type NodeTargetRefusalEvent struct {
 	Cancelled bool
 }
 
+// BurnFiredEvent records a planted finite burn's ignition for the Event
+// Flash app.go raises (ADR 0048 / decision 4). NodeIndex is the fired
+// node's 0-based ordinal within its craft's Nodes slice at fire time
+// (matches the "node #N" convention used elsewhere, e.g.
+// FrameTransition.NodeIndex), so the message can say "node 1 firing".
+type BurnFiredEvent struct {
+	When      time.Time
+	CraftName string
+	NodeIndex int
+	DV        float64
+}
+
+// BurnFinishedEvent records a finite burn's exhaustion for the matching
+// Event Flash (ADR 0048 / decision 4). DV is the node's original planned
+// Δv (ActiveBurn.PlannedDV), the same figure BurnFiredEvent reported at
+// ignition — not DVRemaining, which reads ~0 by the time the burn tears
+// down. NodesRemaining is the craft's own queued-node count immediately
+// after this burn's node was stripped from Nodes, for the "N remaining"
+// half of the wording.
+type BurnFinishedEvent struct {
+	When           time.Time
+	CraftName      string
+	NodeIndex      int
+	DV             float64
+	NodesRemaining int
+}
+
 // DockEvent records the latest fuse for HUD-side messaging. v0.8.3+.
 type DockEvent struct {
 	When          time.Time
@@ -1453,7 +1495,7 @@ func (w *World) clampedWarp() float64 {
 	// blast past the EndTime in a single tick. Walking all crafts
 	// (not just the active one) catches a planted burn firing on a
 	// non-active craft while the player is flying another.
-	if w.anyCraftThrusting() && selected > burnWarpCap {
+	if w.AnyCraftThrusting() && selected > burnWarpCap {
 		selected = burnWarpCap
 	}
 	// v0.8.6.x+: throttle-change clamp. A throttle adjust at high
@@ -1598,11 +1640,11 @@ func (w *World) recentlyChangedThrottle(window time.Duration) bool {
 	return false
 }
 
-// anyCraftThrusting reports whether any craft in the slate is
+// AnyCraftThrusting reports whether any craft in the slate is
 // currently firing — either a planted finite burn or a held manual
 // burn. Used by clampedWarp to apply the 10× burn cap regardless of
 // which craft owns the burn. v0.8.1+.
-func (w *World) anyCraftThrusting() bool {
+func (w *World) AnyCraftThrusting() bool {
 	for _, c := range w.Crafts {
 		if c == nil {
 			continue
@@ -1819,6 +1861,22 @@ func (w *World) integrateOneCraft(c *spacecraft.Spacecraft, simDelta time.Durati
 	// instead of silently cancelling.
 	if c.ActiveBurn != nil {
 		if w.burnExhausted(c, burnReady) {
+			// ADR 0048 / decision 4: the matching finish half of
+			// LastBurnFiredEvent. DV is the node's original planned Δv
+			// (PlannedDV), not DVRemaining — which is ~0 by now, the
+			// number a "delivered" figure would read but not "the number
+			// that matters" the ADR's voice calls for. len(c.Nodes) is
+			// this craft's own remaining queue: executeDueNodesFor already
+			// ran earlier this tick and stripped the fired node out.
+			// Per-craft — integrateOneCraft runs once per craft in the
+			// slate, so a non-active craft's burn finishing still flashes.
+			w.LastBurnFinishedEvent = &BurnFinishedEvent{
+				When:           w.Clock.SimTime,
+				CraftName:      c.Name,
+				NodeIndex:      c.ActiveBurn.NodeIndex,
+				DV:             c.ActiveBurn.PlannedDV,
+				NodesRemaining: len(c.Nodes),
+			}
 			c.ActiveBurn = nil
 		} else if c.ActiveStageFuel() <= 0 || !burnReady {
 			// #294 review finding 1: an unresolved target-relative burn is

--- a/internal/spacecraft/maneuver.go
+++ b/internal/spacecraft/maneuver.go
@@ -375,6 +375,20 @@ type ActiveBurn struct {
 	// from the wire form (no save/load meaning — a reloaded burn starts
 	// unnoticed).
 	RefusalNoticed bool `json:"-"`
+	// PlannedDV (ADR 0048 / decision 4, additive omitempty) is the firing
+	// node's original n.DV, captured at ignition. DVRemaining decrements
+	// as the burn integrates, so by teardown it no longer names "the
+	// number that matters" for the finish announcement — PlannedDV lets
+	// the fired and finished Event Flashes report the same Δv figure,
+	// matching ADR 0048's example ("node 1 burned — 3054 m/s, ...").
+	PlannedDV float64 `json:"planned_dv,omitempty"`
+	// NodeIndex (ADR 0048 / decision 4, additive omitempty) is the firing
+	// node's 0-based ordinal within its craft's Nodes slice at ignition —
+	// the same "node #N" convention FrameTransition.NodeIndex uses.
+	// executeDueNodesFor already strips a fired node out of c.Nodes, so
+	// by teardown there's no other way to recover which node this was;
+	// captured here so the finish Event Flash can still say "node 1".
+	NodeIndex int `json:"node_index,omitempty"`
 }
 
 // TargetCraftIDValue mirrors ManeuverNode.TargetCraftIDValue — returns

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -348,6 +348,19 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			a.world.LastNodeTargetRefusal = nil
 		}
+		// ADR 0048 / decision 4: burn fired / finished Event Flashes — the
+		// gap the ADR named ("a burn fires and finishes with no notice").
+		// Per-craft (executeDueNodesFor / integrateOneCraft run once per
+		// craft in the slate), so these fire regardless of which vessel is
+		// active. Same flash surface, cleared after one fire.
+		if e := a.world.LastBurnFiredEvent; e != nil {
+			a.flash(fmt.Sprintf("%s: node %d firing — %.0f m/s", e.CraftName, e.NodeIndex+1, e.DV))
+			a.world.LastBurnFiredEvent = nil
+		}
+		if e := a.world.LastBurnFinishedEvent; e != nil {
+			a.flash(fmt.Sprintf("%s: node %d burned — %.0f m/s, %d remaining", e.CraftName, e.NodeIndex+1, e.DV, e.NodesRemaining))
+			a.world.LastBurnFinishedEvent = nil
+		}
 		return a, sim.TickCmd(a.world.Clock.BaseStep)
 
 	case tea.WindowSizeMsg:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -356,27 +356,36 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// crafts can ignite (or exhaust) in the same tick, and both must
 		// reach the player, not just whichever stashed last. Drained (read
 		// then cleared) in full every TickMsg, fired-events before
-		// finished-events (review finding 3's "pick one consistent order")
-		// — one a.flash() call per event, in queue order. KNOWN
-		// LIMITATION: statusMsg is a single-slot display with one shared
-		// TTL, so if more than one event lands in the same tick (e.g. one
-		// craft's burn exhausts the instant another's ignites), only the
-		// LAST a.flash() call's text is actually visible on screen — every
-		// event still reaches a.flash() in order, so none is silently
-		// dropped from processing, but a same-tick collision is a real
-		// visual coin-flip until statusMsg itself grows a queue. That's out
-		// of scope here (no new UI machinery beyond draining the slices).
-		if len(a.world.PendingBurnFiredEvents) > 0 {
-			for _, e := range a.world.PendingBurnFiredEvents {
-				a.flash(fmt.Sprintf("%s: node %d firing — %.0f m/s", e.CraftName, e.NodeIndex+1, e.DV))
-			}
-			a.world.PendingBurnFiredEvents = nil
+		// finished-events, joined into ONE a.flash() call (review finding
+		// 6): statusMsg is a single-slot display with one shared TTL, so
+		// separate flash() calls in the same tick left only the last one
+		// visible — a real coin-flip, not hypothetical: a single craft
+		// with two nodes queued back-to-back collides on ~every chained
+		// burn, since Tick() runs integrateOneCraft (finish) before
+		// executeDueNodes (fire) each tick. Joining costs nothing (two
+		// messages run ~90 chars, well inside the 140-col design floor)
+		// and means no event is ever silently unseen.
+		var burnMsgs []string
+		for _, e := range a.world.PendingBurnFiredEvents {
+			burnMsgs = append(burnMsgs, fmt.Sprintf("%s: node %d firing — %.0f m/s", e.CraftName, e.NodeIndex+1, e.DV))
 		}
-		if len(a.world.PendingBurnFinishedEvents) > 0 {
-			for _, e := range a.world.PendingBurnFinishedEvents {
-				a.flash(fmt.Sprintf("%s: node %d burned — %.0f m/s, %d remaining", e.CraftName, e.NodeIndex+1, e.DV, e.NodesRemaining))
+		a.world.PendingBurnFiredEvents = nil
+		for _, e := range a.world.PendingBurnFinishedEvents {
+			if e.DV == 0 {
+				// #447 review finding 8: a pre-PR save loaded mid-burn
+				// decodes ActiveBurn.PlannedDV as its zero value (the
+				// field didn't exist yet), so DV reads 0 here — not
+				// "burned 0 m/s" (a false statement about a burn that
+				// just delivered real Δv) but simply an unknown figure.
+				// Drop the clause rather than print a fabricated number.
+				burnMsgs = append(burnMsgs, fmt.Sprintf("%s: node %d burned — %d remaining", e.CraftName, e.NodeIndex+1, e.NodesRemaining))
+			} else {
+				burnMsgs = append(burnMsgs, fmt.Sprintf("%s: node %d burned — %.0f m/s, %d remaining", e.CraftName, e.NodeIndex+1, e.DV, e.NodesRemaining))
 			}
-			a.world.PendingBurnFinishedEvents = nil
+		}
+		a.world.PendingBurnFinishedEvents = nil
+		if len(burnMsgs) > 0 {
+			a.flash(strings.Join(burnMsgs, " · "))
 		}
 		return a, sim.TickCmd(a.world.Clock.BaseStep)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -352,14 +352,31 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// gap the ADR named ("a burn fires and finishes with no notice").
 		// Per-craft (executeDueNodesFor / integrateOneCraft run once per
 		// craft in the slate), so these fire regardless of which vessel is
-		// active. Same flash surface, cleared after one fire.
-		if e := a.world.LastBurnFiredEvent; e != nil {
-			a.flash(fmt.Sprintf("%s: node %d firing — %.0f m/s", e.CraftName, e.NodeIndex+1, e.DV))
-			a.world.LastBurnFiredEvent = nil
+		// active. Slices, not single pointers (review finding 1): two
+		// crafts can ignite (or exhaust) in the same tick, and both must
+		// reach the player, not just whichever stashed last. Drained (read
+		// then cleared) in full every TickMsg, fired-events before
+		// finished-events (review finding 3's "pick one consistent order")
+		// — one a.flash() call per event, in queue order. KNOWN
+		// LIMITATION: statusMsg is a single-slot display with one shared
+		// TTL, so if more than one event lands in the same tick (e.g. one
+		// craft's burn exhausts the instant another's ignites), only the
+		// LAST a.flash() call's text is actually visible on screen — every
+		// event still reaches a.flash() in order, so none is silently
+		// dropped from processing, but a same-tick collision is a real
+		// visual coin-flip until statusMsg itself grows a queue. That's out
+		// of scope here (no new UI machinery beyond draining the slices).
+		if len(a.world.PendingBurnFiredEvents) > 0 {
+			for _, e := range a.world.PendingBurnFiredEvents {
+				a.flash(fmt.Sprintf("%s: node %d firing — %.0f m/s", e.CraftName, e.NodeIndex+1, e.DV))
+			}
+			a.world.PendingBurnFiredEvents = nil
 		}
-		if e := a.world.LastBurnFinishedEvent; e != nil {
-			a.flash(fmt.Sprintf("%s: node %d burned — %.0f m/s, %d remaining", e.CraftName, e.NodeIndex+1, e.DV, e.NodesRemaining))
-			a.world.LastBurnFinishedEvent = nil
+		if len(a.world.PendingBurnFinishedEvents) > 0 {
+			for _, e := range a.world.PendingBurnFinishedEvents {
+				a.flash(fmt.Sprintf("%s: node %d burned — %.0f m/s, %d remaining", e.CraftName, e.NodeIndex+1, e.DV, e.NodesRemaining))
+			}
+			a.world.PendingBurnFinishedEvents = nil
 		}
 		return a, sim.TickCmd(a.world.Clock.BaseStep)
 

--- a/internal/tui/app_burn_flash_test.go
+++ b/internal/tui/app_burn_flash_test.go
@@ -65,18 +65,15 @@ func TestBurnFinishedEventFlashesAndClears(t *testing.T) {
 	}
 }
 
-// TestTwoBurnFiredEventsSameTickBothFlash — code-review finding 1's
+// TestTwoBurnFiredEventsSameTickBothVisible — code-review finding 1's
 // app.go-side repro: two crafts igniting the same tick must both reach
-// a.flash(), not just whichever landed last in the queue. statusMsg is a
-// single-slot display (code-review finding 3), so only the LAST flash
-// call's text is visible by the time TickMsg returns — that's the known,
-// documented limitation — but this test pins that the visible text is
-// whichever event was queued last, not silently the first one dropped
-// from processing entirely (i.e. every event actually reaches a.flash();
-// the test would fail differently — statusMsg landing on neither
-// craft's name — if an event were dropped rather than merely
-// overwritten on screen).
-func TestTwoBurnFiredEventsSameTickBothFlash(t *testing.T) {
+// the player, not just whichever landed last in the queue. Review
+// finding 6: rather than separate a.flash() calls overwriting each
+// other on the single-slot status line (the original fix's documented
+// but avoidable limitation), same-tick messages are joined into one
+// flash call — so both events are genuinely visible at once, not a
+// last-write-wins coin-flip.
+func TestTwoBurnFiredEventsSameTickBothVisible(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -87,22 +84,21 @@ func TestTwoBurnFiredEventsSameTickBothFlash(t *testing.T) {
 	}
 	tickAt(a, time.Now())
 
-	const want = "Craft-B: node 1 firing — 222 m/s"
+	const want = "Craft-A: node 1 firing — 111 m/s · Craft-B: node 1 firing — 222 m/s"
 	if a.statusMsg != want {
-		t.Errorf("statusMsg = %q, want %q (last-queued event visible after the drain)", a.statusMsg, want)
+		t.Errorf("statusMsg = %q, want %q (both events joined into one visible flash)", a.statusMsg, want)
 	}
 	if len(a.world.PendingBurnFiredEvents) != 0 {
 		t.Error("PendingBurnFiredEvents was not cleared after flashing")
 	}
 }
 
-// TestBurnFiredAndFinishedSameTickOrder — code-review finding 3: a fire
-// event and a finish event (different bursts) landing in the same tick
-// must not silently lose the fire event to the finish event overwriting
-// it (or vice versa) without at least one being visible in the
-// documented, consistent order (fired before finished). This pins that
-// order: finished (drained second) wins the single status slot.
-func TestBurnFiredAndFinishedSameTickOrder(t *testing.T) {
+// TestBurnFiredAndFinishedSameTickBothVisible — code-review finding 3: a
+// fire event and a finish event (different bursts) landing in the same
+// tick must not silently lose one to the other overwriting it. Review
+// finding 6's join means both are visible, in the drain's fired-before-
+// finished order, rather than only the last-drained one surviving.
+func TestBurnFiredAndFinishedSameTickBothVisible(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -115,11 +111,32 @@ func TestBurnFiredAndFinishedSameTickOrder(t *testing.T) {
 	}
 	tickAt(a, time.Now())
 
-	const want = "Craft-A: node 1 burned — 111 m/s, 0 remaining"
+	const want = "Craft-B: node 1 firing — 500 m/s · Craft-A: node 1 burned — 111 m/s, 0 remaining"
 	if a.statusMsg != want {
-		t.Errorf("statusMsg = %q, want %q (finished flashes after fired, so it's the one left visible)", a.statusMsg, want)
+		t.Errorf("statusMsg = %q, want %q (fired then finished, both visible)", a.statusMsg, want)
 	}
 	if len(a.world.PendingBurnFiredEvents) != 0 || len(a.world.PendingBurnFinishedEvents) != 0 {
 		t.Error("pending burn event slices were not both cleared after flashing")
+	}
+}
+
+// TestBurnFinishedZeroDVDropsFigureInsteadOfLying — #447 review finding
+// 8: a pre-PR save loaded mid-burn decodes ActiveBurn.PlannedDV as its
+// zero value, so a BurnFinishedEvent with DV==0 must not print "burned
+// — 0 m/s" (a false statement about a burn that really delivered Δv) —
+// drop the whole "— N m/s" clause instead.
+func TestBurnFinishedZeroDVDropsFigureInsteadOfLying(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.PendingBurnFinishedEvents = []sim.BurnFinishedEvent{
+		{When: a.world.Clock.SimTime, CraftName: "S-IVB-1", NodeIndex: 0, DV: 0, NodesRemaining: 1},
+	}
+	tickAt(a, time.Now())
+
+	const want = "S-IVB-1: node 1 burned — 1 remaining"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q (no fabricated 0 m/s figure)", a.statusMsg, want)
 	}
 }

--- a/internal/tui/app_burn_flash_test.go
+++ b/internal/tui/app_burn_flash_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// This file pins decision 4's app.go half (grilled 2026-09-06, ADR 0048):
+// World.LastBurnFiredEvent / LastBurnFinishedEvent must reach the player
+// as an Event Flash, worded in the ADR's own voice, and clear after one
+// fire — same contract as LastDockEvent / LastNodeTargetRefusal.
+
+// TestBurnFiredEventFlashesAndClears — the sim.TickMsg case reads
+// World.LastBurnFiredEvent, flashes "<craft>: node <N> firing — <DV>
+// m/s", and nils the field so a single ignition only flashes once.
+func TestBurnFiredEventFlashesAndClears(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.LastBurnFiredEvent = &sim.BurnFiredEvent{
+		When:      a.world.Clock.SimTime,
+		CraftName: "S-IVB-1",
+		NodeIndex: 0,
+		DV:        3054,
+	}
+	tickAt(a, time.Now())
+
+	const want = "S-IVB-1: node 1 firing — 3054 m/s"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, want)
+	}
+	if a.world.LastBurnFiredEvent != nil {
+		t.Error("LastBurnFiredEvent was not cleared after flashing")
+	}
+}
+
+// TestBurnFinishedEventFlashesAndClears — the ADR's own worked example
+// wording verbatim: "node 1 burned — 3054 m/s, 2 remaining".
+func TestBurnFinishedEventFlashesAndClears(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.LastBurnFinishedEvent = &sim.BurnFinishedEvent{
+		When:           a.world.Clock.SimTime,
+		CraftName:      "S-IVB-1",
+		NodeIndex:      0,
+		DV:             3054,
+		NodesRemaining: 2,
+	}
+	tickAt(a, time.Now())
+
+	const want = "S-IVB-1: node 1 burned — 3054 m/s, 2 remaining"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, want)
+	}
+	if a.world.LastBurnFinishedEvent != nil {
+		t.Error("LastBurnFinishedEvent was not cleared after flashing")
+	}
+}

--- a/internal/tui/app_burn_flash_test.go
+++ b/internal/tui/app_burn_flash_test.go
@@ -8,32 +8,35 @@ import (
 )
 
 // This file pins decision 4's app.go half (grilled 2026-09-06, ADR 0048):
-// World.LastBurnFiredEvent / LastBurnFinishedEvent must reach the player
-// as an Event Flash, worded in the ADR's own voice, and clear after one
-// fire — same contract as LastDockEvent / LastNodeTargetRefusal.
+// World.PendingBurnFiredEvents / PendingBurnFinishedEvents must reach the
+// player as Event Flashes, worded in the ADR's own voice, and drain to
+// empty after one TickMsg — same contract as LastDockEvent /
+// LastNodeTargetRefusal, generalized to a queue (code-review finding 1:
+// a single scalar silently dropped a same-tick second event).
 
 // TestBurnFiredEventFlashesAndClears — the sim.TickMsg case reads
-// World.LastBurnFiredEvent, flashes "<craft>: node <N> firing — <DV>
-// m/s", and nils the field so a single ignition only flashes once.
+// World.PendingBurnFiredEvents, flashes "<craft>: node <N> firing — <DV>
+// m/s" for each, and empties the slice so a single ignition only flashes
+// once.
 func TestBurnFiredEventFlashesAndClears(t *testing.T) {
 	a, err := New(nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	a.world.LastBurnFiredEvent = &sim.BurnFiredEvent{
+	a.world.PendingBurnFiredEvents = []sim.BurnFiredEvent{{
 		When:      a.world.Clock.SimTime,
 		CraftName: "S-IVB-1",
 		NodeIndex: 0,
 		DV:        3054,
-	}
+	}}
 	tickAt(a, time.Now())
 
 	const want = "S-IVB-1: node 1 firing — 3054 m/s"
 	if a.statusMsg != want {
 		t.Errorf("statusMsg = %q, want %q", a.statusMsg, want)
 	}
-	if a.world.LastBurnFiredEvent != nil {
-		t.Error("LastBurnFiredEvent was not cleared after flashing")
+	if len(a.world.PendingBurnFiredEvents) != 0 {
+		t.Error("PendingBurnFiredEvents was not cleared after flashing")
 	}
 }
 
@@ -44,20 +47,79 @@ func TestBurnFinishedEventFlashesAndClears(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	a.world.LastBurnFinishedEvent = &sim.BurnFinishedEvent{
+	a.world.PendingBurnFinishedEvents = []sim.BurnFinishedEvent{{
 		When:           a.world.Clock.SimTime,
 		CraftName:      "S-IVB-1",
 		NodeIndex:      0,
 		DV:             3054,
 		NodesRemaining: 2,
-	}
+	}}
 	tickAt(a, time.Now())
 
 	const want = "S-IVB-1: node 1 burned — 3054 m/s, 2 remaining"
 	if a.statusMsg != want {
 		t.Errorf("statusMsg = %q, want %q", a.statusMsg, want)
 	}
-	if a.world.LastBurnFinishedEvent != nil {
-		t.Error("LastBurnFinishedEvent was not cleared after flashing")
+	if len(a.world.PendingBurnFinishedEvents) != 0 {
+		t.Error("PendingBurnFinishedEvents was not cleared after flashing")
+	}
+}
+
+// TestTwoBurnFiredEventsSameTickBothFlash — code-review finding 1's
+// app.go-side repro: two crafts igniting the same tick must both reach
+// a.flash(), not just whichever landed last in the queue. statusMsg is a
+// single-slot display (code-review finding 3), so only the LAST flash
+// call's text is visible by the time TickMsg returns — that's the known,
+// documented limitation — but this test pins that the visible text is
+// whichever event was queued last, not silently the first one dropped
+// from processing entirely (i.e. every event actually reaches a.flash();
+// the test would fail differently — statusMsg landing on neither
+// craft's name — if an event were dropped rather than merely
+// overwritten on screen).
+func TestTwoBurnFiredEventsSameTickBothFlash(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.PendingBurnFiredEvents = []sim.BurnFiredEvent{
+		{When: a.world.Clock.SimTime, CraftName: "Craft-A", NodeIndex: 0, DV: 111},
+		{When: a.world.Clock.SimTime, CraftName: "Craft-B", NodeIndex: 0, DV: 222},
+	}
+	tickAt(a, time.Now())
+
+	const want = "Craft-B: node 1 firing — 222 m/s"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q (last-queued event visible after the drain)", a.statusMsg, want)
+	}
+	if len(a.world.PendingBurnFiredEvents) != 0 {
+		t.Error("PendingBurnFiredEvents was not cleared after flashing")
+	}
+}
+
+// TestBurnFiredAndFinishedSameTickOrder — code-review finding 3: a fire
+// event and a finish event (different bursts) landing in the same tick
+// must not silently lose the fire event to the finish event overwriting
+// it (or vice versa) without at least one being visible in the
+// documented, consistent order (fired before finished). This pins that
+// order: finished (drained second) wins the single status slot.
+func TestBurnFiredAndFinishedSameTickOrder(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.PendingBurnFiredEvents = []sim.BurnFiredEvent{
+		{When: a.world.Clock.SimTime, CraftName: "Craft-B", NodeIndex: 0, DV: 500},
+	}
+	a.world.PendingBurnFinishedEvents = []sim.BurnFinishedEvent{
+		{When: a.world.Clock.SimTime, CraftName: "Craft-A", NodeIndex: 0, DV: 111, NodesRemaining: 0},
+	}
+	tickAt(a, time.Now())
+
+	const want = "Craft-A: node 1 burned — 111 m/s, 0 remaining"
+	if a.statusMsg != want {
+		t.Errorf("statusMsg = %q, want %q (finished flashes after fired, so it's the one left visible)", a.statusMsg, want)
+	}
+	if len(a.world.PendingBurnFiredEvents) != 0 || len(a.world.PendingBurnFinishedEvents) != 0 {
+		t.Error("pending burn event slices were not both cleared after flashing")
 	}
 }

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -216,7 +216,19 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	if w.AutoWarpEngaged() {
 		burnLabel = "[■Burn]"
 	}
-	titleRight := warpRateText(w) + "  " + burnLabel
+	// decisions 2 / 6 (grilled 2026-09-06): the same `● BURN` engine-lit
+	// badge and `[F2 declutter]` tag the orbit map's title bar carries,
+	// via v.hudSource (the shared OrbitView) so a player above the
+	// atmosphere firing an engine, or flying decluttered, gets the same
+	// cues here. Nil-safe: hudSource is only ever nil in a bare test
+	// fixture that doesn't wire one up.
+	burnBadgePlain, burnBadgeRendered := "", ""
+	declutterPlain, declutterRendered := "", ""
+	if v.hudSource != nil {
+		burnBadgePlain, burnBadgeRendered = v.hudSource.burnBadgeText(w)
+		declutterPlain, declutterRendered = v.hudSource.declutterTagText()
+	}
+	titleRight := warpRateText(w) + burnBadgePlain + declutterPlain + "  " + burnLabel
 	titlePad := totalCols - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
 	if titlePad < 1 {
 		titlePad = 1
@@ -232,7 +244,7 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	case !w.AutoWarpEligible():
 		burnRendered = v.theme.Dim.Render(burnLabel)
 	}
-	titleRightRendered := warpRendered + "  " + burnRendered
+	titleRightRendered := warpRendered + burnBadgeRendered + declutterRendered + "  " + burnRendered
 	title := v.theme.Title.Render(titleLeft) + strings.Repeat(" ", titlePad) + titleRightRendered
 
 	// The descent half (ADR 0043 §3): one forecast per frame, shared by
@@ -357,7 +369,15 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	// the side HUD off the right of the terminal. Manual borders
 	// give us exact control: use lipgloss.Width per line for the
 	// pad math, which strips ANSI before measuring.
-	canvasPanel := wrapBorder(canvasStr, v.canvas.Cols(), v.theme.Primary.GetForeground())
+	// decision 2 (grilled 2026-09-06): the same engine-lit border tint the
+	// orbit map carries — Warning while any craft in the slate is
+	// thrusting, Primary otherwise. hudSource nil-check mirrors the title
+	// bar above.
+	borderFg := v.theme.Primary.GetForeground()
+	if v.hudSource != nil {
+		borderFg = v.hudSource.canvasBorderColor(w)
+	}
+	canvasPanel := wrapBorder(canvasStr, v.canvas.Cols(), borderFg)
 
 	// v0.13 playtest move: the launch-relevant readouts (VESSEL core,
 	// LAUNCH, STAGES, ATTITUDE) are all canvas Chips now, composited above,

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1458,6 +1458,14 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 			viewLabel = fmt.Sprintf("view: tilted %g°", w.ViewTilt.Theta)
 		}
 	}
+	// decision 6 (grilled 2026-09-06): "declutter is named in two places
+	// while it is on" — appended after every other conditional above so
+	// it always trails whatever the label already says (e.g. "view:
+	// tilted 30°/anchor · declutter"). Gone the instant F2 clears
+	// v.declutter.
+	if v.declutter {
+		viewLabel += " · declutter"
+	}
 	// Inspect flare (ADR 0041 §3), stamped after every map layer so the
 	// one entity the player asked about is never painted over. The
 	// entity's own ink was already promoted at its draw site above; this
@@ -1506,7 +1514,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	canvasPanel := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(v.theme.Primary.GetForeground()).
+		BorderForeground(v.canvasBorderColor(w)).
 		Render(canvasStr)
 
 	craftChip := ""
@@ -1522,6 +1530,45 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	// transient status / confirm lines ride the canvas bottom border.
 	out := title + "\n" + canvasPanel
 	return out
+}
+
+// canvasBorderColor picks the map canvas border's foreground (decision 2,
+// grilled 2026-09-06: "the whole screen says an engine is lit"): Warning
+// while any craft in the slate is thrusting (AnyCraftThrusting — the same
+// predicate the 10x burn-warp cap uses), Primary otherwise. Shared with
+// LaunchView's wrapBorder call so the pad canvas gets the same cue.
+func (v *OrbitView) canvasBorderColor(w *sim.World) lipgloss.TerminalColor {
+	if w.AnyCraftThrusting() {
+		return v.theme.Warning.GetForeground()
+	}
+	return v.theme.Primary.GetForeground()
+}
+
+// burnBadgeText is the title bar's `● BURN` badge (decision 2): rendered
+// in Warning beside the warp readout while any craft in the slate is
+// thrusting, empty otherwise. Returns both the plain (unstyled, for width
+// math) and rendered forms, prefixed with the two-space gap that
+// separates it from whatever sits to its left — an empty plain form
+// carries no gap, so it costs nothing in either width sum when idle.
+func (v *OrbitView) burnBadgeText(w *sim.World) (plain, rendered string) {
+	if !w.AnyCraftThrusting() {
+		return "", ""
+	}
+	const badge = "  ● BURN"
+	return badge, v.theme.Warning.Render(badge)
+}
+
+// declutterTagText is the title bar's `[F2 declutter]` tag (decision 6,
+// grilled 2026-09-06: "Declutter is named in two places while it is on"):
+// Dim, beside the warp readout, visible only while v.declutter is true —
+// gone the instant F2 is pressed again. Same plain/rendered-pair shape as
+// burnBadgeText, for the same reason.
+func (v *OrbitView) declutterTagText() (plain, rendered string) {
+	if !v.declutter {
+		return "", ""
+	}
+	const tag = "  [F2 declutter]"
+	return tag, v.theme.Dim.Render(tag)
 }
 
 // renderTitleBar composes the orbit-screen title row: the existing
@@ -1588,6 +1635,13 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		pauseChipRendered = "  " + v.theme.Warning.Render("PAUSED")
 	}
 
+	// decisions 2 / 6 (grilled 2026-09-06): the `● BURN` engine-lit badge
+	// and the `[F2 declutter]` tag, both beside the warp/clock readout.
+	// Either or both can be empty; the plain forms carry their own
+	// leading gap so an empty one costs nothing in the width sums below.
+	burnBadgePlain, burnBadgeRendered := v.burnBadgeText(w)
+	declutterPlain, declutterRendered := v.declutterTagText()
+
 	// v0.16 / ADR 0016: the [»Burn] Auto-Warp button. [■Burn] highlighted
 	// while engaged, dimmed when no burn is eligible. The » / ■ runes are
 	// East-Asian *ambiguous* width, so the column math below measures
@@ -1599,7 +1653,7 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		burnLabel = "[■Burn]"
 	}
 
-	rightPlain := clockChip + pauseChipPlain + clockGap + burnLabel + gap + menuLabel + gap + missionsLabel
+	rightPlain := clockChip + pauseChipPlain + burnBadgePlain + declutterPlain + clockGap + burnLabel + gap + menuLabel + gap + missionsLabel
 
 	// Compute the absolute column where the right group starts so the
 	// hit-test ranges match what the player sees on screen.
@@ -1610,7 +1664,7 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		pad = 1
 	}
 	rightStart := leftWidth + pad
-	buttonsStart := rightStart + lipgloss.Width(clockChip+pauseChipPlain+clockGap)
+	buttonsStart := rightStart + lipgloss.Width(clockChip+pauseChipPlain+burnBadgePlain+declutterPlain+clockGap)
 
 	v.burnColStart = buttonsStart
 	v.burnColEnd = v.burnColStart + lipgloss.Width(burnLabel)
@@ -1631,6 +1685,8 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		strings.Repeat(" ", pad) +
 		clockChipRendered +
 		pauseChipRendered +
+		burnBadgeRendered +
+		declutterRendered +
 		clockGap +
 		burnRendered +
 		gap +

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -1,0 +1,375 @@
+package screens
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// This file covers the UX batch grilled 2026-09-06 ("burn state is
+// invisible", designdocs/terminal-space-program/ux-reviews/20260902-1059/
+// triage/action-plan.md): decisions 1, 2, 3, 6, 7. Decision 4 (the burn
+// fired/finished Event Flash) is a sim-level hook and gets its own tests
+// alongside LastDockEvent/LastNodeTargetRefusal's pattern in
+// internal/sim. Decision 5 is confirmed no-change.
+
+// TestThrottleRowIdleVsFiring — decision 1: the VESSEL chip's throttle
+// row always shows the throttle SETTING, suffixed with "(idle)" (Dim)
+// while neither ActiveBurn nor ManualBurn is live on the active craft,
+// or "● FIRING" (Warning) the instant either is — never gated on the
+// number itself.
+func TestThrottleRowIdleVsFiring(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "throttle:  100% (idle)") {
+		t.Errorf("idle throttle row missing '(idle)' suffix:\n%s", out)
+	}
+	if strings.Contains(out, "FIRING") {
+		t.Errorf("idle throttle row should not read FIRING:\n%s", out)
+	}
+
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	out = strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "throttle:  100% ● FIRING") {
+		t.Errorf("live-ActiveBurn throttle row missing '● FIRING':\n%s", out)
+	}
+	if strings.Contains(out, "(idle)") {
+		t.Errorf("firing throttle row should not still read (idle):\n%s", out)
+	}
+
+	c.ActiveBurn = nil
+	c.ManualBurn = &spacecraft.ManualBurn{}
+	out = strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "● FIRING") {
+		t.Errorf("live ManualBurn throttle row missing '● FIRING':\n%s", out)
+	}
+}
+
+// TestEngineLitBorderAndBadge — decision 2: while any craft in the slate
+// is thrusting, the map canvas border switches from Primary to Warning,
+// and the title bar carries a "● BURN" badge — both clear the instant
+// nothing is thrusting.
+func TestEngineLitBorderAndBadge(t *testing.T) {
+	v := NewOrbitView(plainThemeColored())
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+
+	if got, want := v.canvasBorderColor(w), v.theme.Primary.GetForeground(); got != want {
+		t.Errorf("idle border color = %v, want Primary %v", got, want)
+	}
+	title := v.renderTitleBar("Sol", w, 140)
+	if strings.Contains(title, "BURN") {
+		t.Errorf("idle title bar should not carry a BURN badge:\n%s", title)
+	}
+
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	if got, want := v.canvasBorderColor(w), v.theme.Warning.GetForeground(); got != want {
+		t.Errorf("firing border color = %v, want Warning %v", got, want)
+	}
+	title = v.renderTitleBar("Sol", w, 140)
+	if !strings.Contains(title, "BURN") {
+		t.Errorf("firing title bar missing the BURN badge:\n%s", title)
+	}
+
+	c.ActiveBurn = nil
+	if got, want := v.canvasBorderColor(w), v.theme.Primary.GetForeground(); got != want {
+		t.Errorf("border color did not clear when thrust stopped: got %v, want Primary %v", got, want)
+	}
+	title = v.renderTitleBar("Sol", w, 140)
+	if strings.Contains(title, "BURN") {
+		t.Errorf("BURN badge did not clear when thrust stopped:\n%s", title)
+	}
+}
+
+// TestEngineLitBorderNonActiveCraft — decision 2's "the whole screen"
+// framing: AnyCraftThrusting walks the whole slate, so a burn on a
+// non-active craft still lights the border/badge while the player flies
+// a different vessel.
+func TestEngineLitBorderNonActiveCraft(t *testing.T) {
+	v := NewOrbitView(plainThemeColored())
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 500e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.Crafts[1].ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+
+	if got, want := v.canvasBorderColor(w), v.theme.Warning.GetForeground(); got != want {
+		t.Errorf("border should light for a non-active craft's burn: got %v, want Warning %v", got, want)
+	}
+}
+
+// TestLaunchViewEngineLitBorderAndBadge — decision 2's Launch View parity:
+// the pad canvas shares the same border tint and title badge as the map.
+func TestLaunchViewEngineLitBorderAndBadge(t *testing.T) {
+	orbitV := NewOrbitView(plainThemeColored())
+	lv := NewLaunchView(plainThemeColored(), orbitV)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+
+	out := lv.Render(w, 140, 40)
+	if strings.Contains(out, "BURN") {
+		t.Errorf("idle launch title should not carry a BURN badge:\n%s", firstLine(out))
+	}
+
+	c.Landed = false
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	out = lv.Render(w, 140, 40)
+	if !strings.Contains(out, "BURN") {
+		t.Errorf("firing launch title missing the BURN badge:\n%s", firstLine(out))
+	}
+}
+
+// TestTargetChipRecomputesDuringOwnBurn — decision 3: while the active
+// craft has a live ActiveBurn, the predicted-encounter row group
+// (perilune/approach + TCA for a body target, TCA/CA for a craft target)
+// collapses to one "encounter: recomputing…" row; live rows above it
+// (range:, Δi:, |v_rel|:, closing:, lead:) are unaffected.
+func TestTargetChipRecomputesDuringOwnBurn(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	for i, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			w.SetTargetBody(i)
+		}
+	}
+
+	out := strings.Join(v.buildTargetChip(w), "\n")
+	if strings.Contains(out, "recomputing") {
+		t.Errorf("no-burn TARGET chip should not read recomputing:\n%s", out)
+	}
+	if !strings.Contains(out, "range:") {
+		t.Errorf("body-target chip missing range: row:\n%s", out)
+	}
+
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	out = strings.Join(v.buildTargetChip(w), "\n")
+	if !strings.Contains(out, "encounter:") || !strings.Contains(out, "recomputing") {
+		t.Errorf("mid-burn body-target chip missing 'encounter: recomputing…':\n%s", out)
+	}
+	if strings.Contains(out, "perilune:") || strings.Contains(out, "approach:") || strings.Contains(out, "TCA:") {
+		t.Errorf("mid-burn body-target chip still carries stale perilune/approach/TCA rows:\n%s", out)
+	}
+	if !strings.Contains(out, "range:") {
+		t.Errorf("mid-burn body-target chip lost its live range: row:\n%s", out)
+	}
+}
+
+// TestTargetChipCraftRecomputesDuringOwnBurn — decision 3's craft-target
+// branch: closestApproachRows' TCA:/CA: pair is replaced the same way.
+func TestTargetChipCraftRecomputesDuringOwnBurn(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := leadTestWorld(t, 82)
+	c := w.ActiveCraft()
+
+	out := strings.Join(v.buildTargetChip(w), "\n")
+	if strings.Contains(out, "recomputing") {
+		t.Errorf("no-burn craft-target chip should not read recomputing:\n%s", out)
+	}
+
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	out = strings.Join(v.buildTargetChip(w), "\n")
+	if !strings.Contains(out, "encounter:") || !strings.Contains(out, "recomputing") {
+		t.Errorf("mid-burn craft-target chip missing 'encounter: recomputing…':\n%s", out)
+	}
+	if strings.Contains(out, "TCA:") {
+		t.Errorf("mid-burn craft-target chip still carries a stale TCA: row:\n%s", out)
+	}
+	if !strings.Contains(out, "|v_rel|:") || !strings.Contains(out, "closing:") || !strings.Contains(out, "lead:") {
+		t.Errorf("mid-burn craft-target chip lost its live relative-state rows:\n%s", out)
+	}
+}
+
+// TestTargetChipEllipsisCellWidthConsistent guards the same chip →
+// canvas width contract assertChipCellWidthConsistent exists for
+// (orbit_chips_test.go): the "recomputing…" row's ellipsis must measure
+// the same in lipgloss.Width as it does spliced per-cell, or the chip's
+// right edge silently misaligns against the canvas overlay.
+func TestTargetChipEllipsisCellWidthConsistent(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	for i, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			w.SetTargetBody(i)
+		}
+	}
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+	lines := v.buildTargetChip(w)
+	assertChipCellWidthConsistent(t, "TARGET recomputing", lines)
+}
+
+// TestDeclutterFooterAndTitleTag — decision 6: while F2 declutter is on,
+// the canvas footer's view label gets a trailing " · declutter" and the
+// title bar carries a Dim "[F2 declutter]" tag; both clear the instant
+// F2 toggles back off.
+func TestDeclutterFooterAndTitleTag(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+
+	out := v.Render(w, 0, 140, 40)
+	if strings.Contains(out, "declutter") {
+		t.Errorf("declutter cue showing while F2 is off:\n%s", lastLine(out))
+	}
+
+	v.SetDeclutter(true)
+	out = v.Render(w, 0, 140, 40)
+	if !strings.Contains(out, "· declutter") {
+		t.Errorf("footer missing '· declutter' while F2 is on:\n%s", lastLine(out))
+	}
+	if !strings.Contains(out, "[F2 declutter]") {
+		t.Errorf("title bar missing '[F2 declutter]' while F2 is on:\n%s", firstLine(out))
+	}
+
+	v.SetDeclutter(false)
+	out = v.Render(w, 0, 140, 40)
+	if strings.Contains(out, "declutter") {
+		t.Errorf("declutter cue did not clear when F2 toggled back off:\n%s", out)
+	}
+}
+
+// TestLaunchViewDeclutterTitleTag — decision 6's Launch View parity: the
+// shared OrbitView declutter state also tags the launch title bar.
+func TestLaunchViewDeclutterTitleTag(t *testing.T) {
+	orbitV := NewOrbitView(plainThemeColored())
+	lv := NewLaunchView(plainThemeColored(), orbitV)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+
+	out := lv.Render(w, 140, 40)
+	if strings.Contains(out, "declutter") {
+		t.Errorf("launch title carries declutter cue while F2 is off:\n%s", firstLine(out))
+	}
+
+	orbitV.SetDeclutter(true)
+	out = lv.Render(w, 140, 40)
+	if !strings.Contains(firstLine(out), "[F2 declutter]") {
+		t.Errorf("launch title missing '[F2 declutter]' while F2 is on:\n%s", firstLine(out))
+	}
+}
+
+// TestNodesChipHeadRowCountsToIgnitionThenBurnEnd — decision 7: the
+// head row for the next resolved node counts to BurnStart while waiting
+// ("ignition in Ns"), and once that craft's burn is live, the equivalent
+// row (now sourced from ActiveBurn) counts to BurnEnd ("burning, Ns
+// left") instead of the old bare "T-Ns" wording — same vessel/mode/Δv
+// figures either way.
+func TestNodesChipHeadRowCountsToIgnitionThenBurnEnd(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+
+	// A finite (Duration>0) node so BurnStart precedes TriggerTime: with
+	// a 72s duration centered on a node 66s out, ignition is 30s away.
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		DV:          3054,
+		Mode:        spacecraft.BurnPrograde,
+		Duration:    72 * time.Second,
+		TriggerTime: w.Clock.SimTime.Add(66 * time.Second),
+	})
+
+	out := strings.Join(v.buildNodesChip(w), "\n")
+	if !strings.Contains(out, "ignition in 30s") {
+		t.Errorf("waiting head row should read 'ignition in 30s' (BurnStart, not TriggerTime):\n%s", out)
+	}
+	if strings.Contains(out, "T-66s") || strings.Contains(out, "T+66s") {
+		t.Errorf("waiting head row still counts to TriggerTime:\n%s", out)
+	}
+
+	c.Nodes = nil
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnPrograde,
+		DVRemaining: 3054,
+		EndTime:     w.Clock.SimTime.Add(61 * time.Second),
+	}
+	out = strings.Join(v.buildNodesChip(w), "\n")
+	if !strings.Contains(out, "burning, 61s left") {
+		t.Errorf("live-burn head row should read 'burning, 61s left' (BurnEnd):\n%s", out)
+	}
+	if strings.Contains(out, "T-61s") {
+		t.Errorf("live-burn head row still uses the old T-Ns wording:\n%s", out)
+	}
+}
+
+// plainThemeColored gives Primary/Warning/Dim distinguishable ANSI
+// colors (unlike chipTestTheme's no-op styles) so tests can assert an
+// actual color switch, not just presence of text.
+func plainThemeColored() Theme {
+	return Theme{
+		Primary: lipgloss.NewStyle().Foreground(lipgloss.Color("4")),
+		Warning: lipgloss.NewStyle().Foreground(lipgloss.Color("3")),
+		Alert:   lipgloss.NewStyle().Foreground(lipgloss.Color("1")),
+		Dim:     lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
+		HUDBox:  lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+		Footer:  lipgloss.NewStyle(),
+		Title:   lipgloss.NewStyle(),
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func lastLine(s string) string {
+	lines := strings.Split(s, "\n")
+	return lines[len(lines)-1]
+}

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -379,6 +379,41 @@ func TestNodesChipHeadRowClampsOverdueIgnitionToZero(t *testing.T) {
 	}
 }
 
+// TestNodesChipHeadRowSaysAfterBurnWhenHeldBehindLiveBurn — #447 review
+// finding 7: a queued node can be genuinely overdue-but-held because
+// THIS craft's engine is already firing a different, earlier node (the
+// GH #88 same-craft hold). The old "ignition in 0s" (from the finding-4
+// clamp) said imminent for the whole preceding burn's duration; it
+// should say "ignition after burn" instead while nc.ActiveBurn != nil.
+func TestNodesChipHeadRowSaysAfterBurnWhenHeldBehindLiveBurn(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{
+		Mode:        spacecraft.BurnPrograde,
+		DVRemaining: 3054,
+		EndTime:     w.Clock.SimTime.Add(40 * time.Second),
+	}
+	// Overdue (BurnStart already passed) but can't fire — the craft's
+	// engine is busy with ActiveBurn above.
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		DV:          500,
+		Mode:        spacecraft.BurnPrograde,
+		TriggerTime: w.Clock.SimTime.Add(-10 * time.Second),
+	})
+
+	out := strings.Join(v.buildNodesChip(w), "\n")
+	if !strings.Contains(out, "ignition after burn") {
+		t.Errorf("held-behind-live-burn node should read 'ignition after burn':\n%s", out)
+	}
+	if strings.Contains(out, "ignition in 0s") {
+		t.Errorf("held-behind-live-burn node should not read the imminent 'ignition in 0s':\n%s", out)
+	}
+}
+
 // plainThemeColored gives Primary/Warning/Dim distinguishable ANSI
 // colors (unlike chipTestTheme's no-op styles) so tests can assert an
 // actual color switch, not just presence of text.

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -347,6 +347,38 @@ func TestNodesChipHeadRowCountsToIgnitionThenBurnEnd(t *testing.T) {
 	}
 }
 
+// TestNodesChipHeadRowClampsOverdueIgnitionToZero — code-review finding
+// 4: a node whose BurnStart has already passed but which hasn't fired
+// yet (paused right at the boundary, or held past due) must not print a
+// raw negative duration ("ignition in -47s"); it clamps to "ignition in
+// 0s".
+func TestNodesChipHeadRowClampsOverdueIgnitionToZero(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+
+	// BurnStart = TriggerTime - Duration/2 = now - 12s - 36s = now - 48s:
+	// 48s past due, still queued (not fired — this test doesn't tick the
+	// world at all).
+	c.Nodes = append(c.Nodes, spacecraft.ManeuverNode{
+		DV:          3054,
+		Mode:        spacecraft.BurnPrograde,
+		Duration:    72 * time.Second,
+		TriggerTime: w.Clock.SimTime.Add(-12 * time.Second),
+	})
+
+	out := strings.Join(v.buildNodesChip(w), "\n")
+	if !strings.Contains(out, "ignition in 0s") {
+		t.Errorf("overdue-but-unfired head row should clamp to 'ignition in 0s':\n%s", out)
+	}
+	if strings.Contains(out, "ignition in -") {
+		t.Errorf("head row printed a raw negative duration:\n%s", out)
+	}
+}
+
 // plainThemeColored gives Primary/Warning/Dim distinguishable ANSI
 // colors (unlike chipTestTheme's no-op styles) so tests can assert an
 // actual color switch, not just presence of text.

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1233,8 +1233,15 @@ func (v *OrbitView) activeBurnLines(w *sim.World) []string {
 				v.theme.Warning.Render("    ⚠ STALLED — stage to resume (x to cancel)"),
 			)
 		} else {
+			// decision 7 (grilled 2026-09-06): `remaining` already counts
+			// down to ab.EndTime, which the fire site sets to n.BurnEnd() —
+			// this was always "seconds to BurnEnd", the wording just used
+			// to call it T-Ns the same way the pre-ignition head row did.
+			// "burning, Ns left" makes the two head-row states read as one
+			// continuous countdown (ignition → burning) instead of two
+			// unrelated-looking T-fields.
 			lines = append(lines,
-				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s, T-%.0fs",
+				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s, burning, %.0fs left",
 					tag, ab.Mode.String(), ab.DVRemaining, remaining)),
 			)
 		}
@@ -1987,7 +1994,17 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		// transfer actually passes the target rather than eyeballing the
 		// dashed curve. Perilune altitude when the path enters the SOI
 		// (negative ⇒ surface impact), else the flyby miss distance.
-		if ap, ok := w.PredictedTargetApproach(); ok {
+		// decision 3 (grilled 2026-09-06): "the TARGET chip says it is
+		// recomputing during your own burn" — while c has a live
+		// ActiveBurn, the predicted-encounter row group (perilune/
+		// approach + TCA) is stale every integrator step the same way
+		// the projected-orbit chip is (PredictedFinalOrbit's own
+		// ActiveBurn gate, internal/sim/maneuver.go); the range/Δi rows
+		// above stay live since they read the craft's current state
+		// directly, not a chained prediction.
+		if c.ActiveBurn != nil {
+			lines = append(lines, chipRow("encounter:", v.theme.Dim.Render("recomputing…")))
+		} else if ap, ok := w.PredictedTargetApproach(); ok {
 			if ap.EntersSOI {
 				alt := ap.Dist - b.RadiusMeters()
 				if alt <= 0 {
@@ -2059,7 +2076,16 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			// a phantom trajectory. Range/closing above stay meaningful for
 			// a landed target (relative-state math, not propagation) so
 			// only this predicted-encounter row group is gated.
-			if craftHasOrbit(tc) {
+			//
+			// decision 3 (grilled 2026-09-06): a live ActiveBurn on the
+			// active craft gets the same "recomputing…" swap the body-target
+			// branch above uses, for the same reason — closestApproachRows
+			// propagates from a state that's being rewritten every
+			// integrator step mid-burn.
+			switch {
+			case c.ActiveBurn != nil:
+				lines = append(lines, chipRow("encounter:", v.theme.Dim.Render("recomputing…")))
+			case craftHasOrbit(tc):
 				lines = append(lines, v.closestApproachRows(w, c)...)
 			}
 			if rangeM < 50 && vRel < 0.1 {

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -670,7 +670,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	lines = append(lines,
 		fmt.Sprintf("  mass:      %.0f kg", c.TotalMass()),
 		fmt.Sprintf("  Δv budget: %.0f m/s", c.RemainingDeltaV()),
-		fmt.Sprintf("  throttle:  %.0f%%", c.EffectiveThrottle()*100),
+		v.throttleRow(c),
 	)
 	if c.MonopropCapacity > 0 {
 		lines = append(lines,
@@ -684,6 +684,23 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 		}
 	}
 	return lines
+}
+
+// throttleRow renders VESSEL's "throttle:" row (decision 1, grilled
+// 2026-09-06: "the throttle row carries the engine state, both ways").
+// The number itself is always the throttle *setting*
+// (c.EffectiveThrottle()), never gated — only the trailing suffix names
+// whether an engine is actually lit: "(idle)" in Dim while neither
+// ActiveBurn nor ManualBurn is live on this craft, "● FIRING" in Warning
+// the instant either is. Mirrors the same live/idle gate
+// PredictedFinalOrbit (internal/sim/maneuver.go) and buildTargetChip use
+// for "is this craft actually thrusting right now".
+func (v *OrbitView) throttleRow(c *spacecraft.Spacecraft) string {
+	base := fmt.Sprintf("  throttle:  %.0f%%", c.EffectiveThrottle()*100)
+	if c.ActiveBurn == nil && c.ManualBurn == nil {
+		return base + v.theme.Dim.Render(" (idle)")
+	}
+	return base + v.theme.Warning.Render(" ● FIRING")
 }
 
 // buildVesselDestroyedChip is the VESSEL DESTROYED Standing Alert (#427 /
@@ -899,8 +916,16 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 		return fmt.Sprintf("  %s %s %s  %s  %.0f m/s",
 			hudNodeMarker, label, n.Event.String(), n.Mode.String(), n.DV) + over
 	}
-	dt := n.TriggerTime.Sub(w.Clock.SimTime).Seconds()
-	return fmt.Sprintf("  %s %s T%+.0fs  %s  %.0f m/s",
+	// decision 7 (grilled 2026-09-06): the head row counts to BurnStart
+	// (ignition), not TriggerTime (the burn's midpoint) — a 72s finite
+	// burn used to read "T-66s" when ignition was really only 30s away.
+	// "ignition in Ns" says what the number actually answers: when does
+	// the engine light. Once this node's burn is actually live it moves
+	// out of Nodes into ActiveBurn and this row is replaced by
+	// activeBurnLines' "burning, Ns left" row instead — see there for the
+	// counts-to-BurnEnd half of this same head row.
+	dt := n.BurnStart().Sub(w.Clock.SimTime).Seconds()
+	return fmt.Sprintf("  %s %s ignition in %.0fs  %s  %.0f m/s",
 		hudNodeMarker, label, dt, n.Mode.String(), n.DV) + over
 }
 

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -697,7 +697,12 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 // for "is this craft actually thrusting right now".
 func (v *OrbitView) throttleRow(c *spacecraft.Spacecraft) string {
 	base := fmt.Sprintf("  throttle:  %.0f%%", c.EffectiveThrottle()*100)
-	if c.ActiveBurn == nil && c.ManualBurn == nil {
+	// Code-review finding 5: reuse sim.StackMidBurn's exact "is this craft
+	// actively thrusting" predicate (ActiveBurn != nil || ManualBurn !=
+	// nil) rather than an inline copy, so this row's notion of thrusting
+	// can't silently drift from the rest of the codebase's (it already
+	// gates Transfer Control refusal, ADR 0034 addendum).
+	if !sim.StackMidBurn(c) {
 		return base + v.theme.Dim.Render(" (idle)")
 	}
 	return base + v.theme.Warning.Render(" ● FIRING")
@@ -924,7 +929,16 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	// out of Nodes into ActiveBurn and this row is replaced by
 	// activeBurnLines' "burning, Ns left" row instead — see there for the
 	// counts-to-BurnEnd half of this same head row.
+	// Code-review finding 4: BurnStart can be at or past SimTime — paused
+	// right at the boundary, or held past due for want of a resolvable
+	// target — without the node having fired yet (it's still in c.Nodes,
+	// or it's simply not this tick's turn in executeDueNodesFor's walk).
+	// A raw negative dt read as a nonsensical "ignition in -47s"; clamp
+	// to 0 so an overdue-but-not-fired node reads as imminent instead.
 	dt := n.BurnStart().Sub(w.Clock.SimTime).Seconds()
+	if dt < 0 {
+		dt = 0
+	}
 	return fmt.Sprintf("  %s %s ignition in %.0fs  %s  %.0f m/s",
 		hudNodeMarker, label, dt, n.Mode.String(), n.DV) + over
 }

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -929,6 +929,16 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	// out of Nodes into ActiveBurn and this row is replaced by
 	// activeBurnLines' "burning, Ns left" row instead — see there for the
 	// counts-to-BurnEnd half of this same head row.
+	// #447 review finding 7: this node can be genuinely overdue-but-held
+	// because THIS craft's engine is already firing a different, earlier
+	// node (nc.ActiveBurn != nil) — the GH #88 same-craft hold in
+	// executeDueNodesFor. A raw dt clamped to 0 there reads "ignition in
+	// 0s" for the entire preceding burn, which says imminent when the
+	// truth is "once the current burn ends". Say that instead.
+	if nc.ActiveBurn != nil {
+		return fmt.Sprintf("  %s %s ignition after burn  %s  %.0f m/s",
+			hudNodeMarker, label, n.Mode.String(), n.DV) + over
+	}
 	// Code-review finding 4: BurnStart can be at or past SimTime — paused
 	// right at the boundary, or held past due for want of a resolvable
 	// target — without the node having fired yet (it's still in c.Nodes,


### PR DESCRIPTION
## Summary

Implements all 7 decisions from the 2026-09-06 grill session (record: `designdocs/terminal-space-program/ux-reviews/20260902-1059/triage/action-plan.md`, "Decisions, grilled 2026-09-06 (burn state is invisible)"). Design was already settled there — this PR is implementation-only.

1. **Throttle row carries engine state, both ways.** VESSEL chip's `throttle:` row appends `(idle)` (Dim) or `● FIRING` (Warning) depending on whether the active craft has a live `ActiveBurn`/`ManualBurn`. The number stays the throttle *setting* either way. Compact Form doesn't show throttle, so no change there.
2. **The whole screen says an engine is lit.** While `World.AnyCraftThrusting()` (exported from `anyCraftThrusting`, ~3 sim-package callers updated) is true: the map canvas border switches Primary→Warning, and the title bar gets a `● BURN` badge beside the warp readout. Extended to Launch View's pad canvas/title, which carries the equivalent chrome per PR #445.
3. **TARGET chip says it's recomputing during your own burn.** While the active craft has a live `ActiveBurn`, the predicted-encounter row group (perilune/approach + TCA for a body target; TCA/CA for a craft target) collapses to one `encounter: recomputing…` row — same gate `PredictedFinalOrbit` already uses. Live rows above (range/Δi, or |v_rel|/closing/lead) are untouched.
4. **Burn fired / finished Event Flash (ADR 0048).** New `World.LastBurnFiredEvent` / `LastBurnFinishedEvent`, following the `LastDockEvent`/`LastNodeTargetRefusal` stash/consume pattern exactly. Stashed per-craft at the node-ignition site (`executeDueNodesFor`) and the burn-exhaustion teardown site (`integrateOneCraft`), consumed once by `app.go`. `ActiveBurn` gained `PlannedDV`/`NodeIndex` fields (additive, save-compatible, no schema bump) so the finish flash can still report the node's original Δv and "node #N" after `DVRemaining` has drifted and the node's been stripped from the queue. Wording: `"<craft>: node N firing — X m/s"` on ignition, `"<craft>: node N burned — X m/s, K remaining"` on finish (the ADR's own example).
5. **F2 leaves VESSEL/NODES up — no change**, per the decision record (confirmed working as designed, ADR 0010).
6. **Declutter named in two places while on.** Canvas footer's view label gets a trailing `· declutter`; title bar gets a Dim `[F2 declutter]` tag beside the warp readout. Both on the orbit map and (title tag only — see note below) Launch View.
7. **Auto-Warp handback timing unchanged; the countdown counts to ignition.** NODES chip's head row: while a node waits, `"ignition in Ns"` (counts to `BurnStart()`, not `TriggerTime`); once that craft's burn is live, `"burning, Ns left"` (counts to `BurnEnd()`) replaces it in the existing `"● <vessel> — <mode>, Δv N m/s, ..."` line. `autoWarpLeadTime` and the `[m]` planner/`fire at:` readouts are untouched.

### Judgment calls
- **Declutter footer cue on Launch View**: only wired the title-bar `[F2 declutter]` tag there. Launch View's bottom row is a fully-replaced HUD strip (ignite prompt or T+/v_z/downrange/Q telemetry), not a `view:` label with a natural append point like the orbit canvas footer — there was nothing to append `· declutter` to.
- **Burn Flash wording prefixes the craft name** (`"<craft>: node N firing — ..."`) rather than the ADR's bare example, matching the existing convention for other per-craft events like `LastNodeTargetRefusal`'s flash — necessary since this is a per-craft hook and the burning craft may not be the active one.
- **`activeBurnLines`' new "burning, Ns left" wording applies to every thrusting craft's row**, not just the active vessel's — the decision text frames this as "the active vessel" but the underlying function already walks the whole slate (matching decision 2's "whole screen" framing and the pre-existing per-craft behavior of that function).

## Test plan
- New tests: `internal/sim/burn_announce_test.go` (fire/finish event stash, non-active-craft, stall doesn't finish), `internal/tui/app_burn_flash_test.go` (Flash wording + one-shot clear), `internal/tui/screens/orbit_burn_state_visibility_test.go` (throttle row, border/badge on both screens incl. non-active-craft, TARGET chip gating on both branches + ellipsis cell-width guard, declutter footer/title on both screens, NODES head-row wording) — all at Design Size 140×40 where rendering is exercised.
- `go vet ./...` — clean.
- `go test ./... -race -count=1` — full suite green.