### PR TITLE
Fix: ATMOSPHERE chip reappearing every orbit above the atmosphere

### DIFF
--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -156,23 +156,33 @@ type AscentQBand struct {
 	HasMaxQ bool
 }
 
-// AscentQBandFor builds the Q-band instrument for a craft, or ok=false
-// when the primary has no atmosphere at all — issue #348 §3's gate ("Q
-// band only on bodies WITH atmosphere"). Independent of whether the
-// vessel is CURRENTLY inside the atmosphere: a vessel that has already
-// climbed clear of the cutoff still has a meaningful band (it reads
-// "past the top", clamped by qBandRowIndex) carrying the max-Q mark from
-// the climb through it — but only until periapsis itself clears the
-// atmosphere (#449 fix). That comment's "climbed clear" picture assumed
-// a one-pass climb-to-orbit; it didn't account for AscentCueFor's
-// climb-rate gate being orbital-mechanics-blind. Once in a stable orbit,
-// the surface-relative radial rate swings positive on every periapsis→
-// apoapsis half regardless of altitude, so without this check the chip
-// (and the whole ascent-cue bundle it gates, via AscentCueFor's shared
-// `ok`) would flicker back on once per orbit forever, long after the
-// vessel will ever see the atmosphere again. A periapsis still inside
-// the atmosphere means a real re-entry is coming next orbit, so the
-// chip staying live is still correct there.
+// AscentQBandFor builds the Q-band instrument for a craft. ok is false
+// when the primary has no atmosphere at all (issue #348 §3's gate — "Q
+// band only on bodies WITH atmosphere"), or once the vessel is done
+// with the atmosphere for good (#449 fix, see below).
+//
+// "Done for good" mirrors shouldShowLaunchHUD's own hyperbolic-vs-
+// elliptical split (orbit.go), for the same reason: a stable elliptical
+// orbit's periapsis tells you whether the atmosphere is coming back
+// (periapsis inside it: yes, next orbit; periapsis clear: never again),
+// but a hyperbolic/degenerate state's "periapsis" can describe a
+// departure or approach far from the body, where the honest signal is
+// current altitude instead — see shouldShowLaunchHUD's comment for why.
+//
+// Why this check exists at all: the original design (issue #348 §3)
+// kept the band visible "past the top" once a vessel climbed clear of
+// the cutoff, so the max-Q mark from the climb survived on screen. That
+// picture assumed a one-pass climb-to-orbit; it didn't account for the
+// climb-rate signal AscentCueFor's OWN gate uses being orbital-
+// mechanics-blind (tracked separately as a follow-up, #449): a stable
+// orbit's surface-relative radial rate swings positive on every
+// periapsis→apoapsis half regardless of altitude, so without a check
+// here the Q band specifically would flicker back on once per orbit,
+// forever, long after the atmosphere could ever matter again. This
+// fixes the Q band / ATMOSPHERE chip only — AscentCueFor's own `ok`
+// still gates the ascent arc and nose/prograde stubs on raw climb rate,
+// so those two keep cycling once per orbit in a stable orbit; see the
+// follow-up issue for that.
 func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
 	if w == nil || c == nil || c.Primary.Atmosphere == nil {
 		return AscentQBand{}, false
@@ -180,8 +190,17 @@ func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
 	atm := c.Primary.Atmosphere
 	if mu := c.Primary.GravitationalParameter(); mu > 0 {
 		el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-		periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
-		if periapsisAltM >= atm.CutoffAltitude {
+		var doneForGood bool
+		if el.E >= 1 || el.A <= 0 {
+			// Hyperbolic/degenerate: "periapsis" can describe a distant
+			// departure or approach, so go by current altitude instead
+			// (shouldShowLaunchHUD's exact reasoning).
+			doneForGood = c.Altitude() >= atm.CutoffAltitude
+		} else {
+			periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
+			doneForGood = periapsisAltM >= atm.CutoffAltitude
+		}
+		if doneForGood {
 			return AscentQBand{}, false
 		}
 	}

--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -162,12 +162,29 @@ type AscentQBand struct {
 // vessel is CURRENTLY inside the atmosphere: a vessel that has already
 // climbed clear of the cutoff still has a meaningful band (it reads
 // "past the top", clamped by qBandRowIndex) carrying the max-Q mark from
-// the climb through it.
+// the climb through it — but only until periapsis itself clears the
+// atmosphere (#449 fix). That comment's "climbed clear" picture assumed
+// a one-pass climb-to-orbit; it didn't account for AscentCueFor's
+// climb-rate gate being orbital-mechanics-blind. Once in a stable orbit,
+// the surface-relative radial rate swings positive on every periapsis→
+// apoapsis half regardless of altitude, so without this check the chip
+// (and the whole ascent-cue bundle it gates, via AscentCueFor's shared
+// `ok`) would flicker back on once per orbit forever, long after the
+// vessel will ever see the atmosphere again. A periapsis still inside
+// the atmosphere means a real re-entry is coming next orbit, so the
+// chip staying live is still correct there.
 func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
 	if w == nil || c == nil || c.Primary.Atmosphere == nil {
 		return AscentQBand{}, false
 	}
 	atm := c.Primary.Atmosphere
+	if mu := c.Primary.GravitationalParameter(); mu > 0 {
+		el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+		periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
+		if periapsisAltM >= atm.CutoffAltitude {
+			return AscentQBand{}, false
+		}
+	}
 	return AscentQBand{
 		AtmosphereDepthM: atm.CutoffAltitude,
 		CurrentAltM:      c.Altitude(),

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -263,8 +263,24 @@ func TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 	if alt := c.Altitude(); alt <= atm.CutoffAltitude {
 		t.Fatalf("test setup: altitude %.0fm should be above the %.0fm cutoff", alt, atm.CutoffAltitude)
 	}
+	// Pin the test's own premise: nu=90 must actually be on the climbing
+	// half (climb rate above the floor), or this test would keep passing
+	// even if it stopped exercising the reported symptom.
+	rHat := c.State.R.Scale(1 / c.State.R.Norm())
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	if climbRate := vRel.Dot(rHat); climbRate < climbRateFloorMps {
+		t.Fatalf("test setup: climb rate %.3f m/s at nu=90°, want above the %.1f m/s floor (this orbitAt call must land on the climbing half)", climbRate, climbRateFloorMps)
+	}
 	if qb, ok := AscentQBandFor(w, c); ok {
 		t.Errorf("stable orbit above the atmosphere: AscentQBandFor ok=true (HasMaxQ=%v), want false — must not flicker back on every orbit", qb.HasMaxQ)
+	}
+	// End to end: the player-visible path is AscentCueFor -> HasQBand,
+	// not AscentQBandFor directly. AscentCueFor's own `ok` still stands
+	// up here (its climb-rate gate is a deliberately separate, still-
+	// open follow-up — see AscentQBandFor's doc comment) — this pins
+	// that HasQBand specifically is what the fix reaches.
+	if cue, ok := AscentCueFor(w, c, AscentPredictHorizon); !ok || cue.HasQBand {
+		t.Errorf("AscentCueFor(stable orbit above atmosphere) = (HasQBand=%v, ok=%v), want (false, true)", cue.HasQBand, ok)
 	}
 
 	// Still-elliptical orbit whose periapsis (100km) sits INSIDE the
@@ -273,6 +289,58 @@ func TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 	orbitAt(100_000, 226_000, math.Pi/2)
 	if _, ok := AscentQBandFor(w, c); !ok {
 		t.Error("periapsis still inside the atmosphere: AscentQBandFor ok=false, want true (re-entry is still coming)")
+	}
+}
+
+// TestAscentQBandForHyperbolicDepartureStandsDownByAltitude (#449
+// review finding 3): an outbound hyperbola (or an SOI-exiting orbit)
+// can have a "periapsis" — Elements.Periapsis() on a hyperbolic orbit
+// is still well-defined, the closest approach of the unbound path —
+// that sits INSIDE the atmosphere's cutoff even though the vessel is
+// headed away for good and will never come back down through it. Gating
+// on periapsis alone (as the first version of this fix did) kept the
+// chip live all the way to SOI exit for that shape. This mirrors
+// shouldShowLaunchHUD's existing el.E>=1||el.A<=0 split: go by current
+// altitude instead of periapsis once the orbit is hyperbolic/degenerate.
+func TestAscentQBandForHyperbolicDepartureStandsDownByAltitude(t *testing.T) {
+	w, c := ascendTestCraft(t, "earth", 400_000, 50)
+	mu := c.Primary.GravitationalParameter()
+	R := c.Primary.RadiusMeters()
+	atm := c.Primary.Atmosphere
+
+	// A hyperbolic departure with periapsis (100km) INSIDE the
+	// atmosphere, vinf = 3 km/s outbound, evaluated near periapsis
+	// where the vessel is still climbing fast.
+	rp := R + 100_000.0
+	vinf := 3_000.0
+	eps := vinf * vinf / 2
+	a := -mu / (2 * eps)
+	e := 1 - rp/a
+	nu := math.Pi / 6 // still inbound-to-outbound climb, well short of asymptote
+	p := a * (1 - e*e)
+	rMag := p / (1 + e*math.Cos(nu))
+	rHat := orbital.Vec3{X: math.Cos(nu), Y: math.Sin(nu)}
+	c.State.R = rHat.Scale(rMag)
+	h := math.Sqrt(mu * p)
+	vr := (mu / h) * e * math.Sin(nu)
+	vt := (mu / h) * (1 + e*math.Cos(nu))
+	thetaHat := orbital.Vec3{X: -math.Sin(nu), Y: math.Cos(nu)}
+	c.State.V = rHat.Scale(vr).Add(thetaHat.Scale(vt))
+
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	if el.E < 1 {
+		t.Fatalf("test setup: e=%.4f, want a hyperbolic (e>=1) orbit", el.E)
+	}
+	if alt := c.Altitude(); alt < atm.CutoffAltitude {
+		t.Fatalf("test setup: altitude %.0fm should already be above the %.0fm cutoff", alt, atm.CutoffAltitude)
+	}
+	periAltM := el.Periapsis() - R
+	if periAltM >= atm.CutoffAltitude {
+		t.Fatalf("test setup: periapsis altitude %.0fm should be INSIDE the %.0fm cutoff (that's the case this test targets)", periAltM, atm.CutoffAltitude)
+	}
+
+	if _, ok := AscentQBandFor(w, c); ok {
+		t.Error("hyperbolic departure, high above the atmosphere, periapsis inside it: AscentQBandFor ok=true, want false (no re-entry is coming — it's a departure, not a launch)")
 	}
 }
 

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -220,6 +220,62 @@ func TestAscentQBandForSeededAnalyticQ(t *testing.T) {
 	}
 }
 
+// TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere (#449): a
+// vessel that circularized into a stable orbit fully above the
+// atmosphere still swings a nonzero radial (climb) rate on every
+// periapsis→apoapsis half, purely from orbital mechanics — nothing to
+// do with the atmosphere. Before the fix, that made the ATMOSPHERE chip
+// (HasQBand) flicker back on once per orbit forever, long after the
+// vessel could ever see the atmosphere again. Gating on periapsis
+// altitude instead of the instantaneous climb rate fixes it, without
+// touching the still-correct "climbed clear, showing the past-the-top
+// band" case for an orbit whose periapsis is still inside the
+// atmosphere (a real re-entry is coming next orbit).
+func TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
+	w, c := ascendTestCraft(t, "earth", 218_000, 50)
+	mu := c.Primary.GravitationalParameter()
+	R := c.Primary.RadiusMeters()
+	atm := c.Primary.Atmosphere
+
+	// orbitAt builds a Kepler orbit with periapsis/apoapsis altitudes
+	// rp/ra, evaluated at true anomaly nu (radians) — nu = 90° sits on
+	// the climbing half, where the radial rate is at its largest
+	// nonzero value for a given eccentricity.
+	orbitAt := func(rpAltM, raAltM, nu float64) {
+		rp := R + rpAltM
+		ra := R + raAltM
+		a := (rp + ra) / 2
+		e := (ra - rp) / (ra + rp)
+		p := a * (1 - e*e)
+		rMag := p / (1 + e*math.Cos(nu))
+		rHat := orbital.Vec3{X: math.Cos(nu), Y: math.Sin(nu)}
+		c.State.R = rHat.Scale(rMag)
+		h := math.Sqrt(mu * p)
+		vr := (mu / h) * e * math.Sin(nu)
+		vt := (mu / h) * (1 + e*math.Cos(nu))
+		thetaHat := orbital.Vec3{X: -math.Sin(nu), Y: math.Cos(nu)}
+		c.State.V = rHat.Scale(vr).Add(thetaHat.Scale(vt))
+	}
+
+	// Stable orbit, periapsis (210km) and apoapsis (226km) both clear of
+	// the 150km cutoff: the reported bug. Must stand down for good.
+	orbitAt(210_000, 226_000, math.Pi/2)
+	if alt := c.Altitude(); alt <= atm.CutoffAltitude {
+		t.Fatalf("test setup: altitude %.0fm should be above the %.0fm cutoff", alt, atm.CutoffAltitude)
+	}
+	if qb, ok := AscentQBandFor(w, c); ok {
+		t.Errorf("stable orbit above the atmosphere: AscentQBandFor ok=true (HasMaxQ=%v), want false — must not flicker back on every orbit", qb.HasMaxQ)
+	}
+
+	// Still-elliptical orbit whose periapsis (100km) sits INSIDE the
+	// 150km cutoff: a real re-entry is coming next orbit, so the chip
+	// staying live on the climbing half is still the correct call.
+	orbitAt(100_000, 226_000, math.Pi/2)
+	if _, ok := AscentQBandFor(w, c); !ok {
+		t.Error("periapsis still inside the atmosphere: AscentQBandFor ok=false, want true (re-entry is still coming)")
+	}
+}
+
 // TestAscentCueForGatingMatrix is the ascent mirror of
 // TestDescentCorridorForGating: it stands up for a climbing vessel and
 // stands down for a falling, coasting, or landed one — and, critically,


### PR DESCRIPTION
Fixes #449.

## Summary

- `AscentQBandFor` gated the ATMOSPHERE chip on instantaneous radial
  (climb) rate, which is altitude-blind: any real (non-perfectly-
  circular) orbit swings a positive radial rate on every periapsis→
  apoapsis half, so the chip flickered back on once per orbit forever,
  long after clearing the atmosphere for good.
- Now also checks the orbit's periapsis altitude
  (`orbital.ElementsFromState` + `Elements.Periapsis()`); once
  periapsis clears the atmosphere's `CutoffAltitude`, no atmosphere
  pass is ever coming again, so the chip stands down for good. An
  orbit whose periapsis is still inside the atmosphere keeps the chip
  live on the climbing half — a real re-entry is coming next orbit, so
  that's still correct.

## Test plan

- New regression test `TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere`
  pins both the fixed case (stable 210km×226km orbit, clear of Earth's
  150km cutoff) and the still-live case (periapsis 100km, inside the
  cutoff) side by side.
- Reproduced the bug first with a throwaway test before writing the
  fix (confirmed `AscentQBandFor` returned `ok=true` for a stable
  orbit fully above the atmosphere) — not just reasoning from the code.
- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all
  green locally.
- Not yet done: a live playtest confirming the chip actually
  disappears on screen after circularizing, in a real terminal.