### PR TITLE
Departure-plane inclination and Δincl against a vessel (ADR 0050)

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -296,6 +296,7 @@ overlay carries, so you can look one up without leaving the game.
 | `Δv` / `Δincl` | Delta-v / relative inclination to a target's orbital plane |
 | `T-` / `T+` | Countdown convention: `T-` counts down to an event, `T+` counts up since it |
 | `incl (min N°)` | On the pad: the inclination your commanded heading yields, and the Inclination Floor (your launch latitude, unsigned) it can't go below |
+| `depart` | The angle between the orbit you'd reach and the plane the world beneath you travels in: the plane you leave along |
 
 ## Screens
 

--- a/internal/bodies/body.go
+++ b/internal/bodies/body.go
@@ -82,11 +82,17 @@ type CelestialBody struct {
 	// derives sub-observer longitude from orbital phase. v0.8.5+.
 	TidallyLocked bool `json:"tidallyLocked,omitempty"`
 
-	// AxialTilt is the body's obliquity (rotation-axis angle from
-	// the orbital-plane normal), in degrees. Drives view-aware
-	// texture projection (v0.8.5.7+) — ViewTop on a tilted body
-	// reveals polar regions; Uranus's 97° tilt makes it roll
-	// pole-on along its orbit.
+	// AxialTilt is the angle, in degrees, between the body's spin axis
+	// and the world's up (world +Z, the ecliptic pole), NOT the normal
+	// of the body's own orbital plane: orbital.BodyEquatorialFrame and
+	// render.BodyRotationAxisWorld both build the axis as
+	// (sin t·cos a, sin t·sin a, cos t) from world +Z, with a =
+	// AxialAzimuth. For a planet on a near-ecliptic orbit the two
+	// readings agree; for a moon they differ by up to the moon's
+	// orbital inclination (ADR 0050 decision 10: the code is
+	// authoritative). Drives view-aware texture projection
+	// (v0.8.5.7+): ViewTop on a tilted body reveals polar regions;
+	// Uranus's 97° tilt makes it roll pole-on along its orbit.
 	AxialTilt float64 `json:"axialTilt,omitempty"`
 
 	// AxialAzimuth is the body's spin-axis azimuth in the world

--- a/internal/orbital/frame.go
+++ b/internal/orbital/frame.go
@@ -43,6 +43,24 @@ func (a Vec3) Unit() Vec3 {
 	return a.Scale(1 / n)
 }
 
+// PlaneNormalOK reports whether n (an orbital-plane normal, r × v) is
+// far enough from a pole passage to trust as a plane direction, given
+// the primary it was computed against: its spin rate omega (rad/s) and
+// radius R (m). ADR 0050 decision 8: every guard on this quantity used
+// to be an exact `n.Norm() == 0` test, which a real pole never trips:
+// floating-point residue leaves a vessel at the shipped North Pole
+// preset with |n| ~= 3.2e-7, not zero, so an unguarded Δincl wandered
+// 63.20°..88.47° with no period and the planner planned 8127..13099
+// m/s out of that noise. The threshold scales with the primary's own
+// dynamics rather than testing against an absolute epsilon: it trips
+// within 6e-8 degrees of the pole (about 6mm on Earth) and does not
+// trip at 89.99999 degrees or a vessel one metre from the pole, which
+// keeps an honest, real, sweeping figure there.
+func PlaneNormalOK(n Vec3, omega, radiusMeters float64) bool {
+	threshold := 1e-9 * omega * radiusMeters * radiusMeters
+	return n.Norm() >= threshold
+}
+
 // Rotate rotates v about axis by theta radians (right-hand rule),
 // via Rodrigues' formula:
 //

--- a/internal/orbital/frame.go
+++ b/internal/orbital/frame.go
@@ -58,7 +58,11 @@ func (a Vec3) Unit() Vec3 {
 // keeps an honest, real, sweeping figure there.
 func PlaneNormalOK(n Vec3, omega, radiusMeters float64) bool {
 	threshold := 1e-9 * omega * radiusMeters * radiusMeters
-	return n.Norm() >= threshold
+	// review r1 F5: `>`, not `>=`: at omega == 0 the threshold is itself
+	// exactly 0, and `>=` let an exact-zero normal through as "trustworthy"
+	// (PlanVesselPlaneMatch then calls .Unit() on it). Latent today: no
+	// shipped body has zero spin.
+	return n.Norm() > threshold
 }
 
 // Rotate rotates v about axis by theta radians (right-hand rule),

--- a/internal/orbital/frame_test.go
+++ b/internal/orbital/frame_test.go
@@ -47,6 +47,24 @@ func TestPlaneNormalOKTripsNearPoleNotFarFromIt(t *testing.T) {
 	}
 }
 
+// TestPlaneNormalOKRejectsZeroNormalAtZeroOmega pins review r1 F5: with
+// omega == 0 the threshold (1e-9 * omega * R^2) is itself exactly 0, so
+// the old `n.Norm() >= threshold` comparison let an exact-zero normal
+// through as "trustworthy" (PlanVesselPlaneMatch then calls .Unit() on
+// it). No shipped body has zero spin (all 52 catalog bodies either spin
+// or fall back to their orbital period when tidally locked), so this is
+// reachable only via a user overlay body with no rotation and no
+// tidallyLocked flag. `>` closes it while still accepting a real,
+// non-degenerate normal at the same omega.
+func TestPlaneNormalOKRejectsZeroNormalAtZeroOmega(t *testing.T) {
+	if got := PlaneNormalOK(Vec3{}, 0, 6.371e6); got {
+		t.Error("PlaneNormalOK(zero normal, omega=0) = true, want false (no plane, no matter the primary's spin)")
+	}
+	if got := PlaneNormalOK(Vec3{X: 1, Y: 2, Z: 3}, 0, 6.371e6); !got {
+		t.Error("PlaneNormalOK(real normal, omega=0) = false, want true (a genuine plane shouldn't be refused just because the primary doesn't spin)")
+	}
+}
+
 func TestInertialPlanetCentricRoundTrip(t *testing.T) {
 	primary := Vec3{X: 1.5e11, Y: 2.3e10, Z: -4.7e9}
 	cases := []Vec3{

--- a/internal/orbital/frame_test.go
+++ b/internal/orbital/frame_test.go
@@ -7,6 +7,46 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 )
 
+// TestPlaneNormalOKTripsNearPoleNotFarFromIt pins ADR 0050 decision 8:
+// the guard is relative to the primary's own scale (omega, R), not an
+// exact |n| == 0 test, which a real pole never trips (floating-point
+// residue leaves a landed vessel a few metres from a pole with a
+// normal of magnitude ~1e-7, not zero). n = r × v for a co-rotating
+// vessel at colatitude theta (angle from the spin axis) has magnitude
+// omega * R^2 * sin(theta), so the cases below are built directly from
+// that closed form rather than from the game's own spawn/landed code
+// (which this package sits below), at Earth-like omega/R.
+func TestPlaneNormalOKTripsNearPoleNotFarFromIt(t *testing.T) {
+	const omega = 7.292115855e-5     // rad/s, Earth's sidereal spin rate.
+	const radius = 6.371e6           // m, Earth's mean radius.
+	spinAxis := Vec3{Z: 1}
+	normalAtColatitude := func(thetaRad float64) Vec3 {
+		r := Vec3{X: radius * math.Sin(thetaRad), Z: radius * math.Cos(thetaRad)}
+		v := spinAxis.Scale(omega).Cross(r) // omega x r, co-rotation velocity.
+		return r.Cross(v)
+	}
+	cases := []struct {
+		name      string
+		thetaDeg  float64
+		wantOK    bool // true = trustworthy plane, false = degenerate (withhold)
+	}{
+		{"exact pole", 0, false},
+		{"well within the trip radius (colatitude 1e-10 rad)", 1e-10 * 180 / math.Pi, false},
+		{"89.99999 degrees latitude (0.00001 degrees colatitude) must NOT trip", 0.00001, true},
+		{"one metre from the pole must NOT trip", (1.0 / radius) * 180 / math.Pi, true},
+		{"45 degrees latitude, ordinary case", 45, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			n := normalAtColatitude(c.thetaDeg * math.Pi / 180)
+			got := PlaneNormalOK(n, omega, radius)
+			if got != c.wantOK {
+				t.Errorf("PlaneNormalOK(|n|=%.3e) at colatitude %.10f deg = %v, want %v", n.Norm(), c.thetaDeg, got, c.wantOK)
+			}
+		})
+	}
+}
+
 func TestInertialPlanetCentricRoundTrip(t *testing.T) {
 	primary := Vec3{X: 1.5e11, Y: 2.3e10, Z: -4.7e9}
 	cases := []Vec3{

--- a/internal/sim/ascent.go
+++ b/internal/sim/ascent.go
@@ -14,16 +14,17 @@
 //     marked on it — see AscentQBand's doc comment for why "measured so
 //     far" rather than a forecast eventual peak.
 //
-// AscentCueFor gates all three behind climbing PLUS "not done with the
-// atmosphere for good" (#451) — the near-mirror of DescentCorridorFor's
-// falling-plus-no-impact-forecast gate — so the surface view can never
-// show the ascent cues and the descent corridor at once. Not an exact
-// mirror: the two halves stand down on different thresholds (ascent on
-// periapsis vs. the atmosphere cutoff, descent on "no ground contact
-// inside its forecast horizon"), so a low elliptical orbit can show the
-// ascent bundle for its whole climbing half while the descent corridor
-// only lights on the last stretch before periapsis. See
-// atmosphereClearedForGood's doc comment.
+// AscentCueFor gates all three behind climbing PLUS "not finished for
+// good" (#451 on an atmospheric primary, #454 on an airless one), the
+// near-mirror of DescentCorridorFor's falling-plus-no-impact-forecast
+// gate, so the surface view can never show the ascent cues and the
+// descent corridor at once. Not an exact mirror: the two halves stand
+// down on different thresholds (ascent on periapsis vs. the atmosphere
+// cutoff or the surface, descent on "no ground contact inside its
+// forecast horizon"), so a low elliptical orbit can show the ascent
+// bundle for its whole climbing half while the descent corridor only
+// lights on the last stretch before periapsis. See
+// ascentFinishedForGood's doc comment.
 package sim
 
 import (
@@ -167,58 +168,74 @@ type AscentQBand struct {
 	HasMaxQ bool
 }
 
-// atmosphereClearedForGood reports whether c's primary carries an
-// atmosphere AND c's current orbit has cleared it for good — no
-// atmosphere pass is ever coming again. False (never "cleared") for an
-// airless primary, since there's no atmosphere to clear in the first
-// place; that half of the ascent story is scoped out of this check
-// on purpose (#451 is about the atmosphere specifically — #454 tracks
-// the airless-body equivalent, which needs a different "done for
-// good" test: periapsis above the surface, not the atmosphere).
+// ascentFinishedForGood reports whether c's ascent has cleared, for
+// good, the hazard its primary actually carries: an atmosphere pass when
+// the primary has one, or the bare surface when it doesn't. Either way,
+// "cleared" means no repeat of the hazard is ever coming again from the
+// current orbit.
+//
+// Named atmosphereClearedForGood until #454's second half: that version
+// returned false unconditionally for an airless primary (Atmosphere ==
+// nil), since there is no atmosphere to clear, and by construction never
+// latched on the Moon or any other airless body: the ascent arc and
+// nose/prograde attitude stubs kept waking up on every single
+// periapsis-to-apoapsis half of a stable lunar orbit, forever, the exact
+// #451 bug this function itself was written to fix on Earth. The airless
+// equivalent of "an atmosphere pass is never coming again" is "periapsis
+// is above the surface", the same physical boundary PredictImpact
+// (descent.go) already tests when it asks whether a ballistic coast ever
+// reaches the ground, so the two cases now share one function with one
+// threshold: the atmosphere's cutoff altitude when there is an
+// atmosphere, the surface (0) when there isn't.
 //
 // Mirrors shouldShowLaunchHUD's own hyperbolic-vs-elliptical split
 // (orbit.go): a stable elliptical orbit's periapsis tells you whether
-// the atmosphere is coming back (periapsis inside it: yes, next orbit;
-// periapsis clear: never again), but a hyperbolic/degenerate state's
-// "periapsis" can describe a departure or approach far from the body,
-// where the honest signal is current altitude instead.
+// the hazard is coming back (periapsis inside the threshold: yes, next
+// orbit; periapsis clear: never again), but a hyperbolic/degenerate
+// state's "periapsis" can describe a departure or approach far from the
+// body, where the honest signal is current altitude instead.
 //
-// Backs both AscentQBandFor (#449) and AscentCueFor's own gate (#451):
-// the original ascent-cue design (issue #348 §3) keyed everything off
-// instantaneous climb rate, which is orbital-mechanics-blind — a
+// Backs both AscentQBandFor (#449, atmospheric bodies only, see its own
+// gate) and AscentCueFor's own gate (#451 on Earth, #454 airless): the
+// original ascent-cue design (issue #348 §3) keyed everything off
+// instantaneous climb rate, which is orbital-mechanics-blind, and a
 // stable orbit's surface-relative radial rate swings positive on every
-// periapsis→apoapsis half regardless of altitude, so without this
-// check the whole bundle (Q band AND the ascent arc / nose-prograde
-// stubs) would flicker back on once per orbit, forever, long after the
-// atmosphere could ever matter again.
-func atmosphereClearedForGood(c *spacecraft.Spacecraft) bool {
-	atm := c.Primary.Atmosphere
-	if atm == nil {
-		return false
-	}
+// periapsis→apoapsis half regardless of altitude, so without this check
+// the whole bundle (Q band AND the ascent arc / nose-prograde stubs)
+// would flicker back on once per orbit, forever, long after the hazard
+// could ever matter again.
+func ascentFinishedForGood(c *spacecraft.Spacecraft) bool {
 	mu := c.Primary.GravitationalParameter()
 	if mu <= 0 {
 		return false
+	}
+	// The altitude past which the hazard can never recur: the
+	// atmosphere's own cutoff when there is one, the bare surface
+	// otherwise (#454's airless branch).
+	clearAltM := 0.0
+	if atm := c.Primary.Atmosphere; atm != nil {
+		clearAltM = atm.CutoffAltitude
 	}
 	el := orbital.ElementsFromState(c.State.R, c.State.V, mu)
 	if el.E >= 1 || el.A <= 0 {
 		// Hyperbolic/degenerate: go by current altitude instead of
 		// periapsis (shouldShowLaunchHUD's exact reasoning).
-		return c.Altitude() >= atm.CutoffAltitude
+		return c.Altitude() >= clearAltM
 	}
 	periapsisAltM := el.Periapsis() - c.Primary.RadiusMeters()
-	return periapsisAltM >= atm.CutoffAltitude
+	return periapsisAltM >= clearAltM
 }
 
 // AscentQBandFor builds the Q-band instrument for a craft. ok is false
-// when the primary has no atmosphere at all (issue #348 §3's gate — "Q
-// band only on bodies WITH atmosphere"), or once atmosphereClearedForGood
-// (#449 fix).
+// when the primary has no atmosphere at all (issue #348 §3's gate, "Q
+// band only on bodies WITH atmosphere", so ascentFinishedForGood's
+// airless branch never actually gets reached from here), or once
+// ascentFinishedForGood (#449 fix).
 func AscentQBandFor(w *World, c *spacecraft.Spacecraft) (AscentQBand, bool) {
 	if w == nil || c == nil || c.Primary.Atmosphere == nil {
 		return AscentQBand{}, false
 	}
-	if atmosphereClearedForGood(c) {
+	if ascentFinishedForGood(c) {
 		return AscentQBand{}, false
 	}
 	atm := c.Primary.Atmosphere
@@ -258,17 +275,14 @@ type AscentCue struct {
 // within its horizon), and a periapsis-above-ground orbit never
 // produces one, so only this ascent half needed the #451 fix below.
 //
-// #451: raw climb rate is orbital-mechanics-blind the same way
-// AscentQBandFor's was (#449) — a stable orbit's radial rate swings
-// positive on every periapsis→apoapsis half regardless of altitude, so
-// climbRate alone would keep waking the whole bundle (arc, attitude
-// stubs, Q band) up once per orbit forever above the atmosphere.
-// atmosphereClearedForGood adds the same periapsis/altitude check
-// AscentQBandFor uses; it's a no-op for an airless primary (no
-// atmosphere to clear), so a stable lunar orbit still has this exact
-// symptom — tracked separately as #454, since it needs a different
-// "done for good" test (periapsis above the surface, not the
-// atmosphere) rather than growing this fix.
+// #451 (atmospheric) / #454 (airless): raw climb rate is orbital-
+// mechanics-blind the same way AscentQBandFor's was (#449), and a stable
+// orbit's radial rate swings positive on every periapsis→apoapsis half
+// regardless of altitude, so climbRate alone would keep waking the whole
+// bundle (arc, attitude stubs, Q band) up once per orbit forever, above
+// the atmosphere on Earth or above the bare surface on the Moon.
+// ascentFinishedForGood covers both: the atmosphere's cutoff altitude
+// when the primary has one, the surface (0) when it doesn't.
 func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (AscentCue, bool) {
 	if c == nil || c.Landed || c.Crashed {
 		return AscentCue{}, false
@@ -288,7 +302,7 @@ func AscentCueFor(w *World, c *spacecraft.Spacecraft, horizon time.Duration) (As
 	if !(climbRate >= climbRateFloorMps) {
 		return AscentCue{}, false
 	}
-	if atmosphereClearedForGood(c) {
+	if ascentFinishedForGood(c) {
 		return AscentCue{}, false
 	}
 

--- a/internal/sim/ascent_test.go
+++ b/internal/sim/ascent_test.go
@@ -276,7 +276,8 @@ func TestAscentQBandForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 	}
 	// End to end: the player-visible path is AscentCueFor -> HasQBand,
 	// not AscentQBandFor directly. #451 later gave AscentCueFor's own
-	// `ok` the same atmosphereClearedForGood check, so the whole bundle
+	// `ok` the same ascentFinishedForGood check (then named
+	// atmosphereClearedForGood), so the whole bundle
 	// now stands down here too — see
 	// TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere for that
 	// fix's own dedicated coverage. This just pins that AscentQBandFor's
@@ -352,7 +353,8 @@ func TestAscentQBandForHyperbolicDepartureStandsDownByAltitude(t *testing.T) {
 // share AscentQBandFor's exact bug — AscentCueFor's own gate was raw
 // climb rate, orbital-mechanics-blind, so a stable orbit fully above
 // the atmosphere still flickered the whole bundle back on once per
-// orbit. atmosphereClearedForGood now backs this gate too.
+// orbit. ascentFinishedForGood (then named atmosphereClearedForGood)
+// now backs this gate too.
 func TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere(t *testing.T) {
 	w, c := ascendTestCraft(t, "earth", 218_000, 50)
 	c.CurrentAttitudeDir = orbital.Vec3{X: 1}
@@ -458,6 +460,72 @@ func TestAscentCueForGatingMatrix(t *testing.T) {
 	c.Landed = true
 	assertGates("landed", false, false)
 	c.Landed = false
+}
+
+// TestAscentCueForStandsDownOnceLunarPeriapsisClearsSurface (#454, second
+// half): the airless mirror of TestAscentCueForStandsDownOncePeriapsisClearsAtmosphere.
+// atmosphereClearedForGood returns false unconditionally for an airless
+// primary (Atmosphere == nil), by design: there's no atmosphere to
+// clear, so AscentCueFor's gate never latches for a vessel in a stable
+// lunar orbit, and the ascent arc/attitude stubs wake up on every single
+// periapsis-to-apoapsis half, forever, exactly like the pre-#451 bug this
+// mirrors on Earth. Samples BOTH halves of one full orbit: nu=+90°
+// (climbing, where the bug fires) and nu=-90° (falling, where the raw
+// climb-rate gate already stands down on its own, sabotage-proofing this
+// test against a "passes because it never left the falling half" trap.
+//
+// Sabotage proof: run against the unfixed atmosphereClearedForGood
+// (Atmosphere==nil short-circuit to false, no periapsis-above-surface
+// branch), the climbing-half assertion below (`ok == false`) fails with
+// the gate never latches on an airless primary. The falling-half
+// assertion passes even unfixed (climb rate alone already stands it
+// down there), which is exactly why sampling only one phase would have
+// let this regression through silently.
+func TestAscentCueForStandsDownOnceLunarPeriapsisClearsSurface(t *testing.T) {
+	w, c := ascendTestCraft(t, "moon", 210_000, 50)
+	c.CurrentAttitudeDir = orbital.Vec3{X: 1}
+	mu := c.Primary.GravitationalParameter()
+	R := c.Primary.RadiusMeters()
+
+	orbitAt := func(rpAltM, raAltM, nu float64) {
+		rp := R + rpAltM
+		ra := R + raAltM
+		a := (rp + ra) / 2
+		e := (ra - rp) / (ra + rp)
+		p := a * (1 - e*e)
+		rMag := p / (1 + e*math.Cos(nu))
+		rHat := orbital.Vec3{X: math.Cos(nu), Y: math.Sin(nu)}
+		c.State.R = rHat.Scale(rMag)
+		h := math.Sqrt(mu * p)
+		vr := (mu / h) * e * math.Sin(nu)
+		vt := (mu / h) * (1 + e*math.Cos(nu))
+		thetaHat := orbital.Vec3{X: -math.Sin(nu), Y: math.Cos(nu)}
+		c.State.V = rHat.Scale(vr).Add(thetaHat.Scale(vt))
+	}
+
+	// Stable 210x226 km lunar orbit (the ADR's own worked example),
+	// periapsis and apoapsis both clear of the surface. Climbing half
+	// (nu=90°) first.
+	orbitAt(210_000, 226_000, math.Pi/2)
+	rHat := c.State.R.Scale(1 / c.State.R.Norm())
+	vRel := physics.AirRelativeVelocity(c.State.R, c.State.V, c.Primary)
+	if climbRate := vRel.Dot(rHat); climbRate < climbRateFloorMps {
+		t.Fatalf("test setup: climb rate %.3f m/s at nu=90°, want above the %.1f m/s floor (this orbitAt call must land on the climbing half)", climbRate, climbRateFloorMps)
+	}
+	if periAltM := orbital.ElementsFromState(c.State.R, c.State.V, mu).Periapsis() - R; periAltM < 0 {
+		t.Fatalf("test setup: periapsis altitude %.0fm should be above the surface (0m)", periAltM)
+	}
+	if _, ok := AscentCueFor(w, c, AscentPredictHorizon); ok {
+		t.Errorf("stable lunar orbit, climbing half: AscentCueFor ok=true, want false (the arc/attitude stubs must not flicker back on every orbit around an airless body)")
+	}
+
+	// Falling half (nu=-90°) of the same orbit: already stands down via
+	// the raw climb-rate gate even unfixed, which is why sampling only
+	// the climbing half above would be a vacuous proof on its own.
+	orbitAt(210_000, 226_000, -math.Pi/2)
+	if _, ok := AscentCueFor(w, c, AscentPredictHorizon); ok {
+		t.Errorf("stable lunar orbit, falling half: AscentCueFor ok=true, want false")
+	}
 }
 
 // TestAscentCueForAirlessBodyHasCuesButNoQBand: the nose/prograde markers

--- a/internal/sim/maneuver.go
+++ b/internal/sim/maneuver.go
@@ -1194,8 +1194,13 @@ func (w *World) PlanVesselPlaneMatch() (*planner.InclinationPlan, error) {
 	if !ok {
 		return nil, ErrRendezvousNoTarget
 	}
-	nTarget := rT.Cross(vT)
-	if nTarget.Norm() == 0 {
+	// ADR 0050 decision 8: targetPlaneNormalRelativeTo applies the
+	// shared pole guard (a relative threshold, not an exact Norm() == 0
+	// test) so a target landed at a pole refuses here the same way the
+	// chip withholds its Δincl row and TargetPlaneNodePositions draws no
+	// markers.
+	nTarget, ok := targetPlaneNormalRelativeTo(c.Primary, rT, vT)
+	if !ok {
 		return nil, errPlaneMatchDegenerateTarget
 	}
 	nTargetHat := nTarget.Unit()

--- a/internal/sim/target.go
+++ b/internal/sim/target.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
 
@@ -610,6 +611,55 @@ func (w *World) TargetSharesActivePrimary() bool {
 	}
 }
 
+// targetPlaneNormalRelativeTo is the shared pole guard for a target's
+// orbital-plane normal (ADR 0050 decision 8): TargetPlaneNodePositions,
+// PlanVesselPlaneMatch and the TARGET/pad chips' Δincl rows (via
+// TargetPlaneNormal below) all derive a target's plane from rT × vT and
+// used to guard it with an exact `Norm() == 0` test, which a real pole
+// never trips: see orbital.PlaneNormalOK's doc comment for the
+// shipped North Pole preset's 3.2e-7 residue. primary is the active
+// craft's primary (rT, vT are already expressed relative to it by
+// TargetStateRelativeToActivePrimary), whose spin rate and radius set
+// the guard's scale.
+func targetPlaneNormalRelativeTo(primary bodies.CelestialBody, rT, vT orbital.Vec3) (orbital.Vec3, bool) {
+	n := rT.Cross(vT)
+	omegaR := render.BodySpinOmegaWorld(primary)
+	omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+	if !orbital.PlaneNormalOK(n, omega.Norm(), primary.RadiusMeters()) {
+		return orbital.Vec3{}, false
+	}
+	return n, true
+}
+
+// TargetPlaneNormal returns the active craft's bound target's pole-
+// guarded orbital-plane normal (ADR 0050 decisions 6-8): rT × vT in the
+// active primary's frame. Folds in the same-primary gate
+// (TargetSharesActivePrimary) so a vessel orbiting a different primary
+// reads no figure at all rather than the fast-looking wobble that mixes
+// its own lap with its primary's motion round the active primary (the
+// `I` key and the node markers already refuse this case), and the
+// pole guard, so the figure withholds at a pole the same way the
+// planner refuses and the node markers draw nothing.
+//
+// A landed target's relative state is its true co-rotation velocity
+// (ω × r, integrateLanded's actual physics, not a special case), so
+// the normal returned here IS the due-east launch plane for a landed
+// target (decision 7) and the live orbital-plane normal for an
+// orbiting one, with no branching needed between the two. ok is false
+// with no bound craft/ghost target, a target on a different primary, or
+// a pole-degenerate normal.
+func (w *World) TargetPlaneNormal() (orbital.Vec3, bool) {
+	c := w.ActiveCraft()
+	if c == nil || !w.TargetSharesActivePrimary() {
+		return orbital.Vec3{}, false
+	}
+	rT, vT, ok := w.TargetStateRelativeToActivePrimary()
+	if !ok {
+		return orbital.Vec3{}, false
+	}
+	return targetPlaneNormalRelativeTo(c.Primary, rT, vT)
+}
+
 // TargetPlaneNodePositions locates the active craft's crossings of its
 // bound target's orbital plane — an Ascending / Descending Node pair
 // measured against the TARGET's plane, unlike orbital.TimeToNodeCrossing's
@@ -642,8 +692,12 @@ func (w *World) TargetPlaneNodePositions() (anPos, dnPos orbital.Vec3, hasAN, ha
 	if !ok {
 		return orbital.Vec3{}, orbital.Vec3{}, false, false
 	}
-	nTarget := rT.Cross(vT)
-	if nTarget.Norm() == 0 {
+	// ADR 0050 decision 8: shared pole guard (relative to the primary's
+	// own spin rate and radius), not an exact Norm() == 0 test: see
+	// targetPlaneNormalRelativeTo / orbital.PlaneNormalOK's doc comments.
+	var nTarget orbital.Vec3
+	nTarget, ok = targetPlaneNormalRelativeTo(c.Primary, rT, vT)
+	if !ok {
 		return orbital.Vec3{}, orbital.Vec3{}, false, false
 	}
 	mu := c.Primary.GravitationalParameter()

--- a/internal/sim/target_plane_nodes_test.go
+++ b/internal/sim/target_plane_nodes_test.go
@@ -86,6 +86,25 @@ func TestTargetPlaneNodePositions_Coplanar(t *testing.T) {
 	}
 }
 
+// TestTargetPlaneNodePositions_LandedAtPole_NotMeaningful pins ADR 0050
+// decision 8: a target landed at a pole (the shipped North Pole preset)
+// has |rT x vT| ~= 3e-7, not exactly zero, so the pre-decision-8 exact
+// `Norm() == 0` guard let it through and drew a node-marker pair off
+// pure floating-point noise. Reuse the same shared guard
+// PlanVesselPlaneMatch refuses on (vessel_plane_match_test.go's "target
+// landed at the pole" case).
+func TestTargetPlaneNodePositions_LandedAtPole_NotMeaningful(t *testing.T) {
+	w := mustWorld(t)
+	if _, err := w.SpawnCraft(SpawnSpec{Launchpad: true, Latitude: 90}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	if _, _, hasAN, hasDN := w.TargetPlaneNodePositions(); hasAN || hasDN {
+		t.Error("expected no node markers against a target landed at the pole")
+	}
+}
+
 // TestTargetPlaneNodePositions_DifferentPrimaries_NotMeaningful mirrors
 // TargetLeadAngleDeg's cross-SOI refusal: a target orbiting a different
 // primary has no shared plane to measure a line of nodes against.

--- a/internal/sim/vessel_plane_match_test.go
+++ b/internal/sim/vessel_plane_match_test.go
@@ -219,3 +219,54 @@ func TestPlanVesselPlaneMatchRefusals(t *testing.T) {
 		}
 	})
 }
+
+// TestActiveLandedVesselAlreadyRefusesPlaneMatchIndependentOfPole is
+// review r1 F3's follow-up check: does PlanVesselPlaneMatch, or the
+// map's ◇/◆ node markers (TargetPlaneNodePositions), consume the
+// ACTIVE vessel's own landed normal the same fragile way
+// spacecraft.HeadingOrbitNormal did (the bug F3 fixed on the pad's own
+// depart:/Δincl: rows)? Verified empirically, not assumed: no. Both
+// route the active craft's raw (Landed, co-rotation) state through
+// orbital.TimeToNodeCrossing before either function ever computes a
+// plane normal, and TimeToNodeCrossing already finds no node crossing
+// for that state: a probe run during this fix confirmed the identical
+// refusal for a craft landed exactly at the pole, one metre off it, and
+// at an ordinary 28.6° pad, so the refusal comes from the Landed
+// pseudo-orbit's degenerate elements (the #375 shape, periapsis metres
+// from the primary's centre), not from pole proximity. hHat's
+// unguarded .Unit() in PlanVesselPlaneMatch is therefore unreachable
+// for a Landed active craft: dt < 0 returns ErrInclinationNoOp first.
+// Pinned so a future change that starts letting a Landed active craft
+// reach that computation doesn't silently reopen this class of bug.
+func TestActiveLandedVesselAlreadyRefusesPlaneMatchIndependentOfPole(t *testing.T) {
+	poleWorld := func(t *testing.T) *World {
+		t.Helper()
+		w := mustWorld(t)
+		if _, err := w.SpawnCraft(SpawnSpec{AltitudeM: 400e3, Inclination: 45}); err != nil {
+			t.Fatalf("SpawnCraft (orbiter): %v", err)
+		}
+		if _, err := w.SpawnCraft(SpawnSpec{Launchpad: true, Latitude: 90}); err != nil {
+			t.Fatalf("SpawnCraft (pole): %v", err)
+		}
+		w.ActiveCraftIdx = 2 // the pole-landed craft.
+		w.SetTargetCraft(1) // the orbiting craft.
+		if w.Target.Kind != TargetCraft {
+			t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+		}
+		return w
+	}
+
+	t.Run("PlanVesselPlaneMatch refuses", func(t *testing.T) {
+		w := poleWorld(t)
+		if plan, err := w.PlanVesselPlaneMatch(); err == nil {
+			t.Errorf("PlanVesselPlaneMatch() = (%+v, nil), want a refusal for an active vessel landed at the pole", plan)
+		}
+	})
+
+	t.Run("TargetPlaneNodePositions draws no markers", func(t *testing.T) {
+		w := poleWorld(t)
+		if _, _, hasAN, hasDN := w.TargetPlaneNodePositions(); hasAN || hasDN {
+			t.Error("expected no node markers for an active vessel landed at the pole")
+		}
+	})
+}

--- a/internal/sim/vessel_plane_match_test.go
+++ b/internal/sim/vessel_plane_match_test.go
@@ -220,25 +220,31 @@ func TestPlanVesselPlaneMatchRefusals(t *testing.T) {
 	})
 }
 
-// TestActiveLandedVesselAlreadyRefusesPlaneMatchIndependentOfPole is
+// TestActiveLandedVesselAtPoleRefusesPlaneMatchAndDrawsNoMarkers is
 // review r1 F3's follow-up check: does PlanVesselPlaneMatch, or the
 // map's ◇/◆ node markers (TargetPlaneNodePositions), consume the
 // ACTIVE vessel's own landed normal the same fragile way
 // spacecraft.HeadingOrbitNormal did (the bug F3 fixed on the pad's own
-// depart:/Δincl: rows)? Verified empirically, not assumed: no. Both
-// route the active craft's raw (Landed, co-rotation) state through
-// orbital.TimeToNodeCrossing before either function ever computes a
-// plane normal, and TimeToNodeCrossing already finds no node crossing
-// for that state: a probe run during this fix confirmed the identical
-// refusal for a craft landed exactly at the pole, one metre off it, and
-// at an ordinary 28.6° pad, so the refusal comes from the Landed
-// pseudo-orbit's degenerate elements (the #375 shape, periapsis metres
-// from the primary's centre), not from pole proximity. hHat's
-// unguarded .Unit() in PlanVesselPlaneMatch is therefore unreachable
-// for a Landed active craft: dt < 0 returns ErrInclinationNoOp first.
-// Pinned so a future change that starts letting a Landed active craft
-// reach that computation doesn't silently reopen this class of bug.
-func TestActiveLandedVesselAlreadyRefusesPlaneMatchIndependentOfPole(t *testing.T) {
+// depart:/Δincl: rows)? Measured (round 2 review, R2-F2, correcting an
+// earlier version of this comment that claimed a pole-independent
+// mechanism): no, but only at the pole, and not for the reason
+// previously stated here. PlanVesselPlaneMatch returns
+// ErrInclinationNoOp for a Landed active craft at all three latitudes
+// checked (pole, one metre off it, an ordinary 28.6° pad), that part
+// holds everywhere, but the ◇/◆ markers do NOT stay withheld off the
+// pole: TargetPlaneNodePositions draws them (AN/DN both true) one metre
+// off the pole and at 28.6°, so orbital.TimeToNodeCrossing does find a
+// crossing for the Landed pseudo-orbit away from the pole, contradicting
+// the "no node crossing" claim this comment used to make. The refusal
+// this test actually pins is the pole case only: at lat 90 the near-zero
+// angular momentum of the landed co-rotation pseudo-orbit degenerates
+// the crossing search itself, and separately (unmeasured here) whatever
+// PlanVesselPlaneMatch checks after the crossing search still refuses
+// at every latitude. Pinned so a future change that starts drawing
+// markers or planning a burn for a Landed active craft AT THE POLE
+// specifically doesn't silently reopen this class of bug; it says
+// nothing about the mechanism off the pole.
+func TestActiveLandedVesselAtPoleRefusesPlaneMatchAndDrawsNoMarkers(t *testing.T) {
 	poleWorld := func(t *testing.T) *World {
 		t.Helper()
 		w := mustWorld(t)

--- a/internal/sim/vessel_plane_match_test.go
+++ b/internal/sim/vessel_plane_match_test.go
@@ -178,6 +178,29 @@ func TestPlanVesselPlaneMatchRefusals(t *testing.T) {
 		}
 	})
 
+	t.Run("target landed at the pole (ADR 0050 decision 8)", func(t *testing.T) {
+		// The pre-decision-8 guard was an exact `nTarget.Norm() == 0`
+		// test, which a real pole never trips: floating-point residue in
+		// the lat/lon-to-Cartesian conversion leaves |rT x vT| ~= 3e-7,
+		// not exactly zero, at the shipped North Pole preset. Unguarded,
+		// PlanVesselPlaneMatch plants a burn out of that noise (the ADR
+		// measured 8127..13099 m/s across a day with no period) instead
+		// of refusing the way it already does for the exact-zero case
+		// above.
+		w := mustWorld(t)
+		if _, err := w.SpawnCraft(SpawnSpec{
+			Launchpad: true,
+			Latitude:  90,
+		}); err != nil {
+			t.Fatalf("SpawnCraft: %v", err)
+		}
+		w.ActiveCraftIdx = 0
+		w.SetTargetCraft(1)
+		if _, err := w.PlanVesselPlaneMatch(); !errors.Is(err, errPlaneMatchDegenerateTarget) {
+			t.Errorf("err = %v, want errPlaneMatchDegenerateTarget (a landed-at-the-pole target has no trustworthy plane)", err)
+		}
+	})
+
 	t.Run("degenerate target relative state", func(t *testing.T) {
 		w := mustWorld(t)
 		active := w.ActiveCraft()

--- a/internal/spacecraft/thrust_test.go
+++ b/internal/spacecraft/thrust_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jasonfen/terminal-space-program/internal/bodies"
 	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
 )
 
 // TestProgradeAtLEORaisesApoapsis: plan §C17 accept criterion. Starting
@@ -224,6 +225,61 @@ func TestThrustAccelFnAtWithTargetAgreesWithBurnDirectionOnHeadingTrim(t *testin
 
 	if got.Sub(want).Norm() > 1e-6 {
 		t.Errorf("ThrustAccelFnAtWithTarget direction = %+v, want BurnDirectionWithTarget's %+v", got, want)
+	}
+}
+
+// TestThrustAccelFnAtWithTargetAppliesPitchBeforeHeading is the ADR
+// 0049 guard test owed to the InstantSAS thrust closure (ADR 0050
+// slice 2's "Owed" item): ThrustAccelFnAtWithTarget applies PitchTrim
+// then HeadingTrim (thrust.go, the closure's own two `if` blocks just
+// before the final dir.Norm() == 0 check), which is the correct order
+// BurnDirection's sibling site already guards
+// (TestBurnDirectionAppliesPitchBeforeHeading in
+// burn_direction_test.go), but reversing that order here failed
+// nothing in the whole suite before this test existed:
+// TestThrustAccelFnAtWithTargetAgreesWithBurnDirectionOnHeadingTrim
+// next door sets HeadingTrim only (PitchTrim stays zero), so it can't
+// distinguish an order that only diverges when both trims are nonzero.
+// Uses the same climbing-and-eastward state and 180°-from-east heading
+// offset TestBurnDirectionAppliesPitchBeforeHeading proved order-
+// sensitive, and includes the same sanity check that the two
+// compositions actually differ for this input (not a coincidence).
+func TestThrustAccelFnAtWithTargetAppliesPitchBeforeHeading(t *testing.T) {
+	earth := testEarth()
+	sc := NewInLEO(earth)
+	sc.HeadingTrim = math.Pi // 180° offset from due east: commanded bearing 270° (west).
+	sc.PitchTrim = 10 * math.Pi / 180
+	mu := earth.GravitationalParameter()
+
+	r := orbital.Vec3{X: earth.RadiusMeters()}
+	v := orbital.Vec3{X: 100, Y: 8000} // climbing (radial) and moving east (surface-relative).
+
+	spinAxisR := render.BodyRotationAxisWorld(earth)
+	spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
+	omegaR := render.BodySpinOmegaWorld(earth)
+	omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+	vSurf := v.Sub(omega.Cross(r))
+	natural := vSurf.Scale(1 / vSurf.Norm())
+
+	pitchFirst := ApplyHeadingTrim(ApplyPitchTrim(natural, r, spinAxis, sc.PitchTrim), r, spinAxis, sc.HeadingTrim)
+	headingFirst := ApplyPitchTrim(ApplyHeadingTrim(natural, r, spinAxis, sc.HeadingTrim), r, spinAxis, sc.PitchTrim)
+	if pitchFirst.Sub(headingFirst).Norm() < 1e-6 {
+		t.Fatalf("test setup doesn't distinguish order: pitch-first %+v ~= heading-first %+v", pitchFirst, headingFirst)
+	}
+
+	accelFn := sc.ThrustAccelFnAtWithTarget(BurnSurfacePrograde, mu, 1.0, orbital.Vec3{}, orbital.Vec3{})
+	gotAccel := accelFn(r, v, 0)
+	rMag := r.Norm()
+	gFactor := -mu / (rMag * rMag * rMag)
+	gravity := orbital.Vec3{X: r.X * gFactor, Y: r.Y * gFactor, Z: r.Z * gFactor}
+	thrustAccel := gotAccel.Sub(gravity)
+	if thrustAccel.Norm() == 0 {
+		t.Fatal("setup: ThrustAccelFnAtWithTarget produced no thrust component")
+	}
+	got := thrustAccel.Scale(1 / thrustAccel.Norm())
+
+	if got.Sub(pitchFirst).Norm() > 1e-6 {
+		t.Errorf("ThrustAccelFnAtWithTarget direction = %+v, want pitch-before-heading composition %+v (heading-first would give %+v)", got, pitchFirst, headingFirst)
 	}
 }
 

--- a/internal/tui/readout/readout.go
+++ b/internal/tui/readout/readout.go
@@ -53,6 +53,10 @@ const (
 	LabelBurn      = "burn:"      // t_burn -> burn:
 	LabelIncl      = "incl:"      // inclin. -> incl:
 	LabelDeltaIncl = "Δincl:"     // Δi -> Δincl:
+	// LabelDepart is ADR 0050 decision 5's `depart:` row: the angle
+	// between the orbit a launch would reach (or, in flight, the live
+	// orbit) and the plane the world beneath the player travels in.
+	LabelDepart = "depart:"
 	LabelApproach  = "approach:"  // Proximity View's CA: -> approach:
 	LabelTCA       = "TCA:"       // unchanged code
 	LabelRelSpeed  = "rel speed:" // |v_rel| -> rel speed:

--- a/internal/tui/screens/help.go
+++ b/internal/tui/screens/help.go
@@ -190,9 +190,11 @@ var helpSections = []helpSection{
 		{"[»Burn]", "toggle auto-warp to the next burn (same as G, inert during a rendezvous coast); [■Burn] while running, dimmed when none planned"},
 	}},
 	// ADR 0049 (Readout Contract) decision 6: labels are one short word,
-	// but six codes survive on the HUD, so each gets a line here rather
-	// than being spelled out on every chip. Order matches the ADR and
-	// CONTEXT.md's Readout Contract entry.
+	// but five codes survive on the HUD (CA:, e:, τ, the AN/DN angle,
+	// rcs; corrected by the ADR 0050 audit from an earlier "six" here),
+	// so each gets a line here rather than being spelled out on every
+	// chip. Order matches the ADR and CONTEXT.md's Readout Contract
+	// entry.
 	{"READOUT GLOSSARY", [][2]string{
 		{"fpa", "flight path angle: velocity above / below the local horizontal"},
 		{"Q", "dynamic pressure: aerodynamic stress on the airframe, in kPa"},
@@ -202,6 +204,7 @@ var helpSections = []helpSection{
 		{"Δv / Δincl", "delta-v / relative inclination to a target's orbital plane"},
 		{"T- / T+", "countdown convention: T- counts down to an event, T+ counts up since it"},
 		{"incl (min N°)", "on the pad: the inclination your commanded heading yields, and the Inclination Floor (|launch latitude|) it can't go below"},
+		{"depart", "the angle between the orbit you'd reach and the plane the world beneath you travels in: the plane you leave along"},
 	}},
 }
 

--- a/internal/tui/screens/help_rows_test.go
+++ b/internal/tui/screens/help_rows_test.go
@@ -144,13 +144,17 @@ func TestHelpGlossaryBlockContent(t *testing.T) {
 
 // TestHelpGlossarySection (ADR 0049 stage A3a): the glossary rows live
 // together under their own header, not scattered across other sections.
+// ADR 0050 decision 5 made this the ninth entry (`depart`), tightened
+// from the original loose "at least 7" bound to an exact count so a
+// stray addition or removal is caught rather than silently absorbed.
 func TestHelpGlossarySection(t *testing.T) {
 	for _, s := range helpSections {
 		if s.header != "READOUT GLOSSARY" {
 			continue
 		}
-		if len(s.rows) < 7 {
-			t.Errorf("READOUT GLOSSARY has %d rows, want at least 7 (six codes + T-/T+)", len(s.rows))
+		const want = 9
+		if len(s.rows) != want {
+			t.Errorf("READOUT GLOSSARY has %d rows, want exactly %d", len(s.rows), want)
 		}
 		return
 	}

--- a/internal/tui/screens/orbit_airless_pad_incl_test.go
+++ b/internal/tui/screens/orbit_airless_pad_incl_test.go
@@ -1,0 +1,187 @@
+// Package screens: ADR 0050 decision 9 / issue #454 (readout half). An
+// airless pad (Moon, Glyph, ...) never showed the LAUNCH HUD at all, since
+// shouldShowLaunchHUD requires an atmosphere and buildDescentChip ran
+// instead, so a Luna pad had no heading:/incl:/Δincl: rows however long
+// the player warped for. This file pins the fix: while Landed, DESCENT
+// carries the same heading/incl/Δincl block buildLaunchChip's SURFACE
+// chip already shows on an atmospheric pad, sharing the block rather than
+// duplicating it. Whether the LAUNCH HUD itself should ever appear on the
+// Moon is a separate question (#454's own body says so) and is untouched
+// here: shouldShowLaunchHUD keeps returning false for an airless primary.
+
+package screens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// TestDescentChipShowsHeadingAndInclWhileLandedOnMoon is the sabotage-first
+// proof for the readout half of #454. Verified red against the unfixed
+// buildDescentChip (before landedInclHeadingRows existed and before this
+// chip's Landed branch called it): failed with "expected a 'heading:' row
+// on the airless DESCENT chip while Landed" because buildDescentChip's
+// airless pad output was DESCENT + altitude/vert/horiz/fpa/twr/hold only,
+// with nothing about heading or inclination.
+func TestDescentChipShowsHeadingAndInclWhileLandedOnMoon(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	lines := v.buildDescentChip(w)
+	if lines == nil {
+		t.Fatal("buildDescentChip returned nil for a Landed craft on an airless body")
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "heading:") {
+		t.Errorf("expected a 'heading:' row on the airless DESCENT chip while Landed:\n%s", joined)
+	}
+	if !strings.Contains(joined, "incl:") {
+		t.Errorf("expected an 'incl:' row on the airless DESCENT chip while Landed:\n%s", joined)
+	}
+	if !strings.Contains(joined, "(min ") {
+		t.Errorf("expected the incl: row to carry the '(min N°)' Inclination Floor tag, same as the atmospheric pad:\n%s", joined)
+	}
+	// The pre-existing descent rows must still be there: this is growth,
+	// not a swap.
+	for _, want := range []string{"DESCENT", "altitude:", "vert:", "horiz:", "fpa:", "TWR:", "hold:"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected the pre-existing DESCENT row %q to survive:\n%s", want, joined)
+		}
+	}
+}
+
+// TestDescentChipNoDeltaInclWithoutTargetOnMoon mirrors
+// TestLandedPadNoDeltaInclWithoutTarget for the airless DESCENT chip:
+// decision 9's Δincl row is conditional on a body target, same gate as
+// the atmospheric pad.
+func TestDescentChipNoDeltaInclWithoutTargetOnMoon(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	lines := v.buildDescentChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "Δincl:") {
+		t.Errorf("expected no Δincl row on the airless pad without a target set:\n%s", joined)
+	}
+}
+
+// TestDescentChipShowsDeltaInclWithTargetOnMoon mirrors
+// TestLandedPadShowsDeltaInclWithTarget: with a body target set, the
+// airless DESCENT chip's third row is Δincl, exactly like the atmospheric
+// SURFACE chip.
+func TestDescentChipShowsDeltaInclWithTargetOnMoon(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	sys := w.System()
+	earthIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Earth" || b.ID == "earth" {
+			earthIdx = i
+			break
+		}
+	}
+	if earthIdx < 0 {
+		t.Fatalf("earth not found in default system")
+	}
+	w.SetTargetBody(earthIdx)
+
+	lines := v.buildDescentChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Δincl:") {
+		t.Fatalf("expected a Δincl row on the airless pad with a target set:\n%s", joined)
+	}
+}
+
+// TestDescentChipNotLandedHasNoHeadingRow proves the added rows are
+// Landed-only: an airless-body DESCENT chip for a craft still flying
+// (shouldShowDescentHUD true via the low-altitude arm, not Landed) must
+// not gain heading:/incl: rows: those are pad concepts, not a flight
+// readout, and buildLaunchChip's own airborne branch (decision 10) makes
+// the same distinction on atmospheric bodies.
+func TestDescentChipNotLandedHasNoHeadingRow(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := placeLanderOnMoon(t, w, 5_000, 0, 100, 0)
+	if c.Landed {
+		t.Fatal("setup: expected a flying (not Landed) craft")
+	}
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+
+	lines := v.buildDescentChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "heading:") {
+		t.Errorf("expected no 'heading:' row on a flying (not Landed) DESCENT chip:\n%s", joined)
+	}
+}
+
+// TestDescentChipPadRowsAlignToColumn14 mirrors
+// TestLaunchChipPadRowsAlignToColumn14 for the airless DESCENT chip: the
+// shared landedInclHeadingRows helper must land its values at the same
+// column every other DESCENT row uses (launchChipValueCol), not a
+// hand-padded one of its own.
+func TestDescentChipPadRowsAlignToColumn14(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, _ := spawnLandedOnMoon(t, 10, 0)
+
+	sys := w.System()
+	earthIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Earth" || b.ID == "earth" {
+			earthIdx = i
+			break
+		}
+	}
+	if earthIdx < 0 {
+		t.Fatalf("earth not found in default system")
+	}
+	w.SetTargetBody(earthIdx)
+
+	lines := v.buildDescentChip(w)
+
+	rowFor := func(label string) string {
+		t.Helper()
+		for _, l := range lines {
+			if strings.HasPrefix(l, "  "+label) {
+				return l
+			}
+		}
+		t.Fatalf("no row found with label %q in:\n%s", label, strings.Join(lines, "\n"))
+		return ""
+	}
+	valueColumn := func(row, label string) int {
+		t.Helper()
+		prefix := "  " + label
+		if !strings.HasPrefix(row, prefix) {
+			t.Fatalf("row %q does not start with prefix %q", row, prefix)
+		}
+		rest := row[len(prefix):]
+		spaces := 0
+		for _, r := range rest {
+			if r != ' ' {
+				break
+			}
+			spaces++
+		}
+		return lipgloss.Width(prefix) + spaces
+	}
+
+	for _, label := range []string{"heading:", "incl:", "Δincl:"} {
+		row := rowFor(label)
+		gotCol := valueColumn(row, label)
+		if gotCol != launchChipValueCol {
+			t.Errorf("%s row's value column = %d, want %d (launchChipValueCol): row=%q", label, gotCol, launchChipValueCol, row)
+		}
+	}
+}

--- a/internal/tui/screens/orbit_attitude_chip_test.go
+++ b/internal/tui/screens/orbit_attitude_chip_test.go
@@ -33,6 +33,9 @@ func TestAttitudeHoldLabelOrbitModeUnaffected(t *testing.T) {
 	if !strings.Contains(row, "Prograde") || strings.Contains(row, "Target") {
 		t.Errorf("hold row = %q, want plain %q under NavOrbit", row, "Prograde")
 	}
+	if !strings.Contains(row, "(ORBIT)") {
+		t.Errorf("hold row = %q, want it to name the ORBIT frame like the navball button does", row)
+	}
 }
 
 // TestAttitudeHoldLabelNamesTargetFrame is the #421 acceptance test: the
@@ -70,6 +73,9 @@ func TestAttitudeHoldLabelNamesTargetFrame(t *testing.T) {
 			if tc.mustNot != "" && strings.Contains(row, tc.mustNot) {
 				t.Errorf("hold row = %q, must not contain the stale orbital label %q", row, tc.mustNot)
 			}
+			if !strings.Contains(row, "(TGT)") {
+				t.Errorf("hold row = %q, want it to name the TGT frame like the navball button does", row)
+			}
 		})
 	}
 }
@@ -88,6 +94,9 @@ func TestAttitudeHoldLabelNormalHasNoTargetCounterpart(t *testing.T) {
 	row := holdRow(t, v.buildAttitudeChip(w))
 	if !strings.Contains(row, "Normal+") {
 		t.Errorf("hold row = %q, want it to stay %q (no target-relative counterpart)", row, "Normal+")
+	}
+	if !strings.Contains(row, "(TGT)") {
+		t.Errorf("hold row = %q, want it to still name the TGT frame the row is read in, even though Normal+ itself doesn't remap", row)
 	}
 }
 
@@ -111,5 +120,8 @@ func TestAttitudeHoldLabelNoRelativeTargetStaysOrbitFrame(t *testing.T) {
 	}
 	if !strings.Contains(row, "Prograde") {
 		t.Errorf("hold row = %q, want it to fall back to plain %q", row, "Prograde")
+	}
+	if !strings.Contains(row, "(ORBIT)") || strings.Contains(row, "(TGT)") {
+		t.Errorf("hold row = %q, want the frame tag to fall back to ORBIT too (nothing to actually read TGT against)", row)
 	}
 }

--- a/internal/tui/screens/orbit_attitude_chip_test.go
+++ b/internal/tui/screens/orbit_attitude_chip_test.go
@@ -125,3 +125,55 @@ func TestAttitudeHoldLabelNoRelativeTargetStaysOrbitFrame(t *testing.T) {
 		t.Errorf("hold row = %q, want the frame tag to fall back to ORBIT too (nothing to actually read TGT against)", row)
 	}
 }
+
+// TestAttitudeHoldLabelSurfaceModeAlwaysTagsSurf: a surface-framed mode
+// (Surface Prograde/Retrograde) is frame-locked at the moment it's set,
+// unlike Prograde/Retrograde/Radial which read whatever frame nav: is
+// currently in. So its tag names its own frame, not the current nav
+// frame, whatever nav: happens to be showing. Fixes the self-
+// contradiction of a row reading "Surface Prograde (ORBIT)".
+func TestAttitudeHoldLabelSurfaceModeAlwaysTagsSurf(t *testing.T) {
+	cases := []struct {
+		name string
+		nav  sim.NavMode
+	}{
+		{"under NavOrbit", sim.NavOrbit},
+		{"under NavTarget", sim.NavTarget},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := proximityWorld(t, orbital.Vec3{X: 1_000})
+			w.NavMode = tc.nav
+			c := w.ActiveCraft()
+			c.AttitudeMode = spacecraft.BurnSurfacePrograde
+
+			v := newProximityTestView(t, 80, 24)
+			row := holdRow(t, v.buildAttitudeChip(w))
+			if !strings.Contains(row, "(SURF)") {
+				t.Errorf("hold row = %q, want a surface-framed mode to always tag (SURF), regardless of nav:", row)
+			}
+		})
+	}
+}
+
+// TestAttitudeHoldLabelTargetModeAlwaysTagsTgt: a target-relative mode
+// (already Target Prograde/Retrograde/Target/Anti-Target, whether held
+// directly or produced by the #421 remap above) is likewise frame-
+// locked to TARGET; it must keep tagging TGT even if the player then
+// cycles nav: away to SURFACE, rather than following the current nav
+// frame like the frame-agnostic modes do.
+func TestAttitudeHoldLabelTargetModeAlwaysTagsTgt(t *testing.T) {
+	w := proximityWorld(t, orbital.Vec3{X: 1_000})
+	w.NavMode = sim.NavSurface
+	c := w.ActiveCraft()
+	c.AttitudeMode = spacecraft.BurnTargetPrograde
+
+	v := newProximityTestView(t, 80, 24)
+	row := holdRow(t, v.buildAttitudeChip(w))
+	if !strings.Contains(row, "(TGT)") {
+		t.Errorf("hold row = %q, want a target-relative mode to always tag (TGT), regardless of nav:", row)
+	}
+	if strings.Contains(row, "(SURF)") {
+		t.Errorf("hold row = %q, must not follow nav:SURFACE for a frame-locked target mode", row)
+	}
+}

--- a/internal/tui/screens/orbit_attitude_chip_test.go
+++ b/internal/tui/screens/orbit_attitude_chip_test.go
@@ -81,9 +81,15 @@ func TestAttitudeHoldLabelNamesTargetFrame(t *testing.T) {
 }
 
 // TestAttitudeHoldLabelNormalHasNoTargetCounterpart: NormalPlus/Minus
-// have no target-relative equivalent — ResolveAttitudeIntent itself
+// have no target-relative equivalent: ResolveAttitudeIntent itself
 // leaves them orbit-frame under NavTarget too, so the display must match
 // rather than inventing a label that no keypress could ever produce.
+// The frame assertion was flipped in round 2 (R2-F1): Normal+ is
+// orbit-frame by construction (no held BurnMode reads NavMode; the nose
+// is BurnDirectionWithTarget(AttitudeMode, ...) with no nav argument),
+// so it tags ORBIT here too, not the current nav:TARGET, the same as
+// it would under nav:SURFACE, since there is no surface- or
+// target-frame equivalent of orbit normal at all.
 func TestAttitudeHoldLabelNormalHasNoTargetCounterpart(t *testing.T) {
 	w := proximityWorld(t, orbital.Vec3{X: 1_000})
 	w.NavMode = sim.NavTarget
@@ -95,8 +101,11 @@ func TestAttitudeHoldLabelNormalHasNoTargetCounterpart(t *testing.T) {
 	if !strings.Contains(row, "Normal+") {
 		t.Errorf("hold row = %q, want it to stay %q (no target-relative counterpart)", row, "Normal+")
 	}
-	if !strings.Contains(row, "(TGT)") {
-		t.Errorf("hold row = %q, want it to still name the TGT frame the row is read in, even though Normal+ itself doesn't remap", row)
+	if !strings.Contains(row, "(ORBIT)") {
+		t.Errorf("hold row = %q, want it to tag its own ORBIT frame, not the current nav:TARGET frame", row)
+	}
+	if strings.Contains(row, "(TGT)") {
+		t.Errorf("hold row = %q, must not claim a target frame Normal+ never actually holds", row)
 	}
 }
 
@@ -175,5 +184,48 @@ func TestAttitudeHoldLabelTargetModeAlwaysTagsTgt(t *testing.T) {
 	}
 	if strings.Contains(row, "(SURF)") {
 		t.Errorf("hold row = %q, must not follow nav:SURFACE for a frame-locked target mode", row)
+	}
+}
+
+// TestAttitudeHoldLabelBaseModesAlwaysTagOrbit: round 2 review R2-F1, no
+// held BurnMode reads NavMode at all (internal/spacecraft never consults
+// it; the nose is BurnDirectionWithTarget(AttitudeMode, ...)), so a base
+// mode (Prograde/Retrograde/RadialOut/RadialIn/NormalPlus/NormalMinus) is
+// orbit-frame in every nav mode, not just NavOrbit. Tagging it with the
+// current nav frame prints a false claim: "Prograde (SURF)" under
+// nav:SURFACE, or "Normal+ (SURF)" on the pad, when the nose is holding
+// plain orbit-frame prograde / orbit normal the whole time (there is no
+// surface-frame normal in the game). Reproduced live: KSC pad (nav
+// SURFACE by default), press `a` -> `hold: Normal+ (SURF)`; in flight,
+// `w` then `;` -> `hold: Prograde (SURF)` while the nose still holds
+// orbit-frame prograde.
+func TestAttitudeHoldLabelBaseModesAlwaysTagOrbit(t *testing.T) {
+	cases := []struct {
+		name string
+		mode spacecraft.BurnMode
+	}{
+		{"Prograde", spacecraft.BurnPrograde},
+		{"Retrograde", spacecraft.BurnRetrograde},
+		{"RadialOut", spacecraft.BurnRadialOut},
+		{"RadialIn", spacecraft.BurnRadialIn},
+		{"NormalPlus", spacecraft.BurnNormalPlus},
+		{"NormalMinus", spacecraft.BurnNormalMinus},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := proximityWorld(t, orbital.Vec3{X: 1_000})
+			w.NavMode = sim.NavSurface
+			c := w.ActiveCraft()
+			c.AttitudeMode = tc.mode
+
+			v := newProximityTestView(t, 80, 24)
+			row := holdRow(t, v.buildAttitudeChip(w))
+			if !strings.Contains(row, "(ORBIT)") {
+				t.Errorf("hold row = %q, want a base mode to tag (ORBIT) even under nav:SURFACE (the nose has no surface-frame equivalent for this mode)", row)
+			}
+			if strings.Contains(row, "(SURF)") {
+				t.Errorf("hold row = %q, must not claim SURF for a mode the nose never rebinds to surface frame", row)
+			}
+		})
 	}
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1585,6 +1585,24 @@ func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft
 		chipRowAt("heading:", headingLabel, launchChipValueCol),
 		chipRowAt(readout.LabelIncl, padInclLabel+" (min "+floorLabel+")", launchChipValueCol),
 	}
+	// depart: the angle between the plane this pad's commanded heading
+	// would reach and the plane the world beneath it travels in (ADR
+	// 0050 decisions 1-5), directly under incl:. Hidden where it can
+	// never move (decision 3): departRowHidden's eps is also
+	// departSwing's own input, so the two calls share one angle.
+	if refNormal, ok := departReferenceNormal(c.Primary); ok {
+		if eps, hidden := departRowHidden(spinAxis, refNormal); !hidden {
+			if padNormal, ok := spacecraft.HeadingOrbitNormal(c.State.R, spinAxis, c.HeadingTrim); ok {
+				deg, degOK := unfoldedPlaneAngleDeg(padNormal, refNormal)
+				i, iOK := unfoldedPlaneAngleDeg(padNormal, spinAxis)
+				if degOK && iOK {
+					_, _, best := departSwing(i, eps)
+					departLabel := readout.Angle(deg) + " (best " + readout.Angle(best) + ")"
+					rows = append(rows, chipRowAt(readout.LabelDepart, departLabel, launchChipValueCol))
+				}
+			}
+		}
+	}
 	// Δincl: against a body target (its fixed catalog orbital plane) or
 	// a vessel target (ADR 0050 decision 6, ungating the sim.TargetBody-
 	// only restriction ADR 0049 shipped: a vessel in a stable orbit has
@@ -1836,6 +1854,21 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 	period := 2 * math.Pi * math.Sqrt(el.A*el.A*el.A/mu)
 	lines = append(lines, chipRow(readout.LabelPeriod, readout.Period(time.Duration(period*float64(time.Second)))))
 	lines = append(lines, chipRow(readout.LabelIncl, readout.Angle(el.I*180/math.Pi)))
+	// depart:, directly under incl: (ADR 0050 decisions 1-5). The live
+	// orbit's own plane is fixed under two-body coast, so unlike the
+	// pad's row this carries no (best N°): the lowest value reachable
+	// by waiting is the value already on screen (decision 4). Hidden
+	// where it can never move (decision 3), same predicate as the pad.
+	if refNormal, ok := departReferenceNormal(c.Primary); ok {
+		spinAxisR := render.BodyRotationAxisWorld(c.Primary)
+		spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
+		if _, hidden := departRowHidden(spinAxis, refNormal); !hidden {
+			nCraft := craftOrbitNormalForRelativeIncl(c)
+			if deg, ok := unfoldedPlaneAngleDeg(nCraft, refNormal); ok {
+				lines = append(lines, chipRow(readout.LabelDepart, readout.Angle(deg)))
+			}
+		}
+	}
 	lines = append(lines, chipRow("direction:", v.orbitDirectionLabel(el.I)))
 	// #426 (CONTEXT.md Chip entry): eccentricity, always-on, Full form only —
 	// the three eccentricity-graded challenge rungs (chal-high-orbit et al.)
@@ -2150,6 +2183,82 @@ func relativePlaneAngleDeg(nCraft, nTarget orbital.Vec3) (float64, bool) {
 	}
 	ang := math.Acos(cos) * 180 / math.Pi
 	return math.Min(ang, 180-ang), true
+}
+
+// unfoldedPlaneAngleDeg is the plane angle between two normals over
+// the full [0, 180] range, unlike relativePlaneAngleDeg's fold to
+// [0, 90]. ADR 0050 decision 1: the `depart:` row is an inclination
+// like `incl:`, not a coplanarity test, so a normal nearly antiparallel
+// to the reference reads close to 180°, not close to 0° (the ADR's own
+// exoplanet pads read 61°..118°, which relativePlaneAngleDeg could
+// never produce). ok is false when either normal is degenerate (zero
+// vector).
+func unfoldedPlaneAngleDeg(a, b orbital.Vec3) (float64, bool) {
+	if a.Norm() == 0 || b.Norm() == 0 {
+		return 0, false
+	}
+	cos := a.Dot(b) / (a.Norm() * b.Norm())
+	if cos > 1 {
+		cos = 1
+	} else if cos < -1 {
+		cos = -1
+	}
+	return math.Acos(cos) * 180 / math.Pi, true
+}
+
+// departReferenceNormal is ADR 0050 decision 2's reference plane for
+// the `depart:` row: the orbital-plane normal of the world the craft
+// is standing on or orbiting, i.e. primary's own orbit around ITS
+// primary (orbital.OrbitNormalWorld(primary)), in world/ecliptic axes.
+// Not the ecliptic itself: on a moon this is the moon's own orbit
+// around its planet, which is the plane a departure to that planet (or
+// beyond) actually wants. ok is false for a primary with no orbit (a
+// system star): decision 2 says the normal is zero, so no row.
+func departReferenceNormal(primary bodies.CelestialBody) (orbital.Vec3, bool) {
+	ref := orbital.OrbitNormalWorld(primary)
+	if ref.Norm() == 0 {
+		return orbital.Vec3{}, false
+	}
+	return ref, true
+}
+
+// departRowHidden reports whether the `depart:` row can ever move for
+// primary (ADR 0050 decision 3), and the angle eps that decides it: a
+// pad's launch-plane normal precesses about primary's own spin axis as
+// the pad rotates under warp, so if the reference normal sits on that
+// axis (or its antipode) the angle to it is fixed no matter the
+// heading or the hour. eps = unfoldedPlaneAngleDeg(spin axis,
+// reference normal); the row is hidden when eps folds (parallel or
+// antiparallel treated alike) to under 0.005 degrees. eps is also
+// departSwing's own input, since the swing amplitude is set by exactly
+// this angle.
+func departRowHidden(spinAxis, refNormal orbital.Vec3) (eps float64, hidden bool) {
+	eps, ok := unfoldedPlaneAngleDeg(spinAxis, refNormal)
+	if !ok {
+		return 0, true
+	}
+	folded := math.Min(eps, 180-eps)
+	return eps, folded < 0.005
+}
+
+// departSwing returns the pad's `depart:` bounds (ADR 0050 decision 4):
+// as the pad rotates under warp, a launch at inclination padIncl (the
+// existing incl: row, fixed against the spin axis) reaches a departure
+// angle that sweeps from low up to high, because the launch-plane
+// normal precesses about the spin axis at (angular) radius padIncl
+// while the reference normal sits eps away from that same axis. best
+// is the low end: the closest a wait can bring the departure angle,
+// mirroring the Inclination Floor idiom directly above it. Verified
+// against the ADR's own table (both the closed form here and a
+// 3600-sample sweep over a full rotation) before this function was
+// written; see the ADR 0050 progress log, Slice 3.
+func departSwing(padIncl, eps float64) (low, high, best float64) {
+	low = math.Abs(padIncl - eps)
+	high = padIncl + eps
+	if high > 180 {
+		high = 360 - high
+	}
+	return low, high, low
 }
 
 // buildTargetChip surfaces the unified Target slot — a body (name, Δi,

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1585,23 +1585,41 @@ func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft
 		chipRowAt("heading:", headingLabel, launchChipValueCol),
 		chipRowAt(readout.LabelIncl, padInclLabel+" (min "+floorLabel+")", launchChipValueCol),
 	}
-	// Δincl: only while a body target is set, a craft target's Δincl
-	// isn't offered here either (buildTargetChip itself only computes it
-	// for sim.TargetBody), and the plane angle a pad launch would leave
-	// is only meaningful against another body's fixed orbital plane.
-	if w.Target.Kind == sim.TargetBody {
+	// Δincl: against a body target (its fixed catalog orbital plane) or
+	// a vessel target (ADR 0050 decision 6, ungating the sim.TargetBody-
+	// only restriction ADR 0049 shipped: a vessel in a stable orbit has
+	// a perfectly good fixed plane too, and matching one from the pad is
+	// the canonical launch-window problem PlanVesselPlaneMatch, the `I`
+	// key, already solves). Vessel targets route through
+	// World.TargetPlaneNormal, which folds in the same-primary gate
+	// (decision 6's amendment: a lunar orbiter targeted from a KSC pad
+	// reads a fast-looking wobble that mixes its own lap with Luna's own
+	// motion round Earth; TargetSharesActivePrimary already refuses this
+	// case for `I` and the node markers) and the pole guard (decision
+	// 8).
+	var nTarget orbital.Vec3
+	haveTarget := false
+	switch w.Target.Kind {
+	case sim.TargetBody:
 		sysT := w.System()
 		if w.Target.BodyIdx > 0 && w.Target.BodyIdx < len(sysT.Bodies) {
-			b := sysT.Bodies[w.Target.BodyIdx]
-			nCraft := craftOrbitNormalForRelativeIncl(c)
-			nTarget := orbital.OrbitNormalWorld(b)
-			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
-				diLabel := readout.Angle(di)
-				if di > 30 {
-					diLabel = v.theme.Warning.Render(diLabel)
-				}
-				rows = append(rows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
+			nTarget = orbital.OrbitNormalWorld(sysT.Bodies[w.Target.BodyIdx])
+			haveTarget = true
+		}
+	case sim.TargetCraft, sim.TargetGhost:
+		if n, ok := w.TargetPlaneNormal(); ok {
+			nTarget = n
+			haveTarget = true
+		}
+	}
+	if haveTarget {
+		nCraft := craftOrbitNormalForRelativeIncl(c)
+		if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
+			diLabel := readout.Angle(di)
+			if di > 30 {
+				diLabel = v.theme.Warning.Render(diLabel)
 			}
+			rows = append(rows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
 		}
 	}
 	return rows
@@ -2231,6 +2249,27 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 			tLat, tLon := tc.SurfaceLatLon()
 			lines = append(lines, chipRow("landed at:", readout.Angle(tLat)+", "+readout.Angle(tLon)))
 		}
+		// Δincl: against this vessel's plane (ADR 0050 decisions 6-8).
+		// TargetPlaneNormal folds in the same-primary gate (a vessel
+		// orbiting a different primary reads no figure at all rather
+		// than a fast-looking wobble, see its own doc comment) and the
+		// pole guard. A landed target's normal is its co-rotation r × v,
+		// which is exactly the due-east launch plane (decision 7), so
+		// the row says so; an orbiting target's normal is its live
+		// orbital-plane normal and carries no tag.
+		if nTarget, ok := w.TargetPlaneNormal(); ok {
+			nCraft := craftOrbitNormalForRelativeIncl(c)
+			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
+				diLabel := readout.Angle(di)
+				if di > 30 {
+					diLabel = v.theme.Warning.Render(diLabel)
+				}
+				if !craftHasOrbit(tc) {
+					diLabel += " (due east)"
+				}
+				lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
+			}
+		}
 		var rRel, vRelVec orbital.Vec3
 		if tc.Primary.ID == c.Primary.ID {
 			rRel = tc.State.R.Sub(c.State.R)
@@ -2316,6 +2355,20 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 				gPeRow,
 				chipRow(readout.LabelIncl, readout.Angle(gEl.I*180/math.Pi)),
 			)
+		}
+		// Δincl: against this ghost's plane (ADR 0050 decisions 6, 8). A
+		// ghost is always evaluated as if it kept coasting (sim/ghost.go,
+		// "physics never sees it"), never Landed, so no "(due east)" tag
+		// applies here: decision 7 is TargetCraft-only.
+		if nTarget, ok := w.TargetPlaneNormal(); ok {
+			nCraft := craftOrbitNormalForRelativeIncl(c)
+			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
+				diLabel := readout.Angle(di)
+				if di > 30 {
+					diLabel = v.theme.Warning.Render(diLabel)
+				}
+				lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
+			}
 		}
 		rT, vT, ok := w.TargetStateRelativeToActivePrimary()
 		if !ok {

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1589,16 +1589,23 @@ func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft
 	// would reach and the plane the world beneath it travels in (ADR
 	// 0050 decisions 1-5), directly under incl:. Hidden where it can
 	// never move (decision 3): departRowHidden's eps is also
-	// departSwing's own input, so the two calls share one angle.
-	if refNormal, ok := departReferenceNormal(c.Primary); ok {
-		if eps, hidden := departRowHidden(spinAxis, refNormal); !hidden {
-			if padNormal, ok := spacecraft.HeadingOrbitNormal(c.State.R, spinAxis, c.HeadingTrim); ok {
-				deg, degOK := unfoldedPlaneAngleDeg(padNormal, refNormal)
-				i, iOK := unfoldedPlaneAngleDeg(padNormal, spinAxis)
-				if degOK && iOK {
-					_, _, best := departSwing(i, eps)
-					departLabel := readout.Angle(deg) + " (best " + readout.Angle(best) + ")"
-					rows = append(rows, chipRowAt(readout.LabelDepart, departLabel, launchChipValueCol))
+	// departSwing's own input, so the two calls share one angle. Also
+	// withheld at a pole (review r1 F3, landedPlaneNormalOK): the pad's
+	// own co-rotation normal is pole-degenerate there, and
+	// HeadingOrbitNormal's exact Norm() == 0 guard lets floating-point
+	// residue through as a real plane, wandering tens of degrees an hour
+	// with no period.
+	if landedPlaneNormalOK(c) {
+		if refNormal, ok := departReferenceNormal(c.Primary); ok {
+			if eps, hidden := departRowHidden(spinAxis, refNormal); !hidden {
+				if padNormal, ok := spacecraft.HeadingOrbitNormal(c.State.R, spinAxis, c.HeadingTrim); ok {
+					deg, degOK := unfoldedPlaneAngleDeg(padNormal, refNormal)
+					i, iOK := unfoldedPlaneAngleDeg(padNormal, spinAxis)
+					if degOK && iOK {
+						_, _, best := departSwing(i, eps)
+						departLabel := readout.Angle(deg) + " (best " + readout.Angle(best) + ")"
+						rows = append(rows, chipRowAt(readout.LabelDepart, departLabel, launchChipValueCol))
+					}
 				}
 			}
 		}
@@ -1617,6 +1624,7 @@ func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft
 	// 8).
 	var nTarget orbital.Vec3
 	haveTarget := false
+	dueEast := false
 	switch w.Target.Kind {
 	case sim.TargetBody:
 		sysT := w.System()
@@ -1624,20 +1632,29 @@ func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft
 			nTarget = orbital.OrbitNormalWorld(sysT.Bodies[w.Target.BodyIdx])
 			haveTarget = true
 		}
-	case sim.TargetCraft, sim.TargetGhost:
+	case sim.TargetCraft:
+		if n, ok := w.TargetPlaneNormal(); ok {
+			nTarget = n
+			haveTarget = true
+			// (due east) tag (decision 7, review r1 F2): shares
+			// deltaInclLabel with buildTargetChip's TargetCraft branch
+			// so the pad row and the TARGET chip cannot disagree about
+			// whether a landed vessel target's plane assumes due east.
+			if tc, _, ok := w.ResolveTargetCraft(); ok {
+				dueEast = !craftHasOrbit(tc)
+			}
+		}
+	case sim.TargetGhost:
 		if n, ok := w.TargetPlaneNormal(); ok {
 			nTarget = n
 			haveTarget = true
 		}
 	}
 	if haveTarget {
-		nCraft := craftOrbitNormalForRelativeIncl(c)
-		if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
-			diLabel := readout.Angle(di)
-			if di > 30 {
-				diLabel = v.theme.Warning.Render(diLabel)
+		if nCraft, ok := craftOrbitNormalForRelativeIncl(c); ok {
+			if diLabel, ok := v.deltaInclLabel(nCraft, nTarget, dueEast); ok {
+				rows = append(rows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
 			}
-			rows = append(rows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
 		}
 	}
 	return rows
@@ -1863,9 +1880,14 @@ func (v *OrbitView) buildOrbitMetricsChip(w *sim.World) []string {
 		spinAxisR := render.BodyRotationAxisWorld(c.Primary)
 		spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
 		if _, hidden := departRowHidden(spinAxis, refNormal); !hidden {
-			nCraft := craftOrbitNormalForRelativeIncl(c)
-			if deg, ok := unfoldedPlaneAngleDeg(nCraft, refNormal); ok {
-				lines = append(lines, chipRow(readout.LabelDepart, readout.Angle(deg)))
+			// craftHasOrbit already returned early above for a Landed
+			// craft (buildLandedOrbitChip), so this is always a real
+			// in-flight orbit: craftOrbitNormalForRelativeIncl's pole
+			// guard (review r1 F3) never trips here.
+			if nCraft, ok := craftOrbitNormalForRelativeIncl(c); ok {
+				if deg, ok := unfoldedPlaneAngleDeg(nCraft, refNormal); ok {
+					lines = append(lines, chipRow(readout.LabelDepart, readout.Angle(deg)))
+				}
 			}
 		}
 	}
@@ -2138,31 +2160,90 @@ func (v *OrbitView) buildProjectedOrbitChipCompact(w *sim.World) []string {
 	}
 }
 
+// landedPlaneNormalOK reports whether the ACTIVE vessel's own landed
+// state defines a trustworthy orbital plane (ADR 0050 decision 8,
+// extended by review r1 F3: the original guard only covered a TARGET's
+// normal). While Landed, c.State.V IS the true co-rotation velocity
+// (see craftOrbitNormalForRelativeIncl's own comment), so r x v here is
+// exactly the same magnitude quantity a landed TARGET's rT x vT is
+// (sim.targetPlaneNormalRelativeTo), not spacecraft.HeadingOrbitNormal's
+// heading-rotated output, which crosses r against a unit direction
+// rather than the actual co-rotation velocity and so has a different
+// scale. Always true for a craft that isn't Landed (nothing here
+// applies to a real orbit). Shared by both the depart: row (which reads
+// spacecraft.HeadingOrbitNormal directly, not this function) and
+// craftOrbitNormalForRelativeIncl's Δincl normal below, so the two rows
+// withhold together at a pole instead of independently drifting.
+func landedPlaneNormalOK(c *spacecraft.Spacecraft) bool {
+	if !c.Landed {
+		return true
+	}
+	n := c.State.R.Cross(c.State.V)
+	omegaR := render.BodySpinOmegaWorld(c.Primary)
+	omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+	return orbital.PlaneNormalOK(n, omega.Norm(), c.Primary.RadiusMeters())
+}
+
 // craftOrbitNormalForRelativeIncl returns the orbital-plane normal used
-// to compute a Δincl plane angle to a target. While Landed there is no
-// real orbit yet: the craft's actual State.V is always the due-east
-// surface co-rotation velocity regardless of the commanded Heading Trim
-// (ApplyHeadingTrim only rotates a *burn* direction, never the
-// pre-ignition landed state), so reading c.State.R.Cross(c.State.V)
-// directly would silently assume due-east even after the player has
-// trimmed away from it. Route through spacecraft.HeadingOrbitNormal
-// instead, which derives the plane an ascent lit NOW at the commanded
-// heading would leave (ADR 0049 decision 11); it ticks live as the
-// player warps on the pad because the pad's position (hence the local
-// horizon frame) sweeps with the primary's rotation. Once airborne the
-// real state vector is authoritative again: c.State.V then reflects
-// whatever plane the craft actually flew into.
+// to compute a Δincl plane angle to a target, and whether it is
+// trustworthy. While Landed there is no real orbit yet: the craft's
+// actual State.V is always the due-east surface co-rotation velocity
+// regardless of the commanded Heading Trim (ApplyHeadingTrim only
+// rotates a *burn* direction, never the pre-ignition landed state), so
+// reading c.State.R.Cross(c.State.V) directly would silently assume
+// due-east even after the player has trimmed away from it. Route
+// through spacecraft.HeadingOrbitNormal instead, which derives the
+// plane an ascent lit NOW at the commanded heading would leave (ADR
+// 0049 decision 11); it ticks live as the player warps on the pad
+// because the pad's position (hence the local horizon frame) sweeps
+// with the primary's rotation. Once airborne the real state vector is
+// authoritative again: c.State.V then reflects whatever plane the
+// craft actually flew into.
+//
+// ok is false when Landed at a pole (review r1 F3, landedPlaneNormalOK):
+// HeadingOrbitNormal's own guard is an exact Norm() == 0 test that a
+// real pole's floating-point residue never trips, which is why an
+// unguarded Δincl wandered at the shipped North Pole preset.
 //
 // v0.42+ (ADR 0049 decisions 10-11).
-func craftOrbitNormalForRelativeIncl(c *spacecraft.Spacecraft) orbital.Vec3 {
+func craftOrbitNormalForRelativeIncl(c *spacecraft.Spacecraft) (orbital.Vec3, bool) {
 	if c.Landed {
+		if !landedPlaneNormalOK(c) {
+			return orbital.Vec3{}, false
+		}
 		spinAxisR := render.BodyRotationAxisWorld(c.Primary)
 		spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
 		if h, ok := spacecraft.HeadingOrbitNormal(c.State.R, spinAxis, c.HeadingTrim); ok {
-			return h
+			return h, true
 		}
+		return orbital.Vec3{}, false
 	}
-	return c.State.R.Cross(c.State.V)
+	return c.State.R.Cross(c.State.V), true
+}
+
+// deltaInclLabel renders a Δincl value the same way at every call site
+// (review r1 F2): styled Warning past 30°, and tagged "(due east)" when
+// dueEast is true: a landed vessel target's plane is its co-rotation
+// state, which equals the due-east launch plane at every latitude
+// (decision 7), not a real orbit, so the row says so. Before this, the
+// TARGET chip's TargetCraft branch tagged it and the pad's
+// landedInclHeadingRows didn't, so a player who only ever sees the
+// compact TARGET chip at 140x40 (no Δincl at all) saw an untagged
+// figure on the pad with no way to know it assumed due east. ok is
+// false when the two normals don't define an angle (relativePlaneAngleDeg).
+func (v *OrbitView) deltaInclLabel(nCraft, nTarget orbital.Vec3, dueEast bool) (string, bool) {
+	di, ok := relativePlaneAngleDeg(nCraft, nTarget)
+	if !ok {
+		return "", false
+	}
+	label := readout.Angle(di)
+	if di > 30 {
+		label = v.theme.Warning.Render(label)
+	}
+	if dueEast {
+		label += " (due east)"
+	}
+	return label, true
 }
 
 // relativePlaneAngleDeg is the plane angle between two orbital-plane
@@ -2286,14 +2367,15 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		frame := orbital.ReferenceFrameForPrimary(c.Primary)
 		ro := orbital.OrbitReadoutInFrame(c.State.R, c.State.V, mu, frame)
 		if !ro.Hyperbolic {
-			nCraft := craftOrbitNormalForRelativeIncl(c)
-			nTarget := orbital.OrbitNormalWorld(b)
-			di, _ := relativePlaneAngleDeg(nCraft, nTarget)
-			diLabel := readout.Angle(di)
-			if di > 30 {
-				diLabel = v.theme.Warning.Render(diLabel)
+			// review r1 F3: craftOrbitNormalForRelativeIncl's ok is now
+			// honored (was discarded before, which could print a
+			// meaningless "0.00°" for a craft landed at a pole).
+			if nCraft, ok := craftOrbitNormalForRelativeIncl(c); ok {
+				nTarget := orbital.OrbitNormalWorld(b)
+				if diLabel, ok := v.deltaInclLabel(nCraft, nTarget, false); ok {
+					lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
+				}
 			}
-			lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 		}
 		rangeM := w.BodyPosition(b).Sub(w.CraftInertial()).Norm()
 		lines = append(lines, chipRow("range:", readout.Distance(rangeM)))
@@ -2367,16 +2449,10 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		// the row says so; an orbiting target's normal is its live
 		// orbital-plane normal and carries no tag.
 		if nTarget, ok := w.TargetPlaneNormal(); ok {
-			nCraft := craftOrbitNormalForRelativeIncl(c)
-			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
-				diLabel := readout.Angle(di)
-				if di > 30 {
-					diLabel = v.theme.Warning.Render(diLabel)
+			if nCraft, ok := craftOrbitNormalForRelativeIncl(c); ok {
+				if diLabel, ok := v.deltaInclLabel(nCraft, nTarget, !craftHasOrbit(tc)); ok {
+					lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 				}
-				if !craftHasOrbit(tc) {
-					diLabel += " (due east)"
-				}
-				lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 			}
 		}
 		var rRel, vRelVec orbital.Vec3
@@ -2470,13 +2546,10 @@ func (v *OrbitView) buildTargetChip(w *sim.World) []string {
 		// "physics never sees it"), never Landed, so no "(due east)" tag
 		// applies here: decision 7 is TargetCraft-only.
 		if nTarget, ok := w.TargetPlaneNormal(); ok {
-			nCraft := craftOrbitNormalForRelativeIncl(c)
-			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
-				diLabel := readout.Angle(di)
-				if di > 30 {
-					diLabel = v.theme.Warning.Render(diLabel)
+			if nCraft, ok := craftOrbitNormalForRelativeIncl(c); ok {
+				if diLabel, ok := v.deltaInclLabel(nCraft, nTarget, false); ok {
+					lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 				}
-				lines = append(lines, chipRow(readout.LabelDeltaIncl, diLabel))
 			}
 		}
 		rT, vT, ok := w.TargetStateRelativeToActivePrimary()

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1128,8 +1128,21 @@ func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 // and every non-axis mode (Surface*, PlaneChange, Vector) pass through
 // unchanged. Display-only — never mutates the craft's actual held
 // AttitudeMode or its physical nose direction.
+//
+// The maintainer's own follow-up ("hold should also denote surface,
+// orbit, or target in its readout"): every hold: row, not just this
+// one, must name its frame using the same three words the navball
+// button already uses (navModeLabel) so the two never disagree on
+// screen. The frame tag tracks the same NavTarget-without-a-relative-
+// target fallback as the mode remap above (falls back to ORBIT rather
+// than claiming TGT with nothing to actually read against); a
+// surface-framed mode (Surface Prograde/Retrograde) held under a
+// different NavMode still gets tagged with the current nav frame, not
+// forced to SURF, since the tag names the frame the row is being read
+// in, not the frame the mode itself was set in.
 func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
-	if w.NavMode == sim.NavTarget && w.HasRelativeTarget() {
+	frame := w.NavMode
+	if frame == sim.NavTarget && w.HasRelativeTarget() {
 		switch mode {
 		case spacecraft.BurnPrograde:
 			mode = spacecraft.BurnTargetPrograde
@@ -1140,8 +1153,10 @@ func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
 		case spacecraft.BurnRadialIn:
 			mode = spacecraft.BurnAntiTarget
 		}
+	} else if frame == sim.NavTarget {
+		frame = sim.NavOrbit
 	}
-	return mode.String()
+	return fmt.Sprintf("%s (%s)", mode.String(), navModeLabel(frame))
 }
 
 // buildAttitudeChip surfaces the held attitude / nav mode / engine mode /
@@ -1401,7 +1416,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 	}
 	altAGL := c.Altitude()
 	altLabel := readout.Distance(altAGL)
-	sasLabel := c.AttitudeMode.String()
+	sasLabel := attitudeHoldLabel(w, c.AttitudeMode)
 	trimDeg := c.PitchTrim * 180 / math.Pi
 	trimLabel := readout.TrimAngle(trimDeg)
 	if math.Abs(trimDeg) > 0.05 {
@@ -1717,7 +1732,7 @@ func (v *OrbitView) buildDescentChip(w *sim.World) []string {
 		fmt.Sprintf("  %s      %s", readout.LabelHoriz, vHorizLabel),
 		fmt.Sprintf("  %s        %s", readout.LabelFPA, fpaLabel),
 		fmt.Sprintf("  %s        %s", readout.LabelTWR, twrLabel),
-		fmt.Sprintf("  %s       %s", readout.LabelHold, c.AttitudeMode.String()),
+		fmt.Sprintf("  %s       %s", readout.LabelHold, attitudeHoldLabel(w, c.AttitudeMode)),
 	}
 	if c.Landed {
 		lines = append(lines, v.landedInclHeadingRows(w, c)...)

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1135,21 +1135,24 @@ func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 // button already uses (navModeLabel) so the two never disagree on
 // screen.
 //
-// A mode that is itself frame-locked names its own frame, never the
-// current nav frame: Surface Prograde/Retrograde always tag SURF, and
-// every target-relative mode (Target/AntiTarget/Target Prograde/Target
-// Retrograde, whether held directly or produced by the remap above)
-// always tags TGT. Naming the nav frame instead for these would read
-// as a straight self-contradiction on screen ("Surface Prograde
-// (ORBIT)" claims two different frames for the same hold in one row).
-// Every frame-agnostic mode (Prograde, Retrograde, RadialOut/In,
-// NormalPlus/Minus, PlaneChange, Vector) has no frame of its own to
-// lose, so it keeps naming whichever frame the row is actually being
-// read against, including the NavTarget-without-a-relative-target
-// fallback to ORBIT above.
+// The tag names the frame of the HELD MODE, never the current NavMode
+// (round 2 review, R2-F1, correcting an earlier version of this
+// function that tagged frame-agnostic modes with whatever nav: showed).
+// No held BurnMode actually reads NavMode: internal/spacecraft never
+// consults it, and the nose direction is
+// BurnDirectionWithTarget(AttitudeMode, rT, vT) with no nav argument at
+// all (internal/sim/navball.go). So Surface Prograde/Retrograde always
+// tag SURF, every target-relative mode (Target/AntiTarget/Target
+// Prograde/Target Retrograde, whether held directly or produced by the
+// remap above) always tags TGT, and every other mode (Prograde,
+// Retrograde, RadialOut/In, NormalPlus/Minus, PlaneChange, Vector) is
+// orbit-frame by construction and always tags ORBIT, whatever NavMode
+// says. Tagging any of these with the current nav frame instead would
+// assert a frame the hold does not have: a held Prograde is orbit-frame
+// prograde under nav:SURFACE too (the nose does not move), and there is
+// no surface-frame equivalent of Normal+/- at all.
 func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
-	frame := w.NavMode
-	if frame == sim.NavTarget && w.HasRelativeTarget() {
+	if w.NavMode == sim.NavTarget && w.HasRelativeTarget() {
 		switch mode {
 		case spacecraft.BurnPrograde:
 			mode = spacecraft.BurnTargetPrograde
@@ -1160,9 +1163,8 @@ func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
 		case spacecraft.BurnRadialIn:
 			mode = spacecraft.BurnAntiTarget
 		}
-	} else if frame == sim.NavTarget {
-		frame = sim.NavOrbit
 	}
+	frame := sim.NavOrbit
 	switch mode {
 	case spacecraft.BurnSurfacePrograde, spacecraft.BurnSurfaceRetrograde:
 		frame = sim.NavSurface

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1133,13 +1133,20 @@ func (v *OrbitView) buildMissionsChipCompact(w *sim.World) []string {
 // orbit, or target in its readout"): every hold: row, not just this
 // one, must name its frame using the same three words the navball
 // button already uses (navModeLabel) so the two never disagree on
-// screen. The frame tag tracks the same NavTarget-without-a-relative-
-// target fallback as the mode remap above (falls back to ORBIT rather
-// than claiming TGT with nothing to actually read against); a
-// surface-framed mode (Surface Prograde/Retrograde) held under a
-// different NavMode still gets tagged with the current nav frame, not
-// forced to SURF, since the tag names the frame the row is being read
-// in, not the frame the mode itself was set in.
+// screen.
+//
+// A mode that is itself frame-locked names its own frame, never the
+// current nav frame: Surface Prograde/Retrograde always tag SURF, and
+// every target-relative mode (Target/AntiTarget/Target Prograde/Target
+// Retrograde, whether held directly or produced by the remap above)
+// always tags TGT. Naming the nav frame instead for these would read
+// as a straight self-contradiction on screen ("Surface Prograde
+// (ORBIT)" claims two different frames for the same hold in one row).
+// Every frame-agnostic mode (Prograde, Retrograde, RadialOut/In,
+// NormalPlus/Minus, PlaneChange, Vector) has no frame of its own to
+// lose, so it keeps naming whichever frame the row is actually being
+// read against, including the NavTarget-without-a-relative-target
+// fallback to ORBIT above.
 func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
 	frame := w.NavMode
 	if frame == sim.NavTarget && w.HasRelativeTarget() {
@@ -1155,6 +1162,12 @@ func attitudeHoldLabel(w *sim.World, mode spacecraft.BurnMode) string {
 		}
 	} else if frame == sim.NavTarget {
 		frame = sim.NavOrbit
+	}
+	switch mode {
+	case spacecraft.BurnSurfacePrograde, spacecraft.BurnSurfaceRetrograde:
+		frame = sim.NavSurface
+	case spacecraft.BurnTarget, spacecraft.BurnAntiTarget, spacecraft.BurnTargetPrograde, spacecraft.BurnTargetRetrograde:
+		frame = sim.NavTarget
 	}
 	return fmt.Sprintf("%s (%s)", mode.String(), navModeLabel(frame))
 }

--- a/internal/tui/screens/orbit_chip_builders.go
+++ b/internal/tui/screens/orbit_chip_builders.go
@@ -1463,44 +1463,7 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 	// entirely, nothing on the pad is ever locked.
 	var inclBlockRows []string
 	if c.Landed {
-		spinAxisR := render.BodyRotationAxisWorld(c.Primary)
-		spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
-		padInclLabel := "—"
-		if deg, ok := spacecraft.HeadingInclinationDeg(c.State.R, spinAxis, c.HeadingTrim); ok {
-			padInclLabel = readout.Angle(deg)
-		}
-		// Inclination Floor = |current surface latitude|, not the spawn
-		// latitude (item4-B review finding 6): SurfaceLatLon prefers
-		// LandedLatDeg over LaunchLatDeg once the craft has soft-landed
-		// somewhere other than where it launched, so a vessel sitting at
-		// 5°N after flying from a 28.6° pad reads a 5° floor, not a
-		// stale 28.6° one above its own incl: value.
-		floorLat, _ := c.SurfaceLatLon()
-		floorLabel := readout.Angle(math.Abs(floorLat))
-		inclBlockRows = []string{
-			chipRowAt("heading:", headingLabel, launchChipValueCol),
-			chipRowAt(readout.LabelIncl, padInclLabel+" (min "+floorLabel+")", launchChipValueCol),
-		}
-		// Δincl (decision 11): only while a body target is set, a
-		// craft target's Δincl isn't offered here either (buildTargetChip
-		// itself only computes it for sim.TargetBody), and the plane
-		// angle a pad launch would leave is only meaningful against
-		// another body's fixed orbital plane.
-		if w.Target.Kind == sim.TargetBody {
-			sysT := w.System()
-			if w.Target.BodyIdx > 0 && w.Target.BodyIdx < len(sysT.Bodies) {
-				b := sysT.Bodies[w.Target.BodyIdx]
-				nCraft := craftOrbitNormalForRelativeIncl(c)
-				nTarget := orbital.OrbitNormalWorld(b)
-				if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
-					diLabel := readout.Angle(di)
-					if di > 30 {
-						diLabel = v.theme.Warning.Render(diLabel)
-					}
-					inclBlockRows = append(inclBlockRows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
-				}
-			}
-		}
+		inclBlockRows = v.landedInclHeadingRows(w, c)
 	} else {
 		inclLabel := "—"
 		if !math.IsNaN(el.I) && !math.IsInf(el.I, 0) {
@@ -1589,10 +1552,70 @@ func (v *OrbitView) buildLaunchChip(w *sim.World) []string {
 	return lines
 }
 
+// landedInclHeadingRows builds the heading:/incl:/Δincl: block for a
+// Landed craft (ADR 0050 decision 9, ex-decisions-9-11's inclBlockRows).
+// Shared by buildLaunchChip's SURFACE chip (atmospheric pads, the
+// original home of this block) and buildDescentChip's DESCENT chip while
+// Landed (airless pads, #454): shouldShowLaunchHUD returns false the
+// moment Primary.Atmosphere == nil, so an airless pad (Luna, Glyph, any
+// of the 45 bodies with no atmosphere) got buildDescentChip instead and
+// no heading/inclination readout at all, however long the player warped.
+// This function moves the existing rows onto that second surface; it
+// changes no number and does not decide whether the LAUNCH HUD itself
+// should ever appear on the Moon (a separate question #454's own body
+// says this isn't the place to answer).
+func (v *OrbitView) landedInclHeadingRows(w *sim.World, c *spacecraft.Spacecraft) []string {
+	headingAbsDeg := (spacecraft.HeadingTrimDueEastRad + c.HeadingTrim) * 180 / math.Pi
+	headingLabel := readout.Heading(headingAbsDeg)
+	spinAxisR := render.BodyRotationAxisWorld(c.Primary)
+	spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
+	padInclLabel := "—"
+	if deg, ok := spacecraft.HeadingInclinationDeg(c.State.R, spinAxis, c.HeadingTrim); ok {
+		padInclLabel = readout.Angle(deg)
+	}
+	// Inclination Floor = |current surface latitude|, not the spawn
+	// latitude (item4-B review finding 6): SurfaceLatLon prefers
+	// LandedLatDeg over LaunchLatDeg once the craft has soft-landed
+	// somewhere other than where it launched, so a vessel sitting at
+	// 5°N after flying from a 28.6° pad reads a 5° floor, not a
+	// stale 28.6° one above its own incl: value.
+	floorLat, _ := c.SurfaceLatLon()
+	floorLabel := readout.Angle(math.Abs(floorLat))
+	rows := []string{
+		chipRowAt("heading:", headingLabel, launchChipValueCol),
+		chipRowAt(readout.LabelIncl, padInclLabel+" (min "+floorLabel+")", launchChipValueCol),
+	}
+	// Δincl: only while a body target is set, a craft target's Δincl
+	// isn't offered here either (buildTargetChip itself only computes it
+	// for sim.TargetBody), and the plane angle a pad launch would leave
+	// is only meaningful against another body's fixed orbital plane.
+	if w.Target.Kind == sim.TargetBody {
+		sysT := w.System()
+		if w.Target.BodyIdx > 0 && w.Target.BodyIdx < len(sysT.Bodies) {
+			b := sysT.Bodies[w.Target.BodyIdx]
+			nCraft := craftOrbitNormalForRelativeIncl(c)
+			nTarget := orbital.OrbitNormalWorld(b)
+			if di, ok := relativePlaneAngleDeg(nCraft, nTarget); ok {
+				diLabel := readout.Angle(di)
+				if di > 30 {
+					diLabel = v.theme.Warning.Render(diLabel)
+				}
+				rows = append(rows, chipRowAt(readout.LabelDeltaIncl, diLabel, launchChipValueCol))
+			}
+		}
+	}
+	return rows
+}
+
 // buildDescentChip is the airless-body terminal-approach cluster
-// (altitude / vert / horiz / fpa / TWR / hold). Returns nil unless the
-// craft is in a powered descent. Mutually exclusive with the LAUNCH chip
-// via the same Atmosphere gate the originals used.
+// (altitude / vert / horiz / fpa / TWR / hold), plus, while Landed, the
+// same heading:/incl:/Δincl: block the atmospheric SURFACE chip shows
+// (ADR 0050 decision 9, #454): there was previously no pad readout at
+// all on an airless world (shouldShowLaunchHUD requires an atmosphere),
+// so a Luna pad showed none of this however long the player warped.
+// Otherwise returns nil unless the craft is in a powered descent.
+// Mutually exclusive with the LAUNCH chip via the same Atmosphere gate
+// the originals used.
 func (v *OrbitView) buildDescentChip(w *sim.World) []string {
 	c := w.ActiveCraft()
 	if c == nil || !shouldShowDescentHUD(c) {
@@ -1634,7 +1657,7 @@ func (v *OrbitView) buildDescentChip(w *sim.World) []string {
 		vHorizLabel = v.theme.Alert.Render(
 			fmt.Sprintf("%s (> %s = CRASH on contact)", readout.Speed(vHoriz), readout.Speed(sim.CrashVCritMps)))
 	}
-	return []string{
+	lines := []string{
 		v.theme.Primary.Render("DESCENT"),
 		fmt.Sprintf("  %s   %s", readout.LabelAltitude, altLabel),
 		fmt.Sprintf("  %s       %s", readout.LabelVert, readout.Speed(vVert)),
@@ -1643,6 +1666,10 @@ func (v *OrbitView) buildDescentChip(w *sim.World) []string {
 		fmt.Sprintf("  %s        %s", readout.LabelTWR, twrLabel),
 		fmt.Sprintf("  %s       %s", readout.LabelHold, c.AttitudeMode.String()),
 	}
+	if c.Landed {
+		lines = append(lines, v.landedInclHeadingRows(w, c)...)
+	}
+	return lines
 }
 
 // buildLaunchHintChip tells the player the launch/surface view is worth

--- a/internal/tui/screens/orbit_depart_test.go
+++ b/internal/tui/screens/orbit_depart_test.go
@@ -205,6 +205,31 @@ func TestOrbitChipShowsBareDepartRow(t *testing.T) {
 	}
 }
 
+// TestOrbitChipDepartRowReadsPastNinetyForRetrogradeOrbit is
+// TestLandedPadDepartRowReadsPastNinetyForRetrogradeHeading's ORBIT-chip
+// sibling (review r1 F6): a retrograde LEO's depart: row must also stay
+// unfolded past 90° rather than folding into Δincl's [0, 90] range. The
+// reviewer measured `depart: 156.6°` for a retrograde 500 km LEO.
+func TestOrbitChipDepartRowReadsPastNinetyForRetrogradeOrbit(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 500e3, Retrograde: true}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	joined := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	value, _, hasBest := extractDepart(t, joined)
+	if hasBest {
+		t.Errorf("expected ORBIT's depart: row to carry no '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value <= 90 {
+		t.Errorf("depart value %.2f°, want > 90° for a retrograde orbit (folding to [0,90] would read this under 90°)", value)
+	}
+}
+
 // TestUnfoldedPlaneAngleDegDoesNotFoldPastNinety pins ADR 0050 decision
 // 1: depart: is an inclination like incl:, not a coplanarity test like
 // Δincl:, so an obtuse angle between the two normals must read past
@@ -354,6 +379,30 @@ func TestDepartSwingMatchesADRTable(t *testing.T) {
 				t.Errorf("best = %.2f, want %.2f", best, c.wantBest)
 			}
 		})
+	}
+}
+
+// TestLandedPadDepartRowReadsPastNinetyForRetrogradeHeading pins review
+// r1 F6: the pad's depart: row must stay unfolded over [0, 180]
+// (decision 1, unfoldedPlaneAngleDeg), never folded to [0, 90] the way
+// Δincl's coplanarity test is. Every existing depart fixture launches
+// within a few tens of degrees of due east, so a fold bug at this call
+// site left every existing depart test green (the review's own
+// sabotage ledger, case "i"). A KSC pad commanded to heading 270°
+// (due west, HeadingTrim = +180°) reaches a retrograde orbit and must
+// read a depart value past 90°: the reviewer measured `depart: 157.9°
+// (best 128.0°)` at this exact heading.
+func TestLandedPadDepartRowReadsPastNinetyForRetrogradeHeading(t *testing.T) {
+	w, c := spawnLandedOnEarthAt28p6(t)
+	c.HeadingTrim = math.Pi // command heading 270° (due west).
+	v := NewOrbitView(chipTestTheme())
+	joined := strings.Join(v.landedInclHeadingRows(w, c), "\n")
+	value, _, hasBest := extractDepart(t, joined)
+	if !hasBest {
+		t.Fatalf("expected the pad's depart: row to carry a '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value <= 90 {
+		t.Errorf("depart value %.2f°, want > 90° for a retrograde (westward) launch heading (folding to [0,90] would read this under 90°)", value)
 	}
 }
 

--- a/internal/tui/screens/orbit_depart_test.go
+++ b/internal/tui/screens/orbit_depart_test.go
@@ -1,0 +1,412 @@
+package screens
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/jasonfen/terminal-space-program/internal/orbital"
+	"github.com/jasonfen/terminal-space-program/internal/render"
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
+)
+
+// departRe matches a `depart:` row's bare angle and optional `(best
+// N°)` suffix, e.g. "depart:     22.13° (best 5.17°)" or a bare
+// "depart:     28.61°" in orbit (decision 4: no suffix in flight).
+var departRe = regexp.MustCompile(`depart:\s+([0-9]+\.[0-9]+)°(?:\s+\(best ([0-9]+\.[0-9]+)°\))?`)
+
+func extractDepart(t *testing.T, joined string) (value float64, best float64, hasBest bool) {
+	t.Helper()
+	m := departRe.FindStringSubmatch(joined)
+	if m == nil {
+		t.Fatalf("expected a 'depart:' row; got:\n%s", joined)
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("could not parse depart value %q: %v", m[1], err)
+	}
+	if m[2] == "" {
+		return v, 0, false
+	}
+	b, err := strconv.ParseFloat(m[2], 64)
+	if err != nil {
+		t.Fatalf("could not parse depart best %q: %v", m[2], err)
+	}
+	return v, b, true
+}
+
+// TestLandedPadShowsDepartRowWithEarthSwingAndBest pins ADR 0050
+// decisions 1, 2, 4: an Earth pad's `depart:` row (measured against
+// the plane Earth itself travels in around the Sun, decision 2) reads
+// somewhere in the `5.17°..52.05°` swing the ADR derives for a
+// 28.6083° due-east pad (Earth's obliquity 23.44° composed with the
+// pad's own launch inclination), and always carries `(best 5.17°)`,
+// the low end of that swing, since waiting can only improve a launch
+// window, never worsen it. Verified independently against the real
+// catalog before this test was written (cmd/verifydepart, ADR
+// progress log): closed form and a 3600-sample sweep over a full
+// rotation agree to two decimals with the ADR's own numbers.
+func TestLandedPadShowsDepartRowWithEarthSwingAndBest(t *testing.T) {
+	w, c := spawnLandedOnEarthAt28p6(t)
+	v := NewOrbitView(chipTestTheme())
+	rows := v.landedInclHeadingRows(w, c)
+	joined := strings.Join(rows, "\n")
+	value, best, hasBest := extractDepart(t, joined)
+	if !hasBest {
+		t.Fatalf("expected the pad's depart: row to carry a '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value < 5.17-0.01 || value > 52.05+0.01 {
+		t.Errorf("depart value %.2f° outside the ADR's Earth swing 5.17..52.05", value)
+	}
+	if best < 5.16 || best > 5.18 {
+		t.Errorf("depart best = %.2f°, want 5.17° (the ADR's Earth pad best)", best)
+	}
+}
+
+// TestAirlessPadShowsDepartRowWithLunaSwingAndBest pins the same
+// decisions on an AIRLESS pad's DESCENT chip (buildDescentChip, ADR
+// 0050's own insertion point 9a: "one insertion covers atmospheric and
+// airless pads"): a Luna pad's depart: row (against the plane the Moon
+// itself travels in around Earth) reads within the ADR's
+// 23.46°..33.75° swing and carries best 23.46°.
+func TestAirlessPadShowsDepartRowWithLunaSwingAndBest(t *testing.T) {
+	w, _ := spawnLandedOnMoon(t, sim.DefaultLaunchpadLatitude, sim.DefaultLaunchpadLongitudeEast)
+	v := NewOrbitView(chipTestTheme())
+	rows := v.buildDescentChip(w)
+	joined := strings.Join(rows, "\n")
+	value, best, hasBest := extractDepart(t, joined)
+	if !hasBest {
+		t.Fatalf("expected the Luna pad's depart: row to carry a '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value < 23.46-0.01 || value > 33.75+0.01 {
+		t.Errorf("depart value %.2f° outside the ADR's Luna swing 23.46..33.75", value)
+	}
+	if best < 23.45 || best > 23.47 {
+		t.Errorf("depart best = %.2f°, want 23.46° (the ADR's Luna pad best)", best)
+	}
+}
+
+// TestLandedPadShowsDepartRowWithMarsSwingAndBest is
+// TestLandedPadShowsDepartRowWithEarthSwingAndBest's Mars sibling
+// (ADR 0050's table: 4.80°..52.42°, best 4.80°). Mars is in the Sol
+// system (the default view), unlike Kern/Glyph below.
+func TestLandedPadShowsDepartRowWithMarsSwingAndBest(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "mars",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if c.Primary.ID != "mars" {
+		t.Fatalf("setup: expected craft primary = mars, got %q", c.Primary.ID)
+	}
+	v := NewOrbitView(chipTestTheme())
+	joined := strings.Join(v.landedInclHeadingRows(w, c), "\n")
+	value, best, hasBest := extractDepart(t, joined)
+	if !hasBest {
+		t.Fatalf("expected the Mars pad's depart: row to carry a '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value < 4.80-0.01 || value > 52.42+0.01 {
+		t.Errorf("depart value %.2f° outside the ADR's Mars swing 4.80..52.42", value)
+	}
+	if best < 4.79 || best > 4.81 {
+		t.Errorf("depart best = %.2f°, want 4.80° (the ADR's Mars pad best)", best)
+	}
+}
+
+// TestAirlessPadShowsDepartRowWithGlyphSwingAndBest is
+// TestAirlessPadShowsDepartRowWithLunaSwingAndBest's Lumen sibling
+// (ADR 0050's table: 22.61°..34.61°, best 22.61°). Glyph, like Kern,
+// only resolves via ParentBodyID once the view has browsed to Lumen.
+func TestAirlessPadShowsDepartRowWithGlyphSwingAndBest(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	for i := 0; i < len(w.Systems) && w.Systems[w.SystemIdx].Name != "Lumen"; i++ {
+		w.CycleSystem()
+	}
+	if w.Systems[w.SystemIdx].Name != "Lumen" {
+		t.Fatalf("could not browse to Lumen (stuck viewing %q)", w.Systems[w.SystemIdx].Name)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutKernStackID,
+		ParentBodyID:    "glyph",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if c.Primary.ID != "glyph" {
+		t.Fatalf("setup: expected craft primary = glyph, got %q", c.Primary.ID)
+	}
+	if c.Primary.Atmosphere != nil {
+		t.Fatalf("setup: expected Glyph to be airless; got %+v", c.Primary.Atmosphere)
+	}
+	v := NewOrbitView(chipTestTheme())
+	joined := strings.Join(v.buildDescentChip(w), "\n")
+	value, best, hasBest := extractDepart(t, joined)
+	if !hasBest {
+		t.Fatalf("expected the Glyph pad's depart: row to carry a '(best N°)' suffix; got:\n%s", joined)
+	}
+	if value < 22.61-0.01 || value > 34.61+0.01 {
+		t.Errorf("depart value %.2f° outside the ADR's Glyph swing 22.61..34.61", value)
+	}
+	if best < 22.60 || best > 22.62 {
+		t.Errorf("depart best = %.2f°, want 22.61° (the ADR's Glyph pad best)", best)
+	}
+}
+
+// TestOrbitChipShowsBareDepartRow pins ADR 0050 decisions 1, 2, 4: the
+// ORBIT chip's depart: row sits directly under incl: (before
+// direction:) and, unlike the pad's, carries no `(best N°)` suffix: an
+// orbital plane doesn't move under two-body coast, so the lowest value
+// reachable by waiting is the value already on screen, and printing it
+// twice would restate the row above it on every orbit in the game.
+func TestOrbitChipShowsBareDepartRow(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	joined := strings.Join(v.buildOrbitMetricsChip(w), "\n")
+	if !strings.Contains(joined, readout.LabelIncl) {
+		t.Fatalf("setup: ORBIT chip missing incl: row:\n%s", joined)
+	}
+	inclIdx := strings.Index(joined, readout.LabelIncl)
+	departIdx := strings.Index(joined, "depart:")
+	if departIdx < 0 {
+		t.Fatalf("expected ORBIT chip to show a depart: row; got:\n%s", joined)
+	}
+	if departIdx < inclIdx {
+		t.Errorf("expected depart: to sit directly under incl:, got depart: before incl: in:\n%s", joined)
+	}
+	if strings.Contains(joined, "(best") {
+		t.Errorf("expected ORBIT's depart: row to carry no '(best N°)' suffix; got:\n%s", joined)
+	}
+}
+
+// TestUnfoldedPlaneAngleDegDoesNotFoldPastNinety pins ADR 0050 decision
+// 1: depart: is an inclination like incl:, not a coplanarity test like
+// Δincl:, so an obtuse angle between the two normals must read past
+// 90° (up to 180°), unlike relativePlaneAngleDeg's fold to [0, 90].
+// The ADR's own exoplanet pads read 61°..118°, a range
+// relativePlaneAngleDeg could never produce.
+func TestUnfoldedPlaneAngleDegDoesNotFoldPastNinety(t *testing.T) {
+	a := orbital.Vec3{Z: 1}
+	// 120 degrees from +Z, in the X-Z plane.
+	b := orbital.Vec3{X: math.Sin(120 * math.Pi / 180), Z: math.Cos(120 * math.Pi / 180)}
+	deg, ok := unfoldedPlaneAngleDeg(a, b)
+	if !ok {
+		t.Fatal("unfoldedPlaneAngleDeg: expected ok=true for two non-degenerate normals")
+	}
+	if deg < 119.99 || deg > 120.01 {
+		t.Errorf("unfoldedPlaneAngleDeg = %.2f, want ~120 (relativePlaneAngleDeg would fold this to 60)", deg)
+	}
+	if folded, ok := relativePlaneAngleDeg(a, b); !ok || folded > 61 || folded < 59 {
+		t.Fatalf("setup: relativePlaneAngleDeg = %.2f (ok=%v), want ~60 (confirms the two helpers genuinely differ)", folded, ok)
+	}
+}
+
+// TestDepartRowNeverWarningColoured pins ADR 0050's Consequences: "depart:
+// takes no Warning colour. It states a fact rather than a hazard." Uses
+// plainThemeColored (distinguishable ANSI per style, unlike
+// chipTestTheme's no-op styles) with the color profile forced to ANSI
+// (go test's non-TTY stdout would otherwise make every Render a no-op
+// regardless of style, per TestOrbitChipSubSurfacePeriapsisIsWarningColoured's
+// own doc comment), on a pad whose depart value (~52°, the high end of
+// the Earth swing) sits well past the 30° threshold that DOES colour
+// the neighbouring Δincl row: proving the absence is deliberate, not
+// an artifact of a low number that would never have triggered Warning
+// anyway.
+func TestDepartRowNeverWarningColoured(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	w, c := spawnLandedOnEarthAt28p6(t)
+	v := NewOrbitView(plainThemeColored())
+	t0 := w.Clock.SimTime
+	radius := c.Primary.RadiusMeters()
+	place := func(at time.Time) {
+		w.Clock.SimTime = at
+		dir := render.BodyFixedToWorld(c.Primary, c.LaunchLatDeg, c.LaunchLonDeg, at)
+		c.State.R = orbital.Vec3{X: radius * dir.X, Y: radius * dir.Y, Z: radius * dir.Z}
+		omegaR := render.BodySpinOmegaWorld(c.Primary)
+		omega := orbital.Vec3{X: omegaR.X, Y: omegaR.Y, Z: omegaR.Z}
+		c.State.V = omega.Cross(c.State.R)
+	}
+	// A due-east launch normal precesses about the spin axis as the
+	// primary rotates, so the depart value sweeps across a sidereal day
+	// (the ADR's own 5.17..52.05 swing); scan a handful of hours rather
+	// than assume any one offset lands near the high end.
+	best := 0.0
+	var bestAt time.Time
+	for h := 0; h < 24; h++ {
+		at := t0.Add(time.Duration(h) * time.Hour)
+		place(at)
+		val, _, _ := extractDepart(t, stripANSI(strings.Join(v.landedInclHeadingRows(w, c), "\n")))
+		if val > best {
+			best = val
+			bestAt = at
+		}
+	}
+	place(bestAt)
+
+	rows := v.landedInclHeadingRows(w, c)
+	var departLine string
+	for _, l := range rows {
+		if strings.Contains(stripANSI(l), "depart:") {
+			departLine = l
+			break
+		}
+	}
+	if departLine == "" {
+		t.Fatalf("expected a depart: row; got:\n%s", strings.Join(rows, "\n"))
+	}
+	value, _, hasBest := extractDepart(t, stripANSI(departLine))
+	if !hasBest {
+		t.Fatalf("setup: expected the depart: row to carry a best suffix; got: %q", departLine)
+	}
+	if value < 30 {
+		t.Fatalf("setup: expected a depart value past the 30 degree Warning threshold this test means to probe, got %.2f", value)
+	}
+	if departLine != stripANSI(departLine) {
+		t.Errorf("depart: row carries colour codes despite a value (%.2f°) past the Δincl Warning threshold; ADR says depart: never takes Warning: %q", value, departLine)
+	}
+}
+
+// TestDepartSwingMatchesADRTable locks in departSwing's closed form
+// against every body in the ADR 0050 table (decision 2's own numbers),
+// independent of any chip rendering: low/high/best for i=28.6083°
+// (every body's due-east pad inclination, latitude-independent of the
+// primary) at each body's own eps (spin axis to reference normal).
+// eps values are read from the catalog via unfoldedPlaneAngleDeg
+// rather than hardcoded, so this test tracks the real bodies rather
+// than a second copy of the numbers.
+func TestDepartSwingMatchesADRTable(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	const padIncl = sim.DefaultLaunchpadLatitude
+	find := func(id string) (bodyEps float64) {
+		t.Helper()
+		for i := 0; i < len(w.Systems); i++ {
+			for _, b := range w.Systems[i].Bodies {
+				if b.ID != id {
+					continue
+				}
+				spinAxisR := render.BodyRotationAxisWorld(b)
+				spinAxis := orbital.Vec3{X: spinAxisR.X, Y: spinAxisR.Y, Z: spinAxisR.Z}
+				ref, ok := departReferenceNormal(b)
+				if !ok {
+					t.Fatalf("%s: no reference normal", id)
+				}
+				eps, _ := unfoldedPlaneAngleDeg(spinAxis, ref)
+				return eps
+			}
+		}
+		t.Fatalf("body %q not found in any loaded system", id)
+		return 0
+	}
+	cases := []struct {
+		id                          string
+		wantLow, wantHigh, wantBest float64
+	}{
+		{"earth", 5.17, 52.05, 5.17},
+		{"mars", 4.80, 52.42, 4.80},
+		{"mercury", 21.63, 35.59, 21.63},
+		{"moon", 23.46, 33.75, 23.46},
+		{"glyph", 22.61, 34.61, 22.61},
+	}
+	for _, c := range cases {
+		t.Run(c.id, func(t *testing.T) {
+			eps := find(c.id)
+			low, high, best := departSwing(padIncl, eps)
+			const tol = 0.01
+			if math.Abs(low-c.wantLow) > tol {
+				t.Errorf("low = %.2f, want %.2f", low, c.wantLow)
+			}
+			if math.Abs(high-c.wantHigh) > tol {
+				t.Errorf("high = %.2f, want %.2f", high, c.wantHigh)
+			}
+			if math.Abs(best-c.wantBest) > tol {
+				t.Errorf("best = %.2f, want %.2f", best, c.wantBest)
+			}
+		})
+	}
+}
+
+// TestFrozenPadHasNoDepartRowOnKern pins ADR 0050 decision 3: Kern's
+// own orbit around Lumen's star has zero inclination and Kern's spin
+// axis carries zero AxialTilt (Lumen's faithful zero-obliquity
+// mirror), so the reference normal sits exactly on Kern's spin axis
+// (eps == 0) and a depart: row would read the pad's fixed incl: value
+// at every heading and every hour: a row that can never move. Verified
+// independently against the catalog (cmd/verifydepart, ADR progress
+// log) before this test: eps=0.0000, closedForm=[28.61..28.61].
+func TestFrozenPadHasNoDepartRowOnKern(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// ADR 0015 / system_binding_test.go's own TestSpawnBindsToViewedSystem:
+	// SpawnCraft's ParentBodyID lookup only searches the *viewed* System
+	// (w.System(), keyed off w.SystemIdx), not every loaded System. NewWorld
+	// starts viewing Sol, so without browsing to Lumen first, FindBody("kern")
+	// misses and SpawnCraft silently falls back to the active craft's
+	// existing primary (Earth) instead of erroring: caught here because the
+	// first draft of this test asserted against Earth's own swing without
+	// realizing it (Absent, or just unmatched? It was unmatched).
+	for i := 0; i < len(w.Systems); i++ {
+		if w.Systems[w.SystemIdx].Name == "Lumen" {
+			break
+		}
+		w.CycleSystem()
+	}
+	if w.Systems[w.SystemIdx].Name != "Lumen" {
+		t.Fatalf("could not browse to Lumen (stuck viewing %q)", w.Systems[w.SystemIdx].Name)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutKernStackID,
+		ParentBodyID:    "kern",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: launchpad spawn should set Landed=true")
+	}
+	if c.Primary.ID != "kern" {
+		t.Fatalf("setup: expected craft primary = kern, got %q", c.Primary.ID)
+	}
+	v := NewOrbitView(chipTestTheme())
+	rows := v.landedInclHeadingRows(w, c)
+	joined := strings.Join(rows, "\n")
+	if strings.Contains(joined, "depart:") {
+		t.Errorf("expected no depart: row on a frozen Kern pad (eps==0); got:\n%s", joined)
+	}
+}

--- a/internal/tui/screens/orbit_descent_hud_test.go
+++ b/internal/tui/screens/orbit_descent_hud_test.go
@@ -209,6 +209,37 @@ func TestDescentHUDRendersVHorizAlertOnImpactorApproach(t *testing.T) {
 	}
 }
 
+// TestDescentChipHoldNamesFrame: the DESCENT chip's hold: row is the
+// airless-body twin of the SURFACE chip's; it must name its frame
+// through the same attitudeHoldLabel helper rather than a bare
+// AttitudeMode.String() (ADR 0050 review F1: hold: should denote
+// surface, orbit, or target).
+func TestDescentChipHoldNamesFrame(t *testing.T) {
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c := placeLanderOnMoon(t, w, 5_000, 0, 100, 0)
+	if !shouldShowDescentHUD(c) {
+		t.Fatalf("predicate gate didn't fire; can't drive render path")
+	}
+	w.NavMode = sim.NavOrbit
+	c.AttitudeMode = spacecraft.BurnPrograde
+
+	view := NewOrbitView(descentHUDTheme())
+	view.Resize(200, 60)
+	lines := view.buildDescentChip(w)
+	var holdLine string
+	for _, l := range lines {
+		if s := strings.TrimSpace(l); strings.HasPrefix(s, "hold:") {
+			holdLine = s
+		}
+	}
+	if !strings.Contains(holdLine, "(ORBIT)") {
+		t.Errorf("DESCENT hold row = %q, want it to name the ORBIT frame like the navball button does", holdLine)
+	}
+}
+
 // TestDescentHUDQuietAtHighStableOrbit — verifies the rendered HUD
 // does NOT emit a DESCENT section when the craft is in a stable
 // high orbit (predicate returns false). Pins the symmetric case to

--- a/internal/tui/screens/orbit_landed_no_orbit_test.go
+++ b/internal/tui/screens/orbit_landed_no_orbit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jasonfen/terminal-space-program/internal/render"
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+	"github.com/jasonfen/terminal-space-program/internal/tui/readout"
 )
 
 // spawnLandedOnMoon spawns a Saturn V landed on the Moon — an airless
@@ -260,8 +261,13 @@ func TestTargetChipLandedTargetShowsNoApPe(t *testing.T) {
 		t.Fatal("TARGET chip returned nil for a landed target")
 	}
 	joined := strings.Join(lines, "\n")
+	// ADR 0050 decision 7 adds a "Δincl:" row for a landed target, which
+	// contains "incl:" as a substring, so strip it out before checking
+	// that the un-prefixed elements-derived "incl:" row (the one #375
+	// swapped for "landed at:") hasn't come back.
+	strippedOfDeltaIncl := strings.ReplaceAll(joined, readout.LabelDeltaIncl, "")
 	for _, unwanted := range []string{"Ap:", "Pe:", "incl:"} {
-		if strings.Contains(joined, unwanted) {
+		if strings.Contains(strippedOfDeltaIncl, unwanted) {
 			t.Errorf("landed target's TARGET chip still shows %q, want it swapped for landing site:\n%s", unwanted, joined)
 		}
 	}

--- a/internal/tui/screens/orbit_landed_pole_guard_test.go
+++ b/internal/tui/screens/orbit_landed_pole_guard_test.go
@@ -1,0 +1,91 @@
+package screens
+
+import (
+	"math"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+)
+
+// poleGuardWorld builds a world with the active craft landed at the
+// given Earth latitude (the shipped North Pole preset is 90, see
+// internal/sim/launch_sites.go's "North-Pole") and the Moon targeted:
+// the review r1 F3 scenario.
+func poleGuardWorld(t *testing.T, latitude float64) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{Launchpad: true, Latitude: latitude})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed {
+		t.Fatal("setup: launchpad spawn should set Landed=true")
+	}
+	sys := w.System()
+	moonIdx := -1
+	for i, b := range sys.Bodies {
+		if b.EnglishName == "Moon" || b.ID == "moon" {
+			moonIdx = i
+			break
+		}
+	}
+	if moonIdx <= 0 {
+		t.Fatalf("moon not found in default system")
+	}
+	w.SetTargetBody(moonIdx)
+	return w
+}
+
+// TestLaunchChipWithholdsDepartAndDeltaInclAtPole pins review r1 F3: the
+// active vessel's own landed co-rotation normal (r x v) is pole-
+// degenerate at the shipped North Pole preset: floating-point residue
+// leaves it a few times 1e-7 in magnitude, not exactly zero, which the
+// pre-fix exact Norm()==0 guards inside spacecraft.HeadingOrbitNormal
+// let through as trustworthy. Unguarded, the review measured depart:
+// wandering 75.45..108.9° and Δincl: 80.34..72.65° across a day with no
+// period. Both rows must withhold at the pole; incl: must not: every
+// launch from the pole is genuinely polar, so 90° is an honest number,
+// not noise.
+func TestLaunchChipWithholdsDepartAndDeltaInclAtPole(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w := poleGuardWorld(t, 90)
+
+	lines := v.buildLaunchChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "depart:") {
+		t.Errorf("expected no depart: row for a vessel landed at the pole, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "Δincl:") {
+		t.Errorf("expected no Δincl: row for a vessel landed at the pole, got:\n%s", joined)
+	}
+	if !regexp.MustCompile(`\bincl:\s+90\.\d\d°`).MatchString(joined) {
+		t.Errorf("expected incl: ~90.00° at the pole (every launch there is polar), got:\n%s", joined)
+	}
+}
+
+// TestLaunchChipShowsDepartAndDeltaInclOneMetreOffPole is the F3 sibling
+// case: ADR 0050 decision 8's own trip radius is ~6mm on Earth, so a
+// vessel landed one metre off the pole keeps an honest, real, sweeping
+// depart:/Δincl: figure rather than losing it to an over-eager guard.
+func TestLaunchChipShowsDepartAndDeltaInclOneMetreOffPole(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	const earthRadiusM = 6.371e6 // matches PlaneNormalOK's own doc comment scale.
+	colatDeg := (1.0 / earthRadiusM) * 180 / math.Pi
+	w := poleGuardWorld(t, 90-colatDeg)
+
+	lines := v.buildLaunchChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "depart:") {
+		t.Errorf("expected a depart: row one metre off the pole, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "Δincl:") {
+		t.Errorf("expected a Δincl: row one metre off the pole, got:\n%s", joined)
+	}
+}

--- a/internal/tui/screens/orbit_launch_hud_test.go
+++ b/internal/tui/screens/orbit_launch_hud_test.go
@@ -188,6 +188,57 @@ func TestLaunchChipSteadyOnPad(t *testing.T) {
 	}
 }
 
+// TestLaunchChipHoldNamesFrame: the SURFACE chip's hold: row is one of
+// the two rows that stay on screen when ATTITUDE folds into the
+// "+N hidden" stub (the ADR 0050 review's F1 finding: on the pad at
+// 140x40 with a target set, ATTITUDE hides and hold: is the only
+// attitude readout left, with no frame in it). It must name its frame
+// through the same attitudeHoldLabel helper the ATTITUDE chip uses, not
+// a bare AttitudeMode.String().
+func TestLaunchChipHoldNamesFrame(t *testing.T) {
+	v := NewOrbitView(Theme{
+		Primary: lipgloss.NewStyle(),
+		Warning: lipgloss.NewStyle(),
+		Alert:   lipgloss.NewStyle(),
+		Dim:     lipgloss.NewStyle(),
+		HUDBox:  lipgloss.NewStyle(),
+	})
+	v.Resize(120, 40)
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	c, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	})
+	if err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if !c.Landed || !shouldShowLaunchHUD(c) {
+		t.Fatalf("setup: want a Landed craft with the LAUNCH chip up (landed=%v, show=%v)", c.Landed, shouldShowLaunchHUD(c))
+	}
+	w.NavMode = sim.NavOrbit
+	c.AttitudeMode = spacecraft.BurnPrograde
+
+	row := func(lines []string, prefix string) string {
+		for _, l := range lines {
+			if s := strings.TrimSpace(l); strings.HasPrefix(s, prefix) {
+				return s
+			}
+		}
+		return ""
+	}
+	lines := v.buildLaunchChip(w)
+	holdLine := row(lines, "hold:")
+	if !strings.Contains(holdLine, "(ORBIT)") {
+		t.Errorf("SURFACE hold row = %q, want it to name the ORBIT frame like the navball button does", holdLine)
+	}
+}
+
 // TestLaunchChipEngineLitIndicator — #427 / ADR 0048 §3: the launch HUD
 // had no engine-lit state at all (the review's own finding: after
 // pressing z then b there was no way to tell from the screen whether the

--- a/internal/tui/screens/orbit_target_delta_incl_test.go
+++ b/internal/tui/screens/orbit_target_delta_incl_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
 	"github.com/jasonfen/terminal-space-program/internal/sim"
 	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
 )
@@ -224,5 +227,71 @@ func TestLaunchChipShowsDeltaInclAgainstVesselTarget(t *testing.T) {
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "Δincl:") {
 		t.Fatalf("expected a 'Δincl:' row on the pad chip when targeting a same-primary vessel, got none:\n%s", joined)
+	}
+}
+
+// TestDeltaInclRowWarningColouredPastThreshold: round 2 review R2-F3.
+// deltaInclLabel (the shared helper behind the pad's Δincl row and the
+// TARGET chip's) colours the value Warning past 30 degrees, but every
+// existing Δincl test uses chipTestTheme's no-op styles or a value that
+// never crosses the threshold, so neutralising that colouring left every
+// Δincl test green. Mirrors TestDepartRowNeverWarningColoured's idiom
+// (plainThemeColored + the color profile forced to ANSI, since go
+// test's non-TTY stdout otherwise makes every Render a no-op regardless
+// of style) but asserts the opposite: unlike depart:, which the ADR
+// says never takes Warning, Δincl: is meant to warn past 30 degrees.
+// Uses the same KSC-active / Baikonur-latitude-landed-target fixture as
+// TestLaunchChipTagsDeltaInclDueEastForLandedVesselTarget, whose Δincl
+// value (~70.6 degrees) sits well past the threshold.
+func TestDeltaInclRowWarningColouredPastThreshold(t *testing.T) {
+	ambient := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI)
+	t.Cleanup(func() { lipgloss.SetColorProfile(ambient) })
+
+	v := NewOrbitView(plainThemeColored())
+	v.Resize(200, 80)
+	w, ksc := spawnLandedOnEarthAt28p6(t)
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        45.9645, // Baikonur's latitude.
+		LongitudeOffset: 63.3052,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 1 // back to the KSC pad craft.
+	if w.ActiveCraft() != ksc {
+		t.Fatalf("setup: expected the active craft to be the KSC pad craft")
+	}
+	w.SetTargetCraft(2) // the Baikonur-latitude landed target.
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+
+	lines := v.buildLaunchChip(w)
+	var diLine string
+	for _, l := range lines {
+		if strings.Contains(stripANSI(l), "Δincl:") {
+			diLine = l
+		}
+	}
+	if diLine == "" {
+		t.Fatalf("expected a Δincl: row; got:\n%s", strings.Join(lines, "\n"))
+	}
+	diRe := regexp.MustCompile(`Δincl:\s+([0-9]+\.[0-9]+)°`)
+	m := diRe.FindStringSubmatch(stripANSI(diLine))
+	if m == nil {
+		t.Fatalf("could not parse a Δincl value out of %q", diLine)
+	}
+	value, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("could not parse Δincl value %q: %v", m[1], err)
+	}
+	if value < 30 {
+		t.Fatalf("setup: expected a Δincl value past the 30 degree Warning threshold this test means to probe, got %.2f", value)
+	}
+	if diLine == stripANSI(diLine) {
+		t.Errorf("Δincl: row carries no colour codes despite a value (%.2f°) past the Warning threshold: %q", value, diLine)
 	}
 }

--- a/internal/tui/screens/orbit_target_delta_incl_test.go
+++ b/internal/tui/screens/orbit_target_delta_incl_test.go
@@ -157,6 +157,50 @@ func TestBuildTargetChipNoDeltaInclForVesselLandedAtPole(t *testing.T) {
 	}
 }
 
+// TestLaunchChipTagsDeltaInclDueEastForLandedVesselTarget pins review r1
+// F2: the pad's own Δincl row (landedInclHeadingRows, shared by the
+// SURFACE and DESCENT chips) and the full TARGET chip's TargetCraft
+// branch both compute Δincl against a landed vessel target's due-east
+// launch plane (decision 7), but only the TARGET chip tagged it
+// "(due east)": see TestBuildTargetChipTagsDeltaInclDueEastForLandedVesselTarget
+// above. At 140x40 the compact TARGET chip carries no Δincl at all, so
+// the untagged pad row was the only figure the player ever saw. Active
+// craft is the KSC pad (28.6083°N); target is a second landed vessel at
+// a different site (Baikonur's latitude), so the two aren't trivially
+// coplanar.
+func TestLaunchChipTagsDeltaInclDueEastForLandedVesselTarget(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, ksc := spawnLandedOnEarthAt28p6(t)
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        45.9645, // Baikonur's latitude.
+		LongitudeOffset: 63.3052,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	if len(w.Crafts) != 3 {
+		t.Fatalf("setup: expected 3 crafts (seed LEO, KSC pad, Baikonur pad), got %d", len(w.Crafts))
+	}
+	w.ActiveCraftIdx = 1 // back to the KSC pad craft.
+	if w.ActiveCraft() != ksc {
+		t.Fatalf("setup: expected the active craft to be the KSC pad craft")
+	}
+	w.SetTargetCraft(2) // the Baikonur-latitude landed target.
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+
+	lines := v.buildLaunchChip(w)
+	joined := strings.Join(lines, "\n")
+	diRe := regexp.MustCompile(`Δincl:\s+([0-9]+\.[0-9]+)°\s+\(due east\)`)
+	if diRe.FindStringSubmatch(joined) == nil {
+		t.Fatalf("expected a pad 'Δincl: N° (due east)' row for the landed vessel target, got:\n%s", joined)
+	}
+}
+
 // TestLaunchChipShowsDeltaInclAgainstVesselTarget pins ADR 0050
 // decision 6: today Δincl: on the pad is gated on sim.TargetBody only,
 // so targeting a vessel prints nothing even though the vessel has a

--- a/internal/tui/screens/orbit_target_delta_incl_test.go
+++ b/internal/tui/screens/orbit_target_delta_incl_test.go
@@ -1,0 +1,184 @@
+package screens
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jasonfen/terminal-space-program/internal/sim"
+	"github.com/jasonfen/terminal-space-program/internal/spacecraft"
+)
+
+// orbitingVesselTargetWorld builds a world with the active craft in the
+// default equatorial LEO seed orbit and a second craft in a 30°-
+// inclined LEO orbit around the same primary, targeted from the
+// active craft: a same-primary vessel target with a real, non-coplanar
+// orbit (ADR 0050 decision 6).
+func orbitingVesselTargetWorld(t *testing.T) *sim.World {
+	t.Helper()
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{AltitudeM: 600e3, Inclination: 30}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+	return w
+}
+
+// TestBuildTargetChipShowsDeltaInclForOrbitingVesselTarget pins ADR
+// 0050 decision 6: the full TARGET chip's TargetCraft branch carries no
+// Δincl row for any vessel today, landed or orbiting. Add it for an
+// orbiting (has-a-real-orbit) target.
+func TestBuildTargetChipShowsDeltaInclForOrbitingVesselTarget(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w := orbitingVesselTargetWorld(t)
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Δincl:") {
+		t.Fatalf("expected a 'Δincl:' row on the TARGET chip for an orbiting vessel target, got none:\n%s", joined)
+	}
+}
+
+// TestBuildTargetChipTagsDeltaInclDueEastForLandedVesselTarget pins
+// ADR 0050 decision 7: a landed target's plane is r × v of its actual
+// co-rotation state, which equals the due-east launch plane at every
+// latitude, so the row says so rather than pretending the assumption
+// isn't there. The active craft's own orbit is the seed equatorial LEO
+// orbit (inclination ~0° in the body-equatorial frame), so the plane
+// angle to a due-east launch plane from the KSC pad latitude
+// (28.6083°) is exactly that latitude, independent of node alignment:
+// this also doubles as a numeric check, not just a presence check.
+func TestBuildTargetChipTagsDeltaInclDueEastForLandedVesselTarget(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{
+		LoadoutID:       spacecraft.LoadoutSaturnVID,
+		ParentBodyID:    "earth",
+		Launchpad:       true,
+		Latitude:        sim.DefaultLaunchpadLatitude,
+		LongitudeOffset: sim.DefaultLaunchpadLongitudeEast,
+	}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0 // the seed equatorial LEO craft.
+	w.SetTargetCraft(1)  // the landed KSC craft.
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "landed at:") {
+		t.Fatalf("setup: expected a 'landed at:' row for the landed target:\n%s", joined)
+	}
+	diRe := regexp.MustCompile(`Δincl:\s+([0-9]+\.[0-9]+)°\s+\(due east\)`)
+	m := diRe.FindStringSubmatch(joined)
+	if m == nil {
+		t.Fatalf("expected a 'Δincl: N° (due east)' row for the landed vessel target, got:\n%s", joined)
+	}
+	got, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		t.Fatalf("could not parse Δincl value %q: %v", m[1], err)
+	}
+	if diff := got - sim.DefaultLaunchpadLatitude; diff > 0.01 || diff < -0.01 {
+		t.Errorf("Δincl (due east) = %.4f°, want ~%.4f° (KSC pad latitude, since the active craft's own orbit is equatorial)", got, sim.DefaultLaunchpadLatitude)
+	}
+}
+
+// TestBuildTargetChipNoDeltaInclAcrossPrimaries pins ADR 0050 decision
+// 6's amendment: a vessel target orbiting a DIFFERENT primary than the
+// active craft gets no Δincl figure at all, matching the `I` key and
+// the node markers (both already refuse via TargetSharesActivePrimary).
+// Without this gate the figure mixes the target's own lap with its
+// primary's motion round the active primary and reads a fast-looking,
+// meaningless wobble.
+func TestBuildTargetChipNoDeltaInclAcrossPrimaries(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	// Active craft (Crafts[0]) is the seed Earth LEO orbit; target a
+	// second craft in lunar orbit, a different primary.
+	if _, err := w.SpawnCraft(sim.SpawnSpec{ParentBodyID: "Moon", AltitudeM: 100e3}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+	if w.TargetSharesActivePrimary() {
+		t.Fatalf("setup: expected the lunar-orbit target and the Earth-orbit active craft to NOT share a primary")
+	}
+
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "Δincl:") {
+		t.Errorf("expected no Δincl row for a vessel target orbiting a different primary, got:\n%s", joined)
+	}
+}
+
+// TestBuildTargetChipNoDeltaInclForVesselLandedAtPole pins ADR 0050
+// decision 8 at the chip layer: a vessel target landed at the shipped
+// North Pole preset has a pole-degenerate plane normal (|rT x vT| ~=
+// 3e-7, not exactly zero), so the chip must withhold the Δincl row the
+// same way PlanVesselPlaneMatch refuses and TargetPlaneNodePositions
+// draws no markers there.
+func TestBuildTargetChipNoDeltaInclForVesselLandedAtPole(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	w, err := sim.NewWorld()
+	if err != nil {
+		t.Fatalf("NewWorld: %v", err)
+	}
+	if _, err := w.SpawnCraft(sim.SpawnSpec{Launchpad: true, Latitude: 90}); err != nil {
+		t.Fatalf("SpawnCraft: %v", err)
+	}
+	w.ActiveCraftIdx = 0
+	w.SetTargetCraft(1)
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+
+	lines := v.buildTargetChip(w)
+	joined := strings.Join(lines, "\n")
+	if strings.Contains(joined, "Δincl:") {
+		t.Errorf("expected no Δincl row for a vessel target landed at the pole, got:\n%s", joined)
+	}
+}
+
+// TestLaunchChipShowsDeltaInclAgainstVesselTarget pins ADR 0050
+// decision 6: today Δincl: on the pad is gated on sim.TargetBody only,
+// so targeting a vessel prints nothing even though the vessel has a
+// perfectly good fixed plane to match. Matching one from the pad is
+// the canonical launch-window problem PlanVesselPlaneMatch (the `I`
+// key) already solves. Ungating landedInclHeadingRows for
+// TargetCraft/TargetGhost is the fix.
+func TestLaunchChipShowsDeltaInclAgainstVesselTarget(t *testing.T) {
+	v := NewOrbitView(chipTestTheme())
+	v.Resize(200, 80)
+	w, _ := spawnLandedOnEarthAt28p6(t)
+	// Crafts[0] is the seed LEO craft NewWorld() spawns before the pad
+	// craft above; targeting it gives a same-primary vessel with a real
+	// orbit, no launch assumed.
+	w.SetTargetCraft(0)
+	if w.Target.Kind != sim.TargetCraft {
+		t.Fatalf("setup: expected TargetCraft, got %v", w.Target.Kind)
+	}
+
+	lines := v.buildLaunchChip(w)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Δincl:") {
+		t.Fatalf("expected a 'Δincl:' row on the pad chip when targeting a same-primary vessel, got none:\n%s", joined)
+	}
+}


### PR DESCRIPTION
## What the player sees

- **Airless pads get a readout.** Standing on Luna, Glyph or any other airless world, the pad now shows `heading:`, `incl: N° (min N°)` and, with a target set, `Δincl:`. Before this, only the 7 of 52 bodies with an atmosphere had any heading or inclination readout on the pad.
- **Lunar orbits stop re-waking the ascent cues.** In a stable orbit around an airless body, the ascent arc and nose-prograde stubs no longer come back once per orbit. "Done climbing for good" now means periapsis above the surface when there is no atmosphere to clear.
- **`Δincl:` against a vessel.** Target another vessel and `Δincl:` reads how far off its orbital plane you are, on the pad and in the full TARGET chip. It is withheld when the target orbits a different world (matching `I` and the node markers, which already refuse), and at a pole, where the old exact-zero guards let floating-point noise through and `I` planned 8 to 13 km/s. A landed target reads the due-east launch plane and says so: `Δincl: 53.59° (due east)`.
- **A `depart:` row.** On the pad and in the ORBIT chip: the angle between your orbit and the plane the world beneath you travels in. On the pad it carries `(best N°)`, the lowest value waiting a rotation can reach, so it answers "is it worth warping". From KSC it sweeps `5.17°..52.05°`; from a Luna pad `23.46°..33.75°`. Hidden on worlds where it cannot move (Kern, Cursor, Shell, Pipe). New ninth line in the F1 readout glossary, mirrored in `docs/controls.md`.
- **`hold:` says which frame it holds in**, everywhere it appears: `hold: Surface Prograde (SURF)`, `hold: Prograde (ORBIT)`, `hold: Target+ (TGT)`. The tag names the frame of the held mode, so it can never contradict itself, and it stays readable on the pad when the ATTITUDE chip folds away.
- The `AxialTilt` doc comment corrected to match the code (measured from the world's up, not the body's orbit normal). No behaviour change.

## Commits

1. Airless pad readout and airless ascent cues
2. `Δincl:` against a vessel, the shared pole guard, the same-primary gate, and the owed ADR 0049 guard test for the InstantSAS trim order
3. The `depart:` row and its glossary line
4. `AxialTilt` comment
5. Review fixes: the `(due east)` tag on the pad row, plane readouts withheld when your own vessel sits at a pole, a pole guard that rejects a zero normal on a non-spinning body, and tests pinning `depart:` as unfolded
6-8. `hold:` names its frame, then names the held mode's own frame

## Notes

- On the pad at 140x40 with a target set, ATTITUDE folds into the `▸ +2 hidden` stub and returns at liftoff. Accepted deliberately: `hold:` carries its frame on the SURFACE chip and the navball keeps the mode button, so what is briefly unavailable is the manual firing clock.
- At exactly 140x40 the TARGET chip renders compact, so the vessel `Δincl:` row shows from 140x50 up or with the navball hidden. The pad row shows at any size.
- `depart:` was not added to the capture chip, PROJECTED ORBIT, the maneuver screen's `new incl`, or the dock-guest orbit chip. Each is one line if wanted later.
- Exoplanet pads show `depart:` reading `61°..118°`, faithful to catalog transit inclinations. That is the known catalog-inclinations issue, filed separately, not this predicate.

## Test plan

- [x] `go vet ./...` and `go test ./... -race -count=1` green after every commit, run independently of the implementer
- [x] CI green on every pushed head, including the final one
- [x] Sabotage-first: every new guard shown red against the unfixed code (the lunar ascent-cue test samples both orbital halves; the InstantSAS trim-order guard goes red with the order reversed; the pole guard trips at the North Pole preset and not at 89.99999°; `depart:` goes red if folded; the Δincl Warning colour goes red if neutralised)
- [x] `depart:` swings computed against the real catalog match the design numbers for Earth, Mars, Mercury, Luna and Glyph
- [x] 140x40 captures read for the Earth pad, the Luna pad, Earth orbit, a landed vessel target, the pole, and every `hold:` frame combination
- [x] Review round 1 (fix-then-ship) and round 2 (fix-then-ship); all findings closed or ruled, both rounds' notes in the planning vault
- [ ] Fly it: KSC pad targeting a vessel, warp until `Δincl:` closes; watch `depart:` sweep toward its best; Luna pad readout; a stable lunar orbit with no cue cycling

Closes #454.
