### PR TITLE
Fix: Launch View [»Burn] click routes to Missions

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -559,6 +559,23 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch a.active {
 		case screenOrbit:
+			// #456 fix: while ViewLaunch is showing, every hit-test
+			// below this point (Menu/Missions/Burn buttons, the navball,
+			// chips, HitAt) reads OrbitView state that LaunchView.Render
+			// never touches — the map's own last-actual-render layout,
+			// frozen and unrelated to what's on screen right now. A
+			// click on THIS screen's [»Burn] button used to fall through
+			// to those stale map coordinates and could land inside e.g.
+			// the map's [Missions] range instead. Route to LaunchView's
+			// own hit-test (added alongside this fix) and swallow every
+			// other click here — none of the map-specific hits below are
+			// meaningful against a screen they were never computed for.
+			if a.world.ViewMode == sim.ViewLaunch {
+				if a.launchView.HitBurnButton(m.X, m.Y) {
+					a.toggleAutoWarpBurn()
+				}
+				return a, nil
+			}
 			// v0.7.4+: title-bar [Menu] / [Missions] buttons take
 			// priority over canvas / HUD hits, since they sit at
 			// row 0 above the body region.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -559,20 +559,38 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch a.active {
 		case screenOrbit:
-			// #456 fix: while ViewLaunch is showing, every hit-test
-			// below this point (Menu/Missions/Burn buttons, the navball,
-			// chips, HitAt) reads OrbitView state that LaunchView.Render
-			// never touches — the map's own last-actual-render layout,
-			// frozen and unrelated to what's on screen right now. A
-			// click on THIS screen's [»Burn] button used to fall through
-			// to those stale map coordinates and could land inside e.g.
-			// the map's [Missions] range instead. Route to LaunchView's
-			// own hit-test (added alongside this fix) and swallow every
-			// other click here — none of the map-specific hits below are
-			// meaningful against a screen they were never computed for.
+			// #456 fix: while ViewLaunch is showing, the Menu/Missions/
+			// Burn title-bar buttons and the navball controls below all
+			// read OrbitView state that LaunchView.Render never touches
+			// — the map's own last-actual-render layout, frozen and
+			// unrelated to what's on screen right now. A click on THIS
+			// screen's [»Burn] button used to fall through to those
+			// stale map coordinates and could land inside e.g. the
+			// map's [Missions] range instead. Route to LaunchView's own
+			// hit-test (added alongside this fix) first.
+			//
+			// Chips are the one exception (#457 review finding 1):
+			// LaunchView.Render composites its chips through the SAME
+			// shared OrbitView (v.hudSource.composeChips), which
+			// rewrites v.chipRects in absolute screen coordinates every
+			// frame regardless of which screen called it — so
+			// a.orbitView.HitChip is live and correct here, not stale,
+			// and the NODES chip's click-to-maneuver-screen route
+			// already worked on Launch View before this fix. Falling
+			// through to it (but no further — HitNavballControl / HitAt
+			// / the vessel-node-body switch below ARE stale) preserves
+			// that instead of silently regressing it.
 			if a.world.ViewMode == sim.ViewLaunch {
 				if a.launchView.HitBurnButton(m.X, m.Y) {
 					a.toggleAutoWarpBurn()
+					return a, nil
+				}
+				if id, ok := a.orbitView.HitChip(m.X, m.Y); ok {
+					if id == settings.ChipNodes {
+						a.world.Clock.Paused = true
+						a.active = screenManeuver
+					}
+					return a, nil
 				}
 				return a, nil
 			}

--- a/internal/tui/app_launchview_burn_click_test.go
+++ b/internal/tui/app_launchview_burn_click_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -107,4 +108,54 @@ func TestLaunchViewIgnoresStaleMapMissionsHit(t *testing.T) {
 	if a.active != before {
 		t.Errorf("a click on the map's stale [Missions] column changed the screen while Launch View was showing: %v -> %v", before, a.active)
 	}
+}
+
+// TestLaunchViewNodesChipClickStillOpensManeuverScreen (#457 review
+// finding 1): unlike the title-bar buttons and the navball, LaunchView
+// composites its chips through the SAME shared OrbitView
+// (hudSource.composeChips), which rewrites chipRects in absolute
+// screen coordinates every frame regardless of which screen called
+// it — so a.orbitView.HitChip is live and correct on Launch View, not
+// stale, and clicking the NODES chip already routed to the maneuver
+// screen before the #456 fix. An earlier version of that fix swallowed
+// every non-burn click unconditionally, silently regressing this. It
+// must keep working.
+func TestLaunchViewNodesChipClickStillOpensManeuverScreen(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.WindowSizeMsg{Width: 140, Height: 40})
+
+	a.world.PlanNode(sim.ManeuverNode{
+		DV:          10,
+		Mode:        spacecraft.BurnPrograde,
+		TriggerTime: a.world.Clock.SimTime.Add(2 * time.Hour),
+	})
+	a.world.ViewMode = sim.ViewLaunch
+	a.View() // Launch View writes chipRects through the shared OrbitView
+
+	col, row, ok := findChipHitCell(a, settings.ChipNodes)
+	if !ok {
+		t.Fatal("test setup: NODES chip not found on Launch View with a node planted")
+	}
+
+	a.Update(tea.MouseMsg{X: col, Y: row, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+
+	if a.active != screenManeuver {
+		t.Errorf("clicking the NODES chip on Launch View did not open the maneuver screen: active = %v", a.active)
+	}
+}
+
+// findChipHitCell scans the whole frame for a cell where HitChip
+// reports the given chip id.
+func findChipHitCell(a *App, want settings.Chip) (col, row int, ok bool) {
+	for r := 0; r < a.height; r++ {
+		for c := 0; c < a.width; c++ {
+			if id, hit := a.orbitView.HitChip(c, r); hit && id == want {
+				return c, r, true
+			}
+		}
+	}
+	return 0, 0, false
 }

--- a/internal/tui/app_launchview_burn_click_test.go
+++ b/internal/tui/app_launchview_burn_click_test.go
@@ -1,0 +1,110 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// findHitCol scans row 0's columns [0, width) for the first one where
+// hit reports true, for click tests that need a real column rather
+// than a hardcoded guess at a screen's current layout.
+func findHitCol(width int, hit func(col, row int) bool) (int, bool) {
+	for col := 0; col < width; col++ {
+		if hit(col, 0) {
+			return col, true
+		}
+	}
+	return 0, false
+}
+
+// TestLaunchViewBurnButtonClickTogglesAutoWarpNotMissions (#456): a
+// click on the Launch View's own [»Burn] button used to fall through
+// to the shared OrbitView's Menu/Missions/Burn hit-test columns, which
+// LaunchView.Render never updates — they stay frozen at whatever the
+// orbit MAP's own, differently-laid-out title bar last computed. Since
+// the map's rightmost title-bar button is [Missions], a click on the
+// launch view's [»Burn] button (which sits at a different column than
+// the map's own burn button) could land inside the map's stale
+// [Missions] range instead, sending the player to the Missions screen.
+//
+// Reproduces the exact bug shape: render the orbit map once first (the
+// realistic case — the player was on the map before this launch, or
+// will cycle back to it), THEN render Launch View, THEN click where
+// Launch View's own [»Burn] button visually sits.
+func TestLaunchViewBurnButtonClickTogglesAutoWarpNotMissions(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.WindowSizeMsg{Width: 140, Height: 40})
+
+	// Render the orbit map once — seeds a.orbitView's title-bar hit-test
+	// fields with the MAP's own layout.
+	a.View()
+
+	// Now switch to Launch View and plant an eligible burn so a
+	// successful dispatch to toggleAutoWarpBurn is observable (engages
+	// Auto-Warp), not just "nothing happened".
+	c := a.world.ActiveCraft()
+	if c == nil {
+		t.Fatal("fresh world has no active craft")
+	}
+	a.world.PlanNode(sim.ManeuverNode{
+		DV:          10,
+		Mode:        spacecraft.BurnPrograde,
+		TriggerTime: a.world.Clock.SimTime.Add(2 * time.Hour),
+	})
+	a.world.ViewMode = sim.ViewLaunch
+	a.View() // render Launch View — sets a.launchView's own hit-test range
+
+	col, ok := findHitCol(140, a.launchView.HitBurnButton)
+	if !ok {
+		t.Fatal("test setup: LaunchView never computed a [»Burn] hit-test range")
+	}
+
+	a.Update(tea.MouseMsg{X: col, Y: 0, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+
+	if a.active == screenMissions {
+		t.Fatalf("clicking Launch View's [»Burn] button navigated to Missions (stale map hit-test), want it to stay on the flight screen")
+	}
+	if a.active == screenMenu {
+		t.Fatalf("clicking Launch View's [»Burn] button opened the Menu (stale map hit-test), want it to stay on the flight screen")
+	}
+	if !a.world.AutoWarpEngaged() {
+		t.Errorf("clicking Launch View's [»Burn] button did not engage Auto-Warp")
+	}
+}
+
+// TestLaunchViewIgnoresStaleMapMissionsHit (#456): the orbit map's own
+// [Missions] button hit-test range, left over from rendering the map
+// before this launch, must not fire while Launch View is showing — the
+// exact mechanism behind the reported bug, isolated from whether the
+// two ranges happen to overlap on any particular layout.
+func TestLaunchViewIgnoresStaleMapMissionsHit(t *testing.T) {
+	a, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	a.Update(tea.WindowSizeMsg{Width: 140, Height: 40})
+	a.View() // seed the map's own Menu/Missions/Burn hit-test columns
+
+	col, ok := findHitCol(140, a.orbitView.HitMissionsButton)
+	if !ok {
+		t.Fatal("test setup: orbit map never computed a [Missions] hit-test range")
+	}
+
+	a.world.ViewMode = sim.ViewLaunch
+	a.View()
+	before := a.active
+
+	a.Update(tea.MouseMsg{X: col, Y: 0, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+
+	if a.active != before {
+		t.Errorf("a click on the map's stale [Missions] column changed the screen while Launch View was showing: %v -> %v", before, a.active)
+	}
+}

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -78,6 +78,17 @@ type LaunchView struct {
 	// "burn at" search (issue #377). See launch_descent_cache.go.
 	descentStopCache         descentStopRenderCache
 	descentStopCacheComputes int
+
+	// burnColStart/burnColEnd track this screen's OWN [»Burn] button
+	// (#456 fix): PR #445 added the button's rendering here but never
+	// gave the click a hit-test of its own, so app.go's mouse dispatch
+	// fell through to the shared OrbitView's burnColStart/menuColStart/
+	// missionsColStart — fields this screen never writes, left stale at
+	// whatever the map's last actual render computed for ITS entirely
+	// different title layout. A click on this screen's visually-correct
+	// [»Burn] button could land inside the map's stale [Missions] range
+	// instead. See Render's title-bar block for where these are set.
+	burnColStart, burnColEnd int
 }
 
 // NewLaunchView constructs the chase-cam screen, paired with the
@@ -246,6 +257,12 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 	}
 	titleRightRendered := warpRendered + declutterRendered + "  " + burnRendered
 	title := v.theme.Title.Render(titleLeft) + strings.Repeat(" ", titlePad) + titleRightRendered
+
+	// #456 fix: this screen's own [»Burn] hit-test, computed from the
+	// exact same pieces the render above just used — burnLabel sits
+	// last in titleRight, so its start column is everything before it.
+	v.burnColStart = lipgloss.Width(titleLeft) + titlePad + lipgloss.Width(titleRight) - lipgloss.Width(burnLabel)
+	v.burnColEnd = v.burnColStart + lipgloss.Width(burnLabel)
 
 	// The descent half (ADR 0043 §3): one forecast per frame, shared by
 	// the scene (dashed arc + ground marker) and the corridor chip, so
@@ -462,6 +479,14 @@ func visibleWidth(lines []string) int {
 		}
 	}
 	return w
+}
+
+// HitBurnButton reports whether (col, row) lands on this screen's own
+// [»Burn] button (#456 fix). Row-0 only, mirroring OrbitView's
+// HitBurnButton — this screen's title bar is the only row-0 content it
+// draws, so the same convention applies.
+func (v *LaunchView) HitBurnButton(col, row int) bool {
+	return row == 0 && col >= v.burnColStart && col < v.burnColEnd
 }
 
 // renderNoActiveVesselMessage stamps a centered "no active vessel"


### PR DESCRIPTION
Fixes #456.

## Summary

- `LaunchView.Render` composes its own title bar with its own
  `[»Burn]` button, but never computed a hit-test range for it.
  `app.go`'s mouse dispatcher always calls `a.orbitView.HitMenuButton`
  / `HitMissionsButton` / `HitBurnButton`, regardless of `ViewMode` —
  fields only the orbit MAP's own `Render` ever writes. A click on
  Launch View's real `[»Burn]` button fell through to whatever the
  map's last actual render left in those fields.
- Reproduced directly: at 140 cols, the map's stale `[Missions]` range
  and Launch View's real `[»Burn]` button position overlap, and since
  `app.go` checks Missions before Burn, that's what fired.
- `LaunchView` now computes its own `burnColStart`/`burnColEnd` during
  `Render` (from the same pieces already used to lay out its title
  bar) and exposes `HitBurnButton`.
- `app.go`'s mouse dispatch branches on `w.ViewMode == sim.ViewLaunch`
  *before* touching any `OrbitView` hit-test state: checks Launch
  View's own burn button and returns, rather than falling through to
  the map's stale Menu/Missions/Burn/navball/chip/body hit-tests —
  all of which read the same kind of state and were never any safer
  than the one bug that got reported.

## Scope note

Launch View's navball panel has no verified click-to-toggle support of
its own; before this fix it fell through to the same stale
`HitNavballControl` coordinates this fix now skips, with no test
proving that ever worked correctly from this screen. Skipping it is
strictly safer than matching a stale, unrelated hit-box, but flagging
it — real mouse support for Launch View's navball, if wanted, needs
its own hit-test plumbing (see the issue's Scope note).

## Test plan

- `TestLaunchViewBurnButtonClickTogglesAutoWarpNotMissions` reproduces
  the exact bug shape (render the map, then Launch View, then click
  Launch View's real burn button) and asserts it engages Auto-Warp
  instead of navigating away.
- `TestLaunchViewIgnoresStaleMapMissionsHit` isolates the mechanism:
  clicking the map's own stale `[Missions]` hit-test column while
  Launch View is showing must not change the screen.
- `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all
  green locally.