### PR TITLE
Fix: ascent arc + attitude stubs still cycling once per orbit above the atmosphere

### DIFF
--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -14,9 +14,16 @@
 //     marked on it — see AscentQBand's doc comment for why "measured so
 //     far" rather than a forecast eventual peak.
 //
-// AscentCueFor gates all three behind one climbing predicate — the
-// mirror image of DescentCorridorFor's falling gate — so the surface
-// view can never show the ascent cues and the descent corridor at once.
+// AscentCueFor gates all three behind climbing PLUS "not done with the
+// atmosphere for good" (#451) — the near-mirror of DescentCorridorFor's
+// falling-plus-no-impact-forecast gate — so the surface view can never
+// show the ascent cues and the descent corridor at once. Not an exact
+// mirror: the two halves stand down on different thresholds (ascent on
+// periapsis vs. the atmosphere cutoff, descent on "no ground contact
+// inside its forecast horizon"), so a low elliptical orbit can show the
+// ascent bundle for its whole climbing half while the descent corridor
+// only lights on the last stretch before periapsis. See
+// atmosphereClearedForGood's doc comment.
 package sim
 
 import (
@@ -33,8 +40,12 @@ import (
 // enough to the sprite to stay legible on the chase-cam canvas — not a
 // full orbital-period lookahead. A craft still governed by atmosphere or
 // gravity typically resolves (apoapsis, or a fall back to ground) well
-// inside 10 minutes; one that reaches a stable orbit inside the horizon
-// just draws a partial arc of it (PredictAscentPath's no-impact branch).
+// inside 10 minutes; one still climbing toward a stable orbit inside the
+// horizon just draws a partial arc of it (PredictAscentPath's no-impact
+// branch) — once that orbit's periapsis actually clears the atmosphere
+// for good, AscentCueFor's own gate stops asking for the arc at all
+// (#451), so this horizon only matters while there's still a real
+// atmosphere pass ahead (or on an airless body, which has no such gate).
 const AscentPredictHorizon = 10 * time.Minute
 
 // climbRateFloorMps is the ascent mirror of descentRateFloorMps
@@ -161,7 +172,9 @@ type AscentQBand struct {
 // atmosphere pass is ever coming again. False (never "cleared") for an
 // airless primary, since there's no atmosphere to clear in the first
 // place; that half of the ascent story is scoped out of this check
-// on purpose (#451 is about the atmosphere specifically).
+// on purpose (#451 is about the atmosphere specifically — #454 tracks
+// the airless-body equivalent, which needs a different "done for
+// good" test: periapsis above the surface, not the atmosphere).
 //
 // Mirrors shouldShowLaunchHUD's own hyperbolic-vs-elliptical split
 // (orbit.go): a stable elliptical orbit's periapsis tells you whether
@@ -240,11 +253,10 @@ type AscentCue struct {
 // by construction — climbRate ≥ floor forces the descent gate's
 // descentRate (= −climbRate) below its own floor, and vice versa.
 // Nothing here needs to consult DescentCorridorFor's result to avoid
-// stacking on top of it. DescentCorridorFor itself doesn't need the
-// atmosphereClearedForGood check below: it already requires a forward
-// impact forecast to succeed (PredictImpact within its horizon), which
-// a stable orbit's periapsis-above-ground never produces — #451
-// confirmed it, so only this ascent half needed the fix.
+// stacking on top of it. DescentCorridorFor needs no equivalent check
+// of its own: its gate is a forward impact forecast (PredictImpact
+// within its horizon), and a periapsis-above-ground orbit never
+// produces one, so only this ascent half needed the #451 fix below.
 //
 // #451: raw climb rate is orbital-mechanics-blind the same way
 // AscentQBandFor's was (#449) — a stable orbit's radial rate swings
@@ -253,7 +265,10 @@ type AscentCue struct {
 // stubs, Q band) up once per orbit forever above the atmosphere.
 // atmosphereClearedForGood adds the same periapsis/altitude check
 // AscentQBandFor uses; it's a no-op for an airless primary (no
-// atmosphere to clear), so this doesn't touch Moon-style ascents.
+// atmosphere to clear), so a stable lunar orbit still has this exact
+// symptom — tracked separately as #454, since it needs a different
+// "done for good" test (periapsis above the surface, not the
+// atmosphere) rather than growing this fix.
 func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (AscentCue, bool) {
 	if c == nil || c.Landed || c.Crashed {
 		return AscentCue{}, false

--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -156,54 +156,59 @@ type AscentQBand struct {
 	HasMaxQ bool
 }
 
+// atmosphereClearedForGood reports whether c's primary carries an
+// atmosphere AND c's current orbit has cleared it for good — no
+// atmosphere pass is ever coming again. False (never "cleared") for an
+// airless primary, since there's no atmosphere to clear in the first
+// place; that half of the ascent story is scoped out of this check
+// on purpose (#451 is about the atmosphere specifically).
+//
+// Mirrors shouldShowLaunchHUD's own hyperbolic-vs-elliptical split
+// (orbit.go): a stable elliptical orbit's periapsis tells you whether
+// the atmosphere is coming back (periapsis inside it: yes, next orbit;
+// periapsis clear: never again), but a hyperbolic/degenerate state's
+// "periapsis" can describe a departure or approach far from the body,
+// where the honest signal is current altitude instead.
+//
+// Backs both AscentQBandFor (#449) and AscentCueFor's own gate (#451):
+// the original ascent-cue design (issue #348 §3) keyed everything off
+// instantaneous climb rate, which is orbital-mechanics-blind — a
+// stable orbit's surface-relative radial rate swings positive on every
+// periapsis→apoapsis half regardless of altitude, so without this
+// check the whole bundle (Q band AND the ascent arc / nose-prograde
+// stubs) would flicker back on once per orbit, forever, long after the
+// atmosphere could ever matter again.
+func atmosphereClearedForGood(c *spacecraft.Spacecraft) bool {
+	atm := c.Primary.Atmosphere
+	if atm == nil {
+		return false
+	}
+	mu := c.Primary.GravitationalParameter()
+	if mu <= 0 {
+		return false
+	}
+	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
+	if el.E >= 1 || el.A <= 0 {
+		// Hyperbolic/degenerate: go by current altitude instead of
+		// periapsis (shouldShowLaunchHUD's exact reasoning).
+		return c.Altitude() >= atm.CutoffAltitude
+	}
+	periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
+	return periapsisAltM >= atm.CutoffAltitude
+}
+
 // AscentQBandFor builds the Q-band instrument for a craft. ok is false
 // when the primary has no atmosphere at all (issue #348 §3's gate — "Q
-// band only on bodies WITH atmosphere"), or once the vessel is done
-// with the atmosphere for good (#449 fix, see below).
-//
-// "Done for good" mirrors shouldShowLaunchHUD's own hyperbolic-vs-
-// elliptical split (orbit.go), for the same reason: a stable elliptical
-// orbit's periapsis tells you whether the atmosphere is coming back
-// (periapsis inside it: yes, next orbit; periapsis clear: never again),
-// but a hyperbolic/degenerate state's "periapsis" can describe a
-// departure or approach far from the body, where the honest signal is
-// current altitude instead — see shouldShowLaunchHUD's comment for why.
-//
-// Why this check exists at all: the original design (issue #348 §3)
-// kept the band visible "past the top" once a vessel climbed clear of
-// the cutoff, so the max-Q mark from the climb survived on screen. That
-// picture assumed a one-pass climb-to-orbit; it didn't account for the
-// climb-rate signal AscentCueFor's OWN gate uses being orbital-
-// mechanics-blind (tracked separately as a follow-up, #449): a stable
-// orbit's surface-relative radial rate swings positive on every
-// periapsis→apoapsis half regardless of altitude, so without a check
-// here the Q band specifically would flicker back on once per orbit,
-// forever, long after the atmosphere could ever matter again. This
-// fixes the Q band / ATMOSPHERE chip only — AscentCueFor's own `ok`
-// still gates the ascent arc and nose/prograde stubs on raw climb rate,
-// so those two keep cycling once per orbit in a stable orbit; see the
-// follow-up issue for that.
+// band only on bodies WITH atmosphere"), or once atmosphereClearedForGood
+// (#449 fix).
 func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
 	if w == nil || c == nil || c.Primary.Atmosphere == nil {
 		return AscentQBand{}, false
 	}
-	atm := c.Primary.Atmosphere
-	if mu := c.Primary.GravitationalParameter(); mu > 0 {
-		el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
-		var doneForGood bool
-		if el.E >= 1 || el.A <= 0 {
-			// Hyperbolic/degenerate: "periapsis" can describe a distant
-			// departure or approach, so go by current altitude instead
-			// (shouldShowLaunchHUD's exact reasoning).
-			doneForGood = c.Altitude() >= atm.CutoffAltitude
-		} else {
-			periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
-			doneForGood = periapsisAltM >= atm.CutoffAltitude
-		}
-		if doneForGood {
-			return AscentQBand{}, false
-		}
+	if atmosphereClearedForGood(c) {
+		return AscentQBand{}, false
 	}
+	atm := c.Primary.Atmosphere
 	return AscentQBand{
 		AtmosphereDepthM: atm.CutoffAltitude,
 		CurrentAltM:      c.Altitude(),
@@ -235,7 +240,20 @@ type AscentCue struct {
 // by construction — climbRate ≥ floor forces the descent gate's
 // descentRate (= −climbRate) below its own floor, and vice versa.
 // Nothing here needs to consult DescentCorridorFor's result to avoid
-// stacking on top of it.
+// stacking on top of it. DescentCorridorFor itself doesn't need the
+// atmosphereClearedForGood check below: it already requires a forward
+// impact forecast to succeed (PredictImpact within its horizon), which
+// a stable orbit's periapsis-above-ground never produces — #451
+// confirmed it, so only this ascent half needed the fix.
+//
+// #451: raw climb rate is orbital-mechanics-blind the same way
+// AscentQBandFor's was (#449) — a stable orbit's radial rate swings
+// positive on every periapsis→apoapsis half regardless of altitude, so
+// climbRate alone would keep waking the whole bundle (arc, attitude
+// stubs, Q band) up once per orbit forever above the atmosphere.
+// atmosphereClearedForGood adds the same periapsis/altitude check
+// AscentQBandFor uses; it's a no-op for an airless primary (no
+// atmosphere to clear), so this doesn't touch Moon-style ascents.
 func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (AscentCue, bool) {
 	if c == nil || c.Landed || c.Crashed {
 		return AscentCue{}, false
@@ -253,6 +271,9 @@ func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (As
 	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
 	climbRate := vRel.Dot(rHat)
 	if !(climbRate >= climbRateFloorMps) {
+		return AscentCue{}, false
+	}
+	if atmosphereClearedForGood(c) {
 		return AscentCue{}, false
 	}
 

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -275,12 +275,15 @@ func TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 		t.Errorf("stable orbit above the atmosphere: AscentQBandFor ok=true (HasMaxQ=%v), want false — must not flicker back on every orbit", qb.HasMaxQ)
 	}
 	// End to end: the player-visible path is AscentCueFor -> HasQBand,
-	// not AscentQBandFor directly. AscentCueFor's own `ok` still stands
-	// up here (its climb-rate gate is a deliberately separate, still-
-	// open follow-up — see AscentQBandFor's doc comment) — this pins
-	// that HasQBand specifically is what the fix reaches.
-	if cue, ok := AscentCueFor(w, c, AscentPredictHorizon); !ok || cue.HasQBand {
-		t.Errorf("AscentCueFor(stable orbit above atmosphere) = (HasQBand=%v, ok=%v), want (false, true)", cue.HasQBand, ok)
+	// not AscentQBandFor directly. #451 later gave AscentCueFor's own
+	// `ok` the same atmosphereClearedForGood check, so the whole bundle
+	// now stands down here too — see
+	// TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere for that
+	// fix's own dedicated coverage. This just pins that AscentQBandFor's
+	// fix reaches HasQBand through the real call path, not only when
+	// called directly.
+	if cue, ok := AscentCueFor(w, c, AscentPredictHorizon); ok || cue.HasQBand {
+		t.Errorf("AscentCueFor(stable orbit above atmosphere) = (HasQBand=%v, ok=%v), want (false, false)", cue.HasQBand, ok)
 	}
 
 	// Still-elliptical orbit whose periapsis (100km) sits INSIDE the
@@ -349,6 +352,72 @@ func TestAscentQBandForHyperbolicDepartureStandsDownByAltitude(t *testing.T) {
 // stands down for a falling, coasting, or landed one — and, critically,
 // AscentCueFor and DescentCorridorFor are never both true for the same
 // state, so the surface view can't stack the two instrument blocks.
+// TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere (#451,
+// follow-up to #449): the ascent arc and nose/prograde attitude stubs
+// share AscentQBandFor's exact bug — AscentCueFor's own gate was raw
+// climb rate, orbital-mechanics-blind, so a stable orbit fully above
+// the atmosphere still flickered the whole bundle back on once per
+// orbit. atmosphereClearedForGood now backs this gate too.
+func TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
+	w, c := ascendTestCraft(t, "earth", 218_000, 50)
+	c.CurrentAttitudeDir = orbital.Vec3{X: 1}
+	mu := c.Primary.GravitationalParameter()
+	R := c.Primary.RadiusMeters()
+	atm := c.Primary.Atmosphere
+
+	orbitAt := func(rpAltM, raAltM, nu float64) {
+		rp := R + rpAltM
+		ra := R + raAltM
+		a := (rp + ra) / 2
+		e := (ra - rp) / (ra + rp)
+		p := a * (1 - e*e)
+		rMag := p / (1 + e*math.Cos(nu))
+		rHat := orbital.Vec3{X: math.Cos(nu), Y: math.Sin(nu)}
+		c.State.R = rHat.Scale(rMag)
+		h := math.Sqrt(mu * p)
+		vr := (mu / h) * e * math.Sin(nu)
+		vt := (mu / h) * (1 + e*math.Cos(nu))
+		thetaHat := orbital.Vec3{X: -math.Sin(nu), Y: math.Cos(nu)}
+		c.State.V = rHat.Scale(vr).Add(thetaHat.Scale(vt))
+	}
+
+	// Stable orbit, periapsis (210km) and apoapsis (226km) both clear of
+	// the 150km cutoff, evaluated on the climbing half (nu=90°) — the
+	// exact shape the #449 reviewer used to find this bundle still
+	// waking up.
+	orbitAt(210_000, 226_000, math.Pi/2)
+	rHat := c.State.R.Scale(1 / c.State.R.Norm())
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	if climbRate := vRel.Dot(rHat); climbRate < climbRateFloorMps {
+		t.Fatalf("test setup: climb rate %.3f m/s at nu=90°, want above the %.1f m/s floor", climbRate, climbRateFloorMps)
+	}
+	if alt := c.Altitude(); alt <= atm.CutoffAltitude {
+		t.Fatalf("test setup: altitude %.0fm should be above the %.0fm cutoff", alt, atm.CutoffAltitude)
+	}
+	if cue, ok := AscentCueFor(w, c, AscentPredictHorizon); ok {
+		t.Errorf("stable orbit above the atmosphere: AscentCueFor ok=true (arc len=%d, HasAttitude=%v), want false — the arc/attitude stubs must not flicker back on every orbit", len(cue.Arc.Path), cue.HasAttitude)
+	}
+
+	// The sign-mirror falling half of the SAME orbit: DescentCorridorFor
+	// was checked and found to already stand down correctly here — it
+	// requires PredictImpact to find actual ground contact within its
+	// horizon, which a periapsis-above-ground orbit never produces. So
+	// only the ascending half needed this fix; this pins that claim
+	// rather than leaving it as an unverified comment.
+	orbitAt(210_000, 226_000, -math.Pi/2)
+	if _, ok := DescentCorridorFor(c, DescentPredictHorizon); ok {
+		t.Error("stable orbit above the atmosphere, falling half: DescentCorridorFor ok=true, want false (no impact is ever coming — already gated by PredictImpact's horizon)")
+	}
+
+	// Still-elliptical orbit whose periapsis (100km) sits INSIDE the
+	// 150km cutoff: a real re-entry is coming next orbit, so the bundle
+	// staying live on the climbing half is still the correct call.
+	orbitAt(100_000, 226_000, math.Pi/2)
+	if _, ok := AscentCueFor(w, c, AscentPredictHorizon); !ok {
+		t.Error("periapsis still inside the atmosphere: AscentCueFor ok=false, want true (re-entry is still coming)")
+	}
+}
+
 func TestAscentCueForGatingMatrix(t *testing.T) {
 	w, c := ascendTestCraft(t, "earth", 1_000, 50)
 	c.CurrentAttitudeDir = orbital.Vec3{X: 1}

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -347,11 +347,6 @@ func TestAscentQBandForHyperbolicDepartureStandsDownByAltitude(t *testing.T) {
 	}
 }
 
-// TestAscentCueForGatingMatrix is the ascent mirror of
-// TestDescentCorridorForGating: it stands up for a climbing vessel and
-// stands down for a falling, coasting, or landed one — and, critically,
-// AscentCueFor and DescentCorridorFor are never both true for the same
-// state, so the surface view can't stack the two instrument blocks.
 // TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere (#451,
 // follow-up to #449): the ascent arc and nose/prograde attitude stubs
 // share AscentQBandFor's exact bug — AscentCueFor's own gate was raw
@@ -418,6 +413,11 @@ func TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 	}
 }
 
+// TestAscentCueForGatingMatrix is the ascent mirror of
+// TestDescentCorridorForGating: it stands up for a climbing vessel and
+// stands down for a falling, coasting, or landed one — and, critically,
+// AscentCueFor and DescentCorridorFor are never both true for the same
+// state, so the surface view can't stack the two instrument blocks.
 func TestAscentCueForGatingMatrix(t *testing.T) {
 	w, c := ascendTestCraft(t, "earth", 1_000, 50)
 	c.CurrentAttitudeDir = orbital.Vec3{X: 1}


### PR DESCRIPTION
Fixes #451 (follow-up to #449/#450).

## Summary

- `AscentCueFor`'s own `ok` gate was raw surface-relative climb rate —
  the same orbital-mechanics-blind signal `AscentQBandFor` had before
  #449. A stable orbit's radial rate swings positive on every
  periapsis→apoapsis half regardless of altitude, so the whole
  ascent-cue bundle (arc, nose/prograde attitude stubs, Q band) kept
  waking back up once per orbit, forever, above the atmosphere.
- Extracted the periapsis/altitude check #449 added into
  `atmosphereClearedForGood`, a shared helper, and gave `AscentCueFor`
  the same gate. It's a no-op for an airless primary (no atmosphere to
  clear), so Moon-style ascents are unaffected.
- The issue's suggested fix also named `DescentCorridorFor` (the
  sign-mirror sibling) as needing the same treatment. **Checked by
  instrumenting it directly rather than assuming the issue's premise
  held** — it's already correct: it requires `PredictImpact` to find
  real ground contact within its horizon, which a periapsis-above-
  ground stable orbit never produces. So only the ascending half
  needed this fix; `descent.go` is untouched.

## Test plan

- New test `TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere`
  pins the fix on the exact bug shape (stable 210km×226km Earth orbit)
  and, on the same orbit's falling half, pins that `DescentCorridorFor`
  was already correct (documents the "why descent.go wasn't touched"
  claim as a test, not just a comment).
- Updated the #450 test's end-to-end assertion (`AscentCueFor` on a
  stable orbit) — it used to pin `ok=true` as the known-open scope
  boundary; now pins `ok=false`, since this PR closes that boundary.
- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all
  green locally.