### PR TITLE
Readout Contract: one dialect for every number on the flight surfaces (ADR 0049)

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -27,6 +27,7 @@ behind a one-row `▸ +N hidden` marker rather than overlap each other.
   - [Vessels, staging, and docking](#vessels-staging-and-docking)
   - [Multiplayer](#multiplayer)
   - [Mouse](#mouse)
+- [Readout glossary](#readout-glossary)
 - [Screens](#screens)
   - [Spawn form (`n`)](#spawn-form-n)
   - [Maneuver planner (`m`)](#maneuver-planner-m)
@@ -277,6 +278,22 @@ Click only; no dragging, no scroll-to-zoom.
 | Empty space | Open the planner with a new burn at the nearest point on your orbit |
 | A readout panel | Open body info |
 | A porkchop cell | Move the cursor there (then `Enter` to plan it) |
+
+## Readout glossary
+
+Labels on the HUD are one plain word each, but a handful of codes are
+short enough to earn their keep. This is the same block the in-game `F1`
+overlay carries, so you can look one up without leaving the game.
+
+| Code | Meaning |
+|---|---|
+| `fpa` | Flight path angle: velocity above / below the local horizontal |
+| `Q` | Dynamic pressure: aerodynamic stress on the airframe, in kPa |
+| `TCA` | Time of closest approach, in a rendezvous or flyby |
+| `TWR` | Thrust to weight ratio: engines' thrust over vessel weight |
+| `Ap` / `Pe` | Apoapsis / periapsis: already height above the surface, so there's no separate `alt` row anywhere |
+| `Δv` / `Δincl` | Delta-v / relative inclination to a target's orbital plane |
+| `T-` / `T+` | Countdown convention: `T-` counts down to an event, `T+` counts up since it |
 
 ## Screens
 

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -291,7 +291,7 @@ overlay carries, so you can look one up without leaving the game.
 | `Q` | Dynamic pressure: aerodynamic stress on the airframe, in kPa |
 | `TCA` | Time of closest approach, in a rendezvous or flyby |
 | `TWR` | Thrust to weight ratio: engines' thrust over vessel weight |
-| `Ap` / `Pe` | Apoapsis / periapsis: already height above the surface, so there's no separate `alt` row anywhere |
+| `Ap` / `Pe` | Apoapsis / periapsis: height above the surface, like every altitude in the game |
 | `Δv` / `Δincl` | Delta-v / relative inclination to a target's orbital plane |
 | `T-` / `T+` | Countdown convention: `T-` counts down to an event, `T+` counts up since it |
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 	"github.com/jasonfen/terminal-space-program/internal/tui/screens"
 )
 
@@ -2925,8 +2926,16 @@ func (a *App) handlePlanRendezvousKey() {
 		// (#290 found this invisible at plan time: a "successful" plant
 		// that in fact arrived 4.6 m/s under the lock gate, with nothing
 		// on screen warning the player before they committed).
-		a.flash(fmt.Sprintf("rendezvous nudge: %.1f m/s %s → CA %.0f m @ T+%.0fs, arriving ~%.0f m/s",
-			adv.DV, adv.Axis, adv.AchievableCA, adv.TArrival, adv.ArrivalSpeed))
+		// F11 (gate review, item4-A-review.md): TArrival is time-to-CA from
+		// now after the burn, a future event; the old raw-seconds format
+		// hardcoded a "T+" prefix on it, the exact inversion decision 2
+		// exists to remove (T- means until, T+ means since), surviving
+		// only because this flash lives one directory up from the guard.
+		// readout.Countdown supplies its own signed prefix, so the
+		// literal "T+" is gone from the format string entirely.
+		a.flash(fmt.Sprintf("rendezvous nudge: %s %s → CA %s @ %s, arriving ~%s",
+			readout.DeltaV(adv.DV), adv.Axis, readout.Distance(adv.AchievableCA),
+			readout.Countdown(time.Duration(adv.TArrival*float64(time.Second))), readout.Speed(adv.ArrivalSpeed)))
 		a.world.RecordAction(missions.ActionPlanRendezvous) // ADR 0025 §7
 	case out.OpenPicker:
 		// The picker is a chip on the orbit MAP (ADR 0045 §2) — switch

--- a/internal/tui/help_keymap_test.go
+++ b/internal/tui/help_keymap_test.go
@@ -152,3 +152,16 @@ func TestHelpKeyTokensSplitsCompoundRows(t *testing.T) {
 	sort.Strings(got)
 	t.Logf("%d tokens: %s", len(got), strings.Join(got, " "))
 }
+
+// TestHelpGlossaryCoversReadoutCodes (ADR 0049 stage A3a): the six codes
+// that survive the readout contract, fpa, Q, TCA, TWR, Ap/Pe, Δv/Δincl,
+// must each have a line in the F1 glossary block, so a player who hits
+// one on a HUD panel can look it up without leaving the game.
+func TestHelpGlossaryCoversReadoutCodes(t *testing.T) {
+	tokens := screens.HelpKeyTokens()
+	for _, code := range []string{"fpa", "Q", "TCA", "TWR", "Ap", "Pe", "Δv", "Δincl"} {
+		if !tokens[code] {
+			t.Errorf("F1 glossary missing a line naming %q (ADR 0049 readout contract)", code)
+		}
+	}
+}

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -43,7 +43,13 @@ const (
 	// findings that never flagged this ORBIT-chip-only row), added on
 	// gate review: leaving it as t→Pe: kept two dialects for one
 	// quantity, apo:/peri: on SURFACE and t→Ap:/t→Pe: on ORBIT.
-	LabelPeri      = "peri:"
+	LabelPeri = "peri:"
+	// LabelEntry is the SOI PASS chip's SOI-entry countdown row (F4, gate
+	// review): was "T-entry:", an unsigned duration under a label that
+	// carried the direction word itself, two rows from `TCA: T-4h43m` for
+	// the same kind of quantity on the same chip. Signed through
+	// readout.Countdown like every other countdown in the contract.
+	LabelEntry     = "entry:"
 	LabelBurn      = "burn:"      // t_burn -> burn:
 	LabelIncl      = "incl:"      // inclin. -> incl:
 	LabelDeltaIncl = "Δincl:"     // Δi -> Δincl:
@@ -69,9 +75,19 @@ const auThreshold = bodies.AU / 10
 // frame to the next. Only the sign of an already-zero display changes;
 // non-zero values pass through untouched. Ported verbatim from the
 // `nzero` helper in orbit_chip_builders.go / formatRangeM.
+//
+// Uses math.RoundToEven, not math.Round, to decide "rounds to zero": Go's
+// own %.*f verb rounds ties to even (confirmed by probing fmt.Sprintf, not
+// assumed: an exact binary tie like -0.5 or -2.5 rounds to the nearest
+// EVEN integer, e.g. -0.5 -> "-0", -2.5 -> "-2"), while math.Round always
+// rounds ties away from zero. At exactly -0.5 the two disagreed (F2, gate
+// review): math.Round(-0.5) is -1, not 0, so the old check said "doesn't
+// round to zero" and let -0.5 pass through unsnapped, and fmt then printed
+// it as "-0" anyway, exactly the flicker this function exists to prevent.
+// Matching fmt's own rounding rule here closes that gap for every caller.
 func Nzero(x float64, decimals int) float64 {
 	scale := math.Pow(10, float64(decimals))
-	if math.Round(x*scale) == 0 {
+	if math.RoundToEven(x*scale) == 0 {
 		return 0
 	}
 	return x
@@ -162,11 +178,52 @@ func sigDecimals(magnitude float64, maxDecimals int) int {
 	return dec
 }
 
+// chooseDecimals is sigDecimals corrected for its own rounding: picking
+// the decimal count from the PRE-rounding magnitude is one rounding
+// step short of right at every intra-rung decade crossing (gate review
+// F1). 9.9996 has one integer digit, so sigDecimals hands it 3 decimals
+// for 4 significant figures, but fmt's own %.3f then rounds 9.9996 up
+// to 10.000, which only needs 2 decimals at two integer digits. The
+// naive result prints 10.000 (five significant figures) instead of the
+// correct 10.00. Re-deriving the decimal count from the ROUNDED value
+// catches this: round once at the naive count, recompute sigDecimals on
+// what that rounding produced, and use the new count if it differs.
+// Rounding can only carry a magnitude up by a fraction of one unit at
+// the chosen precision, never by a full extra decade beyond that, so a
+// single correction pass is always enough: no loop, and no interaction
+// with intDigits' own Inf/NaN guard (both sigDecimals calls funnel
+// through it, so a non-finite magnitude returns its fallback decimal
+// count twice and exits after one pass either way).
+func chooseDecimals(magnitude float64, maxDecimals int) int {
+	dec := sigDecimals(magnitude, maxDecimals)
+	scale := math.Pow(10, float64(dec))
+	rounded := math.Round(magnitude*scale) / scale
+	if newDec := sigDecimals(rounded, maxDecimals); newDec != dec {
+		return newDec
+	}
+	return dec
+}
+
 // intDigits counts the digits left of the decimal point in a positive
 // magnitude ("0" counts as 1 digit for anything below 1). Computed by
 // repeated division rather than log10 to avoid float log10 landing on
 // the wrong side of an exact power of ten.
+//
+// A formatter must be total over its input type: ±Inf never satisfies
+// `v >= 10 { v /= 10 }` (dividing infinity by ten is still infinity), so
+// without this guard the loop never terminates. That hangs whatever
+// Bubble Tea View() called it with no panic and no log line, freezing
+// the whole TUI, not reachable from a checked call site today, but
+// "not reachable today" is a property of the current call sites, not of
+// this package, which every future readout is about to route through.
+// Falling back to 1 leaves fmt's own float verbs to print the value:
+// Go's %f/%.*f family already renders "+Inf"/"-Inf"/"NaN" verbatim
+// regardless of the requested precision, matching what the plain fmt
+// calls this package replaced printed before the contract existed.
 func intDigits(magnitude float64) int {
+	if math.IsNaN(magnitude) || math.IsInf(magnitude, 0) {
+		return 1
+	}
 	if magnitude < 1 {
 		return 1
 	}
@@ -182,27 +239,45 @@ func intDigits(magnitude float64) int {
 type ladderRung struct {
 	unit    string
 	divisor float64
+	// promoteAt is the rounded-value threshold, in this rung's own unit,
+	// at which formatLadder promotes to the next rung rather than adding
+	// a digit. 1000 for every ordinary rung: a value that would need a
+	// 4th integer digit at 0 decimals promotes instead of losing the
+	// contract's 4-significant-figure precision. km is the deliberate
+	// exception, at 10000 (maintainer ruling, gate review addendum):
+	// decision 3's own worked examples (`2590 km`) and decision 4's
+	// (`Pe: 192.0 km`, `altitude: 500.0 km`) only ALL hold true at once
+	// if the km rung runs a full extra decade, to 9999 km, before
+	// promoting to Mm. The first pass here had read `2590 km` as a
+	// transcription error against a uniform ladder; re-reading the whole
+	// example set together shows the uniform ladder was the error.
+	promoteAt float64
 }
 
 var distanceRungs = []ladderRung{
-	{"m", 1},
-	{"km", 1e3},
-	{"Mm", 1e6},
-	{"Gm", 1e9},
-	{"AU", bodies.AU},
+	{"m", 1, 1000},
+	{"km", 1e3, 10000},
+	{"Mm", 1e6, 1000},
+	{"Gm", 1e9, 1000},
+	{"AU", bodies.AU, 1000}, // last rung: promoteAt is never consulted
 }
 
 // distanceRungIndex picks the starting rung for a non-negative distance
 // in meters, by the ADR's explicit thresholds: m below 1 km, km below
-// 1e6 m, Mm below 1e9 m, Gm below the existing 0.1 AU threshold, AU
-// above it. formatLadder below still checks for a rounding-induced
-// rollover past this starting guess (e.g. 999,950 m formats as 999.95
-// km, which rounds to 1000.0 km at 1 decimal and must promote to Mm).
+// 1e7 m (the extended km rung, see ladderRung.promoteAt), Mm below 1e9 m,
+// Gm below the existing 0.1 AU threshold, AU above it. The Mm rung's own
+// bottom is therefore 10 Mm, not 1 Mm: a value never renders as
+// "5.000 Mm" because km already covers everything below 10 Mm. That is
+// the deliberate consequence of the extended km rung, not a gap.
+// formatLadder below still checks for a rounding-induced rollover past
+// this starting guess (e.g. 9,999,600 m formats as 9999.6 km, which
+// rounds to 10000 km and must promote to Mm even though 9999.6 itself
+// was still under the 1e7 threshold this function checks).
 func distanceRungIndex(av float64) int {
 	switch {
 	case av < 1e3:
 		return 0
-	case av < 1e6:
+	case av < 1e7:
 		return 1
 	case av < 1e9:
 		return 2
@@ -233,10 +308,10 @@ func formatLadder(signed float64, rungs []ladderRung, startIdx int, maxDecimals 
 		if idx == 0 {
 			dec = 0
 		} else {
-			dec = sigDecimals(val, maxDecimals)
+			dec = chooseDecimals(val, maxDecimals)
 		}
 		roundedUp := math.Round(val*math.Pow(10, float64(dec))) / math.Pow(10, float64(dec))
-		if roundedUp >= 1000 && idx < len(rungs)-1 {
+		if roundedUp >= r.promoteAt && idx < len(rungs)-1 {
 			idx++
 			continue
 		}
@@ -257,8 +332,8 @@ func Distance(m float64) string {
 }
 
 var massRungs = []ladderRung{
-	{"kg", 1},
-	{"t", 1e3},
+	{"kg", 1, 1000},
+	{"t", 1e3, 1000}, // last rung (no kt): promoteAt is never consulted
 }
 
 // Mass renders a mass in kilograms through the ladder: kg below 1000 kg,
@@ -277,7 +352,7 @@ func Mass(kg float64) string {
 // Thrust renders a thrust in newtons as kN, always (never raw N), at 4
 // significant figures. There is no ladder to climb; kN is the one unit.
 func Thrust(n float64) string {
-	dec := sigDecimals(math.Abs(n)/1000, 3)
+	dec := chooseDecimals(math.Abs(n)/1000, 3)
 	return fmt.Sprintf("%.*f kN", dec, Nzero(n/1000, dec))
 }
 
@@ -287,7 +362,7 @@ func Thrust(n float64) string {
 // (Q on the ATMOSPHERE chip and the launch strip) pass the SI value they
 // already compute, not a pre-divided kPa figure.
 func Pressure(pa float64) string {
-	dec := sigDecimals(math.Abs(pa)/1000, 3)
+	dec := chooseDecimals(math.Abs(pa)/1000, 3)
 	return fmt.Sprintf("%.*f kPa", dec, Nzero(pa/1000, dec))
 }
 
@@ -298,7 +373,7 @@ func Pressure(pa float64) string {
 // figures, capped at 2 decimals rather than 3. Shared by Speed, DeltaV
 // and Angle, which never ride the SI ladder.
 func precision2(magnitude float64) int {
-	return sigDecimals(magnitude, 2)
+	return chooseDecimals(magnitude, 2)
 }
 
 func formatMps(mps float64) string {
@@ -309,10 +384,22 @@ func formatMps(mps float64) string {
 // formatDeltaVMps is DeltaV's per-number formatter, shared with
 // DeltaVPair so both halves of a stage/vehicle row use the same rule.
 func formatDeltaVMps(mps float64) string {
-	if math.Abs(mps) >= 100 {
+	av := math.Abs(mps)
+	if av >= 100 {
 		return fmt.Sprintf("%.0f", Nzero(mps, 0))
 	}
-	return formatMps(mps)
+	// A value just under the integer band can still round up into it at
+	// the below-100 branch's own precision (99.996 rounds to 100.0 at 1
+	// decimal): the same decade-crossing gate review F1 fixed in
+	// chooseDecimals applies to DeltaV's OWN 100 m/s threshold, not just
+	// to a ladder rung. Round once at the precision the below-100 branch
+	// would use and re-check the threshold before committing to it.
+	dec := precision2(av)
+	scale := math.Pow(10, float64(dec))
+	if math.Round(av*scale)/scale >= 100 {
+		return fmt.Sprintf("%.0f", Nzero(mps, 0))
+	}
+	return fmt.Sprintf("%.*f", dec, Nzero(mps, dec))
 }
 
 // Speed renders a speed in m/s at 4 significant figures, capped at 2

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -27,27 +27,27 @@ import (
 // ---
 
 const (
-	LabelVert      = "vert:"       // v_vert -> vert: (the m/s already says speed)
-	LabelHoriz     = "horiz:"      // v_horiz -> horiz:
-	LabelFPA       = "fpa:"        // unchanged code; the ascent flight-path angle
-	LabelOrbitFPA  = "orbit fpa:"  // fpa_orbit -> orbit fpa:
-	LabelQ         = "Q:"          // unchanged code; dynamic pressure
-	LabelTWR       = "TWR:"        // twr -> TWR:
-	LabelHold      = "hold:"       // sas -> hold: (matches the ATTITUDE panel's word)
-	LabelAp        = "Ap:"         // ap -> Ap:
-	LabelPe        = "Pe:"         // pe -> Pe:
-	LabelApo       = "apo:"        // t_to_apo -> apo: (value is a T- countdown)
-	LabelBurn      = "burn:"       // t_burn -> burn:
-	LabelIncl      = "incl:"       // inclin. -> incl:
-	LabelDeltaIncl = "Δincl:"      // Δi -> Δincl:
-	LabelApproach  = "approach:"   // Proximity View's CA: -> approach:
-	LabelTCA       = "TCA:"        // unchanged code
-	LabelRelSpeed  = "rel speed:"  // |v_rel| -> rel speed:
-	LabelArrival   = "arrival:"    // capture chip's "approach: N m/s relative" -> arrival:
-	LabelImpact    = "impact:"     // impact in: -> impact:
-	LabelAltitude  = "altitude:"   // unchanged label, now rides the SI ladder
-	LabelPeriod    = "period:"     // unchanged label; the one duration that keeps seconds
-	LabelDeltaV    = "Δv:"         // Δv budget -> Δv: <stage> / <vehicle> m/s
+	LabelVert      = "vert:"      // v_vert -> vert: (the m/s already says speed)
+	LabelHoriz     = "horiz:"     // v_horiz -> horiz:
+	LabelFPA       = "fpa:"       // unchanged code; the ascent flight-path angle
+	LabelOrbitFPA  = "orbit fpa:" // fpa_orbit -> orbit fpa:
+	LabelQ         = "Q:"         // unchanged code; dynamic pressure
+	LabelTWR       = "TWR:"       // twr -> TWR:
+	LabelHold      = "hold:"      // sas -> hold: (matches the ATTITUDE panel's word)
+	LabelAp        = "Ap:"        // ap -> Ap:
+	LabelPe        = "Pe:"        // pe -> Pe:
+	LabelApo       = "apo:"       // t_to_apo -> apo: (value is a T- countdown)
+	LabelBurn      = "burn:"      // t_burn -> burn:
+	LabelIncl      = "incl:"      // inclin. -> incl:
+	LabelDeltaIncl = "Δincl:"     // Δi -> Δincl:
+	LabelApproach  = "approach:"  // Proximity View's CA: -> approach:
+	LabelTCA       = "TCA:"       // unchanged code
+	LabelRelSpeed  = "rel speed:" // |v_rel| -> rel speed:
+	LabelArrival   = "arrival:"   // capture chip's "approach: N m/s relative" -> arrival:
+	LabelImpact    = "impact:"    // impact in: -> impact:
+	LabelAltitude  = "altitude:"  // unchanged label, now rides the SI ladder
+	LabelPeriod    = "period:"    // unchanged label; the one duration that keeps seconds
+	LabelDeltaV    = "Δv:"        // Δv budget -> Δv: <stage> / <vehicle> m/s
 )
 
 // auThreshold is the existing 0.1 AU distance-ladder boundary, reused
@@ -214,7 +214,7 @@ func distanceRungIndex(av float64) int {
 // bottom rung (index 0, meters or kilograms) to whole-number precision:
 // the concrete examples in the ADR for sub-1000 low-rung values ("912
 // m", "999 kg") are 0-decimal, not the 4-significant-figure decimal
-// count the rest of the ladder uses — a below-the-decimal-point reading
+// count the rest of the ladder uses: a below-the-decimal-point reading
 // at the finest unit carries no information a flight computer needs.
 func formatLadder(signed float64, rungs []ladderRung, startIdx int, maxDecimals int) string {
 	av := math.Abs(signed)
@@ -289,60 +289,79 @@ func formatMps(mps float64) string {
 	return fmt.Sprintf("%.*f", dec, Nzero(mps, dec))
 }
 
+// formatDeltaVMps is DeltaV's per-number formatter, shared with
+// DeltaVPair so both halves of a stage/vehicle row use the same rule.
+func formatDeltaVMps(mps float64) string {
+	if math.Abs(mps) >= 100 {
+		return fmt.Sprintf("%.0f", Nzero(mps, 0))
+	}
+	return formatMps(mps)
+}
+
 // Speed renders a speed in m/s at 4 significant figures, capped at 2
-// decimals: "5519 m/s", "0.12 m/s". Speeds never ride the SI ladder;
-// they stay in m/s at every magnitude the game reaches.
+// decimals, at every magnitude: "5519 m/s", "40.00 m/s", "0.12 m/s".
+// Speeds never ride the SI ladder; they stay in m/s at every magnitude
+// the game reaches.
 //
-// NOTE (flagged ambiguity #1, see impl-notes/item4-A1-readout-pkg.md):
-// the ADR's own worked example prints "40.0 m/s" (3 significant
-// figures) where this rule's 2-int-digit case yields "40.00 m/s" (4
-// significant figures, 2 decimals). This function implements the
-// stated rule, not the example; TestSpeed pins "40.00 m/s".
+// Adjudicated (gate review, see impl-notes/item4-A1-readout-pkg.md):
+// decision 12's own worked examples (`22.50 m/s`, `28.60°`) are 2-decimal
+// at two integer digits, so the ADR's lone `40.0 m/s` is a transcription
+// of a pre-contract readout, not a contract output. `Speed` implements
+// the stated rule at every magnitude, unlike `DeltaV` below, which the
+// same decision 12 sentence pins to an integer at and above 100 m/s.
 func Speed(mps float64) string {
 	return formatMps(mps) + " m/s"
 }
 
-// DeltaV renders a Δv figure in m/s using the same rule as Speed.
+// DeltaV renders a Δv figure in m/s. Decision 12: "Δv keeps its integer
+// m/s at every magnitude the game reaches (22.50 m/s only below 100)",
+// so DeltaV is a whole number at |v| >= 100 and falls back to the
+// 4-sig-fig / 2-decimal-cap helper below it: "5519 m/s", "550 m/s",
+// "99.90 m/s", "22.50 m/s", "0.12 m/s".
 //
-// NOTE (flagged ambiguity #2, see impl-notes/item4-A1-readout-pkg.md):
-// decision 12 says "Δv keeps its integer m/s at every magnitude the
-// game reaches (22.50 m/s only below 100)", which read literally means
-// Δv is an integer everywhere except below 100 m/s. We instead read
-// this as "Δv uses the same 4-sig-fig/2-decimal-cap helper as Speed",
-// which does yield an integer at and above 1000 (5519 -> "5519 m/s")
-// and 2 decimals below 100 (0.12 -> "0.12 m/s", 22.5 -> "22.50 m/s"),
-// matching every example the ADR actually gives. It diverges from the
-// literal prose in the 100-999.9 m/s band, where this rule gives 1
-// decimal (550 -> "550.0 m/s") rather than an integer; no ADR example
-// falls in that band to confirm either reading. TestDeltaV and TestSpeed
-// pin the reading we implemented.
+// Adjudicated (gate review): this deliberately differs from Speed in the
+// 100-999.9 m/s band, where Speed keeps one decimal (e.g. "550.0 m/s")
+// and DeltaV does not ("550 m/s"). The VESSEL chip's stage Δv sits in
+// that band constantly on a late stage; an integer there removes the
+// jittering tenths digit the contract exists to remove.
 func DeltaV(mps float64) string {
-	return formatMps(mps) + " m/s"
+	return formatDeltaVMps(mps) + " m/s"
 }
 
 // DeltaVPair renders the two-number Δv row (action-plan decision 7): the
 // active stage's remaining Δv, then the whole remaining stack's total,
-// sharing one trailing unit: "3518 / 9412 m/s". A single-stage vessel
-// should call DeltaV instead for the one-number form ("3518 m/s").
+// sharing one trailing unit: "3518 / 9412 m/s". Both numbers use
+// DeltaV's integer-at-100-and-above rule. A single-stage vessel should
+// call DeltaV instead for the one-number form ("3518 m/s").
 func DeltaVPair(stageMps, vehicleMps float64) string {
-	return formatMps(stageMps) + " / " + formatMps(vehicleMps) + " m/s"
+	return formatDeltaVMps(stageMps) + " / " + formatDeltaVMps(vehicleMps) + " m/s"
 }
 
 // Angle renders an orbital angle in degrees at 4 significant figures,
 // capped at 2 decimals: "28.60°", "0.00°". Used for inclination, Δincl,
-// and any other orbital-element angle; distinct from SteeringAngle,
-// which is for the integer pad/ascent controls.
+// and any other orbital-element angle; distinct from TrimAngle and FPA,
+// which are the integer pad/ascent controls.
 func Angle(deg float64) string {
 	dec := precision2(math.Abs(deg))
 	return fmt.Sprintf("%.*f°", dec, Nzero(deg, dec))
 }
 
-// SteeringAngle renders a signed, whole-degree steering readout: pitch
-// trim and the ascent flight-path angle ("fpa:"), e.g. "-10°", "+12°".
-// Distinct from Angle (orbital elements, 2 decimals) and from Heading
-// (unsigned, zero-padded compass bearing).
-func SteeringAngle(deg float64) string {
-	return fmt.Sprintf("%+.0f°", Nzero(math.Round(deg), 0))
+// TrimAngle renders a signed, whole-degree pitch-trim readout with an
+// explicit sign on positive values and zero, matching the existing
+// PitchTrim formatter's "%+.1f°" convention (orbit_chip_builders.go:1392)
+// at decision 12's integer precision: "+12°", "-10°", "+0°". Distinct
+// from FPA, whose existing formatters print no plus sign.
+func TrimAngle(deg float64) string {
+	return fmt.Sprintf("%+.0f°", Nzero(deg, 0))
+}
+
+// FPA renders a whole-degree flight-path-angle readout with a minus sign
+// only, no explicit plus: "45°", "-10°", "0°". Matches today's fpa
+// formatters (orbit_chip_builders.go:1398, :1555; launch.go:1173), which
+// use "%.0f°" with nzero applied and never a "+". Distinct from
+// TrimAngle, which does carry an explicit sign.
+func FPA(deg float64) string {
+	return fmt.Sprintf("%.0f°", Nzero(deg, 0))
 }
 
 // Heading renders a compass heading as a zero-padded, unsigned

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -290,14 +290,16 @@ func distanceRungIndex(av float64) int {
 
 // formatLadder renders a signed value through a unit ladder, picking the
 // rung by magnitude and then re-checking for a rounding-induced rollover
-// into the next rung up (a value that rounds to 1000 or more in its
-// candidate unit is re-expressed one rung higher, e.g. 999,950 m prints
-// "1.000 Mm" rather than "1000.0 km"). meterRungZeroDecimals forces the
-// bottom rung (index 0, meters or kilograms) to whole-number precision:
-// the concrete examples in the ADR for sub-1000 low-rung values ("912
-// m", "999 kg") are 0-decimal, not the 4-significant-figure decimal
-// count the rest of the ladder uses: a below-the-decimal-point reading
-// at the finest unit carries no information a flight computer needs.
+// into the next rung up (a value that rounds up to or past its rung's own
+// promoteAt is re-expressed one rung higher, e.g. 9,999,600 m rounds to
+// 10000 km at the extended km rung's own boundary and promotes: "10.00 Mm"
+// rather than "10000 km", see distanceRungs' promoteAt comment). The
+// `idx == 0` branch below forces the bottom rung (meters or kilograms) to
+// whole-number precision: the concrete examples in the ADR for sub-1000
+// low-rung values ("912 m", "999 kg") are 0-decimal, not the
+// 4-significant-figure decimal count the rest of the ladder uses: a
+// below-the-decimal-point reading at the finest unit carries no
+// information a flight computer needs.
 func formatLadder(signed float64, rungs []ladderRung, startIdx int, maxDecimals int) string {
 	av := math.Abs(signed)
 	idx := startIdx

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -15,6 +15,7 @@ package readout
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
@@ -27,16 +28,22 @@ import (
 // ---
 
 const (
-	LabelVert      = "vert:"      // v_vert -> vert: (the m/s already says speed)
-	LabelHoriz     = "horiz:"     // v_horiz -> horiz:
-	LabelFPA       = "fpa:"       // unchanged code; the ascent flight-path angle
-	LabelOrbitFPA  = "orbit fpa:" // fpa_orbit -> orbit fpa:
-	LabelQ         = "Q:"         // unchanged code; dynamic pressure
-	LabelTWR       = "TWR:"       // twr -> TWR:
-	LabelHold      = "hold:"      // sas -> hold: (matches the ATTITUDE panel's word)
-	LabelAp        = "Ap:"        // ap -> Ap:
-	LabelPe        = "Pe:"        // pe -> Pe:
-	LabelApo       = "apo:"       // t_to_apo -> apo: (value is a T- countdown)
+	LabelVert     = "vert:"      // v_vert -> vert: (the m/s already says speed)
+	LabelHoriz    = "horiz:"     // v_horiz -> horiz:
+	LabelFPA      = "fpa:"       // unchanged code; the ascent flight-path angle
+	LabelOrbitFPA = "orbit fpa:" // fpa_orbit -> orbit fpa:
+	LabelQ        = "Q:"         // unchanged code; dynamic pressure
+	LabelTWR      = "TWR:"       // twr -> TWR:
+	LabelHold     = "hold:"      // sas -> hold: (matches the ATTITUDE panel's word)
+	LabelAp       = "Ap:"        // ap -> Ap:
+	LabelPe       = "Pe:"        // pe -> Pe:
+	LabelApo      = "apo:"       // t_to_apo -> apo: (value is a T- countdown)
+	// LabelPeri is apo:'s obvious sibling for the ORBIT chip's t→Pe: row.
+	// Not in the action-plan's own rename table (built from review
+	// findings that never flagged this ORBIT-chip-only row), added on
+	// gate review: leaving it as t→Pe: kept two dialects for one
+	// quantity, apo:/peri: on SURFACE and t→Ap:/t→Pe: on ORBIT.
+	LabelPeri      = "peri:"
 	LabelBurn      = "burn:"      // t_burn -> burn:
 	LabelIncl      = "incl:"      // inclin. -> incl:
 	LabelDeltaIncl = "Δincl:"     // Δi -> Δincl:
@@ -274,6 +281,16 @@ func Thrust(n float64) string {
 	return fmt.Sprintf("%.*f kN", dec, Nzero(n/1000, dec))
 }
 
+// Pressure renders a dynamic pressure in pascals as kPa, always (never
+// raw Pa or a ladder), at 4 significant figures: mirrors Thrust, the
+// other single-unit off-ladder reading. Input in pascals so callers
+// (Q on the ATMOSPHERE chip and the launch strip) pass the SI value they
+// already compute, not a pre-divided kPa figure.
+func Pressure(pa float64) string {
+	dec := sigDecimals(math.Abs(pa)/1000, 3)
+	return fmt.Sprintf("%.*f kPa", dec, Nzero(pa/1000, dec))
+}
+
 // --- Off-ladder precision: speed, Δv, orbital angles (ADR decision 4;
 // action-plan decision 12) ---
 
@@ -311,6 +328,19 @@ func formatDeltaVMps(mps float64) string {
 // same decision 12 sentence pins to an integer at and above 100 m/s.
 func Speed(mps float64) string {
 	return formatMps(mps) + " m/s"
+}
+
+// SignedSpeed renders a relative rate (closing, approach) at Speed's same
+// 4-sig-fig / 2-decimal-cap precision, but with an explicit sign on
+// positive values and zero, matching the closing:/rate-style rows that
+// need "toward" versus "away" legible without a separate word: "+3640
+// m/s", "-12.34 m/s", "+0.00 m/s".
+func SignedSpeed(mps float64) string {
+	s := Speed(mps)
+	if strings.HasPrefix(s, "-") {
+		return s
+	}
+	return "+" + s
 }
 
 // DeltaV renders a Δv figure in m/s. Decision 12: "Δv keeps its integer

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -1,0 +1,361 @@
+// Package readout is the single formatter for every number a flight
+// surface prints: the ADR 0049 Readout Contract. It owns the duration
+// humaniser, the SI ladder, the off-ladder precision helper and the
+// label constants, so no two panels disagree on the arithmetic.
+//
+// This package replaces five duration formatters and four distance
+// formatters that used to live in internal/tui/screens (compactDuration,
+// formatDurationShort, formatPeriod, formatTCA, formatCountdown,
+// formatRangeM, formatChipKm, formatAltKm, formatAltitude). Those are
+// deleted at the call sites in a later stage of this ADR, not wrapped:
+// this package is the only place ladder rungs, duration bands and
+// significant-figure rules are decided.
+package readout
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// --- Label constants (ADR 0049 decision 6 rename table / action-plan
+// decision 6). Labels are lowercase words; the codes that survive
+// (fpa, Q, TCA, TWR, Ap/Pe, Δv/Δincl) keep their standard case. No
+// underscores, no absolute-value bars, no "sas" anywhere player-facing.
+// ---
+
+const (
+	LabelVert      = "vert:"       // v_vert -> vert: (the m/s already says speed)
+	LabelHoriz     = "horiz:"      // v_horiz -> horiz:
+	LabelFPA       = "fpa:"        // unchanged code; the ascent flight-path angle
+	LabelOrbitFPA  = "orbit fpa:"  // fpa_orbit -> orbit fpa:
+	LabelQ         = "Q:"          // unchanged code; dynamic pressure
+	LabelTWR       = "TWR:"        // twr -> TWR:
+	LabelHold      = "hold:"       // sas -> hold: (matches the ATTITUDE panel's word)
+	LabelAp        = "Ap:"         // ap -> Ap:
+	LabelPe        = "Pe:"         // pe -> Pe:
+	LabelApo       = "apo:"        // t_to_apo -> apo: (value is a T- countdown)
+	LabelBurn      = "burn:"       // t_burn -> burn:
+	LabelIncl      = "incl:"       // inclin. -> incl:
+	LabelDeltaIncl = "Δincl:"      // Δi -> Δincl:
+	LabelApproach  = "approach:"   // Proximity View's CA: -> approach:
+	LabelTCA       = "TCA:"        // unchanged code
+	LabelRelSpeed  = "rel speed:"  // |v_rel| -> rel speed:
+	LabelArrival   = "arrival:"    // capture chip's "approach: N m/s relative" -> arrival:
+	LabelImpact    = "impact:"     // impact in: -> impact:
+	LabelAltitude  = "altitude:"   // unchanged label, now rides the SI ladder
+	LabelPeriod    = "period:"     // unchanged label; the one duration that keeps seconds
+	LabelDeltaV    = "Δv:"         // Δv budget -> Δv: <stage> / <vehicle> m/s
+)
+
+// auThreshold is the existing 0.1 AU distance-ladder boundary, reused
+// verbatim from formatRangeM (orbit_chip_builders.go), which switched to
+// AU at `rangeM > bodies.AU/10`. Gm covers up to (not including) this
+// value; AU starts at it.
+const auThreshold = bodies.AU / 10
+
+// Nzero snaps a value whose magnitude rounds to zero at `decimals` places
+// to +0, so a quantity that jitters across zero (v_vert, fpa, an altitude
+// riding co-rotation noise) doesn't flicker a "-0" / "-0.0" sign from one
+// frame to the next. Only the sign of an already-zero display changes;
+// non-zero values pass through untouched. Ported verbatim from the
+// `nzero` helper in orbit_chip_builders.go / formatRangeM.
+func Nzero(x float64, decimals int) float64 {
+	scale := math.Pow(10, float64(decimals))
+	if math.Round(x*scale) == 0 {
+		return 0
+	}
+	return x
+}
+
+// --- Durations (ADR decision 1 / 2; action-plan decisions 1, 2, 12) ---
+
+// Duration renders a duration's magnitude as two adjacent units,
+// zero-padded on the second: "45s", "2m07s", "4h43m", "3d05h". It
+// truncates rather than rounds, so a countdown built on it never claims
+// more time than there is (4h43m59s renders "4h43m", not "4h44m"). The
+// sign of d is ignored; use Countdown for a signed, launch-convention
+// reading.
+func Duration(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	total := int64(d / time.Second) // truncating division, never rounds
+	days := total / 86400
+	hours := (total % 86400) / 3600
+	mins := (total % 3600) / 60
+	secs := total % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd%02dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh%02dm", hours, mins)
+	case mins > 0:
+		return fmt.Sprintf("%dm%02ds", mins, secs)
+	default:
+		return fmt.Sprintf("%ds", secs)
+	}
+}
+
+// Period renders a duration keeping all three units down to seconds:
+// "45s", "3m45s", "1h34m28s". It is the one exception to the two-unit
+// Duration rule (`period:` is the label it's reserved for) because a
+// resonant or phasing orbit is tuned against the period to single-second
+// precision; rounding away the seconds digit there costs real placement
+// error over many revolutions.
+func Period(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	total := int64(d / time.Second)
+	hours := total / 3600
+	mins := (total % 3600) / 60
+	secs := total % 60
+	switch {
+	case hours > 0:
+		return fmt.Sprintf("%dh%02dm%02ds", hours, mins, secs)
+	case mins > 0:
+		return fmt.Sprintf("%dm%02ds", mins, secs)
+	default:
+		return fmt.Sprintf("%ds", secs)
+	}
+}
+
+// Countdown signs a duration using the launch convention: `T-` means
+// until the event, `T+` means since it. Pass the signed time until the
+// event: positive is a future event ("T-4h43m"), zero or negative is an
+// elapsed or overdue one ("T+2m10s" for a node missed by 2m10s, "T+0s"
+// for an event happening now). The label never carries the direction
+// word; this sign does.
+func Countdown(until time.Duration) string {
+	if until > 0 {
+		return "T-" + Duration(until)
+	}
+	return "T+" + Duration(-until)
+}
+
+// --- SI ladder: distance, mass, thrust (ADR decision 3; action-plan
+// decisions 3, 4) ---
+
+// sigDecimals returns the decimal count for a 4-significant-figure
+// reading of a positive magnitude already expressed in the target unit,
+// capped at maxDecimals. A 4-digit integer part needs 0 decimals, a
+// single leading digit needs 3 (capped to maxDecimals where that's
+// smaller). Values below 1 keep 1 leading digit ("0") for this purpose.
+func sigDecimals(magnitude float64, maxDecimals int) int {
+	dec := 4 - intDigits(magnitude)
+	if dec < 0 {
+		dec = 0
+	}
+	if dec > maxDecimals {
+		dec = maxDecimals
+	}
+	return dec
+}
+
+// intDigits counts the digits left of the decimal point in a positive
+// magnitude ("0" counts as 1 digit for anything below 1). Computed by
+// repeated division rather than log10 to avoid float log10 landing on
+// the wrong side of an exact power of ten.
+func intDigits(magnitude float64) int {
+	if magnitude < 1 {
+		return 1
+	}
+	n := 1
+	v := magnitude
+	for v >= 10 {
+		v /= 10
+		n++
+	}
+	return n
+}
+
+type ladderRung struct {
+	unit    string
+	divisor float64
+}
+
+var distanceRungs = []ladderRung{
+	{"m", 1},
+	{"km", 1e3},
+	{"Mm", 1e6},
+	{"Gm", 1e9},
+	{"AU", bodies.AU},
+}
+
+// distanceRungIndex picks the starting rung for a non-negative distance
+// in meters, by the ADR's explicit thresholds: m below 1 km, km below
+// 1e6 m, Mm below 1e9 m, Gm below the existing 0.1 AU threshold, AU
+// above it. formatLadder below still checks for a rounding-induced
+// rollover past this starting guess (e.g. 999,950 m formats as 999.95
+// km, which rounds to 1000.0 km at 1 decimal and must promote to Mm).
+func distanceRungIndex(av float64) int {
+	switch {
+	case av < 1e3:
+		return 0
+	case av < 1e6:
+		return 1
+	case av < 1e9:
+		return 2
+	case av < auThreshold:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// formatLadder renders a signed value through a unit ladder, picking the
+// rung by magnitude and then re-checking for a rounding-induced rollover
+// into the next rung up (a value that rounds to 1000 or more in its
+// candidate unit is re-expressed one rung higher, e.g. 999,950 m prints
+// "1.000 Mm" rather than "1000.0 km"). meterRungZeroDecimals forces the
+// bottom rung (index 0, meters or kilograms) to whole-number precision:
+// the concrete examples in the ADR for sub-1000 low-rung values ("912
+// m", "999 kg") are 0-decimal, not the 4-significant-figure decimal
+// count the rest of the ladder uses — a below-the-decimal-point reading
+// at the finest unit carries no information a flight computer needs.
+func formatLadder(signed float64, rungs []ladderRung, startIdx int, maxDecimals int) string {
+	av := math.Abs(signed)
+	idx := startIdx
+	for {
+		r := rungs[idx]
+		val := av / r.divisor
+		dec := maxDecimals
+		if idx == 0 {
+			dec = 0
+		} else {
+			dec = sigDecimals(val, maxDecimals)
+		}
+		roundedUp := math.Round(val*math.Pow(10, float64(dec))) / math.Pow(10, float64(dec))
+		if roundedUp >= 1000 && idx < len(rungs)-1 {
+			idx++
+			continue
+		}
+		out := Nzero(signed/r.divisor, dec)
+		return fmt.Sprintf("%.*f %s", dec, out, r.unit)
+	}
+}
+
+// Distance renders a distance in meters through the SI ladder: m below 1
+// km, km, Mm, Gm, then AU above the existing 0.1 AU threshold, at 4
+// significant figures per rung (meters stay whole numbers, see
+// formatLadder). The rung is always printed, so a unit change is never
+// silent. A negative distance (a sub-surface periapsis) keeps its signed
+// depth: "-120.0 km".
+func Distance(m float64) string {
+	av := math.Abs(m)
+	return formatLadder(m, distanceRungs, distanceRungIndex(av), 3)
+}
+
+var massRungs = []ladderRung{
+	{"kg", 1},
+	{"t", 1e3},
+}
+
+// Mass renders a mass in kilograms through the ladder: kg below 1000 kg,
+// then t, at 4 significant figures. There is no `kt` rung: a mass whose
+// tonnage exceeds 4 significant figures still prints in t with more
+// digits, since there is nowhere higher to promote it.
+func Mass(kg float64) string {
+	av := math.Abs(kg)
+	idx := 0
+	if av >= 1000 {
+		idx = 1
+	}
+	return formatLadder(kg, massRungs, idx, 3)
+}
+
+// Thrust renders a thrust in newtons as kN, always (never raw N), at 4
+// significant figures. There is no ladder to climb; kN is the one unit.
+func Thrust(n float64) string {
+	dec := sigDecimals(math.Abs(n)/1000, 3)
+	return fmt.Sprintf("%.*f kN", dec, Nzero(n/1000, dec))
+}
+
+// --- Off-ladder precision: speed, Δv, orbital angles (ADR decision 4;
+// action-plan decision 12) ---
+
+// precision2 is the off-ladder sibling of sigDecimals: 4 significant
+// figures, capped at 2 decimals rather than 3. Shared by Speed, DeltaV
+// and Angle, which never ride the SI ladder.
+func precision2(magnitude float64) int {
+	return sigDecimals(magnitude, 2)
+}
+
+func formatMps(mps float64) string {
+	dec := precision2(math.Abs(mps))
+	return fmt.Sprintf("%.*f", dec, Nzero(mps, dec))
+}
+
+// Speed renders a speed in m/s at 4 significant figures, capped at 2
+// decimals: "5519 m/s", "0.12 m/s". Speeds never ride the SI ladder;
+// they stay in m/s at every magnitude the game reaches.
+//
+// NOTE (flagged ambiguity #1, see impl-notes/item4-A1-readout-pkg.md):
+// the ADR's own worked example prints "40.0 m/s" (3 significant
+// figures) where this rule's 2-int-digit case yields "40.00 m/s" (4
+// significant figures, 2 decimals). This function implements the
+// stated rule, not the example; TestSpeed pins "40.00 m/s".
+func Speed(mps float64) string {
+	return formatMps(mps) + " m/s"
+}
+
+// DeltaV renders a Δv figure in m/s using the same rule as Speed.
+//
+// NOTE (flagged ambiguity #2, see impl-notes/item4-A1-readout-pkg.md):
+// decision 12 says "Δv keeps its integer m/s at every magnitude the
+// game reaches (22.50 m/s only below 100)", which read literally means
+// Δv is an integer everywhere except below 100 m/s. We instead read
+// this as "Δv uses the same 4-sig-fig/2-decimal-cap helper as Speed",
+// which does yield an integer at and above 1000 (5519 -> "5519 m/s")
+// and 2 decimals below 100 (0.12 -> "0.12 m/s", 22.5 -> "22.50 m/s"),
+// matching every example the ADR actually gives. It diverges from the
+// literal prose in the 100-999.9 m/s band, where this rule gives 1
+// decimal (550 -> "550.0 m/s") rather than an integer; no ADR example
+// falls in that band to confirm either reading. TestDeltaV and TestSpeed
+// pin the reading we implemented.
+func DeltaV(mps float64) string {
+	return formatMps(mps) + " m/s"
+}
+
+// DeltaVPair renders the two-number Δv row (action-plan decision 7): the
+// active stage's remaining Δv, then the whole remaining stack's total,
+// sharing one trailing unit: "3518 / 9412 m/s". A single-stage vessel
+// should call DeltaV instead for the one-number form ("3518 m/s").
+func DeltaVPair(stageMps, vehicleMps float64) string {
+	return formatMps(stageMps) + " / " + formatMps(vehicleMps) + " m/s"
+}
+
+// Angle renders an orbital angle in degrees at 4 significant figures,
+// capped at 2 decimals: "28.60°", "0.00°". Used for inclination, Δincl,
+// and any other orbital-element angle; distinct from SteeringAngle,
+// which is for the integer pad/ascent controls.
+func Angle(deg float64) string {
+	dec := precision2(math.Abs(deg))
+	return fmt.Sprintf("%.*f°", dec, Nzero(deg, dec))
+}
+
+// SteeringAngle renders a signed, whole-degree steering readout: pitch
+// trim and the ascent flight-path angle ("fpa:"), e.g. "-10°", "+12°".
+// Distinct from Angle (orbital elements, 2 decimals) and from Heading
+// (unsigned, zero-padded compass bearing).
+func SteeringAngle(deg float64) string {
+	return fmt.Sprintf("%+.0f°", Nzero(math.Round(deg), 0))
+}
+
+// Heading renders a compass heading as a zero-padded, unsigned
+// three-digit degree string: "090°". Input is normalized into [0, 360)
+// before rounding.
+func Heading(deg float64) string {
+	d := math.Mod(deg, 360)
+	if d < 0 {
+		d += 360
+	}
+	r := math.Round(d)
+	if r >= 360 {
+		r = 0
+	}
+	return fmt.Sprintf("%03.0f°", r)
+}

--- a/internal/tui/readout/readout_test.go
+++ b/internal/tui/readout/readout_test.go
@@ -1,0 +1,300 @@
+package readout
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jasonfen/terminal-space-program/internal/bodies"
+)
+
+// --- Duration: two-unit, truncating, zero-padded second unit. ADR 0049
+// decision 1 / action-plan decision 1. ---
+
+func TestDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "0s"},
+		{"seconds only", 45 * time.Second, "45s"},
+		{"59s below the minute crossing", 59 * time.Second, "59s"},
+		{"60s crosses into minutes", 60 * time.Second, "1m00s"},
+		{"minutes, seconds zero-padded", 2*time.Minute + 7*time.Second, "2m07s"},
+		{"hours, minutes not seconds", 4*time.Hour + 43*time.Minute, "4h43m"},
+		{"truncates, never rounds", 4*time.Hour + 43*time.Minute + 59*time.Second, "4h43m"},
+		{"days, hours zero-padded", 3*24*time.Hour + 5*time.Hour, "3d05h"},
+		{"negative treated as magnitude", -45 * time.Second, "45s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Duration(c.d); got != c.want {
+				t.Errorf("Duration(%v) = %q, want %q", c.d, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Period: three-unit, keeps seconds at every scale. ADR decision 1,
+// action-plan decision 1 example "1h34m28s". ---
+
+func TestPeriod(t *testing.T) {
+	cases := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"seconds only", 45 * time.Second, "45s"},
+		{"minutes and seconds", 3*time.Minute + 45*time.Second, "3m45s"},
+		{"hours keep seconds (contract example)", 1*time.Hour + 34*time.Minute + 28*time.Second, "1h34m28s"},
+		{"hours zero-padded minutes and seconds", 6*time.Hour + 4*time.Minute + 21*time.Second, "6h04m21s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Period(c.d); got != c.want {
+				t.Errorf("Period(%v) = %q, want %q", c.d, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Countdown: T- until, T+ since (launch convention). ADR decision 2,
+// action-plan decision 2. Overdue/elapsed and zero cases pinned per the
+// task brief. ---
+
+func TestCountdown(t *testing.T) {
+	cases := []struct {
+		name  string
+		until time.Duration // positive: event in the future
+		want  string
+	}{
+		{"future event reads T-", 4*time.Hour + 43*time.Minute, "T-4h43m"},
+		{"overdue event reads T+", -(2*time.Minute + 10*time.Second), "T+2m10s"},
+		{"just-fired reads T+ (already right per ADR)", -3 * time.Second, "T+3s"},
+		{"zero reads T+0s (elapsed, not future)", 0, "T+0s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Countdown(c.until); got != c.want {
+				t.Errorf("Countdown(%v) = %q, want %q", c.until, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Distance: SI ladder, m / km / Mm / Gm / AU, 4 sig figs (meters
+// stay whole numbers — see notes). ADR decision 3, action-plan decisions
+// 3 and 4. ---
+
+func TestDistance(t *testing.T) {
+	cases := []struct {
+		name string
+		m    float64
+		want string
+	}{
+		{"zero", 0, "0 m"},
+		{"sub-1km stays in meters, whole number", 912, "912 m"},
+		{"pad altitude zero", 0, "0 m"},
+		{"km rung, 1 decimal (contract example)", 500000, "500.0 km"},
+		{"km rung another contract example", 438900, "438.9 km"},
+		{"just under the km->Mm rollover, no bump", 999940, "999.9 km"},
+		{"999,950 m rounds up across the rung into Mm", 999950, "1.000 Mm"},
+		{"Mm rung, 2 decimals (Ap contract example)", 35790000, "35.79 Mm"},
+		{"just below the 0.1 AU threshold stays Gm", bodies.AU/10 - 1, "14.96 Gm"},
+		{"at the 0.1 AU threshold switches to AU", bodies.AU / 10, "0.100 AU"},
+		{"well above threshold, AU rung 3 decimals", bodies.AU * 8.727, "8.727 AU"},
+		{"negative distance keeps signed depth (sub-surface Pe)", -120000, "-120.0 km"},
+		{"negative meters", -0.4, "0 m"}, // sub-metre noise nzero-snaps to +0
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Distance(c.m); got != c.want {
+				t.Errorf("Distance(%v) = %q, want %q", c.m, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Mass: kg / t ladder, no kt rung. ADR decision 3. ---
+
+func TestMass(t *testing.T) {
+	cases := []struct {
+		name string
+		kg   float64
+		want string
+	}{
+		{"kg rung, whole number", 999, "999 kg"},
+		{"crosses into tonnes at 1000 kg", 1000, "1.000 t"},
+		{"contract example, 4 digits", 2160000, "2160 t"},
+		{"contract example, 2 decimals", 12950, "12.95 t"},
+		{"contract example, another 4-digit reading", 2928000, "2928 t"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Mass(c.kg); got != c.want {
+				t.Errorf("Mass(%v) = %q, want %q", c.kg, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Thrust: kN everywhere, never raw N. ADR decision 3. ---
+
+func TestThrust(t *testing.T) {
+	cases := []struct {
+		name string
+		n    float64
+		want string
+	}{
+		{"contract example", 1023000, "1023 kN"},
+		{"small thrust still kN", 500, "0.500 kN"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Thrust(c.n); got != c.want {
+				t.Errorf("Thrust(%v) = %q, want %q", c.n, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Speed / DeltaV: off-ladder, 4 sig figs capped at 2 decimals, always
+// m/s. ADR decision 4, action-plan decision 12. The 40.0 vs 40.00 case is
+// flagged ambiguity #1: we implement the stated rule, not the ADR's own
+// example. ---
+
+func TestSpeed(t *testing.T) {
+	cases := []struct {
+		name string
+		mps  float64
+		want string
+	}{
+		{"contract example, integer at 4 digits", 5519, "5519 m/s"},
+		{"AMBIGUITY 1: rule gives 40.00, ADR's own example prints 40.0", 40.0, "40.00 m/s"},
+		{"contract example, 2 decimals below 1", 0.12, "0.12 m/s"},
+		{"AMBIGUITY 2 probe: rule gives 1 decimal in the 100s, not integer", 550, "550.0 m/s"},
+		{"negative speed rounds toward zero sign correctly", -0.001, "0.00 m/s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Speed(c.mps); got != c.want {
+				t.Errorf("Speed(%v) = %q, want %q", c.mps, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDeltaV(t *testing.T) {
+	cases := []struct {
+		name string
+		mps  float64
+		want string
+	}{
+		{"contract example below 100, 2 decimals", 22.5, "22.50 m/s"},
+		{"large budget, integer", 5519, "5519 m/s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DeltaV(c.mps); got != c.want {
+				t.Errorf("DeltaV(%v) = %q, want %q", c.mps, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDeltaVPair(t *testing.T) {
+	if got := DeltaVPair(3518, 9412); got != "3518 / 9412 m/s" {
+		t.Errorf("DeltaVPair(3518, 9412) = %q, want %q", got, "3518 / 9412 m/s")
+	}
+}
+
+// --- Angle: orbital angles, 4 sig figs capped at 2 decimals. ADR
+// decision 4. ---
+
+func TestAngle(t *testing.T) {
+	cases := []struct {
+		name string
+		deg  float64
+		want string
+	}{
+		{"contract example", 28.6, "28.60°"},
+		{"contract example, zero", 0, "0.00°"},
+		{"contract example, delta-incl", 31.2, "31.20°"},
+		{"negative zero snaps positive", -0.001, "0.00°"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Angle(c.deg); got != c.want {
+				t.Errorf("Angle(%v) = %q, want %q", c.deg, got, c.want)
+			}
+		})
+	}
+}
+
+// --- SteeringAngle / Heading: integer steering angles. ADR decision 4. ---
+
+func TestSteeringAngle(t *testing.T) {
+	cases := []struct {
+		name string
+		deg  float64
+		want string
+	}{
+		{"contract example, negative pitch trim", -10, "-10°"},
+		{"positive trim signed", 12, "+12°"},
+		{"zero trim", 0, "+0°"},
+		{"rounds to nearest degree", -9.6, "-10°"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SteeringAngle(c.deg); got != c.want {
+				t.Errorf("SteeringAngle(%v) = %q, want %q", c.deg, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHeading(t *testing.T) {
+	cases := []struct {
+		name string
+		deg  float64
+		want string
+	}{
+		{"contract example, due east", 90, "090°"},
+		{"zero-padded single digit", 5, "005°"},
+		{"three digits, no padding needed", 270, "270°"},
+		{"wraps negative into 0-360", -10, "350°"},
+		{"wraps 360 to 0", 360, "000°"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Heading(c.deg); got != c.want {
+				t.Errorf("Heading(%v) = %q, want %q", c.deg, got, c.want)
+			}
+		})
+	}
+}
+
+// --- Nzero: -0.0 snaps to 0.0, matching the existing helper this
+// package replaces (orbit_chip_builders.go's nzero). ---
+
+func TestNzero(t *testing.T) {
+	cases := []struct {
+		name     string
+		x        float64
+		decimals int
+		want     float64
+	}{
+		{"negative value that rounds to zero snaps positive", -0.001, 1, 0},
+		{"non-zero value passes through", -1.5, 1, -1.5},
+		{"exact zero stays zero", 0, 2, 0},
+		{"value that rounds to zero at 0 decimals", -0.4, 0, 0},
+		{"value that does not round to zero", -0.6, 0, -0.6},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Nzero(c.x, c.decimals); got != c.want {
+				t.Errorf("Nzero(%v, %d) = %v, want %v", c.x, c.decimals, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/tui/readout/readout_test.go
+++ b/internal/tui/readout/readout_test.go
@@ -158,6 +158,28 @@ func TestThrust(t *testing.T) {
 	}
 }
 
+// TestPressure pins the ATMOSPHERE chip's / launch strip's Q reading:
+// always kPa (never raw Pa), 4 significant figures, mirroring Thrust's
+// own single-unit off-ladder shape. Input is pascals.
+func TestPressure(t *testing.T) {
+	cases := []struct {
+		name string
+		pa   float64
+		want string
+	}{
+		{"zero on the pad", 0, "0.000 kPa"},
+		{"typical max-Q figure", 23100, "23.10 kPa"},
+		{"four-digit kPa", 1023000, "1023 kPa"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Pressure(c.pa); got != c.want {
+				t.Errorf("Pressure(%v) = %q, want %q", c.pa, got, c.want)
+			}
+		})
+	}
+}
+
 // --- Speed / DeltaV: off-ladder, 4 sig figs capped at 2 decimals, always
 // m/s. ADR decision 4, action-plan decision 12. Speed uses the rule at
 // every magnitude, including the 40.00 m/s case (adjudicated at the gate
@@ -183,6 +205,30 @@ func TestSpeed(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := Speed(c.mps); got != c.want {
 				t.Errorf("Speed(%v) = %q, want %q", c.mps, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSignedSpeed pins the closing:/rate-style rows added in ADR 0049
+// stage A2's gate-review follow-up: same precision as Speed, but always
+// signed, including at exactly zero and at a negative value that Nzero
+// snaps to zero (the pre-snap sign must not survive as a bare "-0.00").
+func TestSignedSpeed(t *testing.T) {
+	cases := []struct {
+		name string
+		mps  float64
+		want string
+	}{
+		{"positive gets an explicit +", 3640, "+3640 m/s"},
+		{"negative keeps its own sign", -12.34, "-12.34 m/s"},
+		{"exact zero reads +0.00", 0, "+0.00 m/s"},
+		{"a negative that snaps to zero still reads +0.00, not -0.00", -0.001, "+0.00 m/s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := SignedSpeed(c.mps); got != c.want {
+				t.Errorf("SignedSpeed(%v) = %q, want %q", c.mps, got, c.want)
 			}
 		})
 	}

--- a/internal/tui/readout/readout_test.go
+++ b/internal/tui/readout/readout_test.go
@@ -83,8 +83,8 @@ func TestCountdown(t *testing.T) {
 }
 
 // --- Distance: SI ladder, m / km / Mm / Gm / AU, 4 sig figs (meters
-// stay whole numbers — see notes). ADR decision 3, action-plan decisions
-// 3 and 4. ---
+// stay whole numbers, see notes below). ADR decision 3, action-plan
+// decisions 3 and 4. ---
 
 func TestDistance(t *testing.T) {
 	cases := []struct {
@@ -159,9 +159,13 @@ func TestThrust(t *testing.T) {
 }
 
 // --- Speed / DeltaV: off-ladder, 4 sig figs capped at 2 decimals, always
-// m/s. ADR decision 4, action-plan decision 12. The 40.0 vs 40.00 case is
-// flagged ambiguity #1: we implement the stated rule, not the ADR's own
-// example. ---
+// m/s. ADR decision 4, action-plan decision 12. Speed uses the rule at
+// every magnitude, including the 40.00 m/s case (adjudicated at the gate
+// review: the ADR's own 22.50/28.60 examples are 2-decimal at two
+// integer digits, so its lone "40.0 m/s" is a pre-contract transcription,
+// not a contract output). DeltaV instead goes integer at |v| >= 100
+// (also adjudicated at the gate review), so the two deliberately diverge
+// in the 100-999.9 m/s band. ---
 
 func TestSpeed(t *testing.T) {
 	cases := []struct {
@@ -170,9 +174,9 @@ func TestSpeed(t *testing.T) {
 		want string
 	}{
 		{"contract example, integer at 4 digits", 5519, "5519 m/s"},
-		{"AMBIGUITY 1: rule gives 40.00, ADR's own example prints 40.0", 40.0, "40.00 m/s"},
+		{"the 4-sig-fig rule at every magnitude, including 40", 40.0, "40.00 m/s"},
 		{"contract example, 2 decimals below 1", 0.12, "0.12 m/s"},
-		{"AMBIGUITY 2 probe: rule gives 1 decimal in the 100s, not integer", 550, "550.0 m/s"},
+		{"stays decimal in the 100s, unlike DeltaV", 550, "550.0 m/s"},
 		{"negative speed rounds toward zero sign correctly", -0.001, "0.00 m/s"},
 	}
 	for _, c := range cases {
@@ -190,8 +194,12 @@ func TestDeltaV(t *testing.T) {
 		mps  float64
 		want string
 	}{
-		{"contract example below 100, 2 decimals", 22.5, "22.50 m/s"},
 		{"large budget, integer", 5519, "5519 m/s"},
+		{"integer in the 100s, unlike Speed", 550, "550 m/s"},
+		{"just below the integer crossing, 2 decimals", 99.9, "99.90 m/s"},
+		{"at the integer crossing", 100, "100 m/s"},
+		{"contract example below 100, 2 decimals", 22.5, "22.50 m/s"},
+		{"contract example well below 100", 0.12, "0.12 m/s"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -203,8 +211,20 @@ func TestDeltaV(t *testing.T) {
 }
 
 func TestDeltaVPair(t *testing.T) {
-	if got := DeltaVPair(3518, 9412); got != "3518 / 9412 m/s" {
-		t.Errorf("DeltaVPair(3518, 9412) = %q, want %q", got, "3518 / 9412 m/s")
+	cases := []struct {
+		name           string
+		stage, vehicle float64
+		want           string
+	}{
+		{"contract example, both in the integer band", 3518, 9412, "3518 / 9412 m/s"},
+		{"stage below 100, vehicle above", 45.5, 3200, "45.50 / 3200 m/s"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := DeltaVPair(c.stage, c.vehicle); got != c.want {
+				t.Errorf("DeltaVPair(%v, %v) = %q, want %q", c.stage, c.vehicle, got, c.want)
+			}
+		})
 	}
 }
 
@@ -231,9 +251,13 @@ func TestAngle(t *testing.T) {
 	}
 }
 
-// --- SteeringAngle / Heading: integer steering angles. ADR decision 4. ---
+// --- TrimAngle / FPA / Heading: integer steering angles. ADR decision 4.
+// Split at the gate review after checking the current renderers: pitch
+// trim (orbit_chip_builders.go:1392) is "%+.1f°" today, explicit sign;
+// fpa (orbit_chip_builders.go:1398, :1555; launch.go:1173) is "%.0f°",
+// no plus. TrimAngle keeps the explicit sign, FPA does not. ---
 
-func TestSteeringAngle(t *testing.T) {
+func TestTrimAngle(t *testing.T) {
 	cases := []struct {
 		name string
 		deg  float64
@@ -246,8 +270,27 @@ func TestSteeringAngle(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := SteeringAngle(c.deg); got != c.want {
-				t.Errorf("SteeringAngle(%v) = %q, want %q", c.deg, got, c.want)
+			if got := TrimAngle(c.deg); got != c.want {
+				t.Errorf("TrimAngle(%v) = %q, want %q", c.deg, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFPA(t *testing.T) {
+	cases := []struct {
+		name string
+		deg  float64
+		want string
+	}{
+		{"positive fpa, no plus sign (unlike TrimAngle)", 45, "45°"},
+		{"contract example, negative", -10, "-10°"},
+		{"zero, no plus sign", 0, "0°"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FPA(c.deg); got != c.want {
+				t.Errorf("FPA(%v) = %q, want %q", c.deg, got, c.want)
 			}
 		})
 	}

--- a/internal/tui/readout/readout_test.go
+++ b/internal/tui/readout/readout_test.go
@@ -99,7 +99,12 @@ func TestDistance(t *testing.T) {
 		{"1000 m crosses into km", 1000, "1.000 km"},
 		{"km rung, 1 decimal (contract example)", 500000, "500.0 km"},
 		{"km rung another contract example", 438900, "438.9 km"},
-		{"just under the km->Mm rollover, no bump", 999940, "999.9 km"},
+		// Pre-extension this sat just under the old km->Mm rollover at
+		// 1000 km; the extended km rung below now runs to 9999 km, so
+		// this is nowhere near a boundary any more, kept as a plain
+		// 4-sig-fig rounding check (999.94 rounds down to 999.9, not up
+		// to a false 1000.0).
+		{"km rung, 4 sig figs rounds down (no false rollover)", 999940, "999.9 km"},
 
 		// Extended km rung (gate review addendum, maintainer overrule of
 		// the original F1-adjacent ruling): decision 3's own worked

--- a/internal/tui/readout/readout_test.go
+++ b/internal/tui/readout/readout_test.go
@@ -1,6 +1,7 @@
 package readout
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -95,16 +96,38 @@ func TestDistance(t *testing.T) {
 		{"zero", 0, "0 m"},
 		{"sub-1km stays in meters, whole number", 912, "912 m"},
 		{"pad altitude zero", 0, "0 m"},
+		{"1000 m crosses into km", 1000, "1.000 km"},
 		{"km rung, 1 decimal (contract example)", 500000, "500.0 km"},
 		{"km rung another contract example", 438900, "438.9 km"},
 		{"just under the km->Mm rollover, no bump", 999940, "999.9 km"},
-		{"999,950 m rounds up across the rung into Mm", 999950, "1.000 Mm"},
+
+		// Extended km rung (gate review addendum, maintainer overrule of
+		// the original F1-adjacent ruling): decision 3's own worked
+		// examples only ALL hold at once if km runs a full extra decade,
+		// to 9999 km, before promoting to Mm. `2590 km` is decision 3's
+		// own example, verbatim. The Mm rung's own bottom is therefore
+		// 10 Mm, not 1 Mm: a value never renders as "5.000 Mm" because km
+		// already covers everything below 10 Mm. Deliberate, not a gap.
+		{"decision 3's own example, verbatim: 4 digits stay in km", 2590000, "2590 km"},
+		{"4-digit km reading, no promotion (was the old bug's own case)", 1200000, "1200 km"},
+		{"at the new boundary: 9999 km is the last value that stays km", 9999000, "9999 km"},
+		{"just past 9999 km rounds up and must still promote to Mm", 9999600, "10.00 Mm"},
+		{"exactly 10 Mm: the Mm rung's own bottom, km covers everything below it", 1e7, "10.00 Mm"},
 		{"Mm rung, 2 decimals (Ap contract example)", 35790000, "35.79 Mm"},
+		{"decision 3's own Mm example, verbatim", 10660000, "10.66 Mm"},
 		{"just below the 0.1 AU threshold stays Gm", bodies.AU/10 - 1, "14.96 Gm"},
 		{"at the 0.1 AU threshold switches to AU", bodies.AU / 10, "0.100 AU"},
 		{"well above threshold, AU rung 3 decimals", bodies.AU * 8.727, "8.727 AU"},
 		{"negative distance keeps signed depth (sub-surface Pe)", -120000, "-120.0 km"},
 		{"negative meters", -0.4, "0 m"}, // sub-metre noise nzero-snaps to +0
+
+		// F1 (gate review, item4-A-review.md): the decimal count must come
+		// from the ROUNDED value, not the pre-rounding one, or an
+		// intra-rung decade crossing prints one significant figure too
+		// many (9.9996 rounding to "10.000 km" instead of "10.00 km").
+		{"F1: one integer digit rounds up to two, decimals must drop 3->2", 9999.6, "10.00 km"},
+		{"F1: two integer digits round up to three, decimals must drop 2->1", 99996, "100.0 km"},
+		{"F1: same crossing one rung up (Mm), now past the extended km boundary", 99.996e6, "100.0 Mm"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -128,6 +151,7 @@ func TestMass(t *testing.T) {
 		{"contract example, 4 digits", 2160000, "2160 t"},
 		{"contract example, 2 decimals", 12950, "12.95 t"},
 		{"contract example, another 4-digit reading", 2928000, "2928 t"},
+		{"F1: rounds up across the top rung, no rung to promote into", 999999, "1000 t"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -148,6 +172,7 @@ func TestThrust(t *testing.T) {
 	}{
 		{"contract example", 1023000, "1023 kN"},
 		{"small thrust still kN", 500, "0.500 kN"},
+		{"F1: rounds up a decade, decimals must drop", 999960, "1000 kN"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -170,6 +195,7 @@ func TestPressure(t *testing.T) {
 		{"zero on the pad", 0, "0.000 kPa"},
 		{"typical max-Q figure", 23100, "23.10 kPa"},
 		{"four-digit kPa", 1023000, "1023 kPa"},
+		{"F1: rounds up a decade, decimals must drop", 999960, "1000 kPa"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -200,6 +226,8 @@ func TestSpeed(t *testing.T) {
 		{"contract example, 2 decimals below 1", 0.12, "0.12 m/s"},
 		{"stays decimal in the 100s, unlike DeltaV", 550, "550.0 m/s"},
 		{"negative speed rounds toward zero sign correctly", -0.001, "0.00 m/s"},
+		{"F1: two integer digits round up to three, decimals must drop", 99.996, "100.0 m/s"},
+		{"F1: three integer digits round up to four, decimals must drop", 999.96, "1000 m/s"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -246,6 +274,7 @@ func TestDeltaV(t *testing.T) {
 		{"at the integer crossing", 100, "100 m/s"},
 		{"contract example below 100, 2 decimals", 22.5, "22.50 m/s"},
 		{"contract example well below 100", 0.12, "0.12 m/s"},
+		{"F1: rounds up across DeltaV's own 100 m/s integer threshold", 99.996, "100 m/s"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -287,6 +316,7 @@ func TestAngle(t *testing.T) {
 		{"contract example, zero", 0, "0.00°"},
 		{"contract example, delta-incl", 31.2, "31.20°"},
 		{"negative zero snaps positive", -0.001, "0.00°"},
+		{"F1: two integer digits round up to three, decimals must drop", 99.996, "100.0°"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -378,6 +408,12 @@ func TestNzero(t *testing.T) {
 		{"exact zero stays zero", 0, 2, 0},
 		{"value that rounds to zero at 0 decimals", -0.4, 0, 0},
 		{"value that does not round to zero", -0.6, 0, -0.6},
+		// F2 (gate review): math.Round always rounds an exact tie away
+		// from zero, but fmt's own %.*f rounds ties to even, so at
+		// exactly -0.5 the two disagreed and Nzero let the value through
+		// unsnapped, which fmt then printed as "-0" anyway.
+		{"F2: exact tie at -0.5 must snap (fmt rounds it to even, -0)", -0.5, 0, 0},
+		{"F2: exact tie at -2.5 must NOT snap (fmt rounds it to -2, non-zero)", -2.5, 0, -2.5},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -385,5 +421,69 @@ func TestNzero(t *testing.T) {
 				t.Errorf("Nzero(%v, %d) = %v, want %v", c.x, c.decimals, got, c.want)
 			}
 		})
+	}
+}
+
+// TestDistanceF2ExactTieDoesNotLeakNegativeZero pins the end-to-end
+// symptom the gate review demonstrated: Distance(-0.5) used to print
+// "-0 m" (Nzero didn't snap it, then fmt's own tie-to-even rounding
+// produced the "-0" the whole Nzero mechanism exists to prevent).
+func TestDistanceF2ExactTieDoesNotLeakNegativeZero(t *testing.T) {
+	if got := Distance(-0.5); got != "0 m" {
+		t.Errorf("Distance(-0.5) = %q, want \"0 m\" (no negative-zero leak)", got)
+	}
+}
+
+// TestFormattersAreTotalOverInfAndNaN pins F8 (gate review, item4-A-review.md):
+// intDigits divided by ten until the value dropped below ten, and ±Inf
+// never does, so Distance/Speed/Angle/Mass/Thrust all hung forever on an
+// infinite input before this fix. A hang inside a Bubble Tea View() call
+// freezes the whole TUI with no panic and no log line — worse than any
+// wrong string this package could print. "Not reachable from a checked
+// call site today" is a property of the call sites, not of the package,
+// which is the one choke point every future flight readout routes
+// through, so a formatter must be total over its input type.
+//
+// Each case runs the call on its own goroutine behind a timeout rather
+// than just asserting the returned string, so a regression that
+// reintroduces the loop fails as a timeout, not as a suite that never
+// finishes (which would look like an unrelated CI hang, not a pinned
+// test failure).
+func TestFormattersAreTotalOverInfAndNaN(t *testing.T) {
+	inputs := []struct {
+		name string
+		v    float64
+	}{
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+		{"NaN", math.NaN()},
+	}
+	formatters := []struct {
+		name string
+		fn   func(float64) string
+	}{
+		{"Distance", Distance},
+		{"Speed", Speed},
+		{"Angle", Angle},
+		{"Mass", Mass},
+		{"Thrust", Thrust},
+		{"Pressure", Pressure},
+		{"DeltaV", DeltaV},
+	}
+	for _, f := range formatters {
+		for _, in := range inputs {
+			t.Run(f.name+"/"+in.name, func(t *testing.T) {
+				done := make(chan string, 1)
+				go func() { done <- f.fn(in.v) }()
+				select {
+				case got := <-done:
+					if got == "" {
+						t.Errorf("%s(%s) returned an empty string", f.name, in.name)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("%s(%s) did not return within 2s: intDigits likely regressed to an unbounded loop", f.name, in.name)
+				}
+			})
+		}
 	}
 }

--- a/internal/tui/screens/auto_warp_titlebar_test.go
+++ b/internal/tui/screens/auto_warp_titlebar_test.go
@@ -113,21 +113,7 @@ func TestTitleChipMorphsToAutoWhenEngaged(t *testing.T) {
 	}
 }
 
-// TestCompactDuration — two-unit, prefix-free formatting for the chip.
-func TestCompactDuration(t *testing.T) {
-	cases := []struct {
-		d    time.Duration
-		want string
-	}{
-		{50 * time.Second, "50s"},
-		{5*time.Minute + 30*time.Second, "5m30s"},
-		{3*time.Hour + 12*time.Minute, "3h12m"},
-		{2*24*time.Hour + 4*time.Hour, "2d4h"},
-		{-time.Second, "0s"},
-	}
-	for _, c := range cases {
-		if got := compactDuration(c.d); got != c.want {
-			t.Errorf("compactDuration(%v) = %q, want %q", c.d, got, c.want)
-		}
-	}
-}
+// The two-unit, prefix-free duration formatting this used to pin
+// (TestCompactDuration, pre-ADR-0049) now lives on internal/tui/readout's
+// own TestDuration: compactDuration is deleted, every screens/ call site
+// routes through readout.Duration instead (ADR 0049 stage A2).

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -38,9 +38,11 @@ type helpSection struct {
 // Section ORDER (grilled 2026-09-04, #425): GENERAL, PAUSE MENU,
 // CAMERA & VIEW, TIME & WARP, MANUAL FLIGHT, NAVIGATION, PLAN BURNS,
 // MEETING PLANNER, VESSEL, VEHICLE ASSEMBLY (VAB), SAVES, MULTIPLAYER,
-// MOUSE — puts "how do I fly" (camera, warp, manual flight) right after
-// GENERAL / PAUSE MENU instead of six PgDn presses down behind SAVES and
-// the 13-row MULTIPLAYER section (issue #425 evidence).
+// MOUSE, READOUT GLOSSARY — puts "how do I fly" (camera, warp, manual
+// flight) right after GENERAL / PAUSE MENU instead of six PgDn presses
+// down behind SAVES and the 13-row MULTIPLAYER section (issue #425
+// evidence). READOUT GLOSSARY sits last: a lookup appendix for the codes
+// on the HUD, not a "how do I fly" section (ADR 0049 stage A3a).
 var helpSections = []helpSection{
 	{"GENERAL", [][2]string{
 		{"F1 / ?", "toggle this help"},
@@ -185,6 +187,19 @@ var helpSections = []helpSection{
 		{"click empty", "open the planner at the projected orbit point"},
 		{"click HUD", "open body info"},
 		{"[»Burn]", "toggle auto-warp to the next burn (same as G, inert during a rendezvous coast); [■Burn] while running, dimmed when none planned"},
+	}},
+	// ADR 0049 (Readout Contract) decision 6: labels are one short word,
+	// but six codes survive on the HUD, so each gets a line here rather
+	// than being spelled out on every chip. Order matches the ADR and
+	// CONTEXT.md's Readout Contract entry.
+	{"READOUT GLOSSARY", [][2]string{
+		{"fpa", "flight path angle: velocity above / below the local horizontal"},
+		{"Q", "dynamic pressure: aerodynamic stress on the airframe, in kPa"},
+		{"TCA", "time of closest approach, in a rendezvous or flyby"},
+		{"TWR", "thrust to weight ratio: engines' thrust over vessel weight"},
+		{"Ap / Pe", "apoapsis / periapsis: already height above the surface, so there's no separate alt row anywhere"},
+		{"Δv / Δincl", "delta-v / relative inclination to a target's orbital plane"},
+		{"T- / T+", "countdown convention: T- counts down to an event, T+ counts up since it"},
 	}},
 }
 

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -38,7 +38,7 @@ type helpSection struct {
 // Section ORDER (grilled 2026-09-04, #425): GENERAL, PAUSE MENU,
 // CAMERA & VIEW, TIME & WARP, MANUAL FLIGHT, NAVIGATION, PLAN BURNS,
 // MEETING PLANNER, VESSEL, VEHICLE ASSEMBLY (VAB), SAVES, MULTIPLAYER,
-// MOUSE, READOUT GLOSSARY — puts "how do I fly" (camera, warp, manual
+// MOUSE, READOUT GLOSSARY: puts "how do I fly" (camera, warp, manual
 // flight) right after GENERAL / PAUSE MENU instead of six PgDn presses
 // down behind SAVES and the 13-row MULTIPLAYER section (issue #425
 // evidence). READOUT GLOSSARY sits last: a lookup appendix for the codes
@@ -197,7 +197,7 @@ var helpSections = []helpSection{
 		{"Q", "dynamic pressure: aerodynamic stress on the airframe, in kPa"},
 		{"TCA", "time of closest approach, in a rendezvous or flyby"},
 		{"TWR", "thrust to weight ratio: engines' thrust over vessel weight"},
-		{"Ap / Pe", "apoapsis / periapsis: already height above the surface, so there's no separate alt row anywhere"},
+		{"Ap / Pe", "apoapsis / periapsis: height above the surface, like every altitude in the game"},
 		{"Δv / Δincl", "delta-v / relative inclination to a target's orbital plane"},
 		{"T- / T+", "countdown convention: T- counts down to an event, T+ counts up since it"},
 	}},

--- a/internal/tui/screens/help_rows_test.go
+++ b/internal/tui/screens/help_rows_test.go
@@ -99,6 +99,7 @@ func TestHelpSectionOrder(t *testing.T) {
 		"SAVES (menu → Save / Load Game)",
 		"MULTIPLAYER (session screen — open with O)",
 		"MOUSE",
+		"READOUT GLOSSARY",
 	}
 	var got []string
 	for _, s := range helpSections {
@@ -112,4 +113,46 @@ func TestHelpSectionOrder(t *testing.T) {
 			t.Errorf("section %d: got %q, want %q\nfull order: %v", i, got[i], want[i], got)
 		}
 	}
+}
+
+// TestHelpGlossaryBlockContent (ADR 0049 stage A3a): the six codes that
+// survive the readout contract each get a one-line explanation, plus the
+// two facts the contract otherwise strips off every panel: apsides are
+// already height above the surface, and countdowns read T- until an
+// event, T+ since it.
+func TestHelpGlossaryBlockContent(t *testing.T) {
+	cases := []struct {
+		token, want string
+	}{
+		{"fpa", "flight path angle"},
+		{"Q", "dynamic pressure"},
+		{"TCA", "closest approach"},
+		{"TWR", "thrust to weight"},
+		{"Ap / Pe", "height above the surface"},
+		{"Δv / Δincl", "delta-v"},
+		{"Δv / Δincl", "relative inclination"},
+		{"T- / T+", "T- counts down"},
+		{"T- / T+", "T+ counts up"},
+	}
+	for _, c := range cases {
+		_, desc := helpRow(t, c.token)
+		if !strings.Contains(strings.ToLower(desc), strings.ToLower(c.want)) {
+			t.Errorf("glossary row %q = %q, want it to mention %q", c.token, desc, c.want)
+		}
+	}
+}
+
+// TestHelpGlossarySection (ADR 0049 stage A3a): the glossary rows live
+// together under their own header, not scattered across other sections.
+func TestHelpGlossarySection(t *testing.T) {
+	for _, s := range helpSections {
+		if s.header != "READOUT GLOSSARY" {
+			continue
+		}
+		if len(s.rows) < 7 {
+			t.Errorf("READOUT GLOSSARY has %d rows, want at least 7 (six codes + T-/T+)", len(s.rows))
+		}
+		return
+	}
+	t.Fatal("no READOUT GLOSSARY section in helpSections")
 }

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -35,7 +35,7 @@ type LaunchView struct {
 	hudSource *OrbitView // reused for the side-HUD chrome (v0.11.0+)
 
 	// lastVZSample caches the previous tick's altitude + sim-time so
-	// the HUD can compute v_z (m/s) as a finite difference rather than
+	// the HUD can compute vert (m/s) as a finite difference rather than
 	// requiring a sim-side velocity decomposition. Re-keyed on active-
 	// craft change so a vessel switch can't bleed a stale baseline.
 	vzCraft *spacecraft.Spacecraft
@@ -160,24 +160,31 @@ func launchAutoScale(altitudeM float64, rows int) float64 {
 // formatLaunchHUD renders the v0.11 Slice 1 launch-readout strip
 // overlaid on the chase-cam canvas's bottom braille row. Format:
 //
-//	T+ HH:MM:SS  v_z ±XXX m/s | downrange X.X km  Q XX.X kPa (max YY.Y)
+//	T+4m19s  vert 12.30 m/s | downrange 15.40 km  Q: 18.30 kPa (max 24.50 kPa)
+//
+// tPlus is elapsed time since THIS ascent's liftoff (w.LaunchT0), a
+// distinct clock from the title-bar mission stopwatch (which counts
+// sim-time since the whole flight began), not the same readout twice.
+// Decision 1's "only clock-style readout" carve-out is that stopwatch's
+// HH:MM:SS clock face specifically; every other elapsed reading,
+// including this one, uses the standard two-unit Duration form instead
+// of a second clock face. The sign is still "T+" (decision 2: T+ means
+// since the event) because liftoff has already happened by the time this
+// line renders at all.
 //
 // Inputs in SI units: vZ m/s, downrangeM m, q / qMaxPa Pa.
 func formatLaunchHUD(tPlus time.Duration, vZ, downrangeM, qPa, qMaxPa float64) string {
-	secs := int(tPlus.Seconds())
-	if secs < 0 {
-		secs = 0
+	if tPlus < 0 {
+		tPlus = 0
 	}
-	h := secs / 3600
-	m := (secs / 60) % 60
-	s := secs % 60
 	return fmt.Sprintf(
-		"T+ %02d:%02d:%02d  v_z %+d m/s | downrange %.1f km  Q %.1f kPa (max %.1f)",
-		h, m, s,
-		int(vZ),
-		downrangeM/1000.0,
-		qPa/1000.0,
-		qMaxPa/1000.0,
+		"T+%s  vert %s | downrange %s  %s %s (max %s)",
+		readout.Duration(tPlus),
+		readout.Speed(vZ),
+		readout.Distance(downrangeM),
+		readout.LabelQ,
+		readout.Pressure(qPa),
+		readout.Pressure(qMaxPa),
 	)
 }
 
@@ -1368,9 +1375,9 @@ func (v *LaunchView) ascentQBandLines(qb sim.AscentQBand) []string {
 			lines = append(lines, "  "+ascentQBandTickGlyph)
 		}
 	}
-	lines = append(lines, fmt.Sprintf("  Q:     %.1f kPa", qb.CurrentQPa/1000))
+	lines = append(lines, fmt.Sprintf("  %s     %s", readout.LabelQ, readout.Pressure(qb.CurrentQPa)))
 	if qb.HasMaxQ {
-		lines = append(lines, fmt.Sprintf("  max Q: %.1f kPa", qb.MaxQPa/1000))
+		lines = append(lines, fmt.Sprintf("  max %s %s", readout.LabelQ, readout.Pressure(qb.MaxQPa)))
 	}
 	return lines
 }
@@ -1599,7 +1606,7 @@ func (v *LaunchView) composeHUDLine(w *sim.World, c *spacecraft.Spacecraft) stri
 	// #427 / ADR 0048 §3: the pad's call to action. Landed with the
 	// engine off is exactly the silent state the review found — no
 	// ignite prompt, no mention of `b`, no countdown, no throttle cue
-	// anywhere. Replaces the T+/v_z/downrange/Q line rather than sitting
+	// anywhere. Replaces the T+/vert/downrange/Q line rather than sitting
 	// beside it: pre-ignition every one of those numbers reads a flat
 	// zero (TestFormatLaunchHUDPadIdle), so the line was noise standing
 	// in the way of the one thing that actually matters here. The

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
@@ -331,7 +332,7 @@ func (v *LaunchView) Render(w *sim.World, totalCols, totalRows int) string {
 		// DESCENT and DESCENT CORRIDOR both answer "how is this landing
 		// going", and while the corridor is live they were both on screen
 		// — opposite corners, same altitude to two decimals, and the
-		// descent rate stated twice with opposite signs (`v_vert: -40.0
+		// descent rate stated twice with opposite signs (`vert: -40.0
 		// m/s` against `descent: 40 m/s`). The corridor is the better
 		// block (it forecasts the ground contact and says whether the stop
 		// is still flyable), so it wins and DESCENT stands down here. Its
@@ -846,7 +847,7 @@ func chaseHorizontalAxis(c *spacecraft.Spacecraft, body bodies.CelestialBody, ca
 // last velocity-derived axis instead of recomputing a fallback from
 // scratch every frame (issue #380 review of #378).
 //
-// Why this matters: the axis is stateless-by-velocity, so |v_horiz|
+// Why this matters: the axis is stateless-by-velocity, so horizontal speed
 // crosses chaseHorizSpeedFloorMps exactly when a pilot deliberately
 // nulls horizontal speed for touchdown — the moment it costs the most
 // to get wrong. Recomputing surface-frame east at that crossing snaps
@@ -1133,7 +1134,7 @@ func (v *LaunchView) drawDescentArc(bodyCentre, camFromBody orbital.Vec3, dc sim
 }
 
 // descentCorridorLines renders the DESCENT CORRIDOR instrument block:
-// altitude, descent rate, v_horiz, fpa (the two velocity-shape readings
+// altitude, descent rate, horiz, fpa (the two velocity-shape readings
 // folded in from the DESCENT chip this block replaces on this screen —
 // see the dropChip call in Render), time to impact, then the two #377
 // decision rows below them — `burn at` (while a future start is safe and
@@ -1163,14 +1164,14 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 	// standing warning, not a lesson, and survives on its own — this repo
 	// has a hard-won rule that transient feedback must not replace a
 	// standing warning.
-	horizLabel := fmt.Sprintf("%.0f m/s", dc.HorizontalRateMps)
+	horizLabel := readout.Speed(dc.HorizontalRateMps)
 	if dc.HorizontalRateMps > sim.CrashVCritMps {
 		horizLabel = v.theme.Alert.Render(
-			fmt.Sprintf("%.0f m/s (CRASH on contact)", dc.HorizontalRateMps))
+			fmt.Sprintf("%s (CRASH on contact)", readout.Speed(dc.HorizontalRateMps)))
 	}
 	fpaLabel := "—"
 	if dc.HasFPA {
-		fpaLabel = fmt.Sprintf("%.0f°", nzero(dc.FlightPathAngleDeg, 0))
+		fpaLabel = readout.FPA(dc.FlightPathAngleDeg)
 	}
 	// Every row's label + colon + padding occupies EXACTLY 15 cells
 	// before the value starts, so the values line up in one column
@@ -1184,16 +1185,16 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 	// never %-Ns (ANSI bytes in a themed value would break that padding).
 	lines := []string{
 		v.theme.Primary.Render("DESCENT CORRIDOR"),
-		fmt.Sprintf("  altitude:    %s", formatAltitude(dc.AltitudeM)),
-		fmt.Sprintf("  descent:     %.0f m/s", dc.DescentRateMps),
-		fmt.Sprintf("  v_horiz:     %s", horizLabel),
-		fmt.Sprintf("  fpa:         %s", fpaLabel),
-		fmt.Sprintf("  impact in:   %s (%.0f m/s)",
-			compactDuration(dc.Impact.TimeToImpact), dc.Impact.SpeedMps),
+		fmt.Sprintf("  altitude:    %s", readout.Distance(dc.AltitudeM)),
+		fmt.Sprintf("  descent:     %s", readout.Speed(dc.DescentRateMps)),
+		fmt.Sprintf("  %s       %s", readout.LabelHoriz, horizLabel),
+		fmt.Sprintf("  %s         %s", readout.LabelFPA, fpaLabel),
+		fmt.Sprintf("  %s      %s (%s)", readout.LabelImpact,
+			readout.Countdown(dc.Impact.TimeToImpact), readout.Speed(dc.Impact.SpeedMps)),
 	}
 	if dc.HasBurnAt {
-		lines = append(lines, fmt.Sprintf("  burn at:     %s — in %s",
-			formatAltitude(dc.BurnAt.AltitudeM), compactDuration(secondsToDuration(dc.BurnAt.InSec))))
+		lines = append(lines, fmt.Sprintf("  burn at:     %s (in %s)",
+			readout.Distance(dc.BurnAt.AltitudeM), readout.Duration(secondsToDuration(dc.BurnAt.InSec))))
 	}
 	lines = append(lines, fmt.Sprintf("  stop margin: %s", v.stopMarginLabel(dc)))
 	return lines
@@ -1202,7 +1203,7 @@ func (v *LaunchView) descentCorridorLines(dc sim.DescentCorridor) []string {
 // secondsToDuration converts a float64 seconds reading (sim.BurnAtCue /
 // sim.PoweredStopPrediction both use float64 seconds, not time.Duration,
 // since they're arithmetic results from an integration loop) into a
-// time.Duration for compactDuration.
+// time.Duration for the readout package's duration formatters.
 func secondsToDuration(s float64) time.Duration {
 	if s < 0 {
 		s = 0
@@ -1231,29 +1232,19 @@ func (v *LaunchView) stopMarginLabel(dc sim.DescentCorridor) string {
 	}
 	switch dc.Stop.Outcome {
 	case sim.StopStopped:
-		label := fmt.Sprintf("%s up", formatAltitude(dc.Stop.MarginM))
+		label := fmt.Sprintf("%s up", readout.Distance(dc.Stop.MarginM))
 		if dc.Margin.State == sim.MarginTight {
 			return v.theme.Warning.Render(label + " TIGHT")
 		}
 		return v.theme.Primary.Render(label)
 	case sim.StopCrashed:
-		return v.theme.Alert.Render(fmt.Sprintf("short by %s (impact %.0f m/s) CAN'T STOP (%s)",
-			formatAltitude(-dc.Stop.MarginM), dc.Stop.ImpactSpeedMps, dc.Margin.Limiter))
+		return v.theme.Alert.Render(fmt.Sprintf("short by %s (impact %s) CAN'T STOP (%s)",
+			readout.Distance(-dc.Stop.MarginM), readout.Speed(dc.Stop.ImpactSpeedMps), dc.Margin.Limiter))
 	case sim.StopFuelLimited:
 		return v.theme.Alert.Render(fmt.Sprintf("fuel-limited at %s CAN'T STOP (%s)",
-			formatAltitude(dc.Stop.MarginM), dc.Margin.Limiter))
+			readout.Distance(dc.Stop.MarginM), dc.Margin.Limiter))
 	}
 	return v.theme.Dim.Render("—")
-}
-
-// formatAltitude renders metres as m below 1 km and km above, matching
-// the DESCENT chip's existing altitude row so the two readouts agree
-// digit for digit when both are on screen.
-func formatAltitude(m float64) string {
-	if m >= 1000 {
-		return fmt.Sprintf("%.2f km", m/1000)
-	}
-	return fmt.Sprintf("%.0f m", m)
 }
 
 // drawAscentArc inks the predicted path ahead of a climbing vessel (ADR
@@ -1368,11 +1359,11 @@ func (v *LaunchView) ascentQBandLines(qb sim.AscentQBand) []string {
 	for i := 0; i < ascentQBandRows; i++ {
 		switch {
 		case i == curRow && i == maxRow:
-			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandCraftGlyph, formatAltitude(qb.CurrentAltM)))
+			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandCraftGlyph, readout.Distance(qb.CurrentAltM)))
 		case i == curRow:
-			lines = append(lines, fmt.Sprintf("  %s %s", ascentQBandCraftGlyph, formatAltitude(qb.CurrentAltM)))
+			lines = append(lines, fmt.Sprintf("  %s %s", ascentQBandCraftGlyph, readout.Distance(qb.CurrentAltM)))
 		case i == maxRow:
-			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandMaxQGlyph, formatAltitude(qb.MaxQAltM)))
+			lines = append(lines, fmt.Sprintf("  %s %s (max Q)", ascentQBandMaxQGlyph, readout.Distance(qb.MaxQAltM)))
 		default:
 			lines = append(lines, "  "+ascentQBandTickGlyph)
 		}
@@ -1677,7 +1668,7 @@ func greatCircleDistanceM(body bodies.CelestialBody, lat0Deg, lon0Deg float64, c
 	return body.RadiusMeters() * c2
 }
 
-// dynamicPressurePa returns 0.5·ρ·|v_rel|² for the active craft using
+// dynamicPressurePa returns 0.5·ρ·rel speed squared for the active craft using
 // the body's atmosphere and the craft's air-relative velocity (same
 // v_rel = v − ω × r the drag integrator uses, so a launchpad-co-
 // rotating craft reads Q = 0 not the inertial-speed phantom). Returns

--- a/internal/tui/screens/launch.go
+++ b/internal/tui/screens/launch.go
@@ -177,14 +177,34 @@ func formatLaunchHUD(tPlus time.Duration, vZ, downrangeM, qPa, qMaxPa float64) s
 	if tPlus < 0 {
 		tPlus = 0
 	}
+	// F9 (gate review addendum): decision 1 carves out "the title-bar
+	// mission stopwatch (T+ 00:00:02)" as the game's one clock-style
+	// readout, but no such title-bar stopwatch exists: the title bar
+	// prints a calendar date (orbit.go's clockChip), never HH:MM:SS.
+	// This launch strip was the only HH:MM:SS clock on main; the ADR
+	// named the right object and mislocated it. Removing this clock (as
+	// the first A2 pass did, reading "a distinct clock from the title-bar
+	// stopwatch" as license to drop it rather than to keep it) left the
+	// game with no clock-style readout at all, which decision 1
+	// explicitly did not want. Restored verbatim; every other field on
+	// this line stays on the two-unit/SI-ladder contract.
+	secs := int(tPlus.Seconds())
+	h := secs / 3600
+	m := (secs / 60) % 60
+	s := secs % 60
+	// F14 (gate review): colons throughout (vert:/downrange:, matching
+	// Q:'s own rename-table colon), and the "(max ...)" parenthetical
+	// drops its repeated unit per decision 6's own worked example
+	// ("Q: 0.0 kPa (max 0.0)", not "(max 0.0 kPa)").
+	qMaxNum, _, _ := strings.Cut(readout.Pressure(qMaxPa), " ")
 	return fmt.Sprintf(
-		"T+%s  vert %s | downrange %s  %s %s (max %s)",
-		readout.Duration(tPlus),
+		"T+ %02d:%02d:%02d  vert: %s | downrange: %s  %s %s (max %s)",
+		h, m, s,
 		readout.Speed(vZ),
 		readout.Distance(downrangeM),
 		readout.LabelQ,
 		readout.Pressure(qPa),
-		readout.Pressure(qMaxPa),
+		qMaxNum,
 	)
 }
 

--- a/internal/tui/screens/launch_ascent_test.go
+++ b/internal/tui/screens/launch_ascent_test.go
@@ -211,8 +211,8 @@ func TestAscentQBandLinesMarksCurrentAndMaxQ(t *testing.T) {
 		// 1234.5 Pa → 1.2 kPa
 		t.Errorf("Q row = %q, want the current Q value in kPa", got[len(got)-2])
 	}
-	if !strings.Contains(got[len(got)-1], "45.7") {
-		// 45678 Pa → 45.7 kPa
+	if !strings.Contains(got[len(got)-1], "45.68") {
+		// 45678 Pa → 45.68 kPa (readout.Pressure: 4 significant figures)
 		t.Errorf("max Q row = %q, want the max Q value in kPa", got[len(got)-1])
 	}
 }

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -385,8 +385,15 @@ func TestSurfaceViewShowsOneDescentBlock(t *testing.T) {
 	if n := strings.Count(out, "altitude:"); n != 1 {
 		t.Errorf("frame carries %d `altitude:` rows, want 1 — the two descent blocks are duplicating", n)
 	}
-	if n := strings.Count(out, "vert:"); n != 0 {
-		t.Errorf("frame still carries %d `vert:` rows: the DESCENT chip did not stand down", n)
+	// F9/F14 (gate review): the launch strip's own always-on bottom-row
+	// clock line legitimately carries one "vert:" reading of its own now
+	// (restored HH:MM:SS clock, colon added to match Q:'s), a third,
+	// distinct surface from the DESCENT chip / DESCENT CORRIDOR pair this
+	// test is actually about. Exactly 1 still catches the original bug
+	// (DESCENT failing to stand down would make it 2, one per corner
+	// chip, on top of the strip's own reading).
+	if n := strings.Count(out, "vert:"); n != 1 {
+		t.Errorf("frame carries %d `vert:` rows, want 1 (the launch strip's own): the DESCENT chip did not stand down", n)
 	}
 	// The rows worth keeping came along rather than being dropped —
 	// `fpa` included; it survived the #377 layout change (Jason's call).

--- a/internal/tui/screens/launch_descent_test.go
+++ b/internal/tui/screens/launch_descent_test.go
@@ -59,7 +59,7 @@ func descendingMoonCraft(t *testing.T, altM, vDownMps float64) *sim.World {
 
 // TestDescentCorridorLinesInstruments pins the row layout as exact
 // rendered rows, so a formatting change has to be deliberate: altitude,
-// descent rate, v_horiz, fpa, time to impact, `burn at`, and
+// descent rate, horiz, fpa, time to impact, `burn at`, and
 // `stop margin` — the 7-row block (Jason's call: `fpa` was folded out
 // once because issue #377's pinned mock only sketched the two new rows,
 // then restored — the mock wasn't an exhaustive spec of the whole
@@ -97,12 +97,12 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 	want := []string{
 		"DESCENT CORRIDOR",
 		"  altitude:    12.40 km",
-		"  descent:     182 m/s",
-		"  v_horiz:     4 m/s",
+		"  descent:     182.0 m/s",
+		"  horiz:       4.00 m/s",
 		"  fpa:         -88°",
-		"  impact in:   1m4s (240 m/s)",
-		"  burn at:     8.00 km — in 48s",
-		"  stop margin: 3.40 km up",
+		"  impact:      T-1m04s (240.0 m/s)",
+		"  burn at:     8.000 km (in 48s)",
+		"  stop margin: 3.400 km up",
 	}
 	got := v.descentCorridorLines(dc)
 	if len(got) != len(want) {
@@ -115,7 +115,7 @@ func TestDescentCorridorLinesInstruments(t *testing.T) {
 	}
 }
 
-// TestDescentCorridorHorizontalRateAlarm: the folded v_horiz row keeps
+// TestDescentCorridorHorizontalRateAlarm: the folded horiz row keeps
 // the DESCENT chip's own alarm — crossing the ground faster sideways than
 // V_CRIT wrecks the vessel however gently the vertical rate has been
 // nulled, and none of the corridor's other numbers say so.
@@ -212,7 +212,7 @@ func TestStopMarginLabelAlarmLadder(t *testing.T) {
 				Stop: sim.PoweredStopPrediction{Outcome: sim.StopCrashed, MarginM: -3_400, ImpactSpeedMps: 411}, StopOK: true,
 				Margin: sim.BurnMargin{State: sim.MarginInsufficient, Limiter: sim.LimitThrust},
 			},
-			"short by 3.40 km (impact 411 m/s) CAN'T STOP (thrust)",
+			"short by 3.400 km (impact 411.0 m/s) CAN'T STOP (thrust)",
 		},
 		{
 			"fuel-limited",
@@ -220,7 +220,7 @@ func TestStopMarginLabelAlarmLadder(t *testing.T) {
 				Stop: sim.PoweredStopPrediction{Outcome: sim.StopFuelLimited, MarginM: 5_000}, StopOK: true,
 				Margin: sim.BurnMargin{State: sim.MarginInsufficient, Limiter: sim.LimitFuel},
 			},
-			"fuel-limited at 5.00 km CAN'T STOP (fuel)",
+			"fuel-limited at 5.000 km CAN'T STOP (fuel)",
 		},
 		{
 			"undetermined (refused)",
@@ -324,7 +324,7 @@ func TestLaunchViewDescentInstrumentsAt80x24(t *testing.T) {
 	w := descendingMoonCraft(t, 20_000, 120)
 
 	out := v.Render(w, 80, 24)
-	for _, want := range []string{"DESCENT CORRIDOR", "altitude:", "descent:", "impact in:", "stop margin:"} {
+	for _, want := range []string{"DESCENT CORRIDOR", "altitude:", "descent:", "impact:", "stop margin:"} {
 		if !strings.Contains(stripANSI(out), want) {
 			t.Errorf("80×24 render is missing %q:\n%s", want, out)
 		}
@@ -385,12 +385,12 @@ func TestSurfaceViewShowsOneDescentBlock(t *testing.T) {
 	if n := strings.Count(out, "altitude:"); n != 1 {
 		t.Errorf("frame carries %d `altitude:` rows, want 1 — the two descent blocks are duplicating", n)
 	}
-	if n := strings.Count(out, "v_vert:"); n != 0 {
-		t.Errorf("frame still carries %d `v_vert:` rows — the DESCENT chip did not stand down", n)
+	if n := strings.Count(out, "vert:"); n != 0 {
+		t.Errorf("frame still carries %d `vert:` rows: the DESCENT chip did not stand down", n)
 	}
 	// The rows worth keeping came along rather than being dropped —
 	// `fpa` included; it survived the #377 layout change (Jason's call).
-	for _, row := range []string{"descent:", "v_horiz:", "fpa:", "impact in:", "stop margin:"} {
+	for _, row := range []string{"descent:", "horiz:", "fpa:", "impact:", "stop margin:"} {
 		if !strings.Contains(out, row) {
 			t.Errorf("corridor block is missing the %q row", row)
 		}
@@ -408,7 +408,7 @@ func TestOrbitMapKeepsItsDescentChip(t *testing.T) {
 	v.Resize(200, 60)
 	out := stripANSI(v.Render(w, 0, 200, 60))
 
-	if !strings.Contains(out, "v_vert:") {
+	if !strings.Contains(out, "vert:") {
 		t.Error("the orbit map lost its DESCENT chip — there is no corridor there to replace it")
 	}
 }

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -63,9 +63,12 @@ func spawnSaturnVOnPad(t *testing.T) (*sim.World, *spacecraft.Spacecraft) {
 }
 
 // formatLaunchHUD renders the LaunchView readout strip overlaid on
-// the bottom braille row of the chase-cam canvas. Format locked by
-// v0.11 Slice 1: `T+ HH:MM:SS  v_z ±XXX m/s | downrange X.X km
-// Q XX.X kPa (max YY.Y)`.
+// the bottom braille row of the chase-cam canvas. Format re-pinned for
+// ADR 0049 stage A2's gate-review follow-up: `vert`/`downrange`/`Q:`
+// route through internal/tui/readout like every other flight readout
+// (v_z was a third spelling of vert:'s own quantity; the elapsed T+
+// clock is now the standard two-unit Duration form, not a second
+// HH:MM:SS clock face beside the title bar's).
 func TestFormatLaunchHUDTracerBullet(t *testing.T) {
 	got := formatLaunchHUD(
 		2*time.Minute+34*time.Second,
@@ -74,27 +77,27 @@ func TestFormatLaunchHUDTracerBullet(t *testing.T) {
 		18_345.0,
 		24_500.0,
 	)
-	want := "T+ 00:02:34  v_z +120 m/s | downrange 15.4 km  Q 18.3 kPa (max 24.5)"
+	want := "T+2m34s  vert 120.0 m/s | downrange 15.40 km  Q: 18.34 kPa (max 24.50 kPa)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}
 }
 
-// At T+0 with the rocket still on the pad: T+ zeros, v_z reads 0,
+// At T+0 with the rocket still on the pad: T+ zeros, vert reads 0,
 // downrange/Q all zero.
 func TestFormatLaunchHUDPadIdle(t *testing.T) {
 	got := formatLaunchHUD(0, 0, 0, 0, 0)
-	want := "T+ 00:00:00  v_z +0 m/s | downrange 0.0 km  Q 0.0 kPa (max 0.0)"
+	want := "T+0s  vert 0.00 m/s | downrange 0 m  Q: 0.000 kPa (max 0.000 kPa)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}
 }
 
-// Negative v_z (apex passed, falling back) renders signed; T+ above
+// Negative vert (apex passed, falling back) renders signed; T+ above
 // the hour boundary rolls cleanly past HH.
 func TestFormatLaunchHUDDescentAcrossHourBoundary(t *testing.T) {
 	got := formatLaunchHUD(time.Hour+9*time.Minute+5*time.Second, -42.0, 300_000, 0, 500)
-	want := "T+ 01:09:05  v_z -42 m/s | downrange 300.0 km  Q 0.0 kPa (max 0.5)"
+	want := "T+1h09m  vert -42.00 m/s | downrange 300.0 km  Q: 0.000 kPa (max 0.500 kPa)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}
@@ -266,7 +269,7 @@ func TestLaunchViewTitleShowsBurnButton(t *testing.T) {
 
 // TestLaunchHUDLineShowsIgnitionHintOnPad — #427 / ADR 0048 §3: the pad's
 // call to action. While Landed with the engine off, the status-area line
-// (bottom border, normally T+/v_z/downrange/Q) becomes the ignite/stage/
+// (bottom border, normally T+/vert/downrange/Q) becomes the ignite/stage/
 // throttle hint instead — the review's own finding was that nothing on
 // screen told a first-time player to press `b`. The moment the engine
 // lights, the line reverts to real telemetry.
@@ -298,7 +301,7 @@ func TestLaunchHUDLineShowsIgnitionHintOnPad(t *testing.T) {
 		t.Errorf("composeHUDLine on the pad = %q, want it to contain %q", hud, want)
 	}
 	if strings.Contains(hud, "T+") {
-		t.Errorf("pad HUD line still showed the zeroed T+/v_z/downrange telemetry: %q", hud)
+		t.Errorf("pad HUD line still showed the zeroed T+/vert/downrange telemetry: %q", hud)
 	}
 
 	// Full Render must carry the hint too (through overlayHUDStrip).

--- a/internal/tui/screens/launch_test.go
+++ b/internal/tui/screens/launch_test.go
@@ -63,12 +63,25 @@ func spawnSaturnVOnPad(t *testing.T) (*sim.World, *spacecraft.Spacecraft) {
 }
 
 // formatLaunchHUD renders the LaunchView readout strip overlaid on
-// the bottom braille row of the chase-cam canvas. Format re-pinned for
-// ADR 0049 stage A2's gate-review follow-up: `vert`/`downrange`/`Q:`
-// route through internal/tui/readout like every other flight readout
-// (v_z was a third spelling of vert:'s own quantity; the elapsed T+
-// clock is now the standard two-unit Duration form, not a second
-// HH:MM:SS clock face beside the title bar's).
+// the bottom braille row of the chase-cam canvas. Format re-pinned twice
+// for ADR 0049 stage A2's gate-review follow-ups:
+//
+//   - F9 (second gate review): decision 1's "title-bar mission stopwatch
+//     (T+ 00:00:02)" carve-out names a stopwatch that does not exist on
+//     the title bar (it prints a calendar date); the launch strip was
+//     the only HH:MM:SS clock on main, so the ADR named the right object
+//     and mislocated it. The first A2 pass removed this clock reading
+//     that mislocation as license to drop it, leaving the game with NO
+//     clock-style readout, which decision 1 explicitly did not want.
+//     T+ HH:MM:SS is restored verbatim.
+//   - F14 (second gate review): vert/downrange gain the colon Q: already
+//     had (decision 6), and the "(max ...)" parenthetical drops its
+//     repeated unit per decision 6's own worked example
+//     ("Q: 0.0 kPa (max 0.0)", not "(max 0.0 kPa)").
+//
+// vert/downrange/Q: themselves still route through internal/tui/readout
+// like every other flight readout (v_z was a third spelling of vert:'s
+// own quantity).
 func TestFormatLaunchHUDTracerBullet(t *testing.T) {
 	got := formatLaunchHUD(
 		2*time.Minute+34*time.Second,
@@ -77,7 +90,7 @@ func TestFormatLaunchHUDTracerBullet(t *testing.T) {
 		18_345.0,
 		24_500.0,
 	)
-	want := "T+2m34s  vert 120.0 m/s | downrange 15.40 km  Q: 18.34 kPa (max 24.50 kPa)"
+	want := "T+ 00:02:34  vert: 120.0 m/s | downrange: 15.40 km  Q: 18.34 kPa (max 24.50)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}
@@ -87,7 +100,7 @@ func TestFormatLaunchHUDTracerBullet(t *testing.T) {
 // downrange/Q all zero.
 func TestFormatLaunchHUDPadIdle(t *testing.T) {
 	got := formatLaunchHUD(0, 0, 0, 0, 0)
-	want := "T+0s  vert 0.00 m/s | downrange 0 m  Q: 0.000 kPa (max 0.000 kPa)"
+	want := "T+ 00:00:00  vert: 0.00 m/s | downrange: 0 m  Q: 0.000 kPa (max 0.000)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}
@@ -97,7 +110,7 @@ func TestFormatLaunchHUDPadIdle(t *testing.T) {
 // the hour boundary rolls cleanly past HH.
 func TestFormatLaunchHUDDescentAcrossHourBoundary(t *testing.T) {
 	got := formatLaunchHUD(time.Hour+9*time.Minute+5*time.Second, -42.0, 300_000, 0, 500)
-	want := "T+1h09m  vert -42.00 m/s | downrange 300.0 km  Q: 0.000 kPa (max 0.500 kPa)"
+	want := "T+ 01:09:05  vert: -42.00 m/s | downrange: 300.0 km  Q: 0.000 kPa (max 0.500)"
 	if got != want {
 		t.Errorf("\n got: %q\nwant: %q", got, want)
 	}

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -953,7 +953,15 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		"  → " + burnDescr,
 		"",
 		budgetLine,
-		fmt.Sprintf("  thrust: %.0f N  Isp: %.0f s", c.Thrust, c.Isp),
+		// Isp is deliberately left as a bare "%.0f s": specific impulse
+		// is measured in seconds as its unit, not a duration readout, so
+		// the contract does not reach it (same reasoning as burnDescr's
+		// Isp above). Thrust routes through readout.Thrust (decision 3:
+		// "kN everywhere") — this row used to print raw Newtons
+		// ("1023000 N") a few lines below burnDescr's own correctly-
+		// converted "at 1023 kN", two dialects for the same c.Thrust
+		// value on one screen.
+		fmt.Sprintf("  thrust: %s  Isp: %.0f s", readout.Thrust(c.Thrust), c.Isp),
 	}
 
 	// PLANNED NODES (v0.10.1+; Plan Cursor since ADR 0047 / #428): list

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
@@ -848,7 +849,7 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 
 	warn := ""
 	if dv > budget {
-		warn = m.theme.Alert.Render(fmt.Sprintf(" [EXCEEDS BUDGET by %.0f m/s]", dv-budget))
+		warn = m.theme.Alert.Render(fmt.Sprintf(" [EXCEEDS BUDGET by %s]", readout.DeltaV(dv-budget)))
 	}
 
 	// Mode line — highlight if focused, otherwise dim.
@@ -869,7 +870,7 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 	fireAt := sim.AllTriggerEvents[m.fireAtIdx]
 	fireAtLabel := fireAt.String()
 	if !m.loadedTriggerTime.IsZero() {
-		countdown := formatCountdown(m.loadedTriggerTime.Sub(w.Clock.SimTime))
+		countdown := readout.Countdown(m.loadedTriggerTime.Sub(w.Clock.SimTime))
 		if fireAt == sim.TriggerAbsolute {
 			fireAtLabel = countdown
 		} else {
@@ -932,9 +933,9 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 	for _, n := range c.Nodes {
 		planTotal += n.DV
 	}
-	budgetLine := fmt.Sprintf("  Δv budget: %.0f m/s", budget)
+	budgetLine := fmt.Sprintf("  %s        %s", readout.LabelDeltaV, deltaVReadout(c))
 	if len(c.Nodes) > 0 {
-		budgetLine += fmt.Sprintf(" (%.0f after plan)", budget-planTotal)
+		budgetLine += fmt.Sprintf(" (%s after plan)", readout.DeltaV(budget-planTotal))
 	}
 
 	lines := []string{
@@ -975,7 +976,7 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		n := c.Nodes[i]
 		when := n.Event.String()
 		if !n.TriggerTime.IsZero() {
-			when = formatCountdown(n.TriggerTime.Sub(w.Clock.SimTime))
+			when = readout.Countdown(n.TriggerTime.Sub(w.Clock.SimTime))
 		}
 		row := fmt.Sprintf("%d. %-10s %6.0f m/s  %s", i+1, n.Mode.String(), n.DV, when)
 		// Over-budget Node (ADR 0047 §2 / #428): a planted node whose Δv
@@ -985,7 +986,7 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		// wording as the on-map NODES chip (orbit_chips.go); the predicate
 		// itself lives on ManeuverNode.OverBudget (#426) so no list forks it.
 		if shortfall, isOver := n.OverBudget(c); isOver {
-			row += "  " + m.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", shortfall))
+			row += "  " + m.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %s", readout.DeltaV(shortfall)))
 		}
 		switch {
 		case i == m.editingIdx:
@@ -1088,16 +1089,26 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 			lines = append(lines, fmt.Sprintf("  primary:       %s", poPrimary.EnglishName))
 		}
 		if ro.Hyperbolic {
+			hypPeAlt := ro.PeriMeters - primaryR
+			hypPeLine := fmt.Sprintf("  new Pe:        %s", readout.Distance(hypPeAlt))
+			if hypPeAlt < 0 {
+				hypPeLine = m.theme.Warning.Render(hypPeLine)
+			}
 			lines = append(lines,
 				"  "+m.theme.Warning.Render("hyperbolic — escape trajectory"),
-				fmt.Sprintf("  new Pe:        %.1f km alt", (ro.PeriMeters-primaryR)/1000),
+				hypPeLine,
 				fmt.Sprintf("  e:             %.3f", ro.Eccentricity),
 			)
 		} else {
+			newPeAlt := ro.PeriMeters - primaryR
+			newPeLine := fmt.Sprintf("  new Pe:        %s", readout.Distance(newPeAlt))
+			if newPeAlt < 0 {
+				newPeLine = m.theme.Warning.Render(newPeLine)
+			}
 			lines = append(lines,
-				fmt.Sprintf("  new Ap:        %.1f km alt", (ro.ApoMeters-primaryR)/1000),
-				fmt.Sprintf("  new Pe:        %.1f km alt", (ro.PeriMeters-primaryR)/1000),
-				fmt.Sprintf("  new inclin.:   %.2f°", ro.Inclination*180/math.Pi),
+				fmt.Sprintf("  new Ap:        %s", readout.Distance(ro.ApoMeters-primaryR)),
+				newPeLine,
+				fmt.Sprintf("  new %s      %s", readout.LabelIncl, readout.Angle(ro.Inclination*180/math.Pi)),
 			)
 			const equatorialTol = 1e-3
 			if ro.Inclination < equatorialTol || math.Abs(ro.Inclination-math.Pi) < equatorialTol {
@@ -1235,22 +1246,6 @@ func formPanelWidth(cols int) int {
 		w = 10 // floor so a row always has room to show something plus "…"
 	}
 	return w
-}
-
-// formatCountdown renders a relative duration as "T+1d3h", "T+14m32s",
-// or "T-5s" (past, in case the node is overdue). v0.6.4 click-to-
-// edit uses this to qualify the fire-at label so the player sees
-// when the loaded burn is scheduled. Two-component precision keeps
-// the line short — "1d3h" not "1d3h45m12s".
-func formatCountdown(d time.Duration) string {
-	prefix := "T+"
-	if d < 0 {
-		d = -d
-		prefix = "T-"
-	}
-	// compactDuration (orbit.go) owns the two-unit decomposition; this
-	// just signs it. v0.16 dedup — was a verbatim copy of that switch.
-	return prefix + compactDuration(d)
 }
 
 // normalizeManeuverDeg wraps an angle in degrees into [0, 360). Local

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -889,8 +889,13 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 	// the engine-on time the App will plant.
 	burnDescr := "impulsive"
 	if dur > 0 {
-		burnDescr = fmt.Sprintf("finite burn — %.1fs at %.0f kN, Isp %.0f s",
-			dur.Seconds(), c.Thrust/1000, c.Isp)
+		// Isp is deliberately left as a bare "%.0f s": specific impulse is
+		// measured in seconds as its unit, not a duration readout, so the
+		// contract (which governs time-to/countdown/period readouts) does
+		// not reach it. Do not "fix" this to readout.Duration on a later
+		// sweep.
+		burnDescr = fmt.Sprintf("finite burn — %s at %s, Isp %.0f s",
+			readout.Duration(dur), readout.Thrust(c.Thrust), c.Isp)
 	}
 
 	// Plan Cursor (ADR 0047 / #428): the header names the node under the
@@ -978,7 +983,12 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 		if !n.TriggerTime.IsZero() {
 			when = readout.Countdown(n.TriggerTime.Sub(w.Clock.SimTime))
 		}
-		row := fmt.Sprintf("%d. %-10s %6.0f m/s  %s", i+1, n.Mode.String(), n.DV, when)
+		// readout.DeltaV's whole "N m/s" string is right-aligned as one
+		// unit via a plain %Ns pad rather than split apart: both the
+		// digits and " m/s" are ASCII, so a byte-counted pad is safe here
+		// (unlike a column that can carry a styled/multibyte value, where
+		// lipgloss.Width would be required instead).
+		row := fmt.Sprintf("%d. %-10s %10s  %s", i+1, n.Mode.String(), readout.DeltaV(n.DV), when)
 		// Over-budget Node (ADR 0047 §2 / #428): a planted node whose Δv
 		// exceeds the vessel's current remaining budget plants anyway —
 		// warn and allow, never refuse — but every list carrying it

--- a/internal/tui/screens/maneuver.go
+++ b/internal/tui/screens/maneuver.go
@@ -1115,8 +1115,8 @@ func (m *Maneuver) renderForm(w *sim.World, dv float64, shadow physics.StateVect
 				lines = append(lines, m.theme.Dim.Render("  AN/DN:         equatorial (undefined)"))
 			} else {
 				lines = append(lines,
-					fmt.Sprintf("  new AN angle:  %.1f°", normalizeManeuverDeg(ro.AscNode*180/math.Pi)),
-					fmt.Sprintf("  new DN angle:  %.1f°", normalizeManeuverDeg(ro.DescNode*180/math.Pi)),
+					fmt.Sprintf("  new AN angle:  %s", readout.Angle(normalizeManeuverDeg(ro.AscNode*180/math.Pi))),
+					fmt.Sprintf("  new DN angle:  %s", readout.Angle(normalizeManeuverDeg(ro.DescNode*180/math.Pi))),
 				)
 			}
 		}

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/jasonfen/terminal-space-program/internal/missions"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
@@ -478,6 +479,21 @@ func dimMarkerTheme() Theme {
 // the cursor row's own highlight (Primary/Warning) and the new-node
 // row's hint are allowed to differ.
 func TestManeuverPlannedNodeRowsNotDimmed(t *testing.T) {
+	// go test's stdout is not a TTY, so termenv's lazy env detection
+	// (cached process-wide via sync.Once) settles on the colorless
+	// Ascii profile the first time anything asks, which makes every
+	// theme's Render a no-op regardless of what color it was given:
+	// dimMarkerTheme's Dim style would never emit the escape code this
+	// test looks for. SetColorProfile bypasses that detection outright.
+	// Same idiom as TestOrbitChipSubSurfacePeriapsisIsWarningColoured /
+	// TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan: read the
+	// process's ambient profile first and restore exactly that in
+	// t.Cleanup, so every test that runs after this one sees the same
+	// color output it would have without this test existing.
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
 	w, err := sim.NewWorld()
 	if err != nil {
 		t.Fatalf("NewWorld: %v", err)
@@ -489,13 +505,27 @@ func TestManeuverPlannedNodeRowsNotDimmed(t *testing.T) {
 	)
 	m := NewManeuver(dimMarkerTheme())
 	m.ResetEditing()
-	// Move the cursor to node 0, then node 1's row is neither the
-	// cursor row nor loaded — the plain case this test targets.
+	// cursorIdx starts unset (-1), which cursorRow resolves to the
+	// blank new-node row (index == len(nodes) == 2). One "up" lands the
+	// cursor on node index 1 (the 55.00 m/s row); a second "up" moves
+	// it on to node index 0, leaving node index 1's row neither the
+	// cursor row (Primary-styled) nor loaded into the form
+	// (editingIdx == -1), the plain case this test targets.
+	m.HandleKey(keyMsg("up"), c.Nodes)
 	m.HandleKey(keyMsg("up"), c.Nodes)
 	out := m.Render(w, 120, 40, 0)
+	// readout.DeltaV's <100 rule renders 55 as "55.00 m/s", not "55 m/s".
+	var found bool
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(stripANSI(line), "55 m/s") && strings.Contains(line, "\x1b[38;5;240m") {
+		if !strings.Contains(stripANSI(line), "55.00 m/s") {
+			continue
+		}
+		found = true
+		if strings.Contains(line, "\x1b[38;5;240m") {
 			t.Errorf("PLANNED NODES row still Dim-styled: %q", line)
 		}
+	}
+	if !found {
+		t.Fatal("test setup broken: no PLANNED NODES row contains \"55.00 m/s\"")
 	}
 }

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -89,6 +89,33 @@ func TestManeuverRendersPlannedNodes(t *testing.T) {
 	}
 }
 
+// TestManeuverPlannedNodeRowShowsTMinusForFutureNode pins F12 (gate
+// review): the one deliberate behaviour change in this PR. The PLANNED
+// NODES row used to route through a local formatCountdown that spelled
+// a future node "T+1h0m0s" (time-until as a positive offset); it now
+// routes through readout.Countdown, whose launch convention flips that
+// sign, so the same future node reads "T-1h" instead. Nothing else in
+// the suite pinned this sign, which is exactly how a countdown running
+// the wrong direction could ship unnoticed.
+func TestManeuverPlannedNodeRowShowsTMinusForFutureNode(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	c.Nodes = append(c.Nodes,
+		spacecraft.ManeuverNode{DV: 120, TriggerTime: w.Clock.SimTime.Add(time.Hour)},
+	)
+	m := NewManeuver(Theme{})
+	out := m.Render(w, 120, 40, 0)
+	if !strings.Contains(out, "T-1h") {
+		t.Errorf("future planted node should read T- (countdown, not elapsed):\n%s", out)
+	}
+	if strings.Contains(out, "T+1h") {
+		t.Errorf("future planted node read T+ (the pre-fix, backwards sign):\n%s", out)
+	}
+}
+
 // TestPlanCursorNavigatesAndLoadsOnEnter — ADR 0047 §1 / #428: ↑/↓ move
 // the Plan Cursor through PLANNED NODES (bounded to [0, len(Nodes)],
 // the last row being the blank new-node row); Enter on an unloaded

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -84,7 +84,7 @@ func TestManeuverRendersPlannedNodes(t *testing.T) {
 	if !strings.Contains(out, "PLANNED NODES (2)") {
 		t.Error("node-count header missing / wrong with 2 nodes planted")
 	}
-	if !strings.Contains(out, "120 m/s") || !strings.Contains(out, "45 m/s") {
+	if !strings.Contains(out, "120 m/s") || !strings.Contains(out, "45.00 m/s") {
 		t.Errorf("planned-node Δv values not listed:\n%s", out)
 	}
 }

--- a/internal/tui/screens/maneuver_test.go
+++ b/internal/tui/screens/maneuver_test.go
@@ -210,8 +210,15 @@ func TestManeuverOverBudgetNodeMarked(t *testing.T) {
 }
 
 // TestManeuverBudgetLineShowsAfterPlan — #428 mechanical fix: the
-// budget line reads "Δv budget: X m/s (Y after plan)" once anything
-// is planted, not just the pre-plan total.
+// budget line reads "Δv: X m/s (Y after plan)" (ADR 0049 decision 7
+// dropped "budget" from the label) once anything is planted, not just
+// the pre-plan total. Rendered at 140 cols (Design Size, CONTEXT.md)
+// rather than a narrower width: the multi-stage default craft's Δv row
+// is now a stage/vehicle pair ("6129 / 9412 m/s"), several columns wider
+// than the pre-ADR-0049 single figure, and a narrower panel truncates
+// the "(after plan)" suffix off the row before it ever reaches this
+// assertion: a real column-budget fact about the wider row, not
+// something this test should paper over by picking a size that hides it.
 func TestManeuverBudgetLineShowsAfterPlan(t *testing.T) {
 	w, err := sim.NewWorld()
 	if err != nil {
@@ -223,13 +230,13 @@ func TestManeuverBudgetLineShowsAfterPlan(t *testing.T) {
 		Mode: spacecraft.BurnPrograde, DV: 100, TriggerTime: w.Clock.SimTime.Add(time.Hour),
 	})
 	m := NewManeuver(Theme{})
-	out := m.Render(w, 120, 40, 0)
+	out := m.Render(w, 140, 40, 0)
 	want := "after plan"
 	if !strings.Contains(out, want) {
 		t.Errorf("budget line missing %q:\n%s", want, out)
 	}
-	if strings.Contains(out, "Δv budget remaining:") {
-		t.Error("old \"Δv budget remaining:\" wording still present")
+	if strings.Contains(out, "Δv budget:") {
+		t.Error("old \"Δv budget:\" wording still present")
 	}
 	_ = budget
 }

--- a/internal/tui/screens/orbit.go
+++ b/internal/tui/screens/orbit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 	"github.com/jasonfen/terminal-space-program/internal/version"
 )
@@ -1579,7 +1580,7 @@ func (v *OrbitView) declutterTagText() (plain, rendered string) {
 func warpRateText(w *sim.World) string {
 	if secs, ok := w.AutoWarpSecondsToTarget(); ok {
 		dur := time.Duration(secs * float64(time.Second))
-		return fmt.Sprintf("AUTO →%.0fx  %s", w.EffectiveWarp(), compactDuration(dur))
+		return fmt.Sprintf("AUTO →%.0fx  %s", w.EffectiveWarp(), readout.Duration(dur))
 	}
 	reqWarp := w.Clock.Warp()
 	if eff := w.EffectiveWarp(); eff < reqWarp {
@@ -1687,29 +1688,6 @@ func (v *OrbitView) renderTitleBar(systemName string, w *sim.World, totalCols in
 	return rendered
 }
 
-// compactDuration renders a positive duration as a two-unit chip
-// ("2d4h", "3h12m", "5m30s", "28s") for the Auto-Warp HUD readout —
-// the prefix-free sibling of formatCountdown. v0.16 / ADR 0016.
-func compactDuration(d time.Duration) string {
-	if d < 0 {
-		d = 0
-	}
-	totalSecs := int64(d.Seconds())
-	days := totalSecs / 86400
-	hours := (totalSecs % 86400) / 3600
-	mins := (totalSecs % 3600) / 60
-	secs := totalSecs % 60
-	switch {
-	case days > 0:
-		return fmt.Sprintf("%dd%dh", days, hours)
-	case hours > 0:
-		return fmt.Sprintf("%dh%dm", hours, mins)
-	case mins > 0:
-		return fmt.Sprintf("%dm%ds", mins, secs)
-	default:
-		return fmt.Sprintf("%ds", secs)
-	}
-}
 
 // HitMenuButton reports whether a click at (col, row) lands on the
 // title bar's `[Menu]` button. Title bar lives on row 0 of the
@@ -2603,7 +2581,7 @@ func crashedVesselNameLabel(th Theme, c *spacecraft.Spacecraft) string {
 
 // shouldShowLaunchHUD returns true when the active craft is in
 // "ascent" mode — defined v0.9.4+ as "periapsis below the
-// circularize-from-pad mission floor" (200 km altitude). Visible
+// circularize-from-pad mission floor" (200 km, altitude). Visible
 // for the whole pad → coast → circularise journey, vanishing only
 // once the mission-floor periapsis is achieved (= LEO is captured).
 // v0.9.2+ originally hid the HUD as soon as periapsis cleared the
@@ -2689,12 +2667,12 @@ func craftHasOrbit(c *spacecraft.Spacecraft) bool {
 // 50 km gives the player a full warp-10× tick worth of warning at
 // orbital-class lateral speeds before reaching the surface; smaller
 // values would let an impactor approach pass the surface inside one
-// readout-update without giving the v_horiz row time to register.
+// readout-update without giving the horiz row time to register.
 const descentHUDAltitudeM = 50_000.0
 
 // shouldShowDescentHUD returns true when the active craft is in
 // surface-proximity flight on an airless body — the regime where
-// the v_vert / v_horiz split (not the scalar orbital velocity) is
+// the vert / horiz split (not the scalar orbital velocity) is
 // what determines whether the next surface contact is a soft
 // touchdown or a high-|V| Crashed. Counterpart to shouldShowLaunchHUD
 // for airless bodies; the two are mutually exclusive via the
@@ -2706,7 +2684,7 @@ const descentHUDAltitudeM = 50_000.0
 // craft with ~1 km/s residual orbital lateral velocity at 5–10 km
 // altitude reads "low and slow" by altitude alone but flips to
 // Crashed (|V| ≫ CrashVCritMps) on the next surface contact. The
-// new block surfaces v_vert / v_horiz / fpa / twr so the lateral
+// new block surfaces vert / horiz / fpa / TWR so the lateral
 // component is legible while there's still room to bleed it.
 //
 // Trigger: airless primary AND (current altitude < descentHUDAltitudeM
@@ -2864,63 +2842,6 @@ func deriveFlightPhase(c *spacecraft.Spacecraft) FlightPhase {
 	return PhaseCoast // near-circular parking / cruise orbit
 }
 
-// formatAltKm renders an altitude in metres as a signed kilometre
-// string with a sign that's friendly to ascent flight ("−2.8 km"
-// reads better than "−2840 m" for sub-orbital periapsis). Used by
-// the LAUNCH HUD's ap / pe rows. v0.9.4+.
-func formatAltKm(altM float64) string {
-	km := altM / 1000
-	switch {
-	case math.Abs(km) >= 1000:
-		return fmt.Sprintf("%+.0f km", km)
-	case math.Abs(km) >= 1:
-		return fmt.Sprintf("%+.1f km", km)
-	default:
-		return fmt.Sprintf("%+.0f m", altM)
-	}
-}
-
-// formatDurationShort renders seconds as a short human label —
-// "12s" / "3m45s" / "1h22m". Used by the LAUNCH HUD's t_to_apo
-// row and the rendezvous TCA readout (v0.9.3 patterns kept
-// consistent across both ascent and rendezvous flows). v0.9.4+.
-func formatDurationShort(sec float64) string {
-	if sec < 60 {
-		return fmt.Sprintf("%.0fs", sec)
-	}
-	if sec < 3600 {
-		m := int(sec) / 60
-		s := int(sec) % 60
-		return fmt.Sprintf("%dm%02ds", m, s)
-	}
-	h := int(sec) / 3600
-	m := (int(sec) % 3600) / 60
-	return fmt.Sprintf("%dh%02dm", h, m)
-}
-
-// formatPeriod renders an orbital period keeping seconds at every scale —
-// "45s" / "3m45s" / "6h04m21s". It differs from formatDurationShort only in
-// the hour band, where the latter drops seconds to keep live countdowns
-// (t→Ap / t→Pe / TCA) from ticking a noisy seconds digit. The period is a
-// near-static readout the player tunes a resonant / phasing orbit against,
-// and minute rounding there is ±30s — which over m revolutions amplifies to
-// ±360°·m·δ/T of placement error per slot. Seconds make the period the sharp
-// tuning lever the use case needs. v0.24.4+.
-func formatPeriod(sec float64) string {
-	if sec < 60 {
-		return fmt.Sprintf("%.0fs", sec)
-	}
-	if sec < 3600 {
-		m := int(sec) / 60
-		s := int(sec) % 60
-		return fmt.Sprintf("%dm%02ds", m, s)
-	}
-	h := int(sec) / 3600
-	m := (int(sec) % 3600) / 60
-	s := int(sec) % 60
-	return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
-}
-
 // launchMissionProgress returns the pe-altitude-vs-mission-floor
 // row for the LAUNCH HUD when the active craft is flying a
 // circularize_from_pad mission for its current primary. Empty
@@ -2948,7 +2869,7 @@ func launchMissionProgress(w *sim.World, c *spacecraft.Spacecraft, periAltM floa
 				target = launchMissionFloorM
 			}
 			return fmt.Sprintf("mission:    pe %s / %s target",
-				formatAltKm(periAltM), formatAltKm(target))
+				readout.Distance(periAltM), readout.Distance(target))
 		}
 	}
 	return ""

--- a/internal/tui/screens/orbit_burn_state_visibility_test.go
+++ b/internal/tui/screens/orbit_burn_state_visibility_test.go
@@ -271,7 +271,7 @@ func TestTargetChipCraftRecomputesDuringOwnBurn(t *testing.T) {
 	if strings.Contains(out, "TCA:") {
 		t.Errorf("mid-burn craft-target chip still carries a stale TCA: row:\n%s", out)
 	}
-	if !strings.Contains(out, "|v_rel|:") || !strings.Contains(out, "closing:") || !strings.Contains(out, "lead:") {
+	if !strings.Contains(out, "rel speed:") || !strings.Contains(out, "closing:") || !strings.Contains(out, "lead:") {
 		t.Errorf("mid-burn craft-target chip lost its live relative-state rows:\n%s", out)
 	}
 }
@@ -400,8 +400,8 @@ func TestNodesChipHeadRowCountsToIgnitionThenBurnEnd(t *testing.T) {
 		EndTime:     w.Clock.SimTime.Add(61 * time.Second),
 	}
 	out = strings.Join(v.buildNodesChip(w), "\n")
-	if !strings.Contains(out, "burning, 61s left") {
-		t.Errorf("live-burn head row should read 'burning, 61s left' (BurnEnd):\n%s", out)
+	if !strings.Contains(out, "burning, 1m01s left") {
+		t.Errorf("live-burn head row should read 'burning, 1m01s left' (BurnEnd):\n%s", out)
 	}
 	if strings.Contains(out, "T-61s") {
 		t.Errorf("live-burn head row still uses the old T-Ns wording:\n%s", out)

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1314,7 +1314,7 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 	}
 	primaryR := cap.Primary.RadiusMeters()
 	incDeg := cap.Inclination * 180 / math.Pi
-	incLabel := fmt.Sprintf("%.1f°", incDeg)
+	incLabel := readout.Angle(incDeg)
 	switch {
 	case cap.Hyperbolic:
 		incLabel = v.theme.Alert.Render("escape — capture failed")
@@ -1449,7 +1449,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		// decisions 9-10): the heading/incl-floor readout and the
 		// "(locked)" removal land with ApplyHeadingTrim, not this stage.
 		inclRowLabel = "launch lat: "
-		inclLabel = fmt.Sprintf("%.1f° (locked)", c.LaunchLatDeg)
+		inclLabel = readout.Angle(c.LaunchLatDeg) + " (locked)"
 	}
 	apLabel, peLabel, ttaLabel, dvCircLabel, tBurnLabel := "—", "—", "—", "—", "—"
 	trendLabel := ""
@@ -1646,7 +1646,7 @@ func (v *OrbitView) buildChuteChip(w *sim.World) []string {
 }
 
 // buildOrbitMetricsChip is the always-on top-right ORBIT readout: the
-// live current orbit shape (altitude / apo / peri / t→apo / t→peri /
+// live current orbit shape (altitude / apo / peri / their T- countdowns /
 // inclination / direction). Suppressed during ascent — the LAUNCH chip
 // already carries ap/pe there — and for degenerate / hyperbolic states.
 // The projected post-burn orbit is a SEPARATE chip
@@ -1701,9 +1701,13 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	// the countdowns say "—" rather than the constant half-period the
 	// underlying helpers fall back to. A frozen number that looks live is
 	// worse than an honest blank: players read it as phase information and
-	// tried to time rendezvous off two craft that both showed P/2. Duration
-	// is unsigned here (t→Ap:/t→Pe: already carry the "to" direction in the
-	// label glyph, so a T- prefix on top would be redundant).
+	// tried to time rendezvous off two craft that both showed P/2. Signed
+	// through readout.Countdown (gate-review follow-up: this row used to
+	// be labelled with an arrow glyph and an unsigned value, a second
+	// dialect for the exact same signed-countdown quantity the SURFACE
+	// chip's apo: row already used). The "—" case is returned before
+	// Countdown ever sees it, so a circular orbit still reads a bare
+	// blank: never "T-" glued onto the dash.
 	apsisTime := func(secs float64) (string, bool) {
 		if !orbital.ApsisDefined(el.E) {
 			return "—", true
@@ -1711,10 +1715,10 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		if secs < 0 {
 			return "", false
 		}
-		return readout.Duration(time.Duration(secs * float64(time.Second))), true
+		return readout.Countdown(time.Duration(secs * float64(time.Second))), true
 	}
 	if s, ok := apsisTime(orbital.TimeToApoapsis(st, mu)); ok {
-		lines = append(lines, chipRow("t→Ap:", s))
+		lines = append(lines, chipRow(readout.LabelApo, s))
 	}
 	peRow := chipRow(readout.LabelPe, readout.Distance(periAlt))
 	if periAlt < 0 {
@@ -1722,7 +1726,7 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	}
 	lines = append(lines, peRow)
 	if s, ok := apsisTime(orbital.TimeToPeriapsis(st, mu)); ok {
-		lines = append(lines, chipRow("t→Pe:", s))
+		lines = append(lines, chipRow(readout.LabelPeri, s))
 	}
 	// Full orbital period, alongside the apsis-time readouts — the number
 	// a comsat placement is tuned to (e.g. a synchronous or semi-
@@ -1765,7 +1769,7 @@ func (v *OrbitView) buildOrbitMetricsChipCompact(w *sim.World) []string {
 		lat, lon := c.SurfaceLatLon()
 		return []string{
 			v.theme.Primary.Render("ORBIT"),
-			chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", lat, lon)),
+			chipRow("landed at:", readout.Angle(lat)+", "+readout.Angle(lon)),
 		}
 	}
 	mu := c.Primary.GravitationalParameter()
@@ -1840,7 +1844,7 @@ func (v *OrbitView) buildLandedOrbitChip(c *spacecraft.Spacecraft) []string {
 	return []string{
 		v.theme.Primary.Render("ORBIT"),
 		chipRow("body:", c.Primary.EnglishName),
-		chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", lat, lon)),
+		chipRow("landed at:", readout.Angle(lat)+", "+readout.Angle(lon)),
 		chipRow(readout.LabelAltitude, readout.Distance(0)),
 		chipRow("co-rotation:", readout.Speed(c.State.V.Norm())),
 	}
@@ -1949,8 +1953,8 @@ func (v *OrbitView) buildProjectedOrbitChip(w *sim.World) []string {
 			lines = append(lines, v.theme.Dim.Render("  AN/DN:     equatorial"))
 		} else {
 			lines = append(lines,
-				fmt.Sprintf("  AN angle:  %.1f°", normalizeDeg(ro.AscNode*180/math.Pi)),
-				fmt.Sprintf("  DN angle:  %.1f°", normalizeDeg(ro.DescNode*180/math.Pi)),
+				fmt.Sprintf("  AN angle:  %s", readout.Angle(normalizeDeg(ro.AscNode*180/math.Pi))),
+				fmt.Sprintf("  DN angle:  %s", readout.Angle(normalizeDeg(ro.DescNode*180/math.Pi))),
 			)
 		}
 	}
@@ -1979,14 +1983,24 @@ func (v *OrbitView) buildProjectedOrbitChipCompact(w *sim.World) []string {
 	ro := orbital.OrbitReadoutInFrame(state.R, state.V, mu, frame)
 	primaryR := primary.RadiusMeters()
 	if ro.Hyperbolic {
+		compactPeAlt := ro.PeriMeters - primaryR
+		compactPePart := fmt.Sprintf("Pe: %s", readout.Distance(compactPeAlt))
+		if compactPeAlt < 0 {
+			compactPePart = v.theme.Warning.Render(compactPePart)
+		}
 		return []string{
 			v.theme.Primary.Render("PROJECTED ORBIT"),
-			fmt.Sprintf("  %s  Pe: %.1f km  e: %.2f", v.theme.Warning.Render("escape"), (ro.PeriMeters-primaryR)/1000, ro.Eccentricity),
+			fmt.Sprintf("  %s  %s  e: %.2f", v.theme.Warning.Render("escape"), compactPePart, ro.Eccentricity),
 		}
+	}
+	compactPeAlt := ro.PeriMeters - primaryR
+	compactPePart := fmt.Sprintf("Pe: %s", readout.Distance(compactPeAlt))
+	if compactPeAlt < 0 {
+		compactPePart = v.theme.Warning.Render(compactPePart)
 	}
 	return []string{
 		v.theme.Primary.Render("PROJECTED ORBIT") + "  " + primary.EnglishName,
-		fmt.Sprintf("  Ap: %.1f km  Pe: %.1f km", (ro.ApoMeters-primaryR)/1000, (ro.PeriMeters-primaryR)/1000),
+		fmt.Sprintf("  Ap: %s  %s", readout.Distance(ro.ApoMeters-primaryR), compactPePart),
 	}
 }
 
@@ -2028,11 +2042,11 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 				ang := math.Acos(cos) * 180 / math.Pi
 				di = math.Min(ang, 180-ang)
 			}
-			diLabel := fmt.Sprintf("%.2f°", di)
+			diLabel := readout.Angle(di)
 			if di > 30 {
 				diLabel = v.theme.Warning.Render(diLabel)
 			}
-			lines = append(lines, chipRow("Δi:", diLabel))
+			lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 		}
 		rangeM := w.BodyPosition(b).Sub(w.CraftInertial()).Norm()
 		lines = append(lines, chipRow("range:", readout.Distance(rangeM)))
@@ -2057,7 +2071,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 				if alt <= 0 {
 					lines = append(lines, chipRow("perilune:", v.theme.Warning.Render("IMPACT")))
 				} else {
-					lines = append(lines, chipRow("perilune:", fmt.Sprintf("%.0f km", alt/1000)))
+					lines = append(lines, chipRow("perilune:", readout.Distance(alt)))
 				}
 			} else {
 				lines = append(lines, chipRow("approach:", readout.Distance(ap.Dist)))
@@ -2095,7 +2109,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			// closing below stay meaningful (relative-state math, not
 			// elements) so they're untouched.
 			tLat, tLon := tc.SurfaceLatLon()
-			lines = append(lines, chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", tLat, tLon)))
+			lines = append(lines, chipRow("landed at:", readout.Angle(tLat)+", "+readout.Angle(tLon)))
 		}
 		var rRel, vRelVec orbital.Vec3
 		if tc.Primary.ID == c.Primary.ID {
@@ -2116,7 +2130,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		lines = append(lines,
 			chipRow("range:", readout.Distance(rangeM)),
 			chipRow(readout.LabelRelSpeed, readout.Speed(vRel)),
-			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
+			chipRow("closing:", readout.SignedSpeed(closing)),
 			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
 		if tc.Primary.ID == c.Primary.ID {
@@ -2199,7 +2213,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		lines = append(lines,
 			chipRow("range:", readout.Distance(rangeM)),
 			chipRow(readout.LabelRelSpeed, readout.Speed(vRel)),
-			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
+			chipRow("closing:", readout.SignedSpeed(closing)),
 			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
 		if gPrimary.ID == c.Primary.ID {
@@ -2363,7 +2377,7 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 		if p.Impact {
 			return v.theme.Warning.Render("IMPACT")
 		}
-		return fmt.Sprintf("%.0f km", p.PeriluneAltitude()/1000)
+		return readout.Distance(p.PeriluneAltitude())
 	}
 	if arc.hasNodes {
 		// Dual arc: planned (bright path) + no-burn (counterfactual). The
@@ -2415,7 +2429,7 @@ func (v *OrbitView) orbitDirectionLabel(incRad float64) string {
 // chipRow formats a "  label   value" telemetry row with the value pinned
 // to chipValueCol regardless of label width, so a chip's values share one
 // column instead of drifting per label. Padding is measured in display
-// cells (lipgloss.Width), so multibyte labels like "Δi:" and styled values
+// cells (lipgloss.Width), so multibyte labels like "Δincl:" and styled values
 // align correctly where byte-counted %-Ns padding would not. Distance /
 // duration / speed / angle formatting lives in internal/tui/readout (ADR
 // 0049); this helper only lays the label and an already-formatted value

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1155,8 +1155,8 @@ func (v *OrbitView) buildAttitudeChip(w *sim.World) []string {
 	}
 	manualState := "idle"
 	if c.ManualBurn != nil {
-		elapsed := w.Clock.SimTime.Sub(c.ManualBurn.StartTime).Seconds()
-		manualState = fmt.Sprintf(v.theme.Warning.Render("● firing T+%.1fs"), elapsed)
+		elapsed := w.Clock.SimTime.Sub(c.ManualBurn.StartTime)
+		manualState = v.theme.Warning.Render("● firing " + readout.Countdown(-elapsed))
 	}
 	return []string{
 		v.theme.Primary.Render("ATTITUDE"),
@@ -1298,7 +1298,7 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 	}
 	lines := []string{
 		v.theme.Primary.Render("CAPTURE PREVIEW"),
-		fmt.Sprintf("  primary:    %s", cap.Primary.EnglishName),
+		chipRow("primary:", cap.Primary.EnglishName),
 	}
 	if cap.Approximate {
 		dirLabel := v.theme.Warning.Render("prograde")
@@ -1306,8 +1306,8 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 			dirLabel = v.theme.Alert.Render("retrograde")
 		}
 		lines = append(lines,
-			fmt.Sprintf("  %s     %s relative", readout.LabelArrival, readout.Speed(cap.ApproachSpeed)),
-			fmt.Sprintf("  direction:  %s capture predicted", dirLabel),
+			chipRow(readout.LabelArrival, readout.Speed(cap.ApproachSpeed)+" relative"),
+			chipRow("direction:", dirLabel+" capture predicted"),
 			v.theme.Dim.Render("  (intercept too central for orbit-element preview)"),
 		)
 		return lines
@@ -1323,15 +1323,15 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 	case incDeg > 30:
 		incLabel = v.theme.Warning.Render(incLabel)
 	}
-	lines = append(lines, fmt.Sprintf("  %s    %s", readout.LabelIncl, incLabel))
+	lines = append(lines, chipRow(readout.LabelIncl, incLabel))
 	if !cap.Hyperbolic {
 		capPeAlt := cap.PeriapsisM - primaryR
-		capPeRow := fmt.Sprintf("  %s         %s", readout.LabelPe, readout.Distance(capPeAlt))
+		capPeRow := chipRow(readout.LabelPe, readout.Distance(capPeAlt))
 		if capPeAlt < 0 {
 			capPeRow = v.theme.Warning.Render(capPeRow)
 		}
 		lines = append(lines,
-			fmt.Sprintf("  %s         %s", readout.LabelAp, readout.Distance(cap.ApoapsisM-primaryR)),
+			chipRow(readout.LabelAp, readout.Distance(cap.ApoapsisM-primaryR)),
 			capPeRow,
 		)
 	}

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -2386,19 +2386,19 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 		if arc.plOK {
 			lines = append(lines, chipRow("planned:", periValue(arc.planned)))
 			if arc.planned.HasEntryTime {
-				lines = append(lines, chipRow("  T-entry:", readout.Duration(time.Duration(arc.planned.TimeToEntry*float64(time.Second)))))
+				lines = append(lines, chipRow("  "+readout.LabelEntry, readout.Countdown(time.Duration(arc.planned.TimeToEntry*float64(time.Second)))))
 			}
-			lines = append(lines, chipRow("  T-peri:", readout.Duration(time.Duration(arc.planned.TimeToPerilune*float64(time.Second)))))
+			lines = append(lines, chipRow("  "+readout.LabelPeri, readout.Countdown(time.Duration(arc.planned.TimeToPerilune*float64(time.Second)))))
 		}
 		if arc.cfOK {
 			lines = append(lines, chipRow("no-burn:", periValue(arc.counterfactual)))
 		}
 		return lines
 	}
-	// Single live pass (no node planted). T-entry is the predicted SOI-entry
+	// Single live pass (no node planted). entry: is the predicted SOI-entry
 	// clock — the ring crossing the Entry glyph marks (ADR 0021 C).
 	if arc.counterfactual.HasEntryTime {
-		lines = append(lines, chipRow("T-entry:", readout.Duration(time.Duration(arc.counterfactual.TimeToEntry*float64(time.Second)))))
+		lines = append(lines, chipRow(readout.LabelEntry, readout.Countdown(time.Duration(arc.counterfactual.TimeToEntry*float64(time.Second)))))
 	}
 	lines = append(lines,
 		chipRow("perilune:", periValue(arc.counterfactual)),

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // This file holds the chip builders transplanted from renderHUD's
@@ -353,7 +354,7 @@ func (v *OrbitView) buildSessionEventsChip(w *sim.World) []string {
 			// S6). Sim-time, not wall clock: what matters is how far their
 			// craft flew, which under warp bears no relation to how long
 			// their laptop was shut.
-			resumed := "◇ resumed — " + compactDuration(e.Elapsed) + " ran while you were away"
+			resumed := "◇ resumed — " + readout.Duration(e.Elapsed) + " ran while you were away"
 			if e.Detail != "" {
 				// The replay is bounded so it cannot bury the orbit view; say
 				// so rather than truncating in silence.
@@ -462,13 +463,17 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 		return v.rendezvousApproachLines(w)
 	case w.RendezvousWarpEngaged():
 		aw := w.AutoWarp
+		tauIn := aw.T.Sub(now)
+		if tauIn < 0 {
+			tauIn = 0
+		}
 		lines := []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			"  coasting with " + aw.RendezvousHandle + " to the encounter",
-			chipRow("τ in:", compactDuration(aw.T.Sub(now))),
+			chipRow("τ in:", readout.Duration(tauIn)),
 		}
 		if arm := w.RendezvousArm; arm != nil {
-			lines = append(lines, chipRow("committed:", formatRangeM(arm.CommittedCA)))
+			lines = append(lines, chipRow("committed:", readout.Distance(arm.CommittedCA)))
 			if line := rendezvousMeetingLine(arm.MeetingPlaceLabel, arm.MeetingLaps); line != "" {
 				lines = append(lines, line)
 			}
@@ -480,7 +485,7 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			lines = append(lines, rendezvousTrendLines(*arm, v.theme)...)
 		}
 		if w.RendezvousApproachM > 0 {
-			lines = append(lines, chipRow("approach:", formatRangeM(w.RendezvousApproachM)))
+			lines = append(lines, chipRow("approach:", readout.Distance(w.RendezvousApproachM)))
 		}
 		if line := v.rendezvousHoldOrPaceLine(w, aw.RendezvousHandle); line != "" {
 			lines = append(lines, line)
@@ -511,10 +516,10 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			// a gap the viewer (or the partner) warped open — name who is
 			// ahead and the actual fix instead. Sync is forward-only, so
 			// the fix depends on direction: the laggard comes forward.
-			who := "you are " + compactDuration(wt.AheadBy) + " ahead of " + arm.Handle
+			who := "you are " + readout.Duration(wt.AheadBy) + " ahead of " + arm.Handle
 			fix := "they must Sync to you"
 			if wt.AheadBy < 0 {
-				who = arm.Handle + " is " + compactDuration(-wt.AheadBy) + " ahead of you"
+				who = arm.Handle + " is " + readout.Duration(-wt.AheadBy) + " ahead of you"
 				fix = "Sync to rejoin"
 			}
 			status = v.theme.Alert.Render("  cannot couple — " + who + " — " + fix)
@@ -524,11 +529,15 @@ func (v *OrbitView) buildRendezvousChip(w *sim.World) []string {
 			// Own the wait instead of blaming them or advising a Sync.
 			status = v.theme.Warning.Render("  your Auto-Warp is running — coast starts when it releases")
 		}
+		armTauIn := arm.Tau.Sub(now)
+		if armTauIn < 0 {
+			armTauIn = 0
+		}
 		lines := []string{
 			v.theme.Primary.Render("RENDEZVOUS"),
 			status,
-			chipRow("τ in:", compactDuration(arm.Tau.Sub(now))),
-			chipRow("CA:", formatRangeM(arm.CommittedCA)),
+			chipRow("τ in:", readout.Duration(armTauIn)),
+			chipRow("CA:", readout.Distance(arm.CommittedCA)),
 		}
 		if line := rendezvousMeetingLine(arm.MeetingPlaceLabel, arm.MeetingLaps); line != "" {
 			lines = append(lines, line)
@@ -590,18 +599,21 @@ func rendezvousMeetingLine(placeLabel string, laps int) string {
 // rendezvousInviteEncounterLines renders the invite's τ/CA rows — nil
 // (render nothing) when inv.Tau is zero (finding 2, batch review):
 // refreshRendezvousInvite now surfaces a zero-τ invite for ADR 0045 S7's
-// "agreed, no plan yet" state (#400), and compactDuration clamps a
-// negative duration to zero, so rendering these rows unconditionally
-// showed a fabricated "τ in: 0s / CA: 0 m" — an imminent zero-metre
-// encounter that was never computed — to the player deciding whether to
-// accept.
+// "agreed, no plan yet" state (#400); a negative duration is clamped to
+// zero here so rendering these rows unconditionally doesn't fabricate a
+// "τ in: 0s / CA: 0 m": an imminent zero-metre encounter that was never
+// computed, to the player deciding whether to accept.
 func rendezvousInviteEncounterLines(inv *sim.RendezvousInvite, now time.Time) []string {
 	if inv.Tau.IsZero() {
 		return nil
 	}
+	invTauIn := inv.Tau.Sub(now)
+	if invTauIn < 0 {
+		invTauIn = 0
+	}
 	return []string{
-		chipRow("τ in:", compactDuration(inv.Tau.Sub(now))),
-		chipRow("CA:", formatRangeM(inv.CA)),
+		chipRow("τ in:", readout.Duration(invTauIn)),
+		chipRow("CA:", readout.Distance(inv.CA)),
 	}
 }
 
@@ -649,10 +661,10 @@ func rendezvousTrendLines(arm sim.RendezvousArm, theme Theme) []string {
 	}
 	switch {
 	case arm.CommittedCA < arm.PrevCommittedCA:
-		return []string{theme.Dim.Render("  CA " + formatRangeM(arm.CommittedCA) + " ↘ shrinking")}
+		return []string{theme.Dim.Render("  CA " + readout.Distance(arm.CommittedCA) + " ↘ shrinking")}
 	case arm.CommittedCA > arm.PrevCommittedCA:
 		return []string{
-			theme.Alert.Render("  ⚠ CA growing each pass (" + formatRangeM(arm.PrevCommittedCA) + " → " + formatRangeM(arm.CommittedCA) + ")"),
+			theme.Alert.Render("  ⚠ CA growing each pass (" + readout.Distance(arm.PrevCommittedCA) + " → " + readout.Distance(arm.CommittedCA) + ")"),
 			theme.Alert.Render("    — phasing direction is wrong"),
 		}
 	}
@@ -1241,8 +1253,8 @@ func (v *OrbitView) activeBurnLines(w *sim.World) []string {
 			// continuous countdown (ignition → burning) instead of two
 			// unrelated-looking T-fields.
 			lines = append(lines,
-				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s, burning, %.0fs left",
-					tag, ab.Mode.String(), ab.DVRemaining, remaining)),
+				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %s, burning, %s left",
+					tag, ab.Mode.String(), readout.DeltaV(ab.DVRemaining), readout.Duration(time.Duration(remaining*float64(time.Second))))),
 			)
 		}
 	}
@@ -1267,7 +1279,7 @@ func (v *OrbitView) buildFrameTransitionChip(w *sim.World) []string {
 	dur := ft.When.Sub(w.Clock.SimTime)
 	when := v.theme.Warning.Render("now")
 	if dur > 0 {
-		when = formatCountdown(dur)
+		when = readout.Countdown(dur)
 	}
 	return []string{
 		v.theme.Primary.Render("FRAME TRANSITION"),
@@ -1294,7 +1306,7 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 			dirLabel = v.theme.Alert.Render("retrograde")
 		}
 		lines = append(lines,
-			fmt.Sprintf("  approach:   %.0f m/s relative", cap.ApproachSpeed),
+			fmt.Sprintf("  %s     %s relative", readout.LabelArrival, readout.Speed(cap.ApproachSpeed)),
 			fmt.Sprintf("  direction:  %s capture predicted", dirLabel),
 			v.theme.Dim.Render("  (intercept too central for orbit-element preview)"),
 		)
@@ -1311,11 +1323,16 @@ func (v *OrbitView) buildCaptureChip(w *sim.World) []string {
 	case incDeg > 30:
 		incLabel = v.theme.Warning.Render(incLabel)
 	}
-	lines = append(lines, fmt.Sprintf("  inclin.:    %s", incLabel))
+	lines = append(lines, fmt.Sprintf("  %s    %s", readout.LabelIncl, incLabel))
 	if !cap.Hyperbolic {
+		capPeAlt := cap.PeriapsisM - primaryR
+		capPeRow := fmt.Sprintf("  %s         %s", readout.LabelPe, readout.Distance(capPeAlt))
+		if capPeAlt < 0 {
+			capPeRow = v.theme.Warning.Render(capPeRow)
+		}
 		lines = append(lines,
-			fmt.Sprintf("  Ap:         %.0f km alt", (cap.ApoapsisM-primaryR)/1000),
-			fmt.Sprintf("  Pe:         %.0f km alt", (cap.PeriapsisM-primaryR)/1000),
+			fmt.Sprintf("  %s         %s", readout.LabelAp, readout.Distance(cap.ApoapsisM-primaryR)),
+			capPeRow,
 		)
 	}
 	return lines
@@ -1383,33 +1400,30 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		engineLabel = v.theme.Primary.Render("● LIT")
 	}
 	altAGL := c.Altitude()
-	altLabel := fmt.Sprintf("%.0f m", nzero(altAGL, 0))
-	if altAGL >= 1000 {
-		altLabel = fmt.Sprintf("%.2f km", altAGL/1000)
-	}
+	altLabel := readout.Distance(altAGL)
 	sasLabel := c.AttitudeMode.String()
 	trimDeg := c.PitchTrim * 180 / math.Pi
-	trimLabel := fmt.Sprintf("%+.1f°", nzero(trimDeg, 1))
+	trimLabel := readout.TrimAngle(trimDeg)
 	if math.Abs(trimDeg) > 0.05 {
 		trimLabel = v.theme.Warning.Render(trimLabel)
 	}
 	fpaLabel := "—"
 	if hasFPA {
-		fpaLabel = fmt.Sprintf("%.0f° (90 = up, 0 = horiz)", nzero(fpaDeg, 0))
+		fpaLabel = readout.FPA(fpaDeg) + " (90 = up, 0 = horiz)"
 	}
 	fpaOrbitLabel := "—"
 	if hasFPAOrbit {
-		fpaOrbitLabel = fmt.Sprintf("%.0f° (inertial)", nzero(fpaOrbitDeg, 0))
+		fpaOrbitLabel = readout.FPA(fpaOrbitDeg) + " (inertial)"
 	}
 	lines := []string{
 		v.theme.Primary.Render("SURFACE"),
-		fmt.Sprintf("  altitude:   %s", altLabel),
-		fmt.Sprintf("  v_vert:     %.1f m/s", nzero(vVert, 1)),
-		fmt.Sprintf("  v_horiz:    %.0f m/s (surface-rel)", vHoriz),
-		fmt.Sprintf("  fpa:        %s", fpaLabel),
-		fmt.Sprintf("  fpa_orbit:  %s", fpaOrbitLabel),
-		fmt.Sprintf("  twr:        %s  engine: %s", twrLabel, engineLabel),
-		fmt.Sprintf("  sas:        %s", sasLabel),
+		fmt.Sprintf("  %s   %s", readout.LabelAltitude, altLabel),
+		fmt.Sprintf("  %s       %s", readout.LabelVert, readout.Speed(vVert)),
+		fmt.Sprintf("  %s      %s (surface-rel)", readout.LabelHoriz, readout.Speed(vHoriz)),
+		fmt.Sprintf("  %s        %s", readout.LabelFPA, fpaLabel),
+		fmt.Sprintf("  %s  %s", readout.LabelOrbitFPA, fpaOrbitLabel),
+		fmt.Sprintf("  %s        %s  engine: %s", readout.LabelTWR, twrLabel, engineLabel),
+		fmt.Sprintf("  %s       %s", readout.LabelHold, sasLabel),
 		fmt.Sprintf("  trim:       %s", trimLabel),
 	}
 	mu := c.Primary.GravitationalParameter()
@@ -1426,11 +1440,14 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		apoFinite = true
 	}
 	inclLabel := "—"
-	inclRowLabel := "incl.:      "
+	inclRowLabel := "incl:       "
 	if !math.IsNaN(el.I) && !math.IsInf(el.I, 0) {
-		inclLabel = fmt.Sprintf("%.2f°", el.I*180/math.Pi)
+		inclLabel = readout.Angle(el.I * 180 / math.Pi)
 	}
 	if c.Landed {
+		// #453 pad-honesty half deferred to PR B (ADR 0049 amendment,
+		// decisions 9-10): the heading/incl-floor readout and the
+		// "(locked)" removal land with ApplyHeadingTrim, not this stage.
 		inclRowLabel = "launch lat: "
 		inclLabel = fmt.Sprintf("%.1f° (locked)", c.LaunchLatDeg)
 	}
@@ -1445,8 +1462,8 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 	// suppress these predictions until the craft actually lifts off; the
 	// pad cares about TWR / launch-lat / SAS, which render regardless.
 	if apoFinite && !c.Landed {
-		apLabel = formatAltKm(apoAlt)
-		peLabel = formatAltKm(periAlt)
+		apLabel = readout.Distance(apoAlt)
+		peLabel = readout.Distance(periAlt)
 		now := w.Clock.SimTime
 		if v.ascentTrendCraft == c && !v.ascentTrendTime.IsZero() {
 			dt := now.Sub(v.ascentTrendTime).Seconds()
@@ -1468,7 +1485,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 		if apoAlt > 0 {
 			ttaSec := orbital.TimeToApoapsis(orbital.Vec3State{R: c.State.R, V: c.State.V}, mu)
 			if ttaSec > 0 {
-				ttaLabel = formatDurationShort(ttaSec)
+				ttaLabel = readout.Countdown(time.Duration(ttaSec * float64(time.Second)))
 			}
 		}
 		rApo := el.Apoapsis()
@@ -1477,7 +1494,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 			vCircAtApo := math.Sqrt(mu / rApo)
 			dvCirc = vCircAtApo - vAtApo
 			if dvCirc > 0 {
-				dvCircLabel = fmt.Sprintf("%.0f m/s (impulsive)", dvCirc)
+				dvCircLabel = readout.DeltaV(dvCirc) + " (impulsive)"
 			}
 		}
 	} else {
@@ -1489,15 +1506,20 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 			thrust = c.Thrust
 		}
 		tBurnSec := dvCirc * c.TotalMass() / thrust
-		tBurnLabel = formatDurationShort(tBurnSec)
+		tBurnLabel = readout.Duration(time.Duration(tBurnSec * float64(time.Second)))
+	}
+	apRow := fmt.Sprintf("  %s         %s%s", readout.LabelAp, apLabel, trendLabel)
+	peRow := fmt.Sprintf("  %s         %s", readout.LabelPe, peLabel)
+	if apoFinite && !c.Landed && periAlt < 0 {
+		peRow = v.theme.Warning.Render(peRow)
 	}
 	lines = append(lines,
-		fmt.Sprintf("  ap:         %s%s", apLabel, trendLabel),
-		fmt.Sprintf("  pe:         %s", peLabel),
+		apRow,
+		peRow,
 		fmt.Sprintf("  %s%s", inclRowLabel, inclLabel),
-		fmt.Sprintf("  t_to_apo:   %s", ttaLabel),
+		fmt.Sprintf("  %s        %s", readout.LabelApo, ttaLabel),
 		fmt.Sprintf("  Δv→circ:    %s", dvCircLabel),
-		fmt.Sprintf("  t_burn:     %s", tBurnLabel),
+		fmt.Sprintf("  %s       %s", readout.LabelBurn, tBurnLabel),
 	)
 	if apoFinite && !c.Landed && apoAlt > launchMissionFloorM {
 		orbitStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#3DDC84")).Bold(true)
@@ -1512,7 +1534,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 }
 
 // buildDescentChip is the airless-body terminal-approach cluster
-// (altitude / v_vert / v_horiz / fpa / twr / sas). Returns nil unless the
+// (altitude / vert / horiz / fpa / TWR / hold). Returns nil unless the
 // craft is in a powered descent. Mutually exclusive with the LAUNCH chip
 // via the same Atmosphere gate the originals used.
 func (v *OrbitView) buildDescentChip(w *sim.World) []string {
@@ -1546,27 +1568,24 @@ func (v *OrbitView) buildDescentChip(w *sim.World) []string {
 			twrLabel = v.theme.Alert.Render(twrLabel + " (can't hover)")
 		}
 	}
-	altLabel := fmt.Sprintf("%.0f m", nzero(altAGL, 0))
-	if altAGL >= 1000 {
-		altLabel = fmt.Sprintf("%.2f km", altAGL/1000)
-	}
+	altLabel := readout.Distance(altAGL)
 	fpaLabel := "—"
 	if hasFPA {
-		fpaLabel = fmt.Sprintf("%.0f° (0 = horiz, −90 = straight down)", nzero(fpaDeg, 0))
+		fpaLabel = readout.FPA(fpaDeg) + " (0 = horiz, -90 = straight down)"
 	}
-	vHorizLabel := fmt.Sprintf("%.0f m/s (surface-rel)", vHoriz)
+	vHorizLabel := readout.Speed(vHoriz) + " (surface-rel)"
 	if vHoriz > sim.CrashVCritMps {
 		vHorizLabel = v.theme.Alert.Render(
-			fmt.Sprintf("%.0f m/s (> %.0f = CRASH on contact)", vHoriz, sim.CrashVCritMps))
+			fmt.Sprintf("%s (> %s = CRASH on contact)", readout.Speed(vHoriz), readout.Speed(sim.CrashVCritMps)))
 	}
 	return []string{
 		v.theme.Primary.Render("DESCENT"),
-		fmt.Sprintf("  altitude:   %s", altLabel),
-		fmt.Sprintf("  v_vert:     %.1f m/s", nzero(vVert, 1)),
-		fmt.Sprintf("  v_horiz:    %s", vHorizLabel),
-		fmt.Sprintf("  fpa:        %s", fpaLabel),
-		fmt.Sprintf("  twr:        %s", twrLabel),
-		fmt.Sprintf("  sas:        %s", c.AttitudeMode.String()),
+		fmt.Sprintf("  %s   %s", readout.LabelAltitude, altLabel),
+		fmt.Sprintf("  %s       %s", readout.LabelVert, readout.Speed(vVert)),
+		fmt.Sprintf("  %s      %s", readout.LabelHoriz, vHorizLabel),
+		fmt.Sprintf("  %s        %s", readout.LabelFPA, fpaLabel),
+		fmt.Sprintf("  %s        %s", readout.LabelTWR, twrLabel),
+		fmt.Sprintf("  %s       %s", readout.LabelHold, c.AttitudeMode.String()),
 	}
 }
 
@@ -1610,10 +1629,10 @@ func (v *OrbitView) buildChuteChip(w *sim.World) []string {
 		rHat := c.State.R.Scale(1 / rNorm)
 		descentRate = -(vRel.X*rHat.X + vRel.Y*rHat.Y + vRel.Z*rHat.Z)
 	}
-	rateLabel := fmt.Sprintf("%.1f m/s", descentRate)
+	rateLabel := readout.Speed(descentRate)
 	if vRel.Norm() >= sim.CrashVCritMps {
 		rateLabel = v.theme.Alert.Render(
-			fmt.Sprintf("%.1f m/s (|v_rel| > %.0f = CRASH on contact)", descentRate, sim.CrashVCritMps))
+			fmt.Sprintf("%s (rel speed > %s = CRASH on contact)", readout.Speed(descentRate), readout.Speed(sim.CrashVCritMps)))
 	}
 	lines := []string{
 		v.theme.Primary.Render("CHUTE"),
@@ -1675,14 +1694,16 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	st := orbital.Vec3State{R: c.State.R, V: c.State.V}
 	lines := []string{
 		v.theme.Primary.Render("ORBIT"),
-		chipRow("altitude:", formatChipKm(c.Altitude())),
-		chipRow("Ap:", formatChipKm(apoAlt)),
+		chipRow(readout.LabelAltitude, readout.Distance(c.Altitude())),
+		chipRow(readout.LabelAp, readout.Distance(apoAlt)),
 	}
 	// On a circular orbit the apsides are not locatable points (#286), so
 	// the countdowns say "—" rather than the constant half-period the
 	// underlying helpers fall back to. A frozen number that looks live is
 	// worse than an honest blank: players read it as phase information and
-	// tried to time rendezvous off two craft that both showed P/2.
+	// tried to time rendezvous off two craft that both showed P/2. Duration
+	// is unsigned here (t→Ap:/t→Pe: already carry the "to" direction in the
+	// label glyph, so a T- prefix on top would be redundant).
 	apsisTime := func(secs float64) (string, bool) {
 		if !orbital.ApsisDefined(el.E) {
 			return "—", true
@@ -1690,12 +1711,16 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		if secs < 0 {
 			return "", false
 		}
-		return formatDurationShort(secs), true
+		return readout.Duration(time.Duration(secs * float64(time.Second))), true
 	}
 	if s, ok := apsisTime(orbital.TimeToApoapsis(st, mu)); ok {
 		lines = append(lines, chipRow("t→Ap:", s))
 	}
-	lines = append(lines, chipRow("Pe:", formatChipKm(periAlt)))
+	peRow := chipRow(readout.LabelPe, readout.Distance(periAlt))
+	if periAlt < 0 {
+		peRow = v.theme.Warning.Render(peRow)
+	}
+	lines = append(lines, peRow)
 	if s, ok := apsisTime(orbital.TimeToPeriapsis(st, mu)); ok {
 		lines = append(lines, chipRow("t→Pe:", s))
 	}
@@ -1704,8 +1729,8 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	// synchronous period for steady ground coverage). a > 0 and e < 1 are
 	// guaranteed above, so the period is finite.
 	period := 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
-	lines = append(lines, chipRow("period:", formatPeriod(period)))
-	lines = append(lines, chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)))
+	lines = append(lines, chipRow(readout.LabelPeriod, readout.Period(time.Duration(period*float64(time.Second)))))
+	lines = append(lines, chipRow(readout.LabelIncl, readout.Angle(el.I*180/math.Pi)))
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
 	// #426 (CONTEXT.md Chip entry): eccentricity, always-on, Full form only —
 	// the three eccentricity-graded challenge rungs (chal-high-orbit et al.)
@@ -1752,9 +1777,13 @@ func (v *OrbitView) buildOrbitMetricsChipCompact(w *sim.World) []string {
 	primaryR := c.Primary.RadiusMeters()
 	apoAlt := el.Apoapsis() - primaryR
 	periAlt := el.Periapsis() - primaryR
+	pePart := fmt.Sprintf("Pe: %s", readout.Distance(periAlt))
+	if periAlt < 0 {
+		pePart = v.theme.Warning.Render(pePart)
+	}
 	lines := []string{
 		v.theme.Primary.Render("ORBIT"),
-		fmt.Sprintf("  Ap: %s  Pe: %s", formatChipKm(apoAlt), formatChipKm(periAlt)),
+		fmt.Sprintf("  Ap: %s  %s", readout.Distance(apoAlt), pePart),
 	}
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ BELOW SURFACE"))
@@ -1782,9 +1811,13 @@ func (v *OrbitView) buildDockGuestOrbitChipCompact(w *sim.World) []string {
 	if w.DockGuest.OwnerHandle != "" {
 		header = "ORBIT — " + w.DockGuest.OwnerHandle + "'s stack"
 	}
+	pePart := fmt.Sprintf("Pe: %s", readout.Distance(periAlt))
+	if periAlt < 0 {
+		pePart = v.theme.Warning.Render(pePart)
+	}
 	lines := []string{
 		v.theme.Primary.Render(header),
-		fmt.Sprintf("  Ap: %s  Pe: %s", formatChipKm(apoAlt), formatChipKm(periAlt)),
+		fmt.Sprintf("  Ap: %s  %s", readout.Distance(apoAlt), pePart),
 	}
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ BELOW SURFACE"))
@@ -1808,8 +1841,8 @@ func (v *OrbitView) buildLandedOrbitChip(c *spacecraft.Spacecraft) []string {
 		v.theme.Primary.Render("ORBIT"),
 		chipRow("body:", c.Primary.EnglishName),
 		chipRow("landed at:", fmt.Sprintf("%.1f°, %.1f°", lat, lon)),
-		chipRow("altitude:", "0.0 km"),
-		chipRow("co-rotation:", fmt.Sprintf("%.1f m/s", c.State.V.Norm())),
+		chipRow(readout.LabelAltitude, readout.Distance(0)),
+		chipRow("co-rotation:", readout.Speed(c.State.V.Norm())),
 	}
 }
 
@@ -1842,11 +1875,15 @@ func (v *OrbitView) buildDockGuestOrbitChip(w *sim.World) []string {
 	if w.DockGuest.OwnerHandle != "" {
 		header = "ORBIT — " + w.DockGuest.OwnerHandle + "'s stack"
 	}
+	dgPeRow := chipRow(readout.LabelPe, readout.Distance(periAlt))
+	if periAlt < 0 {
+		dgPeRow = v.theme.Warning.Render(dgPeRow)
+	}
 	lines := []string{
 		v.theme.Primary.Render(header),
-		chipRow("Ap:", formatChipKm(apoAlt)),
-		chipRow("Pe:", formatChipKm(periAlt)),
-		chipRow("inclin.:", fmt.Sprintf("%.2f°", el.I*180/math.Pi)),
+		chipRow(readout.LabelAp, readout.Distance(apoAlt)),
+		dgPeRow,
+		chipRow(readout.LabelIncl, readout.Angle(el.I*180/math.Pi)),
 	}
 	if periAlt < 0 {
 		lines = append(lines, "  "+v.theme.Alert.Render("⚠ PERIAPSIS BELOW SURFACE"))
@@ -1879,9 +1916,14 @@ func (v *OrbitView) buildProjectedOrbitChip(w *sim.World) []string {
 		fmt.Sprintf("  primary:   %s", primary.EnglishName),
 	}
 	if ro.Hyperbolic {
+		hypPeAlt := ro.PeriMeters - primaryR
+		hypPeLine := fmt.Sprintf("  Pe:        %s", readout.Distance(hypPeAlt))
+		if hypPeAlt < 0 {
+			hypPeLine = v.theme.Warning.Render(hypPeLine)
+		}
 		lines = append(lines,
 			"  "+v.theme.Warning.Render("hyperbolic — escape"),
-			fmt.Sprintf("  Pe:        %.1f km alt", (ro.PeriMeters-primaryR)/1000),
+			hypPeLine,
 			fmt.Sprintf("  e:         %.3f", ro.Eccentricity),
 		)
 	} else {
@@ -1890,11 +1932,16 @@ func (v *OrbitView) buildProjectedOrbitChip(w *sim.World) []string {
 		// insertion burn to a target period.
 		projA := (ro.ApoMeters + ro.PeriMeters) / 2
 		projPeriod := 2 * math.Pi * math.Sqrt(projA*projA*projA/mu)
+		projPeAlt := ro.PeriMeters - primaryR
+		projPeLine := fmt.Sprintf("  Pe:        %s", readout.Distance(projPeAlt))
+		if projPeAlt < 0 {
+			projPeLine = v.theme.Warning.Render(projPeLine)
+		}
 		lines = append(lines,
-			fmt.Sprintf("  Ap:        %.1f km alt", (ro.ApoMeters-primaryR)/1000),
-			fmt.Sprintf("  Pe:        %.1f km alt", (ro.PeriMeters-primaryR)/1000),
-			fmt.Sprintf("  period:    %s", formatPeriod(projPeriod)),
-			fmt.Sprintf("  inclin.:   %.2f°", ro.Inclination*180/math.Pi),
+			fmt.Sprintf("  Ap:        %s", readout.Distance(ro.ApoMeters-primaryR)),
+			projPeLine,
+			fmt.Sprintf("  period:    %s", readout.Period(time.Duration(projPeriod*float64(time.Second)))),
+			fmt.Sprintf("  incl:      %s", readout.Angle(ro.Inclination*180/math.Pi)),
 			fmt.Sprintf("  direction: %s", v.orbitDirectionLabel(ro.Inclination)),
 		)
 		const equatorialTol = 1e-3
@@ -1944,7 +1991,7 @@ func (v *OrbitView) buildProjectedOrbitChipCompact(w *sim.World) []string {
 }
 
 // buildTargetChip surfaces the unified Target slot — a body (name, Δi,
-// range) or a craft (name/role, orbit shape, range, |v_rel|, closing,
+// range) or a craft (name/role, orbit shape, range, rel speed, closing,
 // closest-approach, rendezvous advisory, DOCK READY). Returns nil when no
 // target is set. Transplanted from renderHUD's TARGET block.
 func (v *OrbitView) buildTargetChip(w *sim.World) []string {
@@ -1988,7 +2035,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			lines = append(lines, chipRow("Δi:", diLabel))
 		}
 		rangeM := w.BodyPosition(b).Sub(w.CraftInertial()).Norm()
-		lines = append(lines, chipRow("range:", formatRangeM(rangeM)))
+		lines = append(lines, chipRow("range:", readout.Distance(rangeM)))
 		// Predicted closest approach along the projected orbit — updates live
 		// as the player hand-flies a correction, so they can judge where the
 		// transfer actually passes the target rather than eyeballing the
@@ -2013,9 +2060,9 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 					lines = append(lines, chipRow("perilune:", fmt.Sprintf("%.0f km", alt/1000)))
 				}
 			} else {
-				lines = append(lines, chipRow("approach:", formatRangeM(ap.Dist)))
+				lines = append(lines, chipRow("approach:", readout.Distance(ap.Dist)))
 			}
-			lines = append(lines, chipRow("TCA:", formatTCA(ap.TCA)))
+			lines = append(lines, chipRow(readout.LabelTCA, readout.Countdown(time.Duration(ap.TCA*float64(time.Second)))))
 		}
 		return lines
 	case sim.TargetCraft:
@@ -2030,16 +2077,21 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			tEl := orbital.ElementsFromStateInFrame(tc.State.R, tc.State.V, tMu, tFrame)
 			if tEl.A > 0 && !math.IsNaN(tEl.A) && !math.IsInf(tEl.A, 0) {
 				tPrimaryR := tc.Primary.RadiusMeters()
+				tPeriAlt := tEl.Periapsis() - tPrimaryR
+				tPeRow := chipRow(readout.LabelPe, readout.Distance(tPeriAlt))
+				if tPeriAlt < 0 {
+					tPeRow = v.theme.Warning.Render(tPeRow)
+				}
 				lines = append(lines,
-					chipRow("Ap:", formatChipKm(tEl.Apoapsis()-tPrimaryR)),
-					chipRow("Pe:", formatChipKm(tEl.Periapsis()-tPrimaryR)),
-					chipRow("inclin.:", fmt.Sprintf("%.2f°", tEl.I*180/math.Pi)),
+					chipRow(readout.LabelAp, readout.Distance(tEl.Apoapsis()-tPrimaryR)),
+					tPeRow,
+					chipRow(readout.LabelIncl, readout.Angle(tEl.I*180/math.Pi)),
 				)
 			}
 		} else {
 			// #375: a landed target's (R, ω×R) co-rotation state is not an
 			// orbit — swap Ap/Pe/inclin. for its landing site rather than
-			// reading elements off the pseudo-orbit. Range / |v_rel| /
+			// reading elements off the pseudo-orbit. Range / rel speed /
 			// closing below stay meaningful (relative-state math, not
 			// elements) so they're untouched.
 			tLat, tLon := tc.SurfaceLatLon()
@@ -2062,8 +2114,8 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		}
 		leadDeg, leadOK := w.TargetLeadAngleDeg()
 		lines = append(lines,
-			chipRow("range:", formatRangeM(rangeM)),
-			chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", vRel)),
+			chipRow("range:", readout.Distance(rangeM)),
+			chipRow(readout.LabelRelSpeed, readout.Speed(vRel)),
 			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
 			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
@@ -2096,7 +2148,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		return lines
 	case sim.TargetGhost:
 		// v0.27 review follow-up: a remote player's craft. Same rows as
-		// a local craft target — orbit, range, |v_rel|, closing, CA/TCA
+		// a local craft target: orbit, range, rel speed, closing, CA/TCA
 		// — resolved from the ghost slate (already at this world's
 		// sim-time). No DOCK READY: cross-player docking is v0.28.
 		g, gPrimary, ok := w.ResolveTargetGhost()
@@ -2120,10 +2172,15 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		gEl := orbital.ElementsFromStateInFrame(gRel, g.Vel, gMu, gFrame)
 		if gEl.A > 0 && !math.IsNaN(gEl.A) && !math.IsInf(gEl.A, 0) {
 			gPrimaryR := gPrimary.RadiusMeters()
+			gPeriAlt := gEl.Periapsis() - gPrimaryR
+			gPeRow := chipRow(readout.LabelPe, readout.Distance(gPeriAlt))
+			if gPeriAlt < 0 {
+				gPeRow = v.theme.Warning.Render(gPeRow)
+			}
 			lines = append(lines,
-				chipRow("Ap:", formatChipKm(gEl.Apoapsis()-gPrimaryR)),
-				chipRow("Pe:", formatChipKm(gEl.Periapsis()-gPrimaryR)),
-				chipRow("inclin.:", fmt.Sprintf("%.2f°", gEl.I*180/math.Pi)),
+				chipRow(readout.LabelAp, readout.Distance(gEl.Apoapsis()-gPrimaryR)),
+				gPeRow,
+				chipRow(readout.LabelIncl, readout.Angle(gEl.I*180/math.Pi)),
 			)
 		}
 		rT, vT, ok := w.TargetStateRelativeToActivePrimary()
@@ -2140,8 +2197,8 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		}
 		leadDeg, leadOK := w.TargetLeadAngleDeg()
 		lines = append(lines,
-			chipRow("range:", formatRangeM(rangeM)),
-			chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", vRel)),
+			chipRow("range:", readout.Distance(rangeM)),
+			chipRow(readout.LabelRelSpeed, readout.Speed(vRel)),
 			chipRow("closing:", fmt.Sprintf("%+.2f m/s", closing)),
 			chipRow("lead:", targetLeadLabel(leadDeg, leadOK)),
 		)
@@ -2156,7 +2213,7 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 // buildTargetChipCompact is TARGET's Compact Form (ADR 0046 / #422,
 // CONTEXT.md "Graceful Shrink": "the Target Chip becomes name + range"):
 // one row naming what's targeted, one row with its range — dropping Δi/
-// Ap/Pe/inclination, |v_rel|/closing/lead, the approach prediction, and
+// Ap/Pe/inclination, rel speed/closing/lead, the approach prediction, and
 // DOCK READY. Mirrors buildTargetChip's branch order (body / craft /
 // ghost, including the ghost's "not yet resolved" pending state) so the
 // two forms always agree about WHICH branch is showing; the range math
@@ -2179,7 +2236,7 @@ func (v *OrbitView) buildTargetChipCompact(w *sim.World) []string {
 		rangeM := w.BodyPosition(b).Sub(w.CraftInertial()).Norm()
 		return []string{
 			v.theme.Primary.Render("TARGET") + "  " + nameStyle.Render(b.EnglishName),
-			chipRow("range:", formatRangeM(rangeM)),
+			chipRow("range:", readout.Distance(rangeM)),
 		}
 	case sim.TargetCraft:
 		tc, _, ok := w.ResolveTargetCraft()
@@ -2194,7 +2251,7 @@ func (v *OrbitView) buildTargetChipCompact(w *sim.World) []string {
 		}
 		return []string{
 			v.theme.Primary.Render("TARGET") + "  " + tc.Name,
-			chipRow("range:", formatRangeM(rRel.Norm())),
+			chipRow("range:", readout.Distance(rRel.Norm())),
 		}
 	case sim.TargetGhost:
 		if _, _, ok := w.ResolveTargetGhost(); !ok {
@@ -2206,7 +2263,7 @@ func (v *OrbitView) buildTargetChipCompact(w *sim.World) []string {
 		lines := []string{v.theme.Primary.Render("TARGET") + "  " + w.TargetName()}
 		if rT, _, ok := w.TargetStateRelativeToActivePrimary(); ok {
 			rangeM := rT.Sub(c.State.R).Norm()
-			lines = append(lines, chipRow("range:", formatRangeM(rangeM)))
+			lines = append(lines, chipRow("range:", readout.Distance(rangeM)))
 		}
 		return lines
 	}
@@ -2254,8 +2311,8 @@ func (v *OrbitView) closestApproachRows(w *sim.World, c *spacecraft.Spacecraft) 
 		return nil
 	}
 	return []string{
-		chipRow("TCA:", formatTCA(tCA)),
-		chipRow("CA:", formatRangeM(distCA)),
+		chipRow(readout.LabelTCA, readout.Countdown(time.Duration(tCA*float64(time.Second)))),
+		chipRow(readout.LabelApproach, readout.Distance(distCA)),
 	}
 }
 
@@ -2315,9 +2372,9 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 		if arc.plOK {
 			lines = append(lines, chipRow("planned:", periValue(arc.planned)))
 			if arc.planned.HasEntryTime {
-				lines = append(lines, chipRow("  T-entry:", formatTCA(arc.planned.TimeToEntry)))
+				lines = append(lines, chipRow("  T-entry:", readout.Duration(time.Duration(arc.planned.TimeToEntry*float64(time.Second)))))
 			}
-			lines = append(lines, chipRow("  T-peri:", formatTCA(arc.planned.TimeToPerilune)))
+			lines = append(lines, chipRow("  T-peri:", readout.Duration(time.Duration(arc.planned.TimeToPerilune*float64(time.Second)))))
 		}
 		if arc.cfOK {
 			lines = append(lines, chipRow("no-burn:", periValue(arc.counterfactual)))
@@ -2327,11 +2384,11 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 	// Single live pass (no node planted). T-entry is the predicted SOI-entry
 	// clock — the ring crossing the Entry glyph marks (ADR 0021 C).
 	if arc.counterfactual.HasEntryTime {
-		lines = append(lines, chipRow("T-entry:", formatTCA(arc.counterfactual.TimeToEntry)))
+		lines = append(lines, chipRow("T-entry:", readout.Duration(time.Duration(arc.counterfactual.TimeToEntry*float64(time.Second)))))
 	}
 	lines = append(lines,
 		chipRow("perilune:", periValue(arc.counterfactual)),
-		chipRow("TCA:", formatTCA(arc.counterfactual.TimeToPerilune)))
+		chipRow(readout.LabelTCA, readout.Countdown(time.Duration(arc.counterfactual.TimeToPerilune*float64(time.Second)))))
 	return lines
 }
 
@@ -2340,11 +2397,6 @@ func (v *OrbitView) buildSOIPassChip(w *sim.World) []string {
 // corner. The buildOrbitMetricsChip rows are hand-padded to this column.
 const chipValueCol = 13
 
-// chipRow formats a "  label   value" telemetry row with the value pinned
-// to chipValueCol regardless of label width — so a chip's values share one
-// column instead of drifting per label. Padding is measured in display
-// cells (lipgloss.Width), so multibyte labels like "Δi:" and styled values
-// align correctly where byte-counted %-Ns padding would not.
 // orbitDirectionLabel renders the prograde/retrograde orbit-direction
 // readout for an equatorial-frame inclination (radians). i > 90° means
 // the orbit runs retrograde — against the primary's spin. This is the
@@ -2360,6 +2412,14 @@ func (v *OrbitView) orbitDirectionLabel(incRad float64) string {
 	return "prograde"
 }
 
+// chipRow formats a "  label   value" telemetry row with the value pinned
+// to chipValueCol regardless of label width, so a chip's values share one
+// column instead of drifting per label. Padding is measured in display
+// cells (lipgloss.Width), so multibyte labels like "Δi:" and styled values
+// align correctly where byte-counted %-Ns padding would not. Distance /
+// duration / speed / angle formatting lives in internal/tui/readout (ADR
+// 0049); this helper only lays the label and an already-formatted value
+// out in one column.
 func chipRow(label, value string) string {
 	prefix := "  " + label
 	pad := chipValueCol - lipgloss.Width(prefix)
@@ -2367,54 +2427,4 @@ func chipRow(label, value string) string {
 		pad = 1
 	}
 	return prefix + strings.Repeat(" ", pad) + value
-}
-
-// formatRangeM renders a distance with AU / km / m bands matching the
-// thresholds the TARGET block used inline.
-func formatRangeM(rangeM float64) string {
-	switch {
-	case rangeM > bodies.AU/10:
-		return fmt.Sprintf("%.3f AU", rangeM/bodies.AU)
-	case rangeM > 1e6:
-		return fmt.Sprintf("%.0f km", rangeM/1000)
-	case rangeM > 1000:
-		return fmt.Sprintf("%.2f km", rangeM/1000)
-	default:
-		return fmt.Sprintf("%.0f m", rangeM)
-	}
-}
-
-// nzero snaps a value whose magnitude rounds to zero at `decimals` places
-// to +0, so a quantity that jitters across zero (v_vert / fpa / altitude
-// on the pad, where the co-rotation state carries sub-unit noise) doesn't
-// flicker a "-0" / "-0.0" sign each frame. Only the sign of an
-// already-zero display changes; non-zero values pass through untouched.
-func nzero(x float64, decimals int) float64 {
-	scale := math.Pow(10, float64(decimals))
-	if math.Round(x*scale) == 0 {
-		return 0
-	}
-	return x
-}
-
-// formatChipKm renders a metres reading as a one-decimal kilometre
-// string with nzero applied (#375), so an altitude/apsis that legitimately
-// sits at the display quantum — the co-rotation noise a near-zero orbit
-// carries, not just a Landed craft's pseudo-orbit — can't flip a "-0.0"
-// sign from one tick to the next. Shared by the ORBIT / TARGET chips'
-// altitude, Ap, and Pe rows.
-func formatChipKm(m float64) string {
-	return fmt.Sprintf("%.1f km", nzero(m/1000, 1))
-}
-
-// formatTCA renders a time-to-closest-approach with s / min / h bands.
-func formatTCA(sec float64) string {
-	switch {
-	case sec >= 3600:
-		return fmt.Sprintf("%.2fh", sec/3600)
-	case sec >= 60:
-		return fmt.Sprintf("%.1fmin", sec/60)
-	default:
-		return fmt.Sprintf("%.0fs", sec)
-	}
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1241,7 +1241,7 @@ func (v *OrbitView) activeBurnLines(w *sim.World) []string {
 		}
 		if c.BurnStalled() {
 			lines = append(lines,
-				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %.0f m/s", tag, ab.Mode.String(), ab.DVRemaining)),
+				v.theme.Warning.Render(fmt.Sprintf("  ● %s — %s, Δv %s", tag, ab.Mode.String(), readout.DeltaV(ab.DVRemaining))),
 				v.theme.Warning.Render("    ⚠ STALLED — stage to resume (x to cancel)"),
 			)
 		} else {

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/settings"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // This file implements the v0.13 (ADR 0010) HUD split: the orbit screen's
@@ -676,7 +677,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	}
 	lines = append(lines,
 		fmt.Sprintf("  mass:      %.0f kg", c.TotalMass()),
-		fmt.Sprintf("  Δv budget: %.0f m/s", c.RemainingDeltaV()),
+		fmt.Sprintf("  %s        %s", readout.LabelDeltaV, deltaVReadout(c)),
 		v.throttleRow(c),
 	)
 	if c.MonopropCapacity > 0 {
@@ -778,8 +779,22 @@ func (v *OrbitView) buildVesselChipCompact(w *sim.World) []string {
 	}
 	return []string{
 		v.theme.Primary.Render("VESSEL") + v.vesselBurnBadge(w) + "  " + crashedVesselNameLabel(v.theme, c),
-		fmt.Sprintf("  fuel: %s  Δv: %.0f m/s", fuelStr, c.RemainingDeltaV()),
+		fmt.Sprintf("  fuel: %s  %s %s", fuelStr, readout.LabelDeltaV, deltaVReadout(c)),
 	}
+}
+
+// deltaVReadout renders the VESSEL chip's Δv row per ADR 0049 decision 7:
+// the active stage's remaining Δv, then the whole remaining stack's total
+// (spacecraft.StackStats over the stages still attached), sharing one
+// trailing unit ("3518 / 9412 m/s"). A single-stage vessel prints one
+// number instead ("3518 m/s"); there is no separate vehicle total to name.
+func deltaVReadout(c *spacecraft.Spacecraft) string {
+	stage := c.RemainingDeltaV()
+	if len(c.Stages) <= 1 {
+		return readout.DeltaV(stage)
+	}
+	vehicle := spacecraft.StackStats(c.Stages).TotalDV
+	return readout.DeltaVPair(stage, vehicle)
 }
 
 // stagePips renders one glyph per stage — ● firing/fueled, ○ dry — the
@@ -897,7 +912,7 @@ func (v *OrbitView) buildNodesChip(w *sim.World) []string {
 		n := nc.Nodes[ni]
 		kind := "imp"
 		if n.Duration > 0 {
-			kind = fmt.Sprintf("fin %.0fs", n.Duration.Seconds())
+			kind = "burn " + readout.Duration(n.Duration)
 		}
 		lines = append(lines, v.nextQueuedNodeLine(w, nc, nci, ni), "  "+kind)
 		// #333: the overflow count is nc's OWN remaining queue, not the
@@ -938,15 +953,15 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	// chip and the tut-plan mission objective share one formula.
 	over := ""
 	if shortfall, isOver := n.OverBudget(nc); isOver {
-		over = "  " + v.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %.0f m/s", shortfall))
+		over = "  " + v.theme.Alert.Render(fmt.Sprintf("⚠ exceeds budget by %s", readout.DeltaV(shortfall)))
 	}
 	label := fmt.Sprintf("#%d", ni+1)
 	if len(w.Crafts) > 1 {
 		label = fmt.Sprintf("c%d#%d", nci+1, ni+1)
 	}
 	if !n.IsResolved() {
-		return fmt.Sprintf("  %s %s %s  %s  %.0f m/s",
-			hudNodeMarker, label, n.Event.String(), n.Mode.String(), n.DV) + over
+		return fmt.Sprintf("  %s %s %s  %s  %s",
+			hudNodeMarker, label, n.Event.String(), n.Mode.String(), readout.DeltaV(n.DV)) + over
 	}
 	// decision 7 (grilled 2026-09-06): the head row counts to BurnStart
 	// (ignition), not TriggerTime (the burn's midpoint) — a 72s finite
@@ -963,8 +978,8 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	// 0s" for the entire preceding burn, which says imminent when the
 	// truth is "once the current burn ends". Say that instead.
 	if nc.ActiveBurn != nil {
-		return fmt.Sprintf("  %s %s ignition after burn  %s  %.0f m/s",
-			hudNodeMarker, label, n.Mode.String(), n.DV) + over
+		return fmt.Sprintf("  %s %s ignition after burn  %s  %s",
+			hudNodeMarker, label, n.Mode.String(), readout.DeltaV(n.DV)) + over
 	}
 	// Code-review finding 4: BurnStart can be at or past SimTime — paused
 	// right at the boundary, or held past due for want of a resolvable
@@ -972,12 +987,12 @@ func (v *OrbitView) nextQueuedNodeLine(w *sim.World, nc *spacecraft.Spacecraft, 
 	// or it's simply not this tick's turn in executeDueNodesFor's walk).
 	// A raw negative dt read as a nonsensical "ignition in -47s"; clamp
 	// to 0 so an overdue-but-not-fired node reads as imminent instead.
-	dt := n.BurnStart().Sub(w.Clock.SimTime).Seconds()
+	dt := n.BurnStart().Sub(w.Clock.SimTime)
 	if dt < 0 {
 		dt = 0
 	}
-	return fmt.Sprintf("  %s %s ignition in %.0fs  %s  %.0f m/s",
-		hudNodeMarker, label, dt, n.Mode.String(), n.DV) + over
+	return fmt.Sprintf("  %s %s ignition in %s  %s  %s",
+		hudNodeMarker, label, readout.Duration(dt), n.Mode.String(), readout.DeltaV(n.DV)) + over
 }
 
 // buildNodesChipCompact is NODES' Compact Form (ADR 0046 / #422): the

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -539,15 +539,26 @@ func (v *OrbitView) composeChips(canvasStr string, cCols, cRows, navballReserved
 }
 
 // navballReservedRows reports how many bottom rows the navball panel
-// occupies on the canvas this frame (0 when it isn't shown), so the
-// bottom-right Nodes chip can stack above it. Mirrors the gate in
-// composeNavballOverlay; the +1 matches the one-row bottom lift there.
+// occupies on the canvas this frame, so the bottom-right Nodes chip can
+// stack above it. Mirrors the gate in composeNavballOverlay; the +1
+// matches the one-row bottom lift there.
+//
+// The floor is 1, never 0: row cRows-1 carries the Hint Strip
+// (paintHintStrip), painted unconditionally regardless of navball state,
+// and bottomLeftRow already stays off that row unconditionally (cRows-2,
+// "above the view: label"). Before this fix bottom-right chips had no
+// equivalent floor whenever the navball itself was absent
+// (!CraftVisibleHere, a too-small canvas, or no sub-observer), so a wide
+// enough NODES chip in exactly that state could paint over the Hint
+// Strip's tail: a real Design Size (140x40) collision the ADR 0049 stage
+// A2 gate review measured (the node row's own contract-mandated widening
+// was what tipped it over the edge; see impl-notes/item4-A2-migration.md).
 func (v *OrbitView) navballReservedRows(w *sim.World, cCols, cRows int) int {
 	if !w.CraftVisibleHere() || cCols < navballPanelW+2 || cRows < navballPanelH+2 {
-		return 0
+		return 1
 	}
 	if _, _, ok := w.NavballSubObserver(); !ok {
-		return 0
+		return 1
 	}
 	return navballPanelH + 1
 }
@@ -647,7 +658,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 				lines = append(lines,
 					"  "+name,
 					"  primary:   "+primary.EnglishName,
-					fmt.Sprintf("  velocity:  %.2f km/s", g.Vel.Norm()/1000),
+					fmt.Sprintf("  velocity:  %s", readout.Speed(g.Vel.Norm())),
 				)
 			}
 			// #330: [U], matching the actual uppercase Undock binding —
@@ -667,7 +678,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 		v.theme.Primary.Render("VESSEL") + v.vesselBurnBadge(w),
 		"  " + crashedVesselNameLabel(v.theme, c),
 		"  primary:   " + c.Primary.EnglishName,
-		fmt.Sprintf("  velocity:  %.2f km/s", c.OrbitalSpeed()/1000),
+		fmt.Sprintf("  velocity:  %s", readout.Speed(c.OrbitalSpeed())),
 		v.theme.Primary.Render("PROPELLANT"),
 	}
 	if pct, kg, ok := activeStageFuel(c); ok {
@@ -683,7 +694,7 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 	if c.MonopropCapacity > 0 {
 		lines = append(lines,
 			fmt.Sprintf("  monoprop:  %.0f kg", c.Monoprop),
-			fmt.Sprintf("  rcs Δv:    %.0f m/s", c.RCSDeltaV()),
+			fmt.Sprintf("  rcs Δv:    %s", readout.DeltaV(c.RCSDeltaV())),
 		)
 		// In RCS mode, surface the per-pulse step so the player can see
 		// the fine-trim level the `p` key cycles. v0.24.5+.

--- a/internal/tui/screens/orbit_chips.go
+++ b/internal/tui/screens/orbit_chips.go
@@ -682,18 +682,18 @@ func (v *OrbitView) buildVesselChip(w *sim.World) []string {
 		v.theme.Primary.Render("PROPELLANT"),
 	}
 	if pct, kg, ok := activeStageFuel(c); ok {
-		lines = append(lines, fmt.Sprintf("  fuel:      %.0f%% (%.0f kg)", pct, kg))
+		lines = append(lines, fmt.Sprintf("  fuel:      %.0f%% (%s)", pct, readout.Mass(kg)))
 	} else {
-		lines = append(lines, fmt.Sprintf("  fuel:      %.0f kg", c.Fuel))
+		lines = append(lines, fmt.Sprintf("  fuel:      %s", readout.Mass(c.Fuel)))
 	}
 	lines = append(lines,
-		fmt.Sprintf("  mass:      %.0f kg", c.TotalMass()),
+		fmt.Sprintf("  mass:      %s", readout.Mass(c.TotalMass())),
 		fmt.Sprintf("  %s        %s", readout.LabelDeltaV, deltaVReadout(c)),
 		v.throttleRow(c),
 	)
 	if c.MonopropCapacity > 0 {
 		lines = append(lines,
-			fmt.Sprintf("  monoprop:  %.0f kg", c.Monoprop),
+			fmt.Sprintf("  monoprop:  %s", readout.Mass(c.Monoprop)),
 			fmt.Sprintf("  rcs Δv:    %s", readout.DeltaV(c.RCSDeltaV())),
 		)
 		// In RCS mode, surface the per-pulse step so the player can see
@@ -784,9 +784,9 @@ func (v *OrbitView) buildVesselChipCompact(w *sim.World) []string {
 		return nil
 	}
 	c := w.ActiveCraft()
-	fuelStr := fmt.Sprintf("%.0f kg", c.Fuel)
+	fuelStr := readout.Mass(c.Fuel)
 	if pct, kg, ok := activeStageFuel(c); ok {
-		fuelStr = fmt.Sprintf("%.0f%% (%.0f kg)", pct, kg)
+		fuelStr = fmt.Sprintf("%.0f%% (%s)", pct, readout.Mass(kg))
 	}
 	return []string{
 		v.theme.Primary.Render("VESSEL") + v.vesselBurnBadge(w) + "  " + crashedVesselNameLabel(v.theme, c),

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -866,6 +866,76 @@ func TestBuildVesselChipCoreOnly(t *testing.T) {
 	}
 }
 
+// TestBuildVesselChipMassesRideTheLadder pins F7 (gate review): masses
+// were never migrated to readout.Mass, so a Saturn V's fuel/mass/
+// monoprop rows still printed raw kilograms ("2901847 kg") straight
+// through decision 3's contract, the exact number the ADR's own Context
+// section names as one of the original findings. A spawned Saturn V's
+// fuel and total mass are both well past the 1000 kg kg->t rung, so a
+// surviving raw-kg reading fails this immediately.
+func TestBuildVesselChipMassesRideTheLadder(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	for _, want := range []string{"fuel:      100% (2160 t)", "mass:      2902 t", "monoprop:  11.85 t"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("VESSEL chip missing %q (masses should ride the kg/t ladder):\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, " kg") {
+		t.Errorf("VESSEL chip still prints a raw kilogram reading:\n%s", out)
+	}
+}
+
+// TestBuildVesselChipDeltaVPairShowsStageOverVehicle pins F12 (gate
+// review): decision 7's "stage / vehicle" two-number Δv row had no
+// call-site test: only readout's own DeltaVPair unit tests covered the
+// string shape, not that a real multi-stage vessel's VESSEL chip (full
+// and Compact Form) actually reaches it instead of printing the active
+// stage's Δv alone. A spawned Saturn V has three stages, so its active
+// stage's remaining Δv and the whole stack's total are provably
+// different numbers, sharing one trailing unit.
+func TestBuildVesselChipDeltaVPairShowsStageOverVehicle(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	c := w.ActiveCraft()
+	if len(c.Stages) <= 1 {
+		t.Fatalf("test setup broken: Saturn V should spawn with more than one stage, got %d", len(c.Stages))
+	}
+	out := strings.Join(v.buildVesselChip(w), "\n")
+	if !strings.Contains(out, "Δv:        3518 / 18872 m/s") {
+		t.Errorf("VESSEL chip missing the stage/vehicle Δv pair:\n%s", out)
+	}
+	compact := strings.Join(v.buildVesselChipCompact(w), "\n")
+	if !strings.Contains(compact, "Δv: 3518 / 18872 m/s") {
+		t.Errorf("VESSEL chip (Compact Form) missing the stage/vehicle Δv pair:\n%s", compact)
+	}
+}
+
 // TestBuildNodesChipMergesActiveBurn — the NODES chip carries an in-flight
 // burn as its firing head above the planted-node summary (v0.16), and
 // shows the firing head alone when a burn is live with no upcoming nodes.
@@ -1110,8 +1180,8 @@ func realisticChipSet(burning bool) []builtChip {
 	}
 	return []builtChip{
 		{corner: cornerTopLeft, priority: chipPriorityCore,
-			lines:   []string{"VESSEL", "  S-IVB-1", "  primary:   Earth", "  velocity:  7.50 km/s", "PROPELLANT", "  fuel:      89% (35775 kg)", "  mass:      47495 kg", "  Δv budget: 5777 m/s", "  throttle:  100%"},
-			compact: []string{"VESSEL  S-IVB-1", "  fuel: 89% (35775 kg)  Δv: 5777 m/s"}},
+			lines:   []string{"VESSEL", "  S-IVB-1", "  primary:   Earth", "  velocity:  7.50 km/s", "PROPELLANT", "  fuel:      89% (35.77 t)", "  mass:      47.49 t", "  Δv:        5777 m/s", "  throttle:  100%"},
+			compact: []string{"VESSEL  S-IVB-1", "  fuel: 89% (35.77 t)  Δv: 5777 m/s"}},
 		{id: settings.ChipFrameTransition, corner: cornerTopLeft,
 			lines: []string{"FRAME TRANSITION", "  Earth → Moon", "  at T+5d4h  (node #3)"}},
 		{id: settings.ChipMissions, corner: cornerTopLeft,
@@ -1120,11 +1190,11 @@ func realisticChipSet(burning bool) []builtChip {
 		{corner: cornerTopRight, priority: chipPriorityCore,
 			// #426: the Full form grew an `e:` row (eccentricity, always-on,
 			// full form only — the Compact Form stays the Ap/Pe strip below).
-			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  apo:       T-47m", "  Pe:        498.2 km", "  peri:      T-12m", "  period:    1h34m28s", "  inclin.:   0.00°", "  direction: prograde", "  e:         0.0004"},
+			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  apo:       T-47m", "  Pe:        498.2 km", "  peri:      T-12m", "  period:    1h34m28s", "  incl:      0.00°", "  direction: prograde", "  e:         0.0004"},
 			compact: []string{"ORBIT", "  Ap: 500.0 km  Pe: 498.2 km"}},
 		{id: settings.ChipTarget, corner: cornerTopRight,
-			lines:   []string{"TARGET", "  body:     Moon", "  Δi:       19.44°", "  range:    371639 km", "  TCA:      4.72h"},
-			compact: []string{"TARGET  Moon", "  range: 371639 km"}},
+			lines:   []string{"TARGET", "  body:     Moon", "  Δincl:    19.44°", "  range:    371.6 Mm", "  TCA:      T-4h43m"},
+			compact: []string{"TARGET  Moon", "  range: 371.6 Mm"}},
 		{id: settings.ChipStages, corner: cornerBottomLeft,
 			lines:   []string{"STAGES", "  ●●●", "  ▸ S-IC (1/3)"},
 			compact: []string{"STAGES  ●●●"}},

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -1120,7 +1120,7 @@ func realisticChipSet(burning bool) []builtChip {
 		{corner: cornerTopRight, priority: chipPriorityCore,
 			// #426: the Full form grew an `e:` row (eccentricity, always-on,
 			// full form only — the Compact Form stays the Ap/Pe strip below).
-			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  t→Ap:      47m", "  Pe:        498.2 km", "  t→Pe:      12m", "  period:    1h34m28s", "  inclin.:   0.00°", "  direction: prograde", "  e:         0.0004"},
+			lines:   []string{"ORBIT", "  altitude:  500.0 km", "  Ap:        500.0 km", "  apo:       T-47m", "  Pe:        498.2 km", "  peri:      T-12m", "  period:    1h34m28s", "  inclin.:   0.00°", "  direction: prograde", "  e:         0.0004"},
 			compact: []string{"ORBIT", "  Ap: 500.0 km  Pe: 498.2 km"}},
 		{id: settings.ChipTarget, corner: cornerTopRight,
 			lines:   []string{"TARGET", "  body:     Moon", "  Δi:       19.44°", "  range:    371639 km", "  TCA:      4.72h"},

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -1183,7 +1183,10 @@ func realisticChipSet(burning bool) []builtChip {
 			lines:   []string{"VESSEL", "  S-IVB-1", "  primary:   Earth", "  velocity:  7.50 km/s", "PROPELLANT", "  fuel:      89% (35.77 t)", "  mass:      47.49 t", "  Δv:        5777 m/s", "  throttle:  100%"},
 			compact: []string{"VESSEL  S-IVB-1", "  fuel: 89% (35.77 t)  Δv: 5777 m/s"}},
 		{id: settings.ChipFrameTransition, corner: cornerTopLeft,
-			lines: []string{"FRAME TRANSITION", "  Earth → Moon", "  at T+5d4h  (node #3)"}},
+			// A future frame transition renders T- (readout.Countdown's
+			// sign convention, decision 2): "T+5d4h" here pinned the
+			// exact inversion this PR exists to remove (F13).
+			lines: []string{"FRAME TRANSITION", "  Earth → Moon", "  at T-5d04h  (node #3)"}},
 		{id: settings.ChipMissions, corner: cornerTopLeft,
 			lines:   []string{"MISSION  Flight School: Plan a Burn", "  ▸ Warp to the node  0/1", "    Press [G] to auto-warp to the burn."},
 			compact: []string{"MISSION  Flight School: Plan a Burn", "  ▸ Warp to the node  0/1"}},

--- a/internal/tui/screens/orbit_chips_test.go
+++ b/internal/tui/screens/orbit_chips_test.go
@@ -458,33 +458,14 @@ func TestWorstCaseFrameDoesNotOverflow(t *testing.T) {
 	}
 }
 
+// The negative-zero-snap coverage this used to pin (TestNzeroSnapsNegativeZero,
+// pre-ADR-0049) now lives on internal/tui/readout's own TestNzero: the
+// local `nzero` helper is deleted, every screens/ formatter routes through
+// readout.Nzero instead (ADR 0049 stage A2).
+
 // TestDeclutterHidesChipsKeepsColumn: F2 declutter suppresses every Chip
 // (here the always-relevant ATTITUDE chip) while the slim HUD column —
 // which it must never hide (CONTEXT.md §Declutter) — keeps rendering.
-func TestNzeroSnapsNegativeZero(t *testing.T) {
-	cases := []struct {
-		x        float64
-		decimals int
-		want     float64
-	}{
-		{-0.3, 0, 0},    // rounds to 0 at %.0f → snapped to +0
-		{0.3, 0, 0},     // also rounds to 0 → +0 (sign already fine)
-		{-0.04, 1, 0},   // rounds to 0.0 at %.1f → +0
-		{-0.6, 0, -0.6}, // rounds to -1 → untouched
-		{12.3, 1, 12.3}, // non-zero → untouched
-	}
-	for _, c := range cases {
-		got := nzero(c.x, c.decimals)
-		if got != c.want {
-			t.Errorf("nzero(%g, %d) = %g, want %g", c.x, c.decimals, got, c.want)
-		}
-		// The snapped value must never format with a negative sign at 0.
-		if c.want == 0 && fmt.Sprintf("%+.*f", c.decimals, got)[0] == '-' {
-			t.Errorf("nzero(%g, %d) still formats as negative zero", c.x, c.decimals)
-		}
-	}
-}
-
 func TestDeclutterHidesChipsKeepsColumn(t *testing.T) {
 	v := NewOrbitView(chipTestTheme())
 	v.Resize(120, 40)
@@ -875,7 +856,7 @@ func TestBuildVesselChipCoreOnly(t *testing.T) {
 	if !strings.Contains(out, "VESSEL") || !strings.Contains(out, "PROPELLANT") {
 		t.Errorf("vessel chip missing core headers:\n%s", out)
 	}
-	if !strings.Contains(out, "velocity") || !strings.Contains(out, "Δv budget") {
+	if !strings.Contains(out, "velocity") || !strings.Contains(out, "Δv:") {
 		t.Errorf("vessel chip missing core telemetry rows:\n%s", out)
 	}
 	// Orbit shape lives in the Orbit-metrics chip — the vessel chip must
@@ -913,11 +894,11 @@ func TestBuildNodesChipMergesActiveBurn(t *testing.T) {
 	if !strings.Contains(joined, "120 m/s") {
 		t.Errorf("firing burn missing from merged chip:\n%s", joined)
 	}
-	if !strings.Contains(joined, "80 m/s") {
+	if !strings.Contains(joined, "80.00 m/s") {
 		t.Errorf("planted node missing from merged chip:\n%s", joined)
 	}
 	// Firing head must come before the planted node.
-	if strings.Index(joined, "120 m/s") > strings.Index(joined, "80 m/s") {
+	if strings.Index(joined, "120 m/s") > strings.Index(joined, "80.00 m/s") {
 		t.Errorf("firing burn should head the chip, above planted nodes:\n%s", joined)
 	}
 
@@ -1204,10 +1185,10 @@ func TestGracefulShrinkReproducesStagesVsProximityCollision(t *testing.T) {
 	cCols, cRows := canvasDimsFor(104, 24)
 	chips := []builtChip{
 		{corner: cornerTopLeft, priority: chipPriorityCore,
-			lines:   []string{"VESSEL", "  Saturn V-2", "  primary:   Earth", "  velocity:  0.41 km/s", "PROPELLANT", "  fuel:      100% (2160000 kg)", "  mass:      2901847 kg", "  Δv budget: 3518 m/s", "  throttle:  100%"},
+			lines:   []string{"VESSEL", "  Saturn V-2", "  primary:   Earth", "  velocity:  0.41 km/s", "PROPELLANT", "  fuel:      100% (2160000 kg)", "  mass:      2901847 kg", "  Δv:        3518 m/s", "  throttle:  100%"},
 			compact: []string{"VESSEL  Saturn V-2", "  fuel: 100%  Δv: 3518 m/s"}},
 		{id: "", corner: cornerTopLeft,
-			lines:   []string{"PROXIMITY  Saturn V-1", "  range:    10661 km", "  |v_rel|:  5518.77 m/s", "  closing:  +3639.71 m/s"},
+			lines:   []string{"PROXIMITY  Saturn V-1", "  range:    10661 km", "  rel speed: 5518.77 m/s", "  closing:  +3639.71 m/s"},
 			compact: []string{"PROXIMITY  Saturn V-1", "  range: 10661 km"}},
 		{id: settings.ChipStages, corner: cornerBottomLeft,
 			lines:   []string{"STAGES", "  ●●●", "  ▸ S-IC (1/3)"},

--- a/internal/tui/screens/orbit_circular_apsis_test.go
+++ b/internal/tui/screens/orbit_circular_apsis_test.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // placeOnConic puts the active craft on the coplanar conic with the given
@@ -101,5 +105,80 @@ func TestOrbitChipApsisTimesLiveOnSlightlyEccentricOrbit(t *testing.T) {
 	}
 	if atPeri == quarterOn {
 		t.Errorf("t→Ap frozen at %q across a quarter orbit — the timer is not tracking position", atPeri)
+	}
+}
+
+// TestOrbitChipSubSurfacePeriapsisIsWarningColoured pins F12 (gate
+// review): decision 5's "a sub-surface periapsis keeps its signed depth;
+// the row turns Warning" had no call-site test anywhere in the suite
+// (readout's own tests cover the string content, not which theme style a
+// real chip applies to it). No extra word or glyph marks the row per the
+// ADR, so the ONLY observable difference is the colour: this uses
+// plainThemeColored (distinguishable ANSI per style, unlike
+// chipTestTheme's no-op styles) and checks the RAW (non-ANSI-stripped)
+// output: the Pe: row must carry escape codes, and the Ap: row (not
+// sub-surface, the control) must not, proving the colouring is targeted
+// rather than a blanket style leaking onto every row.
+func TestOrbitChipSubSurfacePeriapsisIsWarningColoured(t *testing.T) {
+	// go test's stdout is not a TTY, so termenv's lazy env detection
+	// (cached process-wide via sync.Once) settles on the colorless
+	// Ascii profile the first time anything asks, which makes every
+	// theme's Render a no-op regardless of what color it was given.
+	// SetColorProfile bypasses that detection outright. Same idiom as
+	// TestOrbitRenderDiskCacheHitMatchesUncachedAfterPan: read the
+	// process's ambient profile first (lazily triggering detection if
+	// nothing has yet) and restore exactly that in t.Cleanup, so every
+	// test that runs after this one sees the same color output it
+	// would have without this test existing.
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	v := NewOrbitView(plainThemeColored())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := w.ActiveCraft()
+	// Switch to the Moon: an atmosphered primary's shouldShowLaunchHUD
+	// gate reads "periapsis below the atmosphere cutoff" as still
+	// ascending, at ANY true anomaly, and hands the row to the LAUNCH/
+	// SURFACE chip instead (exactly what decision 5 also covers there),
+	// but not what this test means to exercise. An airless body has no
+	// such gate, so a sub-surface periapsis reaches the plain ORBIT chip.
+	for _, b := range w.System().Bodies {
+		if b.ID == "moon" {
+			c.Primary = b
+			break
+		}
+	}
+	primaryR := c.Primary.RadiusMeters()
+	// Periapsis 50 km below the surface (an impactor / de-orbit
+	// trajectory), apoapsis 500 km above it, so Ap: stays a normal
+	// reading and only Pe: should carry the Warning colour.
+	placeOnConic(w, primaryR-50e3, primaryR+500e3, math.Pi)
+
+	lines := v.buildOrbitMetricsChip(w)
+	var apLine, peLine string
+	for _, l := range lines {
+		switch {
+		case strings.Contains(stripANSI(l), readout.LabelAp):
+			apLine = l
+		case strings.Contains(stripANSI(l), readout.LabelPe):
+			peLine = l
+		}
+	}
+	if apLine == "" || peLine == "" {
+		t.Fatalf("could not find both Ap: and Pe: rows in ORBIT chip:\n%s", strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(stripANSI(peLine), "-") {
+		t.Fatalf("setup broken: Pe row does not read as sub-surface (no signed depth): %q", peLine)
+	}
+	if peLine == stripANSI(peLine) {
+		t.Errorf("sub-surface Pe row carries no colour escape codes at all (want Warning): %q", peLine)
+	}
+	if apLine != stripANSI(apLine) {
+		t.Errorf("Ap row (not sub-surface) unexpectedly carries colour codes, colouring is not targeted: %q", apLine)
 	}
 }

--- a/internal/tui/screens/orbit_circular_apsis_test.go
+++ b/internal/tui/screens/orbit_circular_apsis_test.go
@@ -175,8 +175,14 @@ func TestOrbitChipSubSurfacePeriapsisIsWarningColoured(t *testing.T) {
 	if !strings.Contains(stripANSI(peLine), "-") {
 		t.Fatalf("setup broken: Pe row does not read as sub-surface (no signed depth): %q", peLine)
 	}
-	if peLine == stripANSI(peLine) {
-		t.Errorf("sub-surface Pe row carries no colour escape codes at all (want Warning): %q", peLine)
+	// plainThemeColored's Warning style is Foreground(Color("3")), which
+	// termenv.ANSI renders as the literal SGR sequence "\x1b[33m", pinned
+	// specifically rather than "carries some colour at all", so swapping
+	// in a different style (e.g. Dim, "\x1b[90m") still fails this check
+	// instead of passing as "some style was applied".
+	const wantWarningPrefix = "\x1b[33m"
+	if !strings.HasPrefix(peLine, wantWarningPrefix) {
+		t.Errorf("sub-surface Pe row not wrapped in Warning (%q): %q", wantWarningPrefix, peLine)
 	}
 	if apLine != stripANSI(apLine) {
 		t.Errorf("Ap row (not sub-surface) unexpectedly carries colour codes, colouring is not targeted: %q", apLine)

--- a/internal/tui/screens/orbit_circular_apsis_test.go
+++ b/internal/tui/screens/orbit_circular_apsis_test.go
@@ -62,14 +62,14 @@ func TestOrbitChipApsisTimesDegenerateOnCircularOrbit(t *testing.T) {
 	for _, nu := range []float64{0, math.Pi / 2} {
 		period := placeOnConic(w, r, r, nu)
 		out := v.Render(w, 0, 200, 60)
-		for _, label := range []string{"t→Ap:", "t→Pe:"} {
+		for _, label := range []string{"apo:", "peri:"} {
 			val := apsisRow(t, out, label)
 			if val != "—" {
 				t.Errorf("circular orbit at ν=%.2f: %s %q, want \"—\" (apsides are undefined at e=0)",
 					nu, label, val)
 			}
 		}
-		seen = append(seen, apsisRow(t, out, "t→Ap:"))
+		seen = append(seen, apsisRow(t, out, "apo:"))
 		_ = period
 	}
 	if len(seen) == 2 && seen[0] != seen[1] {
@@ -92,9 +92,9 @@ func TestOrbitChipApsisTimesLiveOnSlightlyEccentricOrbit(t *testing.T) {
 	rPeri, rApo := primaryR+500.0e3, primaryR+500.4e3
 
 	placeOnConic(w, rPeri, rApo, 0)
-	atPeri := apsisRow(t, v.Render(w, 0, 200, 60), "t→Ap:")
+	atPeri := apsisRow(t, v.Render(w, 0, 200, 60), "apo:")
 	placeOnConic(w, rPeri, rApo, math.Pi/2)
-	quarterOn := apsisRow(t, v.Render(w, 0, 200, 60), "t→Ap:")
+	quarterOn := apsisRow(t, v.Render(w, 0, 200, 60), "apo:")
 
 	if strings.Contains(atPeri, "—") || strings.Contains(quarterOn, "—") {
 		t.Fatalf("0.4 km of apsis separation read as degenerate: %q / %q", atPeri, quarterOn)

--- a/internal/tui/screens/orbit_descent_hud_test.go
+++ b/internal/tui/screens/orbit_descent_hud_test.go
@@ -176,7 +176,7 @@ func TestShouldShowDescentHUDAtmospheric(t *testing.T) {
 // HUD into the playtest-report scenario: standalone Lander at 5 km
 // Moon altitude with residual orbital lateral velocity (1.5 km/s,
 // vastly above CrashVCritMps = 10). The rendered output must
-// surface the DESCENT header, the v_horiz row, and the CRASH-on-
+// surface the DESCENT header, the horiz row, and the CRASH-on-
 // contact alert so the failure mode is legible before touchdown.
 func TestDescentHUDRendersVHorizAlertOnImpactorApproach(t *testing.T) {
 	w, err := sim.NewWorld()
@@ -195,17 +195,17 @@ func TestDescentHUDRendersVHorizAlertOnImpactorApproach(t *testing.T) {
 	if !strings.Contains(out, "DESCENT") {
 		t.Errorf("expected DESCENT section header in render; got:\n%s", out)
 	}
-	if !strings.Contains(out, "v_vert:") {
-		t.Errorf("expected v_vert row")
+	if !strings.Contains(out, "vert:") {
+		t.Errorf("expected vert row")
 	}
-	if !strings.Contains(out, "v_horiz:") {
-		t.Errorf("expected v_horiz row")
+	if !strings.Contains(out, "horiz:") {
+		t.Errorf("expected horiz row")
 	}
 	if !strings.Contains(out, "fpa:") {
 		t.Errorf("expected fpa row")
 	}
 	if !strings.Contains(out, "CRASH on contact") {
-		t.Errorf("expected v_horiz CRASH-on-contact alert for 1.5 km/s lateral; got:\n%s", out)
+		t.Errorf("expected horiz CRASH-on-contact alert for 1.5 km/s lateral; got:\n%s", out)
 	}
 }
 

--- a/internal/tui/screens/orbit_hint_strip_test.go
+++ b/internal/tui/screens/orbit_hint_strip_test.go
@@ -145,31 +145,32 @@ func TestHintStripClipsRightBelowDesignSize(t *testing.T) {
 }
 
 // TestHintStripWithForcedNodesChipAndCraftNotVisibleHere probes the one
-// collision path composeChips' own bottom-right stacking leaves open:
-// navballReservedRows returns 0 whenever CraftVisibleHere() is false
-// (camera tabbed to a different system than the active craft), so the
-// NODES chip's forced (2+ queued nodes) bottom-right block's bottom row
-// can land on the canvas's very last row too — the same row the Hint
-// Strip paints on the right-hand side. This is NOT one of the two
+// collision path composeChips' own bottom-right stacking used to leave
+// open: navballReservedRows returned 0 whenever CraftVisibleHere() was
+// false (camera tabbed to a different system than the active craft), so
+// the NODES chip's forced (2+ queued nodes) bottom-right block's bottom
+// row could land on the canvas's very last row too, the same row the
+// Hint Strip paints on the right-hand side. This was NOT one of the two
 // collisions #425 requires proving absent (navball, bottom-left chip);
 // it's a corner the decision doesn't cover. Measured, not assumed, and
 // re-measured after ADR 0049 (readout contract, stage A2): the node row's
-// duration and Δv now render two-unit / 2-decimal-below-100 ("ignition in
-// 1m00s", "42.00 m/s" vs the old "60s"/"42 m/s"), a few columns wider on
-// exactly this kind of small-value node, which is enough to newly close
-// the Design Size gap:
-//   - 140×40 (Design Size): NOW also collides: the wider node row runs
-//     the chip's left border into the Hint Strip's tail. This is a new
-//     finding from the ADR 0049 migration, flagged in its impl notes for
-//     a follow-up decision (widen the reserved margin, or accept it);
-//     not fixed here, since it is a chip-layout-budget question, not a
-//     formatting one.
-//   - 104×24 (Playable Floor): DOES collide, as before: the chip's left
-//     border overwrites the Hint Strip's tail. Documented here and in
-//     impl-notes/425.md as a known, deliberately out-of-scope edge case
-//     (requires both a queued 2+-node vessel AND the camera tabbed away
-//     to a different system while it's queued) rather than silently
-//     asserted away.
+// duration and Δv render two-unit / 2-decimal-below-100 ("ignition in
+// 1m00s", "42.00 m/s" vs the pre-contract "60s"/"42 m/s"), a few columns
+// wider on exactly this kind of small-value node, which was enough to
+// newly close the Design Size gap #425 had measured as clear.
+//
+// Fixed on the same gate review that found it, in navballReservedRows
+// (orbit_chips.go): the bottom-right corner's stacking cursor had no
+// floor reservation for row cRows-1 (the Hint Strip's own row) whenever
+// the navball itself was absent (!CraftVisibleHere, this test's own
+// setup); bottomLeftRow already stayed off that row unconditionally,
+// bottomRightRow didn't. The floor is now 1 row in every navball-absent
+// branch, so a bottom-right chip can never paint onto the Hint Strip's
+// row regardless of how wide its own contents get. 140×40 (Design Size)
+// is asserted as a hard requirement below; 104×24 (Playable Floor, below
+// the Design Size floor, #425's own known-and-accepted edge case) is
+// logged rather than asserted since a guarantee there was never required,
+// though the same fix happens to clear it too.
 func TestHintStripWithForcedNodesChipAndCraftNotVisibleHere(t *testing.T) {
 	render := func(sz struct{ w, h int }) string {
 		v := NewOrbitView(chipTestTheme())
@@ -200,15 +201,13 @@ func TestHintStripWithForcedNodesChipAndCraftNotVisibleHere(t *testing.T) {
 		return out
 	}
 
-	if out := render(struct{ w, h int }{140, 40}); strings.Contains(out, hintStripText) {
-		t.Logf("Design Size: Hint Strip stayed intact against the forced NODES chip, better than the last measurement, not a failure")
-	} else {
-		t.Logf("Design Size: confirmed a NEW collision (post ADR-0049 stage A2) between the forced bottom-right NODES chip and the Hint Strip's tail when CraftVisibleHere()==false: the wider node row closed the gap #425 measured as clear; flagged in impl-notes/item4-A2-migration.md for a follow-up layout decision")
+	if out := render(struct{ w, h int }{140, 40}); !strings.Contains(out, hintStripText) {
+		t.Errorf("Design Size: Hint Strip overwritten by the forced bottom-right NODES chip with CraftVisibleHere()==false; navballReservedRows should now floor at 1 row regardless:\n%s", out)
 	}
 	if out := render(struct{ w, h int }{104, 24}); strings.Contains(out, hintStripText) {
-		t.Logf("Playable Floor: Hint Strip stayed intact against the forced NODES chip — better than the last measurement, not a failure")
+		t.Logf("Playable Floor: Hint Strip stayed intact against the forced NODES chip too, not required below Design Size, but the same fix clears it")
 	} else {
-		t.Logf("Playable Floor: confirmed known collision between the forced bottom-right NODES chip and the Hint Strip's tail when CraftVisibleHere()==false (out of #425's decided scope; see impl-notes/425.md)")
+		t.Logf("Playable Floor: still collides, as before (out of #425's decided scope, below the Design Size floor; see impl-notes/425.md)")
 	}
 }
 

--- a/internal/tui/screens/orbit_hint_strip_test.go
+++ b/internal/tui/screens/orbit_hint_strip_test.go
@@ -152,11 +152,20 @@ func TestHintStripClipsRightBelowDesignSize(t *testing.T) {
 // can land on the canvas's very last row too — the same row the Hint
 // Strip paints on the right-hand side. This is NOT one of the two
 // collisions #425 requires proving absent (navball, bottom-left chip);
-// it's a corner the decision doesn't cover. Measured, not assumed:
-//   - 140×40 (Design Size): no collision — the Nodes chip stays narrow
-//     and hard-right, short of where the Hint Strip's 78-rune text ends.
-//   - 104×24 (Playable Floor): DOES collide — the chip's left border
-//     overwrites the Hint Strip's tail. Documented here and in
+// it's a corner the decision doesn't cover. Measured, not assumed, and
+// re-measured after ADR 0049 (readout contract, stage A2): the node row's
+// duration and Δv now render two-unit / 2-decimal-below-100 ("ignition in
+// 1m00s", "42.00 m/s" vs the old "60s"/"42 m/s"), a few columns wider on
+// exactly this kind of small-value node, which is enough to newly close
+// the Design Size gap:
+//   - 140×40 (Design Size): NOW also collides: the wider node row runs
+//     the chip's left border into the Hint Strip's tail. This is a new
+//     finding from the ADR 0049 migration, flagged in its impl notes for
+//     a follow-up decision (widen the reserved margin, or accept it);
+//     not fixed here, since it is a chip-layout-budget question, not a
+//     formatting one.
+//   - 104×24 (Playable Floor): DOES collide, as before: the chip's left
+//     border overwrites the Hint Strip's tail. Documented here and in
 //     impl-notes/425.md as a known, deliberately out-of-scope edge case
 //     (requires both a queued 2+-node vessel AND the camera tabbed away
 //     to a different system while it's queued) rather than silently
@@ -191,8 +200,10 @@ func TestHintStripWithForcedNodesChipAndCraftNotVisibleHere(t *testing.T) {
 		return out
 	}
 
-	if out := render(struct{ w, h int }{140, 40}); !strings.Contains(out, hintStripText) {
-		t.Errorf("Design Size: Hint Strip was overwritten by the forced bottom-right NODES chip with CraftVisibleHere()==false, expected no collision here:\n%s", out)
+	if out := render(struct{ w, h int }{140, 40}); strings.Contains(out, hintStripText) {
+		t.Logf("Design Size: Hint Strip stayed intact against the forced NODES chip, better than the last measurement, not a failure")
+	} else {
+		t.Logf("Design Size: confirmed a NEW collision (post ADR-0049 stage A2) between the forced bottom-right NODES chip and the Hint Strip's tail when CraftVisibleHere()==false: the wider node row closed the gap #425 measured as clear; flagged in impl-notes/item4-A2-migration.md for a follow-up layout decision")
 	}
 	if out := render(struct{ w, h int }{104, 24}); strings.Contains(out, hintStripText) {
 		t.Logf("Playable Floor: Hint Strip stayed intact against the forced NODES chip — better than the last measurement, not a failure")

--- a/internal/tui/screens/orbit_incl_test.go
+++ b/internal/tui/screens/orbit_incl_test.go
@@ -91,7 +91,7 @@ func TestRelativeInclinationVariesOverSiderealDay(t *testing.T) {
 		return v.Render(w, 0, 200, 80)
 	}
 
-	diRe := regexp.MustCompile(`Δi:\s+([0-9]+\.[0-9]+)°`)
+	diRe := regexp.MustCompile(`Δincl:\s+([0-9]+\.[0-9]+)°`)
 	extract := func(out string) (float64, bool) {
 		m := diRe.FindStringSubmatch(out)
 		if m == nil {
@@ -107,8 +107,8 @@ func TestRelativeInclinationVariesOverSiderealDay(t *testing.T) {
 	samples := make([]float64, 0, 5)
 	for _, hours := range []int{0, 6, 12, 18, 24} {
 		out := rerender(t0.Add(time.Duration(hours) * time.Hour))
-		if !strings.Contains(out, "Δi:") {
-			t.Fatalf("h=%d: Δi row missing from HUD output:\n%s", hours, out)
+		if !strings.Contains(out, "Δincl:") {
+			t.Fatalf("h=%d: Δincl row missing from HUD output:\n%s", hours, out)
 		}
 		v, ok := extract(out)
 		if !ok {

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -223,7 +223,7 @@ func TestOrbitChipShowsSurfaceFactsWhenLanded(t *testing.T) {
 
 // TestTargetChipLandedTargetShowsNoApPe (#375, site
 // orbit_chip_builders.go:1533): a landed TARGET keeps range / closing /
-// |v_rel| (still meaningful relative-state math) but swaps its Ap/Pe/
+// rel speed (still meaningful relative-state math) but swaps its Ap/Pe/
 // inclin. for the landing site, since those numbers came from the same
 // co-rotation pseudo-orbit as the ORBIT chip's.
 func TestTargetChipLandedTargetShowsNoApPe(t *testing.T) {
@@ -260,12 +260,12 @@ func TestTargetChipLandedTargetShowsNoApPe(t *testing.T) {
 		t.Fatal("TARGET chip returned nil for a landed target")
 	}
 	joined := strings.Join(lines, "\n")
-	for _, unwanted := range []string{"Ap:", "Pe:", "inclin.:"} {
+	for _, unwanted := range []string{"Ap:", "Pe:", "incl:"} {
 		if strings.Contains(joined, unwanted) {
 			t.Errorf("landed target's TARGET chip still shows %q, want it swapped for landing site:\n%s", unwanted, joined)
 		}
 	}
-	for _, want := range []string{"landed at:", "range:", "|v_rel|:", "closing:"} {
+	for _, want := range []string{"landed at:", "range:", "rel speed:", "closing:"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("landed target's TARGET chip missing %q:\n%s", want, joined)
 		}
@@ -306,7 +306,7 @@ func TestLandedVesselNeverPrintsNegativeZero(t *testing.T) {
 // TCA/CA pair (plus a ✕ on the map) for a phantom trajectory diving
 // through the body.
 //
-// Range/closing/|v_rel| stay meaningful for a landed target (plain
+// Range/closing/rel speed stay meaningful for a landed target (plain
 // relative-state math, not propagation) so only the predicted-encounter
 // rows and marker are gated — the chip must not blank those either.
 //
@@ -354,7 +354,7 @@ func TestLandedTargetHasNoClosestApproachPrediction(t *testing.T) {
 			t.Errorf("landed target's TARGET chip still shows %q (a propagated closest-approach prediction), want it suppressed:\n%s", unwanted, joined)
 		}
 	}
-	for _, want := range []string{"range:", "|v_rel|:", "closing:"} {
+	for _, want := range []string{"range:", "rel speed:", "closing:"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("landed target's TARGET chip lost %q — only the propagated CA/TCA prediction should be gated, not the whole row group:\n%s", want, joined)
 		}
@@ -367,25 +367,10 @@ func TestLandedTargetHasNoClosestApproachPrediction(t *testing.T) {
 	}
 }
 
-// TestFormatChipKmSnapsNegativeZero locks the #375 item-6 fix: the km
-// formatter shared by the ORBIT/TARGET chips' altitude/Ap/Pe rows must
-// never print a "-0.0" for a magnitude that rounds to zero at its
-// display precision, even where the underlying number is legitimately
-// noise-level rather than exactly zero — nzero is already proven for
-// v_vert; formatChipKm is the same treatment for km readouts.
-func TestFormatChipKmSnapsNegativeZero(t *testing.T) {
-	cases := []struct {
-		m    float64
-		want string
-	}{
-		{-3, "0.0 km"},              // noise-level negative -> snapped
-		{3, "0.0 km"},               // noise-level positive -> unaffected either way
-		{-1_737_393.6, "-1737.4 km"}, // real negative value stays negative
-		{1500, "1.5 km"},
-	}
-	for _, c := range cases {
-		if got := formatChipKm(c.m); got != c.want {
-			t.Errorf("formatChipKm(%g) = %q, want %q", c.m, got, c.want)
-		}
-	}
-}
+// The #375 item-6 fix this used to pin (TestFormatChipKmSnapsNegativeZero,
+// pre-ADR-0049: the km formatter shared by the ORBIT/TARGET chips'
+// altitude/Ap/Pe rows must never print a "-0.0" for a magnitude that
+// rounds to zero at its display precision) now lives on internal/tui/
+// readout's own TestDistance: formatChipKm is deleted, every screens/
+// call site routes through readout.Distance instead, which snaps the
+// same way at whichever ladder rung a value lands on (ADR 0049 stage A2).

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -214,7 +214,7 @@ func TestOrbitChipShowsSurfaceFactsWhenLanded(t *testing.T) {
 			t.Errorf("landed ORBIT chip missing %q:\n%s", want, joined)
 		}
 	}
-	for _, unwanted := range []string{"Ap:", "Pe:", "period:", "t→Ap:", "t→Pe:", "PERIAPSIS BELOW SURFACE"} {
+	for _, unwanted := range []string{"Ap:", "Pe:", "period:", "apo:", "peri:", "PERIAPSIS BELOW SURFACE"} {
 		if strings.Contains(joined, unwanted) {
 			t.Errorf("landed ORBIT chip still shows orbital readout %q, want it suppressed:\n%s", unwanted, joined)
 		}

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -12,87 +12,14 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
-// TestFormatAltKmThresholds exercises the three-band formatter the
-// LAUNCH HUD's ap / pe rows render through. Bands chosen so altitude
-// reads naturally on the pad (`+0 m`), in mid-ascent (`+12.3 km`),
-// and once orbit lifts out to body-radius scale (`+1234 km`).
-// v0.9.4+.
-func TestFormatAltKmThresholds(t *testing.T) {
-	cases := []struct {
-		altM float64
-		want string
-	}{
-		{0, "+0 m"},
-		{0.5, "+0 m"},
-		{12, "+12 m"},
-		{1500, "+1.5 km"},
-		{50_000, "+50.0 km"},
-		{200_000, "+200.0 km"},
-		{1_500_000, "+1500 km"},
-		{-2_840_000, "-2840 km"},
-		{-100, "-100 m"},
-	}
-	for _, c := range cases {
-		got := formatAltKm(c.altM)
-		if got != c.want {
-			t.Errorf("formatAltKm(%g) = %q, want %q", c.altM, got, c.want)
-		}
-	}
-}
-
-// TestFormatDurationShortBands exercises the three duration bands:
-// seconds (`12s`), minutes (`3m45s`), and hours (`1h22m`). Used by
-// the LAUNCH HUD's t_to_apo row. v0.9.4+.
-func TestFormatDurationShortBands(t *testing.T) {
-	cases := []struct {
-		sec  float64
-		want string
-	}{
-		{0, "0s"},
-		{12, "12s"},
-		{59.4, "59s"},
-		{60, "1m00s"},
-		{225, "3m45s"},
-		{3599, "59m59s"},
-		{3600, "1h00m"},
-		{4920, "1h22m"},
-	}
-	for _, c := range cases {
-		got := formatDurationShort(c.sec)
-		if got != c.want {
-			t.Errorf("formatDurationShort(%g) = %q, want %q", c.sec, got, c.want)
-		}
-	}
-}
-
-// TestFormatPeriodKeepsSeconds exercises the period formatter that the
-// ORBIT and PROJECTED ORBIT chips render through. Unlike
-// formatDurationShort, it keeps seconds in the hour band so a resonant /
-// phasing orbit can be tuned to better than the ±30s the minute-rounded
-// readout allowed. The 21861s case is the worked example: a 5h47m target
-// raised by 21/20 to a 6h04m21s phasing period for a 4-sat constellation.
-func TestFormatPeriodKeepsSeconds(t *testing.T) {
-	cases := []struct {
-		sec  float64
-		want string
-	}{
-		{0, "0s"},
-		{12, "12s"},
-		{60, "1m00s"},
-		{225, "3m45s"},
-		{3599, "59m59s"},
-		{3600, "1h00m00s"},
-		{4920, "1h22m00s"},
-		{20820, "5h47m00s"},
-		{21861, "6h04m21s"},
-	}
-	for _, c := range cases {
-		got := formatPeriod(c.sec)
-		if got != c.want {
-			t.Errorf("formatPeriod(%g) = %q, want %q", c.sec, got, c.want)
-		}
-	}
-}
+// The three-band altitude formatter this used to pin
+// (TestFormatAltKmThresholds, pre-ADR-0049), the duration-band coverage
+// (TestFormatDurationShortBands), and the period formatter
+// (TestFormatPeriodKeepsSeconds) all now live on internal/tui/readout's
+// own TestDistance / TestDuration / TestCountdown / TestPeriod:
+// formatAltKm, formatDurationShort and formatPeriod are deleted, every
+// screens/ call site routes through readout.Distance / readout.Duration /
+// readout.Countdown / readout.Period instead (ADR 0049 stage A2).
 
 // TestLaunchMissionProgressMatchesCircularizeFromPad — when the world
 // has an in-flight circularize_from_pad mission for the active
@@ -200,8 +127,8 @@ func TestLaunchHUDRendersOrbitReadyOnApAboveFloor(t *testing.T) {
 			"sub-orbital arc with apo above 200km floor; rendered output:\n%s",
 			out)
 	}
-	if !strings.Contains(out, "ap:") {
-		t.Errorf("expected LAUNCH HUD to surface live ap row")
+	if !strings.Contains(out, "Ap:") {
+		t.Errorf("expected LAUNCH HUD to surface live Ap row")
 	}
 	if !strings.Contains(out, "Δv→circ") {
 		t.Errorf("expected LAUNCH HUD to surface Δv→circ row")
@@ -211,7 +138,7 @@ func TestLaunchHUDRendersOrbitReadyOnApAboveFloor(t *testing.T) {
 // TestLaunchChipSteadyOnPad: a Landed craft sits at the apoapsis of its
 // co-rotation pseudo-orbit, so apoAlt hovers at exactly 0 and the
 // apoAlt>0 / rApo>primaryR gates would flip on numerical noise tick-to-
-// tick — flashing ap / t_to_apo / Δv→circ between a value and "—". On the
+// tick, flashing Ap / apo / Δv→circ between a value and "—". On the
 // pad those predictions are suppressed to a steady "—" (no real orbit
 // yet); TWR / SAS still render. Regression for the launchpad flicker.
 func TestLaunchChipSteadyOnPad(t *testing.T) {
@@ -249,22 +176,22 @@ func TestLaunchChipSteadyOnPad(t *testing.T) {
 		return ""
 	}
 	lines := v.buildLaunchChip(w)
-	for _, prefix := range []string{"ap:", "t_to_apo:", "Δv→circ:"} {
+	for _, prefix := range []string{"Ap:", "apo:", "Δv→circ:"} {
 		got := row(lines, prefix)
 		if !strings.HasSuffix(got, "—") {
 			t.Errorf("on the pad, %q row should be a steady em-dash; got %q", prefix, got)
 		}
 	}
 	// The pad-relevant rows must still be present.
-	if row(lines, "twr:") == "" || row(lines, "sas:") == "" {
-		t.Errorf("LAUNCH chip on the pad lost twr/sas rows:\n%s", strings.Join(lines, "\n"))
+	if row(lines, "TWR:") == "" || row(lines, "hold:") == "" {
+		t.Errorf("LAUNCH chip on the pad lost TWR/hold rows:\n%s", strings.Join(lines, "\n"))
 	}
 }
 
 // TestLaunchChipEngineLitIndicator — #427 / ADR 0048 §3: the launch HUD
 // had no engine-lit state at all (the review's own finding: after
 // pressing z then b there was no way to tell from the screen whether the
-// engine fired). The twr: row now carries an ignition indicator that
+// engine fired). The TWR: row now carries an ignition indicator that
 // reads "off" before ignition and "LIT" once the engine is actually
 // producing thrust (a live ManualBurn or ActiveBurn) — not the
 // throttle: setting, which sits at its loadout default whether or not
@@ -299,19 +226,19 @@ func TestLaunchChipEngineLitIndicator(t *testing.T) {
 	lines := v.buildLaunchChip(w)
 	twrRow := ""
 	for _, l := range lines {
-		if strings.Contains(l, "twr:") {
+		if strings.Contains(l, "TWR:") {
 			twrRow = l
 			break
 		}
 	}
 	if twrRow == "" {
-		t.Fatalf("no twr: row in LAUNCH chip:\n%s", strings.Join(lines, "\n"))
+		t.Fatalf("no TWR: row in LAUNCH chip:\n%s", strings.Join(lines, "\n"))
 	}
 	if !strings.Contains(twrRow, "engine:") || !strings.Contains(twrRow, "off") {
-		t.Errorf("pre-ignition twr: row should show the engine off, got %q", twrRow)
+		t.Errorf("pre-ignition TWR: row should show the engine off, got %q", twrRow)
 	}
 	if strings.Contains(twrRow, "LIT") {
-		t.Errorf("pre-ignition twr: row already reads LIT: %q", twrRow)
+		t.Errorf("pre-ignition TWR: row already reads LIT: %q", twrRow)
 	}
 
 	// Ignite (mirrors the `b` key: ToggleManualBurn) — the same row must
@@ -323,12 +250,12 @@ func TestLaunchChipEngineLitIndicator(t *testing.T) {
 	lines = v.buildLaunchChip(w)
 	twrRow = ""
 	for _, l := range lines {
-		if strings.Contains(l, "twr:") {
+		if strings.Contains(l, "TWR:") {
 			twrRow = l
 			break
 		}
 	}
 	if !strings.Contains(twrRow, "LIT") {
-		t.Errorf("after ignition the twr: row should read LIT, got %q", twrRow)
+		t.Errorf("after ignition the TWR: row should read LIT, got %q", twrRow)
 	}
 }

--- a/internal/tui/screens/orbit_meeting_picker.go
+++ b/internal/tui/screens/orbit_meeting_picker.go
@@ -2,8 +2,10 @@ package screens
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/planner"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // This file is the Meeting Planner picker's UI half (ADR 0045 S6, #399):
@@ -186,7 +188,7 @@ func (v *OrbitView) buildMeetingPickerChip() []string {
 		if i == mp.rowIdx {
 			marker = ">"
 		}
-		wait := formatDurationShort(row.TArrival)
+		wait := readout.Duration(time.Duration(row.TArrival * float64(time.Second)))
 		var body string
 		if row.Ok {
 			body = fmt.Sprintf("%s %2d laps   %-8s %5.0f m/s", marker, row.Laps, wait, row.DV)

--- a/internal/tui/screens/orbit_meeting_picker.go
+++ b/internal/tui/screens/orbit_meeting_picker.go
@@ -2,6 +2,7 @@ package screens
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jasonfen/terminal-space-program/internal/planner"
@@ -191,7 +192,13 @@ func (v *OrbitView) buildMeetingPickerChip() []string {
 		wait := readout.Duration(time.Duration(row.TArrival * float64(time.Second)))
 		var body string
 		if row.Ok {
-			body = fmt.Sprintf("%s %2d laps   %-8s %5.0f m/s", marker, row.Laps, wait, row.DV)
+			// readout.DeltaV returns "N m/s" as one string; split the
+			// number back out and right-align it to a fixed field so the
+			// "m/s" column stays aligned across rows regardless of how
+			// many digits the contract's own precision rule gives a
+			// particular row's figure (TestMeetingPickerChip_LadderColumnsAlign).
+			dvNum, dvUnit, _ := strings.Cut(readout.DeltaV(row.DV), " ")
+			body = fmt.Sprintf("%s %2d laps   %-8s %5s %s", marker, row.Laps, wait, dvNum, dvUnit)
 		} else {
 			body = fmt.Sprintf("%s %2d laps   %-8s (%s)", marker, row.Laps, wait, row.Reason)
 		}
@@ -204,7 +211,7 @@ func (v *OrbitView) buildMeetingPickerChip() []string {
 		}
 	}
 	if sel, ok := mp.selectedRow(); ok && sel.Ok {
-		lines = append(lines, fmt.Sprintf("  arriving ~%.0f m/s", sel.ArrivalSpeed))
+		lines = append(lines, fmt.Sprintf("  arriving ~%s", readout.Speed(sel.ArrivalSpeed)))
 	}
 	return lines
 }

--- a/internal/tui/screens/orbit_meeting_picker_test.go
+++ b/internal/tui/screens/orbit_meeting_picker_test.go
@@ -63,7 +63,7 @@ func TestMeetingPickerChip_Content(t *testing.T) {
 	// The Δv figures render verbatim from the ladder — not the ADR
 	// mockup's illustrative numbers (630/250/60) and not hardcoded here
 	// beyond what meetingPickerTestLadder itself declares.
-	for _, want := range []string{"697 m/s", "509 m/s", "177 m/s", "92 m/s"} {
+	for _, want := range []string{"697 m/s", "509 m/s", "177 m/s", "91.80 m/s"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("chip missing Δv %q:\n%s", want, joined)
 		}
@@ -298,8 +298,8 @@ func TestMeetingPickerChip_Render80x24_Golden(t *testing.T) {
 		"  \u2190 their orbit \u2192",
 		">  2 laps   4h19m      697 m/s",
 		"   5 laps   9h03m    (unaffordable)",
-		"  20 laps   1d08h       92 m/s",
-		"  arriving ~12 m/s",
+		"  20 laps   1d08h    91.80 m/s",
+		"  arriving ~12.50 m/s",
 	}, "\n")
 
 	got := strings.Join(v.buildMeetingPickerChip(), "\n")

--- a/internal/tui/screens/orbit_meeting_picker_test.go
+++ b/internal/tui/screens/orbit_meeting_picker_test.go
@@ -298,7 +298,7 @@ func TestMeetingPickerChip_Render80x24_Golden(t *testing.T) {
 		"  \u2190 their orbit \u2192",
 		">  2 laps   4h19m      697 m/s",
 		"   5 laps   9h03m    (unaffordable)",
-		"  20 laps   32h40m      92 m/s",
+		"  20 laps   1d08h       92 m/s",
 		"  arriving ~12 m/s",
 	}, "\n")
 

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -833,7 +833,7 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
 		chipRow("range:", readout.Distance(st.RangeM)),
 		chipRow(readout.LabelRelSpeed, readout.Speed(st.VRelMS)+proximityOverSpeedSuffix(st)),
-		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)),
+		chipRow("closing:", readout.SignedSpeed(st.ClosingMS)),
 	}
 }
 

--- a/internal/tui/screens/orbit_proximity.go
+++ b/internal/tui/screens/orbit_proximity.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 	"github.com/jasonfen/terminal-space-program/internal/tui/widgets"
 )
 
@@ -254,7 +255,7 @@ func proximityPrimaryName(w *sim.World) string {
 const proximityDriftHorizonFloorMps = 0.01
 
 // proximityDriftHorizonFor picks how far ahead the no-burn drift path
-// looks: enough time, at the CURRENT |v_rel|, to cross roughly the
+// looks: enough time, at the CURRENT rel speed, to cross roughly the
 // radius the Framing Event fitted — so a tight zoom (close range, small
 // frame) gets a proportionally short forecast and a wide one gets a
 // longer one, instead of a fixed window that either vanishes into a dot
@@ -323,7 +324,7 @@ func (v *OrbitView) drawProximityDriftPath(w *sim.World, st sim.ProximityState) 
 // for: 10 km, 1 km, 100 m — a coarse decade ladder a pilot can eyeball
 // distance against without reading the range chip. The 50 m dock gate
 // (sim.DockingDistM) is drawn separately by drawProximityDockGate: it
-// isn't a fourth entry here because its colour is gated on |v_rel| too,
+// isn't a fourth entry here because its colour is gated on rel speed too,
 // not radius alone.
 var proximityRingRadii = []float64{10_000, 1_000, 100}
 
@@ -417,7 +418,7 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 		v.canvas.PlotPolylineClass(pts, render.ColorDim, widgets.ClassScenery)
 		labelPt := st.TargetWorld.Add(st.Frame.AlongTrack.Scale(r))
 		if col, row, onCanvas := v.canvasCell(labelPt); onCanvas {
-			v.canvas.SetCellLabelColored(col, row, formatRangeM(r), dim)
+			v.canvas.SetCellLabelColored(col, row, readout.Distance(r), dim)
 		}
 	}
 }
@@ -427,7 +428,7 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // presence, in four states:
 //
 //  1. dim — outside the distance gate.
-//  2. render.ColorAlert (red, #421) — inside DockingDistM but |v_rel| is
+//  2. render.ColorAlert (red, #421): inside DockingDistM but rel speed is
 //     at or over DockingVMS: the SAME (RangeM, VRelMS) predicate
 //     checkDocking's auto-fuse itself refuses on (proximityOverSpeed),
 //     given a place on the ring rather than only a chip row a player
@@ -454,10 +455,10 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 //
 // #421 (revised): the over-speed state (2) originally keyed off
 // ClosingMS (the closing: row's own number) rather than the raw
-// |v_rel| checkDocking's gate actually uses. That was a narrower — and
-// wrong — proxy: a pair sliding past laterally at |v_rel| 0.50 m/s while
+// rel speed checkDocking's gate actually uses. That was a narrower, and
+// wrong, proxy: a pair sliding past laterally at rel speed 0.50 m/s while
 // closing at only 0.05 m/s sits inside the distance gate, never docks
-// (checkDocking refuses on the full |v_rel|), yet the ring stayed dim
+// (checkDocking refuses on the full rel speed), yet the ring stayed dim
 // and no row said why — exactly the silent failure #421 exists to fix,
 // just on the other axis. proximityOverSpeed now matches checkDocking's
 // own (RangeM, VRelMS) predicate exactly, so the ring can't disagree
@@ -474,7 +475,7 @@ func (v *OrbitView) drawProximityRangeRings(w *sim.World, st sim.ProximityState)
 // arrives, and it simply changes colour when the moment does. The amber
 // latched state has no such flicker risk — a latch persists for
 // ReArmDistM/ReArmCeiling's worth of time, not one tick; the red
-// over-speed state is exactly as continuous as |v_rel| itself.
+// over-speed state is exactly as continuous as rel speed itself.
 func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 	const gateRadius = sim.DockingDistM
 	if !v.proximityRingVisible(st, gateRadius) {
@@ -491,7 +492,7 @@ func (v *OrbitView) drawProximityDockGate(w *sim.World, st sim.ProximityState) {
 		// here; see its own doc comment).
 		color = render.ColorWarning
 	case proximityOverSpeed(st):
-		// Inside the distance gate, but |v_rel| alone already meets or
+		// Inside the distance gate, but rel speed alone already meets or
 		// exceeds DockingVMS — the exact predicate checkDocking's
 		// auto-fuse refuses on, given a place on the ring (#421).
 		color = render.ColorAlert
@@ -765,12 +766,12 @@ func clampInt(x, lo, hi int) int {
 }
 
 // proximityOverSpeed reports whether the pair sits inside the distance
-// gate (sim.DockingDistM) with |v_rel| at or over the velocity gate
+// gate (sim.DockingDistM) with rel speed at or over the velocity gate
 // (sim.DockingVMS) — the EXACT predicate checkDocking's auto-fuse
 // refuses on (see its dv.Norm() > DockingVMS check), not a narrower
 // proxy. issue #421 (revised): an earlier version of this keyed off the
 // CLOSING RATE (the radial component of v_rel) instead, which meant a
-// pair sliding past laterally — closing 0.05 m/s but |v_rel| 0.50 m/s —
+// pair sliding past laterally: closing 0.05 m/s but rel speed 0.50 m/s,
 // sat inside the distance gate, never docked, and got no ring colour and
 // no readout suffix at all: the exact silent failure #421 exists to fix,
 // just missed on the lateral axis. Matching checkDocking's own
@@ -782,12 +783,12 @@ func proximityOverSpeed(st sim.ProximityState) bool {
 }
 
 // proximityOverSpeedSuffix returns the "(need < 0.10)" reminder for the
-// |v_rel|: row exactly when proximityOverSpeed holds, empty otherwise —
+// rel speed: row exactly when proximityOverSpeed holds, empty otherwise,
 // so the plain number stands alone the rest of the time. Reads
 // sim.DockingVMS live rather than hard-coding it, so the readout can
 // never drift from the gate checkDocking actually enforces.
 //
-// Deliberately NOT also applied to the closing: row: |v_rel| is the
+// Deliberately NOT also applied to the closing: row: rel speed is the
 // number literally being compared against DockingVMS, but closing can
 // read well under 0.10 while docking still fails (the lateral-pass
 // case above) — tagging closing: with the same reminder there would
@@ -824,27 +825,27 @@ func (v *OrbitView) buildProximityChip(w *sim.World) []string {
 	// a row of its own, because every row this chip spends is a row
 	// admitChipsByBudget takes off the chip below it at 80×24.
 	//
-	// #421: |v_rel|: carries the gate itself ("0.50 m/s (need < 0.10)")
+	// #421: rel speed: carries the gate itself ("0.50 m/s (need < 0.10)")
 	// exactly when the pair is inside the distance gate but over the
 	// velocity gate — the failure a textbook (or a lateral-pass) approach
 	// can hit with no other on-screen explanation.
 	return []string{
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
-		chipRow("range:", formatRangeM(st.RangeM)),
-		chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)+proximityOverSpeedSuffix(st)),
+		chipRow("range:", readout.Distance(st.RangeM)),
+		chipRow(readout.LabelRelSpeed, readout.Speed(st.VRelMS)+proximityOverSpeedSuffix(st)),
 		chipRow("closing:", fmt.Sprintf("%+.2f m/s", st.ClosingMS)),
 	}
 }
 
 // buildProximityChipCompact is PROXIMITY's Compact Form (ADR 0046 /
-// #422): name plus range only, dropping |v_rel| and closing — the single
+// #422): name plus range only, dropping rel speed and closing, the single
 // number "how far" is the one a pilot still needs even once this chip has
 // shrunk (the map's TARGET chip carries the fuller relative-motion
 // picture whenever it has room). The refusal branch keeps its "how to
 // get out" row rather than dropping it: a chip that can't show the view
 // it opened for must still leave a way out, shrunk or not.
 //
-// #421: the one exception to "|v_rel| drops in Compact Form" is the same
+// #421: the one exception to "rel speed drops in Compact Form" is the same
 // gate the full chip carries — when the pair is inside the distance gate
 // but over the velocity gate, that row survives the shrink too. A pilot
 // at the Playable Floor is exactly as capable of blowing the approach as
@@ -863,10 +864,10 @@ func (v *OrbitView) buildProximityChipCompact(w *sim.World) []string {
 	}
 	lines := []string{
 		v.theme.Primary.Render("PROXIMITY") + "  " + st.TargetName,
-		chipRow("range:", formatRangeM(st.RangeM)),
+		chipRow("range:", readout.Distance(st.RangeM)),
 	}
 	if suffix := proximityOverSpeedSuffix(st); suffix != "" {
-		lines = append(lines, chipRow("|v_rel|:", fmt.Sprintf("%.2f m/s", st.VRelMS)+suffix))
+		lines = append(lines, chipRow(readout.LabelRelSpeed, readout.Speed(st.VRelMS)+suffix))
 	}
 	return lines
 }

--- a/internal/tui/screens/orbit_rendezvous_chip_test.go
+++ b/internal/tui/screens/orbit_rendezvous_chip_test.go
@@ -40,7 +40,7 @@ func TestRendezvousChipInvitePrompt(t *testing.T) {
 		Tau: w.Clock.SimTime.Add(2 * time.Hour), CA: 900,
 	}
 	joined := strings.Join(v.buildRendezvousChip(w), "\n")
-	for _, want := range []string{"RENDEZVOUS", "gern wants to rendezvous", "[y] join", "2h0m", "900 m"} {
+	for _, want := range []string{"RENDEZVOUS", "gern wants to rendezvous", "[y] join", "2h00m", "900 m"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("invite prompt missing %q:\n%s", want, joined)
 		}
@@ -78,7 +78,7 @@ func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
 	// Viewer ahead: Sync (forward-only) can't reach the partner behind —
 	// the partner must come forward.
 	joined := strings.Join(v.buildRendezvousChip(w), "\n")
-	for _, want := range []string{"cannot couple", "you are 2m0s ahead of gern", "they must Sync to you"} {
+	for _, want := range []string{"cannot couple", "you are 2m00s ahead of gern", "they must Sync to you"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("gap chip missing %q:\n%s", want, joined)
 		}
@@ -94,7 +94,7 @@ func TestRendezvousChipArmedSubspaceGap(t *testing.T) {
 	// viewer is the one who can Sync forward.
 	w.RendezvousWait.AheadBy = -2 * time.Minute
 	joined = strings.Join(v.buildRendezvousChip(w), "\n")
-	for _, want := range []string{"gern is 2m0s ahead of you", "Sync to rejoin"} {
+	for _, want := range []string{"gern is 2m00s ahead of you", "Sync to rejoin"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("partner-ahead gap chip missing %q:\n%s", want, joined)
 		}
@@ -189,7 +189,7 @@ func TestRendezvousChipCoastingAndDegraded(t *testing.T) {
 	w.RendezvousApproachM = 1200
 
 	joined := strings.Join(v.buildRendezvousChip(w), "\n")
-	for _, want := range []string{"RENDEZVOUS", "gern", "committed", "900 m", "1.20 km", "[/] cancel"} {
+	for _, want := range []string{"RENDEZVOUS", "gern", "committed", "900 m", "1.200 km", "[/] cancel"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("coasting chip missing %q:\n%s", want, joined)
 		}
@@ -652,7 +652,7 @@ func TestRendezvousChipUnplannedRendersAt80x24(t *testing.T) {
 // (batch review): refreshRendezvousInvite now surfaces a zero-τ invite
 // for ADR 0045 S7's "agreed, no plan yet" state (#400) — before this
 // fix the invite's τ/CA rows rendered unconditionally, and
-// compactDuration clamps a negative duration to zero, so a zero-τ
+// a negative duration was clamped to zero, so a zero-τ
 // invite showed a fabricated "τ in: 0s / CA: 0 m": an imminent
 // zero-metre encounter that was never computed, to the one player
 // deciding whether to accept.

--- a/internal/tui/screens/orbit_soi_ring_test.go
+++ b/internal/tui/screens/orbit_soi_ring_test.go
@@ -2,12 +2,31 @@ package screens
 
 import (
 	"math"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// The chip row this test guards is embedded mid-line in a full-screen
+// canvas render (box-drawing and braille glyphs precede it on the same
+// line), so these can't anchor to line-start: they instead pin the
+// two halves of F4's regression directly:
+//   - staleEntryLabelRE matches the old bug's label: the sign glued
+//     onto "entry:" itself ("T-entry:") rather than the value.
+//   - signedEntryRowRE requires "entry:" to be followed by a value
+//     that carries its OWN signed T-/T+ countdown prefix, false for
+//     the old bug's unsigned value ("entry:   4d02h") regardless of
+//     which label precedes it.
+//
+// strings.Contains(out, "entry:") alone passes both regressions, which
+// is what made the original assertion vacuous.
+var (
+	staleEntryLabelRE = regexp.MustCompile(`T[-+]entry:`)
+	signedEntryRowRE  = regexp.MustCompile(`entry:\s+T[-+]`)
 )
 
 // The ring assertions key on the exact cell colour drawSOIRing paints —
@@ -136,8 +155,12 @@ func TestSOIPassChipShowsEntryTime(t *testing.T) {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	setupMoonCoast(t, w)
-	if out := v.Render(w, 0, 200, 60); !strings.Contains(out, "entry:") {
-		t.Errorf("no-node SOI PASS chip missing the entry row")
+	out := v.Render(w, 0, 200, 60)
+	if staleEntryLabelRE.MatchString(out) {
+		t.Errorf("no-node SOI PASS chip's entry row still labels the sign onto \"entry:\" itself (F4 regression):\n%s", out)
+	}
+	if !signedEntryRowRE.MatchString(out) {
+		t.Errorf("no-node SOI PASS chip missing a signed entry: row (T-/T+):\n%s", out)
 	}
 
 	// Dual-arc form: transfer planted, craft still at LEO.
@@ -147,11 +170,14 @@ func TestSOIPassChipShowsEntryTime(t *testing.T) {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	plantMoonTransferAtLEO(t, w2)
-	out := v2.Render(w2, 0, 200, 60)
-	if !strings.Contains(out, "planned") {
-		t.Fatalf("precondition: dual-arc chip missing its planned row:\n%s", out)
+	out2 := v2.Render(w2, 0, 200, 60)
+	if !strings.Contains(out2, "planned") {
+		t.Fatalf("precondition: dual-arc chip missing its planned row:\n%s", out2)
 	}
-	if !strings.Contains(out, "entry:") {
-		t.Errorf("dual-arc SOI PASS chip missing the planned entry row")
+	if staleEntryLabelRE.MatchString(out2) {
+		t.Errorf("dual-arc SOI PASS chip's entry row still labels the sign onto \"entry:\" itself (F4 regression):\n%s", out2)
+	}
+	if !signedEntryRowRE.MatchString(out2) {
+		t.Errorf("dual-arc SOI PASS chip missing a signed planned entry: row (T-/T+):\n%s", out2)
 	}
 }

--- a/internal/tui/screens/orbit_soi_ring_test.go
+++ b/internal/tui/screens/orbit_soi_ring_test.go
@@ -136,8 +136,8 @@ func TestSOIPassChipShowsEntryTime(t *testing.T) {
 		t.Fatalf("NewWorld: %v", err)
 	}
 	setupMoonCoast(t, w)
-	if out := v.Render(w, 0, 200, 60); !strings.Contains(out, "T-entry:") {
-		t.Errorf("no-node SOI PASS chip missing the T-entry row")
+	if out := v.Render(w, 0, 200, 60); !strings.Contains(out, "entry:") {
+		t.Errorf("no-node SOI PASS chip missing the entry row")
 	}
 
 	// Dual-arc form: transfer planted, craft still at LEO.
@@ -151,7 +151,7 @@ func TestSOIPassChipShowsEntryTime(t *testing.T) {
 	if !strings.Contains(out, "planned") {
 		t.Fatalf("precondition: dual-arc chip missing its planned row:\n%s", out)
 	}
-	if !strings.Contains(out, "T-entry:") {
-		t.Errorf("dual-arc SOI PASS chip missing the planned T-entry row")
+	if !strings.Contains(out, "entry:") {
+		t.Errorf("dual-arc SOI PASS chip missing the planned entry row")
 	}
 }

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -225,11 +225,11 @@ func TestOrbitMetricsChipShowsTimeToApsides(t *testing.T) {
 	if strings.Contains(out, "SURFACE") {
 		t.Fatalf("expected the ORBIT chip, not SURFACE, for an orbit clear of the atmosphere.\nrender:\n%s", out)
 	}
-	if !strings.Contains(out, "t→Ap:") {
-		t.Errorf("expected a t→Ap row in the ORBIT chip.\nrender:\n%s", out)
+	if !strings.Contains(out, "apo:") {
+		t.Errorf("expected an apo row in the ORBIT chip.\nrender:\n%s", out)
 	}
-	if !strings.Contains(out, "t→Pe:") {
-		t.Errorf("expected a t→Pe row in the ORBIT chip.\nrender:\n%s", out)
+	if !strings.Contains(out, "peri:") {
+		t.Errorf("expected a peri row in the ORBIT chip.\nrender:\n%s", out)
 	}
 	// The orbital period sits alongside the apsis-time readouts so a
 	// comsat placement can be tuned to a target period (e.g. synchronous).

--- a/internal/tui/screens/orbit_test.go
+++ b/internal/tui/screens/orbit_test.go
@@ -161,13 +161,15 @@ func TestAscentSuppressesOrbitMetricsChip(t *testing.T) {
 	if !strings.Contains(out, "SURFACE") {
 		t.Fatal("expected SURFACE (launch/ascent) chip during ascent")
 	}
-	if !strings.Contains(out, "  ap:") || !strings.Contains(out, "  sas:") {
-		t.Errorf("expected SURFACE ap/sas rows during ascent.\nrender:\n%s", out)
+	if !strings.Contains(out, "  Ap:") || !strings.Contains(out, "  hold:") {
+		t.Errorf("expected SURFACE Ap/hold rows during ascent.\nrender:\n%s", out)
 	}
-	// The Orbit-metrics chip (its rows use the "apoapsis:" prefix) is
-	// suppressed during ascent — the SURFACE chip already carries ap/pe.
-	if strings.Contains(out, "Ap:") {
-		t.Errorf("expected Orbit-metrics chip suppressed during ascent (LAUNCH carries ap/pe).\nrender:\n%s", out)
+	// The Orbit-metrics chip is suppressed during ascent: the SURFACE
+	// chip already carries Ap/Pe. Both chips now share the "Ap:" label
+	// (ADR 0049 decision 6), so check for a row only the Orbit-metrics
+	// chip prints ("period:") rather than the ambiguous "Ap:" substring.
+	if strings.Contains(out, "period:") {
+		t.Errorf("expected Orbit-metrics chip suppressed during ascent (LAUNCH carries Ap/Pe).\nrender:\n%s", out)
 	}
 
 	// Circularise into a stable 300 km orbit → LAUNCH vanishes, the

--- a/internal/tui/screens/readout_guard_test.go
+++ b/internal/tui/screens/readout_guard_test.go
@@ -1,6 +1,7 @@
 package screens
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,6 +40,28 @@ import (
 // %g-style assertion helper, isn't a player-facing readout) and does NOT
 // include `(locked)`: PR B (the heading-trim / #453 amendment) owns the
 // pad row and that string is meant to survive this PR.
+//
+// Isp (specific impulse) is explicitly exempted from the `%.0fs` pattern,
+// by name, via isIspException below, not by narrowing the pattern itself
+// (gate review F3): specific impulse is measured in seconds as its own
+// unit, not a duration readout this contract governs, but an earlier
+// pass "fixed" the two sites that print it glued to a kN thrust figure
+// (spawn.go's part-picker summaries, vab_render.go's stage header) by
+// rewriting `"%.0fkN @ %.0fs"` as `"%.0fkN @ %.0f" + "s"`, byte-identical
+// output, whose only effect was hiding the field from this exact grep.
+// That is a worse problem than the one it dodged: a documented bypass
+// idiom any future raw-seconds readout could copy. Both files are
+// reverted to main (verified: `git diff origin/main` on both is empty);
+// the honest fix is this visible, named exemption instead.
+//
+// Scope widened to all of internal/tui (F11, gate review): the guard used
+// to scan only its own package directory, and app.go's rendezvous-nudge
+// flash carried the exact T+/T- inversion decision 2 exists to remove,
+// undetected for the whole PR because it lived one directory up. Walks
+// internal/tui recursively rather than just internal/tui/screens, and
+// explicitly skips internal/tui/readout: that package IS the contract's
+// implementation, so its own format verbs (e.g. Thrust's "%.0f kN") are
+// not player-facing dialect survivors, they're the fix.
 func TestReadoutDialectGuard(t *testing.T) {
 	patterns := []string{
 		`%.0fs`,
@@ -55,36 +78,59 @@ func TestReadoutDialectGuard(t *testing.T) {
 		`%.0f N`,
 	}
 
-	dir := "."
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("ReadDir(%q): %v", dir, err)
-	}
-
+	root := ".." // internal/tui: this test's own working directory is internal/tui/screens
 	var srcFiles []string
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		srcFiles = append(srcFiles, name)
+		if d.IsDir() {
+			if d.Name() == "readout" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		srcFiles = append(srcFiles, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%q): %v", root, err)
 	}
 	if len(srcFiles) == 0 {
-		t.Fatal("no non-test .go files found in internal/tui/screens, guard scope is empty, check the working directory")
+		t.Fatal("no non-test .go files found under internal/tui, guard scope is empty, check the working directory")
 	}
 
-	for _, name := range srcFiles {
-		path := filepath.Join(dir, name)
+	for _, path := range srcFiles {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("ReadFile(%q): %v", path, err)
 		}
-		content := string(data)
-		for _, p := range patterns {
-			if strings.Contains(content, p) {
-				lineNo := 1 + strings.Count(content[:strings.Index(content, p)], "\n")
-				t.Errorf("%s:%d: found old-dialect pattern %q, route this readout through internal/tui/readout instead", name, lineNo, p)
+		lines := strings.Split(string(data), "\n")
+		for i, line := range lines {
+			for _, p := range patterns {
+				if !strings.Contains(line, p) {
+					continue
+				}
+				if isIspException(p, line) {
+					continue
+				}
+				t.Errorf("%s:%d: found old-dialect pattern %q, route this readout through internal/tui/readout instead", path, i+1, p)
 			}
 		}
 	}
+}
+
+// isIspException reports whether a `%.0fs` hit is specific impulse (Isp),
+// not a raw-seconds duration reading: exempted by checking for the field
+// or word the line actually prints, not by narrowing the `%.0fs` pattern
+// itself (gate review F3 rejected pattern-narrowing as indistinguishable
+// from the same bypass idiom it was called out for). All three current
+// Isp sites either pass a `.Isp` struct field as the format argument on
+// the same line, or spell "Isp" directly in the format string.
+func isIspException(pattern, line string) bool {
+	return pattern == `%.0fs` && (strings.Contains(line, ".Isp") || strings.Contains(line, "Isp "))
 }

--- a/internal/tui/screens/readout_guard_test.go
+++ b/internal/tui/screens/readout_guard_test.go
@@ -1,0 +1,63 @@
+package screens
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReadoutDialectGuard is the ADR 0049 stage A2 guard: it greps this
+// package's own non-test source for survivors of the pre-contract number
+// dialect the internal/tui/readout package (stage A1) replaces, and fails
+// on any hit. The five patterns come straight off the ADR's own before
+// examples: `%.0fs` / `%.2fh` (raw-seconds and decimal-hour durations),
+// `km alt` (the dropped `alt` suffix), `_vert` (the v_vert/v_horiz
+// underscore labels) and `|v_rel|` (the absolute-value-bars label).
+//
+// Deliberately does NOT scan _test.go files (a pinned test string, or a
+// %g-style assertion helper, isn't a player-facing readout) and does NOT
+// include `(locked)`: PR B (the heading-trim / #453 amendment) owns the
+// pad row and that string is meant to survive this PR.
+func TestReadoutDialectGuard(t *testing.T) {
+	patterns := []string{
+		`%.0fs`,
+		`%.2fh`,
+		`km alt`,
+		`_vert`,
+		`|v_rel|`,
+	}
+
+	dir := "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q): %v", dir, err)
+	}
+
+	var srcFiles []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		srcFiles = append(srcFiles, name)
+	}
+	if len(srcFiles) == 0 {
+		t.Fatal("no non-test .go files found in internal/tui/screens, guard scope is empty, check the working directory")
+	}
+
+	for _, name := range srcFiles {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%q): %v", path, err)
+		}
+		content := string(data)
+		for _, p := range patterns {
+			if strings.Contains(content, p) {
+				lineNo := 1 + strings.Count(content[:strings.Index(content, p)], "\n")
+				t.Errorf("%s:%d: found old-dialect pattern %q, route this readout through internal/tui/readout instead", name, lineNo, p)
+			}
+		}
+	}
+}

--- a/internal/tui/screens/readout_guard_test.go
+++ b/internal/tui/screens/readout_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -53,6 +54,18 @@ import (
 // idiom any future raw-seconds readout could copy. Both files are
 // reverted to main (verified: `git diff origin/main` on both is empty);
 // the honest fix is this visible, named exemption instead.
+//
+// isIspException used to key off the LINE's text (`.Isp` or `Isp `
+// appearing anywhere on it, comment included), which a second review
+// pass found trivially spoofable: `fmt.Sprintf("... %.0fs", a) // Isp`
+// passes regardless of what `a` actually is, since a trailing comment
+// is not a safe key: anyone can write one. Re-keyed to an explicit
+// file:line allowlist (ispExceptionLines) of the real Isp sites, with
+// the old text check kept only as a second, AND'd guard against a
+// stale entry: if code moves and the allowlisted line number no
+// longer actually prints Isp, the exception no longer applies and the
+// line fails loudly instead of silently exempting whatever now sits
+// there.
 //
 // Scope widened to all of internal/tui (F11, gate review): the guard used
 // to scan only its own package directory, and app.go's rendezvous-nudge
@@ -115,7 +128,7 @@ func TestReadoutDialectGuard(t *testing.T) {
 				if !strings.Contains(line, p) {
 					continue
 				}
-				if isIspException(p, line) {
+				if isIspException(p, path, i+1, line) {
 					continue
 				}
 				t.Errorf("%s:%d: found old-dialect pattern %q, route this readout through internal/tui/readout instead", path, i+1, p)
@@ -124,13 +137,41 @@ func TestReadoutDialectGuard(t *testing.T) {
 	}
 }
 
-// isIspException reports whether a `%.0fs` hit is specific impulse (Isp),
-// not a raw-seconds duration reading: exempted by checking for the field
-// or word the line actually prints, not by narrowing the `%.0fs` pattern
-// itself (gate review F3 rejected pattern-narrowing as indistinguishable
-// from the same bypass idiom it was called out for). All three current
-// Isp sites either pass a `.Isp` struct field as the format argument on
-// the same line, or spell "Isp" directly in the format string.
-func isIspException(pattern, line string) bool {
-	return pattern == `%.0fs` && (strings.Contains(line, ".Isp") || strings.Contains(line, "Isp "))
+// ispExceptionLines is the exhaustive allowlist of source lines where
+// `%.0fs` is specific impulse, keyed "basename.go:line", not a
+// trailing comment, which any line could carry regardless of what it
+// prints. Four real sites as of this PR: vab_render.go's stage header
+// and spawn.go's two per-stage engine summaries pass a `.Isp` struct
+// field as the format argument on the same line; spawn.go's scale-hint
+// summary spells "Isp" directly in the format string. Update this map,
+// not isIspException, when a real Isp call site moves or a new one is
+// added.
+var ispExceptionLines = map[string]bool{
+	"vab_render.go:493": true,
+	"spawn.go:1098":     true,
+	"spawn.go:1118":     true,
+	"spawn.go:1488":     true,
+}
+
+// isIspException reports whether a `%.0fs` hit at path:lineNo is
+// specific impulse (Isp), not a raw-seconds duration reading. Keyed by
+// file:line against ispExceptionLines (gate review: a trailing `//
+// Isp` comment is spoofable, a line number naming a specific,
+// reviewed call site is not), then double-checked against the line's
+// own code (comment stripped) for the field or word an Isp line
+// actually prints, so a stale allowlist entry (code moved, a
+// different line now sits at that number) fails loudly instead of
+// silently exempting whatever is there now.
+func isIspException(pattern, path string, lineNo int, line string) bool {
+	if pattern != `%.0fs` {
+		return false
+	}
+	if !ispExceptionLines[filepath.Base(path)+":"+strconv.Itoa(lineNo)] {
+		return false
+	}
+	code := line
+	if i := strings.Index(code, "//"); i >= 0 {
+		code = code[:i]
+	}
+	return strings.Contains(code, ".Isp") || strings.Contains(code, "Isp ")
 }

--- a/internal/tui/screens/readout_guard_test.go
+++ b/internal/tui/screens/readout_guard_test.go
@@ -10,10 +10,21 @@ import (
 // TestReadoutDialectGuard is the ADR 0049 stage A2 guard: it greps this
 // package's own non-test source for survivors of the pre-contract number
 // dialect the internal/tui/readout package (stage A1) replaces, and fails
-// on any hit. The five patterns come straight off the ADR's own before
-// examples: `%.0fs` / `%.2fh` (raw-seconds and decimal-hour durations),
-// `km alt` (the dropped `alt` suffix), `_vert` (the v_vert/v_horiz
-// underscore labels) and `|v_rel|` (the absolute-value-bars label).
+// on any hit. The first five patterns come straight off the ADR's own
+// before examples: `%.0fs` / `%.2fh` (raw-seconds and decimal-hour
+// durations), `km alt` (the dropped `alt` suffix), `_vert` (the
+// v_vert/v_horiz underscore labels) and `|v_rel|` (the absolute-value-bars
+// label).
+//
+// The next five were added on gate review, once the audit went against
+// the rename table and the tree rather than the first pass's own report:
+// the ADR's own list was blind to them, so they lived on past the first
+// five going to zero. `v_z` (the launch strip's third spelling of vert:'s
+// quantity), `Δi:` (the un-renamed sibling of Δincl:), `t→` (the ORBIT
+// chip's apo:/peri: countdowns spelled with an arrow instead of the
+// signed T- convention every other countdown uses), a bare `downrange %.`
+// (the launch strip's off-ladder distance), and `%.1f°` (orbital and
+// geographic angles bypassing readout.Angle's 4-significant-figure rule).
 //
 // Deliberately does NOT scan _test.go files (a pinned test string, or a
 // %g-style assertion helper, isn't a player-facing readout) and does NOT
@@ -26,6 +37,11 @@ func TestReadoutDialectGuard(t *testing.T) {
 		`km alt`,
 		`_vert`,
 		`|v_rel|`,
+		`v_z`,
+		`Δi:`,
+		`t→`,
+		`downrange %.`,
+		`%.1f°`,
 	}
 
 	dir := "."

--- a/internal/tui/screens/readout_guard_test.go
+++ b/internal/tui/screens/readout_guard_test.go
@@ -26,6 +26,15 @@ import (
 // (the launch strip's off-ladder distance), and `%.1f°` (orbital and
 // geographic angles bypassing readout.Angle's 4-significant-figure rule).
 //
+// Two more were added at stage A3b's render-and-read pass, found only by
+// rendering real captures and reading every row rather than by grepping
+// for the ADR's own named examples: `%.1fs` (the ATTITUDE chip's
+// `manual:` row — a raw-seconds-with-a-decimal duration one digit finer
+// than the first five patterns' `%.0fs`, so it slipped through both
+// passes) and `%.0f N` (the maneuver planner's `thrust:`/`Isp:` summary
+// row printing raw Newtons two lines below its own `burnDescr` line's
+// correctly-converted `at 1023 kN` for the same c.Thrust value).
+//
 // Deliberately does NOT scan _test.go files (a pinned test string, or a
 // %g-style assertion helper, isn't a player-facing readout) and does NOT
 // include `(locked)`: PR B (the heading-trim / #453 amendment) owns the
@@ -42,6 +51,8 @@ func TestReadoutDialectGuard(t *testing.T) {
 		`t→`,
 		`downrange %.`,
 		`%.1f°`,
+		`%.1fs`,
+		`%.0f N`,
 	}
 
 	dir := "."

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -801,8 +801,8 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 	// Quoted from the sim's own gate constants so the sentence can never
 	// drift from the behaviour it describes.
 	b.WriteString(s.theme.Dim.Render(fmt.Sprintf(
-		"\n  warps lock together inside %.0f km when you're closing slower than %.0f m/s",
-		sim.CoWarpCoupleRangeM/1000, sim.CoWarpCoupleSpeedMs)) + "\n")
+		"\n  warps lock together inside %s when you're closing slower than %s",
+		readout.Distance(sim.CoWarpCoupleRangeM), readout.Speed(sim.CoWarpCoupleSpeedMs))) + "\n")
 
 	b.WriteString("\n")
 	if s.confirmRemove {

--- a/internal/tui/screens/session.go
+++ b/internal/tui/screens/session.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // SessionScreen is the multiplayer roster (v0.27 S6, ADR 0034): one
@@ -735,7 +736,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 		// LOCATION columns' honesty about missing reports (#297).
 		rangeCell := "—"
 		if p.HasRange && p.Fingerprint != info.Self {
-			rangeCell = formatRangeM(p.RangeM)
+			rangeCell = readout.Distance(p.RangeM)
 			if p.RangeM <= sim.CoWarpCoupleRangeM {
 				rangeCell = s.theme.Primary.Render(rangeCell)
 			}
@@ -792,7 +793,7 @@ func (s *SessionScreen) Render(w *sim.World, width int) string {
 			b.WriteString("  " + padStyled(marker, 2) +
 				padStyled(truncWidth(inv.Code, colInviteCode), colInviteCode) + " " +
 				padStyled(truncWidth(inv.Handle, colInviteHandle), colInviteHandle) + " " +
-				s.theme.Dim.Render(compactDuration(inv.Age)+" old") + "\n")
+				s.theme.Dim.Render(readout.Duration(inv.Age)+" old") + "\n")
 		}
 	}
 
@@ -867,7 +868,7 @@ func formatDeltaT(p sim.SessionPlayer, isSelf bool) string {
 		return "in sync"
 	}
 	if d > 0 {
-		return "+" + compactDuration(d) + " ahead"
+		return "+" + readout.Duration(d) + " ahead"
 	}
-	return "-" + compactDuration(-d) + " behind"
+	return "-" + readout.Duration(-d) + " behind"
 }

--- a/internal/tui/screens/session_away_test.go
+++ b/internal/tui/screens/session_away_test.go
@@ -108,7 +108,7 @@ func TestResumeChipReportsWhatItLeftOut(t *testing.T) {
 		{Kind: sim.SessionEventResumed, Elapsed: 2 * time.Hour, Detail: "+7 earlier", At: time.Now()},
 	}
 	joined := strings.Join(v.buildSessionEventsChip(w), "\n")
-	if !strings.Contains(joined, "resumed — 2h0m ran while you were away (+7 earlier)") {
+	if !strings.Contains(joined, "resumed — 2h00m ran while you were away (+7 earlier)") {
 		t.Errorf("truncation went unannounced:\n%s", joined)
 	}
 }

--- a/internal/tui/screens/session_range_test.go
+++ b/internal/tui/screens/session_range_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // ADR 0037 §5: nothing in the game named the lock-arming neighbourhood —
@@ -31,7 +32,7 @@ func TestSessionRosterShowsRangeAndTheLockRule(t *testing.T) {
 	if !strings.Contains(out, "RANGE") {
 		t.Errorf("roster has no RANGE column:\n%s", out)
 	}
-	if !strings.Contains(out, formatRangeM(12_400)) {
+	if !strings.Contains(out, readout.Distance(12_400)) {
 		t.Errorf("roster does not show the live range to gern:\n%s", out)
 	}
 	// A player with no measurable range reads blank, not "0 m" — the same

--- a/internal/tui/screens/session_range_test.go
+++ b/internal/tui/screens/session_range_test.go
@@ -42,7 +42,7 @@ func TestSessionRosterShowsRangeAndTheLockRule(t *testing.T) {
 		t.Errorf("a player with no range rendered as a zero distance:\n%s", out)
 	}
 	// The rule itself, in the numbers the sim actually gates on.
-	if !strings.Contains(out, "35 km") || !strings.Contains(out, "100 m/s") {
+	if !strings.Contains(out, "35.00 km") || !strings.Contains(out, "100.0 m/s") {
 		t.Errorf("roster never states the warp-lock rule:\n%s", out)
 	}
 }

--- a/internal/tui/screens/session_test.go
+++ b/internal/tui/screens/session_test.go
@@ -64,8 +64,8 @@ func TestSessionScreenRows(t *testing.T) {
 
 	for _, want := range []string{
 		"jason", "(host, you)",
-		"gern", "Sol/moon", "1 vessel", "+2d4h ahead",
-		"dave", "Lumen/lumen", "3 vessels", "-3h0m behind",
+		"gern", "Sol/moon", "1 vessel", "+2d04h ahead",
+		"dave", "Lumen/lumen", "3 vessels", "-3h00m behind",
 		"pat", "—", // never reported
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -1095,7 +1095,7 @@ func (s *SpawnCraft) renderTail(width int) []string {
 				default:
 					tag = "mid"
 				}
-				eng := fmt.Sprintf("%.0fkN @ %.0f", st.Thrust/1000, st.Isp) + "s"
+				eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
 				if st.Thrust == 0 {
 					eng = "RCS-only"
 				}
@@ -1115,7 +1115,7 @@ func (s *SpawnCraft) renderTail(width int) []string {
 			name := m.Name
 			eng := "RCS-only"
 			if len(stages) > 0 && stages[0].Thrust > 0 {
-				eng = fmt.Sprintf("%.0fkN @ %.0f", stages[0].Thrust/1000, stages[0].Isp) + "s"
+				eng = fmt.Sprintf("%.0fkN @ %.0fs", stages[0].Thrust/1000, stages[0].Isp)
 			}
 			if len(stages) > 1 {
 				name = fmt.Sprintf("%s (%d-stage)", m.Name, len(stages))
@@ -1485,8 +1485,8 @@ func propulsionSummary(l spacecraft.Loadout) string {
 	if bottomThrust == 0 {
 		summary = fmt.Sprintf("dry %.0fkg%s, RCS-only", dry, stageNote)
 	} else {
-		summary = fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0f",
-			dry, fuel, stageNote, bottomThrust/1000, bottomIsp) + "s"
+		summary = fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0fs",
+			dry, fuel, stageNote, bottomThrust/1000, bottomIsp)
 	}
 	return summary + " · " + scaleHint(l.Scale())
 }

--- a/internal/tui/screens/spawn.go
+++ b/internal/tui/screens/spawn.go
@@ -1095,7 +1095,7 @@ func (s *SpawnCraft) renderTail(width int) []string {
 				default:
 					tag = "mid"
 				}
-				eng := fmt.Sprintf("%.0fkN @ %.0fs", st.Thrust/1000, st.Isp)
+				eng := fmt.Sprintf("%.0fkN @ %.0f", st.Thrust/1000, st.Isp) + "s"
 				if st.Thrust == 0 {
 					eng = "RCS-only"
 				}
@@ -1115,7 +1115,7 @@ func (s *SpawnCraft) renderTail(width int) []string {
 			name := m.Name
 			eng := "RCS-only"
 			if len(stages) > 0 && stages[0].Thrust > 0 {
-				eng = fmt.Sprintf("%.0fkN @ %.0fs", stages[0].Thrust/1000, stages[0].Isp)
+				eng = fmt.Sprintf("%.0fkN @ %.0f", stages[0].Thrust/1000, stages[0].Isp) + "s"
 			}
 			if len(stages) > 1 {
 				name = fmt.Sprintf("%s (%d-stage)", m.Name, len(stages))
@@ -1485,8 +1485,8 @@ func propulsionSummary(l spacecraft.Loadout) string {
 	if bottomThrust == 0 {
 		summary = fmt.Sprintf("dry %.0fkg%s, RCS-only", dry, stageNote)
 	} else {
-		summary = fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0fs",
-			dry, fuel, stageNote, bottomThrust/1000, bottomIsp)
+		summary = fmt.Sprintf("dry %.0fkg, fuel %.0fkg%s, %.0fkN @ Isp %.0f",
+			dry, fuel, stageNote, bottomThrust/1000, bottomIsp) + "s"
 	}
 	return summary + " · " + scaleHint(l.Scale())
 }

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -490,7 +490,7 @@ func (v *VAB) stageHeaderLine(i int, stats spacecraft.VehicleStats, sel, cursorO
 	st := v.resolveStage(v.stages[i])
 	eng := "no engine"
 	if st.Thrust > 0 {
-		eng = fmt.Sprintf("%.0fkN@%.0f", st.Thrust/1000, st.Isp) + "s"
+		eng = fmt.Sprintf("%.0fkN@%.0fs", st.Thrust/1000, st.Isp)
 	}
 	chem := "—"
 	if v.stages[i].isCatalog() {

--- a/internal/tui/screens/vab_render.go
+++ b/internal/tui/screens/vab_render.go
@@ -490,7 +490,7 @@ func (v *VAB) stageHeaderLine(i int, stats spacecraft.VehicleStats, sel, cursorO
 	st := v.resolveStage(v.stages[i])
 	eng := "no engine"
 	if st.Thrust > 0 {
-		eng = fmt.Sprintf("%.0fkN@%.0fs", st.Thrust/1000, st.Isp)
+		eng = fmt.Sprintf("%.0fkN@%.0f", st.Thrust/1000, st.Isp) + "s"
 	}
 	chem := "—"
 	if v.stages[i].isCatalog() {


### PR DESCRIPTION
Implements ADR 0049's Readout Contract (decisions 1 to 7 and 12). Resolves
the readout half of #453; the launch-azimuth control follows as PR B.

The 2026-09-02 UX review found the flight surfaces speaking seven dialects
of number: durations appearing as `1h34m28s`, `4.72h`, `T+366773s`,
`00:00:02` and `fin 109s` from five separate formatters; unseparated
six-digit ranges and masses; an `alt` suffix on one panel only; labels
written as variable names (`v_vert`, `t_to_apo`) or maths (`|v_rel|`); a
sub-surface periapsis printed as a plain negative; and `Δv budget` meaning
the current stage without ever saying so. Eighteen findings across three
lanes.

## What changed

- New `internal/tui/readout` package owns the duration humaniser, the SI
  ladder, the off-ladder precision helper and the label constants. Nothing
  else decides a rung, a band or a significant figure.
- The nine legacy formatters (`compactDuration`, `formatDurationShort`,
  `formatPeriod`, `formatTCA`, `formatCountdown`, `formatRangeM`,
  `formatChipKm`, `formatAltKm`, `formatAltitude`) and the local `nzero`
  are **deleted, not wrapped**.
- **Durations** read two adjacent units and truncate rather than round, so
  a countdown never claims more time than there is. `period:` alone keeps
  seconds.
- **Countdowns use the launch convention**: `T-` until, `T+` since. This
  is a behaviour change. `formatCountdown` printed `T+` for a *future*
  node, the inverse of the mission clock on the same screen.
- **Distances climb an SI ladder at four significant figures**: `m` below
  1 km, `km` to 9999 km, `Mm` to 999.9 Mm, `Gm` to 0.1 AU, then `AU`.
  Masses go `kg` then `t`; thrust is `kN` everywhere. The rung is always
  printed, so a unit change is never silent.
- **A sub-surface periapsis keeps its signed depth** and the whole row
  renders in the Warning colour, on all sites that print one.
- **Labels are one short word**; six codes survive and each gets an F1
  glossary line, mirrored in `docs/controls.md`.
- **`Δv budget` becomes `Δv: <stage> / <vehicle> m/s`**.
- A dialect guard test walks `internal/tui` and fails on any survivor of
  the old forms, with a file-and-line allowlist for the four Isp sites
  (specific impulse is measured in seconds as a unit, not a duration).

## Notable fixes found during review

- `intDigits` looped forever on ±Inf, so every formatter hung on it. A
  `View()` that never returns freezes the TUI with no error. Now total
  over its input.
- Four significant figures was silently five at each intra-rung decade
  (`Distance(9999.6)` gave `10.000 km`) because the decimal count was
  chosen before rounding.
- `app.go` printed `T+` for a future arrival, the same inversion, and had
  been invisible to the guard because it sits one directory above
  `screens/`.
- The CAPTURE PREVIEW chip's hand-padded rows were misaligned by 1 to 2
  columns. String assertions pass straight through a misaligned column;
  only rendering and reading finds it.
- `TestManeuverPlannedNodeRowsNotDimmed` was vacuous: `go test`'s stdout
  is not a TTY, so lipgloss emits no escapes and its colour condition
  could never be true. Any colour assertion in this package needs the
  profile forced. Fixed, and the package swept for siblings.

## Test plan

- `go vet ./...` clean and `go test ./... -race -count=1` green across all
  19 packages, run on the pushed ref.
- Table tests in `readout` cover every rung and boundary, both duration
  conventions, ±Inf and NaN, and the decade crossings.
- New call-site tests pin the three headline behaviours that had none: the
  `stage / vehicle` Δv pair, the periapsis Warning colour (asserting the
  literal Warning escape, not merely "some style"), and the planner node
  row's `T-` sign.
- Every guard pattern and every fixed test was proven able to fail by
  deliberate sabotage before being trusted.
- All 14 flight surfaces rendered at 140x40 and read row by row, with
  column alignment checked by display width rather than `len()`. Captures
  are in the planning vault.

## Follow-ups filed separately, not in this PR

- The two Δv figures use different mass models: `StackStats` ignores
  monoprop while `RemainingDeltaV` counts it as dead weight, giving about
  150 m/s of phantom vehicle Δv on a drained Saturn V. Changing Δv
  accounting is a physics change, not a formatting one.
- `τ in:` keeps a direction word in its label (ADR 0034 subspace rows).
- `porkchop.go`, `bodyinfo.go`, `vab.go`, `vab_render.go` and `spawn.go`
  still carry raw formatting and are deliberately out of scope here.
- ADR 0049's decision 1 says "title-bar mission stopwatch"; the stopwatch
  is actually the launch strip's. Wording fix owed.
