### PR TITLE
Move the burn-lit cue from the whole screen onto the VESSEL chip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2764,16 +2764,21 @@ the instant F2 clears it. The Launch View shares the same state and gets
 the same title-bar tag.
 _Avoid_: Hide UI, clean mode, F2 mode, toggle overlays.
 
-**Engine-lit cue** (grilled 2026-09-06, "burn state is invisible"):
-The set of always-visible signals that an engine is actually producing
-thrust right now, as opposed to merely set to some throttle. Three parts,
-all gated on live thrust (`AnyCraftThrusting`: a live `ActiveBurn` or
-`ManualBurn` on any craft in the slate) and never on the throttle
-*setting*: the **HUD** chip's `throttle:` row carries a trailing `(idle)`
-(Dim) or `● FIRING` (Warning) suffix; the map canvas border (and the
-Launch View's pad canvas border) switches from Primary to Warning; and
-the title bar (both screens) carries a `● BURN` badge in Warning beside
-the warp readout. All three clear the tick thrust stops.
+**Engine-lit cue** (grilled 2026-09-06, "burn state is invisible";
+revised after the v0.41.0 playtest found the original whole-screen
+treatment too loud): the set of always-visible signals that an engine
+is actually producing thrust right now, as opposed to merely set to
+some throttle. Two parts, both gated on live thrust (`AnyCraftThrusting`:
+a live `ActiveBurn` or `ManualBurn` on any craft in the slate) and never
+on the throttle *setting*: the **VESSEL** chip's `throttle:` row carries
+a trailing `(idle)` (Dim) or `● FIRING` (Warning) suffix for the active
+craft specifically, and the VESSEL chip's own header carries a `● BURN`
+badge in Warning — the whole-slate signal, since `AnyCraftThrusting`
+walks every craft, not just the active one, so this still answers "why
+is warp capped" even when the burning craft isn't the one on screen.
+Both clear the tick thrust stops. (Originally a canvas-border color
+swap plus a separate title-bar badge; both were removed in favor of the
+single VESSEL-chip badge.)
 _Avoid_: "engine on"/"engine off" (ambiguous with the throttle setting),
 LIT (that's the Launch pad's separate pre-ignition `twr:` row indicator,
 ADR 0048 §3, not this cue).

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -216,19 +216,19 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	if w.AutoWarpEngaged() {
 		burnLabel = "[■Burn]"
 	}
-	// decisions 2 / 6 (grilled 2026-09-06): the same `● BURN` engine-lit
-	// badge and `[F2 declutter]` tag the orbit map's title bar carries,
-	// via v.hudSource (the shared OrbitView) so a player above the
-	// atmosphere firing an engine, or flying decluttered, gets the same
-	// cues here. Nil-safe: hudSource is only ever nil in a bare test
-	// fixture that doesn't wire one up.
-	burnBadgePlain, burnBadgeRendered := "", ""
+	// decision 6 (grilled 2026-09-06): the same `[F2 declutter]` tag the
+	// orbit map's title bar carries, via v.hudSource (the shared
+	// OrbitView) so a player flying decluttered gets the same cue here.
+	// Nil-safe: hudSource is only ever nil in a bare test fixture that
+	// doesn't wire one up. Decision 2's `● BURN` badge used to ride here
+	// too; it now lives on the VESSEL chip instead (vesselBurnBadge),
+	// which this screen already shares with the map via hudSource's
+	// side-HUD chips — no separate wiring needed here.
 	declutterPlain, declutterRendered := "", ""
 	if v.hudSource != nil {
-		burnBadgePlain, burnBadgeRendered = v.hudSource.burnBadgeText(w)
 		declutterPlain, declutterRendered = v.hudSource.declutterTagText()
 	}
-	titleRight := warpRateText(w) + burnBadgePlain + declutterPlain + "  " + burnLabel
+	titleRight := warpRateText(w) + declutterPlain + "  " + burnLabel
 	titlePad := totalCols - lipgloss.Width(titleLeft) - lipgloss.Width(titleRight)
 	if titlePad < 1 {
 		titlePad = 1
@@ -244,7 +244,7 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	case !w.AutoWarpEligible():
 		burnRendered = v.theme.Dim.Render(burnLabel)
 	}
-	titleRightRendered := warpRendered + burnBadgeRendered + declutterRendered + "  " + burnRendered
+	titleRightRendered := warpRendered + declutterRendered + "  " + burnRendered
 	title := v.theme.Title.Render(titleLeft) + strings.Repeat(" ", titlePad) + titleRightRendered
 
 	// The descent half (ADR 0043 §3): one forecast per frame, shared by
@@ -369,15 +369,7 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	// the side HUD off the right of the terminal. Manual borders
 	// give us exact control: use lipgloss.Width per line for the
 	// pad math, which strips ANSI before measuring.
-	// decision 2 (grilled 2026-09-06): the same engine-lit border tint the
-	// orbit map carries — Warning while any craft in the slate is
-	// thrusting, Primary otherwise. hudSource nil-check mirrors the title
-	// bar above.
-	borderFg := v.theme.Primary.GetForeground()
-	if v.hudSource != nil {
-		borderFg = v.hudSource.canvasBorderColor(w)
-	}
-	canvasPanel := wrapBorder(canvasStr, v.canvas.Cols(), borderFg)
+	canvasPanel := wrapBorder(canvasStr, v.canvas.Cols(), v.theme.Primary.GetForeground())
 
 	// v0.13 playtest move: the launch-relevant readouts (VESSEL core,
 	// LAUNCH, STAGES, ATTITUDE) are all canvas Chips now, composited above,

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -1526,7 +1526,7 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 
 	canvasPanel := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(v.canvasBorderColor(w)).
+		BorderForeground(v.theme.Primary.GetForeground()).
 		Render(canvasStr)
 
 	craftChip := ""
@@ -1544,37 +1544,13 @@ func (v *OrbitView) Render(w *sim.World, selectedIdx int, totalCols, totalRows i
 	return out
 }
 
-// canvasBorderColor picks the map canvas border's foreground (decision 2,
-// grilled 2026-09-06: "the whole screen says an engine is lit"): Warning
-// while any craft in the slate is thrusting (AnyCraftThrusting — the same
-// predicate the 10x burn-warp cap uses), Primary otherwise. Shared with
-// LaunchView's wrapBorder call so the pad canvas gets the same cue.
-func (v *OrbitView) canvasBorderColor(w *sim.World) lipgloss.TerminalColor {
-	if w.AnyCraftThrusting() {
-		return v.theme.Warning.GetForeground()
-	}
-	return v.theme.Primary.GetForeground()
-}
-
-// burnBadgeText is the title bar's `● BURN` badge (decision 2): rendered
-// in Warning beside the warp readout while any craft in the slate is
-// thrusting, empty otherwise. Returns both the plain (unstyled, for width
-// math) and rendered forms, prefixed with the two-space gap that
-// separates it from whatever sits to its left — an empty plain form
-// carries no gap, so it costs nothing in either width sum when idle.
-func (v *OrbitView) burnBadgeText(w *sim.World) (plain, rendered string) {
-	if !w.AnyCraftThrusting() {
-		return "", ""
-	}
-	const badge = "  ● BURN"
-	return badge, v.theme.Warning.Render(badge)
-}
-
 // declutterTagText is the title bar's `[F2 declutter]` tag (decision 6,
 // grilled 2026-09-06: "Declutter is named in two places while it is on"):
 // Dim, beside the warp readout, visible only while v.declutter is true —
-// gone the instant F2 is pressed again. Same plain/rendered-pair shape as
-// burnBadgeText, for the same reason.
+// gone the instant F2 is pressed again. Returns a plain (unstyled, for
+// width math) and a rendered form; an empty plain form carries no
+// leading gap, so it costs nothing in the width sums that use it when
+// declutter is off.
 func (v *OrbitView) declutterTagText() (plain, rendered string) {
 	if !v.declutter {
 		return "", ""
@@ -1647,11 +1623,15 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		pauseChipRendered = "  " + v.theme.Warning.Render("PAUSED")
 	}
 
-	// decisions 2 / 6 (grilled 2026-09-06): the `● BURN` engine-lit badge
-	// and the `[F2 declutter]` tag, both beside the warp/clock readout.
-	// Either or both can be empty; the plain forms carry their own
-	// leading gap so an empty one costs nothing in the width sums below.
-	burnBadgePlain, burnBadgeRendered := v.burnBadgeText(w)
+	// decision 6 (grilled 2026-09-06): the `[F2 declutter]` tag, beside
+	// the warp/clock readout. Can be empty; the plain form carries its
+	// own leading gap so an empty one costs nothing in the width sums
+	// below. Decision 2's `● BURN` badge lived here too until playtesting
+	// found the whole-screen treatment (this badge + the canvas border
+	// color) too loud — moved onto the VESSEL chip instead (buildVesselChip),
+	// which is the one place both the active craft's own state (decision
+	// 1's throttle row) and any OTHER slate craft's burn now live
+	// together. See buildVesselChip's doc comment.
 	declutterPlain, declutterRendered := v.declutterTagText()
 
 	// v0.16 / ADR 0016: the [»Burn] Auto-Warp button. [■Burn] highlighted
@@ -1665,7 +1645,7 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		burnLabel = "[■Burn]"
 	}
 
-	rightPlain := clockChip + pauseChipPlain + burnBadgePlain + declutterPlain + clockGap + burnLabel + gap + menuLabel + gap + missionsLabel
+	rightPlain := clockChip + pauseChipPlain + declutterPlain + clockGap + burnLabel + gap + menuLabel + gap + missionsLabel
 
 	// Compute the absolute column where the right group starts so the
 	// hit-test ranges match what the player sees on screen.
@@ -1676,7 +1656,7 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		pad = 1
 	}
 	rightStart := leftWidth + pad
-	buttonsStart := rightStart + lipgloss.Width(clockChip+pauseChipPlain+burnBadgePlain+declutterPlain+clockGap)
+	buttonsStart := rightStart + lipgloss.Width(clockChip+pauseChipPlain+declutterPlain+clockGap)
 
 	v.burnColStart = buttonsStart
 	v.burnColEnd = v.burnColStart + lipgloss.Width(burnLabel)
@@ -1697,7 +1677,6 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 		strings.Repeat(" ", pad) +
 		clockChipRendered +
 		pauseChipRendered +
-		burnBadgeRendered +
 		declutterRendered +
 		clockGap +
 		burnRendered +

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -67,7 +67,10 @@ func TestThrottleRowIdleVsFiring(t *testing.T) {
 // instant nothing is thrusting. Originally a canvas-border color swap
 // plus a title-bar badge; that whole-screen treatment read as too loud
 // in play, so the cue now lives on the one chip instead. Also locks in
-// that the removed locations (border color, title bar) stay gone.
+// that the removed locations (border color, title bar) stay gone, and
+// that the Compact Form (ADR 0046 / #422) carries the same badge as the
+// full form — #455 review finding 3, since nothing else in the suite
+// exercises buildVesselChipCompact with a burn on.
 func TestVesselChipBurnBadge(t *testing.T) {
 	v := NewOrbitView(plainThemeColored())
 	v.Resize(140, 40)
@@ -81,6 +84,10 @@ func TestVesselChipBurnBadge(t *testing.T) {
 	if strings.Contains(out, "BURN") {
 		t.Errorf("idle VESSEL chip should not carry a BURN badge:\n%s", out)
 	}
+	compactOut := strings.Join(v.buildVesselChipCompact(w), "\n")
+	if strings.Contains(compactOut, "BURN") {
+		t.Errorf("idle VESSEL chip (Compact Form) should not carry a BURN badge:\n%s", compactOut)
+	}
 	title := v.renderTitleBar("Sol", w, 140)
 	if strings.Contains(title, "BURN") {
 		t.Errorf("title bar should never carry a BURN badge (moved to the VESSEL chip):\n%s", title)
@@ -91,12 +98,20 @@ func TestVesselChipBurnBadge(t *testing.T) {
 	if !strings.Contains(out, "BURN") {
 		t.Errorf("firing VESSEL chip missing the BURN badge:\n%s", out)
 	}
+	compactOut = strings.Join(v.buildVesselChipCompact(w), "\n")
+	if !strings.Contains(compactOut, "BURN") {
+		t.Errorf("firing VESSEL chip (Compact Form) missing the BURN badge:\n%s", compactOut)
+	}
 	title = v.renderTitleBar("Sol", w, 140)
 	if strings.Contains(title, "BURN") {
 		t.Errorf("title bar picked up a BURN badge, want it only on the VESSEL chip:\n%s", title)
 	}
 
 	c.ActiveBurn = nil
+	compactOut = strings.Join(v.buildVesselChipCompact(w), "\n")
+	if strings.Contains(compactOut, "BURN") {
+		t.Errorf("BURN badge (Compact Form) did not clear when thrust stopped:\n%s", compactOut)
+	}
 	out = strings.Join(v.buildVesselChip(w), "\n")
 	if strings.Contains(out, "BURN") {
 		t.Errorf("BURN badge did not clear when thrust stopped:\n%s", out)
@@ -125,6 +140,40 @@ func TestVesselChipBurnBadgeNonActiveCraft(t *testing.T) {
 	out := strings.Join(v.buildVesselChip(w), "\n")
 	if !strings.Contains(out, "BURN") {
 		t.Errorf("VESSEL chip should badge for a non-active craft's burn:\n%s", out)
+	}
+}
+
+// TestVesselChipBurnBadgeOtherSystem — #455 review finding 2:
+// AnyCraftThrusting is slate-wide AND system-blind, same as the 10x
+// burn-warp cap, so the badge must still show on the "(in Sol — [tab]
+// to switch)" early-return branch (camera tabbed away from the active
+// craft's own system) — otherwise a player watching a friend in
+// another system while their own craft executes a planted node loses
+// every on-screen trace of why warp just clamped to 10x.
+func TestVesselChipBurnBadgeOtherSystem(t *testing.T) {
+	v := NewOrbitView(plainThemeColored())
+	v.Resize(140, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
+
+	if len(w.Systems) < 2 {
+		t.Skip("need a second loaded system to browse away from the craft's own")
+	}
+	w.CycleSystem()
+	if w.CraftVisibleHere() {
+		t.Fatal("test setup: craft is still visible after CycleSystem")
+	}
+
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "(in Sol — [tab] to switch)") {
+		t.Fatalf("test setup: expected the other-system placeholder line:\n%s", out)
+	}
+	if !strings.Contains(out, "BURN") {
+		t.Errorf("VESSEL chip should still badge for a burning craft in a system the camera isn't showing:\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -16,7 +16,12 @@ import (
 // triage/action-plan.md): decisions 1, 2, 3, 6, 7. Decision 4 (the burn
 // fired/finished Event Flash) is a sim-level hook and gets its own tests
 // alongside LastDockEvent/LastNodeTargetRefusal's pattern in
-// internal/sim. Decision 5 is confirmed no-change.
+// internal/sim. Decision 5 is confirmed no-change. Decision 2's original
+// implementation (canvas-border color swap + title-bar badge) was
+// revised after live playtesting found the whole-screen treatment too
+// loud — the `● BURN` cue now lives on the VESSEL chip instead
+// (vesselBurnBadge, orbit_chips.go); see this file's TestVesselChip*
+// tests, not a border/title-bar test.
 
 // TestThrottleRowIdleVsFiring — decision 1: the VESSEL chip's throttle
 // row always shows the throttle SETTING, suffixed with "(idle)" (Dim)
@@ -56,11 +61,14 @@ func TestThrottleRowIdleVsFiring(t *testing.T) {
 	}
 }
 
-// TestEngineLitBorderAndBadge — decision 2: while any craft in the slate
-// is thrusting, the map canvas border switches from Primary to Warning,
-// and the title bar carries a "● BURN" badge — both clear the instant
-// nothing is thrusting.
-func TestEngineLitBorderAndBadge(t *testing.T) {
+// TestVesselChipBurnBadge — decision 2 (grilled 2026-09-06, revised on
+// live playtest feedback): while any craft in the slate is thrusting,
+// the VESSEL chip's header carries a "● BURN" badge — clearing the
+// instant nothing is thrusting. Originally a canvas-border color swap
+// plus a title-bar badge; that whole-screen treatment read as too loud
+// in play, so the cue now lives on the one chip instead. Also locks in
+// that the removed locations (border color, title bar) stay gone.
+func TestVesselChipBurnBadge(t *testing.T) {
 	v := NewOrbitView(plainThemeColored())
 	v.Resize(140, 40)
 	w, err := sim.NewWorld()
@@ -69,38 +77,39 @@ func TestEngineLitBorderAndBadge(t *testing.T) {
 	}
 	c := w.ActiveCraft()
 
-	if got, want := v.canvasBorderColor(w), v.theme.Primary.GetForeground(); got != want {
-		t.Errorf("idle border color = %v, want Primary %v", got, want)
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if strings.Contains(out, "BURN") {
+		t.Errorf("idle VESSEL chip should not carry a BURN badge:\n%s", out)
 	}
 	title := v.renderTitleBar("Sol", w, 140)
 	if strings.Contains(title, "BURN") {
-		t.Errorf("idle title bar should not carry a BURN badge:\n%s", title)
+		t.Errorf("title bar should never carry a BURN badge (moved to the VESSEL chip):\n%s", title)
 	}
 
 	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
-	if got, want := v.canvasBorderColor(w), v.theme.Warning.GetForeground(); got != want {
-		t.Errorf("firing border color = %v, want Warning %v", got, want)
-	}
-	title = v.renderTitleBar("Sol", w, 140)
-	if !strings.Contains(title, "BURN") {
-		t.Errorf("firing title bar missing the BURN badge:\n%s", title)
-	}
-
-	c.ActiveBurn = nil
-	if got, want := v.canvasBorderColor(w), v.theme.Primary.GetForeground(); got != want {
-		t.Errorf("border color did not clear when thrust stopped: got %v, want Primary %v", got, want)
+	out = strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "BURN") {
+		t.Errorf("firing VESSEL chip missing the BURN badge:\n%s", out)
 	}
 	title = v.renderTitleBar("Sol", w, 140)
 	if strings.Contains(title, "BURN") {
-		t.Errorf("BURN badge did not clear when thrust stopped:\n%s", title)
+		t.Errorf("title bar picked up a BURN badge, want it only on the VESSEL chip:\n%s", title)
+	}
+
+	c.ActiveBurn = nil
+	out = strings.Join(v.buildVesselChip(w), "\n")
+	if strings.Contains(out, "BURN") {
+		t.Errorf("BURN badge did not clear when thrust stopped:\n%s", out)
 	}
 }
 
-// TestEngineLitBorderNonActiveCraft — decision 2's "the whole screen"
-// framing: AnyCraftThrusting walks the whole slate, so a burn on a
-// non-active craft still lights the border/badge while the player flies
-// a different vessel.
-func TestEngineLitBorderNonActiveCraft(t *testing.T) {
+// TestVesselChipBurnBadgeNonActiveCraft — decision 2's "the whole
+// screen" framing survives the move: AnyCraftThrusting walks the whole
+// slate, so a burn on a non-active craft still badges the VESSEL chip
+// (of whichever craft you're currently flying) — the player needs to
+// know why warp is capped even when the burning craft isn't the one on
+// screen.
+func TestVesselChipBurnBadgeNonActiveCraft(t *testing.T) {
 	v := NewOrbitView(plainThemeColored())
 	v.Resize(140, 40)
 	w, err := sim.NewWorld()
@@ -113,14 +122,17 @@ func TestEngineLitBorderNonActiveCraft(t *testing.T) {
 	w.ActiveCraftIdx = 0
 	w.Crafts[1].ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
 
-	if got, want := v.canvasBorderColor(w), v.theme.Warning.GetForeground(); got != want {
-		t.Errorf("border should light for a non-active craft's burn: got %v, want Warning %v", got, want)
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "BURN") {
+		t.Errorf("VESSEL chip should badge for a non-active craft's burn:\n%s", out)
 	}
 }
 
-// TestLaunchViewEngineLitBorderAndBadge — decision 2's Launch View parity:
-// the pad canvas shares the same border tint and title badge as the map.
-func TestLaunchViewEngineLitBorderAndBadge(t *testing.T) {
+// TestLaunchViewVesselChipBurnBadge — decision 2's Launch View parity,
+// via the shared hudSource: the pad canvas's VESSEL chip carries the
+// same badge the map does, since LaunchView composites its side HUD
+// chips from the same OrbitView.
+func TestLaunchViewVesselChipBurnBadge(t *testing.T) {
 	orbitV := NewOrbitView(plainThemeColored())
 	lv := NewLaunchView(plainThemeColored(), orbitV)
 	w, err := sim.NewWorld()
@@ -140,14 +152,14 @@ func TestLaunchViewEngineLitBorderAndBadge(t *testing.T) {
 
 	out := lv.Render(w, 140, 40)
 	if strings.Contains(out, "BURN") {
-		t.Errorf("idle launch title should not carry a BURN badge:\n%s", firstLine(out))
+		t.Errorf("idle launch view should not carry a BURN badge:\n%s", out)
 	}
 
 	c.Landed = false
 	c.ActiveBurn = &spacecraft.ActiveBurn{DVRemaining: 100, EndTime: w.Clock.SimTime.Add(60 * time.Second)}
 	out = lv.Render(w, 140, 40)
 	if !strings.Contains(out, "BURN") {
-		t.Errorf("firing launch title missing the BURN badge:\n%s", firstLine(out))
+		t.Errorf("firing launch view missing the BURN badge:\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -611,7 +611,12 @@ func activeStageFuel(c *spacecraft.Spacecraft) (pct, massKg float64, ok bool) {
 func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	if !w.CraftVisibleHere() {
 		if w.ActiveCraft() != nil {
-			return []string{v.theme.Dim.Render("VESSEL (in Sol — [tab] to switch)")}
+			// #455 review finding 2: AnyCraftThrusting is slate-wide and
+			// system-blind, same as the 10x burn-warp cap — a craft
+			// burning in a system the camera isn't currently showing
+			// must still badge here, or a player who tabs away mid-burn
+			// loses every on-screen trace of why warp just clamped.
+			return []string{v.theme.Dim.Render("VESSEL (in Sol — [tab] to switch)") + v.vesselBurnBadge(w)}
 		}
 		// #310: an empty slate used to render nothing at all. The camera
 		// meanwhile fell through to the system origin, so the player was left

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -606,6 +606,8 @@ func activeStageFuel(c *spacecraft.Spacecraft) (pct, massKg float64, ok bool) {
 // Orbit shape (apo/peri/incl) lives in the top-right Orbit-metrics chip,
 // attitude in the Attitude chip. Returns a "(in Sol — [tab])" hint when no
 // craft is visible here; nil only when there's no active craft at all.
+// Header carries vesselBurnBadge's whole-slate `● BURN` badge — the one
+// place that cue lives now (see its own doc comment).
 func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	if !w.CraftVisibleHere() {
 		if w.ActiveCraft() != nil {
@@ -656,7 +658,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	}
 	c := w.ActiveCraft()
 	lines := []string{
-		v.theme.Primary.Render("VESSEL"),
+		v.theme.Primary.Render("VESSEL") + v.vesselBurnBadge(w),
 		"  " + crashedVesselNameLabel(v.theme, c),
 		"  primary:   " + c.Primary.EnglishName,
 		fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
@@ -708,6 +710,26 @@ func (v *OrbitView) throttleRow(c *spacecraft.Spacecraft) string {
 	return base + v.theme.Warning.Render(" ● FIRING")
 }
 
+// vesselBurnBadge is the VESSEL chip header's `● BURN` badge (decision
+// 2, grilled 2026-09-06: "the whole screen says an engine is lit").
+// Originally a canvas-border color swap plus a title-bar badge — a
+// live playtest found that whole-screen treatment too loud, so it now
+// lives here instead: on the one chip that's already universal across
+// the map, the launch/chase-cam view (shared via LaunchView.hudSource),
+// and a landed vessel, and that already carries the active craft's own
+// engine state (throttleRow's "(idle)"/"● FIRING"). Gated on
+// AnyCraftThrusting (the whole-slate predicate the 10x burn-warp cap
+// also uses), not just the active craft, so it still answers "why is
+// warp capped" even when the burning craft isn't the one on screen.
+// Returns "" (no leading gap, so it costs nothing appended to a plain
+// string) when nothing in the slate is thrusting.
+func (v *OrbitView) vesselBurnBadge(w *sim.World) string {
+	if !w.AnyCraftThrusting() {
+		return ""
+	}
+	return v.theme.Warning.Render("  ● BURN")
+}
+
 // buildVesselDestroyedChip is the VESSEL DESTROYED Standing Alert (#427 /
 // ADR 0048 decision 1): renders only while the active craft is Crashed,
 // naming both exits — [E] end flight (removes the wreckage) and [F9]
@@ -750,7 +772,7 @@ func (v *OrbitView) buildVesselChipCompact(w *sim.World) []string {
 		fuelStr = fmt.Sprintf("%.0f%% (%.0f kg)", pct, kg)
 	}
 	return []string{
-		v.theme.Primary.Render("VESSEL") + "  " + crashedVesselNameLabel(v.theme, c),
+		v.theme.Primary.Render("VESSEL") + v.vesselBurnBadge(w) + "  " + crashedVesselNameLabel(v.theme, c),
 		fmt.Sprintf("  fuel: %s  Δv: %.0f m/s", fuelStr, c.RemainingDeltaV()),
 	}
 }


### PR DESCRIPTION
## Summary

Playtest feedback on v0.41.0: decision 2 of the 2026-09-06 burn-state
grill (PR #447) — painting the whole map/launch canvas border Warning
and adding a `● BURN` title-bar badge while any craft in the slate is
thrusting — is too loud. Requested fix: move the cue onto the VESSEL
chip (or a similarly universal chip across launch/orbit/landing
views) instead of the whole screen.

- `vesselBurnBadge` (new, `orbit_chips.go`): the same `AnyCraftThrusting`
  predicate, now rendered as a `  ● BURN` badge on the VESSEL chip's
  header (full and Compact forms both). Sits next to decision 1's own
  throttle-row engine state ("(idle)"/"● FIRING") on the same chip —
  the whole-slate cue and the active-craft cue now live together.
- `canvasBorderColor` and `burnBadgeText` removed; both canvases (map
  and launch/chase-cam) go back to a flat Primary border, and the
  title bar no longer carries a burn badge on either screen.
- The VESSEL chip is already universal across the surfaces that
  mattered here: the orbit map, the launch/chase-cam view (shared via
  `LaunchView.hudSource`), and a landed vessel — no new plumbing
  needed to reach all three.

## Test plan

- Rewrote the three tests that pinned the old border/title-badge
  behavior (`TestVesselChipBurnBadge`, `...NonActiveCraft`, and the
  Launch View parity test) to assert the badge lives on the VESSEL
  chip and that BURN never appears in the title bar or border color
  anymore.
- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all
  green locally.
- Not yet done: a live playtest confirming the relocated badge reads
  clearly in a real terminal, on both the map and the chase-cam view.