### PR TITLE
Refusals and confirms: item 3 of the UX-review ranked cycle

### DIFF
--- a/internal/sim/rendezvous.go
+++ b/internal/sim/rendezvous.go
@@ -20,7 +20,11 @@ import (
 // `circularize:` and `save:`, so a prefix here rendered twice
 // ("rendezvous: rendezvous: no vessel target") on every K refusal.
 var (
-	ErrRendezvousNoTarget           = transferError("no vessel target")
+	// item-3 UX batch review finding 3: the "how do I fix this" clause
+	// lives on the sentinel itself (not a special case at one call
+	// site) so every caller — [K] rendezvous, [I] plane-match, the
+	// Meeting Planner's structural refusal — names the fix for free.
+	ErrRendezvousNoTarget           = transferError("no vessel target — [t] to target it")
 	ErrRendezvousDifferentPrimaries = transferError("target around a different primary")
 	ErrRendezvousAlreadyDocked      = transferError("already in DOCK READY range")
 	ErrRendezvousNoImprovement      = transferError("no useful nudge in range")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -169,14 +169,17 @@ type App struct {
 	// confirmation has no meaning across a save / load boundary).
 	endFlightConfirm bool
 
-	// quickloadConfirm (item-3 UX batch, #447-adjacent — reverses ADR
-	// 0033 §H) gates F9 quickload behind the same y/n confirm the Saves
+	// quickloadConfirm (item-3 UX batch, PR #448 — reverses ADR 0033
+	// §H) gates F9 quickload behind the same y/n confirm the Saves
 	// browser's Load already uses. §H kept F9 instant on the theory
 	// that the quicksave lane is zero-risk; the review found the
 	// opposite in practice with a one-slot quicksave lane — a fat-
 	// finger discards everything since the last F5 with no undo.
-	// Mirrors endFlightConfirm's shape exactly (see its Update/Render
-	// call sites).
+	// Modeled on endFlightConfirm's shape (see its Update/Render call
+	// sites) but not identical: it clears on ANY non-"y" key rather
+	// than only y/n/esc, so it can never get stuck armed via the
+	// keyboard — and needs the same "~ must not hide an armed prompt"
+	// guard endFlightConfirm has (see the chat-open check above).
 	quickloadConfirm bool
 
 	// Chat input overlay (ADR 0035 S3). App-level rather than a screen
@@ -791,8 +794,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// while the END FLIGHT confirm is armed — the ~ falls through to
 		// the confirm's swallow-everything intercept below, instead of
 		// opening an overlay that hides an armed destructive prompt
-		// (v0.32 review finding).
-		if a.active == screenOrbit && !a.endFlightConfirm && m.Type == tea.KeyRunes && len(m.Runes) == 1 && m.Runes[0] == '~' {
+		// (v0.32 review finding). item-3 UX batch review: quickloadConfirm
+		// gets the identical guard — the same hole would let ~ hide the F9
+		// prompt behind the chat band, where it survives the round-trip
+		// and fires on whatever key closes chat.
+		if a.active == screenOrbit && !a.endFlightConfirm && !a.quickloadConfirm && m.Type == tea.KeyRunes && len(m.Runes) == 1 && m.Runes[0] == '~' {
 			if a.world.Session == nil {
 				// Solo: say so — a dead key reads as broken (v0.30 lesson).
 				a.toast("chat is multiplayer — host or join a session [O]")
@@ -1414,10 +1420,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// item-3 UX batch (reverses ADR 0033 §H): arm the same y/n
 			// confirm the Saves browser's Load already uses instead of
 			// loading instantly — but only when there's actually a
-			// quicksave to discard-into; an empty lane surfaces straight
-			// to doLoad's own "no quicksave" / "resume autosave" message,
-			// since confirming a load that can only fail teaches nothing.
-			if !a.quicksaveExists() {
+			// quicksave to discard-into. A guest is checked first
+			// (review finding 2): a.quicksaveExists() only reads the
+			// LOCAL saves dir, which can be stale from a prior solo
+			// session on this same machine even though a guest's F9
+			// can never succeed (doLoad's errGuestSaves); the menu's
+			// own Load path already orders the guest check first for
+			// the same reason. An empty local lane (solo, no F5 yet)
+			// surfaces straight to doLoad's own "no quicksave" /
+			// "resume autosave" message — confirming a load that can
+			// only fail teaches nothing.
+			if a.guestSave != nil || !a.quicksaveExists() {
 				a.flashStatus("load", a.doLoad())
 				return a, nil
 			}
@@ -2859,13 +2872,13 @@ func (a *App) flashStatus(op string, err error) {
 func (a *App) handlePlanRendezvousKey() {
 	out, err := a.world.PlanRendezvousOrOpenMeeting()
 	if err != nil {
-		if errors.Is(err, sim.ErrRendezvousNoTarget) {
-			// item-3 UX batch (features finding 13): the refusal named
-			// the missing precondition but not the action that supplies
-			// it — append the one clause the review found missing.
-			a.flash("rendezvous: no vessel target — [t] to target it")
-			return
-		}
+		// item-3 UX batch (features finding 17): the refusal used to
+		// name the missing precondition but not the action that
+		// supplies it. Review finding 3 moved the "[t] to target it"
+		// clause onto sim.ErrRendezvousNoTarget itself (rendezvous.go)
+		// instead of special-casing it here, so [I] plane-match gets
+		// the same fix for free rather than the two sibling keys
+		// disagreeing on whether the refusal names it.
 		a.flash(fmt.Sprintf("rendezvous: %v", err))
 		return
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -169,6 +169,16 @@ type App struct {
 	// confirmation has no meaning across a save / load boundary).
 	endFlightConfirm bool
 
+	// quickloadConfirm (item-3 UX batch, #447-adjacent — reverses ADR
+	// 0033 §H) gates F9 quickload behind the same y/n confirm the Saves
+	// browser's Load already uses. §H kept F9 instant on the theory
+	// that the quicksave lane is zero-risk; the review found the
+	// opposite in practice with a one-slot quicksave lane — a fat-
+	// finger discards everything since the last F5 with no undo.
+	// Mirrors endFlightConfirm's shape exactly (see its Update/Render
+	// call sites).
+	quickloadConfirm bool
+
 	// Chat input overlay (ADR 0035 S3). App-level rather than a screen
 	// so the capturingText obligation is one unconditional check — not
 	// another arm of the per-screen switch a future screen could forget.
@@ -813,6 +823,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
+		// quickloadConfirm intercept (item-3 UX batch): same shape as
+		// endFlightConfirm above — y/Y commits the F9 quickload, every
+		// other key (including n/N/esc) cancels and is swallowed so a
+		// stray flight key doesn't slip through mid-confirm.
+		if a.quickloadConfirm {
+			s := m.String()
+			a.quickloadConfirm = false
+			if s == "y" || s == "Y" {
+				a.flashStatus("load", a.doLoad())
+			}
+			return a, nil
+		}
 		// Meeting Planner picker (ADR 0045 S6, #399): a walkable chip on
 		// the orbit map, not a screen — a.active never changes while it's
 		// open, so this can't be handled by any of the a.active==screenXxx
@@ -1207,8 +1229,19 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.world.Clock.WarpDown()
 			return a, nil
 		case key.Matches(m, a.keys.AutoWarp):
-			// Toggle Auto-Warp to the globally-soonest burn. A no-op when
-			// no burn is eligible (engage returns false silently).
+			// Toggle Auto-Warp to the globally-soonest burn.
+			//
+			// item-3 UX batch: pressing G with nothing eligible used to
+			// no-op silently — AutoWarpEligible() already drives the
+			// Launch View button's dimmed state (#445), but the raw key
+			// had no equivalent. Check it up front and say why instead
+			// of falling into toggleAutoWarpBurn, whose true/false
+			// return is ambiguous between "just disengaged" and "engage
+			// failed" (see ToggleAutoWarp's doc).
+			if !a.world.AutoWarpEngaged() && !a.world.AutoWarpEligible() {
+				a.refuse("auto-warp", "no burn planned to warp to")
+				return a, nil
+			}
 			if a.toggleAutoWarpBurn() {
 				a.world.RecordAction(missions.ActionAutoWarp) // ADR 0025 §7
 			}
@@ -1378,7 +1411,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.flashStatus("save", a.doSave())
 			return a, nil
 		case key.Matches(m, a.keys.Load):
-			a.flashStatus("load", a.doLoad())
+			// item-3 UX batch (reverses ADR 0033 §H): arm the same y/n
+			// confirm the Saves browser's Load already uses instead of
+			// loading instantly — but only when there's actually a
+			// quicksave to discard-into; an empty lane surfaces straight
+			// to doLoad's own "no quicksave" / "resume autosave" message,
+			// since confirming a load that can only fail teaches nothing.
+			if !a.quicksaveExists() {
+				a.flashStatus("load", a.doLoad())
+				return a, nil
+			}
+			a.quickloadConfirm = true
 			return a, nil
 		case key.Matches(m, a.keys.CycleView):
 			a.world.CycleViewMode()
@@ -1534,9 +1577,22 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.CraftSlot):
 			// v0.12.0+: number-row 1..9 jumps to craft index 0..8.
 			// The binding only matches single digits '1'..'9', so the
-			// first byte of the key string is the digit; no-op when no
-			// craft occupies that slot (SwitchToCraftIdx bounds-checks).
-			a.world.SwitchToCraftIdx(int(m.String()[0]-'0') - 1)
+			// first byte of the key string is the digit.
+			//
+			// item-3 UX batch: an empty-slot digit used to swallow the
+			// key with no feedback — say why. Checked directly against
+			// len(Crafts) rather than SwitchToCraftIdx's bool return,
+			// which is false for the *already on that slot* case too
+			// (a harmless redundant press, not a "no vessel there" —
+			// refusing that would be a wrong message, not just a
+			// missing one).
+			digit := int(m.String()[0] - '0')
+			idx := digit - 1
+			if idx >= len(a.world.Crafts) {
+				a.refuse("vessel", fmt.Sprintf("no vessel in slot %d", digit))
+				return a, nil
+			}
+			a.world.SwitchToCraftIdx(idx)
 			return a, nil
 		case key.Matches(m, a.keys.Undock):
 			// v0.28 S5: while docked-as-guest (one of my craft rides in
@@ -1729,11 +1785,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		case key.Matches(m, a.keys.TiltUp), key.Matches(m, a.keys.TiltDown):
-			// v0.10.6+: nudge ViewTilted's polar tilt θ ±5°. No-op when
-			// the active projection isn't ViewTilted — keep the binding
-			// silent on cardinals / orbit-flat so a stray shift+arrow
-			// while in ViewTop doesn't blast a misleading flash.
+			// v0.10.6+: nudge ViewTilted's polar tilt θ ±5°.
+			//
+			// item-3 UX batch: outside ViewTilted this used to no-op
+			// silently, on the theory that a stray shift+arrow in
+			// ViewTop shouldn't blast a misleading flash — but the
+			// review found the opposite: plain ↑ pans in every view, so
+			// the silence on shift+↑ reads as "the modifier is broken",
+			// not "not now". Refuse out loud like every sibling guard.
 			if a.world.ViewMode != sim.ViewTilted {
+				a.refuse("tilt", "only in the tilted view — [v] cycles")
 				return a, nil
 			}
 			delta := sim.ViewTiltThetaStep
@@ -1746,10 +1807,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(m, a.keys.YawLeft), key.Matches(m, a.keys.YawRight):
 			// ADR 0021 G: nudge ViewTilted's yaw φ ±5°, wrapping at
 			// 360° (no clamp — yaw is a full turn around the orbit).
-			// Same gating as the tilt keys: silent outside ViewTilted
-			// so a stray brace in a cardinal view doesn't flash a
-			// misleading toast.
+			//
+			// item-3 UX batch: same fix as the tilt keys above — refuse
+			// out loud outside ViewTilted instead of the old silent
+			// no-op.
 			if a.world.ViewMode != sim.ViewTilted {
+				a.refuse("yaw", "only in the tilted view — [v] cycles")
 				return a, nil
 			}
 			delta := sim.ViewTiltPhiStep
@@ -1783,10 +1846,14 @@ var errGuestSaves = errors.New("no local saves in a session — your program aut
 // follow-up; per-guest settings are a later cycle).
 var errGuestSettings = errors.New("settings belong to the host in a session")
 
-// doLoad replaces the live world with the quicksave lane — F9 stays
-// instant, no confirm (ADR 0033 §H). An empty lane (no F5 yet) is
-// surfaced as a clear "no quicksave" message rather than a raw
-// file-not-found; failures leave the existing world untouched.
+// doLoad replaces the live world with the quicksave lane. F9 used to
+// stay instant with no confirm (ADR 0033 §H); the item-3 UX batch
+// reversed that (see the App.quickloadConfirm doc and the ADR's
+// Amendments section) — this func is now only reached after that
+// confirm, or when the lane is empty and there's nothing to discard.
+// An empty lane (no F5 yet) is surfaced as a clear "no quicksave"
+// message rather than a raw file-not-found; failures leave the
+// existing world untouched.
 //
 // When there is no quicksave but an autosave IS on disk (the common
 // quit → relaunch → F9 case, whose quit state landed in the autosave
@@ -1819,6 +1886,22 @@ func (a *App) hasResumableAutosave() bool {
 	}
 	for _, in := range infos {
 		if in.Lane == save.LaneAutosave && !in.Unreadable {
+			return true
+		}
+	}
+	return false
+}
+
+// quicksaveExists reports whether the quicksave lane holds a readable
+// entry — gates whether F9 arms quickloadConfirm (item-3 UX batch) or
+// falls straight through to doLoad's own empty-lane message.
+func (a *App) quicksaveExists() bool {
+	infos, err := save.List()
+	if err != nil {
+		return false
+	}
+	for _, in := range infos {
+		if in.Lane == save.LaneQuicksave && !in.Unreadable {
 			return true
 		}
 	}
@@ -2776,6 +2859,13 @@ func (a *App) flashStatus(op string, err error) {
 func (a *App) handlePlanRendezvousKey() {
 	out, err := a.world.PlanRendezvousOrOpenMeeting()
 	if err != nil {
+		if errors.Is(err, sim.ErrRendezvousNoTarget) {
+			// item-3 UX batch (features finding 13): the refusal named
+			// the missing precondition but not the action that supplies
+			// it — append the one clause the review found missing.
+			a.flash("rendezvous: no vessel target — [t] to target it")
+			return
+		}
 		a.flash(fmt.Sprintf("rendezvous: %v", err))
 		return
 	}
@@ -2952,6 +3042,12 @@ func (a *App) View() string {
 		}
 		prompt := fmt.Sprintf("END FLIGHT — remove %s? [y/n]", name)
 		base = overlayBottomBorder(base, a.theme.Alert.Render(prompt), border)
+	}
+	// quickloadConfirm rides the same band (item-3 UX batch): takes the
+	// same precedence as the end-flight prompt above, for the same
+	// reason — an armed confirm is the actionable state.
+	if a.quickloadConfirm {
+		base = overlayBottomBorder(base, a.theme.Alert.Render("F9 — discard everything since your last quicksave? [y/n]"), border)
 	}
 	// Chat input (ADR 0035 S3) rides the same band and wins it while
 	// open — it is the live actionable state. A concurrent toast (a DM

--- a/internal/tui/app_chat_input_test.go
+++ b/internal/tui/app_chat_input_test.go
@@ -276,6 +276,31 @@ func TestChatTildeInertDuringEndFlightConfirm(t *testing.T) {
 	}
 }
 
+// TestChatTildeInertDuringQuickloadConfirm (item-3 UX batch review
+// finding 1): the same hole TestChatTildeInertDuringEndFlightConfirm
+// pins for [E] existed for the new F9 confirm — ~ opened chat OVER the
+// armed prompt, hiding it, and the prompt survived the chat round-trip
+// to fire on whatever key closed chat. ~ must not open chat; it falls
+// through to quickloadConfirm's own intercept instead, which — unlike
+// endFlightConfirm's y/n/esc-only clear — cancels on ANY non-"y" key
+// (by design: it can never get stuck armed via the keyboard), so the
+// world must be left untouched.
+func TestChatTildeInertDuringQuickloadConfirm(t *testing.T) {
+	a := newChatApp(t)
+	a.quickloadConfirm = true
+	old := a.world
+	chatPress(a, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'~'}})
+	if a.capturingText() {
+		t.Fatalf("~ must not open chat over an armed quickload confirm")
+	}
+	if a.quickloadConfirm {
+		t.Fatalf("~ should have fallen through and cancelled quickloadConfirm, same as any other non-y key")
+	}
+	if a.world != old {
+		t.Fatalf("~ must never itself trigger the quickload")
+	}
+}
+
 func TestRestoreChatDraft(t *testing.T) {
 	a := newChatApp(t)
 	a.RestoreChatDraft("@gern hold")

--- a/internal/tui/app_guarded_refusal_test.go
+++ b/internal/tui/app_guarded_refusal_test.go
@@ -305,7 +305,7 @@ func TestPlanRendezvousRefusalLabelStillSingular(t *testing.T) {
 	}
 }
 
-// item-3 UX batch (controls finding 10 / #447-adjacent): [G] auto-warp
+// item-3 UX batch (controls finding 10): [G] auto-warp
 // used to no-op silently when no burn was eligible. It must now refuse
 // out loud like every sibling guard.
 func TestAutoWarpRefusesNoEligibleBurn(t *testing.T) {

--- a/internal/tui/app_guarded_refusal_test.go
+++ b/internal/tui/app_guarded_refusal_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
 func pressKey(a *App, r rune) (tea.Model, tea.Cmd) {
@@ -104,8 +106,8 @@ func TestPlanRendezvousReachesPlannerFromBodyInfo(t *testing.T) {
 
 	pressKey(a, 'K')
 
-	if a.statusMsg != "rendezvous: no vessel target" {
-		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from body-info, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target")
+	if a.statusMsg != "rendezvous: no vessel target — [t] to target it" {
+		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from body-info, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target — [t] to target it")
 	}
 	if a.active != screenBodyInfo {
 		t.Errorf("active screen changed to %v", a.active)
@@ -121,8 +123,8 @@ func TestPlanRendezvousReachesPlannerFromMissions(t *testing.T) {
 
 	pressKey(a, 'K')
 
-	if a.statusMsg != "rendezvous: no vessel target" {
-		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from missions, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target")
+	if a.statusMsg != "rendezvous: no vessel target — [t] to target it" {
+		t.Errorf("statusMsg = %q, want %q (K must reach PlanRendezvousNudge from missions, not be screen-gated)", a.statusMsg, "rendezvous: no vessel target — [t] to target it")
 	}
 	if a.active != screenMissions {
 		t.Errorf("active screen changed to %v", a.active)
@@ -300,5 +302,114 @@ func TestPlanRendezvousRefusalLabelStillSingular(t *testing.T) {
 	pressKey(a, 'K')
 	if n := strings.Count(a.statusMsg, "rendezvous:"); n != 1 {
 		t.Errorf("status %q carries the rendezvous label %d times, want exactly 1", a.statusMsg, n)
+	}
+}
+
+// item-3 UX batch (controls finding 10 / #447-adjacent): [G] auto-warp
+// used to no-op silently when no burn was eligible. It must now refuse
+// out loud like every sibling guard.
+func TestAutoWarpRefusesNoEligibleBurn(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a.world.AutoWarpEligible() {
+		t.Skip("fresh world unexpectedly has an eligible burn")
+	}
+
+	pressKey(a, 'G')
+
+	if a.statusMsg != "auto-warp: no burn planned to warp to" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "auto-warp: no burn planned to warp to")
+	}
+	if a.world.AutoWarpEngaged() {
+		t.Fatal("[G] engaged Auto-Warp with no eligible burn")
+	}
+}
+
+// item-3 UX batch (controls finding 10): a number key for an empty
+// vessel slot used to no-op silently. A fresh world has exactly one
+// craft at slot 1, so slot 2 must refuse.
+func TestCraftSlotRefusesEmptySlot(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if len(a.world.Crafts) != 1 {
+		t.Skip("fresh world does not have exactly one craft")
+	}
+
+	pressKey(a, '2')
+
+	if a.statusMsg != "vessel: no vessel in slot 2" {
+		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "vessel: no vessel in slot 2")
+	}
+}
+
+// TestCraftSlotJumpsOccupiedSlot is the control: the existing happy
+// path (slot 1, which always exists) must still work unchanged.
+func TestCraftSlotJumpsOccupiedSlot(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	pressKey(a, '1')
+
+	if a.statusMsg != "" {
+		t.Errorf("statusMsg = %q, want no refusal for an occupied slot", a.statusMsg)
+	}
+}
+
+// item-3 UX batch (controls findings 6 / 10): shift+↑/↓/←/→ (tilt /
+// yaw) used to no-op silently outside the tilted view — the review
+// found that indistinguishable from a broken modifier key, since
+// plain ↑ pans in every view. Table-driven since the fix is identical
+// for all four.
+func TestTiltAndYawRefuseOutsideTiltedView(t *testing.T) {
+	cases := []struct {
+		name string
+		key  tea.KeyType
+		want string
+	}{
+		{"TiltUp", tea.KeyShiftUp, "tilt: only in the tilted view — [v] cycles"},
+		{"TiltDown", tea.KeyShiftDown, "tilt: only in the tilted view — [v] cycles"},
+		{"YawLeft", tea.KeyShiftLeft, "yaw: only in the tilted view — [v] cycles"},
+		{"YawRight", tea.KeyShiftRight, "yaw: only in the tilted view — [v] cycles"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := New(nil)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			// A fresh world defaults to ViewTilted (see
+			// TestYawKeysNudgePhi) — force a non-tilted view so this
+			// exercises the refusal path, not the nudge path.
+			a.world.ViewMode = sim.ViewTop
+
+			a.Update(tea.KeyMsg{Type: tc.key})
+
+			if a.statusMsg != tc.want {
+				t.Errorf("statusMsg = %q, want %q", a.statusMsg, tc.want)
+			}
+		})
+	}
+}
+
+// TestTiltWorksInTiltedView is the control: the existing happy path
+// (tilt nudges θ while ViewTilted is active) must still work unchanged
+// by the outside-the-view refusal fix.
+func TestTiltWorksInTiltedView(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.world.ViewMode = sim.ViewTilted
+
+	a.Update(tea.KeyMsg{Type: tea.KeyShiftUp})
+
+	if !strings.HasPrefix(a.statusMsg, "view: tilted") {
+		t.Errorf("statusMsg = %q, want a %q-prefixed tilt readout", a.statusMsg, "view: tilted")
 	}
 }

--- a/internal/tui/app_saves_test.go
+++ b/internal/tui/app_saves_test.go
@@ -67,10 +67,11 @@ func TestQuicksaveKeyWritesLane(t *testing.T) {
 	}
 }
 
-// TestQuickloadKeySwapsWorld — F9 loads the quicksave lane instantly
-// (no confirm, ADR 0033 §H), replacing the world and re-applying the
-// player's mission-program toggles (the v0.21 Slice 7 behaviour the
-// rewire must preserve).
+// TestQuickloadKeySwapsWorld — F9 arms a y/n confirm (item-3 UX batch;
+// reverses ADR 0033 §H's "F9 stays instant" — see that ADR's
+// Amendments section), and y/Y then replaces the world and re-applies
+// the player's mission-program toggles (the v0.21 Slice 7 behaviour
+// the rewire must preserve).
 func TestQuickloadKeySwapsWorld(t *testing.T) {
 	testStateDirs(t)
 	a, err := New(nil)
@@ -83,8 +84,19 @@ func TestQuickloadKeySwapsWorld(t *testing.T) {
 	a.world.Clock.WarpIdx = 4 // diverge so the swap is observable
 
 	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+	if a.world != old {
+		t.Fatal("F9 replaced the world before the y/n confirm was answered")
+	}
+	if !a.quickloadConfirm {
+		t.Fatal("F9 with a quicksave present did not arm quickloadConfirm")
+	}
+
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if a.quickloadConfirm {
+		t.Error("quickloadConfirm still armed after y")
+	}
 	if a.world == old {
-		t.Fatal("F9 did not replace the world")
+		t.Fatal("F9 did not replace the world after confirming")
 	}
 	if a.world.Clock.WarpIdx != 0 {
 		t.Errorf("WarpIdx = %d, want 0 (the quicksaved state)", a.world.Clock.WarpIdx)
@@ -104,9 +116,33 @@ func TestQuickloadKeySwapsWorld(t *testing.T) {
 	}
 }
 
-// TestQuickloadEmptyLane — F9 before any F5 flashes a clear "no
-// quicksave" message via flashStatus (not a raw file-not-found error)
-// and leaves the live world untouched.
+// TestQuickloadConfirmCancels — n/N/Esc during the F9 confirm cancels
+// without touching the world, the same shape as endFlightConfirm's
+// cancel path.
+func TestQuickloadConfirmCancels(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyF5})
+	old := a.world
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+
+	if a.quickloadConfirm {
+		t.Error("quickloadConfirm still armed after n")
+	}
+	if a.world != old {
+		t.Fatal("F9 replaced the world despite a cancelled confirm")
+	}
+}
+
+// TestQuickloadEmptyLane — F9 before any F5 skips the confirm (there is
+// nothing to discard) and flashes a clear "no quicksave" message via
+// flashStatus (not a raw file-not-found error), leaving the live world
+// untouched.
 func TestQuickloadEmptyLane(t *testing.T) {
 	testStateDirs(t)
 	a, err := New(nil)

--- a/internal/tui/app_saves_test.go
+++ b/internal/tui/app_saves_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/save"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
 )
 
 // testStateDirs isolates both the saves directory (XDG_STATE_HOME) and
@@ -136,6 +137,36 @@ func TestQuickloadConfirmCancels(t *testing.T) {
 	}
 	if a.world != old {
 		t.Fatal("F9 replaced the world despite a cancelled confirm")
+	}
+}
+
+// TestQuickloadGuestSkipsConfirm (item-3 UX batch review finding 2): a
+// session guest's F9 can never succeed — their program autosaves
+// server-side, so the local Saves surface is disabled (errGuestSaves).
+// a.quicksaveExists() only reads the LOCAL saves dir though, so a
+// guest who once played solo on this machine still has a stale local
+// quicksave.json lying around; that must not arm the destructive-
+// sounding y/n prompt for a load that will only refuse.
+func TestQuickloadGuestSkipsConfirm(t *testing.T) {
+	testStateDirs(t)
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.KeyMsg{Type: tea.KeyF5}) // stale solo quicksave on disk
+	a.guestSave = func(*sim.World) error { return nil }
+	old := a.world
+
+	a.Update(tea.KeyMsg{Type: tea.KeyF9})
+
+	if a.quickloadConfirm {
+		t.Fatal("F9 armed the quickload confirm for a guest, who can never actually load locally")
+	}
+	if a.world != old {
+		t.Fatal("F9 replaced the world for a guest")
+	}
+	if !strings.Contains(a.statusMsg, "no local saves in a session") {
+		t.Errorf("statusMsg = %q, want the guest refusal", a.statusMsg)
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -405,15 +405,18 @@ func TestYawKeysNudgePhi(t *testing.T) {
 		t.Errorf("statusMsg = %q, want %q", a.statusMsg, "view: yaw 355°")
 	}
 
-	// Outside ViewTilted the keys are a silent no-op.
+	// Outside ViewTilted the keys refuse out loud instead of silently
+	// no-opping (item-3 UX batch, controls findings 6/10 — see
+	// TestTiltAndYawRefuseOutsideTiltedView for the dedicated coverage;
+	// this just pins that Phi itself still doesn't mutate).
 	a.world.ViewMode = sim.ViewTop
 	a.statusMsg = ""
 	a.Update(tea.KeyMsg{Type: tea.KeyShiftRight})
 	if a.world.ViewTilt.Phi != 355 {
 		t.Errorf("shift+→ in ViewTop mutated Phi to %v, want 355 (no-op)", a.world.ViewTilt.Phi)
 	}
-	if a.statusMsg != "" {
-		t.Errorf("shift+→ in ViewTop flashed %q, want silence", a.statusMsg)
+	if a.statusMsg != "yaw: only in the tilted view — [v] cycles" {
+		t.Errorf("statusMsg = %q, want the refusal", a.statusMsg)
 	}
 }
 

--- a/internal/tui/screens/menu.go
+++ b/internal/tui/screens/menu.go
@@ -95,9 +95,11 @@ const (
 
 // HandleKey maps a raw key string to a MenuAction. Lower- and
 // upper-case both match. The keyboard path skips the click-only
-// confirm gate when in the list state — typing "s" still saves
-// immediately, matching v0.7.3.3 muscle memory. In a confirm state
-// the keys narrow to y / n / enter / esc.
+// confirm gate for the reversible rows — typing "s" still saves
+// immediately, matching v0.7.3.3 muscle memory. "q" is the exception
+// (item-3 UX batch): it arms the same confirm the [Quit] click uses,
+// since quit is the one list-state action that isn't reversible. In a
+// confirm state the keys narrow to y / n / enter / esc.
 func (m *Menu) HandleKey(s string) MenuAction {
 	switch m.mode {
 	case menuModeList:
@@ -115,7 +117,14 @@ func (m *Menu) HandleKey(s string) MenuAction {
 		case "h", "H":
 			return MenuActionHelp
 		case "q", "Q":
-			return MenuActionQuit
+			// item-3 UX batch (controls findings 8/21): route the
+			// keyboard path through the same confirm the [Quit] click
+			// already uses instead of quitting instantly — the two
+			// paths to the single most destructive action must agree,
+			// and the F1 overlay already describes the key as "quit
+			// (confirm + autosave)".
+			m.mode = menuModeConfirmQuit
+			return MenuActionNone
 		case "esc":
 			return MenuActionCancel
 		}

--- a/internal/tui/screens/menu_test.go
+++ b/internal/tui/screens/menu_test.go
@@ -21,8 +21,6 @@ func TestMenuHandleKey(t *testing.T) {
 		{"C", MenuActionControls},
 		{"h", MenuActionHelp},
 		{"H", MenuActionHelp},
-		{"q", MenuActionQuit},
-		{"Q", MenuActionQuit},
 		{"esc", MenuActionCancel},
 		{"x", MenuActionNone},
 		{"", MenuActionNone},
@@ -237,5 +235,31 @@ func TestMenuKeyboardConfirmStillWorks(t *testing.T) {
 	}
 	if m.mode != menuModeList {
 		t.Errorf("mode after n: got %v, want menuModeList", m.mode)
+	}
+}
+
+// TestMenuKeyboardQuitArmsConfirm (item-3 UX batch, controls findings
+// 8/21): typing "q"/"Q" in the list state used to fire MenuActionQuit
+// immediately — disagreeing with the [Quit] click, which always went
+// through the confirm gate. Both paths must now agree.
+func TestMenuKeyboardQuitArmsConfirm(t *testing.T) {
+	m := NewMenu(Theme{})
+
+	for _, key := range []string{"q", "Q"} {
+		m.Reset()
+		if got := m.HandleKey(key); got != MenuActionNone {
+			t.Errorf("HandleKey(%q) = %v, want MenuActionNone (confirm gate)", key, got)
+		}
+		if m.mode != menuModeConfirmQuit {
+			t.Errorf("mode after HandleKey(%q) = %v, want menuModeConfirmQuit", key, m.mode)
+		}
+	}
+
+	// y still commits from the keyboard-armed confirm, same as the
+	// click-armed one already covered above.
+	m.Reset()
+	m.HandleKey("q")
+	if got := m.HandleKey("y"); got != MenuActionQuit {
+		t.Errorf("HandleKey(y) after keyboard q: got %v, want MenuActionQuit", got)
 	}
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -371,8 +371,16 @@ const hintStripText = "[F1] help · [t] target · [m] plan · [n] new vessel · 
 // ("view: tilted 30°/anchor").
 const hintStripGap = 2
 
-// paintHintStrip stamps the Hint Strip onto the canvas's last row,
-// starting hintStripGap columns after labelRunes (the rune-length of the
+// inspectHintStripText replaces the Hint Strip while Inspect is live
+// (item-3 UX batch, features finding 14): the hover→commit contract's
+// commit half — Enter targets, Esc exits — was otherwise invisible
+// unless the player already knew F1. It's still fixed text, painted in
+// the same row the generic strip uses, just swapped for the duration
+// of the highlight.
+const inspectHintStripText = "[enter] target · [esc] exit inspect"
+
+// paintHintStrip stamps text onto the canvas's last row, starting
+// hintStripGap columns after labelRunes (the rune-length of the
 // left-hand label already painted at column 0 on that row) — so it can
 // never overwrite that label. Shared by the map (Render, above) and the
 // Proximity View (orbit_proximity.go's proximityLabel), which paint the
@@ -380,8 +388,8 @@ const hintStripGap = 2
 // Design Size (140×40) it clips on the right via SetCellLabelColored's
 // own out-of-bounds skip — the strip is a legend, not a numeric field,
 // so right-clipping is safe (CONTEXT.md).
-func (v *OrbitView) paintHintStrip(labelRunes int) {
-	v.canvas.SetCellLabelColored(labelRunes+hintStripGap, v.canvas.Rows()-1, hintStripText, v.theme.Dim.GetForeground())
+func (v *OrbitView) paintHintStrip(labelRunes int, text string) {
+	v.canvas.SetCellLabelColored(labelRunes+hintStripGap, v.canvas.Rows()-1, text, v.theme.Dim.GetForeground())
 }
 
 // NewOrbitView constructs the screen with an initially-small canvas; a
@@ -1474,7 +1482,11 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	v.drawInspectFlare()
 
 	v.canvas.SetCellLabelColored(0, v.canvas.Rows()-1, viewLabel, v.theme.Primary.GetForeground())
-	v.paintHintStrip(utf8.RuneCountInString(viewLabel))
+	strip := hintStripText
+	if v.Inspecting() {
+		strip = inspectHintStripText
+	}
+	v.paintHintStrip(utf8.RuneCountInString(viewLabel), strip)
 	// v0.13: the "focus:" indicator moved to the title bar (renderTitleBar)
 	// — the canvas top-left corner is now home to the pinned VESSEL chip,
 	// and "focus: <craft>" was redundant with the chip's vessel name.

--- a/internal/tui/screens/orbit_hint_strip_test.go
+++ b/internal/tui/screens/orbit_hint_strip_test.go
@@ -200,3 +200,41 @@ func TestHintStripWithForcedNodesChipAndCraftNotVisibleHere(t *testing.T) {
 		t.Logf("Playable Floor: confirmed known collision between the forced bottom-right NODES chip and the Hint Strip's tail when CraftVisibleHere()==false (out of #425's decided scope; see impl-notes/425.md)")
 	}
 }
+
+// TestHintStripSwapsForInspect (item-3 UX batch, features finding 14):
+// Inspect flared a name chip with no on-screen word for what Enter or
+// Esc do while it's live. The generic Hint Strip must swap to the
+// inspect-specific one for the duration of the highlight, and swap
+// back once it clears.
+func TestHintStripSwapsForInspect(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	w.Focus = sim.Focus{Kind: sim.FocusCraft}
+
+	out := stripANSI(v.Render(w, 0, 140, 40))
+	if !strings.Contains(out, hintStripText) {
+		t.Fatalf("expected the generic Hint Strip before Inspect is armed:\n%s", out)
+	}
+
+	v.InspectNext()
+	if !v.Inspecting() {
+		t.Fatal("InspectNext did not arm the highlight on a frame with an inspectable craft")
+	}
+	out = stripANSI(v.Render(w, 0, 140, 40))
+	if !strings.Contains(out, inspectHintStripText) {
+		t.Errorf("expected the inspect Hint Strip (%q) while Inspecting:\n%s", inspectHintStripText, out)
+	}
+	if strings.Contains(out, hintStripText) {
+		t.Errorf("generic Hint Strip should not also be present while Inspecting:\n%s", out)
+	}
+
+	v.InspectClear()
+	out = stripANSI(v.Render(w, 0, 140, 40))
+	if !strings.Contains(out, hintStripText) {
+		t.Errorf("expected the generic Hint Strip back after InspectClear:\n%s", out)
+	}
+}

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -153,7 +153,7 @@ func (v *OrbitView) renderProximity(w *sim.World, totalCols, totalRows int) stri
 	// label, so it carries the same Hint Strip (#425), right of whatever
 	// this row's label ended up being (the fixed "view: proximity" form,
 	// or the longer sceneOK form with target name + axis legend).
-	v.paintHintStrip(utf8.RuneCountInString(label))
+	v.paintHintStrip(utf8.RuneCountInString(label), hintStripText)
 
 	canvasStr := v.canvas.String()
 

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -640,6 +640,15 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		b.WriteString(title + "\n\n")
 		b.WriteString("  Not in a multiplayer session.\n\n")
 		b.WriteString(s.theme.Dim.Render("  [h] start hosting — accept ssh guests on this machine; invite them with serve invite.") + "\n\n")
+		// item-3 UX batch (features finding 13): half of multiplayer —
+		// being a guest — had no in-game description at all. Name the
+		// actual connect step so a guest isn't left with only a CLI
+		// phrase and no context for where the invite code comes from.
+		// Two short lines rather than one long one — this screen has no
+		// wrap helper and the hosting line above already sets the
+		// precedent for clipping at low widths.
+		b.WriteString(s.theme.Dim.Render("  Joining someone else's session: connect with `ssh -p 23234 <their host>`,") + "\n")
+		b.WriteString(s.theme.Dim.Render("  then enroll with the invite code they gave you from `serve invite`.") + "\n\n")
 		b.WriteString(s.theme.Footer.Render("  [h] start hosting   [esc] close"))
 		return b.String()
 	}

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -119,6 +119,25 @@ func TestSessionScreenSinglePlayer(t *testing.T) {
 	}
 }
 
+// TestSessionScreenExplainsJoining (item-3 UX batch, features finding
+// 13): the no-session screen explained hosting but not joining — half
+// of multiplayer had no in-game description at all. It must now name
+// the guest connect step (ssh + invite code), not just the CLI phrase.
+func TestSessionScreenExplainsJoining(t *testing.T) {
+	s := NewSessionScreen(sessionTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	out := s.Render(w, 120)
+	if !strings.Contains(out, "ssh -p 23234") {
+		t.Errorf("joining explainer missing the ssh connect step:\n%s", out)
+	}
+	if !strings.Contains(out, "invite code") {
+		t.Errorf("joining explainer missing where the invite code comes from:\n%s", out)
+	}
+}
+
 func key(s string) tea.KeyMsg {
 	switch s {
 	case "enter":


### PR DESCRIPTION
## Summary

Item 3 of the ranked UX-review cycle (see the designdocs handoff
`2026-09-08-burn-state-visibility-shipped-item3-next.md`): the
"refusals and confirms" mechanical batch from
`ux-reviews/20260902-1059/triage/tally.md` (controls 6, 8, 10, 21;
workflows 19; features 13, 14, 17).

- **`G` (auto-warp), digit craft-slot keys, `shift+↑/↓/←/→` (tilt/yaw)**
  now refuse out loud instead of silently no-opping when nothing's
  eligible / the slot is empty / the view isn't tilted (controls 6, 10).
- **Pause menu `q`** now arms the same y/n confirm the `[Quit]` click
  already used, instead of quitting instantly (controls 8, 21).
- **F9 quickload** now arms a y/n confirm before discarding the live
  world. This reverses ADR 0033 §H ("F9 stays instant") per Jason's
  explicit call when the conflict was flagged — amendment note going
  into the vault alongside this PR (workflows 19).
- **Rendezvous `[K]`**'s "no vessel target" refusal now names `[t]` as
  the fix (features 17).
- **Session screen** explains how a guest *joins*, not just how to
  host (features 13).
- **Inspect's Hint Strip** line shows `[enter] target · [esc] exit
  inspect` while a highlight is live, instead of the generic strip
  (features 14).

Two backlog items were dropped after checking current code (not just
the review's snapshot):
- **workflows 8** (`ctrl+d` del-node no-op) — already fixed by #428's
  Plan-Cursor rewire; the remaining no-op is the genuinely-empty
  new-node row, which is correct.
- **features 26** (warp discoverability) — already covered by the
  v0.40 Hint Strip's `[./,] warp` legend.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all
  green locally.
- New/updated tests: `app_guarded_refusal_test.go` (auto-warp, craft
  slot, tilt/yaw refusals), `app_saves_test.go` (F9 confirm arm/commit/
  cancel), `menu_test.go` (keyboard `q` arms confirm), `session_test.go`
  (joining explainer), `orbit_hint_strip_test.go` (inspect swap).
- Not yet done: a live playtest of the F9 confirm and the menu `q`
  confirm in a real terminal — flagging so it isn't assumed.